### PR TITLE
Transport-level interceptors and filters.

### DIFF
--- a/examples/json/client/logger.go
+++ b/examples/json/client/logger.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/yarpc/yarpc-go/transport"
+
+	"golang.org/x/net/context"
+)
+
+type requestLogFilter struct{}
+
+func (requestLogFilter) Apply(
+	ctx context.Context, request *transport.Request, out transport.Outbound) (*transport.Response, error) {
+	fmt.Printf("sending a request to %q\n", request.Procedure)
+	return out.Call(ctx, request)
+}

--- a/examples/json/client/logger.go
+++ b/examples/json/client/logger.go
@@ -30,7 +30,7 @@ import (
 
 type requestLogFilter struct{}
 
-func (requestLogFilter) Apply(
+func (requestLogFilter) Call(
 	ctx context.Context, request *transport.Request, out transport.Outbound) (*transport.Response, error) {
 	fmt.Printf("sending a request to %q\n", request.Procedure)
 	return out.Call(ctx, request)

--- a/examples/json/client/main.go
+++ b/examples/json/client/main.go
@@ -109,6 +109,7 @@ func main() {
 	rpc := yarpc.New(yarpc.Config{
 		Name:      "keyvalue-client",
 		Outbounds: transport.Outbounds{"keyvalue": outbound},
+		Filters:   yarpc.Filters{requestLogFilter{}},
 	})
 
 	client := json.New(rpc.Channel("keyvalue"))

--- a/examples/json/client/main.go
+++ b/examples/json/client/main.go
@@ -109,7 +109,7 @@ func main() {
 	rpc := yarpc.New(yarpc.Config{
 		Name:      "keyvalue-client",
 		Outbounds: transport.Outbounds{"keyvalue": outbound},
-		Filters:   yarpc.Filters{requestLogFilter{}},
+		Filter:    yarpc.Filters(requestLogFilter{}),
 	})
 
 	client := json.New(rpc.Channel("keyvalue"))

--- a/examples/json/json.t
+++ b/examples/json/json.t
@@ -17,6 +17,16 @@ Test code:
   > set baz qux
   > get baz
   > INPUT
+  sending a request to "get"
+  received a request to "get"
   foo = 
+  sending a request to "set"
+  received a request to "set"
+  sending a request to "get"
+  received a request to "get"
   foo = bar
+  sending a request to "set"
+  received a request to "set"
+  sending a request to "get"
+  received a request to "get"
   baz = qux

--- a/examples/json/server/logger.go
+++ b/examples/json/server/logger.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/yarpc/yarpc-go/transport"
+
+	"golang.org/x/net/context"
+)
+
+type requestLogInterceptor struct{}
+
+func (requestLogInterceptor) Apply(
+	ctx context.Context, req *transport.Request, resw transport.ResponseWriter, handler transport.Handler) error {
+	fmt.Printf("received a request to %q\n", req.Procedure)
+	return handler.Handle(ctx, req, resw)
+}

--- a/examples/json/server/logger.go
+++ b/examples/json/server/logger.go
@@ -30,7 +30,7 @@ import (
 
 type requestLogInterceptor struct{}
 
-func (requestLogInterceptor) Apply(
+func (requestLogInterceptor) Handle(
 	ctx context.Context, req *transport.Request, resw transport.ResponseWriter, handler transport.Handler) error {
 	fmt.Printf("received a request to %q\n", req.Procedure)
 	return handler.Handle(ctx, req, resw)

--- a/examples/json/server/main.go
+++ b/examples/json/server/main.go
@@ -83,6 +83,7 @@ func main() {
 			tch.NewInbound(channel, tch.ListenAddr(":28941")),
 			http.NewInbound(":24034"),
 		},
+		Interceptors: yarpc.Interceptors{requestLogInterceptor{}},
 	})
 
 	handler := handler{items: make(map[string]string)}

--- a/examples/json/server/main.go
+++ b/examples/json/server/main.go
@@ -83,7 +83,7 @@ func main() {
 			tch.NewInbound(channel, tch.ListenAddr(":28941")),
 			http.NewInbound(":24034"),
 		},
-		Interceptors: yarpc.Interceptors{requestLogInterceptor{}},
+		Interceptor: yarpc.Interceptors(requestLogInterceptor{}),
 	})
 
 	handler := handler{items: make(map[string]string)}

--- a/internal/filter/chain.go
+++ b/internal/filter/chain.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package filter
+
+import (
+	"github.com/yarpc/yarpc-go/transport"
+
+	"golang.org/x/net/context"
+)
+
+// Chain combines a series of filters into a single Filter.
+func Chain(filters ...transport.Filter) transport.Filter {
+	switch len(filters) {
+	case 0:
+		return transport.NopFilter
+	case 1:
+		return filters[0]
+	default:
+		return chain(filters)
+	}
+}
+
+// filterChain combines a series of filters into a single Filter.
+type chain []transport.Filter
+
+func (c chain) Call(ctx context.Context, request *transport.Request, out transport.Outbound) (*transport.Response, error) {
+	return chainExec{
+		Chain: []transport.Filter(c),
+		Final: out,
+	}.Call(ctx, request)
+}
+
+// chainExec adapts a series of filters into an Outbound. It is scoped to a
+// single call of an Outbound and is not thread-safe.
+type chainExec struct {
+	Chain []transport.Filter
+	Final transport.Outbound
+}
+
+func (x chainExec) Call(ctx context.Context, request *transport.Request) (*transport.Response, error) {
+	if len(x.Chain) == 0 {
+		return x.Final.Call(ctx, request)
+	}
+	next := x.Chain[0]
+	x.Chain = x.Chain[1:]
+	return next.Call(ctx, request, x)
+}

--- a/internal/interceptor/chain.go
+++ b/internal/interceptor/chain.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package interceptor
+
+import (
+	"github.com/yarpc/yarpc-go/transport"
+
+	"golang.org/x/net/context"
+)
+
+// Chain combines a series of Interceptors into a single Interceptor.
+func Chain(interceptors ...transport.Interceptor) transport.Interceptor {
+	switch len(interceptors) {
+	case 0:
+		return transport.NopInterceptor
+	case 1:
+		return interceptors[0]
+	default:
+		return chain(interceptors)
+	}
+}
+
+// interceptorChain combines a series of interceptors into a single Interceptor.
+type chain []transport.Interceptor
+
+func (c chain) Handle(ctx context.Context, req *transport.Request, resw transport.ResponseWriter, h transport.Handler) error {
+	return chainExec{
+		Chain: []transport.Interceptor(c),
+		Final: h,
+	}.Handle(ctx, req, resw)
+}
+
+// chainExec adapts a series of interceptors into a Handler. It is scoped to a
+// single request to the Handler and is not thread-safe.
+type chainExec struct {
+	Chain []transport.Interceptor
+	Final transport.Handler
+}
+
+func (x chainExec) Handle(ctx context.Context, req *transport.Request, resw transport.ResponseWriter) error {
+	if len(x.Chain) == 0 {
+		return x.Final.Handle(ctx, req, resw)
+	}
+	next := x.Chain[0]
+	x.Chain = x.Chain[1:]
+	return next.Handle(ctx, req, resw, x)
+}

--- a/middleware.go
+++ b/middleware.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpc
+
+import (
+	"github.com/yarpc/yarpc-go/internal/filter"
+	"github.com/yarpc/yarpc-go/internal/interceptor"
+	"github.com/yarpc/yarpc-go/transport"
+)
+
+// Filters combines the given collection of filters in-order into a single
+// Filter.
+func Filters(filters ...transport.Filter) transport.Filter {
+	return filter.Chain(filters...)
+}
+
+// Interceptors combines the given collection of interceptors in-order into a
+// single Interceptor.
+func Interceptors(interceptors ...transport.Interceptor) transport.Interceptor {
+	return interceptor.Chain(interceptors...)
+}

--- a/rpc.go
+++ b/rpc.go
@@ -51,20 +51,16 @@ type RPC interface {
 	Stop() error
 }
 
-// Filters is a collection of transport-level Filters.
-type Filters []transport.Filter
-
-// Interceptors is a collection of transport-level Interceptors.
-type Interceptors []transport.Interceptor
-
 // Config specifies the parameters of a new RPC constructed via New.
 type Config struct {
 	Name      string
 	Inbounds  []transport.Inbound
 	Outbounds transport.Outbounds
 
-	Filters      Filters
-	Interceptors Interceptors
+	// Filter and Interceptor that will be applied to all outgoing and incoming
+	// requests respectively.
+	Filter      transport.Filter
+	Interceptor transport.Interceptor
 
 	// TODO FallbackHandler for catch-all endpoints
 }
@@ -75,15 +71,13 @@ func New(cfg Config) RPC {
 		panic("a service name is required")
 	}
 
-	filters := []transport.Filter(cfg.Filters)
-	interceptors := []transport.Interceptor(cfg.Interceptors)
 	return rpc{
 		Name:        cfg.Name,
 		Registry:    transport.NewMapRegistry(cfg.Name),
 		Inbounds:    cfg.Inbounds,
 		Outbounds:   cfg.Outbounds,
-		Filter:      transport.ChainFilters(filters...),
-		Interceptor: transport.ChainInterceptors(interceptors...),
+		Filter:      cfg.Filter,
+		Interceptor: cfg.Interceptor,
 	}
 }
 

--- a/rpc.go
+++ b/rpc.go
@@ -51,14 +51,20 @@ type RPC interface {
 	Stop() error
 }
 
+// Filters is a collection of transport-level Filters.
+type Filters []transport.Filter
+
+// Interceptors is a collection of transport-level Interceptors.
+type Interceptors []transport.Interceptor
+
 // Config specifies the parameters of a new RPC constructed via New.
 type Config struct {
 	Name      string
 	Inbounds  []transport.Inbound
 	Outbounds transport.Outbounds
 
-	Filters      []transport.Filter
-	Interceptors []transport.Interceptor
+	Filters      Filters
+	Interceptors Interceptors
 
 	// TODO FallbackHandler for catch-all endpoints
 }
@@ -69,13 +75,15 @@ func New(cfg Config) RPC {
 		panic("a service name is required")
 	}
 
+	filters := []transport.Filter(cfg.Filters)
+	interceptors := []transport.Interceptor(cfg.Interceptors)
 	return rpc{
 		Name:        cfg.Name,
 		Registry:    transport.NewMapRegistry(cfg.Name),
 		Inbounds:    cfg.Inbounds,
 		Outbounds:   cfg.Outbounds,
-		Filter:      transport.ChainFilters(cfg.Filters...),
-		Interceptor: transport.ChainInterceptors(cfg.Interceptors...),
+		Filter:      transport.ChainFilters(filters...),
+		Interceptor: transport.ChainInterceptors(interceptors...),
 	}
 }
 

--- a/rpc.go
+++ b/rpc.go
@@ -57,6 +57,9 @@ type Config struct {
 	Inbounds  []transport.Inbound
 	Outbounds transport.Outbounds
 
+	Filters      []transport.Filter
+	Interceptors []transport.Interceptor
+
 	// TODO FallbackHandler for catch-all endpoints
 }
 
@@ -65,11 +68,14 @@ func New(cfg Config) RPC {
 	if cfg.Name == "" {
 		panic("a service name is required")
 	}
+
 	return rpc{
-		Name:      cfg.Name,
-		Registry:  transport.NewMapRegistry(cfg.Name),
-		Inbounds:  cfg.Inbounds,
-		Outbounds: cfg.Outbounds,
+		Name:        cfg.Name,
+		Registry:    transport.NewMapRegistry(cfg.Name),
+		Inbounds:    cfg.Inbounds,
+		Outbounds:   cfg.Outbounds,
+		Filter:      transport.ChainFilters(cfg.Filters...),
+		Interceptor: transport.ChainInterceptors(cfg.Interceptors...),
 	}
 }
 
@@ -79,9 +85,11 @@ func New(cfg Config) RPC {
 type rpc struct {
 	transport.Registry
 
-	Name      string
-	Inbounds  []transport.Inbound
-	Outbounds transport.Outbounds
+	Name        string
+	Inbounds    []transport.Inbound
+	Outbounds   transport.Outbounds
+	Filter      transport.Filter
+	Interceptor transport.Interceptor
 }
 
 func (r rpc) Channel(service string) transport.Channel {
@@ -92,8 +100,9 @@ func (r rpc) Channel(service string) transport.Channel {
 	if out, ok := r.Outbounds[service]; ok {
 		// we can eventually write an outbound that load balances between
 		// known outbounds for a service.
+		out = transport.ApplyFilter(out, r.Filter)
 		return transport.Channel{
-			Outbound: request.ValidatorOutbound{out},
+			Outbound: request.ValidatorOutbound{Outbound: out},
 			Caller:   r.Name,
 			Service:  service,
 		}
@@ -118,6 +127,11 @@ func (r rpc) Start() error {
 	}
 
 	return nil
+}
+
+func (r rpc) Register(service, procedure string, handler transport.Handler) {
+	handler = transport.ApplyInterceptor(handler, r.Interceptor)
+	r.Registry.Register(service, procedure, handler)
 }
 
 func (r rpc) Handle(ctx context.Context, req *transport.Request, rw transport.ResponseWriter) error {

--- a/transport/filter.go
+++ b/transport/filter.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package transport
+
+import "golang.org/x/net/context"
+
+// Filter defines transport-level middleware for Outbounds.
+type Filter interface {
+	Apply(ctx context.Context, request *Request, out Outbound) (*Response, error)
+}
+
+// NopFilter is a filter that does not do anything special. It simply calls
+// the underlying Outbound.
+var NopFilter Filter = nopFilter{}
+
+// ApplyFilter wraps the given Outbound with the given Filters in-order.
+func ApplyFilter(o Outbound, f Filter) Outbound {
+	return filteredOutbound{o: o, f: f}
+}
+
+// ChainFilters combines the given filters in-order into a single Filter.
+func ChainFilters(filters ...Filter) Filter {
+	if len(filters) == 0 {
+		return NopFilter
+	}
+	if len(filters) == 1 {
+		return filters[0]
+	}
+	return filterChain(filters)
+}
+
+type filteredOutbound struct {
+	o Outbound
+	f Filter
+}
+
+func (fo filteredOutbound) Call(ctx context.Context, request *Request) (*Response, error) {
+	return fo.f.Apply(ctx, request, fo.o)
+}
+
+type nopFilter struct{}
+
+func (nopFilter) Apply(ctx context.Context, request *Request, out Outbound) (*Response, error) {
+	return out.Call(ctx, request)
+}
+
+// filterChain combines a series of filters into a single Filter.
+type filterChain []Filter
+
+func (fc filterChain) Apply(ctx context.Context, request *Request, out Outbound) (*Response, error) {
+	cx := filterChainExec{
+		Chain: []Filter(fc),
+		Index: 0,
+		Final: out,
+	}
+	return cx.Call(ctx, request)
+}
+
+// filterChainExec adapts a series of filters into an Outbound. It is scoped to
+// a single call of an Outbound and is not thread-safe.
+type filterChainExec struct {
+	Chain []Filter
+	Index int
+	Final Outbound
+}
+
+func (cx *filterChainExec) Call(ctx context.Context, request *Request) (*Response, error) {
+	i := cx.Index
+	if i == len(cx.Chain) {
+		return cx.Final.Call(ctx, request)
+	}
+
+	cx.Index++
+	return cx.Chain[i].Apply(ctx, request, cx)
+}

--- a/transport/filter.go
+++ b/transport/filter.go
@@ -49,6 +49,9 @@ var NopFilter Filter = nopFilter{}
 
 // ApplyFilter applies the given Filter to the given Outbound.
 func ApplyFilter(o Outbound, f Filter) Outbound {
+	if f == nil {
+		return o
+	}
 	return filteredOutbound{o: o, f: f}
 }
 

--- a/transport/interceptor.go
+++ b/transport/interceptor.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package transport
+
+import "golang.org/x/net/context"
+
+// Interceptor defines a transport-level middleware for Inbounds.
+type Interceptor interface {
+	Apply(ctx context.Context, req *Request, resw ResponseWriter, handler Handler) error
+}
+
+// NopInterceptor is a filter that does not do anything special. It simply
+// calls the underlying Handler.
+var NopInterceptor Interceptor = nopInterceptor{}
+
+// ApplyInterceptor wraps the given Handler with the given Interceptors
+// in-order.
+func ApplyInterceptor(h Handler, i Interceptor) Handler {
+	return interceptedHandler{h: h, i: i}
+}
+
+// ChainInterceptors combines the given interceptors in-order into a single
+// Interceptor.
+func ChainInterceptors(interceptors ...Interceptor) Interceptor {
+	if len(interceptors) == 0 {
+		return NopInterceptor
+	}
+	if len(interceptors) == 1 {
+		return interceptors[0]
+	}
+	return interceptorChain(interceptors)
+}
+
+type interceptedHandler struct {
+	h Handler
+	i Interceptor
+}
+
+func (h interceptedHandler) Handle(ctx context.Context, req *Request, resw ResponseWriter) error {
+	return h.i.Apply(ctx, req, resw, h.h)
+}
+
+type nopInterceptor struct{}
+
+func (nopInterceptor) Apply(ctx context.Context, req *Request, resw ResponseWriter, handler Handler) error {
+	return handler.Handle(ctx, req, resw)
+}
+
+type interceptorChain []Interceptor
+
+func (ic interceptorChain) Apply(ctx context.Context, req *Request, resw ResponseWriter, handler Handler) error {
+	ix := interceptorChainExec{
+		Chain: []Interceptor(ic),
+		Index: 0,
+		Final: handler,
+	}
+	return ix.Handle(ctx, req, resw)
+}
+
+// filterChainExec adapts a series of filters into a Handler. It is scoped to
+// a single request to the Handler and is not thread-safe.
+type interceptorChainExec struct {
+	Chain []Interceptor
+	Index int
+	Final Handler
+}
+
+func (ix *interceptorChainExec) Handle(ctx context.Context, req *Request, resw ResponseWriter) error {
+	i := ix.Index
+	if i == len(ix.Chain) {
+		return ix.Final.Handle(ctx, req, resw)
+	}
+
+	ix.Index++
+	return ix.Chain[i].Apply(ctx, req, resw, ix)
+}

--- a/transport/interceptor.go
+++ b/transport/interceptor.go
@@ -27,8 +27,8 @@ type Interceptor interface {
 	Apply(ctx context.Context, req *Request, resw ResponseWriter, handler Handler) error
 }
 
-// NopInterceptor is a filter that does not do anything special. It simply
-// calls the underlying Handler.
+// NopInterceptor is a interceptor that does not do anything special. It
+// simply calls the underlying Handler.
 var NopInterceptor Interceptor = nopInterceptor{}
 
 // ApplyInterceptor wraps the given Handler with the given Interceptors
@@ -75,8 +75,8 @@ func (ic interceptorChain) Apply(ctx context.Context, req *Request, resw Respons
 	return ix.Handle(ctx, req, resw)
 }
 
-// filterChainExec adapts a series of filters into a Handler. It is scoped to
-// a single request to the Handler and is not thread-safe.
+// interceptorChainExec adapts a series of interceptors into a Handler. It is
+// scoped to a single request to the Handler and is not thread-safe.
 type interceptorChainExec struct {
 	Chain []Interceptor
 	Index int

--- a/transport/interceptor.go
+++ b/transport/interceptor.go
@@ -47,6 +47,9 @@ var NopInterceptor Interceptor = nopInterceptor{}
 
 // ApplyInterceptor applies the given Interceptor to the given Handler.
 func ApplyInterceptor(h Handler, i Interceptor) Handler {
+	if i == nil {
+		return h
+	}
 	return interceptedHandler{h: h, i: i}
 }
 


### PR DESCRIPTION
This defines the transport `Interceptor` and `Filter` interfaces. Interceptors
and Filters may be specified for all requests that go through an RPC at the
time the RPC is constructed.

Note that `Interceptor` and `Filter` cannot have the same API because
`Handler` and `Outbound` do not have the same APIs. `Handler` uses
a `ResponseWriter` to write the response rather than returning a `Response`.

Related: yarpc/yarpc#57

----

This PR mostly sketches out the initial API for transport-level middleware.
Feedback on API welcome. Everything is malleable at this point. I haven't put
too much thought into application-level middleware yet; there's no reason for
that API to be tied to the transport-level API. I imagine we'll define
`{json,thrift,raw}.Middleware` types or something similar since the
encoding-specific `Handler`s have no concept of `ResponseWriter`s.

I'll add more tests and documentation once we've agreed that this is the API
we want for transport-level middleware.

CC @yarpc/golang @yarpc/yarpc 