### PR TITLE
http/headers: Move `len(prefix)` outside the loop

### DIFF
--- a/transport/http/header.go
+++ b/transport/http/header.go
@@ -62,9 +62,10 @@ func (hm headerMapper) FromHTTPHeaders(from http.Header, to transport.Headers) t
 		to = make(transport.Headers, len(from))
 	}
 
+	prefixLen := len(hm.Prefix)
 	for k := range from {
 		if strings.HasPrefix(k, hm.Prefix) {
-			key := k[len(hm.Prefix):]
+			key := k[prefixLen:]
 			to.Set(key, from.Get(k))
 		}
 		// Note: undefined behavior for multiple occurrences of the same header


### PR DESCRIPTION
As per https://github.com/yarpc/yarpc-go/pull/183#discussion_r65744479