### PR TITLE
Rename yarpc.RPC to yarpc.Dispatcher

### DIFF
--- a/crossdock/client/ctxpropagation/behavior.go
+++ b/crossdock/client/ctxpropagation/behavior.go
@@ -160,15 +160,15 @@ func Run(t crossdock.T) {
 				}
 			}
 
-			rpc, tconfig := buildDispatcher(t)
-			fatals.NoError(rpc.Start(), "%v: RPC failed to start", tt.desc)
-			defer rpc.Stop()
+			dispatcher, tconfig := buildDispatcher(t)
+			fatals.NoError(dispatcher.Start(), "%v: Dispatcher failed to start", tt.desc)
+			defer dispatcher.Stop()
 
-			jsonClient := json.New(rpc.Channel("yarpc-test"))
+			jsonClient := json.New(dispatcher.Channel("yarpc-test"))
 			for name, handler := range tt.handlers {
 				handler.SetClient(jsonClient)
 				handler.SetTransport(tconfig)
-				json.Register(rpc, json.Procedure(name, handler.Handle))
+				json.Register(dispatcher, json.Procedure(name, handler.Handle))
 			}
 
 			ctx := context.Background()

--- a/crossdock/client/ctxpropagation/behavior.go
+++ b/crossdock/client/ctxpropagation/behavior.go
@@ -299,7 +299,7 @@ func buildRPC(t crossdock.T) (rpc yarpc.Dispatcher, tconfig server.TransportConf
 		fatals.Fail("", "unknown transport %q", trans)
 	}
 
