### PR TITLE
Use crossdock.Assert instead of Fatals in errorstchout

### DIFF
--- a/crossdock/client/errorstchout/behavior.go
+++ b/crossdock/client/errorstchout/behavior.go
@@ -50,7 +50,7 @@ type test struct {
 // client without the YARPC abstraction interposed, typically errors.
 func Run(t crossdock.T) {
 	fatals := crossdock.Fatals(t)
-	assert := crossdock.Fatals(t)
+	assert := crossdock.Assert(t)
 
 	tests := []test{
 		{


### PR DESCRIPTION
Fixes #265 

I'm glad we merged https://github.com/crossdock/crossdock/pull/74, we would have never known that this test was actually doing the right thing.