### PR TITLE
transport/inbound: Track application errors

### DIFF
--- a/encoding/json/response.go
+++ b/encoding/json/response.go
@@ -27,4 +27,7 @@ type Response struct {
 	Headers transport.Headers
 
 	// TODO Response context?
+
+	// TODO Allow users to specify that this JSON response contains an
+	// application error.
 }

--- a/transport/http/handler.go
+++ b/transport/http/handler.go
@@ -99,3 +99,7 @@ func (rw responseWriter) Write(s []byte) (int, error) {
 func (rw responseWriter) AddHeaders(h transport.Headers) {
 	toHTTPHeader(h, rw.w.Header())
 }
+
+func (responseWriter) SetApplicationError() {
+	// Nothing to do.
+}

--- a/transport/response.go
+++ b/transport/response.go
@@ -32,9 +32,14 @@ type Response struct {
 type ResponseWriter interface {
 	io.Writer
 
-	// AddHeaders adds the given headers to the response. If called, this must
+	// AddHeaders adds the given headers to the response. If called, this MUST
 	// be called before any invocation of Write().
 	//
 	// This MUST NOT panic if Headers is nil.
 	AddHeaders(Headers)
+
+	// SetApplicationError specifies that this response contains an
+	// application error. If called, this MUST be called before any invocation
+	// of Write().
+	SetApplicationError()
 }

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -21,6 +21,7 @@
 package tchannel
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/yarpc/yarpc-go/internal/encoding"
@@ -57,6 +58,7 @@ type inboundCallResponse interface {
 	Arg2Writer() (tchannel.ArgWriter, error)
 	Arg3Writer() (tchannel.ArgWriter, error)
 	SendSystemError(err error) error
+	SetApplicationError() error
 }
 
 // tchannelCall wraps a TChannel InboundCall into an inboundCall.
@@ -167,6 +169,16 @@ func (rw *responseWriter) AddHeaders(h transport.Headers) {
 	}
 	for k, v := range h {
 		rw.headers.Set(k, v)
+	}
+}
+
+func (rw *responseWriter) SetApplicationError() {
+	if rw.wroteHeaders {
+		panic("SetApplicationError() cannot be called after calling Write().")
+	}
+	err := rw.response.SetApplicationError()
+	if err != nil {
+		panic(fmt.Sprintf("SetApplicationError() failed: %v", err))
 	}
 }
 

--- a/transport/tchannel/tchannel_utils_test.go
+++ b/transport/tchannel/tchannel_utils_test.go
@@ -80,8 +80,9 @@ func (i *fakeInboundCall) Arg3Reader() (tchannel.ArgReader, error) {
 //
 // The recorder will throw an error if arg2 or arg3 are set to nil.
 type responseRecorder struct {
-	arg2, arg3 *bufferArgWriter
-	systemErr  error
+	arg2, arg3       *bufferArgWriter
+	systemErr        error
+	applicationError bool
 }
 
 func newResponseRecorder() *responseRecorder {
@@ -107,5 +108,10 @@ func (rr *responseRecorder) Arg3Writer() (tchannel.ArgWriter, error) {
 
 func (rr *responseRecorder) SendSystemError(err error) error {
 	rr.systemErr = err
+	return nil
+}
+
+func (rr *responseRecorder) SetApplicationError() error {
+	rr.applicationError = true
 	return nil
 }

--- a/transport/transporttest/reqres.go
+++ b/transport/transporttest/reqres.go
@@ -204,8 +204,14 @@ func (m ResponseMatcher) Matches(got interface{}) bool {
 // FakeResponseWriter is a ResponseWriter that records the headers and the body
 // written to it.
 type FakeResponseWriter struct {
-	Headers transport.Headers
-	Body    bytes.Buffer
+	IsApplicationError bool
+	Headers            transport.Headers
+	Body               bytes.Buffer
+}
+
+// SetApplicationError for FakeResponseWriter.
+func (fw *FakeResponseWriter) SetApplicationError() {
+	fw.IsApplicationError = true
 }
 
 // AddHeaders for FakeResponseWriter.


### PR DESCRIPTION
This allows encoding implementations to set the application error flag on
TChannel responses. HTTP doesn't do anything special for application errors.

----

Thrift application errors will be plugged into this API in a different PR.

CC @yarpc/golang