### PR TITLE
Thrift: Use Protocol enveloping API

### DIFF
--- a/encoding/thrift/envelope.go
+++ b/encoding/thrift/envelope.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package thrift
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/thriftrw/thriftrw-go/protocol"
+	"github.com/thriftrw/thriftrw-go/wire"
+)
+
+type errUnexpectedEnvelopeType wire.EnvelopeType
+
+func (e errUnexpectedEnvelopeType) Error() string {
+	return fmt.Sprintf("unexpected envelope type: %v", wire.EnvelopeType(e))
+}
+
+// disableEnveloper wraps a protocol to not envelope payloads.
+type disableEnveloper struct {
+	protocol.Protocol
+
+	// EnvelopeType to use for decoded envelopes.
+	Type wire.EnvelopeType
+}
+
+func (ev disableEnveloper) EncodeEnveloped(e wire.Envelope, w io.Writer) error {
+	return ev.Encode(e.Value, w)
+}
+
+func (ev disableEnveloper) DecodeEnveloped(r io.ReaderAt) (wire.Envelope, error) {
+	value, err := ev.Decode(r, wire.TStruct)
+	return wire.Envelope{
+		Name:  "", // we don't use the decoded name anywhere
+		Type:  ev.Type,
+		SeqID: 1,
+		Value: value,
+	}, err
+}

