### PR TITLE
docker-compose logs exits automatically in 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
   - make test-examples
   - travis_retry goveralls -coverprofile=cover.out -service=travis-ci
   - make crossdock
-  - timeout 5 docker-compose logs || true
+  - docker-compose logs
 
 after_success:
   - export REPO=yarpc/yarpc-go


### PR DESCRIPTION
docker-compose logs no longer follows log output by default. It now matches the behavior of docker logs and exits after the current logs are printed. Use -f to get the old default behavior.

@yarpc/golang 