### PR TITLE
yarpctest: Support Fake ReqMeta and CallResMeta

### DIFF
--- a/yarpctest/doc.go
+++ b/yarpctest/doc.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package yarpctest provides utilities to test YARPC services and clients.
+package yarpctest

--- a/yarpctest/fake_call_res_meta.go
+++ b/yarpctest/fake_call_res_meta.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpctest
+
+import (
+	"github.com/yarpc/yarpc-go"
+
+	"golang.org/x/net/context"
+)
+
+// CallResMetaBuilder helps build fake yarpc.CallResMeta objects for testing.
+//
+// 	resMeta := NewCallResMetaBuilder(ctx).
+// 		Headers(headers).
+// 		Build()
+type CallResMetaBuilder struct {
+	singleUse
+
+	ctx     context.Context
+	headers yarpc.Headers
+}
+
+// NewCallResMetaBuilder builds a new fake ReqMeta for unit tests
+func NewCallResMetaBuilder(ctx context.Context) *CallResMetaBuilder {
+	return &CallResMetaBuilder{ctx: ctx}
+}
+
+// Headers specifies the response headers for this CallResMeta.
+func (f *CallResMetaBuilder) Headers(h yarpc.Headers) *CallResMetaBuilder {
+	f.ensureUnused(f)
+	f.headers = h
+	return f
+}
+
+// Build builds a yarpc.ReqMeta from this CallResMetaBuilder.
+//
+// The CallResMetaBuilder is not re-usable and becomes invalid after this
+// call.
+func (f *CallResMetaBuilder) Build() yarpc.CallResMeta {
+	resMeta := fakeResMeta(*f)
+	f.use(f)
+	return resMeta
+}
+
+type fakeResMeta CallResMetaBuilder
+
+func (r fakeResMeta) Context() context.Context {
+	return CallResMetaBuilder(r).ctx
+}
+
+func (r fakeResMeta) Headers() yarpc.Headers {
+	return CallResMetaBuilder(r).headers
+}

--- a/yarpctest/fake_call_res_meta_test.go
+++ b/yarpctest/fake_call_res_meta_test.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpctest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	yarpc "github.com/yarpc/yarpc-go"
+	"golang.org/x/net/context"
+)
+
+func TestResMeta(t *testing.T) {
+	tests := []struct {
+		build func(*CallResMetaBuilder) *CallResMetaBuilder
+
+		wantHeaders yarpc.Headers
+	}{
+		{
+			build: func(r *CallResMetaBuilder) *CallResMetaBuilder {
+				return r
+			},
+			wantHeaders: yarpc.NewHeaders(),
+		},
+		{
+			build: func(r *CallResMetaBuilder) *CallResMetaBuilder {
+				return r.Headers(yarpc.NewHeaders().With("foo", "bar"))
+			},
+			wantHeaders: yarpc.NewHeaders().With("foo", "bar"),
+		},
+	}
+
+	for _, tt := range tests {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		reqMeta := tt.build(NewCallResMetaBuilder(ctx)).Build()
+		assert.Equal(t, ctx, reqMeta.Context())
+		assert.Equal(t, tt.wantHeaders, reqMeta.Headers())
+	}
+}

--- a/yarpctest/fake_req_meta.go
+++ b/yarpctest/fake_req_meta.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpctest
+
+import (
+	"github.com/yarpc/yarpc-go"
+	"github.com/yarpc/yarpc-go/transport"
+
+	"golang.org/x/net/context"
+)
+
+// ReqMetaBuilder helps build fake yarpc.ReqMeta objects for testing.
+//
+// 	reqMeta := NewReqMetaBuilder(ctx).
+// 		Encoding(json.Encoding).
+// 		Caller("mytestcaller").
+// 		Procedure("hello").
+// 		Service("testservice").
+// 		Build()
+type ReqMetaBuilder struct {
+	singleUse
+
+	ctx       context.Context
+	encoding  transport.Encoding
+	headers   yarpc.Headers
+	caller    string
+	procedure string
+	service   string
+}
+
+// NewReqMetaBuilder instantiates a new ReqMetaBuilder with the given context.
+func NewReqMetaBuilder(ctx context.Context) *ReqMetaBuilder {
+	return &ReqMetaBuilder{ctx: ctx}
+}
+
+// Encoding specifies the Encoding for the ReqMeta.
+func (f *ReqMetaBuilder) Encoding(e transport.Encoding) *ReqMetaBuilder {
+	f.ensureUnused(f)
+	f.encoding = e
+	return f
+}
+
+// Headers specifies the headers attached to this ReqMeta.
+func (f *ReqMetaBuilder) Headers(h yarpc.Headers) *ReqMetaBuilder {
+	f.ensureUnused(f)
+	f.headers = h
+	return f
+}
+
+// Caller specifies the name of the caller for this request.
+func (f *ReqMetaBuilder) Caller(s string) *ReqMetaBuilder {
+	f.caller = s
+	return f
+}
+
+// Service specifies the target service name for this request.
+func (f *ReqMetaBuilder) Service(s string) *ReqMetaBuilder {
+	f.ensureUnused(f)
+	f.service = s
+	return f
+}
+
+// Procedure specifies the name of the procedure being called.
+func (f *ReqMetaBuilder) Procedure(s string) *ReqMetaBuilder {
+	f.ensureUnused(f)
+	f.procedure = s
+	return f
+}
+
+// Build builds a yarpc.ReqMeta from this ReqMetaBuilder.
+//
+// The ReqMetaBuilder is not re-usable and becomes invalid after this call.
+func (f *ReqMetaBuilder) Build() yarpc.ReqMeta {
+	reqMeta := fakeReqMeta(*f)
+	f.use(f)
+	return reqMeta
+}
+
+type fakeReqMeta ReqMetaBuilder
+
+func (r fakeReqMeta) Caller() string {
+	return ReqMetaBuilder(r).caller
+}
+
+func (r fakeReqMeta) Context() context.Context {
+	return ReqMetaBuilder(r).ctx
+}
+
+func (r fakeReqMeta) Encoding() transport.Encoding {
+	return ReqMetaBuilder(r).encoding
+}
+
+func (r fakeReqMeta) Headers() yarpc.Headers {
+	return ReqMetaBuilder(r).headers
+}
+
+func (r fakeReqMeta) Procedure() string {
+	return ReqMetaBuilder(r).procedure
+}
+
+func (r fakeReqMeta) Service() string {
+	return ReqMetaBuilder(r).service
+}

