### PR TITLE
Combine yarpc.Meta and context.Context

### DIFF
--- a/crossdock/client/echo.go
+++ b/crossdock/client/echo.go
@@ -32,13 +32,8 @@ func EchoBehavior(addr string) Result {
 	token := randString(5)
 
 	_, err := client.Call(
-		ctx,
-		// TODO get Service from client
-		&json.Request{
-			Procedure: "echo",
-			Body:      &server.EchoRequest{Token: token},
-			TTL:       3 * time.Second,
-		},
+		&json.Request{Context: ctx, Procedure: "echo", TTL: 3 * time.Second},
+		&server.EchoRequest{Token: token},
 		&response,
 	)
 

--- a/crossdock/server/echo.go
+++ b/crossdock/server/echo.go
@@ -1,9 +1,6 @@
 package server
 
-import (
-	"github.com/yarpc/yarpc-go"
-	"golang.org/x/net/context"
-)
+import "github.com/yarpc/yarpc-go/encoding/json"
 
 // EchoRequest contains a message to echo
 type EchoRequest struct {
@@ -16,6 +13,6 @@ type EchoResponse struct {
 }
 
 // Echo echoes an EchoResponse
-func Echo(ctx context.Context, meta yarpc.Meta, req *EchoRequest) (*EchoResponse, yarpc.Meta, error) {
-	return &EchoResponse{Token: req.Token}, nil, nil
+func Echo(req *json.Request, body *EchoRequest) (*EchoResponse, *json.Response, error) {
+	return &EchoResponse{Token: body.Token}, nil, nil
 }

--- a/encoding/json/errors.go
+++ b/encoding/json/errors.go
@@ -37,7 +37,7 @@ type marshalError struct {
 }
 
 func (e marshalError) Error() string {
-	return fmt.Sprintf("failed to write JSON: %v", e.Reason)
+	return fmt.Sprintf("failed to serialize JSON: %v", e.Reason)
 }
 
 // IsEncodingError returns true if the given error is an error encountered

--- a/encoding/json/register_test.go
+++ b/encoding/json/register_test.go
@@ -3,10 +3,7 @@ package json
 import (
 	"testing"
 
-	"github.com/yarpc/yarpc-go"
-
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 func TestWrapHandlerInvalid(t *testing.T) {
@@ -17,37 +14,31 @@ func TestWrapHandlerInvalid(t *testing.T) {
 		{"empty", func() {}},
 		{
 			"wrong-response",
-			func(context.Context, yarpc.Meta, map[string]interface{}) (yarpc.Meta, error) {
+			func(*Request, map[string]interface{}) (*Response, error) {
 				return nil, nil
 			},
 		},
 		{
-			"wrong-context",
-			func(string, yarpc.Meta, *struct{}) (*struct{}, yarpc.Meta, error) {
-				return nil, nil, nil
-			},
-		},
-		{
-			"wrong-meta",
-			func(context.Context, string, *struct{}) (*struct{}, yarpc.Meta, error) {
+			"wrong-request",
+			func(string, *struct{}) (*struct{}, *Response, error) {
 				return nil, nil, nil
 			},
 		},
 		{
 			"non-pointer-req",
-			func(context.Context, yarpc.Meta, struct{}) (*struct{}, yarpc.Meta, error) {
+			func(*Request, struct{}) (*struct{}, *Response, error) {
 				return nil, nil, nil
 			},
 		},
 		{
 			"non-pointer-res",
-			func(context.Context, yarpc.Meta, *struct{}) (struct{}, yarpc.Meta, error) {
+			func(*Request, *struct{}) (struct{}, *Response, error) {
 				return struct{}{}, nil, nil
 			},
 		},
 		{
 			"non-string-key",
-			func(context.Context, yarpc.Meta, map[int32]interface{}) (*struct{}, yarpc.Meta, error) {
+			func(*Request, map[int32]interface{}) (*struct{}, *Response, error) {
 				return nil, nil, nil
 			},
 		},
@@ -67,19 +58,19 @@ func TestWrapHandlerValid(t *testing.T) {
 	}{
 		{
 			"foo",
-			func(context.Context, yarpc.Meta, *struct{}) (*struct{}, yarpc.Meta, error) {
+			func(*Request, *struct{}) (*struct{}, *Response, error) {
 				return nil, nil, nil
 			},
 		},
 		{
 			"bar",
-			func(context.Context, yarpc.Meta, map[string]interface{}) (*struct{}, yarpc.Meta, error) {
+			func(*Request, map[string]interface{}) (*struct{}, *Response, error) {
 				return nil, nil, nil
 			},
 		},
 		{
 			"baz",
-			func(context.Context, yarpc.Meta, map[string]interface{}) (map[string]interface{}, yarpc.Meta, error) {
+			func(*Request, map[string]interface{}) (map[string]interface{}, *Response, error) {
 				return nil, nil, nil
 			},
 		},

--- a/encoding/json/request.go
+++ b/encoding/json/request.go
@@ -18,26 +18,26 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package yarpc
+package json
 
-import "github.com/yarpc/yarpc-go/transport"
+import (
+	"time"
 
-// Meta TODO
-type Meta interface {
-	Headers() transport.Headers
-}
+	"github.com/yarpc/yarpc-go/transport"
 
-type meta struct {
-	headers transport.Headers
-}
+	"golang.org/x/net/context"
+)
 
-func (m meta) Headers() transport.Headers {
-	return m.headers
-}
+// Request is a JSON request without the body.
+type Request struct {
+	Context context.Context
 
-// NewMeta constructs a new Meta object with the given headers.
-func NewMeta(hs transport.Headers) Meta {
-	// TODO determine if this is how we want to expose meta construction to
-	// users.
-	return meta{hs}
+	// Name of the procedure being called.
+	Procedure string
+
+	// Request headers
+	Headers transport.Headers
+
+	// TTL is the amount of time in which this request is expected to finish.
+	TTL time.Duration
 }

--- a/encoding/json/response.go
+++ b/encoding/json/response.go
@@ -18,32 +18,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Package json provides the JSON encoding for YARPC.
-//
-// To make outbound requests using this encoding,
-//
-// 	client := json.New(outbound)
-// 	var response GetValueResponse
-// 	resBody, response, err := client.Call(
-// 		&json.Request{
-// 			Context: ctx,
-// 			Procedure: "getValue",
-// 		},
-// 		&GetValueRequest{...},
-// 		&response,
-// 	)
-//
-// To register a JSON procedure, define functions in the format,
-//
-// 	f(req *json.Request, body $reqBody) ($resBody, *json.Response, error)
-//
-// Where '$reqBody' and '$resBody' are either pointers to structs representing
-// your request and response objects, or map[string]interface{}.
-//
-// Use the Register and Procedure functions to register the procedures with a
-// Registry.
-//
-// 	json.Register(r, json.Procedure("getValue", GetValue))
-// 	json.Register(r, json.Procedure("setValue", SetValue))
-//
 package json
+
+import "github.com/yarpc/yarpc-go/transport"
+
+// Response is a JSON response without the body.
+type Response struct {
+	Headers transport.Headers
+
+	// TODO Response context?
+}

--- a/encoding/thrift/register.go
+++ b/encoding/thrift/register.go
@@ -24,20 +24,20 @@ import (
 	"github.com/yarpc/yarpc-go/transport"
 
 	"github.com/thriftrw/thriftrw-go/protocol"
-	"golang.org/x/net/context"
+	"github.com/thriftrw/thriftrw-go/wire"
 )
 
 // Handler represents a Thrift request handler.
 type Handler interface {
-	Handle(ctx context.Context, req *Request) (*Response, error)
+	Handle(req *Request, body wire.Value) (wire.Value, *Response, error)
 }
 
 // HandlerFunc is a convenience type alias for functions that implement that act as Handlers.
-type HandlerFunc func(context.Context, *Request) (*Response, error)
+type HandlerFunc func(*Request, wire.Value) (wire.Value, *Response, error)
 
 // Handle forwards the request to the underlying function.
-func (f HandlerFunc) Handle(ctx context.Context, req *Request) (*Response, error) {
-	return f(ctx, req)
+func (f HandlerFunc) Handle(req *Request, body wire.Value) (wire.Value, *Response, error) {
+	return f(req, body)
 }
 
 // Service represents a Thrift service implementation.

--- a/encoding/thrift/request.go
+++ b/encoding/thrift/request.go
@@ -21,19 +21,20 @@
 package thrift
 
 import (
-	"github.com/yarpc/yarpc-go"
+	"time"
 
-	"github.com/thriftrw/thriftrw-go/wire"
+	"github.com/yarpc/yarpc-go/transport"
+
+	"golang.org/x/net/context"
 )
 
 // Request represents a raw Thrift request.
 type Request struct {
-	// Name of the Thrift service and method.
-	Service, Method string
+	Context context.Context
 
-	// Metadata for the request.
-	Meta yarpc.Meta
+	// Request headers
+	Headers transport.Headers
 
-	// Body of the Thrift request in a protocol-agnostic format.
-	Body wire.Value
+	// TTL is the amount of time in which this request is expected to finish.
+	TTL time.Duration
 }

--- a/encoding/thrift/response.go
+++ b/encoding/thrift/response.go
@@ -20,19 +20,12 @@
 
 package thrift
 
-import (
-	"github.com/yarpc/yarpc-go"
-
-	"github.com/thriftrw/thriftrw-go/wire"
-)
+import "github.com/yarpc/yarpc-go/transport"
 
 // Response represents a raw Thrift response.
 type Response struct {
-	// Metadata for the response.
-	Meta yarpc.Meta
-
-	// Body of the Thrift response in a protocol-agnostic format.
-	Body wire.Value
+	// Response headers
+	Headers transport.Headers
 
 	// TODO: Handle REPLY/EXCEPTION for response envelopes
 }

--- a/examples/json/client/main.go
+++ b/examples/json/client/main.go
@@ -54,8 +54,8 @@ type SetResponse struct {
 func get(ctx context.Context, c json.Client, k string) (string, error) {
 	var response GetResponse
 	_, err := c.Call(
-		ctx,
-		&json.Request{Procedure: "get", Body: &GetRequest{Key: k}},
+		&json.Request{Procedure: "get", Context: ctx},
+		&GetRequest{Key: k},
 		&response,
 	)
 	return response.Value, err
@@ -64,8 +64,8 @@ func get(ctx context.Context, c json.Client, k string) (string, error) {
 func set(ctx context.Context, c json.Client, k string, v string) error {
 	var response SetResponse
 	_, err := c.Call(
-		ctx,
-		&json.Request{Procedure: "set", Body: &SetRequest{Key: k, Value: v}},
+		&json.Request{Procedure: "set", Context: ctx},
+		&SetRequest{Key: k, Value: v},
 		&response,
 	)
 	return err

--- a/examples/json/server/main.go
+++ b/examples/json/server/main.go
@@ -22,13 +22,12 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/yarpc/yarpc-go"
 	"github.com/yarpc/yarpc-go/encoding/json"
 	"github.com/yarpc/yarpc-go/transport"
 	"github.com/yarpc/yarpc-go/transport/http"
-
-	"golang.org/x/net/context"
 )
 
 type GetRequest struct {
@@ -51,12 +50,12 @@ type handler struct {
 	items map[string]string
 }
 
-func (h handler) Get(ctx context.Context, meta yarpc.Meta, req *GetRequest) (*GetResponse, yarpc.Meta, error) {
-	return &GetResponse{Value: h.items[req.Key]}, nil, nil
+func (h handler) Get(req *json.Request, body *GetRequest) (*GetResponse, *json.Response, error) {
+	return &GetResponse{Value: h.items[body.Key]}, nil, nil
 }
 
-func (h handler) Set(ctx context.Context, meta yarpc.Meta, req *SetRequest) (*SetResponse, yarpc.Meta, error) {
-	h.items[req.Key] = req.Value
+func (h handler) Set(req *json.Request, body *SetRequest) (*SetResponse, *json.Response, error) {
+	h.items[body.Key] = body.Value
 	return &SetResponse{}, nil, nil
 }
 
@@ -78,5 +77,8 @@ func main() {
 
 	if err := yarpc.Start(); err != nil {
 		fmt.Println("error:", err.Error())
+		os.Exit(1)
 	}
+
+	select {}
 }

--- a/examples/thrift/keyvalue/client/main.go
+++ b/examples/thrift/keyvalue/client/main.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/yarpc/yarpc-go"
+	"github.com/yarpc/yarpc-go/encoding/thrift"
 	"github.com/yarpc/yarpc-go/examples/thrift/keyvalue"
 	"github.com/yarpc/yarpc-go/transport"
 	"github.com/yarpc/yarpc-go/transport/http"
@@ -67,7 +68,7 @@ func main() {
 			key := args[0]
 
 			ctx, _ := context.WithTimeout(rootCtx, 100*time.Millisecond)
-			if value, _, err := client.GetValue(ctx, nil, key); err != nil {
+			if value, _, err := client.GetValue(&thrift.Request{Context: ctx}, key); err != nil {
 				fmt.Printf("get %q failed: %s\n", key, err)
 			} else {
 				fmt.Println(key, "=", value)
@@ -82,7 +83,7 @@ func main() {
 			key, value := args[0], args[1]
 
 			ctx, _ := context.WithTimeout(rootCtx, 100*time.Millisecond)
-			if _, err := client.SetValue(ctx, nil, key, value); err != nil {
+			if _, err := client.SetValue(&thrift.Request{Context: ctx}, key, value); err != nil {
 				fmt.Printf("set %q = %q failed: %v\n", key, value, err.Error())
 			}
 			continue

--- a/examples/thrift/keyvalue/server/main.go
+++ b/examples/thrift/keyvalue/server/main.go
@@ -28,15 +28,13 @@ import (
 	"github.com/yarpc/yarpc-go/examples/thrift/keyvalue"
 	"github.com/yarpc/yarpc-go/transport"
 	"github.com/yarpc/yarpc-go/transport/http"
-
-	"golang.org/x/net/context"
 )
 
 type handler struct {
 	items map[string]string
 }
 
-func (h handler) GetValue(ctx context.Context, meta yarpc.Meta, key string) (string, yarpc.Meta, error) {
+func (h handler) GetValue(req *thrift.Request, key string) (string, *thrift.Response, error) {
 	if value, ok := h.items[key]; ok {
 		return value, nil, nil
 	}
@@ -44,7 +42,7 @@ func (h handler) GetValue(ctx context.Context, meta yarpc.Meta, key string) (str
 	return "", nil, &keyvalue.ResourceDoesNotExist{Key: key}
 }
 
-func (h handler) SetValue(ctx context.Context, meta yarpc.Meta, key string, value string) (yarpc.Meta, error) {
+func (h handler) SetValue(req *thrift.Request, key string, value string) (*thrift.Response, error) {
 	h.items[key] = value
 	return nil, nil
 }
@@ -61,4 +59,6 @@ func main() {
 	if err := yarpc.Start(); err != nil {
 		fmt.Println("error:", err.Error())
 	}
+
+	select {} // block forever
 }

--- a/transport/response.go
+++ b/transport/response.go
@@ -34,5 +34,7 @@ type ResponseWriter interface {
 
 	// AddHeaders adds the given headers to the response. If called, this must
 	// be called before any invocation of Write().
+	//
+	// This MUST NOT panic if Headers is nil.
 	AddHeaders(Headers)
 }

--- a/transport/transporttest/reqres.go
+++ b/transport/transporttest/reqres.go
@@ -193,6 +193,9 @@ type FakeResponseWriter struct {
 
 // AddHeaders for FakeResponseWriter.
 func (fw *FakeResponseWriter) AddHeaders(h transport.Headers) {
+	if fw.Headers == nil {
+		fw.Headers = make(transport.Headers)
+	}
 	for k, v := range h {
 		fw.Headers.Set(k, v)
 	}


### PR DESCRIPTION
This combines the `yarpc.Meta` and `context.Context` objects into a `{json, thrift}.Request` and changes use of `yarpc.Meta` in responses to a `{json, thrift}.Response`. We'll want to put response context there.

Resolves #23.