### PR TITLE
thrift: Use thriftrw's Enveloper interface

### DIFF
--- a/crossdock/thrift/echo/yarpc/echoclient/client.go
+++ b/crossdock/thrift/echo/yarpc/echoclient/client.go
@@ -44,13 +44,8 @@ type client struct{ c thrift.Client }
 
 func (c client) Echo(reqMeta yarpc.CallReqMeta, ping *echo.Ping) (success *echo.Pong, resMeta yarpc.CallResMeta, err error) {
 	args := echo2.EchoHelper.Args(ping)
-	var w wire.Value
-	w, err = args.ToWire()
-	if err != nil {
-		return
-	}
 	var body wire.Value
-	body, resMeta, err = c.c.Call("echo", reqMeta, w)
+	body, resMeta, err = c.c.Call(reqMeta, args)
 	if err != nil {
 		return
 	}

--- a/crossdock/thrift/echo/yarpc/echoserver/server.go
+++ b/crossdock/thrift/echo/yarpc/echoserver/server.go
@@ -67,7 +67,7 @@ func (h handler) Echo(reqMeta yarpc.ReqMeta, body wire.Value) (thrift.Response, 
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Meta = resMeta
-		response.Body, err = result.ToWire()
+		response.Body = result
 	}
 	return response, err
 }

