### PR TITLE
registry: dispatch on `(service, procedure)` tuple

### DIFF
--- a/crossdock/client/echo/echo_test.go
+++ b/crossdock/client/echo/echo_test.go
@@ -80,7 +80,7 @@ func TestEchoBehaviors(t *testing.T) {
 		{
 			encname:  "raw",
 			behavior: Raw,
-			failed:   `unknown procedure "echo/raw"`,
+			failed:   `BadRequest: unrecognized procedure "echo/raw" for service "yarpc-test"`,
 		},
 		{
 			encname:  "raw",
@@ -104,7 +104,7 @@ func TestEchoBehaviors(t *testing.T) {
 		{
 			encname:  "json",
 			behavior: JSON,
-			failed:   `unknown procedure "echo"`,
+			failed:   `BadRequest: unrecognized procedure "echo" for service "yarpc-test"`,
 		},
 		{
 			encname:  "json",
@@ -129,7 +129,7 @@ func TestEchoBehaviors(t *testing.T) {
 		{
 			encname:  "thrift",
 			behavior: Thrift,
-			failed:   `unknown procedure "Echo::echo"`,
+			failed:   `BadRequest: unrecognized procedure "Echo::echo" for service "yarpc-test"`,
 		},
 		{
 			encname:  "thrift",

--- a/crossdock/client/echo/raw.go
+++ b/crossdock/client/echo/raw.go
@@ -43,6 +43,7 @@ func Raw(s behavior.Sink, p behavior.Params) {
 	resBody, _, err := client.Call(&raw.Request{
 		Context:   ctx,
 		Procedure: "echo/raw",
+		TTL:       time.Second, // TODO context already has timeout; use that
 	}, token)
 
 	if err != nil {

--- a/crossdock/client/echo/thrift.go
+++ b/crossdock/client/echo/thrift.go
@@ -42,7 +42,10 @@ func Thrift(s behavior.Sink, p behavior.Params) {
 
 	token := random.String(5)
 	pong, _, err := client.Echo(
-		&thrift.Request{Context: ctx},
+		&thrift.Request{
+			Context: ctx,
+			TTL:     time.Second, // TODO context already has timeout; use that
+		},
 		&echo.Ping{Beep: token},
 	)
 	if err != nil {

--- a/encoding/json/register.go
+++ b/encoding/json/register.go
@@ -74,7 +74,7 @@ func Procedure(name string, handler interface{}) Registrant {
 // structs.
 func Register(reg transport.Registry, registrant Registrant) {
 	for name, handler := range registrant.getHandlers() {
-		reg.Register(name, wrapHandler(name, handler))
+		reg.Register("", name, wrapHandler(name, handler))
 	}
 }
 

--- a/encoding/raw/register.go
+++ b/encoding/raw/register.go
@@ -52,6 +52,6 @@ func Procedure(name string, handler Handler) Registrant {
 // given Registry.
 func Register(reg transport.Registry, registrant Registrant) {
 	for name, handler := range registrant.getHandlers() {
-		reg.Register(name, rawHandler{handler})
+		reg.Register("", name, rawHandler{handler})
 	}
 }

--- a/encoding/thrift/register.go
+++ b/encoding/thrift/register.go
@@ -59,6 +59,6 @@ func Register(registry transport.Registry, service Service) {
 	proto := service.Protocol()
 	for method, h := range service.Handlers() {
 		handler := thriftHandler{Handler: h, Protocol: proto}
-		registry.Register(procedureName(name, method), handler)
+		registry.Register("", procedureName(name, method), handler)
 	}
 }

--- a/rpc.go
+++ b/rpc.go
@@ -68,7 +68,7 @@ func New(cfg Config) RPC {
 	}
 	return rpc{
 		Name:      cfg.Name,
-		Registry:  make(transport.MapRegistry),
+		Registry:  transport.NewMapRegistry(cfg.Name),
 		Inbounds:  cfg.Inbounds,
 		Outbounds: cfg.Outbounds,
 	}
@@ -122,7 +122,7 @@ func (r rpc) Start() error {
 }
 
 func (r rpc) Handle(ctx context.Context, req *transport.Request, rw transport.ResponseWriter) error {
-	h, err := r.GetHandler(req.Procedure)
+	h, err := r.GetHandler(req.Service, req.Procedure)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This namespaces procedure registration and dispatch to the servcie name. By
default, the name specified when building the RPC is used. This makes it
possible to support more complex forwarding use cases in the future.

The interface for `{raw, json, thrift}.Register` does not change here. We can
add service name customization in the future if necessary.

Depends on #100

@yarpc/golang