### PR TITLE
http: Refactor header extraction logic to allow customizing the prefix

### DIFF
--- a/transport/http/constants.go
+++ b/transport/http/constants.go
@@ -21,6 +21,15 @@
 package http
 
 const (
+	// ApplicationHeaderPrefix is the prefix added to application headers over
+	// the wire.
+	ApplicationHeaderPrefix = "Rpc-Header-"
+
+	// ContextHeaderPrefix is the prefix added to context headers over the wire.
+	ContextHeaderPrefix = "Context-"
+
+	// TODO(abg): Allow customizing header prefixes
+
 	// CallerHeader is the HTTP header used to indiate the service doing the calling
 	CallerHeader = "Rpc-Caller"
 
@@ -29,17 +38,11 @@ const (
 	EncodingHeader = "Rpc-Encoding"
 
 	// TTLMSHeader is the HTTP header used to indicate the ttl in ms
-	TTLMSHeader = "Context-TTL-MS"
+	TTLMSHeader = ContextHeaderPrefix + "TTL-MS"
 
 	// ProcedureHeader is the HTTP header used to indicate the procedure
 	ProcedureHeader = "Rpc-Procedure"
 
 	// ServiceHeader is the HTTP header used to indicate the service
 	ServiceHeader = "Rpc-Service"
-
-	// ApplicationHeaderPrefix is the prefix added to application headers over
-	// the wire.
-	ApplicationHeaderPrefix = "Rpc-Header-"
 )
-
-// TODO Make consistent with other languages^

--- a/transport/http/handler.go
+++ b/transport/http/handler.go
@@ -69,7 +69,7 @@ func (h handler) callHandler(w http.ResponseWriter, req *http.Request) error {
 		Service:   popHeader(req.Header, ServiceHeader),
 		Procedure: popHeader(req.Header, ProcedureHeader),
 		Encoding:  transport.Encoding(popHeader(req.Header, EncodingHeader)),
-		Headers:   fromHTTPHeader(req.Header, nil),
+		Headers:   applicationHeaders.FromHTTPHeaders(req.Header, nil),
 		Body:      req.Body,
 	}
 
@@ -100,7 +100,7 @@ func (rw responseWriter) Write(s []byte) (int, error) {
 }
 
 func (rw responseWriter) AddHeaders(h transport.Headers) {
-	toHTTPHeader(h, rw.w.Header())
+	applicationHeaders.ToHTTPHeaders(h, rw.w.Header())
 }
 
 func (responseWriter) SetApplicationError() {

--- a/transport/http/header_test.go
+++ b/transport/http/header_test.go
@@ -31,10 +31,12 @@ import (
 
 func TestHeaders(t *testing.T) {
 	tests := []struct {
+		prefix    string
 		transport transport.Headers
 		http      http.Header
 	}{
 		{
+			ApplicationHeaderPrefix,
 			transport.Headers{
 				"foo":     "bar",
 				"foo-bar": "hello",
@@ -47,8 +49,9 @@ func TestHeaders(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		assert.Equal(t, tt.transport, fromHTTPHeader(tt.http, nil))
-		assert.Equal(t, tt.http, toHTTPHeader(tt.transport, nil))
+		m := headerMapper{tt.prefix}
+		assert.Equal(t, tt.transport, m.FromHTTPHeaders(tt.http, nil))
+		assert.Equal(t, tt.http, m.ToHTTPHeaders(tt.transport, nil))
 	}
 }
 

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -56,8 +56,7 @@ func (o outbound) Call(ctx context.Context, req *transport.Request) (*transport.
 		return nil, err
 	}
 
-	// TODO throw an error if caller tried to use our ProcedureHeader.
-	request.Header = toHTTPHeader(req.Headers, nil)
+	request.Header = applicationHeaders.ToHTTPHeaders(req.Headers, nil)
 	request.Header.Set(CallerHeader, req.Caller)
 	request.Header.Set(ServiceHeader, req.Service)
 	request.Header.Set(ProcedureHeader, req.Procedure)
@@ -75,7 +74,7 @@ func (o outbound) Call(ctx context.Context, req *transport.Request) (*transport.
 
 	if response.StatusCode >= 200 && response.StatusCode < 300 {
 		return &transport.Response{
-			Headers: fromHTTPHeader(response.Header, nil),
+			Headers: applicationHeaders.FromHTTPHeaders(response.Header, nil),
 			Body:    response.Body,
 		}, nil
 	}


### PR DESCRIPTION
This is needed for context propagation.

@yarpc/golang 