--- a/crossdock/thrift/gauntlet/yarpc/secondserviceclient/client.go
+++ b/crossdock/thrift/gauntlet/yarpc/secondserviceclient/client.go
@@ -44,13 +44,8 @@ type client struct{ c thrift.Client }
 
 func (c client) BlahBlah(reqMeta yarpc.CallReqMeta) (resMeta yarpc.CallResMeta, err error) {
 	args := secondservice.BlahBlahHelper.Args()
-	var w wire.Value
-	w, err = args.ToWire()
-	if err != nil {
-		return
-	}
 	var body wire.Value
-	body, resMeta, err = c.c.Call("blahBlah", reqMeta, w)
+	body, resMeta, err = c.c.Call(reqMeta, args)
 	if err != nil {
 		return
 	}
@@ -64,13 +59,8 @@ func (c client) BlahBlah(reqMeta yarpc.CallReqMeta) (resMeta yarpc.CallResMeta, 
 
 func (c client) SecondtestString(reqMeta yarpc.CallReqMeta, thing *string) (success string, resMeta yarpc.CallResMeta, err error) {
 	args := secondservice.SecondtestStringHelper.Args(thing)
-	var w wire.Value
-	w, err = args.ToWire()
-	if err != nil {
-		return
-	}
 	var body wire.Value
-	body, resMeta, err = c.c.Call("secondtestString", reqMeta, w)
+	body, resMeta, err = c.c.Call(reqMeta, args)
 	if err != nil {
 		return
 	}

--- a/crossdock/thrift/gauntlet/yarpc/secondserviceserver/server.go
+++ b/crossdock/thrift/gauntlet/yarpc/secondserviceserver/server.go
@@ -67,7 +67,7 @@ func (h handler) BlahBlah(reqMeta yarpc.ReqMeta, body wire.Value) (thrift.Respon
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Meta = resMeta
-		response.Body, err = result.ToWire()
+		response.Body = result
 	}
 	return response, err
 }
@@ -84,7 +84,7 @@ func (h handler) SecondtestString(reqMeta yarpc.ReqMeta, body wire.Value) (thrif
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Meta = resMeta
-		response.Body, err = result.ToWire()
+		response.Body = result
 	}
 	return response, err
 }

--- a/crossdock/thrift/gauntlet/yarpc/thrifttestclient/client.go
+++ b/crossdock/thrift/gauntlet/yarpc/thrifttestclient/client.go
@@ -63,13 +63,8 @@ type client struct{ c thrift.Client }
 
 func (c client) TestBinary(reqMeta yarpc.CallReqMeta, thing []byte) (success []byte, resMeta yarpc.CallResMeta, err error) {
 	args := thrifttest.TestBinaryHelper.Args(thing)
-	var w wire.Value
-	w, err = args.ToWire()
-	if err != nil {
-		return
-	}
 	var body wire.Value
-	body, resMeta, err = c.c.Call("testBinary", reqMeta, w)
+	body, resMeta, err = c.c.Call(reqMeta, args)
 	if err != nil {
 		return
 	}
@@ -83,13 +78,8 @@ func (c client) TestBinary(reqMeta yarpc.CallReqMeta, thing []byte) (success []b
 
 func (c client) TestByte(reqMeta yarpc.CallReqMeta, thing *int8) (success int8, resMeta yarpc.CallResMeta, err error) {
 	args := thrifttest.TestByteHelper.Args(thing)
-	var w wire.Value
-	w, err = args.ToWire()
-	if err != nil {
-		return
-	}
 	var body wire.Value
-	body, resMeta, err = c.c.Call("testByte", reqMeta, w)
+	body, resMeta, err = c.c.Call(reqMeta, args)
 	if err != nil {
 		return
 	}
@@ -103,13 +93,8 @@ func (c client) TestByte(reqMeta yarpc.CallReqMeta, thing *int8) (success int8, 
 
 func (c client) TestDouble(reqMeta yarpc.CallReqMeta, thing *float64) (success float64, resMeta yarpc.CallResMeta, err error) {
 	args := thrifttest.TestDoubleHelper.Args(thing)
-	var w wire.Value
-	w, err = args.ToWire()
-	if err != nil {
-		return
-	}
 	var body wire.Value
-	body, resMeta, err = c.c.Call("testDouble", reqMeta, w)
+	body, resMeta, err = c.c.Call(reqMeta, args)
 	if err != nil {
 		return
 	}
@@ -123,13 +108,8 @@ func (c client) TestDouble(reqMeta yarpc.CallReqMeta, thing *float64) (success f
 
 func (c client) TestEnum(reqMeta yarpc.CallReqMeta, thing *gauntlet.Numberz) (success gauntlet.Numberz, resMeta yarpc.CallResMeta, err error) {
 	args := thrifttest.TestEnumHelper.Args(thing)
-	var w wire.Value
-	w, err = args.ToWire()
-	if err != nil {
-		return
-	}
 	var body wire.Value
-	body, resMeta, err = c.c.Call("testEnum", reqMeta, w)
+	body, resMeta, err = c.c.Call(reqMeta, args)
 	if err != nil {
 		return
 	}
@@ -143,13 +123,8 @@ func (c client) TestEnum(reqMeta yarpc.CallReqMeta, thing *gauntlet.Numberz) (su
 
 func (c client) TestException(reqMeta yarpc.CallReqMeta, arg *string) (resMeta yarpc.CallResMeta, err error) {
 	args := thrifttest.TestExceptionHelper.Args(arg)
-	var w wire.Value
-	w, err = args.ToWire()
-	if err != nil {
-		return
-	}
 	var body wire.Value
-	body, resMeta, err = c.c.Call("testException", reqMeta, w)
+	body, resMeta, err = c.c.Call(reqMeta, args)
 	if err != nil {
 		return
 	}
@@ -163,13 +138,8 @@ func (c client) TestException(reqMeta yarpc.CallReqMeta, arg *string) (resMeta y
 
 func (c client) TestI32(reqMeta yarpc.CallReqMeta, thing *int32) (success int32, resMeta yarpc.CallResMeta, err error) {
 	args := thrifttest.TestI32Helper.Args(thing)
-	var w wire.Value
-	w, err = args.ToWire()
-	if err != nil {
-		return
-	}
 	var body wire.Value
-	body, resMeta, err = c.c.Call("testI32", reqMeta, w)
+	body, resMeta, err = c.c.Call(reqMeta, args)
 	if err != nil {
 		return
 	}
@@ -183,13 +153,8 @@ func (c client) TestI32(reqMeta yarpc.CallReqMeta, thing *int32) (success int32,
 
 func (c client) TestI64(reqMeta yarpc.CallReqMeta, thing *int64) (success int64, resMeta yarpc.CallResMeta, err error) {
 	args := thrifttest.TestI64Helper.Args(thing)
-	var w wire.Value
-	w, err = args.ToWire()
-	if err != nil {
-		return
-	}
 	var body wire.Value
-	body, resMeta, err = c.c.Call("testI64", reqMeta, w)
+	body, resMeta, err = c.c.Call(reqMeta, args)
 	if err != nil {
 		return
 	}
@@ -203,13 +168,8 @@ func (c client) TestI64(reqMeta yarpc.CallReqMeta, thing *int64) (success int64,
 
 func (c client) TestInsanity(reqMeta yarpc.CallReqMeta, argument *gauntlet.Insanity) (success map[gauntlet.UserId]map[gauntlet.Numberz]*gauntlet.Insanity, resMeta yarpc.CallResMeta, err error) {
 	args := thrifttest.TestInsanityHelper.Args(argument)
-	var w wire.Value
-	w, err = args.ToWire()
-	if err != nil {
-		return
-	}
 	var body wire.Value
-	body, resMeta, err = c.c.Call("testInsanity", reqMeta, w)
+	body, resMeta, err = c.c.Call(reqMeta, args)
 	if err != nil {
 		return
 	}
@@ -223,13 +183,8 @@ func (c client) TestInsanity(reqMeta yarpc.CallReqMeta, argument *gauntlet.Insan
 
 func (c client) TestList(reqMeta yarpc.CallReqMeta, thing []int32) (success []int32, resMeta yarpc.CallResMeta, err error) {
 	args := thrifttest.TestListHelper.Args(thing)
-	var w wire.Value
-	w, err = args.ToWire()
-	if err != nil {
-		return
-	}
 	var body wire.Value
-	body, resMeta, err = c.c.Call("testList", reqMeta, w)
+	body, resMeta, err = c.c.Call(reqMeta, args)
 	if err != nil {
 		return
 	}
@@ -243,13 +198,8 @@ func (c client) TestList(reqMeta yarpc.CallReqMeta, thing []int32) (success []in
 
 func (c client) TestMap(reqMeta yarpc.CallReqMeta, thing map[int32]int32) (success map[int32]int32, resMeta yarpc.CallResMeta, err error) {
 	args := thrifttest.TestMapHelper.Args(thing)
-	var w wire.Value
-	w, err = args.ToWire()
-	if err != nil {
-		return
-	}
 	var body wire.Value
-	body, resMeta, err = c.c.Call("testMap", reqMeta, w)
+	body, resMeta, err = c.c.Call(reqMeta, args)
 	if err != nil {
 		return
 	}
@@ -263,13 +213,8 @@ func (c client) TestMap(reqMeta yarpc.CallReqMeta, thing map[int32]int32) (succe
 
 func (c client) TestMapMap(reqMeta yarpc.CallReqMeta, hello *int32) (success map[int32]map[int32]int32, resMeta yarpc.CallResMeta, err error) {
 	args := thrifttest.TestMapMapHelper.Args(hello)
-	var w wire.Value
-	w, err = args.ToWire()
-	if err != nil {
-		return
-	}
 	var body wire.Value
-	body, resMeta, err = c.c.Call("testMapMap", reqMeta, w)
+	body, resMeta, err = c.c.Call(reqMeta, args)
 	if err != nil {
 		return
 	}
@@ -283,13 +228,8 @@ func (c client) TestMapMap(reqMeta yarpc.CallReqMeta, hello *int32) (success map
 
 func (c client) TestMulti(reqMeta yarpc.CallReqMeta, arg0 *int8, arg1 *int32, arg2 *int64, arg3 map[int16]string, arg4 *gauntlet.Numberz, arg5 *gauntlet.UserId) (success *gauntlet.Xtruct, resMeta yarpc.CallResMeta, err error) {
 	args := thrifttest.TestMultiHelper.Args(arg0, arg1, arg2, arg3, arg4, arg5)
-	var w wire.Value
-	w, err = args.ToWire()
-	if err != nil {
-		return
-	}
 	var body wire.Value
-	body, resMeta, err = c.c.Call("testMulti", reqMeta, w)
+	body, resMeta, err = c.c.Call(reqMeta, args)
 	if err != nil {
 		return
 	}
@@ -303,13 +243,8 @@ func (c client) TestMulti(reqMeta yarpc.CallReqMeta, arg0 *int8, arg1 *int32, ar
 
 func (c client) TestMultiException(reqMeta yarpc.CallReqMeta, arg0 *string, arg1 *string) (success *gauntlet.Xtruct, resMeta yarpc.CallResMeta, err error) {
 	args := thrifttest.TestMultiExceptionHelper.Args(arg0, arg1)
-	var w wire.Value
-	w, err = args.ToWire()
-	if err != nil {
-		return
-	}
 	var body wire.Value
-	body, resMeta, err = c.c.Call("testMultiException", reqMeta, w)
+	body, resMeta, err = c.c.Call(reqMeta, args)
 	if err != nil {
 		return
 	}
@@ -323,13 +258,8 @@ func (c client) TestMultiException(reqMeta yarpc.CallReqMeta, arg0 *string, arg1
 
 func (c client) TestNest(reqMeta yarpc.CallReqMeta, thing *gauntlet.Xtruct2) (success *gauntlet.Xtruct2, resMeta yarpc.CallResMeta, err error) {
 	args := thrifttest.TestNestHelper.Args(thing)
-	var w wire.Value
-	w, err = args.ToWire()
-	if err != nil {
-		return
-	}
 	var body wire.Value
-	body, resMeta, err = c.c.Call("testNest", reqMeta, w)
+	body, resMeta, err = c.c.Call(reqMeta, args)
 	if err != nil {
 		return
 	}
@@ -343,13 +273,8 @@ func (c client) TestNest(reqMeta yarpc.CallReqMeta, thing *gauntlet.Xtruct2) (su
 
 func (c client) TestSet(reqMeta yarpc.CallReqMeta, thing map[int32]struct{}) (success map[int32]struct{}, resMeta yarpc.CallResMeta, err error) {
 	args := thrifttest.TestSetHelper.Args(thing)
-	var w wire.Value
-	w, err = args.ToWire()
-	if err != nil {
-		return
-	}
 	var body wire.Value
-	body, resMeta, err = c.c.Call("testSet", reqMeta, w)
+	body, resMeta, err = c.c.Call(reqMeta, args)
 	if err != nil {
 		return
 	}
@@ -363,13 +288,8 @@ func (c client) TestSet(reqMeta yarpc.CallReqMeta, thing map[int32]struct{}) (su
 
 func (c client) TestString(reqMeta yarpc.CallReqMeta, thing *string) (success string, resMeta yarpc.CallResMeta, err error) {
 	args := thrifttest.TestStringHelper.Args(thing)
-	var w wire.Value
-	w, err = args.ToWire()
-	if err != nil {
-		return
-	}
 	var body wire.Value
-	body, resMeta, err = c.c.Call("testString", reqMeta, w)
+	body, resMeta, err = c.c.Call(reqMeta, args)
 	if err != nil {
 		return
 	}
@@ -383,13 +303,8 @@ func (c client) TestString(reqMeta yarpc.CallReqMeta, thing *string) (success st
 
 func (c client) TestStringMap(reqMeta yarpc.CallReqMeta, thing map[string]string) (success map[string]string, resMeta yarpc.CallResMeta, err error) {
 	args := thrifttest.TestStringMapHelper.Args(thing)
-	var w wire.Value
-	w, err = args.ToWire()
-	if err != nil {
-		return
-	}
 	var body wire.Value
-	body, resMeta, err = c.c.Call("testStringMap", reqMeta, w)
+	body, resMeta, err = c.c.Call(reqMeta, args)
 	if err != nil {
 		return
 	}
@@ -403,13 +318,8 @@ func (c client) TestStringMap(reqMeta yarpc.CallReqMeta, thing map[string]string
 
 func (c client) TestStruct(reqMeta yarpc.CallReqMeta, thing *gauntlet.Xtruct) (success *gauntlet.Xtruct, resMeta yarpc.CallResMeta, err error) {
 	args := thrifttest.TestStructHelper.Args(thing)
-	var w wire.Value
-	w, err = args.ToWire()
-	if err != nil {
-		return
-	}
 	var body wire.Value
-	body, resMeta, err = c.c.Call("testStruct", reqMeta, w)
+	body, resMeta, err = c.c.Call(reqMeta, args)
 	if err != nil {
 		return
 	}
@@ -423,13 +333,8 @@ func (c client) TestStruct(reqMeta yarpc.CallReqMeta, thing *gauntlet.Xtruct) (s
 
 func (c client) TestTypedef(reqMeta yarpc.CallReqMeta, thing *gauntlet.UserId) (success gauntlet.UserId, resMeta yarpc.CallResMeta, err error) {
 	args := thrifttest.TestTypedefHelper.Args(thing)
-	var w wire.Value
-	w, err = args.ToWire()
-	if err != nil {
-		return
-	}
 	var body wire.Value
-	body, resMeta, err = c.c.Call("testTypedef", reqMeta, w)
+	body, resMeta, err = c.c.Call(reqMeta, args)
 	if err != nil {
 		return
 	}
@@ -443,13 +348,8 @@ func (c client) TestTypedef(reqMeta yarpc.CallReqMeta, thing *gauntlet.UserId) (
 
 func (c client) TestVoid(reqMeta yarpc.CallReqMeta) (resMeta yarpc.CallResMeta, err error) {
 	args := thrifttest.TestVoidHelper.Args()
-	var w wire.Value
-	w, err = args.ToWire()
-	if err != nil {
-		return
-	}
 	var body wire.Value
-	body, resMeta, err = c.c.Call("testVoid", reqMeta, w)
+	body, resMeta, err = c.c.Call(reqMeta, args)
 	if err != nil {
 		return
 	}

--- a/crossdock/thrift/gauntlet/yarpc/thrifttestserver/server.go
+++ b/crossdock/thrift/gauntlet/yarpc/thrifttestserver/server.go
@@ -86,7 +86,7 @@ func (h handler) TestBinary(reqMeta yarpc.ReqMeta, body wire.Value) (thrift.Resp
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Meta = resMeta
-		response.Body, err = result.ToWire()
+		response.Body = result
 	}
 	return response, err
 }
@@ -103,7 +103,7 @@ func (h handler) TestByte(reqMeta yarpc.ReqMeta, body wire.Value) (thrift.Respon
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Meta = resMeta
-		response.Body, err = result.ToWire()
+		response.Body = result
 	}
 	return response, err
 }
@@ -120,7 +120,7 @@ func (h handler) TestDouble(reqMeta yarpc.ReqMeta, body wire.Value) (thrift.Resp
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Meta = resMeta
-		response.Body, err = result.ToWire()
+		response.Body = result
 	}
 	return response, err
 }
@@ -137,7 +137,7 @@ func (h handler) TestEnum(reqMeta yarpc.ReqMeta, body wire.Value) (thrift.Respon
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Meta = resMeta
-		response.Body, err = result.ToWire()
+		response.Body = result
 	}
 	return response, err
 }
@@ -154,7 +154,7 @@ func (h handler) TestException(reqMeta yarpc.ReqMeta, body wire.Value) (thrift.R
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Meta = resMeta
-		response.Body, err = result.ToWire()
+		response.Body = result
 	}
 	return response, err
 }
@@ -171,7 +171,7 @@ func (h handler) TestI32(reqMeta yarpc.ReqMeta, body wire.Value) (thrift.Respons
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Meta = resMeta
-		response.Body, err = result.ToWire()
+		response.Body = result
 	}
 	return response, err
 }
@@ -188,7 +188,7 @@ func (h handler) TestI64(reqMeta yarpc.ReqMeta, body wire.Value) (thrift.Respons
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Meta = resMeta
-		response.Body, err = result.ToWire()
+		response.Body = result
 	}
 	return response, err
 }
@@ -205,7 +205,7 @@ func (h handler) TestInsanity(reqMeta yarpc.ReqMeta, body wire.Value) (thrift.Re
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Meta = resMeta
-		response.Body, err = result.ToWire()
+		response.Body = result
 	}
 	return response, err
 }
@@ -222,7 +222,7 @@ func (h handler) TestList(reqMeta yarpc.ReqMeta, body wire.Value) (thrift.Respon
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Meta = resMeta
-		response.Body, err = result.ToWire()
+		response.Body = result
 	}
 	return response, err
 }
@@ -239,7 +239,7 @@ func (h handler) TestMap(reqMeta yarpc.ReqMeta, body wire.Value) (thrift.Respons
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Meta = resMeta
-		response.Body, err = result.ToWire()
+		response.Body = result
 	}
 	return response, err
 }
@@ -256,7 +256,7 @@ func (h handler) TestMapMap(reqMeta yarpc.ReqMeta, body wire.Value) (thrift.Resp
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Meta = resMeta
-		response.Body, err = result.ToWire()
+		response.Body = result
 	}
 	return response, err
 }
@@ -273,7 +273,7 @@ func (h handler) TestMulti(reqMeta yarpc.ReqMeta, body wire.Value) (thrift.Respo
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Meta = resMeta
-		response.Body, err = result.ToWire()
+		response.Body = result
 	}
 	return response, err
 }
@@ -290,7 +290,7 @@ func (h handler) TestMultiException(reqMeta yarpc.ReqMeta, body wire.Value) (thr
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Meta = resMeta
-		response.Body, err = result.ToWire()
+		response.Body = result
 	}
 	return response, err
 }
@@ -307,7 +307,7 @@ func (h handler) TestNest(reqMeta yarpc.ReqMeta, body wire.Value) (thrift.Respon
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Meta = resMeta
-		response.Body, err = result.ToWire()
+		response.Body = result
 	}
 	return response, err
 }
@@ -324,7 +324,7 @@ func (h handler) TestSet(reqMeta yarpc.ReqMeta, body wire.Value) (thrift.Respons
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Meta = resMeta
-		response.Body, err = result.ToWire()
+		response.Body = result
 	}
 	return response, err
 }
@@ -341,7 +341,7 @@ func (h handler) TestString(reqMeta yarpc.ReqMeta, body wire.Value) (thrift.Resp
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Meta = resMeta
-		response.Body, err = result.ToWire()
+		response.Body = result
 	}
 	return response, err
 }
@@ -358,7 +358,7 @@ func (h handler) TestStringMap(reqMeta yarpc.ReqMeta, body wire.Value) (thrift.R
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Meta = resMeta
-		response.Body, err = result.ToWire()
+		response.Body = result
 	}
 	return response, err
 }
@@ -375,7 +375,7 @@ func (h handler) TestStruct(reqMeta yarpc.ReqMeta, body wire.Value) (thrift.Resp
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Meta = resMeta
-		response.Body, err = result.ToWire()
+		response.Body = result
 	}
 	return response, err
 }
@@ -392,7 +392,7 @@ func (h handler) TestTypedef(reqMeta yarpc.ReqMeta, body wire.Value) (thrift.Res
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Meta = resMeta
-		response.Body, err = result.ToWire()
+		response.Body = result
 	}
 	return response, err
 }
@@ -409,7 +409,7 @@ func (h handler) TestVoid(reqMeta yarpc.ReqMeta, body wire.Value) (thrift.Respon
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Meta = resMeta
-		response.Body, err = result.ToWire()
+		response.Body = result
 	}
 	return response, err
 }

--- a/encoding/thrift/inbound.go
+++ b/encoding/thrift/inbound.go
@@ -59,6 +59,11 @@ func (t thriftHandler) Handle(ctx context.Context, treq *transport.Request, rw t
 		return err
 	}
 
+	resBody, err := res.Body.ToWire()
+	if err != nil {
+		return err
+	}
+
 	if res.IsApplicationError {
 		rw.SetApplicationError()
 	}
@@ -69,7 +74,7 @@ func (t thriftHandler) Handle(ctx context.Context, treq *transport.Request, rw t
 		// TODO(abg): propagate response context
 	}
 
-	if err := t.Protocol.Encode(res.Body, rw); err != nil {
+	if err := t.Protocol.Encode(resBody, rw); err != nil {
 		return encoding.ResponseBodyEncodeError(treq, err)
 	}
 

--- a/encoding/thrift/inbound_test.go
+++ b/encoding/thrift/inbound_test.go
@@ -75,7 +75,7 @@ func TestThriftHandler(t *testing.T) {
 			},
 			requestBody,
 		).Return(Response{
-			Body:               wire.NewValueStruct(wire.Struct{}),
+			Body:               emptyEnveloper{},
 			IsApplicationError: isApplicationError,
 		}, nil)
 
@@ -95,6 +95,20 @@ func TestThriftHandler(t *testing.T) {
 			"isApplicationError did not match")
 		assert.Equal(t, rw.Body.String(), "hello", "body did not match")
 	}
+}
+
+type emptyEnveloper struct{}
+
+func (emptyEnveloper) MethodName() string {
+	return "someMethod"
+}
+
+func (emptyEnveloper) EnvelopeType() wire.EnvelopeType {
+	return wire.Reply
+}
+
+func (emptyEnveloper) ToWire() (wire.Value, error) {
+	return wire.NewValueStruct(wire.Struct{}), nil
 }
 
 type fakeReqMeta struct {

--- a/encoding/thrift/response.go
+++ b/encoding/thrift/response.go
@@ -21,13 +21,14 @@
 package thrift
 
 import (
-	"github.com/thriftrw/thriftrw-go/wire"
 	"github.com/yarpc/yarpc-go"
+
+	"github.com/thriftrw/thriftrw-go/envelope"
 )
 
 // Response contains the response from a generated Thrift handler.
 type Response struct {
-	Body wire.Value
+	Body envelope.Enveloper
 	Meta yarpc.ResMeta
 
 	IsApplicationError bool

--- a/examples/thrift/keyvalue/kv/yarpc/keyvalueclient/client.go
+++ b/examples/thrift/keyvalue/kv/yarpc/keyvalueclient/client.go
@@ -44,13 +44,8 @@ type client struct{ c thrift.Client }
 
 func (c client) GetValue(reqMeta yarpc.CallReqMeta, key *string) (success string, resMeta yarpc.CallResMeta, err error) {
 	args := keyvalue.GetValueHelper.Args(key)
-	var w wire.Value
-	w, err = args.ToWire()
-	if err != nil {
-		return
-	}
 	var body wire.Value
-	body, resMeta, err = c.c.Call("getValue", reqMeta, w)
+	body, resMeta, err = c.c.Call(reqMeta, args)
 	if err != nil {
 		return
 	}
@@ -64,13 +59,8 @@ func (c client) GetValue(reqMeta yarpc.CallReqMeta, key *string) (success string
 
 func (c client) SetValue(reqMeta yarpc.CallReqMeta, key *string, value *string) (resMeta yarpc.CallResMeta, err error) {
 	args := keyvalue.SetValueHelper.Args(key, value)
-	var w wire.Value
-	w, err = args.ToWire()
-	if err != nil {
-		return
-	}
 	var body wire.Value
-	body, resMeta, err = c.c.Call("setValue", reqMeta, w)
+	body, resMeta, err = c.c.Call(reqMeta, args)
 	if err != nil {
 		return
 	}

--- a/examples/thrift/keyvalue/kv/yarpc/keyvalueserver/server.go
+++ b/examples/thrift/keyvalue/kv/yarpc/keyvalueserver/server.go
@@ -67,7 +67,7 @@ func (h handler) GetValue(reqMeta yarpc.ReqMeta, body wire.Value) (thrift.Respon
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Meta = resMeta
-		response.Body, err = result.ToWire()
+		response.Body = result
 	}
 	return response, err
 }
@@ -84,7 +84,7 @@ func (h handler) SetValue(reqMeta yarpc.ReqMeta, body wire.Value) (thrift.Respon
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Meta = resMeta
-		response.Body, err = result.ToWire()
+		response.Body = result
 	}
 	return response, err
 }


### PR DESCRIPTION
This changes the Thrift encoding's inbound and outbound interfaces to use the
`Enveloper` interface from thriftrw rather than passing the same information
using extra parameters.

An advantage of this design is that we will be able to use this same interface
to implement enveloping for HTTP/Thrift requests.

Enveloper: https://godoc.org/github.com/thriftrw/thriftrw-go/envelope#Enveloper
Related thriftrw change: https://github.com/thriftrw/thriftrw-go/pull/160

@yarpc/golang