### PR TITLE
Test against Go 1.7rc1 and tip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ language: go
 go:
   - 1.5
   - 1.6
-  - 1.7
+  - 1.7rc1
+  - tip
 
 services:
   - docker


### PR DESCRIPTION
Testing against `1.7` actually results in `1.5.1` from being ran, thanks to this issue:

https://github.com/travis-ci/gimme/issues/53

Instead, we should run against versions available in Gimme.