### PR TITLE
[crossdock-lib PART1] - Carve out space for crossdock lib

### DIFF
--- a/crossdock-go/README.md
+++ b/crossdock-go/README.md
@@ -1,0 +1,3 @@
+# Crossdock-go
+
+A Go library for writing Crossdock clients.

--- a/crossdock-go/crossdock/call.go
+++ b/crossdock-go/crossdock/call.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package crossdock
+
+import (
+	"encoding/json"
+	"log"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+	"golang.org/x/net/context/ctxhttp"
+)
+
+// Call makes a GET request to the client
+func Call(t *testing.T, clientURL string, behavior string, args url.Values) {
+	args.Set("behavior", behavior)
+	u, err := url.Parse(clientURL)
+	require.NoError(t, err, "failed to parse URL")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	u.RawQuery = args.Encode()
+	log.Println("GET", u.String())
+	res, err := ctxhttp.Get(ctx, nil, u.String())
+
+	require.NoError(t, err, "request %v failed", args)
+	defer res.Body.Close()
+
+	var results Results
+	require.NoError(t, json.NewDecoder(res.Body).Decode(&results),
+		"failed to decode response for %v", args)
+
+	for _, result := range results {
+		if result.Status != "passed" && result.Status != "skipped" {
+			t.Errorf("request %v failed: %s", args, result.Output)
+		}
+	}
+}
+
+// Results represents the response of an entire test
+type Results []Result
+
+// Result represents one of many results in a test run
+type Result struct {
+	Status string `json:"status"`
+	Output string `json:"output"`
+}

--- a/crossdock-go/crossdock/client.go
+++ b/crossdock-go/crossdock/client.go
@@ -18,64 +18,43 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package client
+package crossdock
 
 import (
 	"encoding/json"
 	"log"
 	"net/http"
-
-	"github.com/yarpc/yarpc-go/crossdock/client/behavior"
-	"github.com/yarpc/yarpc-go/crossdock/client/echo"
-	"github.com/yarpc/yarpc-go/crossdock/client/errors"
-	"github.com/yarpc/yarpc-go/crossdock/client/headers"
-	"github.com/yarpc/yarpc-go/crossdock/client/tchclient"
-	"github.com/yarpc/yarpc-go/crossdock/client/tchserver"
 )
 
 // BehaviorParam is the url param representing the test to run
 const BehaviorParam = "behavior"
 
+// Dispatcher is a func that runs when the Crossdock client receives a request
+type Dispatcher func(s Sink, behavior string, ps Params)
+
 // Start begins a blocking Crossdock client
