### PR TITLE
Add Channels to store caller-specific information

### DIFF
--- a/crossdock/client/echo.go
+++ b/crossdock/client/echo.go
@@ -35,8 +35,6 @@ func EchoBehavior(addr string) Result {
 		ctx,
 		// TODO get Service from client
 		&json.Request{
-			Caller:    "client",
-			Service:   "yarpc-test",
 			Procedure: "echo",
 			Body:      &server.EchoRequest{Token: token},
 			TTL:       3 * time.Second,

--- a/examples/json/client/main.go
+++ b/examples/json/client/main.go
@@ -55,7 +55,7 @@ func get(ctx context.Context, c json.Client, k string) (string, error) {
 	var response GetResponse
 	_, err := c.Call(
 		ctx,
-		&json.Request{Service: "keyvalue", Caller: "keyvalue-client", Procedure: "get", Body: &GetRequest{Key: k}},
+		&json.Request{Procedure: "get", Body: &GetRequest{Key: k}},
 		&response,
 	)
 	return response.Value, err
@@ -65,7 +65,7 @@ func set(ctx context.Context, c json.Client, k string, v string) error {
 	var response SetResponse
 	_, err := c.Call(
 		ctx,
-		&json.Request{Service: "keyvalue", Caller: "keyvalue-client", Procedure: "set", Body: &SetRequest{Key: k, Value: v}},
+		&json.Request{Procedure: "set", Body: &SetRequest{Key: k, Value: v}},
 		&response,
 	)
 	return err

--- a/examples/thrift/keyvalue/service.go
+++ b/examples/thrift/keyvalue/service.go
@@ -39,10 +39,10 @@ type keyValueClient struct {
 	client thrift.Client
 }
 
-func NewKeyValueClient(t transport.Outbound) KeyValue {
+func NewKeyValueClient(c transport.Channel) KeyValue {
 	return keyValueClient{
 		client: thrift.New(thrift.Config{
-			Outbound: t,
+			Channel:  c,
 			Protocol: protocol.Binary,
 		}),
 	}

--- a/transport/outbound.go
+++ b/transport/outbound.go
@@ -32,3 +32,18 @@ type Outbound interface {
 
 // Outbounds is a map of service name to Outbound for that service.
 type Outbounds map[string]Outbound
+
+// Channel scopes an Outbound to a single caller-service pair.
+type Channel struct {
+	// Caller is the name of the service making the request.
+	Caller string
+
+	// Service is the name of the service to which the request is being made.
+	Service string
+
+	// Outbound is the transport used to send the request.
+	Outbound Outbound
+
+	// TODO: Can add caller-service-specific TTLs here. These can be inherited
+	//from the YARPC otherwise.
+}


### PR DESCRIPTION
A Channel keeps track of caller-callee specific state. Encoding-specific
clients are constructed with Channels instead of Outbounds, allowing sending
down information like caller name, callee name, etc. We will be able to track
things like caller-specific TTLs, number of ongoing requests to a caller, etc.
on these objects.