### PR TITLE
Client side errors and crossdock tests

### DIFF
--- a/crossdock/client/errors/behavior_test.go
+++ b/crossdock/client/errors/behavior_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/yarpc/yarpc-go"
 	"github.com/yarpc/yarpc-go/crossdock/client/behavior"
 	"github.com/yarpc/yarpc-go/crossdock/server"
-	"github.com/yarpc/yarpc-go/encoding/json"
 	"github.com/yarpc/yarpc-go/transport"
 	"github.com/yarpc/yarpc-go/transport/http"
 
@@ -40,10 +39,7 @@ func TestRun(t *testing.T) {
 		Inbounds: []transport.Inbound{http.NewInbound(":8081")},
 	})
 
-	json.Register(rpc, json.Procedure("echo", server.EchoJSON))
-	json.Register(rpc, json.Procedure("unexpected-error", server.UnexpectedError))
-	json.Register(rpc, json.Procedure("bad-response", server.BadResponse))
-
+	server.Register(rpc)
 	require.NoError(t, rpc.Start(), "failed to start RPC server")
 	defer rpc.Stop()
 

--- a/crossdock/server/error.go
+++ b/crossdock/server/error.go
@@ -27,7 +27,7 @@ import (
 )
 
 // UnexpectedError fails with an unexpected error.
-func UnexpectedError(req *json.Request, body map[string]interface{}) (map[string]interface{}, *json.Response, error) {
+func UnexpectedError(req *json.Request, body interface{}) (interface{}, *json.Response, error) {
 	return nil, nil, fmt.Errorf("error")
 }
 

--- a/crossdock/server/phone.go
+++ b/crossdock/server/phone.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/yarpc/yarpc-go/encoding/json"
+	"github.com/yarpc/yarpc-go/transport"
+	ht "github.com/yarpc/yarpc-go/transport/http"
+	"golang.org/x/net/context"
+)
+
+// PhoneRequest is a request to make another request to a different service.
+type PhoneRequest struct {
+	Service   string `json:"service"`
+	Procedure string `json:"procedure"`
+	Transport struct {
+		HTTP struct {
+			Host string `json:"host"`
+			Port int    `json:"port"`
+		} `json:"http"`
+	} `json:"transport"`
+	Body interface{} `json:"body"`
+}
+
+// PhoneResponse is the response of a Phone request.
+type PhoneResponse struct {
+	Service   string      `json:"service"`
+	Procedure string      `json:"procedure"`
+	Body      interface{} `json:"body"`
+}
+
+// Phone implements the phone procedure
+func Phone(req *json.Request, body *PhoneRequest) (*PhoneResponse, *json.Response, error) {
+	// TODO(abg): Support other transports
+	t := body.Transport.HTTP
+	outbound := ht.NewOutboundWithClient(
+		fmt.Sprintf("http://%s:%d", t.Host, t.Port),
+		&http.Client{Transport: new(http.Transport)},
+	)
+	client := json.New(transport.Channel{
+		Caller:   "yarpc-test", // TODO use req.Service,
+		Service:  body.Service,
+		Outbound: outbound,
+	})
+
+	resBody := PhoneResponse{
+		Service:   "yarpc-test", // TODO use req.Service
+		Procedure: req.Procedure,
+	}
+
+	ctx, _ := context.WithTimeout(req.Context, 500*time.Millisecond)
+	_, err := client.Call(&json.Request{
+		Context:   ctx,
+		Procedure: body.Procedure,
+		TTL:       500 * time.Millisecond, // TODO(abg): delete once context timeout is enforced/used
+	}, body.Body, &resBody.Body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &resBody, nil, nil
+}

--- a/crossdock/server/phone.go
+++ b/crossdock/server/phone.go
@@ -21,6 +21,7 @@
 package server
 
 import (
+	js "encoding/json"
 	"fmt"
 	"time"
 
@@ -40,14 +41,14 @@ type PhoneRequest struct {
 			Port int    `json:"port"`
 		} `json:"http"`
 	} `json:"transport"`
-	Body interface{} `json:"body"`
+	Body *js.RawMessage `json:"body"`
 }
 
 // PhoneResponse is the response of a Phone request.
 type PhoneResponse struct {
-	Service   string      `json:"service"`
-	Procedure string      `json:"procedure"`
-	Body      interface{} `json:"body"`
+	Service   string         `json:"service"`
+	Procedure string         `json:"procedure"`
+	Body      *js.RawMessage `json:"body"`
 }
 
 // Phone implements the phone procedure

