### PR TITLE
crossdock: Add ctxpropagation behavior

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ ENV GO15VENDOREXPERIMENT 1
 ADD . /go/src/github.com/yarpc/yarpc-go
 RUN go install github.com/yarpc/yarpc-go/crossdock
 ENTRYPOINT /go/bin/crossdock
-EXPOSE 8080-8083
+EXPOSE 8080-8087

--- a/crossdock/client/ctxpropagation/behavior.go
+++ b/crossdock/client/ctxpropagation/behavior.go
@@ -42,13 +42,17 @@ import (
 // Run verifies that context is propagated across multiple hops.
 //
 // Behavior parameters:
-// - server: Address of the crossdock test subject server.
+//
+// - ctxclient: Address of this client.
+// - ctxserver: Address of the crossdock test subject server.
 // - transport: The transport to make requests to the test subject with.
 //
-// This behavior sets up yet another server in-process which the Phone
-// procedure on the test subject is responsible for calling. Usually this
-// behavior will receive requests from the Phone procedure on a transport
-// different from the one used to call Phone.
+// This behavior sets up a server in-process which the Phone procedure on the
+// test subject is responsible for calling.
+//
+// Outgoing calls to the Phone procedure will be made using the transport
+// specified as a parameter, and incoming calls from the Phone procedure will
+// be received over a different transport.
 func Run(t crossdock.T) {
 	checks := crossdock.Checks(t)
 	assert := crossdock.Assert(t)

--- a/crossdock/client/ctxpropagation/behavior.go
+++ b/crossdock/client/ctxpropagation/behavior.go
@@ -1,0 +1,303 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ctxpropagation
+
+import (
+	js "encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/yarpc/yarpc-go"
+	"github.com/yarpc/yarpc-go/crossdock-go"
+	"github.com/yarpc/yarpc-go/crossdock/client/params"
+	server "github.com/yarpc/yarpc-go/crossdock/server/yarpc"
+	"github.com/yarpc/yarpc-go/encoding/json"
+	"github.com/yarpc/yarpc-go/internal/baggage"
+	"github.com/yarpc/yarpc-go/transport"
+	ht "github.com/yarpc/yarpc-go/transport/http"
+	tch "github.com/yarpc/yarpc-go/transport/tchannel"
+
+	"github.com/uber/tchannel-go"
+	"golang.org/x/net/context"
+)
+
+type handler interface {
+	Inject(json.Client, server.TransportConfig) // this is hacky but whatever
+	Handle(*json.ReqMeta, interface{}) (interface{}, *json.ResMeta, error)
+}
+
+func assertBaggageMatches(t crossdock.T, ctx context.Context, want transport.Headers) bool {
+	assert := crossdock.Assert(t)
+	got := baggage.FromContext(ctx)
+	if len(want) == 0 { // nils
+		return assert.Len(got, 0, "baggage must be empty: %v", got)
+	}
+
+	return assert.Equal(want, got, "baggage must match")
+}
+
+// singleHopHandler provides a JSON handler which verifies that it receives the
+// specified baggage.
+type singleHopHandler struct {
+	t           crossdock.T
+	wantBaggage transport.Headers
+}
+
+func (h *singleHopHandler) Inject(json.Client, server.TransportConfig) {
+}
+
+func (h *singleHopHandler) Handle(reqMeta *json.ReqMeta, body interface{}) (interface{}, *json.ResMeta, error) {
+	assertBaggageMatches(h.t, reqMeta.Context, h.wantBaggage)
+	return map[string]interface{}{}, &json.ResMeta{Headers: reqMeta.Headers}, nil
+}
+
+// multiHopHandler provides a JSON handler which verfiies that it receives the
+// specified baggage, adds new baggage to the context, and makes a Phone request
+// to the Test Subject, requesting a call to a different procedure.
+type multiHopHandler struct {
+	t crossdock.T
+
+	phoneClient        json.Client
+	phoneCallTo        string
+	phoneCallTransport server.TransportConfig
+
+	addBaggage  transport.Headers
+	wantBaggage transport.Headers
+}
+
+func (h *multiHopHandler) Inject(c json.Client, tc server.TransportConfig) {
+	h.phoneClient = c
+	h.phoneCallTransport = tc
+}
+
+func (h *multiHopHandler) Handle(reqMeta *json.ReqMeta, body interface{}) (interface{}, *json.ResMeta, error) {
+	if h.phoneClient == nil {
+		panic("call Inject() first")
+	}
+
+	assertBaggageMatches(h.t, reqMeta.Context, h.wantBaggage)
+	for key, value := range h.addBaggage {
+		reqMeta.Context = yarpc.WithBaggage(reqMeta.Context, key, value)
+	}
+
+	var resp js.RawMessage
+	resMeta, err := h.phoneClient.Call(
+		&json.ReqMeta{
+			Procedure: "phone",
+			Headers:   reqMeta.Headers,
+			Context:   reqMeta.Context,
+		}, &server.PhoneRequest{
+			Service:   "ctxclient",
+			Procedure: h.phoneCallTo,
+			Transport: h.phoneCallTransport,
+			Body:      &js.RawMessage{'{', '}'},
+		}, &resp)
+	return map[string]interface{}{}, resMeta, err
+}
+
+// Run verifies that context is propagated across multiple hops.
+//
+// Behavior parameters:
+// - server: Address of the crossdock test subject server.
+// - transport: The transport to make requests to the test subject with.
+//
+// This behavior sets up yet another server in-process which the Phone
+// procedure on the test subject is responsible for calling. Usually this
+// behavior will receive requests from the Phone procedure on a transport
+// different from the one used to call Phone.
+func Run(t crossdock.T) {
+	checks := crossdock.Checks(t)
+	assert := crossdock.Assert(t)
+	fatals := crossdock.Fatals(t)
+
+	tests := []struct {
+		desc      string
+		initCtx   context.Context
+		handlers  map[string]handler
+		procedure string
+	}{
+		{
+			desc: "no baggage",
+			handlers: map[string]handler{
+				"hello": &singleHopHandler{
+					t:           t,
+					wantBaggage: transport.Headers{},
+				},
+			},
+		},
+		{
+			desc:    "existing baggage",
+			initCtx: yarpc.WithBaggage(context.Background(), "token", "42"),
+			handlers: map[string]handler{
+				"hello": &singleHopHandler{
+					t:           t,
+					wantBaggage: transport.Headers{"token": "42"},
+				},
+			},
+		},
+		{
+			desc:      "add baggage",
+			procedure: "one",
+			handlers: map[string]handler{
+				"one": &multiHopHandler{
+					t:           t,
+					phoneCallTo: "two",
+					addBaggage:  transport.Headers{"x": "1"},
+					wantBaggage: transport.Headers{},
+				},
+				"two": &multiHopHandler{
+					t:           t,
+					phoneCallTo: "three",
+					addBaggage:  transport.Headers{"y": "2"},
+					wantBaggage: transport.Headers{"x": "1"},
+				},
+				"three": &singleHopHandler{
+					t:           t,
+					wantBaggage: transport.Headers{"x": "1", "y": "2"},
+				},
+			},
+		},
+		{
+			desc:      "add baggage: existing baggage",
+			initCtx:   yarpc.WithBaggage(context.Background(), "token", "123"),
+			procedure: "one",
+			handlers: map[string]handler{
+				"one": &multiHopHandler{
+					t:           t,
+					phoneCallTo: "two",
+					addBaggage:  transport.Headers{"hello": "world"},
+					wantBaggage: transport.Headers{"token": "123"},
+				},
+				"two": &singleHopHandler{
+					t:           t,
+					wantBaggage: transport.Headers{"token": "123", "hello": "world"},
+				},
+			},
+		},
+		{
+			desc:      "overwrite baggage",
+			initCtx:   yarpc.WithBaggage(context.Background(), "x", "1"),
+			procedure: "one",
+			handlers: map[string]handler{
+				"one": &multiHopHandler{
+					t:           t,
+					phoneCallTo: "two",
+					addBaggage:  transport.Headers{"x": "2", "y": "3"},
+					wantBaggage: transport.Headers{"x": "1"},
+				},
+				"two": &multiHopHandler{
+					t:           t,
+					phoneCallTo: "three",
+					addBaggage:  transport.Headers{"y": "4"},
+					wantBaggage: transport.Headers{"x": "2", "y": "3"},
+				},
+				"three": &singleHopHandler{
+					t:           t,
+					wantBaggage: transport.Headers{"x": "2", "y": "4"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		func() {
+			procedure := tt.procedure
+			if procedure == "" {
+				if !assert.Len(tt.handlers, 1,
+					"%v: invalid test: starting procedure must be provided", tt.desc) {
+					return
+				}
+				for k := range tt.handlers {
+					procedure = k
+				}
+			}
+
+			// We need to build the channel here so that we can have it close in
+			// client-only cases.
+			//
+			// TODO: this shouldn't be an issue once Outbounds support a Close
+			// method.
+			ch, err := tchannel.NewChannel("ctxclient", nil)
+			fatals.NoError(err, "failed to create TChannel")
+			defer ch.Close()
+
+			rpc, tconfig := buildRPC(t, ch)
+			fatals.NoError(rpc.Start(), "%v: RPC failed to start", tt.desc)
+			defer rpc.Stop()
+
+			jsonClient := json.New(rpc.Channel("yarpc-test"))
+			for name, handler := range tt.handlers {
+				handler.Inject(jsonClient, tconfig)
+				json.Register(rpc, json.Procedure(name, handler.Handle))
+			}
+
+			ctx := context.Background()
+			if tt.initCtx != nil {
+				ctx = tt.initCtx
+			}
+			ctx, _ = context.WithTimeout(ctx, time.Second)
+
+			var resp js.RawMessage
+			_, err = jsonClient.Call(
+				&json.ReqMeta{Procedure: "phone", Context: ctx},
+				&server.PhoneRequest{
+					Service:   "ctxclient",
+					Procedure: procedure,
+					Transport: tconfig,
+					Body:      &js.RawMessage{'{', '}'},
+				}, &resp)
+
+			checks.NoError(err, "%v: request failed", tt.desc)
+		}()
+	}
+}
+
+func buildRPC(t crossdock.T, ch *tchannel.Channel) (rpc yarpc.RPC, tconfig server.TransportConfig) {
+	fatals := crossdock.Fatals(t)
+
+	self := t.Param("ctxclient")
+	subject := t.Param("ctxserver")
+	fatals.NotEmpty(self, "ctxclient is required")
+	fatals.NotEmpty(subject, "ctxserver is required")
+
+	var outbound transport.Outbound
+	switch trans := t.Param(params.Transport); trans {
+	case "http":
+		outbound = ht.NewOutbound(fmt.Sprintf("http://%s:8081", subject))
+		tconfig.TChannel = &server.TChannelTransport{Host: self, Port: 8087}
+	case "tchannel":
+		outbound = tch.NewOutbound(ch, tch.HostPort(fmt.Sprintf("%s:8082", subject)))
+		tconfig.HTTP = &server.HTTPTransport{Host: self, Port: 8086}
+	default:
+		fatals.Fail("", "unknown transport %q", trans)
+	}
+
+	rpc = yarpc.New(yarpc.Config{
+		Name: "ctxclient",
+		Inbounds: []transport.Inbound{
+			tch.NewInbound(ch, tch.ListenAddr(":8087")),
+			ht.NewInbound(":8086"),
+		},
+		Outbounds: transport.Outbounds{"yarpc-test": outbound},
+	})
+
+	return rpc, tconfig
+}

--- a/crossdock/client/ctxpropagation/behavior.go
+++ b/crossdock/client/ctxpropagation/behavior.go
@@ -47,8 +47,10 @@ type handler interface {
 func assertBaggageMatches(t crossdock.T, ctx context.Context, want transport.Headers) bool {
 	assert := crossdock.Assert(t)
 	got := baggage.FromContext(ctx)
-	if len(want) == 0 { // nils
-		return assert.Len(got, 0, "baggage must be empty: %v", got)
+
+	if len(want) == 0 {
+		// len check to handle nil vs empty cases gracefully.
+		return assert.Empty(got, "baggage must be empty: %v", got)
 	}
 
 	return assert.Equal(want, got, "baggage must match")

--- a/crossdock/client/start.go
+++ b/crossdock/client/start.go
@@ -22,6 +22,7 @@ package client
 
 import (
 	"github.com/yarpc/yarpc-go/crossdock-go"
+	"github.com/yarpc/yarpc-go/crossdock/client/ctxpropagation"
 	"github.com/yarpc/yarpc-go/crossdock/client/echo"
 	"github.com/yarpc/yarpc-go/crossdock/client/errors"
 	"github.com/yarpc/yarpc-go/crossdock/client/gauntlet"
@@ -41,6 +42,7 @@ var behaviors = crossdock.Behaviors{
 	"tchserver":      tchserver.Run,
 	"thriftgauntlet": gauntlet.Run,
 	"outboundttl":    outboundttl.Run,
+	"ctxpropagation": ctxpropagation.Run,
 }
 
 // Start registers behaviors and begins the Crossdock client

--- a/crossdock/main_test.go
+++ b/crossdock/main_test.go
@@ -95,6 +95,16 @@ func TestCrossdock(t *testing.T) {
 				"transport": []string{"http", "tchannel"},
 			},
 		},
+		{
+			name: "ctxpropagation",
+			axes: axes{
+				"transport": []string{"http", "tchannel"},
+			},
+			params: params{
+				"ctxserver": "127.0.0.1",
+				"ctxclient": "127.0.0.1",
+			},
+		},
 	}
 
 	for _, bb := range behaviors {

--- a/crossdock/server/yarpc/phone.go
+++ b/crossdock/server/yarpc/phone.go
@@ -23,6 +23,7 @@ package yarpc
 import (
 	js "encoding/json"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/yarpc/yarpc-go/encoding/json"
@@ -73,9 +74,12 @@ func Phone(reqMeta *json.ReqMeta, body *PhoneRequest) (*PhoneResponse, *json.Res
 
 	switch {
 	case body.Transport.HTTP != nil:
+		cl := &http.Client{Transport: new(http.Transport)}
+		// ^See crossdock/client/rpc/rpc.go for explanation
+
 		t := body.Transport.HTTP
 		url := fmt.Sprintf("http://%s:%d", t.Host, t.Port)
-		outbound = ht.NewOutbound(url)
+		outbound = ht.NewOutboundWithClient(url, cl)
 	case body.Transport.TChannel != nil:
 		t := body.Transport.TChannel
 		hostport := fmt.Sprintf("%s:%d", t.Host, t.Port)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,22 +35,22 @@ services:
     go:
         build: .
         ports:
-            - "8080-8083"
+            - "8080-8087"
 
     node:
         image: yarpc/yarpc-node
         ports:
-            - "8080-8083"
+            - "8080-8087"
 
     java:
         image: yarpc/yarpc-java
         ports:
-            - "8080-8083"
+            - "8080-8087"
 
     python:
         image: yarpc/yarpc-python
         ports:
-            - "8080-8083"
+            - "8080-8087"
 
     python-sync:
         image: yarpc/yarpc-python

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
             - AXIS_TRANSPORT=http,tchannel
             - AXIS_ENCODING=raw,json,thrift
             - AXIS_ERRORS=go,node
+            - AXIS_CTXCLIENT=go
+            - AXIS_CTXSERVER=go
             - AXIS_GAUNTLET=go
 
             - BEHAVIOR_RAW=client,server,transport
@@ -28,6 +30,7 @@ services:
             - BEHAVIOR_TCHSERVER=client,server,encoding
             - BEHAVIOR_THRIFTGAUNTLET=gauntlet,server,transport
             - BEHAVIOR_OUTBOUNDTTL=client,server,transport
+            - BEHAVIOR_CTXPROPAGATION=ctxclient,ctxserver,transport
 
     go:
         build: .


### PR DESCRIPTION
This behavior tests that we propagate baggage consistently across multiple
hops.

This behavior is currently tested against Go only.

---

Depends on https://github.com/yarpc/yarpc-go/pull/207