### PR TITLE
json/inbound: Support interface{} for request/response bodies

### DIFF
--- a/encoding/json/inbound.go
+++ b/encoding/json/inbound.go
@@ -97,3 +97,11 @@ func (r mapReader) Read(d *json.Decoder) (reflect.Value, error) {
 	err := d.Decode(value.Interface())
 	return value.Elem(), err
 }
+
+type ifaceEmptyReader struct{}
+
+func (ifaceEmptyReader) Read(d *json.Decoder) (reflect.Value, error) {
+	value := reflect.New(_interfaceEmptyType)
+	err := d.Decode(value.Interface())
+	return value.Elem(), err
+}

--- a/encoding/json/inbound_test.go
+++ b/encoding/json/inbound_test.go
@@ -76,6 +76,23 @@ func TestHandleMapSuccess(t *testing.T) {
 	assert.Equal(t, "true", response.Success)
 }
 
+func TestHandleInterfaceEmptySuccess(t *testing.T) {
+	h := func(_ *Request, body interface{}) (interface{}, *Response, error) {
+		return body, nil, nil
+	}
+
+	handler := jsonHandler{reader: ifaceEmptyReader{}, handler: reflect.ValueOf(h)}
+
+	resw := new(transporttest.FakeResponseWriter)
+	err := handler.Handle(context.Background(), &transport.Request{
+		Procedure: "foo",
+		Body:      jsonBody(`{"foo": 42, "bar": ["a", "b", "c"]}`),
+	}, resw)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{"foo": 42, "bar": ["a", "b", "c"]}`, resw.Body.String())
+}
+
 func TestHandleSuccessWithResponseHeaders(t *testing.T) {
 	h := func(*Request, *simpleRequest) (*simpleResponse, *Response, error) {
 		response := &Response{Headers: transport.Headers{"foo": "bar"}}

--- a/encoding/json/inbound_test.go
+++ b/encoding/json/inbound_test.go
@@ -86,11 +86,11 @@ func TestHandleInterfaceEmptySuccess(t *testing.T) {
 	resw := new(transporttest.FakeResponseWriter)
 	err := handler.Handle(context.Background(), &transport.Request{
 		Procedure: "foo",
-		Body:      jsonBody(`{"foo": 42, "bar": ["a", "b", "c"]}`),
+		Body:      jsonBody(`["a", "b", "c"]`),
 	}, resw)
 	require.NoError(t, err)
 
-	assert.JSONEq(t, `{"foo": 42, "bar": ["a", "b", "c"]}`, resw.Body.String())
+	assert.JSONEq(t, `["a", "b", "c"]`, resw.Body.String())
 }
 
 func TestHandleSuccessWithResponseHeaders(t *testing.T) {

--- a/encoding/json/register_test.go
+++ b/encoding/json/register_test.go
@@ -74,6 +74,12 @@ func TestWrapHandlerValid(t *testing.T) {
 				return nil, nil, nil
 			},
 		},
+		{
+			"qux",
+			func(*Request, interface{}) (map[string]interface{}, *Response, error) {
+				return nil, nil, nil
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This lets JSON procedures handle all JSON requests.

@yarpc/golang