--- a/crossdock/server/phone.go
+++ b/crossdock/server/phone.go
@@ -22,7 +22,6 @@ package server
 
 import (
 	"fmt"
-	"net/http"
 	"time"
 
 	"github.com/yarpc/yarpc-go/encoding/json"
@@ -55,10 +54,7 @@ type PhoneResponse struct {
 func Phone(req *json.Request, body *PhoneRequest) (*PhoneResponse, *json.Response, error) {
 	// TODO(abg): Support other transports
 	t := body.Transport.HTTP
-	outbound := ht.NewOutboundWithClient(
-		fmt.Sprintf("http://%s:%d", t.Host, t.Port),
-		&http.Client{Transport: new(http.Transport)},
-	)
+	outbound := ht.NewOutbound(fmt.Sprintf("http://%s:%d", t.Host, t.Port))
 	client := json.New(transport.Channel{
 		Caller:   "yarpc-test", // TODO use req.Service,
 		Service:  body.Service,

--- a/crossdock/server/subject.go
+++ b/crossdock/server/subject.go
@@ -37,4 +37,5 @@ func Register(reg transport.Registry) {
 
 	json.Register(reg, json.Procedure("unexpected-error", UnexpectedError))
 	json.Register(reg, json.Procedure("bad-response", BadResponse))
+	json.Register(reg, json.Procedure("phone", Phone))
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
             - AXIS_CLIENT=go,node # ,java,python,python-sync
             - AXIS_SERVER=go,node # ,java,python
             - AXIS_TRANSPORT=http,tchannel
-            - AXIS_ERRORS=go # ,node,java
+            - AXIS_ERRORS=go,node
 
             - BEHAVIOR_RAW=client,server,transport
             - BEHAVIOR_JSON=client,server,transport

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
             - "8080-8082"
 
     node:
-        image: yarpc/yarpc-node:crossdock-remote-errors
+        image: yarpc/yarpc-node:crossdock-errors
         ports:
             - "8080-8082"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
             - "8080-8082"
 
     node:
-        image: yarpc/yarpc-node:crossdock-errors
+        image: yarpc/yarpc-node:crossdock-remote-errors
         ports:
             - "8080-8082"
 

--- a/encoding/json/request.go
+++ b/encoding/json/request.go
@@ -32,6 +32,8 @@ import (
 type Request struct {
 	Context context.Context
 
+	// TODO(abg): Expose service name
+
 	// Name of the procedure being called.
 	Procedure string
 

--- a/encoding/raw/inbound_test.go
+++ b/encoding/raw/inbound_test.go
@@ -117,7 +117,7 @@ func TestRawHandler(t *testing.T) {
 
 		if tt.wantErr != "" {
 			if assert.Error(t, err) {
-				assert.Contains(t, err.Error(), tt.wantErr)
+				assert.Equal(t, err.Error(), tt.wantErr)
 			}
 		} else {
 			if assert.NoError(t, err) {

--- a/encoding/raw/outbound_test.go
+++ b/encoding/raw/outbound_test.go
@@ -111,7 +111,7 @@ func TestCall(t *testing.T) {
 
 		if tt.wantErr != "" {
 			if assert.Error(t, err) {
-				assert.Contains(t, err.Error(), tt.wantErr)
+				assert.Equal(t, err.Error(), tt.wantErr)
 			}
 		} else {
 			if assert.NoError(t, err) {

--- a/internal/encoding/server.go
+++ b/internal/encoding/server.go
@@ -62,9 +62,9 @@ func (e serverEncodingError) Error() string {
 // AsHandlerError converts this error into a handler-level error.
 func (e serverEncodingError) AsHandlerError() transport.HandlerError {
 	if e.IsResponse {
-		return transport.UnexpectedError{Reason: e}
+		return transport.LocalUnexpectedError(e)
 	}
-	return transport.BadRequestError{Reason: e}
+	return transport.LocalBadRequestError(e)
 }
 
 func newServerEncodingError(req *transport.Request, err error) serverEncodingError {

--- a/internal/request/errors.go
+++ b/internal/request/errors.go
@@ -37,7 +37,7 @@ type missingParametersError struct {
 }
 
 func (e missingParametersError) AsHandlerError() transport.HandlerError {
-	return transport.BadRequestError{Reason: e}
+	return transport.LocalBadRequestError(e)
 }
 
 func (e missingParametersError) Error() string {
@@ -67,7 +67,7 @@ type invalidTTLError struct {
 }
 
 func (e invalidTTLError) AsHandlerError() transport.HandlerError {
-	return transport.BadRequestError{Reason: e}
+	return transport.LocalBadRequestError(e)
 }
 
 func (e invalidTTLError) Error() string {

--- a/transport/errors.go
+++ b/transport/errors.go
@@ -108,23 +108,21 @@ func (e localBadRequestError) Error() string {
 	return "BadRequest: " + e.Reason.Error()
 }
 
-type remoteBadRequestError struct {
-	Message string
-}
+type remoteBadRequestError string
 
-var _ BadRequestError = remoteBadRequestError{}
+var _ BadRequestError = remoteBadRequestError("")
 
 // RemoteBadRequestError builds a new BadRequestError with the given message.
 //
 // It represents a BadRequest failure from a remote service.
 func RemoteBadRequestError(message string) BadRequestError {
-	return remoteBadRequestError{Message: message}
+	return remoteBadRequestError(message)
 }
 
 func (remoteBadRequestError) badRequestError() {}
 
 func (e remoteBadRequestError) Error() string {
-	return e.Message
+	return string(e)
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -159,23 +157,21 @@ func (e localUnexpectedError) Error() string {
 	return "UnexpectedError: " + e.Reason.Error()
 }
 
-type remoteUnexpectedError struct {
-	Message string
-}
+type remoteUnexpectedError string
 
-var _ UnexpectedError = remoteUnexpectedError{}
+var _ UnexpectedError = remoteUnexpectedError("")
 
 // RemoteUnexpectedError builds a new UnexpectedError with the given message.
 //
 // It represents an UnexpectedError from a remote service.
 func RemoteUnexpectedError(message string) UnexpectedError {
-	return remoteUnexpectedError{Message: message}
+	return remoteUnexpectedError(message)
 }
 
 func (remoteUnexpectedError) unexpectedError() {}
 
 func (e remoteUnexpectedError) Error() string {
-	return e.Message
+	return string(e)
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/transport/errors.go
+++ b/transport/errors.go
@@ -22,6 +22,18 @@ package transport
 
 import "fmt"
 
+// The general error hierarchy we have is:
+//
+// BadRequestError
+//  |- localBadRequestError: Used as-is to send a 400 level failure.
+//  |- remoteBadRequestError: Causes a localUnexpectedError.
+// UnexpectedError
+//  |- localUnexpectedError: Used as-is to send a 500 level failure.
+//  |- remoteUnexpectedError: Causes a new localUnexpectedError.
+//
+// Only the local versions of the error types are HandlerErrors. The remote
+// versions need to be converted using AsHandlerError.
+
 // HandlerError represents error types that can be returned from a Handler
 // that the Inbound implementation MUST handle.
 //
@@ -31,8 +43,6 @@ import "fmt"
 type HandlerError interface {
 	error
 
-	// private function because we want control over which types are valid
-	// HandlerErrors.
 	handlerError()
 }
 
@@ -61,44 +71,106 @@ func AsHandlerError(service, procedure string, err error) error {
 	}
 }
 
-// isHandlerError may be mixed into types which are valid HandlerErrors.
-type isHandlerError struct{}
-
-func (isHandlerError) handlerError() {}
-
 //////////////////////////////////////////////////////////////////////////////
 
 // BadRequestError is a failure to process a request because the request was
 // invalid.
-type BadRequestError struct {
-	isHandlerError
+type BadRequestError interface {
+	error
 
+	badRequestError()
+}
+
+type localBadRequestError struct {
 	Reason error
 }
 
-func (e BadRequestError) Error() string {
+var _ BadRequestError = localBadRequestError{}
+var _ HandlerError = localBadRequestError{}
+
+// LocalBadRequestError wraps the given error into a BadRequestError.
+//
+// It represents a local failure while processing an invalid request.
+func LocalBadRequestError(err error) HandlerError {
+	return localBadRequestError{Reason: err}
+}
+
+func (localBadRequestError) handlerError()    {}
+func (localBadRequestError) badRequestError() {}
+
+func (e localBadRequestError) Error() string {
 	return "BadRequest: " + e.Reason.Error()
 }
 
-// AsHandlerError on a BadRequestError returns the error as-is.
-func (e BadRequestError) AsHandlerError() HandlerError { return e }
+type remoteBadRequestError struct {
+	Message string
+}
+
+var _ BadRequestError = remoteBadRequestError{}
+
+// RemoteBadRequestError builds a new BadRequestError with the given message.
+//
+// It represents a BadRequest failure from a remote service.
+func RemoteBadRequestError(message string) BadRequestError {
+	return remoteBadRequestError{Message: message}
+}
+
+func (remoteBadRequestError) badRequestError() {}
+
+func (e remoteBadRequestError) Error() string {
+	return e.Message
+}
+
+//////////////////////////////////////////////////////////////////////////////
 
 // UnexpectedError is a failure to process a request for an unexpected reason.
-type UnexpectedError struct {
-	isHandlerError
+type UnexpectedError interface {
+	error
 
+	unexpectedError()
+}
+
+type localUnexpectedError struct {
 	Reason error
 }
 
-func (e UnexpectedError) Error() string {
+var _ UnexpectedError = localUnexpectedError{}
+var _ HandlerError = localUnexpectedError{}
+
+// LocalUnexpectedError wraps the given error into an UnexpectedError.
+//
+// It represens a local failure while processing a request.
+func LocalUnexpectedError(err error) HandlerError {
+	return localUnexpectedError{Reason: err}
+}
+
+func (localUnexpectedError) handlerError()    {}
+func (localUnexpectedError) unexpectedError() {}
+
+func (e localUnexpectedError) Error() string {
 	return "UnexpectedError: " + e.Reason.Error()
 }
 
-// AsHandlerError on an UnexpectedError returns the error as-is.
-func (e UnexpectedError) AsHandlerError() HandlerError { return e }
+type remoteUnexpectedError struct {
+	Message string
+}
+
+var _ UnexpectedError = remoteUnexpectedError{}
+
+// RemoteUnexpectedError builds a new UnexpectedError with the given message.
+//
+// It represents an UnexpectedError from a remote service.
+func RemoteUnexpectedError(message string) UnexpectedError {
+	return remoteUnexpectedError{Message: message}
+}
+
+func (remoteUnexpectedError) unexpectedError() {}
+
+func (e remoteUnexpectedError) Error() string {
+	return e.Message
+}
 
 //////////////////////////////////////////////////////////////////////////////
-// Private errors
 
 // unrecognizedProcedureError is a failure to process a request because the
 // procedure and/or service name was unrecognized.
@@ -112,7 +184,7 @@ func (e unrecognizedProcedureError) Error() string {
 }
 
 func (e unrecognizedProcedureError) AsHandlerError() HandlerError {
-	return BadRequestError{Reason: e}
+	return LocalBadRequestError(e)
 }
 
 // procedureFailedError is a failure to execute a procedure due to an
@@ -129,5 +201,5 @@ func (e procedureFailedError) Error() string {
 }
 
 func (e procedureFailedError) AsHandlerError() HandlerError {
-	return UnexpectedError{Reason: e}
+	return LocalUnexpectedError(e)
 }

--- a/transport/errors.go
+++ b/transport/errors.go
@@ -22,17 +22,23 @@ package transport
 
 import "fmt"
 
-// The general error hierarchy we have is:
+// The general hierarchy we have is:
 //
-// BadRequestError
-//  |- localBadRequestError: Used as-is to send a 400 level failure.
-//  |- remoteBadRequestError: Causes a localUnexpectedError.
-// UnexpectedError
-//  |- localUnexpectedError: Used as-is to send a 500 level failure.
-//  |- remoteUnexpectedError: Causes a new localUnexpectedError.
+// 	BadRequestError                 HandlerError
+// 	 |                                        |
+// 	 +--------> localBadRequestError <--------+
+// 	 |                                        |
+// 	 +--------> remoteBadRequestError         |
+// 	                                          |
+// 	UnexpectedError                           |
+// 	 |                                        |
+// 	 +--------> localUnexpectedError <--------+
+// 	 |
+// 	 +--------> remoteUnexpectedError
 //
-// Only the local versions of the error types are HandlerErrors. The remote
-// versions need to be converted using AsHandlerError.
+// Only the local versions of the error types are HandlerErrors. If a Handler
+// returns one of the remote versions, they will be wrapped in a new
+// UnexpectedError.
 
 // HandlerError represents error types that can be returned from a Handler
 // that the Inbound implementation MUST handle.

--- a/transport/errors.go
+++ b/transport/errors.go
@@ -129,7 +129,9 @@ func (e remoteBadRequestError) Error() string {
 
 //////////////////////////////////////////////////////////////////////////////
 
-// UnexpectedError is a failure to process a request for an unexpected reason.
+// UnexpectedError is a server failure due to unhandled errors. This can be
+// caused if the remote server panics while processing the request or fails to
+// handle any other errors.
 type UnexpectedError interface {
 	error
 

--- a/transport/http/handler_test.go
+++ b/transport/http/handler_test.go
@@ -56,41 +56,41 @@ func TestHandlerFailures(t *testing.T) {
 		req *http.Request
 		msg string
 	}{
-		{&http.Request{Method: "GET"}, "not found"},
+		{&http.Request{Method: "GET"}, "404 page not found\n"},
 		{
 			&http.Request{
 				Method: "POST",
 				Header: headerCopyWithout(baseHeaders, CallerHeader),
 			},
-			"BadRequest: missing caller name",
+			"BadRequest: missing caller name\n",
 		},
 		{
 			&http.Request{
 				Method: "POST",
 				Header: headerCopyWithout(baseHeaders, ServiceHeader),
 			},
-			"BadRequest: missing service name",
+			"BadRequest: missing service name\n",
 		},
 		{
 			&http.Request{
 				Method: "POST",
 				Header: headerCopyWithout(baseHeaders, ProcedureHeader),
 			},
-			"BadRequest: missing procedure",
+			"BadRequest: missing procedure\n",
 		},
 		{
 			&http.Request{
 				Method: "POST",
 				Header: headerCopyWithout(baseHeaders, TTLMSHeader),
 			},
-			"BadRequest: missing TTL",
+			"BadRequest: missing TTL\n",
 		},
 		{
 			&http.Request{
 				Method: "POST",
 				Header: headersWithBadTTL,
 			},
-			`BadRequest: invalid TTL "not a number" for procedure "hello" of service "fake": must be positive integer`,
+			`BadRequest: invalid TTL "not a number" for procedure "hello" of service "fake": must be positive integer` + "\n",
 		},
 	}
 
@@ -106,7 +106,7 @@ func TestHandlerFailures(t *testing.T) {
 
 		code := rw.Code
 		assert.True(t, code >= 400 && code < 500, "expected 400 level code")
-		assert.Contains(t, rw.Body.String(), tt.msg)
+		assert.Equal(t, rw.Body.String(), tt.msg)
 	}
 }
 
@@ -148,7 +148,9 @@ func TestHandlerInternalFailure(t *testing.T) {
 
 	code := httpResponse.Code
 	assert.True(t, code >= 500 && code < 600, "expected 500 level response")
-	assert.Contains(t, httpResponse.Body.String(), "great sadness")
+	assert.Equal(t,
+		`UnexpectedError: error for procedure "hello" of service "fake": great sadness`+"\n",
+		httpResponse.Body.String())
 }
 
 func headerCopyWithout(headers http.Header, names ...string) http.Header {

--- a/transport/http/handler_test.go
+++ b/transport/http/handler_test.go
@@ -88,6 +88,12 @@ func TestHandlerFailures(t *testing.T) {
 		{
 			&http.Request{
 				Method: "POST",
+			},
+			"BadRequest: missing service name, procedure, caller name, and TTL\n",
+		},
+		{
+			&http.Request{
+				Method: "POST",
 				Header: headersWithBadTTL,
 			},
 			`BadRequest: invalid TTL "not a number" for procedure "hello" of service "fake": must be positive integer` + "\n",

--- a/transport/http/inbound_test.go
+++ b/transport/http/inbound_test.go
@@ -91,8 +91,7 @@ func TestInboundMux(t *testing.T) {
 	})
 
 	if assert.Error(t, err, "RPC call to / should have failed") {
-		assert.Contains(t, err.Error(), "404")
-		assert.Contains(t, err.Error(), "page not found")
+		assert.Equal(t, err.Error(), "404 page not found")
 	}
 
 	o = NewOutbound(addr + "rpc/v1")

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -84,7 +84,7 @@ func (o outbound) Call(ctx context.Context, req *transport.Request) (*transport.
 		}
 
 		// Trim the trailing newline from HTTP error messages
-		if contents[len(contents)-1] == '\n' {
+		if len(contents) > 0 && contents[len(contents)-1] == '\n' {
 			contents = contents[:len(contents)-1]
 		}
 		message := string(contents)

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -76,15 +76,18 @@ func (o outbound) Call(ctx context.Context, req *transport.Request) (*transport.
 	if response.StatusCode < 200 || response.StatusCode >= 400 {
 		contents, err := ioutil.ReadAll(response.Body)
 		if err != nil {
-			return nil, err // TODO error type
+			return nil, err
 		}
 
 		if err := response.Body.Close(); err != nil {
-			return nil, err // TODO error type
+			return nil, err
 		}
 
-		// TODO error type
-		return nil, fmt.Errorf("request %v failed: %v: %s", request, response.Status, contents)
+		if response.StatusCode < 500 {
+			return nil, transport.RemoteBadRequestError(string(contents))
+		}
+
+		return nil, transport.RemoteUnexpectedError(string(contents))
 	}
 
 	return &transport.Response{

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/yarpc/yarpc-go/transport"
@@ -84,10 +85,7 @@ func (o outbound) Call(ctx context.Context, req *transport.Request) (*transport.
 		}
 
 		// Trim the trailing newline from HTTP error messages
-		if len(contents) > 0 && contents[len(contents)-1] == '\n' {
-			contents = contents[:len(contents)-1]
-		}
-		message := string(contents)
+		message := strings.TrimSuffix(string(contents), "\n")
 
 		if response.StatusCode < 500 {
 			return nil, transport.RemoteBadRequestError(message)

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -83,11 +83,17 @@ func (o outbound) Call(ctx context.Context, req *transport.Request) (*transport.
 			return nil, err
 		}
 
+		// Trim the trailing newline from HTTP error messages
+		if contents[len(contents)-1] == '\n' {
+			contents = contents[:len(contents)-1]
+		}
+		message := string(contents)
+
 		if response.StatusCode < 500 {
-			return nil, transport.RemoteBadRequestError(string(contents))
+			return nil, transport.RemoteBadRequestError(message)
 		}
 
-		return nil, transport.RemoteUnexpectedError(string(contents))
+		return nil, transport.RemoteUnexpectedError(message)
 	}
 
 	return &transport.Response{

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -73,29 +73,29 @@ func (o outbound) Call(ctx context.Context, req *transport.Request) (*transport.
 		return nil, err
 	}
 
-	// TODO 300 redirects?
-	if response.StatusCode < 200 || response.StatusCode >= 400 {
-		contents, err := ioutil.ReadAll(response.Body)
-		if err != nil {
-			return nil, err
-		}
-
-		if err := response.Body.Close(); err != nil {
-			return nil, err
-		}
-
-		// Trim the trailing newline from HTTP error messages
-		message := strings.TrimSuffix(string(contents), "\n")
-
-		if response.StatusCode < 500 {
-			return nil, transport.RemoteBadRequestError(message)
-		}
-
-		return nil, transport.RemoteUnexpectedError(message)
+	if response.StatusCode >= 200 && response.StatusCode < 300 {
+		return &transport.Response{
+			Headers: fromHTTPHeader(response.Header, nil),
+			Body:    response.Body,
+		}, nil
 	}
 
-	return &transport.Response{
-		Headers: fromHTTPHeader(response.Header, nil),
-		Body:    response.Body,
-	}, nil
+	// TODO Behavior for 300-range status codes is undefined
+	contents, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := response.Body.Close(); err != nil {
+		return nil, err
+	}
+
+	// Trim the trailing newline from HTTP error messages
+	message := strings.TrimSuffix(string(contents), "\n")
+
+	if response.StatusCode >= 400 && response.StatusCode < 500 {
+		return nil, transport.RemoteBadRequestError(message)
+	}
+
+	return nil, transport.RemoteUnexpectedError(message)
 }

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -97,7 +97,7 @@ func TestCallFailures(t *testing.T) {
 	}{
 		{"not a URL", []string{"unsupported protocol scheme"}},
 		{notFoundServer.URL, []string{"404", "page not found"}},
-		{internalErrorServer.URL, []string{"500", "great sadness"}},
+		{internalErrorServer.URL, []string{"great sadness"}},
 	}
 
 	for _, tt := range tests {

--- a/transport/register.go
+++ b/transport/register.go
@@ -86,7 +86,7 @@ func (m MapRegistry) Register(service, procedure string, handler Handler) {
 }
 
 // GetHandler retrieves the Handler for the given Procedure or returns an
-// UnknownProcedureErr.
+// error.
 func (m MapRegistry) GetHandler(service, procedure string) (Handler, error) {
 	if service == "" {
 		service = m.defaultService

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -150,6 +150,8 @@ func fromSystemError(err tchannel.SystemError) error {
 	case tchannel.ErrCodeUnexpected:
 		return transport.RemoteUnexpectedError(err.Message())
 	default:
-		return err // TODO(abg): How to handle other error codes?
+		return err
+		// TODO(abg): How to handle other error codes?
+		// https://github.com/yarpc/yarpc/issues/54
 	}
 }

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -145,13 +145,9 @@ func writeBody(body io.Reader, call *tchannel.OutboundCall) error {
 
 func fromSystemError(err tchannel.SystemError) error {
 	switch err.Code() {
-	case tchannel.ErrCodeBadRequest:
+	case tchannel.ErrCodeCancelled, tchannel.ErrCodeBusy, tchannel.ErrCodeBadRequest:
 		return transport.RemoteBadRequestError(err.Message())
-	case tchannel.ErrCodeUnexpected:
-		return transport.RemoteUnexpectedError(err.Message())
 	default:
-		return err
-		// TODO(abg): How to handle other error codes?
-		// https://github.com/yarpc/yarpc/issues/54
+		return transport.RemoteUnexpectedError(err.Message())
 	}
 }

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -99,6 +99,8 @@ func (o outbound) Call(ctx context.Context, req *transport.Request) (*transport.
 	}
 
 	if err := writeHeaders(format, req.Headers, call.Arg2Writer); err != nil {
+		// TODO(abg): This will wrap IO errors while writing headers as encode
+		// errors. We should fix that.
 		return nil, encoding.RequestHeadersEncodeError(req, err)
 	}
 
@@ -107,16 +109,21 @@ func (o outbound) Call(ctx context.Context, req *transport.Request) (*transport.
 	}
 
 	res := call.Response()
-
-	// TODO(abg): handle errors
-
 	headers, err := readHeaders(format, res.Arg2Reader)
 	if err != nil {
-		return nil, encoding.RequestHeadersDecodeError(req, err)
+		if err, ok := err.(tchannel.SystemError); ok {
+			return nil, fromSystemError(err)
+		}
+		// TODO(abg): This will wrap IO errors while reading headers as decode
+		// errors. We should fix that.
+		return nil, encoding.ResponseHeadersDecodeError(req, err)
 	}
 
 	resBody, err := res.Arg3Reader()
 	if err != nil {
+		if err, ok := err.(tchannel.SystemError); ok {
+			return nil, fromSystemError(err)
+		}
 		return nil, err
 	}
 
@@ -134,4 +141,15 @@ func writeBody(body io.Reader, call *tchannel.OutboundCall) error {
 	}
 
 	return w.Close()
+}
+
+func fromSystemError(err tchannel.SystemError) error {
+	switch err.Code() {
+	case tchannel.ErrCodeBadRequest:
+		return transport.RemoteBadRequestError(err.Message())
+	case tchannel.ErrCodeUnexpected:
+		return transport.RemoteUnexpectedError(err.Message())
+	default:
+		return err // TODO(abg): How to handle other error codes?
+	}
 }


### PR DESCRIPTION
This implements support for consistent errors on the client side. Clients will
only see `transport.UnexpectedError` or `transport.BadRequestError`.

The design for errors is:

- Certain error types are `HandlerError`s. The Inbound has to know how to
  handle these. Examples: BadRequest and Unexpected.
- Other error types know how to convert themselves into HandlerErrors by
  implementing proving a `AsHandlerError() error` function. For example,
  UnknownProcedureError knows that it should be converted into a
  BadRequestError.
- All other error types are converted into UnexpectedErrors with information
  about the procedure and service.

The hierarchy we have is,

```
BadRequestError                 HandlerError
 |                                        |
 +--------> localBadRequestError <--------+
 |                                        |
 +--------> remoteBadRequestError         |
                                          |
UnexpectedError                           |
 |                                        |
 +--------> localUnexpectedError <--------+
 |
 +--------> remoteUnexpectedError
```

Note that only the `local` versions of the error types are valid
`HandlerError`s. That is, only the local versions make it to the Inbound as-is
and must be handled (resulting in a 400-level error for `BadRequest` and
500-level for `Unexpected`). If a remote version of either error is returned by
a `Handler`, it causes a *new* `UnexpectedError` which includes the procedure
name and service for that call. This way, we end up with full information for
multi-hop failures:

    UnexpectedError: error for procedure "foo" of service "a":
        UnexpectedError: error for procedure "bar" of service "b":
            BadRequest: unrecognized procedure "baz" for service "c"