--- a/yarpctest/fake_req_meta_test.go
+++ b/yarpctest/fake_req_meta_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpctest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/yarpc/yarpc-go"
+	"github.com/yarpc/yarpc-go/transport"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
+)
+
+func TestReqMeta(t *testing.T) {
+	tests := []struct {
+		build func(*ReqMetaBuilder) *ReqMetaBuilder
+
+		wantEncoding  transport.Encoding
+		wantHeaders   yarpc.Headers
+		wantCaller    string
+		wantProcedure string
+		wantService   string
+	}{
+		{
+			build: func(r *ReqMetaBuilder) *ReqMetaBuilder {
+				return r
+			},
+			wantEncoding:  "",
+			wantHeaders:   yarpc.NewHeaders(),
+			wantCaller:    "",
+			wantProcedure: "",
+			wantService:   "",
+		},
+		{
+			build: func(r *ReqMetaBuilder) *ReqMetaBuilder {
+				return r.
+					Encoding(transport.Encoding("myencoding")).
+					Headers(yarpc.NewHeaders().With("foo", "bar")).
+					Caller("caller").
+					Service("service").
+					Procedure("procedure")
+			},
+			wantEncoding:  "myencoding",
+			wantHeaders:   yarpc.NewHeaders().With("foo", "bar"),
+			wantCaller:    "caller",
+			wantService:   "service",
+			wantProcedure: "procedure",
+		},
+	}
+
+	for _, tt := range tests {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		reqMeta := tt.build(NewReqMetaBuilder(ctx)).Build()
+		assert.Equal(t, ctx, reqMeta.Context())
+		assert.Equal(t, tt.wantEncoding, reqMeta.Encoding())
+		assert.Equal(t, tt.wantHeaders, reqMeta.Headers())
+		assert.Equal(t, tt.wantCaller, reqMeta.Caller())
+		assert.Equal(t, tt.wantProcedure, reqMeta.Procedure())
+		assert.Equal(t, tt.wantService, reqMeta.Service())
+	}
+}

--- a/yarpctest/single_use.go
+++ b/yarpctest/single_use.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpctest
+
+import "fmt"
+
+// singleUse is a helper for types that can only be used once.
+type singleUse struct{ used bool }
+
+// ensureUnused panics if this object has already been used.
+//
+// The argument to this function is used for the error message only.
+func (s *singleUse) ensureUnused(o interface{}) {
+	if s.used {
+		panic(fmt.Sprintf("%v cannot be used again", o))
+	}
+}
+
+// use marks this object as used.
+//
+// It panics if the object was already used. The argument to the function is
+// used for the error message.
+func (s *singleUse) use(o interface{}) {
+	s.ensureUnused(o)
+	s.used = true
+}

--- a/yarpctest/single_use_test.go
+++ b/yarpctest/single_use_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpctest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSingleUse(t *testing.T) {
+	var s singleUse
+
+	assert.NotPanics(t, func() { s.ensureUnused("foo") })
+	assert.NotPanics(t, func() { s.use("foo") })
+
+	assert.Panics(t, func() { s.ensureUnused("foo") })
+	assert.Panics(t, func() { s.use("foo") })
+}


### PR DESCRIPTION
This adds the yarpctest package and support for building fake `ReqMeta` and
`CallResMeta` objects for testing.

Resloves #274

CC @yarpc/golang