### PR TITLE
Use RPC prefix and Context-TTL-MS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,10 +10,10 @@ services:
             - python
             - python-sync
         environment:
-            - WAIT_FOR=go
+            - WAIT_FOR=go,node,java,python,python-sync
 
-            - AXIS_CLIENT=go
-            - AXIS_SERVER=go
+            - AXIS_CLIENT=go,node,java,python,python-sync
+            - AXIS_SERVER=go,node,java,python
             - AXIS_TRANSPORT=http,tchannel
 
             - BEHAVIOR_RAW=client,server,transport
@@ -26,22 +26,22 @@ services:
             - "8080-8082"
 
     node:
-        image: yarpc/yarpc-node
+        image: yarpc/yarpc-node:use-rpc-prefix
         ports:
             - "8080-8082"
 
     java:
-        image: yarpc/yarpc-java
+        image: yarpc/yarpc-java:use-rpc-prefix
         ports:
             - "8080-8082"
 
     python:
-        image: yarpc/yarpc-python
+        image: yarpc/yarpc-python:use-rpc-prefix
         ports:
             - "8080:8082"
 
     python-sync:
-        image: yarpc/yarpc-python
+        image: yarpc/yarpc-python:use-rpc-prefix
         ports:
             - 8080
         environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,10 +10,10 @@ services:
             - python
             - python-sync
         environment:
-            - WAIT_FOR=go,node,java,python,python-sync
+            - WAIT_FOR=go
 
-            - AXIS_CLIENT=go,node,java,python,python-sync
-            - AXIS_SERVER=go,node,java,python
+            - AXIS_CLIENT=go
+            - AXIS_SERVER=go
             - AXIS_TRANSPORT=http,tchannel
 
             - BEHAVIOR_RAW=client,server,transport

--- a/transport/http/constants.go
+++ b/transport/http/constants.go
@@ -29,7 +29,7 @@ const (
 	EncodingHeader = "RPC-Encoding"
 
 	// TTLMSHeader is the HTTP header used to indicate the ttl in ms
-	TTLMSHeader = "RPC-TTLms"
+	TTLMSHeader = "RPC-Context-TTL-MS"
 
 	// ProcedureHeader is the HTTP header used to indicate the procedure
 	ProcedureHeader = "RPC-Procedure"

--- a/transport/http/constants.go
+++ b/transport/http/constants.go
@@ -22,20 +22,20 @@ package http
 
 const (
 	// CallerHeader is the HTTP header used to indiate the service doing the calling
-	CallerHeader = "YARPC-Caller"
+	CallerHeader = "RPC-Caller"
 
 	// EncodingHeader is the HTTP header used to specify the name of the
 	// encoding.
-	EncodingHeader = "YARPC-Encoding"
+	EncodingHeader = "RPC-Encoding"
 
 	// TTLMSHeader is the HTTP header used to indicate the ttl in ms
-	TTLMSHeader = "YARPC-TTLms"
+	TTLMSHeader = "RPC-TTLms"
 
 	// ProcedureHeader is the HTTP header used to indicate the procedure
-	ProcedureHeader = "YARPC-Procedure"
+	ProcedureHeader = "RPC-Procedure"
 
 	// ServiceHeader is the HTTP header used to indicate the service
-	ServiceHeader = "YARPC-Service"
+	ServiceHeader = "RPC-Service"
 )
 
 // TODO Make consistent with other languages^

--- a/transport/http/constants.go
+++ b/transport/http/constants.go
@@ -29,7 +29,7 @@ const (
 	EncodingHeader = "RPC-Encoding"
 
 	// TTLMSHeader is the HTTP header used to indicate the ttl in ms
-	TTLMSHeader = "RPC-Context-TTL-MS"
+	TTLMSHeader = "Context-TTL-MS"
 
 	// ProcedureHeader is the HTTP header used to indicate the procedure
 	ProcedureHeader = "RPC-Procedure"


### PR DESCRIPTION
* use `RPC-` prefix instead of `YARPC-` prefix.
* use `Context-TTL-MS` instead of `YARPC-Ttlms`.