### PR TITLE
thrift: Add opaque options for clients and registration

### DIFF
--- a/crossdock/thrift/echo/yarpc/echoclient/client.go
+++ b/crossdock/thrift/echo/yarpc/echoclient/client.go
@@ -36,8 +36,8 @@ type Interface interface {
 	Echo(reqMeta yarpc.CallReqMeta, ping *echo.Ping) (*echo.Pong, yarpc.CallResMeta, error)
 }
 
-func New(c transport.Channel) Interface {
-	return client{c: thrift.New(thrift.Config{Service: "Echo", Channel: c, Protocol: protocol.Binary})}
+func New(c transport.Channel, opts ...thrift.ClientOption) Interface {
+	return client{c: thrift.New(thrift.Config{Service: "Echo", Channel: c, Protocol: protocol.Binary}, opts...)}
 }
 
 type client struct{ c thrift.Client }

--- a/crossdock/thrift/gauntlet/yarpc/secondserviceclient/client.go
+++ b/crossdock/thrift/gauntlet/yarpc/secondserviceclient/client.go
@@ -36,8 +36,8 @@ type Interface interface {
 	SecondtestString(reqMeta yarpc.CallReqMeta, thing *string) (string, yarpc.CallResMeta, error)
 }
 
-func New(c transport.Channel) Interface {
-	return client{c: thrift.New(thrift.Config{Service: "SecondService", Channel: c, Protocol: protocol.Binary})}
+func New(c transport.Channel, opts ...thrift.ClientOption) Interface {
+	return client{c: thrift.New(thrift.Config{Service: "SecondService", Channel: c, Protocol: protocol.Binary}, opts...)}
 }
 
 type client struct{ c thrift.Client }

--- a/crossdock/thrift/gauntlet/yarpc/thrifttestclient/client.go
+++ b/crossdock/thrift/gauntlet/yarpc/thrifttestclient/client.go
@@ -55,8 +55,8 @@ type Interface interface {
 	TestVoid(reqMeta yarpc.CallReqMeta) (yarpc.CallResMeta, error)
 }
 
-func New(c transport.Channel) Interface {
-	return client{c: thrift.New(thrift.Config{Service: "ThriftTest", Channel: c, Protocol: protocol.Binary})}
+func New(c transport.Channel, opts ...thrift.ClientOption) Interface {
+	return client{c: thrift.New(thrift.Config{Service: "ThriftTest", Channel: c, Protocol: protocol.Binary}, opts...)}
 }
 
 type client struct{ c thrift.Client }

--- a/encoding/thrift/options.go
+++ b/encoding/thrift/options.go
@@ -25,8 +25,8 @@ type clientConfig struct {
 }
 
 // ClientOption customizes the behavior of a Thrift client.
-type ClientOption struct {
-	apply func(*clientConfig)
+type ClientOption interface {
+	applyClientOption(*clientConfig)
 }
 
 type registerConfig struct {
@@ -35,6 +35,12 @@ type registerConfig struct {
 
 // RegisterOption customizes the behavior of a Thrift handler during
 // registration.
-type RegisterOption struct {
-	apply func(*registerConfig)
+type RegisterOption interface {
+	applyRegisterOption(*registerConfig)
+}
+
+// Option unifies options that apply to both, Thrift clients and handlers.
+type Option interface {
+	ClientOption
+	RegisterOption
 }

--- a/encoding/thrift/options.go
+++ b/encoding/thrift/options.go
@@ -26,7 +26,7 @@ type clientConfig struct {
 
 // ClientOption customizes the behavior of a Thrift client.
 type ClientOption struct {
-	f func(*clientConfig)
+	apply func(*clientConfig)
 }
 
 type registerConfig struct {
@@ -36,5 +36,5 @@ type registerConfig struct {
 // RegisterOption customizes the behavior of a Thrift handler during
 // registration.
 type RegisterOption struct {
-	f func(*registerConfig)
+	apply func(*registerConfig)
 }

--- a/encoding/thrift/options.go
+++ b/encoding/thrift/options.go
@@ -25,7 +25,9 @@ type clientConfig struct {
 }
 
 // ClientOption customizes the behavior of a Thrift client.
-type ClientOption struct{ f func(*clientConfig) }
+type ClientOption struct {
+	f func(*clientConfig)
+}
 
 type registerConfig struct {
 	// TODO: disableEnveloping bool
@@ -33,4 +35,6 @@ type registerConfig struct {
 
 // RegisterOption customizes the behavior of a Thrift handler during
 // registration.
-type RegisterOption struct{ f func(*registerConfig) }
+type RegisterOption struct {
+	f func(*registerConfig)
+}

--- a/encoding/thrift/options.go
+++ b/encoding/thrift/options.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package thrift
+
+type clientConfig struct {
+	// TODO: disableEnveloping bool
+}
+
+// ClientOption customizes the behavior of a Thrift client.
+type ClientOption struct{ f func(*clientConfig) }
+
+type registerConfig struct {
+	// TODO: disableEnveloping bool
+}
+
+// RegisterOption customizes the behavior of a Thrift handler during
+// registration.
+type RegisterOption struct{ f func(*registerConfig) }

--- a/encoding/thrift/outbound.go
+++ b/encoding/thrift/outbound.go
@@ -83,7 +83,7 @@ func New(c Config, opts ...ClientOption) Client {
 
 	var cc clientConfig
 	for _, opt := range opts {
-		opt.apply(&cc)
+		opt.applyClientOption(&cc)
 	}
 
 	return thriftClient{

--- a/encoding/thrift/outbound.go
+++ b/encoding/thrift/outbound.go
@@ -83,7 +83,7 @@ func New(c Config, opts ...ClientOption) Client {
 
 	var cc clientConfig
 	for _, opt := range opts {
-		opt.f(&cc)
+		opt.apply(&cc)
 	}
 
 	return thriftClient{

--- a/encoding/thrift/outbound.go
+++ b/encoding/thrift/outbound.go
@@ -60,7 +60,7 @@ type Config struct {
 }
 
 // New creates a new Thrift client.
-func New(c Config) Client {
+func New(c Config, opts ...ClientOption) Client {
 	// Code generated for Thrift client instantiation will probably be something
 	// like this:
 	//
@@ -79,6 +79,11 @@ func New(c Config) Client {
 	p := c.Protocol
 	if p == nil {
 		p = protocol.Binary
+	}
+
+	var cc clientConfig
+	for _, opt := range opts {
+		opt.f(&cc)
 	}
 
 	return thriftClient{

--- a/encoding/thrift/register.go
+++ b/encoding/thrift/register.go
@@ -58,7 +58,7 @@ type Service interface {
 func Register(registry transport.Registry, service Service, opts ...RegisterOption) {
 	var rc registerConfig
 	for _, opt := range opts {
-		opt.apply(&rc)
+		opt.applyRegisterOption(&rc)
 	}
 
 	name := service.Name()

--- a/encoding/thrift/register.go
+++ b/encoding/thrift/register.go
@@ -58,7 +58,7 @@ type Service interface {
 func Register(registry transport.Registry, service Service, opts ...RegisterOption) {
 	var rc registerConfig
 	for _, opt := range opts {
-		opt.f(&rc)
+		opt.apply(&rc)
 	}
 
 	name := service.Name()

--- a/encoding/thrift/register.go
+++ b/encoding/thrift/register.go
@@ -55,7 +55,12 @@ type Service interface {
 
 // Register registers the handlers for the methods of the given service with the
 // given Registry.
-func Register(registry transport.Registry, service Service) {
+func Register(registry transport.Registry, service Service, opts ...RegisterOption) {
+	var rc registerConfig
+	for _, opt := range opts {
+		opt.f(&rc)
+	}
+
 	name := service.Name()
 	proto := disableEnveloper{
 		Protocol: service.Protocol(),

--- a/examples/thrift/hello/thrift/hello/yarpc/helloclient/client.go
+++ b/examples/thrift/hello/thrift/hello/yarpc/helloclient/client.go
@@ -16,8 +16,8 @@ type Interface interface {
 	Echo(reqMeta yarpc.CallReqMeta, echo *hello.EchoRequest) (*hello.EchoResponse, yarpc.CallResMeta, error)
 }
 
-func New(c transport.Channel) Interface {
-	return client{c: thrift.New(thrift.Config{Service: "Hello", Channel: c, Protocol: protocol.Binary})}
+func New(c transport.Channel, opts ...thrift.ClientOption) Interface {
+	return client{c: thrift.New(thrift.Config{Service: "Hello", Channel: c, Protocol: protocol.Binary}, opts...)}
 }
 
 type client struct{ c thrift.Client }

--- a/examples/thrift/keyvalue/kv/yarpc/keyvalueclient/client.go
+++ b/examples/thrift/keyvalue/kv/yarpc/keyvalueclient/client.go
@@ -36,8 +36,8 @@ type Interface interface {
 	SetValue(reqMeta yarpc.CallReqMeta, key *string, value *string) (yarpc.CallResMeta, error)
 }
 
-func New(c transport.Channel) Interface {
-	return client{c: thrift.New(thrift.Config{Service: "KeyValue", Channel: c, Protocol: protocol.Binary})}
+func New(c transport.Channel, opts ...thrift.ClientOption) Interface {
+	return client{c: thrift.New(thrift.Config{Service: "KeyValue", Channel: c, Protocol: protocol.Binary}, opts...)}
 }
 
 type client struct{ c thrift.Client }


### PR DESCRIPTION
The client change requires a code generation change, but this will allow
users to do,

    keyvalueclient.New(
        dispatcher.Channel("keyvalue"),
        thrift.DisableEnveloping,
        thrift.ClientOptionA(x),
        thrift.ClientOptionB(y),
    )

Similarly, without any code generation changes, we'll be able to support,

    thrift.Register(
        dispatcher,
        keyvalueserver.New(foo),
        thrift.DisableEnveloping,
        thrift.ServerOptionA(x),
        thrift.ServerOptionB(y),
    )

Note that `DisableEnveloping` has the type `Option` so it can be used for both, client and registration options.

Related thriftrw change: https://github.com/thriftrw/thriftrw-go/pull/167

----

With this change, we'll be able to disable enveloping for HTTP in #256, allowing our existing crossdock tests to pass.