### PR TITLE
Respect existing handlers when passed in a TChannel

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: 672ef6a9d191e20f5fc1e1f0ac53bb00bda74d8245b4326671c2fddf99823045
-updated: 2016-04-22T14:51:18.938752258-07:00
+hash: 7d6d74172f119bd6119d5e7657a8dd1fd732562685eb953d54d2566e40d67a5c
+updated: 2016-05-19T10:37:57.413800851-07:00
 imports:
 - name: github.com/davecgh/go-spew
-  version: 2df174808ee097f90d259e432cc04442cf60be21
+  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
   - spew
 - name: github.com/golang/mock
@@ -14,23 +14,26 @@ imports:
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: 9f9027faeb0dad515336ed2f28317f9f8f527ab4
+  version: 6cb3b85ef5a0efef77caef88363ec4d4b5c0976d
   subpackages:
   - assert
   - require
 - name: github.com/thriftrw/thriftrw-go
-  version: fa2079dcd5e7f71ecd4a1af10a428b1e21f5bf75
+  version: 228cb2a82bf886b81b532a4e975258a27cc71083
   subpackages:
   - wire
   - protocol
   - protocol/binary
 - name: github.com/uber/tchannel-go
-  version: 7c19f22ebc511caa55133e458d8a22f1dbfdb981
+  version: 1e3d3705581f8f9c1356e2966bc90782243b516d
   subpackages:
+  - atomic
+  - relay
   - tnet
+  - trand
   - typed
 - name: golang.org/x/net
-  version: 04b9de9b512f58addf28c9853d50ebef61c3953e
+  version: 5916dcb167ed985a5b9e6871fbfd74848a4c170b
   subpackages:
   - context
   - context/ctxhttp

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,15 +1,21 @@
 package: github.com/yarpc/yarpc-go
 import:
 - package: golang.org/x/net
+  version: master
   subpackages:
   - context
   - context/ctxhttp
 - package: github.com/stretchr/testify
+  version: master
   subpackages:
   - assert
   - require
 - package: github.com/thriftrw/thriftrw-go
+  version: master
 - package: github.com/golang/mock
+  version: master
   subpackages:
   - gomock
 - package: github.com/uber/tchannel-go
+  # TODO: Change this to master once SubChannel.GetHandlers() is available to master.
+  version: dev

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -71,10 +71,16 @@ func (c tchannelCall) Response() inboundCallResponse {
 
 // handler wraps a transport.Handler into a TChannel Handler.
 type handler struct {
-	Handler transport.Handler
+	existing map[string]tchannel.Handler
+	Handler  transport.Handler
 }
 
 func (h handler) Handle(ctx context.Context, call *tchannel.InboundCall) {
+	if m, ok := h.existing[call.MethodString()]; ok {
+		m.Handle(ctx, call)
+		return
+	}
+
 	h.handle(ctx, tchannelCall{call})
 }
 

--- a/transport/tchannel/handler_test.go
+++ b/transport/tchannel/handler_test.go
@@ -193,7 +193,7 @@ func TestHandlerFailures(t *testing.T) {
 		resp := newResponseRecorder()
 		tt.call.resp = resp
 
-		handler{thandler}.handle(ctx, tt.call)
+		handler{nil, thandler}.handle(ctx, tt.call)
 		err := resp.systemErr
 		require.Error(t, err, "expected error for %q", tt.desc)
 


### PR DESCRIPTION
The user may want to register non-YARPC methods (and the channel may
have some meta/introspection methods) that we should respect.

cc @yarpc/golang 