### PR TITLE
http/outbound: timeout on ctx.Err() instead of DeadlineExceeded

### DIFF
--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -111,7 +111,7 @@ func (o outbound) Call(ctx context.Context, req *transport.Request) (*transport.
 
 	response, err := ctxhttp.Do(ctx, o.Client, request)
 	if err != nil {
-		if err == context.DeadlineExceeded {
+		if err == ctx.Err() {
 			return nil, errors.NewTimeoutError(req.Service, req.Procedure, deadline.Sub(start))
 		}
 


### PR DESCRIPTION
`ctxhttp.Do` returns `ctx.Err()` when the request times out or gets canceled,
so we should check for that rather than `context.DeadlineExceeded` when timing
out.

CC @breerly @prashantv