### PR TITLE
cover.sh: Add support for skipping packages

### DIFF
--- a/scripts/cover.sh
+++ b/scripts/cover.sh
@@ -10,6 +10,19 @@ if [[ -d "$COVER" ]]; then
 fi
 mkdir -p "$COVER"
 
+# If a package directory has a .nocover file, don't count it when calculating
+# coverage.
+filter=""
+for pkg in "$@"; do
+	if [[ -f "$GOPATH/src/$pkg/.nocover" ]]; then
+		if [[ -n "$filter" ]]; then
+			filter="$filter, "
+		fi
+		filter="\"$pkg\": true"
+	fi
+done
+
+
 i=0
 for pkg in "$@"; do
 	i=$((i + 1))
@@ -23,18 +36,24 @@ for pkg in "$@"; do
 
 	coverpkg=$(go list -json "$pkg" | jq -r '
 		.Deps
-		| map(select(startswith("'"$ROOT_PKG"'")))
-		| map(select(contains("/vendor/") | not))
 		| . + ["'"$pkg"'"]
+		| map
+			( select(startswith("'"$ROOT_PKG"'"))
+			| select(contains("/vendor/") | not)
+			| select(in({'"$filter"'}) | not)
+			)
 		| join(",")
 	')
 	if [[ -n "$extracoverpkg" ]]; then
 		coverpkg="$extracoverpkg$coverpkg"
 	fi
 
-	go test \
-		-coverprofile "$COVER/cover.${i}.out" -coverpkg "$coverpkg" \
-		-v "$pkg"
+	args=""
+	if [[ -n "$coverpkg" ]]; then
+		args="-coverprofile $COVER/cover.${i}.out -coverpkg $coverpkg"
+	fi
+
+	go test $args -v "$pkg"
 done
 
 gocovmerge "$COVER"/*.out > cover.out


### PR DESCRIPTION
This adds support to the cover.sh script for skipping packages. If a package
directory has a `.nocover` file in it, its coverage will not be tracked for
any tests.