### PR TITLE
crossdock/behaviors: Integrate with testify

### DIFF
--- a/crossdock/client/behavior/sink.go
+++ b/crossdock/client/behavior/sink.go
@@ -28,6 +28,7 @@ import (
 // Sink records the result of calling different behaviors.
 type Sink interface {
 	Put(interface{})
+	FailNow()
 }
 
 // Skipf records a skipped test.
@@ -57,9 +58,7 @@ func Errorf(s Sink, format string, args ...interface{}) {
 // This may be used to stop executing in case of irrecoverable errors.
 func Fatalf(s Sink, format string, args ...interface{}) {
 	Errorf(s, format, args...)
-
-	// Exit this goroutine and call any deferred functions
-	runtime.Goexit()
+	s.FailNow()
 }
 
 // Successf records a successful test.
@@ -77,6 +76,11 @@ func Successf(s Sink, format string, args ...interface{}) {
 
 // entrySink is a sink that keeps track of entries in-order
 type entrySink struct{ entries []interface{} }
+
+func (e *entrySink) FailNow() {
+	// Exit this goroutine and call any deferred functions
+	runtime.Goexit()
+}
 
 // Put an entry into the EntrySink.
 func (e *entrySink) Put(v interface{}) {

--- a/crossdock/client/behavior/testify.go
+++ b/crossdock/client/behavior/testify.go
@@ -1,0 +1,567 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package behavior
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Assert builds an Assertions object that writes success or failure to the
+// given sink.
+//
+// Each assertion made with the Assertions object will result in either a
+// failure or a success being written to the sink.
+func Assert(s Sink) Assertions {
+	return sinkAssertions{s, assert.New(sinkTestingT{s})}
+}
+
+// Require builds an Assertions object that writes success or failure to the
+// given sink. In case of failure, it also stops executing the current
+// behavior.
+//
+// Each assertion made with the Assertions object will result in either a
+// failure or a success being written to the sink.
+func Require(s Sink) Assertions {
+	return sinkAssertions{s, requireAssertions{require.New(sinkTestingT{s})}}
+}
+
+// Fatals builds an Assertions object similar to Require, except that success
+// cases are not written to the Sink, only failures are.
+//
+// Behavior exception stops after the first failure.
+func Fatals(s Sink) Assertions {
+	return requireAssertions{require.New(sinkTestingT{s})}
+}
+
+// sinkTestingT adapts a Sink into an {require,assert}.TestingT
+type sinkTestingT struct{ s Sink }
+
+func (st sinkTestingT) FailNow() { st.s.FailNow() }
+
+func (st sinkTestingT) Errorf(format string, args ...interface{}) {
+	// We need to prepend a newline because the error message from testify
+	// always includes a \r at the start.
+	Errorf(st.s, "\n"+format, args...)
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// Assertions
+
+// Assertions provides the same interface as the assert.Assertions struct.
+type Assertions interface {
+	Condition(comp assert.Comparison, msgAndArgs ...interface{}) bool
+	Contains(s interface{}, contains interface{}, msgAndArgs ...interface{}) bool
+	Empty(object interface{}, msgAndArgs ...interface{}) bool
+	Equal(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool
+	EqualError(theError error, errString string, msgAndArgs ...interface{}) bool
+	EqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool
+	Error(err error, msgAndArgs ...interface{}) bool
+	Exactly(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool
+	Fail(failureMessage string, msgAndArgs ...interface{}) bool
+	FailNow(failureMessage string, msgAndArgs ...interface{}) bool
+	False(value bool, msgAndArgs ...interface{}) bool
+	Implements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) bool
+	InDelta(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) bool
+	InDeltaSlice(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) bool
+	InEpsilon(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) bool
+	InEpsilonSlice(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) bool
+	IsType(expectedType interface{}, object interface{}, msgAndArgs ...interface{}) bool
+	JSONEq(expected string, actual string, msgAndArgs ...interface{}) bool
+	Len(object interface{}, length int, msgAndArgs ...interface{}) bool
+	Nil(object interface{}, msgAndArgs ...interface{}) bool
+	NoError(err error, msgAndArgs ...interface{}) bool
+	NotContains(s interface{}, contains interface{}, msgAndArgs ...interface{}) bool
+	NotEmpty(object interface{}, msgAndArgs ...interface{}) bool
+	NotEqual(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool
+	NotNil(object interface{}, msgAndArgs ...interface{}) bool
+	NotPanics(f assert.PanicTestFunc, msgAndArgs ...interface{}) bool
+	NotRegexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) bool
+	NotZero(i interface{}, msgAndArgs ...interface{}) bool
+	Panics(f assert.PanicTestFunc, msgAndArgs ...interface{}) bool
+	Regexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) bool
+	True(value bool, msgAndArgs ...interface{}) bool
+	WithinDuration(expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) bool
+	Zero(i interface{}, msgAndArgs ...interface{}) bool
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// Sink
+
+func formatMsgAndArgs(msgAndArgs []interface{}) string {
+	if len(msgAndArgs) == 0 {
+		return ""
+	}
+	if len(msgAndArgs) == 1 {
+		return msgAndArgs[0].(string)
+	}
+	return fmt.Sprintf(msgAndArgs[0].(string), msgAndArgs[1:]...)
+}
+
+type sinkAssertions struct {
+	// We need to wrap assert rather than using it as-is because we need to
+	// log success messages.
+	s Sink
+	a Assertions
+}
+
+var _ Assertions = (*sinkAssertions)(nil)
+
+func (sa sinkAssertions) Condition(comp assert.Comparison, msgAndArgs ...interface{}) bool {
+	if sa.a.Condition(comp, msgAndArgs...) {
+		Successf(sa.s, formatMsgAndArgs(msgAndArgs))
+		return true
+	}
+	return false
+}
+
+func (sa sinkAssertions) Contains(s interface{}, contains interface{}, msgAndArgs ...interface{}) bool {
+	if sa.a.Contains(s, contains, msgAndArgs...) {
+		Successf(sa.s, formatMsgAndArgs(msgAndArgs))
+		return true
+	}
+	return false
+}
+
+func (sa sinkAssertions) Empty(object interface{}, msgAndArgs ...interface{}) bool {
+	if sa.a.Empty(object, msgAndArgs...) {
+		Successf(sa.s, formatMsgAndArgs(msgAndArgs))
+		return true
+	}
+	return false
+}
+
+func (sa sinkAssertions) Equal(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
+	if sa.a.Equal(expected, actual, msgAndArgs...) {
+		Successf(sa.s, formatMsgAndArgs(msgAndArgs))
+		return true
+	}
+	return false
+}
+
+func (sa sinkAssertions) EqualError(theError error, errString string, msgAndArgs ...interface{}) bool {
+	if sa.a.EqualError(theError, errString, msgAndArgs...) {
+		Successf(sa.s, formatMsgAndArgs(msgAndArgs))
+		return true
+	}
+	return false
+}
+
+func (sa sinkAssertions) EqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
+	if sa.a.EqualValues(expected, actual, msgAndArgs...) {
+		Successf(sa.s, formatMsgAndArgs(msgAndArgs))
+		return true
+	}
+	return false
+}
+
+func (sa sinkAssertions) Error(err error, msgAndArgs ...interface{}) bool {
+	if sa.a.Error(err, msgAndArgs...) {
+		Successf(sa.s, formatMsgAndArgs(msgAndArgs))
+		return true
+	}
+	return false
+}
+
+func (sa sinkAssertions) Exactly(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
+	if sa.a.Exactly(expected, actual, msgAndArgs...) {
+		Successf(sa.s, formatMsgAndArgs(msgAndArgs))
+		return true
+	}
+	return false
+}
+
+func (sa sinkAssertions) Fail(failureMessage string, msgAndArgs ...interface{}) bool {
+	if sa.a.Fail(failureMessage, msgAndArgs...) {
+		Successf(sa.s, formatMsgAndArgs(msgAndArgs))
+		return true
+	}
+	return false
+}
+
+func (sa sinkAssertions) FailNow(failureMessage string, msgAndArgs ...interface{}) bool {
+	if sa.a.FailNow(failureMessage, msgAndArgs...) {
+		Successf(sa.s, formatMsgAndArgs(msgAndArgs))
+		return true
+	}
+	return false
+}
+
+func (sa sinkAssertions) False(value bool, msgAndArgs ...interface{}) bool {
+	if sa.a.False(value, msgAndArgs...) {
+		Successf(sa.s, formatMsgAndArgs(msgAndArgs))
+		return true
+	}
+	return false
+}
+
+func (sa sinkAssertions) Implements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) bool {
+	if sa.a.Implements(interfaceObject, object, msgAndArgs...) {
+		Successf(sa.s, formatMsgAndArgs(msgAndArgs))
+		return true
+	}
+	return false
+}
+
+func (sa sinkAssertions) InDelta(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
+	if sa.a.InDelta(expected, actual, delta, msgAndArgs...) {
+		Successf(sa.s, formatMsgAndArgs(msgAndArgs))
+		return true
+	}
+	return false
+}
+
+func (sa sinkAssertions) InDeltaSlice(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
+	if sa.a.InDeltaSlice(expected, actual, delta, msgAndArgs...) {
+		Successf(sa.s, formatMsgAndArgs(msgAndArgs))
+		return true
+	}
+	return false
+}
+
+func (sa sinkAssertions) InEpsilon(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) bool {
+	if sa.a.InEpsilon(expected, actual, epsilon, msgAndArgs...) {
+		Successf(sa.s, formatMsgAndArgs(msgAndArgs))
+		return true
+	}
+	return false
+}
+
+func (sa sinkAssertions) InEpsilonSlice(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
+	if sa.a.InEpsilonSlice(expected, actual, delta, msgAndArgs...) {
+		Successf(sa.s, formatMsgAndArgs(msgAndArgs))
+		return true
+	}
+	return false
+}
+
+func (sa sinkAssertions) IsType(expectedType interface{}, object interface{}, msgAndArgs ...interface{}) bool {
+	if sa.a.IsType(expectedType, object, msgAndArgs...) {
+		Successf(sa.s, formatMsgAndArgs(msgAndArgs))
+		return true
+	}
+	return false
+}
+
+func (sa sinkAssertions) JSONEq(expected string, actual string, msgAndArgs ...interface{}) bool {
+	if sa.a.JSONEq(expected, actual, msgAndArgs...) {
+		Successf(sa.s, formatMsgAndArgs(msgAndArgs))
+		return true
+	}
+	return false
+}
+
+func (sa sinkAssertions) Len(object interface{}, length int, msgAndArgs ...interface{}) bool {
+	if sa.a.Len(object, length, msgAndArgs...) {
+		Successf(sa.s, formatMsgAndArgs(msgAndArgs))
+		return true
+	}
+	return false
+}
+
+func (sa sinkAssertions) Nil(object interface{}, msgAndArgs ...interface{}) bool {
+	if sa.a.Nil(object, msgAndArgs...) {
+		Successf(sa.s, formatMsgAndArgs(msgAndArgs))
+		return true
+	}
+	return false
+}
+
+func (sa sinkAssertions) NoError(err error, msgAndArgs ...interface{}) bool {
+	if sa.a.NoError(err, msgAndArgs...) {
+		Successf(sa.s, formatMsgAndArgs(msgAndArgs))
+		return true
+	}
+	return false
+}
+
+func (sa sinkAssertions) NotContains(s interface{}, contains interface{}, msgAndArgs ...interface{}) bool {
+	if sa.a.NotContains(s, contains, msgAndArgs...) {
+		Successf(sa.s, formatMsgAndArgs(msgAndArgs))
+		return true
+	}
+	return false
+}
+
+func (sa sinkAssertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) bool {
+	if sa.a.NotEmpty(object, msgAndArgs...) {
+		Successf(sa.s, formatMsgAndArgs(msgAndArgs))
+		return true
+	}
+	return false
+}
+
+func (sa sinkAssertions) NotEqual(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
+	if sa.a.NotEqual(expected, actual, msgAndArgs...) {
+		Successf(sa.s, formatMsgAndArgs(msgAndArgs))
+		return true
+	}
+	return false
+}
+
+func (sa sinkAssertions) NotNil(object interface{}, msgAndArgs ...interface{}) bool {
+	if sa.a.NotNil(object, msgAndArgs...) {
+		Successf(sa.s, formatMsgAndArgs(msgAndArgs))
+		return true
+	}
+	return false
+}
+
+func (sa sinkAssertions) NotPanics(f assert.PanicTestFunc, msgAndArgs ...interface{}) bool {
+	if sa.a.NotPanics(f, msgAndArgs...) {
+		Successf(sa.s, formatMsgAndArgs(msgAndArgs))
+		return true
+	}
+	return false
+}
+
+func (sa sinkAssertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
+	if sa.a.NotRegexp(rx, str, msgAndArgs...) {
+		Successf(sa.s, formatMsgAndArgs(msgAndArgs))
+		return true
+	}
+	return false
+}
+
+func (sa sinkAssertions) NotZero(i interface{}, msgAndArgs ...interface{}) bool {
+	if sa.a.NotZero(i, msgAndArgs...) {
+		Successf(sa.s, formatMsgAndArgs(msgAndArgs))
+		return true
+	}
+	return false
+}
+
+func (sa sinkAssertions) Panics(f assert.PanicTestFunc, msgAndArgs ...interface{}) bool {
+	if sa.a.Panics(f, msgAndArgs...) {
+		Successf(sa.s, formatMsgAndArgs(msgAndArgs))
+		return true
+	}
+	return false
+}
+
+func (sa sinkAssertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
+	if sa.a.Regexp(rx, str, msgAndArgs...) {
+		Successf(sa.s, formatMsgAndArgs(msgAndArgs))
+		return true
+	}
+	return false
+}
+
+func (sa sinkAssertions) True(value bool, msgAndArgs ...interface{}) bool {
+	if sa.a.True(value, msgAndArgs...) {
+		Successf(sa.s, formatMsgAndArgs(msgAndArgs))
+		return true
+	}
+	return false
+}
+
+func (sa sinkAssertions) WithinDuration(expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) bool {
+	if sa.a.WithinDuration(expected, actual, delta, msgAndArgs...) {
+		Successf(sa.s, formatMsgAndArgs(msgAndArgs))
+		return true
+	}
+	return false
+}
+
+func (sa sinkAssertions) Zero(i interface{}, msgAndArgs ...interface{}) bool {
+	if sa.a.Zero(i, msgAndArgs...) {
+		Successf(sa.s, formatMsgAndArgs(msgAndArgs))
+		return true
+	}
+	return false
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// Require
+
+// Adapts a require.Assertions into an Assertions. This simply returns true
+// for all cases because execution just stops in case of failure.
+type requireAssertions struct{ r *require.Assertions }
+
+var _ Assertions = (*requireAssertions)(nil)
+
+func (r requireAssertions) Condition(comp assert.Comparison, msgAndArgs ...interface{}) bool {
+	r.r.Condition(comp, msgAndArgs...)
+	return true
+}
+
+func (r requireAssertions) Contains(s interface{}, contains interface{}, msgAndArgs ...interface{}) bool {
+	r.r.Contains(s, contains, msgAndArgs...)
+	return true
+}
+
+func (r requireAssertions) Empty(object interface{}, msgAndArgs ...interface{}) bool {
+	r.r.Empty(object, msgAndArgs...)
+	return true
+}
+
+func (r requireAssertions) Equal(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
+	r.r.Equal(expected, actual, msgAndArgs...)
+	return true
+}
+
+func (r requireAssertions) EqualError(theError error, errString string, msgAndArgs ...interface{}) bool {
+	r.r.EqualError(theError, errString, msgAndArgs...)
+	return true
+}
+
+func (r requireAssertions) EqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
+	r.r.EqualValues(expected, actual, msgAndArgs...)
+	return true
+}
+
+func (r requireAssertions) Error(err error, msgAndArgs ...interface{}) bool {
+	r.r.Error(err, msgAndArgs...)
+	return true
+}
+
+func (r requireAssertions) Exactly(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
+	r.r.Exactly(expected, actual, msgAndArgs...)
+	return true
+}
+
+func (r requireAssertions) Fail(failureMessage string, msgAndArgs ...interface{}) bool {
+	r.r.Fail(failureMessage, msgAndArgs...)
+	return true
+}
+
+func (r requireAssertions) FailNow(failureMessage string, msgAndArgs ...interface{}) bool {
+	r.r.FailNow(failureMessage, msgAndArgs...)
+	return true
+}
+
+func (r requireAssertions) False(value bool, msgAndArgs ...interface{}) bool {
+	r.r.False(value, msgAndArgs...)
+	return true
+}
+
+func (r requireAssertions) Implements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) bool {
+	r.r.Implements(interfaceObject, object, msgAndArgs...)
+	return true
+}
+
+func (r requireAssertions) InDelta(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
+	r.r.InDelta(expected, actual, delta, msgAndArgs...)
+	return true
+}
+
+func (r requireAssertions) InDeltaSlice(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
+	r.r.InDeltaSlice(expected, actual, delta, msgAndArgs...)
+	return true
+}
+
+func (r requireAssertions) InEpsilon(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) bool {
+	r.r.InEpsilon(expected, actual, epsilon, msgAndArgs...)
+	return true
+}
+
+func (r requireAssertions) InEpsilonSlice(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) bool {
+	r.r.InEpsilonSlice(expected, actual, delta, msgAndArgs...)
+	return true
+}
+
+func (r requireAssertions) IsType(expectedType interface{}, object interface{}, msgAndArgs ...interface{}) bool {
+	r.r.IsType(expectedType, object, msgAndArgs...)
+	return true
+}
+
+func (r requireAssertions) JSONEq(expected string, actual string, msgAndArgs ...interface{}) bool {
+	r.r.JSONEq(expected, actual, msgAndArgs...)
+	return true
+}
+
+func (r requireAssertions) Len(object interface{}, length int, msgAndArgs ...interface{}) bool {
+	r.r.Len(object, length, msgAndArgs...)
+	return true
+}
+
+func (r requireAssertions) Nil(object interface{}, msgAndArgs ...interface{}) bool {
+	r.r.Nil(object, msgAndArgs...)
+	return true
+}
+
+func (r requireAssertions) NoError(err error, msgAndArgs ...interface{}) bool {
+	r.r.NoError(err, msgAndArgs...)
+	return true
+}
+
+func (r requireAssertions) NotContains(s interface{}, contains interface{}, msgAndArgs ...interface{}) bool {
+	r.r.NotContains(s, contains, msgAndArgs...)
+	return true
+}
+
+func (r requireAssertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) bool {
+	r.r.NotEmpty(object, msgAndArgs...)
+	return true
+}
+
+func (r requireAssertions) NotEqual(expected interface{}, actual interface{}, msgAndArgs ...interface{}) bool {
+	r.r.NotEqual(expected, actual, msgAndArgs...)
+	return true
+}
+
+func (r requireAssertions) NotNil(object interface{}, msgAndArgs ...interface{}) bool {
+	r.r.NotNil(object, msgAndArgs...)
+	return true
+}
+
+func (r requireAssertions) NotPanics(f assert.PanicTestFunc, msgAndArgs ...interface{}) bool {
+	r.r.NotPanics(f, msgAndArgs...)
+	return true
+}
+
+func (r requireAssertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
+	r.r.NotRegexp(rx, str, msgAndArgs...)
+	return true
+}
+
+func (r requireAssertions) NotZero(i interface{}, msgAndArgs ...interface{}) bool {
+	r.r.NotZero(i, msgAndArgs...)
+	return true
+}
+
+func (r requireAssertions) Panics(f assert.PanicTestFunc, msgAndArgs ...interface{}) bool {
+	r.r.Panics(f, msgAndArgs...)
+	return true
+}
+
+func (r requireAssertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) bool {
+	r.r.Regexp(rx, str, msgAndArgs...)
+	return true
+}
+
+func (r requireAssertions) True(value bool, msgAndArgs ...interface{}) bool {
+	r.r.True(value, msgAndArgs...)
+	return true
+}
+
+func (r requireAssertions) WithinDuration(expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) bool {
+	r.r.WithinDuration(expected, actual, delta, msgAndArgs...)
+	return true
+}
+
+func (r requireAssertions) Zero(i interface{}, msgAndArgs ...interface{}) bool {
+	r.r.Zero(i, msgAndArgs...)
+	return true
+}

--- a/crossdock/client/echo/echo_test.go
+++ b/crossdock/client/echo/echo_test.go
@@ -91,7 +91,7 @@ func TestEchoBehaviors(t *testing.T) {
 						return []byte("lol"), nil, nil
 					}))
 			},
