### PR TITLE
Hide error constructors

### DIFF
--- a/crossdock/client/gauntlet/behavior.go
+++ b/crossdock/client/gauntlet/behavior.go
@@ -447,7 +447,7 @@ func BuildArgs(t crossdock.T, desc string, ft reflect.Type, give []interface{}) 
 }
 
 func isUnrecognizedProcedure(err error) bool {
-	if _, isBadRequest := err.(transport.BadRequestError); isBadRequest {
+	if transport.IsBadRequestError(err) {
 		// TODO: Once all other languages implement the gauntlet test
 		// subject, we can remove this check.
 		return strings.Contains(err.Error(), "unrecognized procedure")

--- a/crossdock/client/outboundttl/behavior.go
+++ b/crossdock/client/outboundttl/behavior.go
@@ -49,13 +49,13 @@ func Run(t crossdock.T) {
 	}, nil)
 	fatals.Error(err, "expected a failure for timeout")
 
-	if err, ok := err.(transport.BadRequestError); ok {
+	if transport.IsBadRequestError(err) {
 		t.Skipf("sleep/raw method not implemented: %v", err)
 		return
 	}
 
 	form := strings.HasPrefix(err.Error(), `timeout for procedure "sleep/raw" of service "yarpc-test" after`)
 	assert.True(form, "error message has expected prefix for timeouts, got %q", err.Error())
-	_, ok := err.(transport.TimeoutError)
-	assert.True(ok, "error should be a TimeoutError, got %T", err)
+	assert.True(
+		transport.IsTimeoutError(err), "error should be a TimeoutError, got %T", err)
 }

--- a/internal/encoding/server.go
+++ b/internal/encoding/server.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/yarpc/yarpc-go/internal/errors"
 	"github.com/yarpc/yarpc-go/transport"
 )
 
@@ -60,11 +61,11 @@ func (e serverEncodingError) Error() string {
 }
 
 // AsHandlerError converts this error into a handler-level error.
-func (e serverEncodingError) AsHandlerError() transport.HandlerError {
+func (e serverEncodingError) AsHandlerError() errors.HandlerError {
 	if e.IsResponse {
-		return transport.LocalUnexpectedError(e)
+		return errors.LocalUnexpectedError(e)
 	}
-	return transport.LocalBadRequestError(e)
+	return errors.LocalBadRequestError(e)
 }
 
 func newServerEncodingError(req *transport.Request, err error) serverEncodingError {

--- a/internal/errors/bad_request.go
+++ b/internal/errors/bad_request.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package errors
+
+// BadRequestError is a failure to process a request because the request was
+// invalid.
+type BadRequestError interface {
+	error
+
+	badRequestError()
+}
+
+type localBadRequestError struct {
+	Reason error
+}
+
+var _ BadRequestError = localBadRequestError{}
+var _ HandlerError = localBadRequestError{}
+
+// LocalBadRequestError wraps the given error into a BadRequestError.
+//
+// It represents a local failure while processing an invalid request.
+func LocalBadRequestError(err error) HandlerError {
+	return localBadRequestError{Reason: err}
+}
+
+func (localBadRequestError) handlerError()    {}
+func (localBadRequestError) badRequestError() {}
+
+func (e localBadRequestError) Error() string {
+	return "BadRequest: " + e.Reason.Error()
+}
+
+type remoteBadRequestError string
+
+var _ BadRequestError = remoteBadRequestError("")
+
+// RemoteBadRequestError builds a new BadRequestError with the given message.
+//
+// It represents a BadRequest failure from a remote service.
+func RemoteBadRequestError(message string) BadRequestError {
+	return remoteBadRequestError(message)
+}
+
+func (remoteBadRequestError) badRequestError() {}
+
+func (e remoteBadRequestError) Error() string {
+	return string(e)
+}

--- a/internal/errors/transport.go
+++ b/internal/errors/transport.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package errors
+
+import "fmt"
+
+// The general hierarchy we have is:
+//
+// 	BadRequestError                 HandlerError
+// 	 |                                        |
+// 	 +--------> localBadRequestError <--------+
+// 	 |                                        |
+// 	 +--------> remoteBadRequestError         |
+// 	                                          |
+// 	UnexpectedError                           |
+// 	 |                                        |
+// 	 +--------> localUnexpectedError <--------+
+// 	 |
+// 	 +--------> remoteUnexpectedError
+//
+// Only the local versions of the error types are HandlerErrors. If a Handler
+// returns one of the remote versions, they will be wrapped in a new
+// UnexpectedError.
+
+// HandlerError represents error types that can be returned from a Handler
+// that the Inbound implementation MUST handle.
+//
+// Currently, this includes BadRequestError and UnexpectedError only. Error
+// types which know how to convert themselves into BadRequestError or
+// UnexpectedError may provide a `AsHandlerError() HandlerError` method.
+type HandlerError interface {
+	error
+
+	handlerError()
+}
+
+type asHandlerError interface {
+	AsHandlerError() HandlerError
+}
+
+// AsHandlerError converts an error into a HandlerError, leaving it unchanged
+// if it is already one.
+func AsHandlerError(service, procedure string, err error) error {
+	if err == nil {
+		return err
+	}
+
+	switch e := err.(type) {
+	case HandlerError:
+		return e
+	case asHandlerError:
+		return e.AsHandlerError()
+	default:
+		return ProcedureFailedError{
+			Service:   service,
+			Procedure: procedure,
+			Reason:    err,
+		}.AsHandlerError()
+	}
+}
+
+// UnrecognizedProcedureError is a failure to process a request because the
+// procedure and/or service name was unrecognized.
+type UnrecognizedProcedureError struct {
+	Service   string
+	Procedure string
+}
+
+func (e UnrecognizedProcedureError) Error() string {
+	return fmt.Sprintf(`unrecognized procedure %q for service %q`, e.Procedure, e.Service)
+}
+
+// AsHandlerError for UnrecognizedProcedureError.
+func (e UnrecognizedProcedureError) AsHandlerError() HandlerError {
+	return LocalBadRequestError(e)
+}
+
+// ProcedureFailedError is a failure to execute a procedure due to an
+// unexpected error.
+type ProcedureFailedError struct {
+	Service   string
+	Procedure string
+	Reason    error
+}
+
+func (e ProcedureFailedError) Error() string {
+	return fmt.Sprintf(`error for procedure %q of service %q: %v`,
+		e.Procedure, e.Service, e.Reason)
+}
+
+// AsHandlerError for ProcedureFailedError.
+func (e ProcedureFailedError) AsHandlerError() HandlerError {
+	return LocalUnexpectedError(e)
+}

--- a/internal/errors/unexpected.go
+++ b/internal/errors/unexpected.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package errors
+
+// UnexpectedError is a server failure due to unhandled errors. This can be
+// caused if the remote server panics while processing the request or fails to
+// handle any other errors.
+type UnexpectedError interface {
+	error
+
+	unexpectedError()
+}
+
+type localUnexpectedError struct {
+	Reason error
+}
+
+var _ UnexpectedError = localUnexpectedError{}
+var _ HandlerError = localUnexpectedError{}
+
+// LocalUnexpectedError wraps the given error into an UnexpectedError.
+//
+// It represens a local failure while processing a request.
+func LocalUnexpectedError(err error) HandlerError {
+	return localUnexpectedError{Reason: err}
+}
+
+func (localUnexpectedError) handlerError()    {}
+func (localUnexpectedError) unexpectedError() {}
+
+func (e localUnexpectedError) Error() string {
+	return "UnexpectedError: " + e.Reason.Error()
+}
+
+type remoteUnexpectedError string
+
+var _ UnexpectedError = remoteUnexpectedError("")
+
+// RemoteUnexpectedError builds a new UnexpectedError with the given message.
+//
+// It represents an UnexpectedError from a remote service.
+func RemoteUnexpectedError(message string) UnexpectedError {
+	return remoteUnexpectedError(message)
+}
+
+func (remoteUnexpectedError) unexpectedError() {}
+
+func (e remoteUnexpectedError) Error() string {
+	return string(e)
+}

--- a/internal/request/errors.go
+++ b/internal/request/errors.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/yarpc/yarpc-go/transport"
+	"github.com/yarpc/yarpc-go/internal/errors"
 )
 
 // missingParametersError is a failure to process a request because it was
@@ -36,8 +36,8 @@ type missingParametersError struct {
 	Parameters []string
 }
 
-func (e missingParametersError) AsHandlerError() transport.HandlerError {
-	return transport.LocalBadRequestError(e)
+func (e missingParametersError) AsHandlerError() errors.HandlerError {
+	return errors.LocalBadRequestError(e)
 }
 
 func (e missingParametersError) Error() string {
@@ -66,8 +66,8 @@ type invalidTTLError struct {
 	TTL       string
 }
 
-func (e invalidTTLError) AsHandlerError() transport.HandlerError {
-	return transport.LocalBadRequestError(e)
+func (e invalidTTLError) AsHandlerError() errors.HandlerError {
+	return errors.LocalBadRequestError(e)
 }
 
 func (e invalidTTLError) Error() string {

--- a/transport/http/handler.go
+++ b/transport/http/handler.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 
 	"github.com/yarpc/yarpc-go/internal/baggage"
+	"github.com/yarpc/yarpc-go/internal/errors"
 	"github.com/yarpc/yarpc-go/internal/request"
 	"github.com/yarpc/yarpc-go/transport"
 
@@ -56,9 +57,9 @@ func (h handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	err = transport.AsHandlerError(service, procedure, err)
+	err = errors.AsHandlerError(service, procedure, err)
 	status := http.StatusInternalServerError
-	if _, ok := err.(transport.BadRequestError); ok {
+	if transport.IsBadRequestError(err) {
 		status = http.StatusBadRequest
 	}
 	http.Error(w, err.Error(), status)

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/yarpc/yarpc-go/internal/baggage"
+	"github.com/yarpc/yarpc-go/internal/errors"
 	"github.com/yarpc/yarpc-go/transport"
 
 	"golang.org/x/net/context"
@@ -79,7 +80,7 @@ func (o outbound) Call(ctx context.Context, req *transport.Request) (*transport.
 	response, err := ctxhttp.Do(ctx, o.Client, request)
 	if err != nil {
 		if err == context.DeadlineExceeded {
-			return nil, transport.NewTimeoutError(req.Service, req.Procedure, deadline.Sub(start))
+			return nil, errors.NewTimeoutError(req.Service, req.Procedure, deadline.Sub(start))
 		}
 
 		return nil, err
@@ -106,8 +107,8 @@ func (o outbound) Call(ctx context.Context, req *transport.Request) (*transport.
 	message := strings.TrimSuffix(string(contents), "\n")
 
 	if response.StatusCode >= 400 && response.StatusCode < 500 {
-		return nil, transport.RemoteBadRequestError(message)
+		return nil, errors.RemoteBadRequestError(message)
 	}
 
-	return nil, transport.RemoteUnexpectedError(message)
+	return nil, errors.RemoteUnexpectedError(message)
 }

--- a/transport/register.go
+++ b/transport/register.go
@@ -20,6 +20,8 @@
 
 package transport
 
+import "github.com/yarpc/yarpc-go/internal/errors"
+
 // TODO: Until golang/mock#4 is fixed, imports in the generated code have to
 // be fixed by hand. They use vendor/* import paths rather than direct.
 
@@ -82,7 +84,7 @@ func (m MapRegistry) GetHandler(service, procedure string) (Handler, error) {
 	if h, ok := m.entries[registryEntry{service, procedure}]; ok {
 		return h, nil
 	}
-	return nil, unrecognizedProcedureError{
+	return nil, errors.UnrecognizedProcedureError{
 		Service:   service,
 		Procedure: procedure,
 	}

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 
 	"github.com/yarpc/yarpc-go/internal/encoding"
+	"github.com/yarpc/yarpc-go/internal/errors"
 	"github.com/yarpc/yarpc-go/internal/request"
 	"github.com/yarpc/yarpc-go/transport"
 
@@ -96,9 +97,9 @@ func (h handler) handle(ctx context.Context, call inboundCall) {
 		return
 	}
 
-	err = transport.AsHandlerError(call.ServiceName(), call.MethodString(), err)
+	err = errors.AsHandlerError(call.ServiceName(), call.MethodString(), err)
 	status := tchannel.ErrCodeUnexpected
-	if _, ok := err.(transport.BadRequestError); ok {
+	if transport.IsBadRequestError(err) {
 		status = tchannel.ErrCodeBadRequest
 	}
 

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/yarpc/yarpc-go/internal/encoding"
+	"github.com/yarpc/yarpc-go/internal/errors"
 	"github.com/yarpc/yarpc-go/transport"
 
 	"github.com/uber/tchannel-go"
@@ -118,7 +119,7 @@ func (o outbound) Call(ctx context.Context, req *transport.Request) (*transport.
 	headers, err := readHeaders(format, res.Arg2Reader)
 	if err != nil {
 		if err == tchannel.ErrTimeout {
-			return nil, transport.NewTimeoutError(req.Service, req.Procedure, ttl)
+			return nil, errors.NewTimeoutError(req.Service, req.Procedure, ttl)
 		}
 		if err, ok := err.(tchannel.SystemError); ok {
 			return nil, fromSystemError(err)
@@ -155,8 +156,8 @@ func writeBody(body io.Reader, call *tchannel.OutboundCall) error {
 func fromSystemError(err tchannel.SystemError) error {
 	switch err.Code() {
 	case tchannel.ErrCodeCancelled, tchannel.ErrCodeBusy, tchannel.ErrCodeBadRequest:
-		return transport.RemoteBadRequestError(err.Message())
+		return errors.RemoteBadRequestError(err.Message())
 	default:
-		return transport.RemoteUnexpectedError(err.Message())
+		return errors.RemoteUnexpectedError(err.Message())
 	}
 }


### PR DESCRIPTION
This hides constructors for transport errors in an internal package, reducing
the error-related surface area of the transport package to:

- `transport.IsBadRequestError`
- `transport.IsUnexpectedError`
- `transport.IsTimeoutError`

Note that previously, the way to check if something was one of these errors
was to type-cast into that interface. Since there's no behavior attached to
these errors at this time, I think it's safe to switch to the `Is*` approach.

Resolves https://github.com/yarpc/yarpc-go/issues/112