-	rpc = yarpc.New(yarpc.Config{
+	rpc = yarpc.NewDispatcher(yarpc.Config{
 		Name: "ctxclient",
 		Inbounds: []transport.Inbound{
 			tch.NewInbound(ch, tch.ListenAddr(":8087")),

--- a/crossdock/client/ctxpropagation/behavior.go
+++ b/crossdock/client/ctxpropagation/behavior.go
@@ -160,7 +160,7 @@ func Run(t crossdock.T) {
 				}
 			}
 
-			rpc, tconfig := buildRPC(t)
+			rpc, tconfig := buildDispatcher(t)
 			fatals.NoError(rpc.Start(), "%v: RPC failed to start", tt.desc)
 			defer rpc.Stop()
 
@@ -276,7 +276,7 @@ func (h *multiHopHandler) Handle(reqMeta yarpc.ReqMeta, body interface{}) (inter
 	return map[string]interface{}{}, resMeta, err
 }
 
-func buildRPC(t crossdock.T) (rpc yarpc.Dispatcher, tconfig server.TransportConfig) {
+func buildDispatcher(t crossdock.T) (dispatcher yarpc.Dispatcher, tconfig server.TransportConfig) {
 	fatals := crossdock.Fatals(t)
 
 	self := t.Param("ctxclient")
@@ -299,7 +299,7 @@ func buildRPC(t crossdock.T) (rpc yarpc.Dispatcher, tconfig server.TransportConf
 		fatals.Fail("", "unknown transport %q", trans)
 	}
 
-	rpc = yarpc.NewDispatcher(yarpc.Config{
+	dispatcher = yarpc.NewDispatcher(yarpc.Config{
 		Name: "ctxclient",
 		Inbounds: []transport.Inbound{
 			tch.NewInbound(ch, tch.ListenAddr(":8087")),
@@ -308,5 +308,5 @@ func buildRPC(t crossdock.T) (rpc yarpc.Dispatcher, tconfig server.TransportConf
 		Outbounds: transport.Outbounds{"yarpc-test": outbound},
 	})
 
-	return rpc, tconfig
+	return dispatcher, tconfig
 }

--- a/crossdock/client/ctxpropagation/behavior.go
+++ b/crossdock/client/ctxpropagation/behavior.go
@@ -276,7 +276,7 @@ func (h *multiHopHandler) Handle(reqMeta yarpc.ReqMeta, body interface{}) (inter
 	return map[string]interface{}{}, resMeta, err
 }
 
-func buildRPC(t crossdock.T) (rpc yarpc.RPC, tconfig server.TransportConfig) {
+func buildRPC(t crossdock.T) (rpc yarpc.Dispatcher, tconfig server.TransportConfig) {
 	fatals := crossdock.Fatals(t)
 
 	self := t.Param("ctxclient")

--- a/crossdock/client/dispatcher/dispatcher.go
+++ b/crossdock/client/dispatcher/dispatcher.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package rpc
+package dispatcher
 
 import (
 	"fmt"

--- a/crossdock/client/dispatcher/dispatcher_test.go
+++ b/crossdock/client/dispatcher/dispatcher_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package rpc
+package dispatcher
 
 import (
 	"testing"
@@ -60,10 +60,10 @@ func TestCreate(t *testing.T) {
 
 	for _, tt := range tests {
 		entries := crossdock.Run(tt.params, func(ct crossdock.T) {
-			rpc := Create(ct)
+			dispatcher := Create(ct)
 
 			// should get here only if the request succeeded
-			ch := rpc.Channel("yarpc-test")
+			ch := dispatcher.Channel("yarpc-test")
 			assert.Equal(t, "client", ch.Caller)
 			assert.Equal(t, "yarpc-test", ch.Service)
 		})

--- a/crossdock/client/echo/json.go
+++ b/crossdock/client/echo/json.go
@@ -24,8 +24,8 @@ import (
 	"time"
 
 	"github.com/yarpc/yarpc-go"
+	disp "github.com/yarpc/yarpc-go/crossdock/client/dispatcher"
 	"github.com/yarpc/yarpc-go/crossdock/client/random"
-	"github.com/yarpc/yarpc-go/crossdock/client/rpc"
 	"github.com/yarpc/yarpc-go/encoding/json"
 
 	"github.com/crossdock/crossdock-go"
@@ -42,11 +42,11 @@ func JSON(t crossdock.T) {
 	t = createEchoT("json", t)
 	fatals := crossdock.Fatals(t)
 
-	rpc := rpc.Create(t)
-	fatals.NoError(rpc.Start(), "could not start RPC")
-	defer rpc.Stop()
+	dispatcher := disp.Create(t)
+	fatals.NoError(dispatcher.Start(), "could not start Dispatcher")
+	defer dispatcher.Stop()
 
-	client := json.New(rpc.Channel("yarpc-test"))
+	client := json.New(dispatcher.Channel("yarpc-test"))
 	ctx, _ := context.WithTimeout(context.Background(), time.Second)
 
 	var response jsonEcho

--- a/crossdock/client/echo/raw.go
+++ b/crossdock/client/echo/raw.go
@@ -25,8 +25,8 @@ import (
 	"time"
 
 	"github.com/yarpc/yarpc-go"
+	disp "github.com/yarpc/yarpc-go/crossdock/client/dispatcher"
 	"github.com/yarpc/yarpc-go/crossdock/client/random"
-	"github.com/yarpc/yarpc-go/crossdock/client/rpc"
 	"github.com/yarpc/yarpc-go/encoding/raw"
 
 	"github.com/crossdock/crossdock-go"
@@ -38,11 +38,11 @@ func Raw(t crossdock.T) {
 	t = createEchoT("raw", t)
 	fatals := crossdock.Fatals(t)
 
-	rpc := rpc.Create(t)
-	fatals.NoError(rpc.Start(), "could not start RPC")
-	defer rpc.Stop()
+	dispatcher := disp.Create(t)
+	fatals.NoError(dispatcher.Start(), "could not start Dispatcher")
+	defer dispatcher.Stop()
 
-	client := raw.New(rpc.Channel("yarpc-test"))
+	client := raw.New(dispatcher.Channel("yarpc-test"))
 	ctx, _ := context.WithTimeout(context.Background(), time.Second)
 
 	token := random.Bytes(5)

--- a/crossdock/client/echo/thrift.go
+++ b/crossdock/client/echo/thrift.go
@@ -24,8 +24,8 @@ import (
 	"time"
 
 	"github.com/yarpc/yarpc-go"
+	disp "github.com/yarpc/yarpc-go/crossdock/client/dispatcher"
 	"github.com/yarpc/yarpc-go/crossdock/client/random"
-	"github.com/yarpc/yarpc-go/crossdock/client/rpc"
 	"github.com/yarpc/yarpc-go/crossdock/thrift/echo"
 	"github.com/yarpc/yarpc-go/crossdock/thrift/echo/yarpc/echoclient"
 
@@ -38,11 +38,11 @@ func Thrift(t crossdock.T) {
 	t = createEchoT("thrift", t)
 	fatals := crossdock.Fatals(t)
 
-	rpc := rpc.Create(t)
-	fatals.NoError(rpc.Start(), "could not start RPC")
-	defer rpc.Stop()
+	dispatcher := disp.Create(t)
+	fatals.NoError(dispatcher.Start(), "could not start Dispatcher")
+	defer dispatcher.Stop()
 
-	client := echoclient.New(rpc.Channel("yarpc-test"))
+	client := echoclient.New(dispatcher.Channel("yarpc-test"))
 	ctx, _ := context.WithTimeout(context.Background(), time.Second)
 
 	token := random.String(5)

--- a/crossdock/client/gauntlet/behavior.go
+++ b/crossdock/client/gauntlet/behavior.go
@@ -71,7 +71,7 @@ func Run(t crossdock.T) {
 }
 
 // RunGauntlet takes an rpc object and runs the gauntlet
-func RunGauntlet(t crossdock.T, rpc yarpc.RPC, serverName string) {
+func RunGauntlet(t crossdock.T, rpc yarpc.Dispatcher, serverName string) {
 	t = createGauntletT(t)
 	checks := crossdock.Checks(t)
 

--- a/crossdock/client/gauntlet/behavior.go
+++ b/crossdock/client/gauntlet/behavior.go
@@ -26,9 +26,9 @@ import (
 	"time"
 
 	"github.com/yarpc/yarpc-go"
+	disp "github.com/yarpc/yarpc-go/crossdock/client/dispatcher"
 	"github.com/yarpc/yarpc-go/crossdock/client/params"
 	"github.com/yarpc/yarpc-go/crossdock/client/random"
-	"github.com/yarpc/yarpc-go/crossdock/client/rpc"
 	"github.com/yarpc/yarpc-go/crossdock/thrift/gauntlet"
 	"github.com/yarpc/yarpc-go/crossdock/thrift/gauntlet/yarpc/secondserviceclient"
 	"github.com/yarpc/yarpc-go/crossdock/thrift/gauntlet/yarpc/thrifttestclient"
@@ -63,11 +63,11 @@ type TT struct {
 func Run(t crossdock.T) {
 	fatals := crossdock.Fatals(t)
 
-	rpc := rpc.Create(t)
-	fatals.NoError(rpc.Start(), "could not start RPC")
-	defer rpc.Stop()
+	dispatcher := disp.Create(t)
+	fatals.NoError(dispatcher.Start(), "could not start Dispatcher")
+	defer dispatcher.Stop()
 
-	RunGauntlet(t, rpc, serverName)
+	RunGauntlet(t, dispatcher, serverName)
 }
 
 // RunGauntlet takes an rpc object and runs the gauntlet

--- a/crossdock/client/gauntlet/behavior.go
+++ b/crossdock/client/gauntlet/behavior.go
@@ -71,7 +71,7 @@ func Run(t crossdock.T) {
 }
 
 // RunGauntlet takes an rpc object and runs the gauntlet
-func RunGauntlet(t crossdock.T, rpc yarpc.Dispatcher, serverName string) {
+func RunGauntlet(t crossdock.T, dispatcher yarpc.Dispatcher, serverName string) {
 	t = createGauntletT(t)
 	checks := crossdock.Checks(t)
 
@@ -362,7 +362,7 @@ func RunGauntlet(t crossdock.T, rpc yarpc.Dispatcher, serverName string) {
 
 		desc := BuildDesc(tt)
 
-		client := buildClient(t, desc, tt.Service, rpc.Channel(serverName))
+		client := buildClient(t, desc, tt.Service, dispatcher.Channel(serverName))
 		f := client.MethodByName(tt.Function)
 		if !checks.True(f.IsValid(), "%v: invalid function", desc) {
 			continue

--- a/crossdock/client/headers/behavior.go
+++ b/crossdock/client/headers/behavior.go
@@ -24,9 +24,9 @@ import (
 	"time"
 
 	"github.com/yarpc/yarpc-go"
+	disp "github.com/yarpc/yarpc-go/crossdock/client/dispatcher"
 	"github.com/yarpc/yarpc-go/crossdock/client/params"
 	"github.com/yarpc/yarpc-go/crossdock/client/random"
-	"github.com/yarpc/yarpc-go/crossdock/client/rpc"
 	"github.com/yarpc/yarpc-go/crossdock/thrift/echo"
 	"github.com/yarpc/yarpc-go/crossdock/thrift/echo/yarpc/echoclient"
 	"github.com/yarpc/yarpc-go/encoding/json"
@@ -51,19 +51,19 @@ func Run(t crossdock.T) {
 	assert := crossdock.Assert(t)
 	checks := crossdock.Checks(t)
 
-	rpc := rpc.Create(t)
-	fatals.NoError(rpc.Start(), "could not start RPC")
-	defer rpc.Stop()
+	dispatcher := disp.Create(t)
+	fatals.NoError(dispatcher.Start(), "could not start Dispatcher")
+	defer dispatcher.Stop()
 
 	var caller headerCaller
 	encoding := t.Param(params.Encoding)
 	switch encoding {
 	case "raw":
-		caller = rawCaller{raw.New(rpc.Channel("yarpc-test"))}
+		caller = rawCaller{raw.New(dispatcher.Channel("yarpc-test"))}
 	case "json":
-		caller = jsonCaller{json.New(rpc.Channel("yarpc-test"))}
+		caller = jsonCaller{json.New(dispatcher.Channel("yarpc-test"))}
 	case "thrift":
-		caller = thriftCaller{echoclient.New(rpc.Channel("yarpc-test"))}
+		caller = thriftCaller{echoclient.New(dispatcher.Channel("yarpc-test"))}
 	default:
 		fatals.Fail("", "unknown encoding %q", encoding)
 	}

--- a/crossdock/client/outboundttl/behavior.go
+++ b/crossdock/client/outboundttl/behavior.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"github.com/yarpc/yarpc-go"
-	"github.com/yarpc/yarpc-go/crossdock/client/rpc"
+	disp "github.com/yarpc/yarpc-go/crossdock/client/dispatcher"
 	"github.com/yarpc/yarpc-go/encoding/raw"
 	"github.com/yarpc/yarpc-go/transport"
 
@@ -42,11 +42,11 @@ func Run(t crossdock.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
-	rpc := rpc.Create(t)
-	fatals.NoError(rpc.Start(), "could not start RPC")
-	defer rpc.Stop()
+	dispatcher := disp.Create(t)
+	fatals.NoError(dispatcher.Start(), "could not start Dispatcher")
+	defer dispatcher.Stop()
 
-	ch := raw.New(rpc.Channel("yarpc-test"))
+	ch := raw.New(dispatcher.Channel("yarpc-test"))
 	_, _, err := ch.Call(yarpc.NewReqMeta(ctx).Procedure("sleep/raw"), nil)
 	fatals.Error(err, "expected a failure for timeout")
 

--- a/crossdock/client/rpc/rpc.go
+++ b/crossdock/client/rpc/rpc.go
@@ -61,7 +61,7 @@ func Create(t crossdock.T) yarpc.Dispatcher {
 		fatals.Fail("", "unknown transport %q", trans)
 	}
 
-	return yarpc.New(yarpc.Config{
+	return yarpc.NewDispatcher(yarpc.Config{
 		Name:      "client",
 		Outbounds: transport.Outbounds{"yarpc-test": outbound},
 	})

--- a/crossdock/client/rpc/rpc.go
+++ b/crossdock/client/rpc/rpc.go
@@ -35,7 +35,7 @@ import (
 )
 
 // Create creates an RPC from the given parameters or fails the whole behavior.
-func Create(t crossdock.T) yarpc.RPC {
+func Create(t crossdock.T) yarpc.Dispatcher {
 	fatals := crossdock.Fatals(t)
 
 	server := t.Param(params.Server)

--- a/crossdock/client/tchserver/behavior.go
+++ b/crossdock/client/tchserver/behavior.go
@@ -48,7 +48,7 @@ func Run(t crossdock.T) {
 	ch, err := tchannel.NewChannel("yarpc-client", nil)
 	fatals.NoError(err, "could not create channel")
 
-	rpc := yarpc.New(yarpc.Config{
+	rpc := yarpc.NewDispatcher(yarpc.Config{
 		Name: "yarpc-client",
 		Outbounds: transport.Outbounds{
 			serverName: tch.NewOutbound(ch, tch.HostPort(serverHostPort)),

--- a/crossdock/client/tchserver/behavior.go
+++ b/crossdock/client/tchserver/behavior.go
@@ -48,22 +48,22 @@ func Run(t crossdock.T) {
 	ch, err := tchannel.NewChannel("yarpc-client", nil)
 	fatals.NoError(err, "could not create channel")
 
-	rpc := yarpc.NewDispatcher(yarpc.Config{
+	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name: "yarpc-client",
 		Outbounds: transport.Outbounds{
 			serverName: tch.NewOutbound(ch, tch.HostPort(serverHostPort)),
 		},
 	})
-	fatals.NoError(rpc.Start(), "could not start RPC")
-	defer rpc.Stop()
+	fatals.NoError(dispatcher.Start(), "could not start RPC")
+	defer dispatcher.Stop()
 
 	switch encoding {
 	case "raw":
-		runRaw(t, rpc)
+		runRaw(t, dispatcher)
 	case "json":
-		runJSON(t, rpc)
+		runJSON(t, dispatcher)
 	case "thrift":
-		runThrift(t, rpc)
+		runThrift(t, dispatcher)
 	default:
 		fatals.Fail("", "unknown encoding %q", encoding)
 	}

--- a/crossdock/client/tchserver/behavior.go
+++ b/crossdock/client/tchserver/behavior.go
@@ -54,7 +54,7 @@ func Run(t crossdock.T) {
 			serverName: tch.NewOutbound(ch, tch.HostPort(serverHostPort)),
 		},
 	})
-	fatals.NoError(dispatcher.Start(), "could not start RPC")
+	fatals.NoError(dispatcher.Start(), "could not start Dispatcher")
 	defer dispatcher.Stop()
 
 	switch encoding {

--- a/crossdock/client/tchserver/json.go
+++ b/crossdock/client/tchserver/json.go
@@ -31,14 +31,14 @@ import (
 	"golang.org/x/net/context"
 )
 
-func runJSON(t crossdock.T, rpc yarpc.Dispatcher) {
+func runJSON(t crossdock.T, dispatcher yarpc.Dispatcher) {
 	assert := crossdock.Assert(t)
 	checks := crossdock.Checks(t)
 
 	headers := yarpc.NewHeaders().With("hello", "json")
 	token := random.String(5)
 
-	resBody, resMeta, err := jsonCall(rpc, headers, token)
+	resBody, resMeta, err := jsonCall(dispatcher, headers, token)
 	if skipOnConnRefused(t, err) {
 		return
 	}
@@ -52,8 +52,8 @@ type jsonEcho struct {
 	Token string `json:"token"`
 }
 
-func jsonCall(rpc yarpc.Dispatcher, headers yarpc.Headers, token string) (string, yarpc.CallResMeta, error) {
-	client := json.New(rpc.Channel(serverName))
+func jsonCall(dispatcher yarpc.Dispatcher, headers yarpc.Headers, token string) (string, yarpc.CallResMeta, error) {
+	client := json.New(dispatcher.Channel(serverName))
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()

--- a/crossdock/client/tchserver/json.go
+++ b/crossdock/client/tchserver/json.go
@@ -31,7 +31,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-func runJSON(t crossdock.T, rpc yarpc.RPC) {
+func runJSON(t crossdock.T, rpc yarpc.Dispatcher) {
 	assert := crossdock.Assert(t)
 	checks := crossdock.Checks(t)
 
@@ -52,7 +52,7 @@ type jsonEcho struct {
 	Token string `json:"token"`
 }
 
-func jsonCall(rpc yarpc.RPC, headers yarpc.Headers, token string) (string, yarpc.CallResMeta, error) {
+func jsonCall(rpc yarpc.Dispatcher, headers yarpc.Headers, token string) (string, yarpc.CallResMeta, error) {
 	client := json.New(rpc.Channel(serverName))
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)

--- a/crossdock/client/tchserver/raw.go
+++ b/crossdock/client/tchserver/raw.go
@@ -31,7 +31,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-func runRaw(t crossdock.T, rpc yarpc.Dispatcher) {
+func runRaw(t crossdock.T, dispatcher yarpc.Dispatcher) {
 	assert := crossdock.Assert(t)
 	checks := crossdock.Checks(t)
 
@@ -39,7 +39,7 @@ func runRaw(t crossdock.T, rpc yarpc.Dispatcher) {
 	headers := yarpc.NewHeaders().With("hello", "raw")
 	token := random.Bytes(5)
 
-	resBody, resMeta, err := rawCall(rpc, headers, token)
+	resBody, resMeta, err := rawCall(dispatcher, headers, token)
 	if skipOnConnRefused(t, err) {
 		return
 	}
@@ -49,8 +49,8 @@ func runRaw(t crossdock.T, rpc yarpc.Dispatcher) {
 	}
 }
 
-func rawCall(rpc yarpc.Dispatcher, headers yarpc.Headers, token []byte) ([]byte, yarpc.CallResMeta, error) {
-	client := raw.New(rpc.Channel(serverName))
+func rawCall(dispatcher yarpc.Dispatcher, headers yarpc.Headers, token []byte) ([]byte, yarpc.CallResMeta, error) {
+	client := raw.New(dispatcher.Channel(serverName))
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()

--- a/crossdock/client/tchserver/raw.go
+++ b/crossdock/client/tchserver/raw.go
@@ -31,7 +31,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-func runRaw(t crossdock.T, rpc yarpc.RPC) {
+func runRaw(t crossdock.T, rpc yarpc.Dispatcher) {
 	assert := crossdock.Assert(t)
 	checks := crossdock.Checks(t)
 
@@ -49,7 +49,7 @@ func runRaw(t crossdock.T, rpc yarpc.RPC) {
 	}
 }
 
-func rawCall(rpc yarpc.RPC, headers yarpc.Headers, token []byte) ([]byte, yarpc.CallResMeta, error) {
+func rawCall(rpc yarpc.Dispatcher, headers yarpc.Headers, token []byte) ([]byte, yarpc.CallResMeta, error) {
 	client := raw.New(rpc.Channel(serverName))
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)

--- a/crossdock/client/tchserver/thrift.go
+++ b/crossdock/client/tchserver/thrift.go
@@ -33,14 +33,14 @@ import (
 	"golang.org/x/net/context"
 )
 
-func runThrift(t crossdock.T, rpc yarpc.Dispatcher) {
+func runThrift(t crossdock.T, dispatcher yarpc.Dispatcher) {
 	assert := crossdock.Assert(t)
 	checks := crossdock.Checks(t)
 
 	headers := yarpc.NewHeaders().With("hello", "thrift")
 	token := random.String(5)
 
-	resBody, resMeta, err := thriftCall(rpc, headers, token)
+	resBody, resMeta, err := thriftCall(dispatcher, headers, token)
 	if skipOnConnRefused(t, err) {
 		return
 	}
@@ -49,11 +49,11 @@ func runThrift(t crossdock.T, rpc yarpc.Dispatcher) {
 		assert.Equal(headers, resMeta.Headers(), "headers echoed")
 	}
 
-	gauntlet.RunGauntlet(t, rpc, serverName)
+	gauntlet.RunGauntlet(t, dispatcher, serverName)
 }
 
-func thriftCall(rpc yarpc.Dispatcher, headers yarpc.Headers, token string) (string, yarpc.CallResMeta, error) {
-	client := echoclient.New(rpc.Channel(serverName))
+func thriftCall(dispatcher yarpc.Dispatcher, headers yarpc.Headers, token string) (string, yarpc.CallResMeta, error) {
+	client := echoclient.New(dispatcher.Channel(serverName))
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()

--- a/crossdock/client/tchserver/thrift.go
+++ b/crossdock/client/tchserver/thrift.go
@@ -33,7 +33,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-func runThrift(t crossdock.T, rpc yarpc.RPC) {
+func runThrift(t crossdock.T, rpc yarpc.Dispatcher) {
 	assert := crossdock.Assert(t)
 	checks := crossdock.Checks(t)
 
@@ -52,7 +52,7 @@ func runThrift(t crossdock.T, rpc yarpc.RPC) {
 	gauntlet.RunGauntlet(t, rpc, serverName)
 }
 
-func thriftCall(rpc yarpc.RPC, headers yarpc.Headers, token string) (string, yarpc.CallResMeta, error) {
+func thriftCall(rpc yarpc.Dispatcher, headers yarpc.Headers, token string) (string, yarpc.CallResMeta, error) {
 	client := echoclient.New(rpc.Channel(serverName))
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)

--- a/crossdock/server/yarpc/server.go
+++ b/crossdock/server/yarpc/server.go
@@ -72,16 +72,16 @@ func Stop() {
 	}
 }
 
-func register(rpc transport.Registry) {
-	raw.Register(rpc, raw.Procedure("echo/raw", EchoRaw))
-	json.Register(rpc, json.Procedure("echo", EchoJSON))
-	thrift.Register(rpc, echoserver.New(EchoThrift{}))
-	thrift.Register(rpc, thrifttestserver.New(thriftTest{}))
-	thrift.Register(rpc, secondserviceserver.New(secondService{}))
+func register(reg transport.Registry) {
+	raw.Register(reg, raw.Procedure("echo/raw", EchoRaw))
+	json.Register(reg, json.Procedure("echo", EchoJSON))
+	thrift.Register(reg, echoserver.New(EchoThrift{}))
+	thrift.Register(reg, thrifttestserver.New(thriftTest{}))
+	thrift.Register(reg, secondserviceserver.New(secondService{}))
 
-	json.Register(rpc, json.Procedure("unexpected-error", UnexpectedError))
-	json.Register(rpc, json.Procedure("bad-response", BadResponse))
-	json.Register(rpc, json.Procedure("phone", Phone))
+	json.Register(reg, json.Procedure("unexpected-error", UnexpectedError))
+	json.Register(reg, json.Procedure("bad-response", BadResponse))
+	json.Register(reg, json.Procedure("phone", Phone))
 
-	raw.Register(rpc, raw.Procedure("sleep/raw", SleepRaw))
+	raw.Register(reg, raw.Procedure("sleep/raw", SleepRaw))
 }

--- a/crossdock/server/yarpc/server.go
+++ b/crossdock/server/yarpc/server.go
@@ -38,7 +38,7 @@ import (
 	"github.com/uber/tchannel-go"
 )
 
-var rpc yarpc.RPC
+var rpc yarpc.Dispatcher
 
 // Start starts the test server that clients will make requests to
 func Start() {

--- a/crossdock/server/yarpc/server.go
+++ b/crossdock/server/yarpc/server.go
@@ -38,7 +38,7 @@ import (
 	"github.com/uber/tchannel-go"
 )
 
-var rpc yarpc.Dispatcher
+var dispatcher yarpc.Dispatcher
 
 // Start starts the test server that clients will make requests to
 func Start() {
@@ -47,7 +47,7 @@ func Start() {
 		log.Fatalln("couldn't create tchannel: %v", err)
 	}
 
-	rpc = yarpc.NewDispatcher(yarpc.Config{
+	dispatcher = yarpc.NewDispatcher(yarpc.Config{
 		Name: "yarpc-test",
 		Inbounds: []transport.Inbound{
 			http.NewInbound(":8081"),
@@ -55,19 +55,19 @@ func Start() {
 		},
 	})
 
-	register(rpc)
+	register(dispatcher)
 
-	if err := rpc.Start(); err != nil {
+	if err := dispatcher.Start(); err != nil {
 		fmt.Println("error:", err.Error())
 	}
 }
 
 // Stop stops running the RPC test subject
 func Stop() {
-	if rpc == nil {
+	if dispatcher == nil {
 		return
 	}
-	if err := rpc.Stop(); err != nil {
+	if err := dispatcher.Stop(); err != nil {
 		fmt.Println("failed to stop:", err.Error())
 	}
 }

--- a/crossdock/server/yarpc/server.go
+++ b/crossdock/server/yarpc/server.go
@@ -47,7 +47,7 @@ func Start() {
 		log.Fatalln("couldn't create tchannel: %v", err)
 	}
 
-	rpc = yarpc.New(yarpc.Config{
+	rpc = yarpc.NewDispatcher(yarpc.Config{
 		Name: "yarpc-test",
 		Inbounds: []transport.Inbound{
 			http.NewInbound(":8081"),

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -79,7 +79,7 @@ func NewDispatcher(cfg Config) Dispatcher {
 		panic("a service name is required")
 	}
 
-	return rpc{
+	return dispatcher{
 		Name:        cfg.Name,
 		Registry:    transport.NewMapRegistry(cfg.Name),
 		inbounds:    cfg.Inbounds,
@@ -89,10 +89,10 @@ func NewDispatcher(cfg Config) Dispatcher {
 	}
 }
 
-// rpc is the standard RPC implementation.
+// dispatcher is the standard RPC implementation.
 //
 // It allows use of multiple Inbounds and Outbounds together.
-type rpc struct {
+type dispatcher struct {
 	transport.Registry
 
 	Name        string
@@ -103,43 +103,43 @@ type rpc struct {
 	inbounds []transport.Inbound
 }
 
-func (r rpc) Inbounds() []transport.Inbound {
-	inbounds := make([]transport.Inbound, len(r.inbounds))
-	copy(inbounds, r.inbounds)
+func (d dispatcher) Inbounds() []transport.Inbound {
+	inbounds := make([]transport.Inbound, len(d.inbounds))
+	copy(inbounds, d.inbounds)
 	return inbounds
 }
 
-func (r rpc) Channel(service string) transport.Channel {
+func (d dispatcher) Channel(service string) transport.Channel {
 	// TODO keep map[string]*Channel instead of Outbound when New is called. The
 	// channels will allow persisting service-specific settings like "always
 	// use this TTL for this service."
 
-	if out, ok := r.Outbounds[service]; ok {
+	if out, ok := d.Outbounds[service]; ok {
 		// we can eventually write an outbound that load balances between
 		// known outbounds for a service.
-		out = transport.ApplyFilter(out, r.Filter)
+		out = transport.ApplyFilter(out, d.Filter)
 		return transport.Channel{
 			Outbound: request.ValidatorOutbound{Outbound: out},
-			Caller:   r.Name,
+			Caller:   d.Name,
 			Service:  service,
 		}
 	}
 	panic(noOutboundForService{Service: service})
 }
 
-func (r rpc) Start() error {
+func (d dispatcher) Start() error {
 	startInbound := func(i transport.Inbound) func() error {
 		return func() error {
-			return i.Start(r)
+			return i.Start(d)
 		}
 	}
 
 	var wait sync.ErrorWaiter
-	for _, i := range r.inbounds {
+	for _, i := range d.inbounds {
 		wait.Submit(startInbound(i))
 	}
 
-	for _, o := range r.Outbounds {
+	for _, o := range d.Outbounds {
 		// TODO record the name of the service whose outbound failed
 		wait.Submit(o.Start)
 	}
@@ -150,25 +150,25 @@ func (r rpc) Start() error {
 	return nil
 }
 
-func (r rpc) Register(service, procedure string, handler transport.Handler) {
-	handler = transport.ApplyInterceptor(handler, r.Interceptor)
-	r.Registry.Register(service, procedure, handler)
+func (d dispatcher) Register(service, procedure string, handler transport.Handler) {
+	handler = transport.ApplyInterceptor(handler, d.Interceptor)
+	d.Registry.Register(service, procedure, handler)
 }
 
-func (r rpc) Handle(ctx context.Context, req *transport.Request, rw transport.ResponseWriter) error {
-	h, err := r.GetHandler(req.Service, req.Procedure)
+func (d dispatcher) Handle(ctx context.Context, req *transport.Request, rw transport.ResponseWriter) error {
+	h, err := d.GetHandler(req.Service, req.Procedure)
 	if err != nil {
 		return err
 	}
 	return h.Handle(ctx, req, rw)
 }
 
-func (r rpc) Stop() error {
+func (d dispatcher) Stop() error {
 	var wait sync.ErrorWaiter
-	for _, i := range r.inbounds {
+	for _, i := range d.inbounds {
 		wait.Submit(i.Stop)
 	}
-	for _, o := range r.Outbounds {
+	for _, o := range d.Outbounds {
 		wait.Submit(o.Stop)
 	}
 

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -73,8 +73,8 @@ type Config struct {
 	// TODO FallbackHandler for catch-all endpoints
 }
 
-// New builds a new RPC using the specified configuration.
-func New(cfg Config) Dispatcher {
+// NewDispatcher builds a new Dispatcher using the specified Config.
+func NewDispatcher(cfg Config) Dispatcher {
 	if cfg.Name == "" {
 		panic("a service name is required")
 	}

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -28,8 +28,10 @@ import (
 	"golang.org/x/net/context"
 )
 
-// RPC TODO
-type RPC interface {
+// Dispatcher object is used to configure a YARPC application; it is used by
+// Clients to send RPCs, and by Procedures to recieve them. This object is what
+// enables an application to be transport-agnostic.
+type Dispatcher interface {
 	transport.Handler
 	transport.Registry
 
@@ -72,7 +74,7 @@ type Config struct {
 }
 
 // New builds a new RPC using the specified configuration.
-func New(cfg Config) RPC {
+func New(cfg Config) Dispatcher {
 	if cfg.Name == "" {
 		panic("a service name is required")
 	}

--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/uber/tchannel-go"
 )
 
-func basicRPC(t *testing.T) RPC {
+func basicRPC(t *testing.T) Dispatcher {
 	ch, err := tchannel.NewChannel("test", nil)
 	require.NoError(t, err, "failed to create TChannel")
 

--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -81,7 +81,7 @@ func TestInboundsOrderIsMaintained(t *testing.T) {
 func TestInboundsOrderAfterStart(t *testing.T) {
 	dispatcher := basicDispatcher(t)
 
-	require.NoError(t, dispatcher.Start(), "failed to start RPC")
+	require.NoError(t, dispatcher.Start(), "failed to start Dispatcher")
 	defer dispatcher.Stop()
 
 	inbounds := dispatcher.Inbounds()

--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -40,7 +40,7 @@ func basicRPC(t *testing.T) Dispatcher {
 	ch, err := tchannel.NewChannel("test", nil)
 	require.NoError(t, err, "failed to create TChannel")
 
-	return New(Config{
+	return NewDispatcher(Config{
 		Name: "test",
 		Inbounds: []transport.Inbound{
 			tch.NewInbound(ch, tch.ListenAddr(":0")),
@@ -243,7 +243,7 @@ func TestStartStopFailures(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
 
-		rpc := New(Config{
+		rpc := NewDispatcher(Config{
 			Name:      "test",
 			Inbounds:  tt.inbounds(mockCtrl),
 			Outbounds: tt.outbounds(mockCtrl),

--- a/encoding/raw/doc.go
+++ b/encoding/raw/doc.go
@@ -35,5 +35,5 @@
 // 		// ...
 // 	}
 //
-// 	raw.Register(rpc, raw.Procedure("submit", Submit))
+// 	raw.Register(dispatcher, raw.Procedure("submit", Submit))
 package raw

--- a/examples/json/client/main.go
+++ b/examples/json/client/main.go
@@ -102,17 +102,17 @@ func main() {
 		log.Fatalf("invalid outbound: %q\n", outboundName)
 	}
 
-	rpc := yarpc.NewDispatcher(yarpc.Config{
+	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name:      "keyvalue-client",
 		Outbounds: transport.Outbounds{"keyvalue": outbound},
 		Filter:    yarpc.Filters(requestLogFilter{}),
 	})
-	if err := rpc.Start(); err != nil {
+	if err := dispatcher.Start(); err != nil {
 		log.Fatalf("failed to start RPC: %v", err)
 	}
-	defer rpc.Stop()
+	defer dispatcher.Stop()
 
-	client := json.New(rpc.Channel("keyvalue"))
+	client := json.New(dispatcher.Channel("keyvalue"))
 
 	scanner := bufio.NewScanner(os.Stdin)
 	rootCtx := context.Background()

--- a/examples/json/client/main.go
+++ b/examples/json/client/main.go
@@ -102,7 +102,7 @@ func main() {
 		log.Fatalf("invalid outbound: %q\n", outboundName)
 	}
 
-	rpc := yarpc.New(yarpc.Config{
+	rpc := yarpc.NewDispatcher(yarpc.Config{
 		Name:      "keyvalue-client",
 		Outbounds: transport.Outbounds{"keyvalue": outbound},
 		Filter:    yarpc.Filters(requestLogFilter{}),

--- a/examples/json/client/main.go
+++ b/examples/json/client/main.go
@@ -108,7 +108,7 @@ func main() {
 		Filter:    yarpc.Filters(requestLogFilter{}),
 	})
 	if err := dispatcher.Start(); err != nil {
-		log.Fatalf("failed to start RPC: %v", err)
+		log.Fatalf("failed to start Dispatcher: %v", err)
 	}
 	defer dispatcher.Stop()
 

--- a/examples/json/server/main.go
+++ b/examples/json/server/main.go
@@ -77,7 +77,7 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	rpc := yarpc.NewDispatcher(yarpc.Config{
+	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name: "keyvalue",
 		Inbounds: []transport.Inbound{
 			tch.NewInbound(channel, tch.ListenAddr(":28941")),
@@ -88,10 +88,10 @@ func main() {
 
 	handler := handler{items: make(map[string]string)}
 
-	json.Register(rpc, json.Procedure("get", handler.Get))
-	json.Register(rpc, json.Procedure("set", handler.Set))
+	json.Register(dispatcher, json.Procedure("get", handler.Get))
+	json.Register(dispatcher, json.Procedure("set", handler.Set))
 
-	if err := rpc.Start(); err != nil {
+	if err := dispatcher.Start(); err != nil {
 		fmt.Println("error:", err.Error())
 		os.Exit(1)
 	}

--- a/examples/json/server/main.go
+++ b/examples/json/server/main.go
@@ -77,7 +77,7 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	rpc := yarpc.New(yarpc.Config{
+	rpc := yarpc.NewDispatcher(yarpc.Config{
 		Name: "keyvalue",
 		Inbounds: []transport.Inbound{
 			tch.NewInbound(channel, tch.ListenAddr(":28941")),

--- a/examples/thrift/keyvalue/client/main.go
+++ b/examples/thrift/keyvalue/client/main.go
@@ -69,7 +69,7 @@ func main() {
 		Filter:    cache,
 	})
 	if err := dispatcher.Start(); err != nil {
-		log.Fatalf("failed to start RPC: %v", err)
+		log.Fatalf("failed to start Dispatcher: %v", err)
 	}
 	defer dispatcher.Stop()
 

--- a/examples/thrift/keyvalue/client/main.go
+++ b/examples/thrift/keyvalue/client/main.go
@@ -63,17 +63,17 @@ func main() {
 	}
 
 	cache := NewCacheFilter()
-	rpc := yarpc.NewDispatcher(yarpc.Config{
+	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name:      "keyvalue-client",
 		Outbounds: transport.Outbounds{"keyvalue": outbound},
 		Filter:    cache,
 	})
-	if err := rpc.Start(); err != nil {
+	if err := dispatcher.Start(); err != nil {
 		log.Fatalf("failed to start RPC: %v", err)
 	}
-	defer rpc.Stop()
+	defer dispatcher.Stop()
 
-	client := keyvalueclient.New(rpc.Channel("keyvalue"))
+	client := keyvalueclient.New(dispatcher.Channel("keyvalue"))
 
 	scanner := bufio.NewScanner(os.Stdin)
 	rootCtx := context.Background()

--- a/examples/thrift/keyvalue/client/main.go
+++ b/examples/thrift/keyvalue/client/main.go
@@ -63,7 +63,7 @@ func main() {
 	}
 
 	cache := NewCacheFilter()
-	rpc := yarpc.New(yarpc.Config{
+	rpc := yarpc.NewDispatcher(yarpc.Config{
 		Name:      "keyvalue-client",
 		Outbounds: transport.Outbounds{"keyvalue": outbound},
 		Filter:    cache,

--- a/examples/thrift/keyvalue/server/main.go
+++ b/examples/thrift/keyvalue/server/main.go
@@ -66,7 +66,7 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	rpc := yarpc.NewDispatcher(yarpc.Config{
+	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name: "keyvalue",
 		Inbounds: []transport.Inbound{
 			tch.NewInbound(channel, tch.ListenAddr(":28941")),
@@ -75,9 +75,9 @@ func main() {
 	})
 
 	handler := handler{items: make(map[string]string)}
-	thrift.Register(rpc, keyvalueserver.New(&handler))
+	thrift.Register(dispatcher, keyvalueserver.New(&handler))
 
-	if err := rpc.Start(); err != nil {
+	if err := dispatcher.Start(); err != nil {
 		fmt.Println("error:", err.Error())
 	}
 

--- a/examples/thrift/keyvalue/server/main.go
+++ b/examples/thrift/keyvalue/server/main.go
@@ -66,7 +66,7 @@ func main() {
 		log.Fatalln(err)
 	}
 
-	rpc := yarpc.New(yarpc.Config{
+	rpc := yarpc.NewDispatcher(yarpc.Config{
 		Name: "keyvalue",
 		Inbounds: []transport.Inbound{
 			tch.NewInbound(channel, tch.ListenAddr(":28941")),


### PR DESCRIPTION
This replaces the term RPC with Dispatcher. 

A Dispatcher configures a YARPC application, and is responsible for sending/receiving RPCs. The Dispatcher is used by Clients to send RPCs, and is what hands RPCs to Procedures.

Resolves #251 