### PR TITLE
Outbounds: Verify that Start is called before Call

### DIFF
--- a/crossdock/client/echo/json.go
+++ b/crossdock/client/echo/json.go
@@ -39,7 +39,11 @@ type jsonEcho struct {
 // JSON implements the 'json' behavior.
 func JSON(t crossdock.T) {
 	t = createEchoT("json", t)
+	fatals := crossdock.Fatals(t)
+
 	rpc := rpc.Create(t)
+	fatals.NoError(rpc.Start(), "could not start RPC")
+	defer rpc.Stop()
 
 	client := json.New(rpc.Channel("yarpc-test"))
 	ctx, _ := context.WithTimeout(context.Background(), time.Second)

--- a/crossdock/client/echo/raw.go
+++ b/crossdock/client/echo/raw.go
@@ -35,7 +35,11 @@ import (
 // Raw implements the 'raw' behavior.
 func Raw(t crossdock.T) {
 	t = createEchoT("raw", t)
+	fatals := crossdock.Fatals(t)
+
 	rpc := rpc.Create(t)
+	fatals.NoError(rpc.Start(), "could not start RPC")
+	defer rpc.Stop()
 
 	client := raw.New(rpc.Channel("yarpc-test"))
 	ctx, _ := context.WithTimeout(context.Background(), time.Second)

--- a/crossdock/client/echo/thrift.go
+++ b/crossdock/client/echo/thrift.go
@@ -36,7 +36,11 @@ import (
 // Thrift implements the 'thrift' behavior.
 func Thrift(t crossdock.T) {
 	t = createEchoT("thrift", t)
+	fatals := crossdock.Fatals(t)
+
 	rpc := rpc.Create(t)
+	fatals.NoError(rpc.Start(), "could not start RPC")
+	defer rpc.Stop()
 
 	client := echoclient.New(rpc.Channel("yarpc-test"))
 	ctx, _ := context.WithTimeout(context.Background(), time.Second)

--- a/crossdock/client/gauntlet/behavior.go
+++ b/crossdock/client/gauntlet/behavior.go
@@ -62,7 +62,13 @@ type TT struct {
 
 // Run executes the thriftgauntlet behavior.
 func Run(t crossdock.T) {
-	RunGauntlet(t, rpc.Create(t), serverName)
+	fatals := crossdock.Fatals(t)
+
+	rpc := rpc.Create(t)
+	fatals.NoError(rpc.Start(), "could not start RPC")
+	defer rpc.Stop()
+
+	RunGauntlet(t, rpc, serverName)
 }
 
 // RunGauntlet takes an rpc object and runs the gauntlet

--- a/crossdock/client/headers/behavior.go
+++ b/crossdock/client/headers/behavior.go
@@ -47,11 +47,14 @@ func createHeadersT(t crossdock.T) crossdock.T {
 // Run runs the headers behavior
 func Run(t crossdock.T) {
 	t = createHeadersT(t)
-	rpc := rpc.Create(t)
 
 	fatals := crossdock.Fatals(t)
 	assert := crossdock.Assert(t)
 	checks := crossdock.Checks(t)
+
+	rpc := rpc.Create(t)
+	fatals.NoError(rpc.Start(), "could not start RPC")
+	defer rpc.Stop()
 
 	var caller headerCaller
 	encoding := t.Param(params.Encoding)

--- a/crossdock/client/outboundttl/behavior.go
+++ b/crossdock/client/outboundttl/behavior.go
@@ -42,6 +42,9 @@ func Run(t crossdock.T) {
 	defer cancel()
 
 	rpc := rpc.Create(t)
+	fatals.NoError(rpc.Start(), "could not start RPC")
+	defer rpc.Stop()
+
 	ch := raw.New(rpc.Channel("yarpc-test"))
 	_, _, err := ch.Call(&raw.ReqMeta{
 		Context:   ctx,

--- a/crossdock/server/yarpc/phone.go
+++ b/crossdock/server/yarpc/phone.go
@@ -92,6 +92,11 @@ func Phone(reqMeta *json.ReqMeta, body *PhoneRequest) (*PhoneResponse, *json.Res
 		return nil, nil, fmt.Errorf("unconfigured transport")
 	}
 
+	if err := outbound.Start(); err != nil {
+		return nil, nil, err
+	}
+	defer outbound.Stop()
+
 	client := json.New(transport.Channel{
 		Caller:   "yarpc-test", // TODO use reqMeta.Service,
 		Service:  body.Service,

--- a/examples/json/client/main.go
+++ b/examples/json/client/main.go
@@ -113,6 +113,10 @@ func main() {
 		Outbounds: transport.Outbounds{"keyvalue": outbound},
 		Filter:    yarpc.Filters(requestLogFilter{}),
 	})
+	if err := rpc.Start(); err != nil {
+		log.Fatalf("failed to start RPC: %v", err)
+	}
+	defer rpc.Stop()
 
 	client := json.New(rpc.Channel("keyvalue"))
 

--- a/examples/thrift/keyvalue/client/main.go
+++ b/examples/thrift/keyvalue/client/main.go
@@ -69,6 +69,10 @@ func main() {
 		Outbounds: transport.Outbounds{"keyvalue": outbound},
 		Filter:    cache,
 	})
+	if err := rpc.Start(); err != nil {
+		log.Fatalf("failed to start RPC: %v", err)
+	}
+	defer rpc.Stop()
 
 	client := keyvalueclient.New(rpc.Channel("keyvalue"))
 

--- a/internal/errors/outbound.go
+++ b/internal/errors/outbound.go
@@ -18,53 +18,22 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package tchserver
+package errors
 
-import (
-	"fmt"
+import "fmt"
 
-	"github.com/yarpc/yarpc-go"
-	"github.com/yarpc/yarpc-go/crossdock-go"
-	"github.com/yarpc/yarpc-go/crossdock/client/params"
-	"github.com/yarpc/yarpc-go/transport"
-	tch "github.com/yarpc/yarpc-go/transport/tchannel"
+// ErrOutboundAlreadyStarted represents a failure because Start() was already
+// called on the outbound.
+type ErrOutboundAlreadyStarted string
 
-	"github.com/uber/tchannel-go"
-)
+func (e ErrOutboundAlreadyStarted) Error() string {
+	return fmt.Sprintf("%s has already been started", string(e))
+}
 
-const (
-	serverPort = 8083
-	serverName = "tchannel-server"
-)
+// ErrOutboundNotStarted represents a failure because Start() was not called
+// on an outbound or if Stop() was called.
+type ErrOutboundNotStarted string
 
-// Run executes the tchserver test
-func Run(t crossdock.T) {
-	fatals := crossdock.Fatals(t)
-
-	encoding := t.Param(params.Encoding)
-	server := t.Param(params.Server)
-	serverHostPort := fmt.Sprintf("%v:%v", server, serverPort)
-
-	ch, err := tchannel.NewChannel("yarpc-client", nil)
-	fatals.NoError(err, "could not create channel")
-
-	rpc := yarpc.New(yarpc.Config{
-		Name: "yarpc-client",
-		Outbounds: transport.Outbounds{
-			serverName: tch.NewOutbound(ch, tch.HostPort(serverHostPort)),
-		},
-	})
-	fatals.NoError(rpc.Start(), "could not start RPC")
-	defer rpc.Stop()
-
-	switch encoding {
-	case "raw":
-		runRaw(t, rpc)
-	case "json":
-		runJSON(t, rpc)
-	case "thrift":
-		runThrift(t, rpc)
-	default:
-		fatals.Fail("", "unknown encoding %q", encoding)
-	}
+func (e ErrOutboundNotStarted) Error() string {
+	return fmt.Sprintf("%s has not been started or was stopped", string(e))
 }


### PR DESCRIPTION
This changes both, HTTP and TChannel Outbound implementations to verify that
`Start()` is called before allowing any calls to go through them.

Calling `Call()` without `Start()` causes a panic because this is not really a
recoverable error. Someone forgot to call `rpc.Start()`.

Resolves #233