### PR TITLE
HTTP: Add Rpc-Header prefix for application headers

### DIFF
--- a/crossdock/client/behavior/testify.go
+++ b/crossdock/client/behavior/testify.go
@@ -37,6 +37,14 @@ func Assert(s Sink) Assertions {
 	return sinkAssertions{s, assert.New(sinkTestingT{s})}
 }
 
+// Checks builds an Assertions object that writes failures to the given sink.
+//
+// This is the same as Assert except that nothing is written to the sink in
+// case of success.
+func Checks(s Sink) Assertions {
+	return assert.New(sinkTestingT{s})
+}
+
 // Require builds an Assertions object that writes success or failure to the
 // given sink. In case of failure, it also stops executing the current
 // behavior.

--- a/crossdock/client/client.go
+++ b/crossdock/client/client.go
@@ -27,6 +27,7 @@ import (
 	"github.com/yarpc/yarpc-go/crossdock/client/behavior"
 	"github.com/yarpc/yarpc-go/crossdock/client/echo"
 	"github.com/yarpc/yarpc-go/crossdock/client/errors"
+	"github.com/yarpc/yarpc-go/crossdock/client/headers"
 )
 
 // Start begins a blocking Crossdock client
@@ -61,6 +62,8 @@ func dispatch(s behavior.Sink, ps behavior.Params) {
 		echo.Thrift(s, ps)
 	case "errors":
 		errors.Run(s, ps)
+	case "headers":
+		headers.Run(s, ps)
 	default:
 		behavior.Skipf(s, "unknown behavior %q", v)
 	}