-			failed: "got [108 111 108]",
+			failed: "server said: [108 111 108]",
 		},
 		{
 			encname:  "raw",
@@ -116,7 +116,7 @@ func TestEchoBehaviors(t *testing.T) {
 						return map[string]interface{}{"token": "invalid"}, nil, nil
 					}))
 			},
-			failed: "got invalid",
+			failed: "server said: invalid",
 		},
 		{
 			encname:  "json",
@@ -137,7 +137,7 @@ func TestEchoBehaviors(t *testing.T) {
 			register: func(rpc yarpc.RPC) {
 				thrift.Register(rpc, echoserver.New(invalidThriftEcho{}))
 			},
-			failed: "got derp",
+			failed: "server said: derp",
 		},
 		{
 			encname:  "thrift",

--- a/crossdock/client/echo/json.go
+++ b/crossdock/client/echo/json.go
@@ -54,13 +54,6 @@ func JSON(s behavior.Sink, p behavior.Params) {
 		&jsonEcho{Token: token},
 		&response,
 	)
-	if err != nil {
-		behavior.Fatalf(s, "call to echo failed: %v", err)
-	}
-
-	if response.Token != token {
-		behavior.Fatalf(s, "expected %v, got %v", token, response.Token)
-	}
-
-	behavior.Successf(s, "server said: %v", response.Token)
+	behavior.Fatals(s).NoError(err, "call to echo failed: %v", err)
+	behavior.Assert(s).Equal(token, response.Token, "server said: %v", response.Token)
 }

--- a/crossdock/client/echo/raw.go
+++ b/crossdock/client/echo/raw.go
@@ -46,13 +46,6 @@ func Raw(s behavior.Sink, p behavior.Params) {
 		TTL:       time.Second, // TODO context already has timeout; use that
 	}, token)
 
