### PR TITLE
cover.sh: Fix .nocover support

### DIFF
--- a/scripts/cover.sh
+++ b/scripts/cover.sh
@@ -18,10 +18,9 @@ for pkg in "$@"; do
 		if [[ -n "$filter" ]]; then
 			filter="$filter, "
 		fi
-		filter="\"$pkg\": true"
+		filter="$filter\"$pkg\": true"
 	fi
 done
-
 
 i=0
 for pkg in "$@"; do


### PR DESCRIPTION
Turns out we weren't actually respecting the `.nocover` files because we were
overwriting the list.

Resolves #143.