--- a/encoding/thrift/envelope_test.go
+++ b/encoding/thrift/envelope_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package thrift
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"reflect"
+	"testing"
+	"testing/quick"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/thriftrw/thriftrw-go/protocol"
+	"github.com/thriftrw/thriftrw-go/wire"
+)
+
+func TestDisableEnveloperEncode(t *testing.T) {
+	rand := rand.New(rand.NewSource(time.Now().Unix()))
+
+	tests := []struct {
+		value wire.Value
+		want  []byte
+	}{
+		{
+			wire.NewValueStruct(wire.Struct{Fields: []wire.Field{}}),
+			[]byte{0x00},
+		},
+		{
+			wire.NewValueStruct(wire.Struct{Fields: []wire.Field{
+				{ID: 1, Value: wire.NewValueI32(42)},
+			}}),
+			[]byte{
+				0x08, 0x00, 0x01,
+				0x00, 0x00, 0x00, 0x2a,
+				0x00,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		e := wire.Envelope{Value: tt.value, Type: wire.Call}
+		generate(&e.Name, rand)
+		generate(&e.SeqID, rand)
+
+		var buffer bytes.Buffer
+		proto := disableEnveloper{protocol.Binary, wire.Reply}
+		if !assert.NoError(t, proto.EncodeEnveloped(e, &buffer)) {
+			continue
+		}
+
+		assert.Equal(t, tt.want, buffer.Bytes())
+
+		gotE, err := proto.DecodeEnveloped(bytes.NewReader(tt.want))
+		if !assert.NoError(t, err) {
+			continue
+		}
+
+		assert.Equal(t, wire.Reply, gotE.Type)
+		assert.True(t, wire.ValuesAreEqual(tt.value, gotE.Value))
+	}
+}
+
+// generate generates a random value into the given pointer.
+//
+// 	var i int
+// 	generate(&i, rand)
+//
+// If the type implements the quick.Generator interface, that is used.
+func generate(v interface{}, r *rand.Rand) {
+	t := reflect.TypeOf(v)
+	if t.Kind() != reflect.Ptr {
+		panic(fmt.Sprintf("%v is not a pointer type", t))
+	}
+
+	out, ok := quick.Value(t.Elem(), r)
+	if !ok {
+		panic(fmt.Sprintf("could not generate a value for %v", t))
+	}
+
+	reflect.ValueOf(v).Elem().Set(out)
+}

--- a/encoding/thrift/fakes_test.go
+++ b/encoding/thrift/fakes_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package thrift
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/yarpc/yarpc-go"
+	"github.com/yarpc/yarpc-go/transport"
+
+	"github.com/thriftrw/thriftrw-go/wire"
+	"golang.org/x/net/context"
+)
+
+type fakeEnveloper wire.EnvelopeType
+
+func (fakeEnveloper) MethodName() string {
+	return "someMethod"
+}
+
+func (e fakeEnveloper) EnvelopeType() wire.EnvelopeType {
+	return wire.EnvelopeType(e)
+}
+
+func (fakeEnveloper) ToWire() (wire.Value, error) {
+	return wire.NewValueStruct(wire.Struct{}), nil
+}
+
+type fakeReqMeta struct {
+	context   context.Context
+	caller    string
+	service   string
+	procedure string
+	encoding  transport.Encoding
+	headers   yarpc.Headers
+}
+
+func (f fakeReqMeta) Matches(x interface{}) bool {
+	reqMeta, ok := x.(yarpc.ReqMeta)
+	if !ok {
+		return false
+	}
+
+	// TODO: log to testing.T on mismatch if test becomes more complex
+	if f.context != reqMeta.Context() {
+		return false
+	}
+
+	if f.caller != reqMeta.Caller() {
+		return false
+	}
+	if f.service != reqMeta.Service() {
+		return false
+	}
+	if f.procedure != reqMeta.Procedure() {
+		return false
+	}
+	if f.encoding != reqMeta.Encoding() {
+		return false
+	}
+	if !reflect.DeepEqual(f.headers, reqMeta.Headers()) {
+		return false
+	}
+	return true
+}
+
+func (f fakeReqMeta) String() string {
+	return fmt.Sprintf("%#v", f)
+}

--- a/encoding/thrift/outbound_test.go
+++ b/encoding/thrift/outbound_test.go
@@ -1,0 +1,160 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package thrift
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"testing"
+	"time"
+
+	"github.com/yarpc/yarpc-go"
+	"github.com/yarpc/yarpc-go/transport"
+	"github.com/yarpc/yarpc-go/transport/transporttest"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thriftrw/thriftrw-go/envelope"
+	"github.com/thriftrw/thriftrw-go/wire"
+	"golang.org/x/net/context"
+)
+
+func TestClient(t *testing.T) {
+	tests := []struct {
+		giveRequestBody      envelope.Enveloper // outgoing request body
+		giveResponseEnvelope *wire.Envelope     // returned response envelope
+
+		expectCall          bool           // whether outbound.Call is expected
+		wantRequestEnvelope *wire.Envelope // expected envelope to encode
+		wantError           string         // whether an error is expected
+	}{
+		{
+			giveRequestBody: fakeEnveloper(wire.Call),
+			wantRequestEnvelope: &wire.Envelope{
+				Name:  "someMethod",
+				SeqID: 1,
+				Type:  wire.Call,
+				Value: wire.NewValueStruct(wire.Struct{}),
+			},
+			expectCall: true,
+			giveResponseEnvelope: &wire.Envelope{
+				Name:  "someMethod",
+				SeqID: 1,
+				Type:  wire.Reply,
+				Value: wire.NewValueStruct(wire.Struct{}),
+			},
+		},
+		{
+			giveRequestBody: fakeEnveloper(wire.Reply),
+			wantError: `failed to encode "thrift" request body for procedure ` +
+				`"MyService::someMethod" of service "service": unexpected envelope type: Reply`,
+		},
+		{
+			giveRequestBody: fakeEnveloper(wire.Call),
+			wantRequestEnvelope: &wire.Envelope{
+				Name:  "someMethod",
+				SeqID: 1,
+				Type:  wire.Call,
+				Value: wire.NewValueStruct(wire.Struct{}),
+			},
+			expectCall: true,
+			giveResponseEnvelope: &wire.Envelope{
+				Name:  "someMethod",
+				SeqID: 1,
+				Type:  wire.Exception,
+				Value: wire.NewValueStruct(wire.Struct{}),
+			},
+			wantError: "TApplicationException: TStruct({})", // TODO: what do
+		},
+		{
+			giveRequestBody: fakeEnveloper(wire.Call),
+			wantRequestEnvelope: &wire.Envelope{
+				Name:  "someMethod",
+				SeqID: 1,
+				Type:  wire.Call,
+				Value: wire.NewValueStruct(wire.Struct{}),
+			},
+			expectCall: true,
+			giveResponseEnvelope: &wire.Envelope{
+				Name:  "someMethod",
+				SeqID: 1,
+				Type:  wire.Call,
+				Value: wire.NewValueStruct(wire.Struct{}),
+			},
+			wantError: `failed to decode "thrift" response body for procedure ` +
+				`"MyService::someMethod" of service "service": unexpected envelope type: Call`,
+		},
+	}
+
+	for _, tt := range tests {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		proto := NewMockProtocol(mockCtrl)
+		if tt.wantRequestEnvelope != nil {
+			proto.EXPECT().EncodeEnveloped(*tt.wantRequestEnvelope, gomock.Any()).
+				Do(func(_ wire.Envelope, w io.Writer) {
+					_, err := w.Write([]byte("irrelevant"))
+					require.NoError(t, err, "Write() failed")
+				}).Return(nil)
+		}
+
+		ctx, _ := context.WithTimeout(context.Background(), time.Second)
+
+		trans := transporttest.NewMockOutbound(mockCtrl)
+		if tt.expectCall {
+			trans.EXPECT().Call(ctx,
+				transporttest.NewRequestMatcher(t, &transport.Request{
+					Caller:    "caller",
+					Service:   "service",
+					Encoding:  Encoding,
+					Procedure: "MyService::someMethod",
+					Body:      bytes.NewReader([]byte("irrelevant")),
+				}),
+			).Return(&transport.Response{
+				Body: ioutil.NopCloser(bytes.NewReader([]byte("irrelevant"))),
+			}, nil)
+		}
+
+		if tt.giveResponseEnvelope != nil {
+			proto.EXPECT().DecodeEnveloped(gomock.Any()).Return(*tt.giveResponseEnvelope, nil)
+		}
+
+		c := thriftClient{
+			t:             trans,
+			p:             proto,
+			thriftService: "MyService",
+			caller:        "caller",
+			service:       "service",
+		}
+
+		_, _, err := c.Call(yarpc.NewReqMeta(ctx), tt.giveRequestBody)
+		if tt.wantError != "" {
+			if assert.Error(t, err, "expected failure") {
+				assert.Contains(t, err.Error(), tt.wantError)
+			}
+		} else {
+			assert.NoError(t, err, "expected success")
+		}
+	}
+}

--- a/encoding/thrift/register.go
+++ b/encoding/thrift/register.go
@@ -57,7 +57,10 @@ type Service interface {
 // given Registry.
 func Register(registry transport.Registry, service Service) {
 	name := service.Name()
-	proto := service.Protocol()
+	proto := disableEnveloper{
+		Protocol: service.Protocol(),
+		Type:     wire.Call, // we only decode requests
+	}
 	for method, h := range service.Handlers() {
 		handler := thriftHandler{Handler: h, Protocol: proto}
 		registry.Register("", procedureName(name, method), handler)


### PR DESCRIPTION
We currently wrap all protocols to not envelope so that this doesn't result in
any change of behavior, but in the future we will want to do that only for
TChannel.

@yarpc/golang