### PR TITLE
Add opaque yarpc.Headers type

### DIFF
--- a/crossdock/client/errors/behavior.go
+++ b/crossdock/client/errors/behavior.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/yarpc/yarpc-go/crossdock-go"
 	"github.com/yarpc/yarpc-go/crossdock/client/params"
-	"github.com/yarpc/yarpc-go/transport"
 )
 
 type httpClient struct {
@@ -42,7 +41,7 @@ type httpResponse struct {
 	Status int
 }
 
-func (h httpClient) Call(t crossdock.T, hs transport.Headers, body string) httpResponse {
+func (h httpClient) Call(t crossdock.T, hs map[string]string, body string) httpResponse {
 	fatals := crossdock.Fatals(t)
 
 	req := http.Request{
@@ -95,7 +94,7 @@ func Run(t crossdock.T) {
 	assert := crossdock.Assert(t)
 
 	// one valid request before we throw the errors at it
-	res := client.Call(t, transport.Headers{
+	res := client.Call(t, map[string]string{
 		"RPC-Caller":     "yarpc-test",
 		"RPC-Service":    "yarpc-test",
 		"RPC-Procedure":  "echo",
@@ -113,7 +112,7 @@ func Run(t crossdock.T) {
 
 	tests := []struct {
 		name    string
-		headers transport.Headers
+		headers map[string]string
 		body    string
 
 		wantStatus         int
@@ -122,7 +121,7 @@ func Run(t crossdock.T) {
 	}{
 		{
 			name:       "no service",
-			headers:    transport.Headers{},
+			headers:    map[string]string{},
 			body:       "{}",
 			wantStatus: 400,
 			wantBody: "BadRequest: missing service name, procedure, " +
@@ -130,7 +129,7 @@ func Run(t crossdock.T) {
 		},
 		{
 			name: "wrong service",
-			headers: transport.Headers{
+			headers: map[string]string{
 				"RPC-Caller":     "yarpc-test",
 				"RPC-Service":    "not-yarpc-test",
 				"RPC-Procedure":  "echo",
@@ -143,7 +142,7 @@ func Run(t crossdock.T) {
 		},
 		{
 			name: "no procedure",
-			headers: transport.Headers{
+			headers: map[string]string{
 				"RPC-Service": "yarpc-test",
 			},
 			body:       "{}",
@@ -152,7 +151,7 @@ func Run(t crossdock.T) {
 		},
 		{
 			name: "no caller",
-			headers: transport.Headers{
+			headers: map[string]string{
 				"RPC-Service":   "yarpc-test",
 				"RPC-Procedure": "echo",
 			},
@@ -162,7 +161,7 @@ func Run(t crossdock.T) {
 		},
 		{
 			name: "no handler",
-			headers: transport.Headers{
+			headers: map[string]string{
 				"RPC-Caller":     "yarpc-test",
 				"RPC-Service":    "yarpc-test",
 				"RPC-Procedure":  "no-such-procedure",
@@ -175,7 +174,7 @@ func Run(t crossdock.T) {
 		},
 		{
 			name: "no timeout",
-			headers: transport.Headers{
+			headers: map[string]string{
 				"RPC-Caller":    "yarpc-test",
 				"RPC-Service":   "yarpc-test",
 				"RPC-Procedure": "echo",
@@ -186,7 +185,7 @@ func Run(t crossdock.T) {
 		},
 		{
 			name: "invalid timeout",
-			headers: transport.Headers{
+			headers: map[string]string{
 				"RPC-Caller":     "yarpc-test",
 				"RPC-Service":    "yarpc-test",
 				"RPC-Procedure":  "echo",
@@ -199,7 +198,7 @@ func Run(t crossdock.T) {
 		},
 		{
 			name: "invalid request",
-			headers: transport.Headers{
+			headers: map[string]string{
 				"RPC-Caller":     "yarpc-test",
 				"RPC-Service":    "yarpc-test",
 				"RPC-Procedure":  "echo",
@@ -213,7 +212,7 @@ func Run(t crossdock.T) {
 		},
 		{
 			name: "unexpected error",
-			headers: transport.Headers{
+			headers: map[string]string{
 				"RPC-Caller":     "yarpc-test",
 				"RPC-Service":    "yarpc-test",
 				"RPC-Procedure":  "unexpected-error",
@@ -226,7 +225,7 @@ func Run(t crossdock.T) {
 		},
 		{
 			name: "bad response",
-			headers: transport.Headers{
+			headers: map[string]string{
 				"RPC-Caller":     "yarpc-test",
 				"RPC-Service":    "yarpc-test",
 				"RPC-Procedure":  "bad-response",
@@ -240,7 +239,7 @@ func Run(t crossdock.T) {
 		},
 		{
 			name: "remote bad request",
-			headers: transport.Headers{
+			headers: map[string]string{
 				"RPC-Caller":     "yarpc-test",
 				"RPC-Service":    "yarpc-test",
 				"RPC-Procedure":  "phone",
@@ -259,7 +258,7 @@ func Run(t crossdock.T) {
 		},
 		{
 			name: "remote unexpected error",
-			headers: transport.Headers{
+			headers: map[string]string{
 				"RPC-Caller":     "yarpc-test",
 				"RPC-Service":    "yarpc-test",
 				"RPC-Procedure":  "phone",

--- a/crossdock/client/tchserver/json.go
+++ b/crossdock/client/tchserver/json.go
@@ -27,7 +27,6 @@ import (
 	"github.com/yarpc/yarpc-go/crossdock-go"
 	"github.com/yarpc/yarpc-go/crossdock/client/random"
 	"github.com/yarpc/yarpc-go/encoding/json"
-	"github.com/yarpc/yarpc-go/transport"
 
 	"golang.org/x/net/context"
 )
@@ -36,9 +35,7 @@ func runJSON(t crossdock.T, rpc yarpc.RPC) {
 	assert := crossdock.Assert(t)
 	checks := crossdock.Checks(t)
 
-	headers := transport.Headers{
-		"hello": "json",
-	}
+	headers := yarpc.NewHeaders().With("hello", "json")
 	token := random.String(5)
 
 	resBody, resMeta, err := jsonCall(rpc, headers, token)
@@ -55,7 +52,7 @@ type jsonEcho struct {
 	Token string `json:"token"`
 }
 
-func jsonCall(rpc yarpc.RPC, headers transport.Headers, token string) (string, *json.ResMeta, error) {
+func jsonCall(rpc yarpc.RPC, headers yarpc.Headers, token string) (string, *json.ResMeta, error) {
 	client := json.New(rpc.Channel(serverName))
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)

--- a/crossdock/client/tchserver/raw.go
+++ b/crossdock/client/tchserver/raw.go
@@ -27,7 +27,6 @@ import (
 	"github.com/yarpc/yarpc-go/crossdock-go"
 	"github.com/yarpc/yarpc-go/crossdock/client/random"
 	"github.com/yarpc/yarpc-go/encoding/raw"
-	"github.com/yarpc/yarpc-go/transport"
 
 	"golang.org/x/net/context"
 )
@@ -37,9 +36,7 @@ func runRaw(t crossdock.T, rpc yarpc.RPC) {
 	checks := crossdock.Checks(t)
 
 	// TODO headers should be at yarpc, not transport
-	headers := transport.Headers{
-		"hello": "raw",
-	}
+	headers := yarpc.NewHeaders().With("hello", "raw")
 	token := random.Bytes(5)
 
 	resBody, resMeta, err := rawCall(rpc, headers, token)
@@ -52,7 +49,7 @@ func runRaw(t crossdock.T, rpc yarpc.RPC) {
 	}
 }
 
-func rawCall(rpc yarpc.RPC, headers transport.Headers, token []byte) ([]byte, *raw.ResMeta, error) {
+func rawCall(rpc yarpc.RPC, headers yarpc.Headers, token []byte) ([]byte, *raw.ResMeta, error) {
 	client := raw.New(rpc.Channel(serverName))
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)

--- a/crossdock/client/tchserver/thrift.go
+++ b/crossdock/client/tchserver/thrift.go
@@ -30,7 +30,6 @@ import (
 	"github.com/yarpc/yarpc-go/crossdock/thrift/echo"
 	"github.com/yarpc/yarpc-go/crossdock/thrift/echo/yarpc/echoclient"
 	"github.com/yarpc/yarpc-go/encoding/thrift"
-	"github.com/yarpc/yarpc-go/transport"
 
 	"golang.org/x/net/context"
 )
@@ -39,9 +38,7 @@ func runThrift(t crossdock.T, rpc yarpc.RPC) {
 	assert := crossdock.Assert(t)
 	checks := crossdock.Checks(t)
 
-	headers := transport.Headers{
-		"hello": "thrift",
-	}
+	headers := yarpc.NewHeaders().With("hello", "thrift")
 	token := random.String(5)
 
 	resBody, resMeta, err := thriftCall(rpc, headers, token)
@@ -56,7 +53,7 @@ func runThrift(t crossdock.T, rpc yarpc.RPC) {
 	gauntlet.RunGauntlet(t, rpc, serverName)
 }
 
-func thriftCall(rpc yarpc.RPC, headers transport.Headers, token string) (string, *thrift.ResMeta, error) {
+func thriftCall(rpc yarpc.RPC, headers yarpc.Headers, token string) (string, *thrift.ResMeta, error) {
 	client := echoclient.New(rpc.Channel(serverName))
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)

--- a/encoding/json/inbound.go
+++ b/encoding/json/inbound.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"reflect"
 
+	"github.com/yarpc/yarpc-go"
 	"github.com/yarpc/yarpc-go/internal/encoding"
 	"github.com/yarpc/yarpc-go/transport"
 
@@ -53,7 +54,7 @@ func (h jsonHandler) Handle(ctx context.Context, treq *transport.Request, rw tra
 	reqMeta := ReqMeta{
 		Context:   ctx,
 		Procedure: treq.Procedure,
-		Headers:   treq.Headers,
+		Headers:   yarpc.Headers(treq.Headers),
 	}
 
 	results := h.handler.Call([]reflect.Value{reflect.ValueOf(&reqMeta), reqBody})
@@ -64,7 +65,7 @@ func (h jsonHandler) Handle(ctx context.Context, treq *transport.Request, rw tra
 	}
 
 	if resMeta := results[1].Interface().(*ResMeta); resMeta != nil {
-		rw.AddHeaders(resMeta.Headers)
+		rw.AddHeaders(transport.Headers(resMeta.Headers))
 	}
 
 	result := results[0].Interface()

--- a/encoding/json/inbound_test.go
+++ b/encoding/json/inbound_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/yarpc/yarpc-go"
 	"github.com/yarpc/yarpc-go/transport"
 	"github.com/yarpc/yarpc-go/transport/transporttest"
 
@@ -95,7 +96,7 @@ func TestHandleInterfaceEmptySuccess(t *testing.T) {
 
 func TestHandleSuccessWithResponseHeaders(t *testing.T) {
 	h := func(*ReqMeta, *simpleRequest) (*simpleResponse, *ResMeta, error) {
-		resMeta := &ResMeta{Headers: transport.Headers{"foo": "bar"}}
+		resMeta := &ResMeta{Headers: yarpc.NewHeaders().With("foo", "bar")}
 		return &simpleResponse{Success: true}, resMeta, nil
 	}
 
@@ -111,7 +112,7 @@ func TestHandleSuccessWithResponseHeaders(t *testing.T) {
 	}, resw)
 	require.NoError(t, err)
 
-	assert.Equal(t, transport.Headers{"foo": "bar"}, resw.Headers)
+	assert.Equal(t, transport.NewHeaders().With("foo", "bar"), resw.Headers)
 }
 
 func jsonBody(s string) io.Reader {

--- a/encoding/json/outbound.go
+++ b/encoding/json/outbound.go
@@ -24,6 +24,7 @@ import (
 	"bytes"
 	"encoding/json"
 
+	"github.com/yarpc/yarpc-go"
 	"github.com/yarpc/yarpc-go/internal/encoding"
 	"github.com/yarpc/yarpc-go/transport"
 )
@@ -60,7 +61,7 @@ func (c jsonClient) Call(reqMeta *ReqMeta, reqBody interface{}, resBodyOut inter
 		Service:   c.service,
 		Encoding:  Encoding,
 		Procedure: reqMeta.Procedure,
-		Headers:   reqMeta.Headers,
+		Headers:   transport.Headers(reqMeta.Headers),
 	}
 
 	encoded, err := json.Marshal(reqBody)
@@ -83,5 +84,5 @@ func (c jsonClient) Call(reqMeta *ReqMeta, reqBody interface{}, resBodyOut inter
 		return nil, err
 	}
 
-	return &ResMeta{Headers: tres.Headers}, nil
+	return &ResMeta{Headers: yarpc.Headers(tres.Headers)}, nil
 }

--- a/encoding/json/outbound_test.go
+++ b/encoding/json/outbound_test.go
@@ -26,6 +26,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/yarpc/yarpc-go"
 	"github.com/yarpc/yarpc-go/transport"
 	"github.com/yarpc/yarpc-go/transport/transporttest"
 
@@ -48,7 +49,7 @@ func TestCall(t *testing.T) {
 
 	tests := []struct {
 		procedure       string
-		headers         transport.Headers
+		headers         yarpc.Headers
 		body            interface{}
 		encodedRequest  string
 		encodedResponse string
@@ -58,7 +59,7 @@ func TestCall(t *testing.T) {
 
 		// Either want, or wantType and wantErr must be set.
 		want        interface{} // expected response body
-		wantHeaders transport.Headers
+		wantHeaders yarpc.Headers
 		wantType    reflect.Type // type of response body
 		wantErr     string       // error message
 	}{
@@ -86,12 +87,12 @@ func TestCall(t *testing.T) {
 		},
 		{
 			procedure:       "requestHeaders",
-			headers:         transport.Headers{"user-id": "42"},
+			headers:         yarpc.NewHeaders().With("user-id", "42"),
 			body:            map[string]interface{}{},
 			encodedRequest:  "{}",
 			encodedResponse: "{}",
 			want:            map[string]interface{}{},
-			wantHeaders:     transport.Headers{"success": "true"},
+			wantHeaders:     yarpc.NewHeaders().With("success", "true"),
 		},
 	}
 
@@ -111,14 +112,14 @@ func TestCall(t *testing.T) {
 						Service:   service,
 						Procedure: tt.procedure,
 						Encoding:  Encoding,
-						Headers:   tt.headers,
+						Headers:   transport.Headers(tt.headers),
 						Body:      bytes.NewReader([]byte(tt.encodedRequest)),
 					}),
 			).Return(
 				&transport.Response{
 					Body: ioutil.NopCloser(
 						bytes.NewReader([]byte(tt.encodedResponse))),
-					Headers: tt.wantHeaders,
+					Headers: transport.Headers(tt.wantHeaders),
 				}, nil)
 		}
 

--- a/encoding/json/request.go
+++ b/encoding/json/request.go
@@ -21,7 +21,7 @@
 package json
 
 import (
-	"github.com/yarpc/yarpc-go/transport"
+	"github.com/yarpc/yarpc-go"
 
 	"golang.org/x/net/context"
 )
@@ -36,7 +36,7 @@ type ReqMeta struct {
 	Procedure string
 
 	// Request headers
-	Headers transport.Headers
+	Headers yarpc.Headers
 }
 
 // Note: The shape of this request object is extremely similar to the

--- a/encoding/json/response.go
+++ b/encoding/json/response.go
@@ -20,11 +20,11 @@
 
 package json
 
-import "github.com/yarpc/yarpc-go/transport"
+import "github.com/yarpc/yarpc-go"
 
 // ResMeta is a JSON response without the body.
 type ResMeta struct {
-	Headers transport.Headers
+	Headers yarpc.Headers
 
 	// TODO Response context?
 

--- a/encoding/raw/inbound.go
+++ b/encoding/raw/inbound.go
@@ -23,6 +23,7 @@ package raw
 import (
 	"io/ioutil"
 
+	"github.com/yarpc/yarpc-go"
 	"github.com/yarpc/yarpc-go/transport"
 
 	"golang.org/x/net/context"
@@ -46,7 +47,7 @@ func (r rawHandler) Handle(ctx context.Context, treq *transport.Request, rw tran
 	reqMeta := ReqMeta{
 		Context:   ctx,
 		Procedure: treq.Procedure,
-		Headers:   treq.Headers,
+		Headers:   yarpc.Headers(treq.Headers),
 	}
 
 	resBody, resMeta, err := r.h(&reqMeta, reqBody)
@@ -55,7 +56,7 @@ func (r rawHandler) Handle(ctx context.Context, treq *transport.Request, rw tran
 	}
 
 	if resMeta != nil {
-		rw.AddHeaders(resMeta.Headers)
+		rw.AddHeaders(transport.Headers(resMeta.Headers))
 	}
 
 	if _, err := rw.Write(resBody); err != nil {

--- a/encoding/raw/inbound_test.go
+++ b/encoding/raw/inbound_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/yarpc/yarpc-go"
 	"github.com/yarpc/yarpc-go/transport"
 	"github.com/yarpc/yarpc-go/transport/transporttest"
 
@@ -88,10 +89,10 @@ func TestRawHandler(t *testing.T) {
 			bodyChunks: [][]byte{},
 			handler: func(reqMeta *ReqMeta, body []byte) ([]byte, *ResMeta, error) {
 				return []byte{}, &ResMeta{
-					Headers: transport.Headers{"hello": "world"},
+					Headers: yarpc.NewHeaders().With("hello", "world"),
 				}, nil
 			},
-			wantHeaders: transport.Headers{"hello": "world"},
+			wantHeaders: transport.NewHeaders().With("hello", "world"),
 		},
 	}
 

--- a/encoding/raw/outbound.go
+++ b/encoding/raw/outbound.go
@@ -24,6 +24,7 @@ import (
 	"bytes"
 	"io/ioutil"
 
+	"github.com/yarpc/yarpc-go"
 	"github.com/yarpc/yarpc-go/transport"
 )
 
@@ -57,7 +58,7 @@ func (c rawClient) Call(reqMeta *ReqMeta, body []byte) ([]byte, *ResMeta, error)
 		Service:   c.service,
 		Encoding:  Encoding,
 		Procedure: reqMeta.Procedure,
-		Headers:   reqMeta.Headers,
+		Headers:   transport.Headers(reqMeta.Headers),
 		Body:      bytes.NewReader(body),
 	}
 
@@ -72,5 +73,5 @@ func (c rawClient) Call(reqMeta *ReqMeta, body []byte) ([]byte, *ResMeta, error)
 		return nil, nil, err
 	}
 
-	return resBody, &ResMeta{Headers: tres.Headers}, nil
+	return resBody, &ResMeta{Headers: yarpc.Headers(tres.Headers)}, nil
 }

--- a/encoding/raw/outbound_test.go
+++ b/encoding/raw/outbound_test.go
@@ -25,6 +25,7 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/yarpc/yarpc-go"
 	"github.com/yarpc/yarpc-go/transport"
 	"github.com/yarpc/yarpc-go/transport/transporttest"
 
@@ -45,13 +46,13 @@ func TestCall(t *testing.T) {
 
 	tests := []struct {
 		procedure    string
-		headers      transport.Headers
+		headers      yarpc.Headers
 		body         []byte
 		responseBody [][]byte
 
 		want        []byte
 		wantErr     string
-		wantHeaders transport.Headers
+		wantHeaders yarpc.Headers
 	}{
 		{
 			procedure:    "foo",
@@ -67,11 +68,11 @@ func TestCall(t *testing.T) {
 		},
 		{
 			procedure:    "headers",
-			headers:      transport.Headers{"x": "y"},
+			headers:      yarpc.NewHeaders().With("x", "y"),
 			body:         []byte{},
 			responseBody: [][]byte{},
 			want:         []byte{},
-			wantHeaders:  transport.Headers{"a": "b"},
+			wantHeaders:  yarpc.NewHeaders().With("a", "b"),
 		},
 	}
 
@@ -95,14 +96,14 @@ func TestCall(t *testing.T) {
 					Caller:    caller,
 					Service:   service,
 					Procedure: tt.procedure,
-					Headers:   tt.headers,
+					Headers:   transport.Headers(tt.headers),
 					Encoding:  Encoding,
 					Body:      bytes.NewReader(tt.body),
 				}),
 		).Return(
 			&transport.Response{
 				Body:    ioutil.NopCloser(responseBody),
-				Headers: tt.wantHeaders,
+				Headers: transport.Headers(tt.wantHeaders),
 			}, nil)
 
 		resBody, res, err := client.Call(&ReqMeta{

--- a/encoding/raw/request.go
+++ b/encoding/raw/request.go
@@ -21,7 +21,7 @@
 package raw
 
 import (
-	"github.com/yarpc/yarpc-go/transport"
+	"github.com/yarpc/yarpc-go"
 
 	"golang.org/x/net/context"
 )
@@ -34,7 +34,7 @@ type ReqMeta struct {
 	Procedure string
 
 	// Request headers
-	Headers transport.Headers
+	Headers yarpc.Headers
 }
 
 // Note: The shape of this request object is extremely similar to the

--- a/encoding/raw/response.go
+++ b/encoding/raw/response.go
@@ -20,11 +20,11 @@
 
 package raw
 
-import "github.com/yarpc/yarpc-go/transport"
+import "github.com/yarpc/yarpc-go"
 
 // ResMeta is a Raw response without the body.
 type ResMeta struct {
-	Headers transport.Headers
+	Headers yarpc.Headers
 
 	// TODO Response context?
 }

--- a/encoding/thrift/inbound.go
+++ b/encoding/thrift/inbound.go
@@ -24,6 +24,7 @@ import (
 	"bytes"
 	"io/ioutil"
 
+	"github.com/yarpc/yarpc-go"
 	"github.com/yarpc/yarpc-go/internal/encoding"
 	"github.com/yarpc/yarpc-go/transport"
 
@@ -54,7 +55,7 @@ func (t thriftHandler) Handle(ctx context.Context, treq *transport.Request, rw t
 
 	res, err := t.Handler.Handle(&ReqMeta{
 		Context: ctx,
-		Headers: treq.Headers,
+		Headers: yarpc.Headers(treq.Headers),
 	}, reqBody)
 	if err != nil {
 		return err
@@ -66,7 +67,7 @@ func (t thriftHandler) Handle(ctx context.Context, treq *transport.Request, rw t
 
 	resMeta := res.Meta
 	if resMeta != nil {
-		rw.AddHeaders(resMeta.Headers)
+		rw.AddHeaders(transport.Headers(resMeta.Headers))
 	}
 
 	if err := t.Protocol.Encode(res.Body, rw); err != nil {

--- a/encoding/thrift/outbound.go
+++ b/encoding/thrift/outbound.go
@@ -24,6 +24,7 @@ import (
 	"bytes"
 	"io/ioutil"
 
+	"github.com/yarpc/yarpc-go"
 	"github.com/yarpc/yarpc-go/internal/encoding"
 	"github.com/yarpc/yarpc-go/transport"
 
@@ -119,7 +120,7 @@ func (c thriftClient) Call(method string, reqMeta *ReqMeta, reqBody wire.Value) 
 		Service:   c.service,
 		Encoding:  Encoding,
 		Procedure: procedureName(c.thriftService, method),
-		Headers:   reqMeta.Headers,
+		Headers:   transport.Headers(reqMeta.Headers),
 	}
 
 	var buffer bytes.Buffer
@@ -144,5 +145,5 @@ func (c thriftClient) Call(method string, reqMeta *ReqMeta, reqBody wire.Value) 
 		return wire.Value{}, nil, encoding.ResponseBodyDecodeError(&treq, err)
 	}
 
-	return resBody, &ResMeta{Headers: tres.Headers}, nil
+	return resBody, &ResMeta{Headers: yarpc.Headers(tres.Headers)}, nil
 }

--- a/encoding/thrift/request.go
+++ b/encoding/thrift/request.go
@@ -21,7 +21,7 @@
 package thrift
 
 import (
-	"github.com/yarpc/yarpc-go/transport"
+	"github.com/yarpc/yarpc-go"
 
 	"golang.org/x/net/context"
 )
@@ -31,5 +31,5 @@ type ReqMeta struct {
 	Context context.Context
 
 	// Request headers
-	Headers transport.Headers
+	Headers yarpc.Headers
 }

--- a/encoding/thrift/response.go
+++ b/encoding/thrift/response.go
@@ -21,15 +21,14 @@
 package thrift
 
 import (
-	"github.com/yarpc/yarpc-go/transport"
-
 	"github.com/thriftrw/thriftrw-go/wire"
+	"github.com/yarpc/yarpc-go"
 )
 
 // ResMeta represents a raw Thrift response.
 type ResMeta struct {
 	// Response headers
-	Headers transport.Headers
+	Headers yarpc.Headers
 
 	// TODO: Handle REPLY/EXCEPTION for response envelopes
 }

--- a/internal/filter/chain_test.go
+++ b/internal/filter/chain_test.go
@@ -27,7 +27,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/yarpc/yarpc-go/encoding/raw"
 	"github.com/yarpc/yarpc-go/transport"
 	"github.com/yarpc/yarpc-go/transport/transporttest"
 
@@ -61,7 +60,7 @@ func TestChain(t *testing.T) {
 	req := &transport.Request{
 		Caller:    "somecaller",
 		Service:   "someservice",
-		Encoding:  raw.Encoding,
+		Encoding:  transport.Encoding("raw"),
 		Procedure: "hello",
 		Body:      bytes.NewReader([]byte{1, 2, 3}),
 	}

--- a/internal/headers.go
+++ b/internal/headers.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package internal
+
+import "strings"
+
+var emptyMap = map[string]string{}
+
+// Headers provides the implementation of both, yarpc.Headers and
+// transport.Headers.
+//
+// Keys in the map are canonicalized using CanonicalizeHeaderKey.
+type Headers struct {
+	items map[string]string
+}
+
+// NewHeadersWithCapacity allocates a new Headers object. capacity specifies
+// the initial capacity of the headers map. A capacity of zero or less is
+// ignored.
+func NewHeadersWithCapacity(capacity int) Headers {
+	if capacity <= 0 {
+		return Headers{}
+	}
+	return Headers{items: make(map[string]string, capacity)}
+}
+
+// With returns a Headers object with the given key-value pair added to it.
+//
+// Returns a Headers object possibly backed by a different data store.
+func (h Headers) With(k, v string) Headers {
+	if h.items == nil {
+		h.items = make(map[string]string)
+	}
+	h.items[CanonicalizeHeaderKey(k)] = v
+	return h
+}
+
+// Items returns the underlying map for this Headers object. The returned map
+// MUST NOT be mutated. Doing so will result in undefined behavior.
+//
+// This ALWAYS returns a non-nil result.
+func (h Headers) Items() map[string]string {
+	if h.items == nil {
+		return emptyMap
+	}
+	return h.items
+}
+
+// Get retrieves the value associated with the given key.
+func (h Headers) Get(k string) (string, bool) {
+	v, ok := h.items[CanonicalizeHeaderKey(k)]
+	return v, ok
+}
+
+// Del deletes the header with the given name.
+func (h Headers) Del(k string) {
+	delete(h.items, CanonicalizeHeaderKey(k))
+}
+
+// Len returns the number of headers defined on this object.
+func (h Headers) Len() int {
+	return len(h.items)
+}
+
+// CanonicalizeHeaderKey canonicalizes the given header key for storage into
+// the Headers map.
+func CanonicalizeHeaderKey(k string) string {
+	// TODO: Deal with unsupported header keys (anything that's not a valid HTTP
+	// header key).
+	return strings.ToLower(k)
+}

--- a/internal/interceptor/chain_test.go
+++ b/internal/interceptor/chain_test.go
@@ -26,7 +26,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/yarpc/yarpc-go/encoding/raw"
 	"github.com/yarpc/yarpc-go/transport"
 	"github.com/yarpc/yarpc-go/transport/transporttest"
 
@@ -59,7 +58,7 @@ func TestChain(t *testing.T) {
 	req := &transport.Request{
 		Caller:    "somecaller",
 		Service:   "someservice",
-		Encoding:  raw.Encoding,
+		Encoding:  transport.Encoding("raw"),
 		Procedure: "hello",
 		Body:      bytes.NewReader([]byte{1, 2, 3}),
 	}

--- a/transport/header_test.go
+++ b/transport/header_test.go
@@ -67,7 +67,7 @@ func TestNewHeaders(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		headers := NewHeaders(tt.headers)
+		headers := HeadersFromMap(tt.headers)
 		for k, v := range tt.matches {
 			vg, ok := headers.Get(k)
 			assert.True(t, ok, "expected true for %q", k)

--- a/transport/http/handler.go
+++ b/transport/http/handler.go
@@ -71,7 +71,7 @@ func (h handler) callHandler(w http.ResponseWriter, req *http.Request) error {
 		Service:   popHeader(req.Header, ServiceHeader),
 		Procedure: popHeader(req.Header, ProcedureHeader),
 		Encoding:  transport.Encoding(popHeader(req.Header, EncodingHeader)),
-		Headers:   applicationHeaders.FromHTTPHeaders(req.Header, nil),
+		Headers:   applicationHeaders.FromHTTPHeaders(req.Header, transport.Headers{}),
 		Body:      req.Body,
 	}
 
@@ -86,8 +86,9 @@ func (h handler) callHandler(w http.ResponseWriter, req *http.Request) error {
 		return err
 	}
 
-	if headers := baggageHeaders.FromHTTPHeaders(req.Header, nil); len(headers) > 0 {
-		ctx = baggage.NewContextWithHeaders(ctx, headers)
+	headers := baggageHeaders.FromHTTPHeaders(req.Header, transport.Headers{})
+	if headers.Len() > 0 {
+		ctx = baggage.NewContextWithHeaders(ctx, headers.Items())
 	}
 
 	// TODO capture and handle panic

--- a/transport/http/handler_test.go
+++ b/transport/http/handler_test.go
@@ -94,8 +94,8 @@ func TestHandlerHeaders(t *testing.T) {
 		giveHeaders http.Header
 
 		wantTTL     time.Duration
-		wantHeaders transport.Headers
-		wantBaggage transport.Headers
+		wantHeaders map[string]string
+		wantBaggage map[string]string
 	}{
 		{
 			giveHeaders: http.Header{
@@ -104,10 +104,10 @@ func TestHandlerHeaders(t *testing.T) {
 				"Context-Foo":    {"Baz"},
 			},
 			wantTTL: time.Second,
-			wantHeaders: transport.Headers{
+			wantHeaders: map[string]string{
 				"foo": "bar",
 			},
-			wantBaggage: transport.Headers{
+			wantBaggage: map[string]string{
 				"foo": "Baz",
 			},
 		},
@@ -119,8 +119,8 @@ func TestHandlerHeaders(t *testing.T) {
 				"Context-Rpc-Service": {"hello"},
 			},
 			wantTTL:     100 * time.Millisecond,
-			wantHeaders: transport.Headers{},
-			wantBaggage: transport.Headers{"rpc-service": "hello"},
+			wantHeaders: map[string]string{},
+			wantBaggage: map[string]string{"rpc-service": "hello"},
 		},
 	}
 
@@ -139,7 +139,7 @@ func TestHandlerHeaders(t *testing.T) {
 					Service:   "service",
 					Encoding:  raw.Encoding,
 					Procedure: "hello",
-					Headers:   tt.wantHeaders,
+					Headers:   transport.HeadersFromMap(tt.wantHeaders),
 					Body:      bytes.NewReader([]byte("world")),
 				}),
 			gomock.Any(),
@@ -307,7 +307,7 @@ func TestResponseWriter(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	writer := newResponseWriter(recorder)
 
-	headers := transport.NewHeaders(map[string]string{
+	headers := transport.HeadersFromMap(map[string]string{
 		"foo":       "bar",
 		"shard-key": "123",
 	})

--- a/transport/http/header.go
+++ b/transport/http/header.go
@@ -43,9 +43,9 @@ var (
 // If 'to' is nil, a new map will be assigned.
 func (hm headerMapper) ToHTTPHeaders(from transport.Headers, to http.Header) http.Header {
 	if to == nil {
-		to = make(http.Header, len(from))
+		to = make(http.Header, from.Len())
 	}
-	for k, v := range from {
+	for k, v := range from.Items() {
 		to.Add(hm.Prefix+k, v)
 	}
 	return to
@@ -58,15 +58,11 @@ func (hm headerMapper) ToHTTPHeaders(from transport.Headers, to http.Header) htt
 //
 // If 'to' is nil, a new map will be assigned.
 func (hm headerMapper) FromHTTPHeaders(from http.Header, to transport.Headers) transport.Headers {
-	if to == nil {
-		to = make(transport.Headers, len(from))
-	}
-
 	prefixLen := len(hm.Prefix)
 	for k := range from {
 		if strings.HasPrefix(k, hm.Prefix) {
 			key := k[prefixLen:]
-			to.Set(key, from.Get(k))
+			to = to.With(key, from.Get(k))
 		}
 		// Note: undefined behavior for multiple occurrences of the same header
 	}

--- a/transport/http/header_test.go
+++ b/transport/http/header_test.go
@@ -37,10 +37,10 @@ func TestHeaders(t *testing.T) {
 	}{
 		{
 			ApplicationHeaderPrefix,
-			transport.Headers{
+			transport.HeadersFromMap(map[string]string{
 				"foo":     "bar",
 				"foo-bar": "hello",
-			},
+			}),
 			http.Header{
 				"Rpc-Header-Foo":     []string{"bar"},
 				"Rpc-Header-Foo-Bar": []string{"hello"},
@@ -50,7 +50,7 @@ func TestHeaders(t *testing.T) {
 
 	for _, tt := range tests {
 		m := headerMapper{tt.prefix}
-		assert.Equal(t, tt.transport, m.FromHTTPHeaders(tt.http, nil))
+		assert.Equal(t, tt.transport, m.FromHTTPHeaders(tt.http, transport.Headers{}))
 		assert.Equal(t, tt.http, m.ToHTTPHeaders(tt.transport, nil))
 	}
 }

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -63,7 +63,7 @@ func (o outbound) Call(ctx context.Context, req *transport.Request) (*transport.
 	}
 
 	request.Header = applicationHeaders.ToHTTPHeaders(req.Headers, nil)
-	if hs := baggage.FromContext(ctx); hs != nil {
+	if hs := baggage.FromContext(ctx); hs.Len() > 0 {
 		request.Header = baggageHeaders.ToHTTPHeaders(hs, request.Header)
 	}
 
@@ -87,8 +87,10 @@ func (o outbound) Call(ctx context.Context, req *transport.Request) (*transport.
 	}
 
 	if response.StatusCode >= 200 && response.StatusCode < 300 {
+		appHeaders := applicationHeaders.FromHTTPHeaders(
+			response.Header, transport.NewHeaders())
 		return &transport.Response{
-			Headers: applicationHeaders.FromHTTPHeaders(response.Header, nil),
+			Headers: appHeaders,
 			Body:    response.Body,
 		}, nil
 	}

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -98,7 +98,7 @@ func TestOutboundHeaders(t *testing.T) {
 	}{
 		{
 			desc:    "application headers",
-			headers: transport.Headers{"foo": "bar", "baz": "Qux"},
+			headers: transport.NewHeaders().With("foo", "bar").With("baz", "Qux"),
 			wantHeaders: map[string]string{
 				"Rpc-Header-Foo": "bar",
 				"Rpc-Header-Baz": "Qux",
@@ -118,7 +118,7 @@ func TestOutboundHeaders(t *testing.T) {
 		{
 			desc:    "application headers and baggage",
 			context: yarpc.WithBaggage(context.Background(), "foo", "bar"),
-			headers: transport.Headers{"foo": "baz"},
+			headers: transport.NewHeaders().With("foo", "baz"),
 			wantHeaders: map[string]string{
 				"Context-Foo":    "bar",
 				"Rpc-Header-Foo": "baz",

--- a/transport/response.go
+++ b/transport/response.go
@@ -37,6 +37,7 @@ type ResponseWriter interface {
 	//
 	// This MUST NOT panic if Headers is nil.
 	AddHeaders(Headers)
+	// TODO(abg): Ability to set individual headers instead?
 
 	// SetApplicationError specifies that this response contains an
 	// application error. If called, this MUST be called before any invocation

--- a/transport/roundtrip_test.go
+++ b/transport/roundtrip_test.go
@@ -112,9 +112,9 @@ func TestSimpleRoundTrip(t *testing.T) {
 		wantError func(error)
 	}{
 		{
-			requestHeaders:  transport.Headers{"token": "1234"},
+			requestHeaders:  transport.NewHeaders().With("token", "1234"),
 			requestBody:     "world",
-			responseHeaders: transport.Headers{"status": "ok"},
+			responseHeaders: transport.NewHeaders().With("status", "ok"),
 			responseBody:    "hello, world",
 		},
 		{
@@ -180,7 +180,7 @@ func TestSimpleRoundTrip(t *testing.T) {
 					return tt.responseError
 				}
 
-				if len(tt.responseHeaders) > 0 {
+				if tt.responseHeaders.Len() > 0 {
 					w.AddHeaders(tt.responseHeaders)
 				}
 

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -157,7 +157,6 @@ func newResponseWriter(treq *transport.Request, call inboundCall) *responseWrite
 	return &responseWriter{
 		treq:     treq,
 		response: call.Response(),
-		headers:  make(transport.Headers),
 		format:   call.Format(),
 	}
 }
@@ -166,8 +165,8 @@ func (rw *responseWriter) AddHeaders(h transport.Headers) {
 	if rw.wroteHeaders {
 		panic("AddHeaders() cannot be called after calling Write().")
 	}
-	for k, v := range h {
-		rw.headers.Set(k, v)
+	for k, v := range h.Items() {
+		rw.headers = rw.headers.With(k, v)
 	}
 }
 

--- a/transport/tchannel/header_test.go
+++ b/transport/tchannel/header_test.go
@@ -54,7 +54,7 @@ func TestEncodeAndDecodeHeaders(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		headers := transport.NewHeaders(tt.headers)
+		headers := transport.HeadersFromMap(tt.headers)
 		assert.Equal(t, tt.bytes, encodeHeaders(headers))
 
 		result, err := decodeHeaders(bytes.NewReader(tt.bytes))
@@ -128,7 +128,7 @@ func TestReadAndWriteHeaders(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		headers := transport.NewHeaders(tt.headers)
+		headers := transport.HeadersFromMap(tt.headers)
 
 		buffer := newBufferArgWriter()
 		err := writeHeaders(tt.format, headers, func() (tchannel.ArgWriter, error) {
@@ -138,7 +138,7 @@ func TestReadAndWriteHeaders(t *testing.T) {
 
 		// Result must match either tt.bytes or tt.orBytes.
 		if !bytes.Equal(tt.bytes, buffer.Bytes()) {
-			assert.Equal(t, tt.orBytes, buffer.Bytes())
+			assert.Equal(t, tt.orBytes, buffer.Bytes(), "failed for %v", tt.format)
 		}
 
 		result, err := readHeaders(tt.format, func() (tchannel.ArgReader, error) {
@@ -146,7 +146,7 @@ func TestReadAndWriteHeaders(t *testing.T) {
 			return tchannel.ArgReader(reader), nil
 		})
 		require.NoError(t, err)
-		assert.Equal(t, headers, result)
+		assert.Equal(t, headers, result, "failed for %v", tt.format)
 	}
 }
 

--- a/transport/tchannel/outbound_test.go
+++ b/transport/tchannel/outbound_test.go
@@ -65,7 +65,7 @@ func TestOutboundHeaders(t *testing.T) {
 			},
 		},
 		{
-			headers: transport.Headers{"contextfoo": "bar"},
+			headers: transport.NewHeaders().With("contextfoo", "bar"),
 			wantHeaders: []byte{
 				0x00, 0x01,
 				0x00, 0x0A, 'c', 'o', 'n', 't', 'e', 'x', 't', 'f', 'o', 'o',
@@ -73,7 +73,7 @@ func TestOutboundHeaders(t *testing.T) {
 			},
 		},
 		{
-			headers: transport.Headers{"Foo": "bar"},
+			headers: transport.NewHeaders().With("Foo", "bar"),
 			wantHeaders: []byte{
 				0x00, 0x01,
 				0x00, 0x03, 'f', 'o', 'o',
@@ -81,7 +81,7 @@ func TestOutboundHeaders(t *testing.T) {
 			},
 		},
 		{
-			headers:   transport.Headers{"context-foo": "bar"},
+			headers:   transport.NewHeaders().With("context-foo", "bar"),
 			wantError: `application headers cannot start with "Context-"`,
 		},
 	}

--- a/transport/transporttest/context.go
+++ b/transport/transporttest/context.go
@@ -38,7 +38,7 @@ import (
 type ContextMatcher struct {
 	t       *testing.T
 	ttl     time.Duration
-	baggage transport.Headers
+	baggage *transport.Headers
 
 	TTLDelta time.Duration
 }
@@ -58,10 +58,11 @@ func (ttl ContextTTL) run(c *ContextMatcher) {
 
 // ContextBaggage requires that the Context have the given baggage associated
 // with it.
-type ContextBaggage transport.Headers
+type ContextBaggage map[string]string
 
 func (b ContextBaggage) run(c *ContextMatcher) {
-	c.baggage = transport.Headers(b)
+	h := transport.HeadersFromMap(b)
+	c.baggage = &h
 }
 
 // NewContextMatcher creates a ContextMatcher to verify properties about a
@@ -103,7 +104,7 @@ func (c *ContextMatcher) Matches(got interface{}) bool {
 
 	if c.baggage != nil {
 		headers := baggage.FromContext(ctx)
-		if !reflect.DeepEqual(c.baggage, headers) {
+		if !reflect.DeepEqual(*c.baggage, headers) {
 			c.t.Logf("Headers did not match:\n\t   %v (want)\n\t!= %v (got)", c.baggage, headers)
 			return false
 		}

--- a/transport/transporttest/reqres.go
+++ b/transport/transporttest/reqres.go
@@ -203,11 +203,8 @@ func (fw *FakeResponseWriter) SetApplicationError() {
 
 // AddHeaders for FakeResponseWriter.
 func (fw *FakeResponseWriter) AddHeaders(h transport.Headers) {
-	if fw.Headers == nil {
-		fw.Headers = make(transport.Headers)
-	}
-	for k, v := range h {
-		fw.Headers.Set(k, v)
+	for k, v := range h.Items() {
+		fw.Headers = fw.Headers.With(k, v)
 	}
 }
 

--- a/transport/transporttest/reqres.go
+++ b/transport/transporttest/reqres.go
@@ -97,7 +97,7 @@ func (m RequestMatcher) Matches(got interface{}) bool {
 	}
 
 	// len check to handle nil vs empty cases gracefully.
-	if len(l.Headers) != len(r.Headers) {
+	if l.Headers.Len() != r.Headers.Len() {
 		if !reflect.DeepEqual(l.Headers, r.Headers) {
 			m.t.Logf("Headers did not match:\n\t   %v\n\t!= %v", l.Headers, r.Headers)
 			return false
@@ -124,8 +124,8 @@ func (m RequestMatcher) String() string {
 
 // checkSuperSet checks if the items in l are all also present in r.
 func checkSuperSet(l, r transport.Headers) error {
-	missing := make([]string, 0, len(l))
-	for k, vl := range l {
+	missing := make([]string, 0, l.Len())
+	for k, vl := range l.Items() {
 		vr, ok := r.Get(k)
 		if !ok || vr != vl {
 			missing = append(missing, k)


### PR DESCRIPTION
This adds an `internal.Headers` opaque type which backs both, `yarpc.Headers`
and `transport.Headers`. Both of those expose the subsets of the API they care
about.

A feature of the new Headers representation is that zero-value is always valid.
You can do,

```go
var headers yarpc.Headers  // or transport.Headers or internal.Headers
headers = headers.With("a", "1").With("b", "2")
headers = headers.With("c", "3")
```

Or,

```go
headers := yarpc.NewHeaders().With("a", "1")
headers = headers.With("b", "2")
```

Note that the Headers object returned by `With` **must** be used in place of
the original because it *may* not point to the same underlying map.

`yarpc.Headers`, `transport.Headers` and `internal.Headers`, all expose the
following functions.

    func (h Headers) Del(k string)
    func (h Headers) Get(k string) (string, bool)
    func (h Headers) Len() int
    func (h Headers) With(k, v string) Headers

`yarpc.Headers` exposes the following additional functions.

    func NewHeaders() Headers
    func (h Headers) Keys() []string

`transport.Headers` exposes the following additional functions:

    func HeadersFromMap(m map[string]string) Headers
    func NewHeaders() Headers
    func NewHeadersWithCapacity(capacity int) Headers
    func (h Headers) Items() map[string]string

Resolves #68, #212

-------------------------------------------------------------------------------

Note: This diff modifies a large number of files but the bulk of those changes
are mechanical updates of `transport.Headers{...}`, to
`transport.NewHeaders().With(..).With(..)`. I recommend reviewing individual
commits rather than the whole diff. In particular, the fist 5 commits.
