### PR TITLE
Use Crossdock V2

### DIFF
--- a/crossdock/client/echo.go
+++ b/crossdock/client/echo.go
@@ -18,7 +18,7 @@ import (
 )
 
 // EchoBehavior asserts that a server response is the same as the request
-func EchoBehavior(addr string) Result {
+func EchoBehavior(addr string) (string, error) {
 	yarpc := yarpc.New(yarpc.Config{
 		Name: "client",
 		Outbounds: transport.Outbounds{
@@ -38,21 +38,13 @@ func EchoBehavior(addr string) Result {
 	)
 
 	if err != nil {
-		return Result{
-			Passed:  false,
-			Message: fmt.Sprintf("Got err: %v", err),
-		}
+		return "", fmt.Errorf("Got err: %v", err)
 	}
 	if response.Token != token {
-		return Result{
-			Passed:  false,
-			Message: fmt.Sprintf("Got %v, wanted %v", response.Token, token),
-		}
+		return "", fmt.Errorf("Got %v, wanted %v", response.Token, token)
 	}
-	return Result{
-		Passed:  true,
-		Message: fmt.Sprintf("Server said: %v", response.Token),
-	}
+
+	return fmt.Sprintf("Server said: %v", response.Token), nil
 }
 
 func randString(length int64) string {

--- a/crossdock/main.go
+++ b/crossdock/main.go
@@ -1,14 +1,11 @@
 package main
 
 import (
-	"net/http"
-
 	"github.com/yarpc/yarpc-go/crossdock/client"
 	"github.com/yarpc/yarpc-go/crossdock/server"
 )
 
 func main() {
-	server.StartServerUnderTest()
-	http.HandleFunc("/", client.TestCaseHandler)
-	http.ListenAndServe(":8080", nil)
+	server.Start()
+	client.Start()
 }

--- a/crossdock/server/server.go
+++ b/crossdock/server/server.go
@@ -9,8 +9,8 @@ import (
 	"github.com/yarpc/yarpc-go/transport/http"
 )
 
-// StartServerUnderTest starts the test server that clients will make requests to
-func StartServerUnderTest() {
+// Start starts the test server that clients will make requests to
+func Start() {
 	yarpc := yarpc.New(yarpc.Config{
 		Name: "yarpc-test",
 		Inbounds: []transport.Inbound{

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,10 @@ services:
         image: yarpc/crossdock:v2
         links:
             - yarpc-go
+            - yarpc-python
         environment:
-            - CROSSDOCK_CLIENTS=yarpc-go
-            - CROSSDOCK_AXIS_SERVER=yarpc-go
+            - CROSSDOCK_CLIENTS=yarpc-go,yarpc-python
+            - CROSSDOCK_AXIS_SERVER=yarpc-go,yarpc-python
             - CROSSDOCK_AXIS_BEHAVIOR=echo
 
     yarpc-go:
@@ -29,7 +30,7 @@ services:
             - 8081
 
     yarpc-python:
-        image: yarpc/yarpc-python
+        image: yarpc/yarpc-python:crossdock-v2
         ports:
             - 8080
             - 8081

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,12 @@ services:
         image: yarpc/crossdock:v2
         links:
             - yarpc-go
+            - yarpc-node
+            - yarpc-java
             - yarpc-python
         environment:
-            - CROSSDOCK_CLIENTS=yarpc-go,yarpc-python
-            - CROSSDOCK_AXIS_SERVER=yarpc-go,yarpc-python
+            - CROSSDOCK_CLIENTS=yarpc-go,yarpc-node,yarpc-java,yarpc-python
+            - CROSSDOCK_AXIS_SERVER=yarpc-go,yarpc-node,yarpc-java,yarpc-python
             - CROSSDOCK_AXIS_BEHAVIOR=echo
 
     yarpc-go:
@@ -18,13 +20,13 @@ services:
             - 8081
 
     yarpc-node:
-        image: yarpc/yarpc-node
+        image: yarpc/yarpc-node:crossdock-v2
         ports:
             - 8080
             - 8081
 
     yarpc-java:
-        image: yarpc/yarpc-java
+        image: yarpc/yarpc-java:crossdock-v2
         ports:
             - 8080
             - 8081

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,15 +2,12 @@ version: '2'
 
 services:
     crossdock:
-        image: yarpc/crossdock
+        image: yarpc/crossdock:v2
         links:
             - yarpc-go
-            - yarpc-node
-            - yarpc-java
-            - yarpc-python
         environment:
-            - CROSSDOCK_CLIENTS=yarpc-go,yarpc-node,yarpc-java,yarpc-python
-            - CROSSDOCK_AXIS_SERVER=yarpc-go,yarpc-node,yarpc-java,yarpc-python
+            - CROSSDOCK_CLIENTS=yarpc-go
+            - CROSSDOCK_AXIS_SERVER=yarpc-go
             - CROSSDOCK_AXIS_BEHAVIOR=echo
 
     yarpc-go:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,10 +6,9 @@ services:
         links:
             - yarpc-go
             - yarpc-python
-            - yarpc-node
         environment:
-            - CROSSDOCK_CLIENTS=yarpc-go,yarpc-python,yarpc-node
-            - CROSSDOCK_AXIS_SERVER=yarpc-go,yarpc-python,yarpc-node
+            - CROSSDOCK_CLIENTS=yarpc-go,yarpc-python
+            - CROSSDOCK_AXIS_SERVER=yarpc-go,yarpc-python
             - CROSSDOCK_AXIS_BEHAVIOR=echo
 
     yarpc-go:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,10 @@ services:
         links:
             - yarpc-go
             - yarpc-python
+            - yarpc-node
         environment:
-            - CROSSDOCK_CLIENTS=yarpc-go,yarpc-python
-            - CROSSDOCK_AXIS_SERVER=yarpc-go,yarpc-python
+            - CROSSDOCK_CLIENTS=yarpc-go,yarpc-python,yarpc-node
+            - CROSSDOCK_AXIS_SERVER=yarpc-go,yarpc-python,yarpc-node
             - CROSSDOCK_AXIS_BEHAVIOR=echo
 
     yarpc-go:


### PR DESCRIPTION
(so that we know when we broke the test suite or not)

- [x] update to use `crossdock:v2` container
- [x] add python back at `yarpc/yarpc-python:crossdock-v2`
- [x] add node back at `yarpc/yarpc-node:crossdock-v2`
- [x] add java back at `yarpc/yarpc-java:crossdock-v2`
