### PR TITLE
transporttest: Matchers should not cause test failures

### DIFF
--- a/transport/transporttest/context.go
+++ b/transport/transporttest/context.go
@@ -22,13 +22,13 @@ package transporttest
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
 	"github.com/yarpc/yarpc-go/internal/baggage"
 	"github.com/yarpc/yarpc-go/transport"
 
-	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 )
 
@@ -101,7 +101,8 @@ func (c *ContextMatcher) Matches(got interface{}) bool {
 
 	if c.baggage != nil {
 		headers := baggage.FromContext(ctx)
-		if !assert.Equal(c.t, c.baggage, headers, "context baggage did not match") {
+		if !reflect.DeepEqual(c.baggage, headers) {
+			c.t.Logf("Headers did not match:\n\t   %v (want)\n\t!= %v (got)", c.baggage, headers)
 			return false
 		}
 	}

--- a/transport/transporttest/reqres.go
+++ b/transport/transporttest/reqres.go
@@ -24,10 +24,10 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"reflect"
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/yarpc/yarpc-go/transport"
 )
 
@@ -97,9 +97,11 @@ func (m RequestMatcher) Matches(got interface{}) bool {
 	}
 
 	// len check to handle nil vs empty cases gracefully.
-	if len(l.Headers) != len(r.Headers) && !assert.Equal(m.t, l.Headers, r.Headers) {
-		m.t.Logf("Headers mismatch")
-		return false
+	if len(l.Headers) != len(r.Headers) {
+		if !reflect.DeepEqual(l.Headers, r.Headers) {
+			m.t.Logf("Headers did not match:\n\t   %v\n\t!= %v", l.Headers, r.Headers)
+			return false
+		}
 	}
 
 	rbody, err := ioutil.ReadAll(r.Body)


### PR DESCRIPTION
If a Matcher fails to match, it should only emit a log, and not cause the test
to fail.