### PR TITLE
tchannel: Propagate baggage

### DIFF
--- a/transport/tchannel/constants.go
+++ b/transport/tchannel/constants.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tchannel
+
+// BaggageHeaderPrefix is the prefix added to context headers over the wire.
+//
+// Application headers MUST NOT start with this.
+const BaggageHeaderPrefix = "Context-"

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -118,7 +118,7 @@ func (h handler) callHandler(ctx context.Context, call inboundCall) error {
 		Procedure: call.MethodString(),
 	}
 
-	headers, err := readHeaders(call.Format(), call.Arg2Reader)
+	ctx, headers, err := readRequestHeaders(ctx, call.Format(), call.Arg2Reader)
 	if err != nil {
 		return encoding.RequestHeadersDecodeError(treq, err)
 	}

--- a/transport/tchannel/header.go
+++ b/transport/tchannel/header.go
@@ -26,13 +26,12 @@ import (
 	"io"
 	"strings"
 
-	"golang.org/x/net/context"
-
 	"github.com/yarpc/yarpc-go/internal/baggage"
 	"github.com/yarpc/yarpc-go/transport"
 	"github.com/yarpc/yarpc-go/transport/tchannel/internal"
 
 	"github.com/uber/tchannel-go"
+	"golang.org/x/net/context"
 )
 
 // pullBaggage pulls the context headers from the given transport.Headers,

--- a/transport/tchannel/header.go
+++ b/transport/tchannel/header.go
@@ -107,6 +107,7 @@ func writeRequestHeaders(
 ) error {
 	ctxHeaders := baggage.FromContext(ctx)
 	headers := make(transport.Headers, len(ctxHeaders)+len(appHeaders))
+	// TODO: zero-alloc version
 
 	prefix := strings.ToLower(BaggageHeaderPrefix)
 	for k, v := range appHeaders {

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -104,7 +104,7 @@ func (o outbound) Call(ctx context.Context, req *transport.Request) (*transport.
 		return nil, err
 	}
 
-	if err := writeHeaders(format, req.Headers, call.Arg2Writer); err != nil {
+	if err := writeRequestHeaders(ctx, format, req.Headers, call.Arg2Writer); err != nil {
 		// TODO(abg): This will wrap IO errors while writing headers as encode
 		// errors. We should fix that.
 		return nil, encoding.RequestHeadersEncodeError(req, err)

--- a/transport/tchannel/outbound_test.go
+++ b/transport/tchannel/outbound_test.go
@@ -124,7 +124,7 @@ func TestOutboundHeaders(t *testing.T) {
 			if ctx == nil {
 				ctx = context.Background()
 			}
-			ctx, _ = context.WithTimeout(ctx, 200*time.Millisecond)
+			ctx, _ = context.WithTimeout(ctx, time.Second)
 
 			res, err := out.Call(
 				ctx,

--- a/transport/tchannel/tchannel_utils_test.go
+++ b/transport/tchannel/tchannel_utils_test.go
@@ -28,6 +28,24 @@ import (
 	"github.com/uber/tchannel-go"
 )
 
+func readArgs(r tchannel.ArgReadable) (arg2, arg3 []byte, err error) {
+	err = tchannel.NewArgReader(r.Arg2Reader()).Read(&arg2)
+	if err != nil {
+		return
+	}
+
+	err = tchannel.NewArgReader(r.Arg3Reader()).Read(&arg3)
+	return
+}
+
+func writeArgs(w tchannel.ArgWritable, arg2, arg3 []byte) error {
+	if err := tchannel.NewArgWriter(w.Arg2Writer()).Write(arg2); err != nil {
+		return err
+	}
+
+	return tchannel.NewArgWriter(w.Arg3Writer()).Write(arg3)
+}
+
 // This file provides utilities to help test TChannel behavior used by
 // multiple tests.
 


### PR DESCRIPTION
This adds context propagation for TChannel in both directions.

As discussed in-person, baggage is sent with application headers, prepended
with `Context-`. Application headers are forbidden from starting with
`Context-`.

@yarpc/golang