### PR TITLE
tchannel: Add Inbound with Channel()

### DIFF
--- a/transport/tchannel/inbound.go
+++ b/transport/tchannel/inbound.go
@@ -28,7 +28,7 @@ import (
 	"github.com/uber/tchannel-go"
 )
 
-// Inbound represents a TChannel Inbound.
+// Inbound is a TChannel Inbound.
 type Inbound interface {
 	transport.Inbound
 

--- a/transport/tchannel/inbound.go
+++ b/transport/tchannel/inbound.go
@@ -28,6 +28,14 @@ import (
 	"github.com/uber/tchannel-go"
 )
 
+// Inbound represents a TChannel Inbound.
+type Inbound interface {
+	transport.Inbound
+
+	// Returns the underlying Channel for this Inbound.
+	Channel() *tchannel.Channel
+}
+
 // InboundOption configures Inbound.
 type InboundOption func(*inbound)
 
@@ -40,10 +48,10 @@ func ListenAddr(addr string) InboundOption {
 	return func(i *inbound) { i.addr = addr }
 }
 
-// NewInbound builds a new TChannel inbound from the given Channel.
-// Existing methods registered on the channel remain registered and
-// are preferred when a call is received.
-func NewInbound(ch *tchannel.Channel, opts ...InboundOption) transport.Inbound {
+// NewInbound builds a new TChannel inbound from the given Channel. Existing
+// methods registered on the channel remain registered and are preferred when
+// a call is received.
+func NewInbound(ch *tchannel.Channel, opts ...InboundOption) Inbound {
 	i := &inbound{ch: ch}
 	for _, opt := range opts {
 		opt(i)
@@ -55,6 +63,10 @@ type inbound struct {
 	ch       *tchannel.Channel
 	addr     string
 	listener net.Listener
+}
+
+func (i *inbound) Channel() *tchannel.Channel {
+	return i.ch
 }
 
 func (i *inbound) Start(h transport.Handler) error {

--- a/transport/tchannel/inbound_test.go
+++ b/transport/tchannel/inbound_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/yarpc/yarpc-go/transport"
 	"github.com/yarpc/yarpc-go/transport/transporttest"
 
 	"github.com/stretchr/testify/assert"
@@ -35,11 +34,14 @@ import (
 
 func TestInboundStartNew(t *testing.T) {
 	tests := []struct {
-		withInbound func(*tchannel.Channel, func(transport.Inbound))
+		withInbound func(*tchannel.Channel, func(Inbound))
 	}{
 		{
-			func(ch *tchannel.Channel, f func(transport.Inbound)) {
+			func(ch *tchannel.Channel, f func(Inbound)) {
 				i := NewInbound(ch)
+				// Can't do Equal because we want to match the pointer, not a
+				// DeepEqual.
+				assert.True(t, ch == i.Channel(), "channel does not match")
 				require.NoError(t, i.Start(new(transporttest.MockHandler)))
 				defer i.Stop()
 
@@ -47,8 +49,9 @@ func TestInboundStartNew(t *testing.T) {
 			},
 		},
 		{
-			func(ch *tchannel.Channel, f func(transport.Inbound)) {
+			func(ch *tchannel.Channel, f func(Inbound)) {
 				i := NewInbound(ch, ListenAddr(":0"))
+				assert.True(t, ch == i.Channel(), "channel does not match")
 				require.NoError(t, i.Start(new(transporttest.MockHandler)))
 				defer i.Stop()
 
@@ -60,7 +63,7 @@ func TestInboundStartNew(t *testing.T) {
 	for _, tt := range tests {
 		ch, err := tchannel.NewChannel("foo", nil)
 		require.NoError(t, err)
-		tt.withInbound(ch, func(i transport.Inbound) {
+		tt.withInbound(ch, func(i Inbound) {
 			assert.Equal(t, tchannel.ChannelListening, ch.State())
 			assert.NoError(t, i.Stop())
 			assert.Equal(t, tchannel.ChannelClosed, ch.State())


### PR DESCRIPTION
As with http, we now have a custom `tchannel.Inbound` interface which embeds
the `transport.Inbound` interface. We expose the underlying TChannel Channel
using this function.

This will also come in handy later when we want the Inbound to own the
Channel.

@yarpc/golang