### PR TITLE
http: Remove NewOutboundWithClient, add options

### DIFF
--- a/crossdock/client/dispatcher/dispatcher.go
+++ b/crossdock/client/dispatcher/dispatcher.go
@@ -22,7 +22,6 @@ package dispatcher
 
 import (
 	"fmt"
-	"net/http"
 
 	"github.com/yarpc/yarpc-go"
 	"github.com/yarpc/yarpc-go/crossdock/client/params"
@@ -45,14 +44,7 @@ func Create(t crossdock.T) yarpc.Dispatcher {
 	trans := t.Param(params.Transport)
 	switch trans {
 	case "http":
-		// Go HTTP servers have keep-alive enabled by default. If we re-use
-		// HTTP clients, the same connection will be used to make requests.
-		// This is undesirable during tests because we want to isolate the
-		// different test requests. Additionally, keep-alive causes the test
-		// server to continue listening on the existing connection for some
-		// time after we close the listener.
-		cl := &http.Client{Transport: new(http.Transport)}
-		outbound = ht.NewOutboundWithClient(fmt.Sprintf("http://%s:8081", server), cl)
+		outbound = ht.NewOutbound(fmt.Sprintf("http://%s:8081", server))
 	case "tchannel":
 		ch, err := tchannel.NewChannel("client", nil)
 		fatals.NoError(err, "couldn't create tchannel")

--- a/crossdock/server/yarpc/phone.go
+++ b/crossdock/server/yarpc/phone.go
@@ -23,7 +23,6 @@ package yarpc
 import (
 	js "encoding/json"
 	"fmt"
-	"net/http"
 	"time"
 
 	"github.com/yarpc/yarpc-go"
@@ -75,12 +74,9 @@ func Phone(reqMeta yarpc.ReqMeta, body *PhoneRequest) (*PhoneResponse, yarpc.Res
 
 	switch {
 	case body.Transport.HTTP != nil:
-		cl := &http.Client{Transport: new(http.Transport)}
-		// ^See crossdock/client/rpc/rpc.go for explanation
-
 		t := body.Transport.HTTP
 		url := fmt.Sprintf("http://%s:%d", t.Host, t.Port)
-		outbound = ht.NewOutboundWithClient(url, cl)
+		outbound = ht.NewOutbound(url)
 	case body.Transport.TChannel != nil:
 		t := body.Transport.TChannel
 		hostport := fmt.Sprintf("%s:%d", t.Host, t.Port)

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -23,7 +23,6 @@ package http
 import (
 	"fmt"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -71,18 +70,7 @@ func NewOutbound(url string, opts ...OutboundOption) transport.Outbound {
 
 	// Instead of using a global client for all outbounds, we use an HTTP
 	// client per outbound if unspecified.
-	client := &http.Client{
-		Transport: &http.Transport{
-			// options lifted from https://golang.org/src/net/http/transport.go
-			Proxy: http.ProxyFromEnvironment,
-			Dial: (&net.Dialer{
-				Timeout:   30 * time.Second,
-				KeepAlive: cfg.keepAlive,
-			}).Dial,
-			TLSHandshakeTimeout:   10 * time.Second,
-			ExpectContinueTimeout: 1 * time.Second,
-		},
-	}
+	client := buildClient(&cfg)
 
 	// TODO: Use option pattern with varargs instead
 	return outbound{Client: client, URL: url, started: atomic.NewBool(false)}

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -48,8 +48,14 @@ func NewOutbound(url string) transport.Outbound {
 }
 
 // NewOutboundWithClient builds a new HTTP outbound that sends requests to the
-// given URL using the given HTTP client.
+// given URL using the given HTTP client. If the client is nil, a new one is
+// assigned.
 func NewOutboundWithClient(url string, client *http.Client) transport.Outbound {
+	if client == nil {
+		// Instead of using a global client for all outbounds, we use an HTTP
+		// client per outbound if unspecified.
+		client = &http.Client{Transport: &http.Transport{}}
+	}
 	// TODO: Use option pattern with varargs instead
 	return outbound{Client: client, URL: url, started: atomic.NewBool(false)}
 }

--- a/transport/http/outbound_client.go
+++ b/transport/http/outbound_client.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// +build go1.6
+
+package http
+
+import (
+	"net"
+	"net/http"
+	"time"
+)
+
+func buildClient(cfg *outboundConfig) *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			// options lifted from https://golang.org/src/net/http/transport.go
+			Proxy: http.ProxyFromEnvironment,
+			Dial: (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: cfg.keepAlive,
+			}).Dial,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+		},
+	}
+}

--- a/transport/http/outbound_client_pre_go16.go
+++ b/transport/http/outbound_client_pre_go16.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// +build !go1.6
+
+package http
+
+import (
+	"net"
+	"net/http"
+	"time"
+)
+
+func buildClient(cfg *outboundConfig) *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			// options lifted from https://golang.org/src/net/http/transport.go
+			Proxy: http.ProxyFromEnvironment,
+			Dial: (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: cfg.keepAlive,
+			}).Dial,
+			TLSHandshakeTimeout: 10 * time.Second,
+		},
+	}
+}

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -189,7 +189,7 @@ func TestCallFailures(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		out := NewOutboundWithClient(tt.url, http.DefaultClient)
+		out := NewOutbound(tt.url)
 		require.NoError(t, out.Start(), "failed to start outbound")
 		defer out.Stop()
 


### PR DESCRIPTION
Instead of using the global `http.DefaultClient`, we will now use unique HTTP
clients and transports for each outbound. This allows us to drop the hacks
where we were creating new clients for tests because the default client left
the connection open too long (which kept the server from shutting down).

The `http.KeepAlive` option allows configuring the keep-alive period, or
disabling it by using 0.