-	if err != nil {
-		behavior.Fatalf(s, "call to echo/raw failed: %v", err)
-	}
-
-	if !bytes.Equal(token, resBody) {
-		behavior.Fatalf(s, "expected %v, got %v", token, resBody)
-	}
-
-	behavior.Successf(s, "server said: %v", resBody)
+	behavior.Fatals(s).NoError(err, "call to echo/raw failed: %v", err)
+	behavior.Assert(s).True(bytes.Equal(token, resBody), "server said: %v", resBody)
 }

--- a/crossdock/client/echo/thrift.go
+++ b/crossdock/client/echo/thrift.go
@@ -48,13 +48,7 @@ func Thrift(s behavior.Sink, p behavior.Params) {
 		},
 		&echo.Ping{Beep: token},
 	)
-	if err != nil {
-		behavior.Fatalf(s, "call to Echo::echo failed: %v", err)
-	}
 
-	if token != pong.Boop {
-		behavior.Fatalf(s, "expected %v, got %v", token, pong.Boop)
-	}
-
-	behavior.Successf(s, "server said: %v", pong.Boop)
+	behavior.Fatals(s).NoError(err, "call to Echo::echo failed: %v", err)
+	behavior.Assert(s).Equal(token, pong.Boop, "server said: %v", pong.Boop)
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,18 @@
 hash: 672ef6a9d191e20f5fc1e1f0ac53bb00bda74d8245b4326671c2fddf99823045
