### PR TITLE
ContextMatcher: ContextBaggage is an alias

### DIFF
--- a/transport/http/handler_test.go
+++ b/transport/http/handler_test.go
@@ -57,10 +57,10 @@ func TestHandlerSucces(t *testing.T) {
 	rpcHandler.EXPECT().Handle(
 		transporttest.NewContextMatcher(t,
 			transporttest.ContextTTL(time.Second),
-			transporttest.ContextBaggage(transport.Headers{
+			transporttest.ContextBaggage{
 				"foo": "bar",
 				"bar": "baz",
-			}),
+			},
 		),
 		transporttest.NewRequestMatcher(
 			t, &transport.Request{


### PR DESCRIPTION
This makes usage of ContextBaggage:

    transporttest.NewContextMatcher(t,
        transporttest.ContextBaggage{"foo": "bar"})

Instead of

    transporttest.NewContextMatcher(t,
        transporttest.ContextBaggage(transport.Headers{"foo": "bar"}))