--- a/crossdock/client/echo/behavior.go
+++ b/crossdock/client/echo/behavior.go
@@ -96,7 +96,7 @@ func createRPC(s behavior.Sink, p behavior.Params) yarpc.RPC {
 		fatals.NoError(err, "couldn't create tchannel")
 		outbound = tch.NewOutbound(ch, tch.HostPort(server+":8082"))
 	default:
-		fatals.True(false, "unknown transport %q", trans)
+		fatals.Fail("", "unknown transport %q", trans)
 	}
 
 	return yarpc.New(yarpc.Config{

--- a/crossdock/client/headers/behavior.go
+++ b/crossdock/client/headers/behavior.go
@@ -136,6 +136,11 @@ func Run(s behavior.Sink, ps behavior.Params) {
 			transport.Headers{"Rpc-Procedure": "does not exist"},
 			transport.Headers{"rpc-procedure": "does not exist"},
 		},
+		{
+			"mixed case value",
+			transport.Headers{"token": "MIXED case Value"},
+			transport.Headers{"token": "MIXED case Value"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/crossdock/client/headers/behavior.go
+++ b/crossdock/client/headers/behavior.go
@@ -158,9 +158,8 @@ type headerCaller interface {
 type rawCaller struct{ c raw.Client }
 
 func (c rawCaller) Call(h transport.Headers) (transport.Headers, error) {
-	ctx, _ := context.WithTimeout(context.Background(), time.Second)
 	_, res, err := c.c.Call(&raw.Request{
-		Context:   ctx,
+		Context:   newTestContext(),
 		Headers:   h,
 		Procedure: "echo/raw",
 		TTL:       time.Second, // TODO context contains the timeout
@@ -175,11 +174,9 @@ func (c rawCaller) Call(h transport.Headers) (transport.Headers, error) {
 type jsonCaller struct{ c json.Client }
 
 func (c jsonCaller) Call(h transport.Headers) (transport.Headers, error) {
-	ctx, _ := context.WithTimeout(context.Background(), time.Second)
-
 	var resBody interface{}
 	res, err := c.c.Call(&json.Request{
-		Context:   ctx,
+		Context:   newTestContext(),
 		Headers:   h,
 		Procedure: "echo",
 		TTL:       time.Second, // TODO context contains the timeout
@@ -194,9 +191,8 @@ func (c jsonCaller) Call(h transport.Headers) (transport.Headers, error) {
 type thriftCaller struct{ c echoclient.Interface }
 
 func (c thriftCaller) Call(h transport.Headers) (transport.Headers, error) {
-	ctx, _ := context.WithTimeout(context.Background(), time.Second)
 	_, res, err := c.c.Echo(&thrift.Request{
-		Context: ctx,
+		Context: newTestContext(),
 		Headers: h,
 		TTL:     time.Second,
 	}, &echo.Ping{Beep: "hello"})
@@ -205,4 +201,9 @@ func (c thriftCaller) Call(h transport.Headers) (transport.Headers, error) {
 		return nil, err
 	}
 	return res.Headers, nil
+}
+
+func newTestContext() context.Context {
+	ctx, _ := context.WithTimeout(context.Background(), time.Second)
+	return ctx
 }

--- a/crossdock/client/headers/behavior.go
+++ b/crossdock/client/headers/behavior.go
@@ -1,0 +1,169 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package headers
+
+import (
+	"time"
+
+	"github.com/yarpc/yarpc-go/crossdock/client/behavior"
+	"github.com/yarpc/yarpc-go/crossdock/client/random"
+	"github.com/yarpc/yarpc-go/crossdock/thrift/echo"
+	"github.com/yarpc/yarpc-go/crossdock/thrift/echo/yarpc/echoclient"
+	"github.com/yarpc/yarpc-go/encoding/json"
+	"github.com/yarpc/yarpc-go/encoding/raw"
+	"github.com/yarpc/yarpc-go/encoding/thrift"
+	"github.com/yarpc/yarpc-go/transport"
+
+	"golang.org/x/net/context"
+)
+
+// Run runs the headers behavior
+func Run(s behavior.Sink, ps behavior.Params) {
+	fatals := behavior.Fatals(s)
+	assert := behavior.Assert(s)
+	checks := behavior.Checks(s)
+
+	rpc := createRPC(s, ps)
+
+	encoding := ps.Param(EncodingParam)
+	fatals.NotEmpty(encoding, "encoding is required")
+
+	var caller headerCaller
+
+	switch encoding {
+	case "raw":
+		caller = rawCaller{raw.New(rpc.Channel("yarpc-test"))}
+	case "json":
+		caller = jsonCaller{json.New(rpc.Channel("yarpc-test"))}
+	case "thrift":
+		caller = thriftCaller{echoclient.New(rpc.Channel("yarpc-test"))}
+	default:
+		fatals.True(false, "unknown encoding %q", encoding)
+	}
+
+	token1 := random.String(10)
+	token2 := random.String(10)
+
+	tests := []struct {
+		desc string
+		give transport.Headers
+		want transport.Headers
+	}{
+		{
+			"valid headers",
+			transport.Headers{"token1": token1, "token2": token2},
+			transport.Headers{"token1": token1, "token2": token2},
+		},
+		{
+			"non-string values",
+			transport.Headers{"token": "42"},
+			transport.Headers{"token": "42"},
+		},
+		{
+			"empty strings",
+			transport.Headers{"token": ""},
+			transport.Headers{"token": ""},
+		},
+		{
+			"no headers",
+			nil,
+			transport.Headers{},
+		},
+		{
+			"empty map",
+			transport.Headers{},
+			transport.Headers{},
+		},
+		{
+			"varying casing",
+			transport.Headers{"ToKeN1": token1, "tOkEn2": token2},
+			transport.Headers{"token1": token1, "token2": token2},
+		},
+		{
+			"http header conflict",
+			transport.Headers{"Rpc-Procedure": "does not exist"},
+			transport.Headers{"rpc-procedure": "does not exist"},
+		},
+	}
+
+	for _, tt := range tests {
+		got, err := caller.Call(tt.give)
+		if checks.NoError(err, "%v: call failed", tt.desc) {
+			assert.Equal(tt.want, got, "%v: returns valid headers", tt.desc)
+		}
+	}
+}
+
+type headerCaller interface {
+	Call(transport.Headers) (transport.Headers, error)
+}
+
+type rawCaller struct{ c raw.Client }
+
+func (c rawCaller) Call(h transport.Headers) (transport.Headers, error) {
+	ctx, _ := context.WithTimeout(context.Background(), time.Second)
+	_, res, err := c.c.Call(&raw.Request{
+		Context:   ctx,
+		Headers:   h,
+		Procedure: "echo/raw",
+		TTL:       time.Second, // TODO context contains the timeout
+	}, []byte("hello"))
+
+	if err != nil {
+		return nil, err
+	}
+	return res.Headers, nil
+}
+
+type jsonCaller struct{ c json.Client }
+
+func (c jsonCaller) Call(h transport.Headers) (transport.Headers, error) {
+	ctx, _ := context.WithTimeout(context.Background(), time.Second)
+
+	var resBody interface{}
+	res, err := c.c.Call(&json.Request{
+		Context:   ctx,
+		Headers:   h,
+		Procedure: "echo",
+		TTL:       time.Second, // TODO context contains the timeout
+	}, map[string]interface{}{}, &resBody)
+
+	if err != nil {
+		return nil, err
+	}
+	return res.Headers, nil
+}
+
+type thriftCaller struct{ c echoclient.Interface }
+
+func (c thriftCaller) Call(h transport.Headers) (transport.Headers, error) {
+	ctx, _ := context.WithTimeout(context.Background(), time.Second)
+	_, res, err := c.c.Echo(&thrift.Request{
+		Context: ctx,
+		Headers: h,
+		TTL:     time.Second,
+	}, &echo.Ping{Beep: "hello"})
+
+	if err != nil {
+		return nil, err
+	}
+	return res.Headers, nil
+}

--- a/crossdock/client/headers/behavior.go
+++ b/crossdock/client/headers/behavior.go
@@ -90,7 +90,7 @@ func Run(s behavior.Sink, ps behavior.Params) {
 	case "thrift":
 		caller = thriftCaller{echoclient.New(rpc.Channel("yarpc-test"))}
 	default:
-		fatals.True(false, "unknown encoding %q", encoding)
+		fatals.Fail("", "unknown encoding %q", encoding)
 	}
 
 	token1 := random.String(10)
@@ -130,15 +130,11 @@ func Run(s behavior.Sink, ps behavior.Params) {
 			"varying casing",
 			transport.Headers{"ToKeN1": token1, "tOkEn2": token2},
 			transport.Headers{"token1": token1, "token2": token2},
-			// TODO(abg): Do we expect to get back the same casing or
-			// normalized?
 		},
 		{
 			"http header conflict",
 			transport.Headers{"Rpc-Procedure": "does not exist"},
 			transport.Headers{"rpc-procedure": "does not exist"},
-			// TODO(abg): Do we expect to get back the same casing or
-			// normalized?
 		},
 	}
 

--- a/crossdock/client/headers/behavior.go
+++ b/crossdock/client/headers/behavior.go
@@ -96,11 +96,15 @@ func Run(s behavior.Sink, ps behavior.Params) {
 			"varying casing",
 			transport.Headers{"ToKeN1": token1, "tOkEn2": token2},
 			transport.Headers{"token1": token1, "token2": token2},
+			// TODO(abg): Do we expect to get back the same casing or
+			// normalized?
 		},
 		{
 			"http header conflict",
 			transport.Headers{"Rpc-Procedure": "does not exist"},
 			transport.Headers{"rpc-procedure": "does not exist"},
+			// TODO(abg): Do we expect to get back the same casing or
+			// normalized?
 		},
 	}
 

--- a/crossdock/client/headers/constants.go
+++ b/crossdock/client/headers/constants.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package headers
+
+// Names of parameter keys for the behavior.
+const (
+	EncodingParam  = "encoding"
+	ServerParam    = "server"
+	TransportParam = "transport"
+)

--- a/crossdock/client/headers/rpc.go
+++ b/crossdock/client/headers/rpc.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package headers
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/yarpc/yarpc-go"
+	"github.com/yarpc/yarpc-go/crossdock/client/behavior"
+	"github.com/yarpc/yarpc-go/transport"
+	ht "github.com/yarpc/yarpc-go/transport/http"
+	tch "github.com/yarpc/yarpc-go/transport/tchannel"
+
+	"github.com/uber/tchannel-go"
+)
+
+// createRPC creates an RPC from the given parameters or fails the whole
+// behavior.
+func createRPC(s behavior.Sink, p behavior.Params) yarpc.RPC {
+	fatals := behavior.Fatals(s)
+
+	server := p.Param(ServerParam)
+	fatals.NotEmpty(server, "server is required")
+
+	var outbound transport.Outbound
+	trans := p.Param(TransportParam)
+	switch trans {
+	case "http":
+		// Go HTTP servers have keep-alive enabled by default. If we re-use
+		// HTTP clients, the same connection will be used to make requests.
+		// This is undesirable during tests because we want to isolate the
+		// different test requests. Additionally, keep-alive causes the test
+		// server to continue listening on the existing connection for some
+		// time after we close the listener.
+		cl := &http.Client{Transport: new(http.Transport)}
+		outbound = ht.NewOutboundWithClient(fmt.Sprintf("http://%s:8081", server), cl)
+	case "tchannel":
+		ch, err := tchannel.NewChannel("client", nil)
+		fatals.NoError(err, "couldn't create tchannel")
+		outbound = tch.NewOutbound(ch, tch.HostPort(server+":8082"))
+	default:
+		fatals.True(false, "unknown transport %q", trans)
+	}
+
+	return yarpc.New(yarpc.Config{
+		Name:      "client",
+		Outbounds: transport.Outbounds{"yarpc-test": outbound},
+	})
+}

--- a/crossdock/client/headers/rpc.go
+++ b/crossdock/client/headers/rpc.go
@@ -58,7 +58,7 @@ func createRPC(s behavior.Sink, p behavior.Params) yarpc.RPC {
 		fatals.NoError(err, "couldn't create tchannel")
 		outbound = tch.NewOutbound(ch, tch.HostPort(server+":8082"))
 	default:
-		fatals.True(false, "unknown transport %q", trans)
+		fatals.Fail("", "unknown transport %q", trans)
 	}
 
 	return yarpc.New(yarpc.Config{

--- a/crossdock/crossdock_test.go
+++ b/crossdock/crossdock_test.go
@@ -84,6 +84,13 @@ func TestCrossdock(t *testing.T) {
 		{
 			name: "errors",
 		},
+		{
+			name: "headers",
+			axes: axes{
+				"transport": []string{"http", "tchannel"},
+				"encoding":  []string{"raw", "json", "thrift"},
+			},
+		},
 	}
 
 	for _, bb := range behaviors {

--- a/crossdock/server/echo.go
+++ b/crossdock/server/echo.go
@@ -29,12 +29,12 @@ import (
 
 // EchoRaw implements the echo/raw procedure.
 func EchoRaw(req *raw.Request, body []byte) ([]byte, *raw.Response, error) {
-	return body, nil, nil
+	return body, &raw.Response{Headers: req.Headers}, nil
 }
 
 // EchoJSON implements the echo procedure.
 func EchoJSON(req *json.Request, body map[string]interface{}) (map[string]interface{}, *json.Response, error) {
-	return body, nil, nil
+	return body, &json.Response{Headers: req.Headers}, nil
 }
 
 // EchoThrift implements the Thrift Echo service.
@@ -42,5 +42,5 @@ type EchoThrift struct{}
 
 // Echo endpoint for the Echo service.
 func (EchoThrift) Echo(req *thrift.Request, ping *echo.Ping) (*echo.Pong, *thrift.Response, error) {
-	return &echo.Pong{Boop: ping.Beep}, nil, nil
+	return &echo.Pong{Boop: ping.Beep}, &thrift.Response{Headers: req.Headers}, nil
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,19 +10,21 @@ services:
             - python
             - python-sync
         environment:
-            - WAIT_FOR=go # ,node,java,python,python-sync
+            - WAIT_FOR=go,node # ,java,python,python-sync
 
-            - AXIS_CLIENT=go # ,node,java,python,python-sync
-            - AXIS_SERVER=go # ,node,java,python
+            - AXIS_CLIENT=go,node # ,java,python,python-sync
+            - AXIS_SERVER=go,node # ,java,python
             - AXIS_TRANSPORT=http,tchannel
-            - AXIS_ERRORS=go # ,node
             - AXIS_ENCODING=raw,json,thrift
+            # - AXIS_ERRORS=go,node
+            # ^ TODO: uncomment when other languages' error branch is merged
 
             - BEHAVIOR_RAW=client,server,transport
             - BEHAVIOR_JSON=client,server,transport
             - BEHAVIOR_THRIFT=client,server,transport
-            - BEHAVIOR_ERRORS=errors,server
             - BEHAVIOR_HEADERS=client,server,transport,encoding
+            # - BEHAVIOR_ERRORS=errors,server
+            # ^ TODO: uncomment when other languages' error branch is merged
 
     go:
         build: .
@@ -30,7 +32,7 @@ services:
             - "8080-8082"
 
     node:
-        image: yarpc/yarpc-node:crossdock-errors
+        image: yarpc/yarpc-node:crossdock-headers
         ports:
             - "8080-8082"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,17 +10,19 @@ services:
             - python
             - python-sync
         environment:
-            - WAIT_FOR=go,node # ,java,python,python-sync
+            - WAIT_FOR=go # ,node,java,python,python-sync
 
-            - AXIS_CLIENT=go,node # ,java,python,python-sync
-            - AXIS_SERVER=go,node # ,java,python
+            - AXIS_CLIENT=go # ,node,java,python,python-sync
+            - AXIS_SERVER=go # ,node,java,python
             - AXIS_TRANSPORT=http,tchannel
-            - AXIS_ERRORS=go,node
+            - AXIS_ERRORS=go # ,node
+            - AXIS_ENCODING=raw,json,thrift
 
             - BEHAVIOR_RAW=client,server,transport
             - BEHAVIOR_JSON=client,server,transport
             - BEHAVIOR_THRIFT=client,server,transport
             - BEHAVIOR_ERRORS=errors,server
+            - BEHAVIOR_HEADERS=client,server,transport,encoding
 
     go:
         build: .

--- a/transport/http/constants.go
+++ b/transport/http/constants.go
@@ -22,20 +22,24 @@ package http
 
 const (
 	// CallerHeader is the HTTP header used to indiate the service doing the calling
-	CallerHeader = "RPC-Caller"
+	CallerHeader = "Rpc-Caller"
 
 	// EncodingHeader is the HTTP header used to specify the name of the
 	// encoding.
-	EncodingHeader = "RPC-Encoding"
+	EncodingHeader = "Rpc-Encoding"
 
 	// TTLMSHeader is the HTTP header used to indicate the ttl in ms
 	TTLMSHeader = "Context-TTL-MS"
 
 	// ProcedureHeader is the HTTP header used to indicate the procedure
-	ProcedureHeader = "RPC-Procedure"
+	ProcedureHeader = "Rpc-Procedure"
 
 	// ServiceHeader is the HTTP header used to indicate the service
-	ServiceHeader = "RPC-Service"
+	ServiceHeader = "Rpc-Service"
+
+	// ApplicationHeaderPrefix is the prefix added to application headers over
+	// the wire.
+	ApplicationHeaderPrefix = "Rpc-Header-"
 )
 
 // TODO Make consistent with other languages^

--- a/transport/http/handler_test.go
+++ b/transport/http/handler_test.go
@@ -187,7 +187,7 @@ func TestResponseWriter(t *testing.T) {
 	_, err := writer.Write([]byte("hello"))
 	require.NoError(t, err)
 
-	assert.Equal(t, "bar", recorder.Header().Get("foo"))
-	assert.Equal(t, "123", recorder.Header().Get("shard-key"))
+	assert.Equal(t, "bar", recorder.Header().Get("rpc-header-foo"))
+	assert.Equal(t, "123", recorder.Header().Get("rpc-header-shard-key"))
 	assert.Equal(t, "hello", recorder.Body.String())
 }

--- a/transport/http/header.go
+++ b/transport/http/header.go
@@ -22,6 +22,7 @@ package http
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/yarpc/yarpc-go/transport"
 )
@@ -37,7 +38,7 @@ func toHTTPHeader(from transport.Headers, to http.Header) http.Header {
 		to = make(http.Header)
 	}
 	for k, v := range from {
-		to.Add(k, v)
+		to.Add(ApplicationHeaderPrefix+k, v)
 	}
 	return to
 }
@@ -54,10 +55,12 @@ func fromHTTPHeader(from http.Header, to transport.Headers) transport.Headers {
 	}
 
 	for k := range from {
-		to.Set(k, from.Get(k))
-		// undefined behavior for multiple occurrences of the same header
-		// TODO figure out which headers we are actually allowing in here
-		// TODO figure out header scheme for headers that are exposed like this
+		if strings.HasPrefix(k, ApplicationHeaderPrefix) {
+			realK := k[len(ApplicationHeaderPrefix):]
+			to.Set(realK, from.Get(k))
+		}
+		// Note: undefined behavior for multiple occurrences of the same
+		// header
 	}
 	return to
 }

--- a/transport/http/header_test.go
+++ b/transport/http/header_test.go
@@ -40,8 +40,8 @@ func TestHeaders(t *testing.T) {
 				"foo-bar": "hello",
 			},
 			http.Header{
-				"Foo":     []string{"bar"},
-				"Foo-Bar": []string{"hello"},
+				"Rpc-Header-Foo":     []string{"bar"},
+				"Rpc-Header-Foo-Bar": []string{"hello"},
 			},
 		},
 	}

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -52,7 +52,7 @@ func TestCallSuccess(t *testing.T) {
 				assert.Equal(t, []byte("world"), body)
 			}
 
-			w.Header().Set("foo", "bar")
+			w.Header().Set("rpc-header-foo", "bar")
 			_, err = w.Write([]byte("great success"))
 			assert.NoError(t, err)
 		},

--- a/transport/tchannel/header.go
+++ b/transport/tchannel/header.go
@@ -41,9 +41,9 @@ import (
 func readHeaders(format tchannel.Format, getReader func() (tchannel.ArgReader, error)) (transport.Headers, error) {
 	if format == tchannel.JSON {
 		// JSON is special
-		var headers transport.Headers
+		var headers map[string]string
 		err := tchannel.NewArgReader(getReader()).ReadJSON(&headers)
-		return headers, err
+		return transport.NewHeaders(headers), err
 		// ^headers will never be nil
 	}
 

--- a/transport/tchannel/header.go
+++ b/transport/tchannel/header.go
@@ -36,12 +36,15 @@ import (
 // OutboundCallResponse.
 //
 // If the format is JSON, the headers are expected to be JSON encoded.
+//
+// This function always returns a non-nil Headers object in case of success.
 func readHeaders(format tchannel.Format, getReader func() (tchannel.ArgReader, error)) (transport.Headers, error) {
 	if format == tchannel.JSON {
 		// JSON is special
 		var headers transport.Headers
 		err := tchannel.NewArgReader(getReader()).ReadJSON(&headers)
 		return headers, err
+		// ^headers will never be nil
 	}
 
 	r, err := getReader()
@@ -52,6 +55,11 @@ func readHeaders(format tchannel.Format, getReader func() (tchannel.ArgReader, e
 	headers, err := decodeHeaders(r)
 	if err != nil {
 		return nil, err
+	}
+
+	// normalize headers to an empty map if nil
+	if headers == nil {
+		headers = make(transport.Headers)
 	}
 
 	return headers, r.Close()


### PR DESCRIPTION
This changes the HTTP transport to prefix application headers with
`Rpc-Header-`, as per https://github.com/yarpc/yarpc/issues/55.

It also introduces the `headers` crossdock behavior as defined in
https://github.com/yarpc/yarpc/blob/master/crossdock.md#headers.

CC @yarpc/yarpc 
