### PR TITLE
rpc: Change append(foo, bar...) to copy(foo, bar)

### DIFF
--- a/rpc.go
+++ b/rpc.go
@@ -102,8 +102,8 @@ type rpc struct {
 }
 
 func (r rpc) Inbounds() []transport.Inbound {
-	inbounds := make([]transport.Inbound, 0, len(r.inbounds))
-	inbounds = append(inbounds, r.inbounds...)
+	inbounds := make([]transport.Inbound, len(r.inbounds))
+	copy(inbounds, r.inbounds)
 	return inbounds
 }
 


### PR DESCRIPTION
As per
https://github.com/yarpc/yarpc-go/pull/225/files/8c848e022b50a3c5d46c4980b28f5a61f5269fa1#r67798985