### PR TITLE
Drop Handler interface for raw encoding.

### DIFF
--- a/encoding/raw/inbound.go
+++ b/encoding/raw/inbound.go
@@ -46,7 +46,7 @@ func (r rawHandler) Handle(ctx context.Context, treq *transport.Request, rw tran
 		TTL:       treq.TTL,
 	}
 
-	resBody, res, err := r.h.Handle(&request, reqBody)
+	resBody, res, err := r.h(&request, reqBody)
 	if err != nil {
 		return err
 	}

--- a/encoding/raw/register.go
+++ b/encoding/raw/register.go
@@ -31,9 +31,7 @@ type Registrant interface {
 }
 
 // Handler implements a single procedure.
-type Handler interface {
-	Handle(req *Request, body []byte) ([]byte, *Response, error)
-}
+type Handler func(*Request, []byte) ([]byte, *Response, error)
 
 // procedure is a registrant with a single handler.
 type procedure struct {


### PR DESCRIPTION
Without this change, we have to create a separate Handler type for each
method.

```go
type getValue struct {}

func (getValue) Handle(...) ... { ... }

type setValue struct {}

func (setValue) Handle(...) ... { ... }

raw.Register(rpc, raw.Procedure("getValue", getValue{}))
raw.Register(rpc, raw.Procedure("setValue", setValue{}))
```

With this change,

```go
type KeyValue struct {}

func (KeyValue) GetValue(...) ... { ... }
func (KeyValue) SetValue(...) ... { ... }

keyValue := KeyValue{}
raw.Register(rpc, raw.Procedure("getValue", keyValue.GetValue))
raw.Register(rpc, raw.Procedure("setValue", keyValue.SetValue))
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/yarpc/yarpc-go/72)
<!-- Reviewable:end -->
