### PR TITLE
headers: Verify headers exactly in all tests

### DIFF
--- a/encoding/raw/outbound_test.go
+++ b/encoding/raw/outbound_test.go
@@ -95,6 +95,7 @@ func TestCall(t *testing.T) {
 					Caller:    caller,
 					Service:   service,
 					Procedure: tt.procedure,
+					Headers:   tt.headers,
 					Encoding:  Encoding,
 					Body:      bytes.NewReader(tt.body),
 				}),

--- a/transport/http/handler_test.go
+++ b/transport/http/handler_test.go
@@ -139,6 +139,7 @@ func TestHandlerHeaders(t *testing.T) {
 					Service:   "service",
 					Encoding:  raw.Encoding,
 					Procedure: "hello",
+					Headers:   tt.wantHeaders,
 					Body:      bytes.NewReader([]byte("world")),
 				}),
 			gomock.Any(),

--- a/transport/transporttest/reqres.go
+++ b/transport/transporttest/reqres.go
@@ -96,7 +96,7 @@ func (m RequestMatcher) Matches(got interface{}) bool {
 		return false
 	}
 
-	// != check to handle nil vs empty cases gracefully.
+	// len check to handle nil vs empty cases gracefully.
 	if len(l.Headers) != len(r.Headers) && !assert.Equal(m.t, l.Headers, r.Headers) {
 		m.t.Logf("Headers mismatch")
 		return false

--- a/transport/transporttest/reqres.go
+++ b/transport/transporttest/reqres.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/yarpc/yarpc-go/transport"
 )
 
@@ -95,8 +96,9 @@ func (m RequestMatcher) Matches(got interface{}) bool {
 		return false
 	}
 
-	if err := checkSuperSet(l.Headers, r.Headers); err != nil {
-		m.t.Logf("Headers mismatch: %v != %v\n\t%v", l.Headers, r.Headers, err)
+	// != check to handle nil vs empty cases gracefully.
+	if len(l.Headers) != len(r.Headers) && !assert.Equal(m.t, l.Headers, r.Headers) {
+		m.t.Logf("Headers mismatch")
 		return false
 	}
 


### PR DESCRIPTION
Previously, we were checking that the headers in the request were a superset
of what we expected because we were not namespacing application headers to
`Rpc-Header-*` in HTTP, so we had to allow for extra headers like
`User-Agent`, `Content-Length`, etc.

Now that we're using namespaced HTTP headers, we can check that application
headers match *exactly* what we expect.

CC @yarpc/golang