### PR TITLE
crossdock: Add tagging and remove custom Ts

### DIFF
--- a/crossdock-go/entry.go
+++ b/crossdock-go/entry.go
@@ -20,6 +20,8 @@
 
 package crossdock
 
+import "fmt"
+
 // Status represents the result of running a behavior.
 type Status string
 
@@ -30,10 +32,31 @@ const (
 	Failed  Status = "failed"
 )
 
+const (
+	statusKey = "status"
+	outputKey = "output"
+)
+
 // Entry is the most basic form of a test result.
-//
-// Each behavior can emit one or more entries.
-type Entry struct {
-	Status Status `json:"status"`
-	Output string `json:"output"`
+type Entry map[string]interface{}
+
+// Status returns the Status stored in the Entry.
+func (e Entry) Status() Status {
+	switch v := e[statusKey].(type) {
+	case string:
+		return Status(v)
+	case Status:
+		return v
+	default:
+		panic(fmt.Sprintf("invalid status: %v", v))
+	}
+}
+
+// Output returns the output attached to the entry.
+func (e Entry) Output() string {
+	s, ok := e[outputKey].(string)
+	if ok {
+		return s
+	}
+	return ""
 }

--- a/crossdock-go/run.go
+++ b/crossdock-go/run.go
@@ -27,7 +27,7 @@ import "runtime/debug"
 //
 // Functions like Fatalf won't work if the behavior is not executed inside a
 // Run context.
-func Run(params Params, f func(T)) []interface{} {
+func Run(params Params, f func(T)) []Entry {
 	behavior := params[BehaviorParam]
 	delete(params, BehaviorParam)
 	t := entryT{

--- a/crossdock-go/run_test.go
+++ b/crossdock-go/run_test.go
@@ -44,9 +44,9 @@ func TestRunRecordsFailureOnFatal(t *testing.T) {
 	for _, tt := range tests {
 		entries := Run(nil, tt.f)
 		assert.Len(t, entries, 1)
-		entry := entries[0].(Entry)
-		assert.Equal(t, Failed, entry.Status)
-		assert.Contains(t, entry.Output, tt.output)
+		entry := entries[0]
+		assert.Equal(t, Failed, entry.Status())
+		assert.Contains(t, entry.Output(), tt.output)
 	}
 
 }

--- a/crossdock/client/echo/behavior.go
+++ b/crossdock/client/echo/behavior.go
@@ -25,40 +25,10 @@ import (
 	"github.com/yarpc/yarpc-go/crossdock/client/params"
 )
 
-// echoEntry is an entry emitted by the echo behaviors.
-type echoEntry struct {
-	crossdock.Entry
-
-	Transport string `json:"transport"`
-	Encoding  string `json:"encoding"`
-	Server    string `json:"server"`
-}
-
-// echoT wraps a sink to emit echoEntry entries instead.
-type echoT struct {
-	crossdock.T
-
-	Transport string
-	Encoding  string
-	Server    string
-}
-
-func (t echoT) Put(e interface{}) {
-	t.T.Put(echoEntry{
-		Entry:     e.(crossdock.Entry),
-		Transport: t.Transport,
-		Encoding:  t.Encoding,
-		Server:    t.Server,
-	})
-}
-
-// createEchoT wraps a Sink to have transport, encoding, and server
-// information.
+// createEchoT tags the given T with the transport, encoding and server.
 func createEchoT(encoding string, t crossdock.T) crossdock.T {
-	return echoT{
-		T:         t,
-		Transport: t.Param(params.Transport),
-		Encoding:  encoding,
-		Server:    t.Param(params.Server),
-	}
+	t.Tag("transport", t.Param(params.Transport))
+	t.Tag("encoding", encoding)
+	t.Tag("server", t.Param(params.Server))
+	return t
 }

--- a/crossdock/client/gauntlet/behavior.go
+++ b/crossdock/client/gauntlet/behavior.go
@@ -42,34 +42,10 @@ import (
 
 const serverName = "yarpc-test"
 
-type gauntletEntry struct {
-	crossdock.Entry
-
-	Transport string `json:"transport"`
-	Server    string `json:"server"`
-}
-
-type gauntletT struct {
-	crossdock.T
-
-	Transport string
-	Server    string
-}
-
-func (t gauntletT) Put(e interface{}) {
-	t.T.Put(gauntletEntry{
-		Entry:     e.(crossdock.Entry),
-		Transport: t.Transport,
-		Server:    t.Server,
-	})
-}
-
 func createGauntletT(t crossdock.T) crossdock.T {
-	return gauntletT{
-		T:         t,
-		Transport: t.Param(params.Transport),
-		Server:    t.Param(params.Server),
-	}
+	t.Tag("transport", t.Param(params.Transport))
+	t.Tag("server", t.Param(params.Server))
+	return t
 }
 
 // TT is the gauntlets table test struct
@@ -376,6 +352,9 @@ func RunGauntlet(t crossdock.T, rpc yarpc.RPC, serverName string) {
 	}
 
 	for _, tt := range tests {
+		t.Tag("service", tt.Service)
+		t.Tag("function", tt.Function)
+
 		desc := BuildDesc(tt)
 
 		client := buildClient(t, desc, tt.Service, rpc.Channel(serverName))

--- a/crossdock/client/headers/behavior.go
+++ b/crossdock/client/headers/behavior.go
@@ -37,40 +37,11 @@ import (
 	"golang.org/x/net/context"
 )
 
-// headersEntry is an entry emitted by the headers behavior.
-type headersEntry struct {
-	crossdock.Entry
-
-	Transport string `json:"transport"`
-	Encoding  string `json:"encoding"`
-	Server    string `json:"server"`
-}
-
-// headersT wraps a sink to emit headersEntry entries.
-type headersT struct {
-	crossdock.T
-
-	Transport string
-	Encoding  string
-	Server    string
-}
-
-func (t headersT) Put(e interface{}) {
-	t.T.Put(headersEntry{
-		Entry:     e.(crossdock.Entry),
-		Transport: t.Transport,
-		Encoding:  t.Encoding,
-		Server:    t.Server,
-	})
-}
-
 func createHeadersT(t crossdock.T) crossdock.T {
-	return headersT{
-		T:         t,
-		Transport: t.Param(params.Transport),
-		Encoding:  t.Param(params.Encoding),
-		Server:    t.Param(params.Server),
-	}
+	t.Tag("transport", t.Param(params.Transport))
+	t.Tag("encoding", t.Param(params.Encoding))
+	t.Tag("server", t.Param(params.Server))
+	return t
 }
 
 // Run runs the headers behavior

--- a/crossdock/client/rpc/rpc_test.go
+++ b/crossdock/client/rpc/rpc_test.go
@@ -69,9 +69,9 @@ func TestCreate(t *testing.T) {
 		})
 
 		if tt.errOut != "" && assert.Len(t, entries, 1) {
-			e := entries[0].(crossdock.Entry)
-			assert.Equal(t, crossdock.Failed, e.Status)
-			assert.Contains(t, e.Output, tt.errOut)
+			e := entries[0]
+			assert.Equal(t, crossdock.Failed, e.Status())
+			assert.Contains(t, e.Output(), tt.errOut)
 		}
 	}
 }


### PR DESCRIPTION
The tagging functionality makes the custom `T` implementation unnecessary.