### PR TITLE
Implement full YARPC interface.

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -18,27 +18,19 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package transport
+package yarpc
 
-// Inbound is a transport that knows how to receive requests for procedure
-// calls.
-type Inbound interface {
-	// Serve starts accepting new requests and dispatches them to the given
-	// Handler.
-	//
-	// The function MUST block while the Inbound is running. The caller is
-	// responsible for running it concurrently if necessary.
-	//
-	// An error may be returned if the Inbound failed to start up.
-	//
-	// Implementations may assume that this function is called at most once.
-	Serve(handler Handler) error
+import "strings"
 
-	// Close the inbound and stop accepting new requests.
-	//
-	// This MAY block while the server drains ongoing requests.
-	Close() error
+// errorGroup represents a collection of errors.
+type errorGroup struct {
+	Errors []error
+}
 
-	// TODO some way for the inbound to expose the host and port it's
-	// listening on
+func (e errorGroup) Error() string {
+	messages := []string{"the following errors occurred:"}
+	for _, err := range e.Errors {
+		messages = append(messages, "\t"+err.Error())
+	}
+	return strings.Join(messages, "\n")
 }

--- a/errors.go
+++ b/errors.go
@@ -30,7 +30,7 @@ type errorGroup struct {
 func (e errorGroup) Error() string {
 	messages := []string{"the following errors occurred:"}
 	for _, err := range e.Errors {
-		messages = append(messages, "\t"+err.Error())
+		messages = append(messages, err.Error())
 	}
-	return strings.Join(messages, "\n")
+	return strings.Join(messages, "\n\t")
 }

--- a/examples/json/server.go
+++ b/examples/json/server.go
@@ -21,11 +21,12 @@
 package main
 
 import (
+	"log"
+
 	"github.com/yarpc/yarpc-go"
 	"github.com/yarpc/yarpc-go/scheme/json"
 	"github.com/yarpc/yarpc-go/transport"
 	"github.com/yarpc/yarpc-go/transport/http"
-	"github.com/yarpc/yarpc-go/transport/tchannel"
 
 	"golang.org/x/net/context"
 )
@@ -43,24 +44,17 @@ func (h handler) Set(ctx context.Context, meta yarpc.Meta, req *SetRequest) (*Se
 	return &SetResponse{}, nil, nil
 }
 
-func (h handler) GetHandlers() map[string]interface{} {
-	return map[string]interface{}{
-		"get": h.Get,
-		"set": h.Set,
-	}
-}
-
 func main() {
 	yarpc := yarpc.New(yarpc.Config{
 		Name: "myService",
 		Inbounds: []transport.Inbound{
-			http.Inbound{},
-			tchannel.Inbound{},
+			http.Inbound(":8080"),
+			// TODO tchannel.Inbound{},
 		},
 		Outbounds: map[string]transport.Outbounds{
 			"moe": {
 				http.Outbound("http://localhost:8080"),
-				tchannel.Outbound("localhost:4040"),
+				// TODO tchannel.Outbound("localhost:4040"),
 			},
 		},
 	})
@@ -68,4 +62,9 @@ func main() {
 	handler := handler{items: make(map[string]string)}
 	json.Register(yarpc, json.Procedure("get", handler.Get))
 	json.Register(yarpc, json.Procedure("set", handler.Set))
+
+	err := yarpc.Serve()
+	if err != nil {
+		log.Fatalln(err)
+	}
 }

--- a/examples/json/server.go
+++ b/examples/json/server.go
@@ -63,8 +63,7 @@ func main() {
 	json.Register(yarpc, json.Procedure("get", handler.Get))
 	json.Register(yarpc, json.Procedure("set", handler.Set))
 
-	err := yarpc.Serve()
-	if err != nil {
+	if err := yarpc.Serve(); err != nil {
 		log.Fatalln(err)
 	}
 }

--- a/rpc.go
+++ b/rpc.go
@@ -104,8 +104,7 @@ func (r rpc) Serve() error {
 		wait.Submit(callServe(i))
 	}
 
-	errors := wait.Wait()
-	if len(errors) > 0 {
+	if errors := wait.Wait(); len(errors) > 0 {
 		return errorGroup{Errors: errors}
 	}
 
@@ -126,8 +125,7 @@ func (r rpc) Close() error {
 		wait.Submit(i.Close)
 	}
 
-	errors := wait.Wait()
-	if len(errors) > 0 {
+	if errors := wait.Wait(); len(errors) > 0 {
 		return errorGroup{Errors: errors}
 	}
 

--- a/scheme/json/errors.go
+++ b/scheme/json/errors.go
@@ -18,27 +18,35 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package transport
+package json
 
-// Inbound is a transport that knows how to receive requests for procedure
-// calls.
-type Inbound interface {
-	// Serve starts accepting new requests and dispatches them to the given
-	// Handler.
-	//
-	// The function MUST block while the Inbound is running. The caller is
-	// responsible for running it concurrently if necessary.
-	//
-	// An error may be returned if the Inbound failed to start up.
-	//
-	// Implementations may assume that this function is called at most once.
-	Serve(handler Handler) error
+import "fmt"
 
-	// Close the inbound and stop accepting new requests.
-	//
-	// This MAY block while the server drains ongoing requests.
-	Close() error
+// unmarshalError is raised when there's an error parsing JSON input.
+type unmarshalError struct {
+	Reason error
+}
 
-	// TODO some way for the inbound to expose the host and port it's
-	// listening on
+func (e unmarshalError) Error() string {
+	return fmt.Sprintf("failed to parse JSON: %v", e.Reason)
+}
+
+// marshalError is raised when there's an error serializing to JSON.
+type marshalError struct {
+	Reason error
+}
+
+func (e marshalError) Error() string {
+	return fmt.Sprintf("failed to write JSON: %v", e.Reason)
+}
+
+// IsEncodingError returns true if the given error is an error encountered
+// while trying to serialize or deserialize JSON.
+func IsEncodingError(e error) bool {
+	switch e.(type) {
+	case marshalError, unmarshalError:
+		return true
+	default:
+		return false
+	}
 }

--- a/scheme/json/inbound.go
+++ b/scheme/json/inbound.go
@@ -46,7 +46,7 @@ type jsonHandler struct {
 func (h jsonHandler) Handle(ctx context.Context, treq *transport.Request) (*transport.Response, error) {
 	req, err := h.reader.Read(json.NewDecoder(treq.Body))
 	if err != nil {
-		return nil, err
+		return nil, unmarshalError{Reason: err}
 	}
 
 	results := h.handler.Call([]reflect.Value{
@@ -67,8 +67,7 @@ func (h jsonHandler) Handle(ctx context.Context, treq *transport.Request) (*tran
 
 	body, err := json.Marshal(results[0].Interface())
 	if err != nil {
-		// TODO proper error types
-		return nil, err
+		return nil, marshalError{Reason: err}
 	}
 
 	return &transport.Response{

--- a/scheme/json/outbound.go
+++ b/scheme/json/outbound.go
@@ -66,8 +66,7 @@ type jsonClient struct {
 func (c jsonClient) Call(ctx context.Context, req *Request, responseOut interface{}) (yarpc.Meta, error) {
 	encoded, err := json.Marshal(req.Body)
 	if err != nil {
-		// TODO error type
-		return nil, err
+		return nil, marshalError{Reason: err}
 	}
 
 	treq := transport.Request{
@@ -83,7 +82,7 @@ func (c jsonClient) Call(ctx context.Context, req *Request, responseOut interfac
 
 	dec := json.NewDecoder(tres.Body)
 	if err := dec.Decode(responseOut); err != nil {
-		return nil, err
+		return nil, unmarshalError{Reason: err}
 	}
 
 	if err := tres.Body.Close(); err != nil {

--- a/sync/err.go
+++ b/sync/err.go
@@ -37,8 +37,7 @@ func (ew *ErrorWaiter) Submit(f func() error) {
 	ew.wait.Add(1)
 	go func() {
 		defer ew.wait.Done()
-		err := f()
-		if err != nil {
+		if err := f(); err != nil {
 			ew.lock.Lock()
 			ew.errors = append(ew.errors, err)
 			ew.lock.Unlock()

--- a/transport/http/constants.go
+++ b/transport/http/constants.go
@@ -18,27 +18,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package transport
+package http
 
-// Inbound is a transport that knows how to receive requests for procedure
-// calls.
-type Inbound interface {
-	// Serve starts accepting new requests and dispatches them to the given
-	// Handler.
-	//
-	// The function MUST block while the Inbound is running. The caller is
-	// responsible for running it concurrently if necessary.
-	//
-	// An error may be returned if the Inbound failed to start up.
-	//
-	// Implementations may assume that this function is called at most once.
-	Serve(handler Handler) error
+// ProcedureHeader is the header used by the HTTP outbound to send and receive
+// the procedure name.
+const ProcedureHeader = "YARPC-Procedure"
 
-	// Close the inbound and stop accepting new requests.
-	//
-	// This MAY block while the server drains ongoing requests.
-	Close() error
-
-	// TODO some way for the inbound to expose the host and port it's
-	// listening on
-}
+// TODO Make consistent with other languages^

--- a/transport/http/errors.go
+++ b/transport/http/errors.go
@@ -18,27 +18,15 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package transport
+package http
 
-// Inbound is a transport that knows how to receive requests for procedure
-// calls.
-type Inbound interface {
-	// Serve starts accepting new requests and dispatches them to the given
-	// Handler.
-	//
-	// The function MUST block while the Inbound is running. The caller is
-	// responsible for running it concurrently if necessary.
-	//
-	// An error may be returned if the Inbound failed to start up.
-	//
-	// Implementations may assume that this function is called at most once.
-	Serve(handler Handler) error
+import "fmt"
 
-	// Close the inbound and stop accepting new requests.
-	//
-	// This MAY block while the server drains ongoing requests.
-	Close() error
+// internalError is raised when an HTTP handler raises an unexpected error.
+type internalError struct {
+	Reason error
+}
 
-	// TODO some way for the inbound to expose the host and port it's
-	// listening on
+func (e internalError) Error() string {
+	return fmt.Sprintf("internal service error: %v", e.Reason)
 }

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -54,8 +54,9 @@ func (h httpOutbound) Call(ctx context.Context, req *transport.Request) (*transp
 		return nil, err
 	}
 
-	// TODO where does the procedure go?
+	// TODO throw an error if caller tried to use our ProcedureHeader.
 	request.Header = toHTTPHeader(req.Headers, nil)
+	request.Header.Set(ProcedureHeader, req.Procedure)
 	response, err := ctxhttp.Do(ctx, h.Client, request)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Depends on #11.

examples/json/server.go can now run and process requests.

```
$ curl -X POST -H 'YARPC-Procedure: set' http://localhost:8080 -d '{"key": "hello", "value": "world"}'
{}
$ curl -X POST -H 'YARPC-Procedure: get' http://localhost:8080 -d '{"key": "hello"}'
{"value":"world"}
```