-updated: 2016-03-07T12:38:16.774674074-08:00
+updated: 2016-04-22T14:51:18.938752258-07:00
 imports:
+- name: github.com/davecgh/go-spew
+  version: 2df174808ee097f90d259e432cc04442cf60be21
+  subpackages:
+  - spew
 - name: github.com/golang/mock
   version: bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
   subpackages:
   - gomock
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib
 - name: github.com/stretchr/testify
   version: 9f9027faeb0dad515336ed2f28317f9f8f527ab4
   subpackages:
@@ -13,8 +21,8 @@ imports:
 - name: github.com/thriftrw/thriftrw-go
   version: fa2079dcd5e7f71ecd4a1af10a428b1e21f5bf75
   subpackages:
-  - protocol
   - wire
+  - protocol
   - protocol/binary
 - name: github.com/uber/tchannel-go
   version: 7c19f22ebc511caa55133e458d8a22f1dbfdb981


### PR DESCRIPTION
Turns out that testify has a very light dependency on `testing.T`. It only expects, 

    type TestingT interface {
        Errorf(format string, args ...interface{})
        FailNow()
    }

I integrated that into our `Sink`, `behavior.{Error,Fatal,Success}f` framework to allow specifying assertions through testify. This allows us to rely on testify's convenient assertion methods (which provide readable failure messages) rather than implementing our own. 

Note that although the testify.go file is a bit large, not much of it is handwritten. It's a copy-paste + search-and-replace of the methods listed under the Assertions interface of `testify/assert` (except the HTTP* methods). We can codegen it later if it turns out that we need to actually update it.