### PR TITLE
Added raw encoding

### DIFF
--- a/encoding/json/doc.go
+++ b/encoding/json/doc.go
@@ -23,14 +23,14 @@
 // To make outbound requests using this encoding,
 //
 // 	client := json.New(outbound)
-// 	var response GetValueResponse
-// 	resBody, response, err := client.Call(
+// 	var resBody GetValueResponse
+// 	response, err := client.Call(
 // 		&json.Request{
 // 			Context: ctx,
 // 			Procedure: "getValue",
 // 		},
 // 		&GetValueRequest{...},
-// 		&response,
+// 		&resBody,
 // 	)
 //
 // To register a JSON procedure, define functions in the format,

--- a/encoding/raw/doc.go
+++ b/encoding/raw/doc.go
@@ -18,31 +18,25 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package json
-
-import (
-	"time"
-
-	"github.com/yarpc/yarpc-go/transport"
-
-	"golang.org/x/net/context"
-)
-
-// Request is a JSON request without the body.
-type Request struct {
-	Context context.Context
-
-	// Name of the procedure being called.
-	Procedure string
-
-	// Request headers
-	Headers transport.Headers
-
-	// TTL is the amount of time in which this request is expected to finish.
-	TTL time.Duration
-}
-
-// Note: The shape of this request object is extremely similar to the
-// raw.Request object, but since we can't unify all the Request objects
-// (thrift.Request is very different), each encoding will have its own Request
-// object.
+// Package raw provides the raw encoding for YARPC.
+//
+// To make outbound requests,
+//
+// 	client := raw.New(channel)
+// 	resBody, response, err := client.Call(
+// 		&raw.Request{
+// 			Context: ctx,
+// 			Procedure: "submit",
+// 		},
+// 		[]byte{1, 2, 3},
+// 	)
+//
+// To register a raw procedure, define a Registrant or use Procedure to make a
+// single-function Registrant, and register it with Register.
+//
+// 	func Submit(req *raw.Request, reqBody []byte) ([]byte, *raw.Response, error) {
+// 		// ...
+// 	}
+//
+// 	raw.Register(rpc, raw.Procedure("submit", Submit))
+package raw

--- a/encoding/raw/request.go
+++ b/encoding/raw/request.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package json
+package raw
 
 import (
 	"time"
@@ -28,7 +28,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-// Request is a JSON request without the body.
+// Request is a Raw request without the body.
 type Request struct {
 	Context context.Context
 
@@ -43,6 +43,6 @@ type Request struct {
 }
 
 // Note: The shape of this request object is extremely similar to the
-// raw.Request object, but since we can't unify all the Request objects
+// json.Request object, but since we can't unify all the Request objects
 // (thrift.Request is very different), each encoding will have its own Request
 // object.

--- a/encoding/raw/response.go
+++ b/encoding/raw/response.go
@@ -18,31 +18,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package json
+package raw
 
-import (
-	"time"
+import "github.com/yarpc/yarpc-go/transport"
 
-	"github.com/yarpc/yarpc-go/transport"
-
-	"golang.org/x/net/context"
-)
-
-// Request is a JSON request without the body.
-type Request struct {
-	Context context.Context
-
-	// Name of the procedure being called.
-	Procedure string
-
-	// Request headers
+// Response is a Raw response without the body.
+type Response struct {
 	Headers transport.Headers
 
-	// TTL is the amount of time in which this request is expected to finish.
-	TTL time.Duration
+	// TODO Response context?
 }
-
-// Note: The shape of this request object is extremely similar to the
-// raw.Request object, but since we can't unify all the Request objects
-// (thrift.Request is very different), each encoding will have its own Request
-// object.


### PR DESCRIPTION
Provides an API similar to the JSON encoding except only `[]byte`s are allowed for request and response bodies.

Depends on #50.