-func Start() {
-	http.HandleFunc("/", behaviorRequestHandler)
+func Start(dispatcher Dispatcher) {
+	http.Handle("/", requestHandler{dispatcher: dispatcher})
 	log.Fatal(http.ListenAndServe(":8080", nil))
 }
 
-func behaviorRequestHandler(w http.ResponseWriter, r *http.Request) {
+type requestHandler struct {
+	dispatcher Dispatcher
+}
+
+func (h requestHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.Method == "HEAD" {
 		return
 	}
 
-	entries := behavior.Run(func(s behavior.Sink) {
-		dispatch(s, httpParams{r})
+	params := httpParams{r}
+	entries := Run(func(s Sink) {
+		h.dispatcher(s, params.Param("behavior"), params)
 	})
 
 	enc := json.NewEncoder(w)
 	if err := enc.Encode(entries); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-	}
-}
-
-func dispatch(s behavior.Sink, ps behavior.Params) {
-	v := ps.Param(BehaviorParam)
-	switch v {
-	case "raw":
-		echo.Raw(s, ps)
-	case "json":
-		echo.JSON(s, ps)
-	case "thrift":
-		echo.Thrift(s, ps)
-	case "errors":
-		errors.Run(s, ps)
-	case "headers":
-		headers.Run(s, ps)
-	case "tchclient":
-		tchclient.Run(s, ps)
-	case "tchserver":
-		tchserver.Run(s, ps)
-	default:
-		behavior.Skipf(s, "unknown behavior %q", v)
 	}
 }
 

--- a/crossdock-go/crossdock/combinations.go
+++ b/crossdock-go/crossdock/combinations.go
@@ -18,14 +18,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package main
+package crossdock
 
 import "sort"
 
-// combinations takes a map from axis name to list of values for that axis and
+// Combinations takes a map from axis name to list of values for that axis and
 // returns a collection of entries which contain all combinations of each axis
 // value with every other axis' values.
-func combinations(axes map[string][]string) []map[string]string {
+func Combinations(axes map[string][]string) []map[string]string {
 	// sort the names to get deterministic ordering
 	names := make([]string, 0, len(axes))
 	for name := range axes {

--- a/crossdock-go/crossdock/combinations_test.go
+++ b/crossdock-go/crossdock/combinations_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package main
+package crossdock
 
 import (
 	"testing"
@@ -80,6 +80,6 @@ func TestCombinations(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		assert.Equal(t, tt.want, combinations(tt.axes))
+		assert.Equal(t, tt.want, Combinations(tt.axes))
 	}
 }

--- a/crossdock-go/crossdock/doc.go
+++ b/crossdock-go/crossdock/doc.go
@@ -34,4 +34,4 @@
 // 	entries := behavior.Run(func(s Sink) {
 // 		MyBehavior(s, someParams)
 // 	})
-package behavior
+package crossdock

--- a/crossdock-go/crossdock/entry.go
+++ b/crossdock-go/crossdock/entry.go
@@ -18,32 +18,22 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package behavior
+package crossdock
 
-import "runtime/debug"
+// Status represents the result of running a behavior.
+type Status string
 
-// Run the given function inside a behavior context and return the entries
-// logged by it.
+// Different valid Statuses.
+const (
+	Passed  Status = "passed"
+	Skipped Status = "skipped"
+	Failed  Status = "failed"
+)
+
+// Entry is the most basic form of a test result.
 //
-// Functions like Fatalf won't work if the behavior is not executed inside a
-// Run context.
-func Run(f func(Sink)) []interface{} {
-	var s entrySink
-	done := make(chan struct{})
-
-	// We run the function inside a goroutine so that Fatalf can simply call
-	// runtime.Goexit to stop execution.
-	go func() {
-		defer func() {
-			if err := recover(); err != nil {
-				Errorf(&s, "%v\n%s", err, string(debug.Stack()))
-			}
-			close(done)
-		}()
-
-		f(&s)
-	}()
-
-	<-done
-	return s.entries
+// Each behavior can emit one or more entries.
+type Entry struct {
+	Status Status `json:"status"`
+	Output string `json:"output"`
 }

--- a/crossdock-go/crossdock/params.go
+++ b/crossdock-go/crossdock/params.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package behavior
+package crossdock
 
 // Params provides access to the behavior parameters.
 type Params interface {

--- a/crossdock-go/crossdock/run_test.go
+++ b/crossdock-go/crossdock/run_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package behavior
+package crossdock
 
 import (
 	"testing"

--- a/crossdock-go/crossdock/sink.go
+++ b/crossdock-go/crossdock/sink.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package behavior
+package crossdock
 
 import (
 	"fmt"

--- a/crossdock-go/crossdock/testify.go
+++ b/crossdock-go/crossdock/testify.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package behavior
+package crossdock
 
 import (
 	"fmt"

--- a/crossdock-go/crossdock/wait.go
+++ b/crossdock-go/crossdock/wait.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package crossdock
+
+import (
+	"log"
+	"testing"
+	"time"
+
+	"golang.org/x/net/context"
+	"golang.org/x/net/context/ctxhttp"
+)
+
+// Wait sends attempts HEAD requests to url
+func Wait(t *testing.T, url string, attempts int) {
+	ctx := context.Background()
+
+	for a := 0; a < attempts; a++ {
+		ctx, cancel := context.WithTimeout(ctx, time.Second)
+		defer cancel()
+
+		log.Println("HEAD", url)
+		_, err := ctxhttp.Head(ctx, nil, url)
+		if err == nil {
+			log.Println("Client is ready, beginning test...")
+			return
+		}
+
+		sleepFor := 100 * time.Millisecond
+		log.Println(err, "- sleeping for", sleepFor)
+		time.Sleep(sleepFor)
+	}
+
+	t.Fatalf("could not talk to client in %d attempts", attempts)
+}

--- a/crossdock/client/behavior/rpc.go
+++ b/crossdock/client/behavior/rpc.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 
 	"github.com/yarpc/yarpc-go"
+	"github.com/yarpc/yarpc-go/crossdock-go/crossdock"
 	"github.com/yarpc/yarpc-go/crossdock/client/params"
 	"github.com/yarpc/yarpc-go/transport"
 	ht "github.com/yarpc/yarpc-go/transport/http"
@@ -35,8 +36,8 @@ import (
 
 // CreateRPC creates an RPC from the given parameters or fails the whole
 // behavior.
-func CreateRPC(s Sink, p Params) yarpc.RPC {
-	fatals := Fatals(s)
+func CreateRPC(s crossdock.Sink, p crossdock.Params) yarpc.RPC {
+	fatals := crossdock.Fatals(s)
 
 	server := p.Param(params.Server)
 	fatals.NotEmpty(server, "server is required")

--- a/crossdock/client/behavior/rpc_test.go
+++ b/crossdock/client/behavior/rpc_test.go
@@ -24,33 +24,34 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/yarpc/yarpc-go/crossdock-go/crossdock"
 )
 
 func TestCreateRPC(t *testing.T) {
 	tests := []struct {
-		p      Params
+		p      crossdock.Params
 		errOut string
 	}{
 		{
-			ParamsFromMap{"server": "localhost"},
+			crossdock.ParamsFromMap{"server": "localhost"},
 			`unknown transport ""`,
 		},
 		{
-			ParamsFromMap{"transport": "http"},
+			crossdock.ParamsFromMap{"transport": "http"},
 			"server is required",
 		},
 		{
-			ParamsFromMap{"server": "localhost", "transport": "foo"},
+			crossdock.ParamsFromMap{"server": "localhost", "transport": "foo"},
 			`unknown transport "foo"`,
 		},
 		{
-			p: ParamsFromMap{
+			p: crossdock.ParamsFromMap{
 				"server":    "localhost",
 				"transport": "http",
 			},
 		},
 		{
-			p: ParamsFromMap{
+			p: crossdock.ParamsFromMap{
 				"server":    "localhost",
 				"transport": "tchannel",
 			},
@@ -58,7 +59,7 @@ func TestCreateRPC(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		entries := Run(func(s Sink) {
+		entries := crossdock.Run(func(s crossdock.Sink) {
 			rpc := CreateRPC(s, tt.p)
 
 			// should get here only if the request succeeded
@@ -68,8 +69,8 @@ func TestCreateRPC(t *testing.T) {
 		})
 
 		if tt.errOut != "" && assert.Len(t, entries, 1) {
-			e := entries[0].(Entry)
-			assert.Equal(t, Failed, e.Status)
+			e := entries[0].(crossdock.Entry)
+			assert.Equal(t, crossdock.Failed, e.Status)
 			assert.Contains(t, e.Output, tt.errOut)
 		}
 	}

--- a/crossdock/client/echo/behavior.go
+++ b/crossdock/client/echo/behavior.go
@@ -21,13 +21,13 @@
 package echo
 
 import (
-	"github.com/yarpc/yarpc-go/crossdock/client/behavior"
+	"github.com/yarpc/yarpc-go/crossdock-go/crossdock"
 	"github.com/yarpc/yarpc-go/crossdock/client/params"
 )
 
 // echoEntry is an entry emitted by the echo behaviors.
 type echoEntry struct {
-	behavior.Entry
+	crossdock.Entry
 
 	Transport string `json:"transport"`
 	Encoding  string `json:"encoding"`
@@ -36,7 +36,7 @@ type echoEntry struct {
 
 // echoSink wraps a sink to emit echoEntry entries instead.
 type echoSink struct {
-	behavior.Sink
+	crossdock.Sink
 
 	Transport string
 	Encoding  string
@@ -45,7 +45,7 @@ type echoSink struct {
 
 func (s echoSink) Put(e interface{}) {
 	s.Sink.Put(echoEntry{
-		Entry:     e.(behavior.Entry),
+		Entry:     e.(crossdock.Entry),
 		Transport: s.Transport,
 		Encoding:  s.Encoding,
 		Server:    s.Server,
@@ -54,7 +54,7 @@ func (s echoSink) Put(e interface{}) {
 
 // createEchoSink wraps a Sink to have transport, encoding, and server
 // information.
-func createEchoSink(encoding string, s behavior.Sink, p behavior.Params) behavior.Sink {
+func createEchoSink(encoding string, s crossdock.Sink, p crossdock.Params) crossdock.Sink {
 	return echoSink{
 		Sink:      s,
 		Transport: p.Param(params.Transport),

--- a/crossdock/client/echo/behavior_test.go
+++ b/crossdock/client/echo/behavior_test.go
@@ -23,7 +23,7 @@ package echo
 import (
 	"testing"
 
-	"github.com/yarpc/yarpc-go/crossdock/client/behavior"
+	"github.com/yarpc/yarpc-go/crossdock-go/crossdock"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -31,17 +31,17 @@ import (
 func TestEchoSink(t *testing.T) {
 	tests := []struct {
 		server, transport, encoding string
-		act                         func(behavior.Sink)
+		act                         func(crossdock.Sink)
 		entry                       echoEntry
 	}{
 		{
 			"localhost", "tchannel", "json",
-			func(s behavior.Sink) {
-				behavior.Successf(s, "it worked!")
+			func(s crossdock.Sink) {
+				crossdock.Successf(s, "it worked!")
 			},
 			echoEntry{
-				Entry: behavior.Entry{
-					Status: behavior.Passed,
+				Entry: crossdock.Entry{
+					Status: crossdock.Passed,
 					Output: "it worked!",
 				},
 				Transport: "tchannel",
@@ -51,12 +51,12 @@ func TestEchoSink(t *testing.T) {
 		},
 		{
 			"localhost", "http", "thrift",
-			func(s behavior.Sink) {
-				behavior.Skipf(s, "what even is")
+			func(s crossdock.Sink) {
+				crossdock.Skipf(s, "what even is")
 			},
 			echoEntry{
-				Entry: behavior.Entry{
-					Status: behavior.Skipped,
+				Entry: crossdock.Entry{
+					Status: crossdock.Skipped,
 					Output: "what even is",
 				},
 				Transport: "http",
@@ -66,12 +66,12 @@ func TestEchoSink(t *testing.T) {
 		},
 		{
 			"localhost", "http", "raw",
-			func(s behavior.Sink) {
-				behavior.Fatalf(s, "great sadness")
+			func(s crossdock.Sink) {
+				crossdock.Fatalf(s, "great sadness")
 			},
 			echoEntry{
-				Entry: behavior.Entry{
-					Status: behavior.Failed,
+				Entry: crossdock.Entry{
+					Status: crossdock.Failed,
 					Output: "great sadness",
 				},
 				Transport: "http",
@@ -82,8 +82,8 @@ func TestEchoSink(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		entries := behavior.Run(func(s behavior.Sink) {
-			es := createEchoSink(tt.encoding, s, behavior.ParamsFromMap{
+		entries := crossdock.Run(func(s crossdock.Sink) {
+			es := createEchoSink(tt.encoding, s, crossdock.ParamsFromMap{
 				"server":    tt.server,
 				"transport": tt.transport,
 			})

--- a/crossdock/client/echo/json.go
+++ b/crossdock/client/echo/json.go
@@ -23,6 +23,7 @@ package echo
 import (
 	"time"
 
+	"github.com/yarpc/yarpc-go/crossdock-go/crossdock"
 	"github.com/yarpc/yarpc-go/crossdock/client/behavior"
 	"github.com/yarpc/yarpc-go/crossdock/client/random"
 	"github.com/yarpc/yarpc-go/encoding/json"
@@ -36,7 +37,7 @@ type jsonEcho struct {
 }
 
 // JSON implements the 'json' behavior.
-func JSON(s behavior.Sink, p behavior.Params) {
+func JSON(s crossdock.Sink, p crossdock.Params) {
 	s = createEchoSink("json", s, p)
 	rpc := behavior.CreateRPC(s, p)
 
@@ -54,6 +55,6 @@ func JSON(s behavior.Sink, p behavior.Params) {
 		&jsonEcho{Token: token},
 		&response,
 	)
-	behavior.Fatals(s).NoError(err, "call to echo failed: %v", err)
-	behavior.Assert(s).Equal(token, response.Token, "server said: %v", response.Token)
+	crossdock.Fatals(s).NoError(err, "call to echo failed: %v", err)
+	crossdock.Assert(s).Equal(token, response.Token, "server said: %v", response.Token)
 }

--- a/crossdock/client/echo/raw.go
+++ b/crossdock/client/echo/raw.go
@@ -24,6 +24,7 @@ import (
 	"bytes"
 	"time"
 
+	"github.com/yarpc/yarpc-go/crossdock-go/crossdock"
 	"github.com/yarpc/yarpc-go/crossdock/client/behavior"
 	"github.com/yarpc/yarpc-go/crossdock/client/random"
 	"github.com/yarpc/yarpc-go/encoding/raw"
@@ -32,7 +33,7 @@ import (
 )
 
 // Raw implements the 'raw' behavior.
-func Raw(s behavior.Sink, p behavior.Params) {
+func Raw(s crossdock.Sink, p crossdock.Params) {
 	s = createEchoSink("raw", s, p)
 	rpc := behavior.CreateRPC(s, p)
 
@@ -46,6 +47,6 @@ func Raw(s behavior.Sink, p behavior.Params) {
 		TTL:       time.Second, // TODO context already has timeout; use that
 	}, token)
 
-	behavior.Fatals(s).NoError(err, "call to echo/raw failed: %v", err)
-	behavior.Assert(s).True(bytes.Equal(token, resBody), "server said: %v", resBody)
+	crossdock.Fatals(s).NoError(err, "call to echo/raw failed: %v", err)
+	crossdock.Assert(s).True(bytes.Equal(token, resBody), "server said: %v", resBody)
 }

--- a/crossdock/client/echo/thrift.go
+++ b/crossdock/client/echo/thrift.go
@@ -23,6 +23,7 @@ package echo
 import (
 	"time"
 
+	"github.com/yarpc/yarpc-go/crossdock-go/crossdock"
 	"github.com/yarpc/yarpc-go/crossdock/client/behavior"
 	"github.com/yarpc/yarpc-go/crossdock/client/random"
 	"github.com/yarpc/yarpc-go/crossdock/thrift/echo"
@@ -33,7 +34,7 @@ import (
 )
 
 // Thrift implements the 'thrift' behavior.
-func Thrift(s behavior.Sink, p behavior.Params) {
+func Thrift(s crossdock.Sink, p crossdock.Params) {
 	s = createEchoSink("thrift", s, p)
 	rpc := behavior.CreateRPC(s, p)
 
@@ -49,6 +50,6 @@ func Thrift(s behavior.Sink, p behavior.Params) {
 		&echo.Ping{Beep: token},
 	)
 
-	behavior.Fatals(s).NoError(err, "call to Echo::echo failed: %v", err)
-	behavior.Assert(s).Equal(token, pong.Boop, "server said: %v", pong.Boop)
+	crossdock.Fatals(s).NoError(err, "call to Echo::echo failed: %v", err)
+	crossdock.Assert(s).Equal(token, pong.Boop, "server said: %v", pong.Boop)
 }

--- a/crossdock/client/errors/behavior.go
+++ b/crossdock/client/errors/behavior.go
@@ -27,7 +27,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/yarpc/yarpc-go/crossdock/client/behavior"
+	"github.com/yarpc/yarpc-go/crossdock-go/crossdock"
 	"github.com/yarpc/yarpc-go/crossdock/client/params"
 	"github.com/yarpc/yarpc-go/transport"
 )
@@ -42,8 +42,8 @@ type httpResponse struct {
 	Status int
 }
 
-func (h httpClient) Call(s behavior.Sink, hs transport.Headers, body string) httpResponse {
-	fatals := behavior.Fatals(s)
+func (h httpClient) Call(s crossdock.Sink, hs transport.Headers, body string) httpResponse {
+	fatals := crossdock.Fatals(s)
 
 	req := http.Request{
 		Method:        "POST",
@@ -72,8 +72,8 @@ func (h httpClient) Call(s behavior.Sink, hs transport.Headers, body string) htt
 	}
 }
 
-func buildHTTPClient(s behavior.Sink, ps behavior.Params) httpClient {
-	fatals := behavior.Fatals(s)
+func buildHTTPClient(s crossdock.Sink, ps crossdock.Params) httpClient {
+	fatals := crossdock.Fatals(s)
 
 	server := ps.Param(params.Server)
 	fatals.NotEmpty(server, "server is required")
@@ -88,9 +88,9 @@ func buildHTTPClient(s behavior.Sink, ps behavior.Params) httpClient {
 }
 
 // Run runs the errors behavior.
-func Run(s behavior.Sink, ps behavior.Params) {
+func Run(s crossdock.Sink, ps crossdock.Params) {
 	client := buildHTTPClient(s, ps)
-	assert := behavior.Assert(s)
+	assert := crossdock.Assert(s)
 
 	// one valid request before we throw the errors at it
 	res := client.Call(s, transport.Headers{

--- a/crossdock/client/gauntlet/behavior.go
+++ b/crossdock/client/gauntlet/behavior.go
@@ -1,0 +1,512 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package gauntlet
+
+import (
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/yarpc/yarpc-go/crossdock-go/crossdock"
+	"github.com/yarpc/yarpc-go/crossdock/client/behavior"
+	"github.com/yarpc/yarpc-go/crossdock/client/params"
+	"github.com/yarpc/yarpc-go/crossdock/client/random"
+	"github.com/yarpc/yarpc-go/crossdock/thrift/gauntlet"
+	"github.com/yarpc/yarpc-go/crossdock/thrift/gauntlet/yarpc/secondserviceclient"
+	"github.com/yarpc/yarpc-go/crossdock/thrift/gauntlet/yarpc/thrifttestclient"
+	"github.com/yarpc/yarpc-go/encoding/thrift"
+	"github.com/yarpc/yarpc-go/transport"
+
+	"golang.org/x/net/context"
+)
+
+type gauntletEntry struct {
+	crossdock.Entry
+
+	Transport string `json:"transport"`
+	Server    string `json:"server"`
+}
+
+type gauntletSink struct {
+	crossdock.Sink
+
+	Transport string
+	Server    string
+}
+
+func (s gauntletSink) Put(e interface{}) {
+	s.Sink.Put(gauntletEntry{
+		Entry:     e.(crossdock.Entry),
+		Transport: s.Transport,
+		Server:    s.Server,
+	})
+}
+
+func createGauntletSink(s crossdock.Sink, ps crossdock.Params) crossdock.Sink {
+	return gauntletSink{
+		Sink:      s,
+		Transport: ps.Param(params.Transport),
+		Server:    ps.Param(params.Server),
+	}
+}
+
+// Run executes the thriftgauntlet behavior.
+func Run(s crossdock.Sink, ps crossdock.Params) {
+	s = createGauntletSink(s, ps)
+	assert := crossdock.Assert(s)
+	checks := crossdock.Checks(s)
+
+	rpc := behavior.CreateRPC(s, ps)
+
+	bytesToken := random.Bytes(10)
+	tests := []struct {
+		service  string        // thrift service name; defaults to ThriftTest
+		function string        // name of the Go function on the client
+		details  string        // optional extra details about what this test does
+		give     []interface{} // arguments besides thrift.Request
+
+		want          interface{} // expected response; nil for void
+		wantError     error       // expected error
+		wantErrorLike string      // for just matching error messages
+	}{
+		{
+			function: "TestBinary",
+			give:     []interface{}{bytesToken},
+			want:     bytesToken,
+		},
+		{
+			function: "TestByte",
+			give:     []interface{}{bytep(42)},
+			want:     int8(42),
+		},
+		{
+			function: "TestDouble",
+			give:     []interface{}{doublep(12.34)},
+			want:     float64(12.34),
+		},
+		{
+			function: "TestEnum",
+			details:  "MyNumberz",
+			give:     []interface{}{numberzp(gauntlet.MyNumberz)},
+			want:     gauntlet.MyNumberz,
+		},
+		{
+			function: "TestEnum",
+			details:  "NumberzThree",
+			give:     []interface{}{numberzp(gauntlet.NumberzThree)},
+			want:     gauntlet.NumberzThree,
+		},
+		{
+			function: "TestEnum",
+			details:  "unrecognized Numberz",
+			give:     []interface{}{numberzp(gauntlet.Numberz(42))},
+			want:     gauntlet.Numberz(42),
+		},
+		{
+			function: "TestException",
+			details:  "Xception",
+			give:     []interface{}{stringp("Xception")},
+			wantError: &gauntlet.Xception{
+				ErrorCode: int32p(1001),
+				Message:   stringp("Xception"),
+			},
+		},
+		{
+			function:      "TestException",
+			details:       "TException",
+			give:          []interface{}{stringp("TException")},
+			wantErrorLike: `UnexpectedError: error for procedure "ThriftTest::testException" of service "yarpc-test": great sadness`,
+		},
+		{
+			function: "TestException",
+			details:  "no error",
+			give:     []interface{}{stringp("yolo")},
+		},
+		{
+			function: "TestI32",
+			give:     []interface{}{int32p(123)},
+			want:     int32(123),
+		},
+		{
+			function: "TestI64",
+			give:     []interface{}{int64p(18934714)},
+			want:     int64(18934714),
+		},
+		{
+			function: "TestInsanity",
+			give: []interface{}{
+				&gauntlet.Insanity{
+					UserMap: map[gauntlet.Numberz]gauntlet.UserId{
+						gauntlet.NumberzThree: gauntlet.UserId(100),
+						gauntlet.Numberz(100): gauntlet.UserId(200),
+					},
+					Xtructs: []*gauntlet.Xtruct{
+						{StringThing: stringp("0")},
+						{ByteThing: bytep(1)},
+						{I32Thing: int32p(2)},
+						{I64Thing: int64p(3)},
+					},
+				},
+			},
+			want: map[gauntlet.UserId]map[gauntlet.Numberz]*gauntlet.Insanity{
+				1: {
+					gauntlet.NumberzTwo: &gauntlet.Insanity{
+						UserMap: map[gauntlet.Numberz]gauntlet.UserId{
+							gauntlet.NumberzThree: gauntlet.UserId(100),
+							gauntlet.Numberz(100): gauntlet.UserId(200),
+						},
+						Xtructs: []*gauntlet.Xtruct{
+							{StringThing: stringp("0")},
+							{ByteThing: bytep(1)},
+							{I32Thing: int32p(2)},
+							{I64Thing: int64p(3)},
+						},
+					},
+					gauntlet.NumberzThree: &gauntlet.Insanity{
+						UserMap: map[gauntlet.Numberz]gauntlet.UserId{
+							gauntlet.NumberzThree: gauntlet.UserId(100),
+							gauntlet.Numberz(100): gauntlet.UserId(200),
+						},
+						Xtructs: []*gauntlet.Xtruct{
+							{StringThing: stringp("0")},
+							{ByteThing: bytep(1)},
+							{I32Thing: int32p(2)},
+							{I64Thing: int64p(3)},
+						},
+					},
+				},
+				2: {
+					gauntlet.NumberzSix: &gauntlet.Insanity{},
+				},
+			},
+		},
+		{
+			function: "TestList",
+			give:     []interface{}{[]int32{1, 2, 3}},
+			want:     []int32{1, 2, 3},
+		},
+		{
+			function: "TestMap",
+			give:     []interface{}{map[int32]int32{1: 2, 3: 4, 5: 6}},
+			want:     map[int32]int32{1: 2, 3: 4, 5: 6},
+		},
+		{
+			function: "TestMapMap",
+			give:     []interface{}{int32p(42)},
+			want: map[int32]map[int32]int32{
+				-4: {
+					-4: -4,
+					-3: -3,
+					-2: -2,
+					-1: -1,
+				},
+				4: {
+					1: 1,
+					2: 2,
+					3: 3,
+					4: 4,
+				},
+			},
+		},
+		{
+			function: "TestMulti",
+			give: []interface{}{
+				bytep(100),
+				int32p(200),
+				int64p(300),
+				map[int16]string{1: "1", 2: "2", 3: "3"},
+				numberzp(gauntlet.NumberzEight),
+				useridp(42),
+			},
+			want: &gauntlet.Xtruct{
+				StringThing: stringp("Hello2"),
+				ByteThing:   bytep(100),
+				I32Thing:    int32p(200),
+				I64Thing:    int64p(300),
+			},
+		},
+		{
+			function: "TestMultiException",
+			details:  "Xception",
+			give:     []interface{}{stringp("Xception"), stringp("foo")},
+			wantError: &gauntlet.Xception{
+				ErrorCode: int32p(1001),
+				Message:   stringp("This is an Xception"),
+			},
+		},
+		{
+			function: "TestMultiException",
+			details:  "Xception2",
+			give:     []interface{}{stringp("Xception2"), stringp("foo")},
+			wantError: &gauntlet.Xception2{
+				ErrorCode:   int32p(2002),
+				StructThing: &gauntlet.Xtruct{StringThing: stringp("foo")},
+			},
+		},
+		{
+			function: "TestMultiException",
+			details:  "no error",
+			give:     []interface{}{stringp("hello"), stringp("foo")},
+			want:     &gauntlet.Xtruct{StringThing: stringp("foo")},
+		},
+		{
+			function: "TestNest",
+			give: []interface{}{
+				&gauntlet.Xtruct2{
+					ByteThing: bytep(-1),
+					I32Thing:  int32p(-1234),
+					StructThing: &gauntlet.Xtruct{
+						StringThing: stringp("0"),
+						ByteThing:   bytep(1),
+						I32Thing:    int32p(2),
+						I64Thing:    int64p(3),
+					},
+				},
+			},
+			want: &gauntlet.Xtruct2{
+				ByteThing: bytep(-1),
+				I32Thing:  int32p(-1234),
+				StructThing: &gauntlet.Xtruct{
+					StringThing: stringp("0"),
+					ByteThing:   bytep(1),
+					I32Thing:    int32p(2),
+					I64Thing:    int64p(3),
+				},
+			},
+		},
+		{
+			function: "TestSet",
+			give: []interface{}{
+				map[int32]struct{}{
+					1:  struct{}{},
+					2:  struct{}{},
+					-1: struct{}{},
+					-2: struct{}{},
+				},
+			},
+			want: map[int32]struct{}{
+				1:  struct{}{},
+				2:  struct{}{},
+				-1: struct{}{},
+				-2: struct{}{},
+			},
+		},
+		{
+			function: "TestString",
+			give:     []interface{}{stringp("hello")},
+			want:     "hello",
+		},
+		{
+			function: "TestStringMap",
+			give: []interface{}{
+				map[string]string{
+					"foo":   "bar",
+					"hello": "world",
+				},
+			},
+			want: map[string]string{
+				"foo":   "bar",
+				"hello": "world",
+			},
+		},
+		{
+			function: "TestStruct",
+			give: []interface{}{
+				&gauntlet.Xtruct{
+					StringThing: stringp("0"),
+					ByteThing:   bytep(1),
+					I32Thing:    int32p(2),
+					I64Thing:    int64p(3),
+				},
+			},
+			want: &gauntlet.Xtruct{
+				StringThing: stringp("0"),
+				ByteThing:   bytep(1),
+				I32Thing:    int32p(2),
+				I64Thing:    int64p(3),
+			},
+		},
+		{
+			function: "TestTypedef",
+			give:     []interface{}{useridp(42)},
+			want:     gauntlet.UserId(42),
+		},
+		{
+			function: "TestVoid",
+			give:     []interface{}{},
+		},
+		{
+			service:  "SecondService",
+			function: "BlahBlah",
+			give:     []interface{}{},
+		},
+		{
+			service:  "SecondService",
+			function: "SecondtestString",
+			give:     []interface{}{stringp("hello")},
+			want:     "hello",
+		},
+	}
+
+	for _, tt := range tests {
+		// We log in one of the following formats,
+		//
+		// $function: $message
+		// $function: $description: $message
+		// $service: $function: $message
+		// $service: $function: $description: $message
+		desc := tt.function
+		if tt.details != "" {
+			desc = desc + ": " + tt.details
+		}
+		if tt.service != "" {
+			desc = tt.service + ": " + desc
+		}
+
+		client := buildClient(s, desc, tt.service, rpc.Channel("yarpc-test"))
+		f := client.MethodByName(tt.function)
+		if !checks.True(f.IsValid(), "%v: invalid function", desc) {
+			continue
+		}
+
+		ctx, _ := context.WithTimeout(context.Background(), time.Second)
+		req := thrift.Request{
+			Context: ctx,
+			TTL:     time.Second, // TODO context TTL should be enough
+		}
+
+		args := []reflect.Value{reflect.ValueOf(&req)}
+		if give, ok := buildArgs(s, desc, f.Type(), tt.give); ok {
+			args = append(args, give...)
+		} else {
+			continue
+		}
+
+		got, err := extractCallResponse(s, desc, f.Call(args))
+		if isUnrecognizedProcedure(err) {
+			crossdock.Skipf(s, "%v: procedure not defined", desc)
+			continue
+		}
+
+		if tt.wantError != nil || tt.wantErrorLike != "" {
+			if !checks.Error(err, "%v: expected failure but got: %v", desc, got) {
+				continue
+			}
+			if tt.wantError != nil {
+				assert.Equal(tt.wantError, err, "%v: server returned error: %v", desc, err)
+			}
+			if tt.wantErrorLike != "" {
+				assert.Contains(err.Error(), tt.wantErrorLike, "%v: server returned error: %v", desc, err)
+			}
+		} else {
+			if !checks.NoError(err, "%v: call failed", desc) {
+				continue
+			}
+
+			if tt.want != nil {
+				assert.Equal(tt.want, got, "%v: server returned: %v", desc, got)
+			}
+		}
+	}
+}
+
+func isUnrecognizedProcedure(err error) bool {
+	if _, isBadRequest := err.(transport.BadRequestError); isBadRequest {
+		// TODO: Once all other languages implement the gauntlet test
+		// subject, we can remove this check.
+		return strings.Contains(err.Error(), "unrecognized procedure")
+	}
+	return false
+}
+
+func buildClient(s crossdock.Sink, desc string, service string, channel transport.Channel) reflect.Value {
+	switch service {
+	case "", "ThriftTest":
+		return reflect.ValueOf(thrifttestclient.New(channel))
+	case "SecondService":
+		return reflect.ValueOf(secondserviceclient.New(channel))
+	default:
+		crossdock.Fatals(s).Fail("", "%v: unknown thrift service", desc)
+		return reflect.Value{} // we'll never actually get here
+	}
+}
+
+func extractCallResponse(s crossdock.Sink, desc string, returns []reflect.Value) (interface{}, error) {
+	var (
+		err error
+		got interface{}
+	)
+
+	switch len(returns) {
+	case 2:
+		e := returns[1].Interface()
+		if e != nil {
+			err = e.(error)
+		}
+	case 3:
+		got = returns[0].Interface()
+		e := returns[2].Interface()
+		if e != nil {
+			err = e.(error)
+		}
+	default:
+		crossdock.Assert(s).Fail("",
+			"%v: received unexpected number of return values: %v", desc, returns)
+	}
+
+	return got, err
+}
+
+func buildArgs(s crossdock.Sink, desc string, ft reflect.Type, give []interface{}) (_ []reflect.Value, ok bool) {
+	check := crossdock.Checks(s)
+	wantIn := len(give) + 1
+	if !check.Equal(wantIn, ft.NumIn(), "%v: should accept %d arguments", desc, wantIn) {
+		return nil, false
+	}
+
+	var args []reflect.Value
+	for i, v := range give {
+		var val reflect.Value
+		vt := ft.In(i + 1)
+		if v == nil {
+			// nil is an invalid argument to ValueOf. For nil, use the zero
+			// value for that argument.
+			val = reflect.Zero(vt)
+		} else {
+			val = reflect.ValueOf(v)
+		}
+		if !check.Equal(vt, val.Type(), "%v: argument %v type mismatch", desc, i) {
+			return nil, false
+		}
+		args = append(args, val)
+	}
+
+	return args, true
+}
+
+func bytep(x int8) *int8         { return &x }
+func int32p(x int32) *int32      { return &x }
+func int64p(x int64) *int64      { return &x }
+func doublep(x float64) *float64 { return &x }
+func stringp(x string) *string   { return &x }
+
+func numberzp(x gauntlet.Numberz) *gauntlet.Numberz { return &x }
+func useridp(x gauntlet.UserId) *gauntlet.UserId    { return &x }

--- a/crossdock/client/headers/behavior.go
+++ b/crossdock/client/headers/behavior.go
@@ -23,6 +23,7 @@ package headers
 import (
 	"time"
 
+	"github.com/yarpc/yarpc-go/crossdock-go/crossdock"
 	"github.com/yarpc/yarpc-go/crossdock/client/behavior"
 	"github.com/yarpc/yarpc-go/crossdock/client/params"
 	"github.com/yarpc/yarpc-go/crossdock/client/random"
@@ -38,7 +39,7 @@ import (
 
 // headersEntry is an entry emitted by the headers behavior.
 type headersEntry struct {
-	behavior.Entry
+	crossdock.Entry
 
 	Transport string `json:"transport"`
 	Encoding  string `json:"encoding"`
@@ -47,7 +48,7 @@ type headersEntry struct {
 
 // headersSink wraps a sink to emit headersEntry entries.
 type headersSink struct {
-	behavior.Sink
+	crossdock.Sink
 
 	Transport string
 	Encoding  string
@@ -56,14 +57,14 @@ type headersSink struct {
 
 func (s headersSink) Put(e interface{}) {
 	s.Sink.Put(headersEntry{
-		Entry:     e.(behavior.Entry),
+		Entry:     e.(crossdock.Entry),
 		Transport: s.Transport,
 		Encoding:  s.Encoding,
 		Server:    s.Server,
 	})
 }
 
-func createHeadersSink(s behavior.Sink, ps behavior.Params) behavior.Sink {
+func createHeadersSink(s crossdock.Sink, ps crossdock.Params) crossdock.Sink {
 	return headersSink{
 		Sink:      s,
 		Transport: ps.Param(params.Transport),
@@ -73,13 +74,13 @@ func createHeadersSink(s behavior.Sink, ps behavior.Params) behavior.Sink {
 }
 
 // Run runs the headers behavior
-func Run(s behavior.Sink, ps behavior.Params) {
+func Run(s crossdock.Sink, ps crossdock.Params) {
 	s = createHeadersSink(s, ps)
 	rpc := behavior.CreateRPC(s, ps)
 
-	fatals := behavior.Fatals(s)
-	assert := behavior.Assert(s)
-	checks := behavior.Checks(s)
+	fatals := crossdock.Fatals(s)
+	assert := crossdock.Assert(s)
+	checks := crossdock.Checks(s)
 
 	var caller headerCaller
 	encoding := ps.Param(params.Encoding)

--- a/crossdock/client/tchclient/behavior.go
+++ b/crossdock/client/tchclient/behavior.go
@@ -23,7 +23,7 @@ package tchclient
 import (
 	"fmt"
 
-	"github.com/yarpc/yarpc-go/crossdock/client/behavior"
+	"github.com/yarpc/yarpc-go/crossdock-go/crossdock"
 	"github.com/yarpc/yarpc-go/crossdock/client/params"
 
 	"github.com/uber/tchannel-go"
@@ -37,8 +37,8 @@ const (
 var log = tchannel.SimpleLogger
 
 // Run executes the tchclient test
-func Run(s behavior.Sink, ps behavior.Params) {
-	fatals := behavior.Fatals(s)
+func Run(s crossdock.Sink, ps crossdock.Params) {
+	fatals := crossdock.Fatals(s)
 
 	encoding := ps.Param(params.Encoding)
 	server := ps.Param(params.Server)

--- a/crossdock/client/tchclient/json.go
+++ b/crossdock/client/tchclient/json.go
@@ -23,15 +23,15 @@ package tchclient
 import (
 	"time"
 
-	"github.com/yarpc/yarpc-go/crossdock/client/behavior"
+	"github.com/yarpc/yarpc-go/crossdock-go/crossdock"
 	"github.com/yarpc/yarpc-go/crossdock/client/random"
 
 	"github.com/uber/tchannel-go/json"
 )
 
-func runJSON(s behavior.Sink, call call) {
-	assert := behavior.Assert(s)
-	checks := behavior.Checks(s)
+func runJSON(s crossdock.Sink, call call) {
+	assert := crossdock.Assert(s)
+	checks := crossdock.Checks(s)
 
 	headers := map[string]string{
 		"hello": "json",

--- a/crossdock/client/tchclient/raw.go
+++ b/crossdock/client/tchclient/raw.go
@@ -23,16 +23,16 @@ package tchclient
 import (
 	"time"
 
-	"github.com/yarpc/yarpc-go/crossdock/client/behavior"
+	"github.com/yarpc/yarpc-go/crossdock-go/crossdock"
 	"github.com/yarpc/yarpc-go/crossdock/client/random"
 
 	"github.com/uber/tchannel-go/raw"
 	"golang.org/x/net/context"
 )
 
-func runRaw(s behavior.Sink, call call) {
-	assert := behavior.Assert(s)
-	checks := behavior.Checks(s)
+func runRaw(s crossdock.Sink, call call) {
+	assert := crossdock.Assert(s)
+	checks := crossdock.Checks(s)
 
 	headers := []byte{
 		0x00, 0x01, // 1 header

--- a/crossdock/client/tchclient/thrift.go
+++ b/crossdock/client/tchclient/thrift.go
@@ -23,16 +23,16 @@ package tchclient
 import (
 	"time"
 
-	"github.com/yarpc/yarpc-go/crossdock/client/behavior"
+	"github.com/yarpc/yarpc-go/crossdock-go/crossdock"
 	"github.com/yarpc/yarpc-go/crossdock/client/random"
 	"github.com/yarpc/yarpc-go/crossdock/thrift/gen-go/echo"
 
 	"github.com/uber/tchannel-go/thrift"
 )
 
-func runThrift(s behavior.Sink, call call) {
-	assert := behavior.Assert(s)
-	checks := behavior.Checks(s)
+func runThrift(s crossdock.Sink, call call) {
+	assert := crossdock.Assert(s)
+	checks := crossdock.Checks(s)
 
 	headers := map[string]string{
 		"hello": "thrift",

--- a/crossdock/client/tchserver/behavior.go
+++ b/crossdock/client/tchserver/behavior.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 
 	"github.com/yarpc/yarpc-go"
-	"github.com/yarpc/yarpc-go/crossdock/client/behavior"
+	"github.com/yarpc/yarpc-go/crossdock-go/crossdock"
 	"github.com/yarpc/yarpc-go/crossdock/client/params"
 	"github.com/yarpc/yarpc-go/transport"
 	tch "github.com/yarpc/yarpc-go/transport/tchannel"
@@ -38,8 +38,8 @@ const (
 )
 
 // Run executes the tchserver test
-func Run(s behavior.Sink, ps behavior.Params) {
-	fatals := behavior.Fatals(s)
+func Run(s crossdock.Sink, ps crossdock.Params) {
+	fatals := crossdock.Fatals(s)
 
 	encoding := ps.Param(params.Encoding)
 	server := ps.Param(params.Server)

--- a/crossdock/client/tchserver/json.go
+++ b/crossdock/client/tchserver/json.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/yarpc/yarpc-go"
-	"github.com/yarpc/yarpc-go/crossdock/client/behavior"
+	"github.com/yarpc/yarpc-go/crossdock-go/crossdock"
 	"github.com/yarpc/yarpc-go/crossdock/client/random"
 	"github.com/yarpc/yarpc-go/encoding/json"
 	"github.com/yarpc/yarpc-go/transport"
@@ -32,9 +32,9 @@ import (
 	"golang.org/x/net/context"
 )
 
-func runJSON(s behavior.Sink, rpc yarpc.RPC) {
-	assert := behavior.Assert(s)
-	checks := behavior.Checks(s)
+func runJSON(s crossdock.Sink, rpc yarpc.RPC) {
+	assert := crossdock.Assert(s)
+	checks := crossdock.Checks(s)
 
 	headers := transport.Headers{
 		"hello": "json",

--- a/crossdock/client/tchserver/raw.go
+++ b/crossdock/client/tchserver/raw.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/yarpc/yarpc-go"
-	"github.com/yarpc/yarpc-go/crossdock/client/behavior"
+	"github.com/yarpc/yarpc-go/crossdock-go/crossdock"
 	"github.com/yarpc/yarpc-go/crossdock/client/random"
 	"github.com/yarpc/yarpc-go/encoding/raw"
 	"github.com/yarpc/yarpc-go/transport"
@@ -32,9 +32,9 @@ import (
 	"golang.org/x/net/context"
 )
 
-func runRaw(s behavior.Sink, rpc yarpc.RPC) {
-	assert := behavior.Assert(s)
-	checks := behavior.Checks(s)
+func runRaw(s crossdock.Sink, rpc yarpc.RPC) {
+	assert := crossdock.Assert(s)
+	checks := crossdock.Checks(s)
 
 	// TODO headers should be at yarpc, not transport
 	headers := transport.Headers{

--- a/crossdock/client/tchserver/skip.go
+++ b/crossdock/client/tchserver/skip.go
@@ -23,16 +23,16 @@ package tchserver
 import (
 	"net"
 
-	"github.com/yarpc/yarpc-go/crossdock/client/behavior"
+	"github.com/yarpc/yarpc-go/crossdock-go/crossdock"
 )
 
 // skipOnConnRefused will mark the test as skipped if we get ECONNREFUSED.
 // This just means that the server we are hitting has not yet implemented a
 // pure TCH server at port 8083. This is OK, Go is the only one who has done it this.
-func skipOnConnRefused(s behavior.Sink, err error) bool {
+func skipOnConnRefused(s crossdock.Sink, err error) bool {
 	switch err.(type) {
 	case *net.OpError:
-		behavior.Skipf(s, "tchannel server not implemented: %v", err)
+		crossdock.Skipf(s, "tchannel server not implemented: %v", err)
 		return true
 	}
 	return false

--- a/crossdock/client/tchserver/thrift.go
+++ b/crossdock/client/tchserver/thrift.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/yarpc/yarpc-go"
-	"github.com/yarpc/yarpc-go/crossdock/client/behavior"
+	"github.com/yarpc/yarpc-go/crossdock-go/crossdock"
 	"github.com/yarpc/yarpc-go/crossdock/client/random"
 	"github.com/yarpc/yarpc-go/crossdock/thrift/echo"
 	"github.com/yarpc/yarpc-go/crossdock/thrift/echo/yarpc/echoclient"
@@ -34,9 +34,9 @@ import (
 	"golang.org/x/net/context"
 )
 
-func runThrift(s behavior.Sink, rpc yarpc.RPC) {
-	assert := behavior.Assert(s)
-	checks := behavior.Checks(s)
+func runThrift(s crossdock.Sink, rpc yarpc.RPC) {
+	assert := crossdock.Assert(s)
+	checks := crossdock.Checks(s)
 
 	headers := transport.Headers{
 		"hello": "thrift",

--- a/crossdock/crossdock_test.go
+++ b/crossdock/crossdock_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/yarpc/yarpc-go/crossdock-go/crossdock"
 	"github.com/yarpc/yarpc-go/crossdock/client"
 	"github.com/yarpc/yarpc-go/crossdock/server"
 
@@ -109,7 +110,7 @@ func TestCrossdock(t *testing.T) {
 			continue
 		}
 
-		for _, entry := range combinations(bb.axes) {
+		for _, entry := range crossdock.Combinations(bb.axes) {
 			entryArgs := url.Values{}
 			for k := range args {
 				entryArgs.Set(k, args.Get(k))

--- a/crossdock/crossdock_test.go
+++ b/crossdock/crossdock_test.go
@@ -25,7 +25,6 @@ import (
 	"testing"
 
 	"github.com/yarpc/yarpc-go/crossdock-go/crossdock"
-	"github.com/yarpc/yarpc-go/crossdock/client"
 	"github.com/yarpc/yarpc-go/crossdock/server"
 )
 
@@ -34,7 +33,7 @@ const clientURL = "http://127.0.0.1:8080"
 func TestCrossdock(t *testing.T) {
 	server.Start()
 	defer server.Stop()
-	go client.Start()
+	go crossdock.Start(dispatch)
 
 	crossdock.Wait(t, clientURL, 10)
 
@@ -81,6 +80,12 @@ func TestCrossdock(t *testing.T) {
 			name: "tchserver",
 			axes: axes{
 				"encoding": []string{"raw", "json", "thrift"},
+			},
+		},
+		{
+			name: "thriftgauntlet",
+			axes: axes{
+				"transport": []string{"http", "tchannel"},
 			},
 		},
 	}

--- a/crossdock/crossdock_test.go
+++ b/crossdock/crossdock_test.go
@@ -48,7 +48,7 @@ func TestCrossdock(t *testing.T) {
 	defer server.Stop()
 	go client.Start()
 
-	wait(t)
+	crossdock.Wait(t, clientURL, 10)
 
 	type params map[string]string
 	type axes map[string][]string
@@ -125,29 +125,6 @@ func TestCrossdock(t *testing.T) {
 			call(t, entryArgs)
 		}
 	}
-}
-
-func wait(t *testing.T) {
-	totalAttempts := 10
-	ctx := context.Background()
-
-	for attempts := 0; attempts < totalAttempts; attempts++ {
-		ctx, cancel := context.WithTimeout(ctx, time.Second)
-		defer cancel()
-
-		log.Println("HEAD", clientURL)
-		_, err := ctxhttp.Head(ctx, nil, clientURL)
-		if err == nil {
-			log.Println("Client is ready, beginning test...")
-			return
-		}
-
-		sleepFor := 100 * time.Millisecond
-		log.Println(err, "- sleeping for", sleepFor)
-		time.Sleep(sleepFor)
-	}
-
-	t.Fatalf("could not talk to client in %d attempts", totalAttempts)
 }
 
 func call(t *testing.T, args url.Values) {

--- a/crossdock/main.go
+++ b/crossdock/main.go
@@ -21,11 +21,40 @@
 package main
 
 import (
-	"github.com/yarpc/yarpc-go/crossdock/client"
+	"github.com/yarpc/yarpc-go/crossdock-go/crossdock"
+	"github.com/yarpc/yarpc-go/crossdock/client/echo"
+	"github.com/yarpc/yarpc-go/crossdock/client/errors"
+	"github.com/yarpc/yarpc-go/crossdock/client/gauntlet"
+	"github.com/yarpc/yarpc-go/crossdock/client/headers"
+	"github.com/yarpc/yarpc-go/crossdock/client/tchclient"
+	"github.com/yarpc/yarpc-go/crossdock/client/tchserver"
 	"github.com/yarpc/yarpc-go/crossdock/server"
 )
 
 func main() {
 	server.Start()
-	client.Start()
+	crossdock.Start(dispatch)
+}
+
+func dispatch(s crossdock.Sink, behavior string, ps crossdock.Params) {
+	switch behavior {
+	case "raw":
+		echo.Raw(s, ps)
+	case "json":
+		echo.JSON(s, ps)
+	case "thrift":
+		echo.Thrift(s, ps)
+	case "errors":
+		errors.Run(s, ps)
+	case "headers":
+		headers.Run(s, ps)
+	case "tchclient":
+		tchclient.Run(s, ps)
+	case "tchserver":
+		tchserver.Run(s, ps)
+	case "thriftgauntlet":
+		gauntlet.Run(s, ps)
+	default:
+		crossdock.Skipf(s, "unknown behavior %q", behavior)
+	}
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
             - AXIS_TRANSPORT=http,tchannel
             - AXIS_ENCODING=raw,json,thrift
             - AXIS_ERRORS=go,node
+            - AXIS_GAUNTLET=go
 
             - BEHAVIOR_RAW=client,server,transport
             - BEHAVIOR_JSON=client,server,transport
@@ -25,6 +26,7 @@ services:
             - BEHAVIOR_ERRORS=errors,server
             - BEHAVIOR_TCHCLIENT=client,server,encoding
             - BEHAVIOR_TCHSERVER=client,server,encoding
+            - BEHAVIOR_THRIFTGAUNTLET=gauntlet,server,transport
 
     go:
         build: .


### PR DESCRIPTION
This just moves a few pieces into a new top-level package, `crossdock-go`. 

@yarpc/golang 

I'd like to play with #148 next, but want to start moving out the reusable pieces first.