### PR TITLE
Always output Crossdock logs during Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ install:
 script:
   - make test_ci
   - make crossdock
+  - timeout 5 docker-compose logs || true
 
 after_success:
   - export REPO=yarpc/yarpc-go

--- a/Makefile
+++ b/Makefile
@@ -52,5 +52,7 @@ install_ci: install
 
 .PHONY: test_ci
 test_ci:
-	goveralls -service=travis-ci -v $(PACKAGES)
+        # @see https://github.com/mattn/goveralls/issues/68
+	#goveralls -service=travis-ci -v $(PACKAGES)
+	go test -v $(PACKAGES)
 	make -C examples


### PR DESCRIPTION
This will save us much time when things go wrong.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yarpc/yarpc-go/77)
<!-- Reviewable:end -->
