### PR TITLE
Require encoding over the wire

### DIFF
--- a/crossdock/client/errors/behavior.go
+++ b/crossdock/client/errors/behavior.go
@@ -99,6 +99,7 @@ func Run(t crossdock.T) {
 		"RPC-Caller":     "yarpc-test",
 		"RPC-Service":    "yarpc-test",
 		"RPC-Procedure":  "echo",
+		"RPC-Encoding":   "json",
 		"Context-TTL-MS": "100",
 	}, `{"token":"10"}`)
 	assert.Equal(200, res.Status,
@@ -126,7 +127,7 @@ func Run(t crossdock.T) {
 			body:       "{}",
 			wantStatus: 400,
 			wantBody: "BadRequest: missing service name, procedure, " +
-				"caller name, and TTL\n",
+				"caller name, TTL, and encoding\n",
 		},
 		{
 			name: "wrong service",
@@ -134,6 +135,7 @@ func Run(t crossdock.T) {
 				"RPC-Caller":     "yarpc-test",
 				"RPC-Service":    "not-yarpc-test",
 				"RPC-Procedure":  "echo",
+				"RPC-Encoding":   "json",
 				"Context-TTL-MS": "100",
 			},
 			body:       `{"token":"10"}`,
@@ -148,7 +150,7 @@ func Run(t crossdock.T) {
 			},
 			body:       "{}",
 			wantStatus: 400,
-			wantBody:   "BadRequest: missing procedure, caller name, and TTL\n",
+			wantBody:   "BadRequest: missing procedure, caller name, TTL, and encoding\n",
 		},
 		{
 			name: "no caller",
@@ -158,7 +160,7 @@ func Run(t crossdock.T) {
 			},
 			body:       "{}",
 			wantStatus: 400,
-			wantBody:   "BadRequest: missing caller name and TTL\n",
+			wantBody:   "BadRequest: missing caller name, TTL, and encoding\n",
 		},
 		{
 			name: "no handler",
@@ -166,6 +168,7 @@ func Run(t crossdock.T) {
 				"RPC-Caller":     "yarpc-test",
 				"RPC-Service":    "yarpc-test",
 				"RPC-Procedure":  "no-such-procedure",
+				"RPC-Encoding":   "json",
 				"Context-TTL-MS": "100",
 			},
 			body:       "{}",
@@ -182,7 +185,19 @@ func Run(t crossdock.T) {
 			},
 			body:       "{}",
 			wantStatus: 400,
-			wantBody:   "BadRequest: missing TTL\n",
+			wantBody:   "BadRequest: missing TTL and encoding\n",
+		},
+		{
+			name: "no encoding",
+			headers: map[string]string{
+				"RPC-Caller":     "yarpc-test",
+				"RPC-Service":    "yarpc-test",
+				"RPC-Procedure":  "echo",
+				"Context-TTL-MS": "100",
+			},
+			body:       "{}",
+			wantStatus: 400,
+			wantBody:   "BadRequest: missing encoding\n",
 		},
 		{
 			name: "invalid timeout",
@@ -190,6 +205,7 @@ func Run(t crossdock.T) {
 				"RPC-Caller":     "yarpc-test",
 				"RPC-Service":    "yarpc-test",
 				"RPC-Procedure":  "echo",
+				"RPC-Encoding":   "json",
 				"Context-TTL-MS": "moo",
 			},
 			body:       "{}",
@@ -203,6 +219,7 @@ func Run(t crossdock.T) {
 				"RPC-Caller":     "yarpc-test",
 				"RPC-Service":    "yarpc-test",
 				"RPC-Procedure":  "echo",
+				"RPC-Encoding":   "json",
 				"Context-TTL-MS": "100",
 			},
 			body:       "i am not json",
@@ -212,11 +229,27 @@ func Run(t crossdock.T) {
 				`caller "yarpc-test":`,
 		},
 		{
+			name: "encoding mismatch",
+			headers: map[string]string{
+				"RPC-Caller":     "yarpc-test",
+				"RPC-Service":    "yarpc-test",
+				"RPC-Procedure":  "echo",
+				"RPC-Encoding":   "thrift",
+				"Context-TTL-MS": "100",
+			},
+			body:       "{}",
+			wantStatus: 400,
+			wantBody: `BadRequest: failed to decode "json" request body ` +
+				`for procedure "echo" of service "yarpc-test" from ` +
+				`caller "yarpc-test": expected encoding "json" but got "thrift"` + "\n",
+		},
+		{
 			name: "unexpected error",
 			headers: map[string]string{
 				"RPC-Caller":     "yarpc-test",
 				"RPC-Service":    "yarpc-test",
 				"RPC-Procedure":  "unexpected-error",
+				"RPC-Encoding":   "json",
 				"Context-TTL-MS": "100",
 			},
 			body:       "{}",
@@ -230,6 +263,7 @@ func Run(t crossdock.T) {
 				"RPC-Caller":     "yarpc-test",
 				"RPC-Service":    "yarpc-test",
 				"RPC-Procedure":  "bad-response",
+				"RPC-Encoding":   "json",
 				"Context-TTL-MS": "100",
 			},
 			body:       "{}",
@@ -244,6 +278,7 @@ func Run(t crossdock.T) {
 				"RPC-Caller":     "yarpc-test",
 				"RPC-Service":    "yarpc-test",
 				"RPC-Procedure":  "phone",
+				"RPC-Encoding":   "json",
 				"Context-TTL-MS": "100",
 			},
 			body: `{
@@ -263,6 +298,7 @@ func Run(t crossdock.T) {
 				"RPC-Caller":     "yarpc-test",
 				"RPC-Service":    "yarpc-test",
 				"RPC-Procedure":  "phone",
+				"RPC-Encoding":   "json",
 				"Context-TTL-MS": "100",
 			},
 			body: `{

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,11 +13,11 @@ services:
         environment:
             - WAIT_FOR=go,node,java,python,python-sync
 
-            - AXIS_CLIENT=go # ,node,java,python,python-sync
-            - AXIS_SERVER=go # ,node,java,python
+            - AXIS_CLIENT=go,node,python,python-sync # ,java
+            - AXIS_SERVER=go,node,python # ,java
             - AXIS_TRANSPORT=http,tchannel
             - AXIS_ENCODING=raw,json,thrift
-            - AXIS_ERRORSHTTPOUT=go # ,node
+            - AXIS_ERRORSHTTPOUT=go,node
             # AXIS_ERRORSHTTPIN TODO
             - AXIS_ERRORSTCHOUT=go
             # AXIS_ERRORSTCHIN TODO
@@ -50,7 +50,7 @@ services:
 
     node:
         dns_search: .
-        image: yarpc/yarpc-node
+        image: yarpc/yarpc-node:require-encoding
         ports:
             - "8080-8087"
 
@@ -62,13 +62,13 @@ services:
 
     python:
         dns_search: .
-        image: yarpc/yarpc-python
+        image: yarpc/yarpc-python:require-encoding
         ports:
             - "8080-8087"
 
     python-sync:
         dns_search: .
-        image: yarpc/yarpc-python
+        image: yarpc/yarpc-python:require-encoding
         ports:
             - 8080
         environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,11 +13,11 @@ services:
         environment:
             - WAIT_FOR=go,node,java,python,python-sync
 
-            - AXIS_CLIENT=go,node,java,python,python-sync
-            - AXIS_SERVER=go,node,java,python
+            - AXIS_CLIENT=go # ,node,java,python,python-sync
+            - AXIS_SERVER=go # ,node,java,python
             - AXIS_TRANSPORT=http,tchannel
             - AXIS_ENCODING=raw,json,thrift
-            - AXIS_ERRORSHTTPOUT=node,go
+            - AXIS_ERRORSHTTPOUT=go # ,node
             # AXIS_ERRORSHTTPIN TODO
             - AXIS_ERRORSTCHOUT=go
             # AXIS_ERRORSTCHIN TODO

--- a/encoding/json/inbound.go
+++ b/encoding/json/inbound.go
@@ -44,8 +44,9 @@ type jsonHandler struct {
 }
 
 func (h jsonHandler) Handle(ctx context.Context, _ transport.Options, treq *transport.Request, rw transport.ResponseWriter) error {
-	treq.Encoding = Encoding
-	// TODO(abg): Should we fail requests if Rpc-Encoding does not match?
+	if err := encoding.Expect(treq, Encoding); err != nil {
+		return err
+	}
 
 	reqBody, err := h.reader.Read(json.NewDecoder(treq.Body))
 	if err != nil {

--- a/encoding/json/inbound_test.go
+++ b/encoding/json/inbound_test.go
@@ -43,6 +43,7 @@ func TestHandleStructSuccess(t *testing.T) {
 	err := handler.Handle(context.Background(), transport.Options{},
 		&transport.Request{
 			Procedure: "simpleCall",
+			Encoding:  "json",
 			Body:      jsonBody(`{"name": "foo", "attributes": {"bar": 42}}`),
 		}, resw)
 	require.NoError(t, err)
@@ -70,6 +71,7 @@ func TestHandleMapSuccess(t *testing.T) {
 	err := handler.Handle(context.Background(), transport.Options{},
 		&transport.Request{
 			Procedure: "foo",
+			Encoding:  "json",
 			Body:      jsonBody(`{"foo": 42, "bar": ["a", "b", "c"]}`),
 		}, resw)
 	require.NoError(t, err)
@@ -90,6 +92,7 @@ func TestHandleInterfaceEmptySuccess(t *testing.T) {
 	err := handler.Handle(context.Background(), transport.Options{},
 		&transport.Request{
 			Procedure: "foo",
+			Encoding:  "json",
 			Body:      jsonBody(`["a", "b", "c"]`),
 		}, resw)
 	require.NoError(t, err)
@@ -113,6 +116,7 @@ func TestHandleSuccessWithResponseHeaders(t *testing.T) {
 	err := handler.Handle(context.Background(), transport.Options{},
 		&transport.Request{
 			Procedure: "simpleCall",
+			Encoding:  "json",
 			Body:      jsonBody(`{"name": "foo", "attributes": {"bar": 42}}`),
 		}, resw)
 	require.NoError(t, err)

--- a/encoding/raw/inbound.go
+++ b/encoding/raw/inbound.go
@@ -23,6 +23,7 @@ package raw
 import (
 	"io/ioutil"
 
+	"github.com/yarpc/yarpc-go/internal/encoding"
 	"github.com/yarpc/yarpc-go/internal/meta"
 	"github.com/yarpc/yarpc-go/transport"
 
@@ -35,8 +36,9 @@ type rawHandler struct {
 }
 
 func (r rawHandler) Handle(ctx context.Context, _ transport.Options, treq *transport.Request, rw transport.ResponseWriter) error {
-	treq.Encoding = Encoding
-	// TODO(abg): Should we fail requests if Rpc-Encoding does not match?
+	if err := encoding.Expect(treq, Encoding); err != nil {
+		return err
+	}
 
 	reqBody, err := ioutil.ReadAll(treq.Body)
 	if err != nil {

--- a/encoding/raw/inbound_test.go
+++ b/encoding/raw/inbound_test.go
@@ -112,6 +112,7 @@ func TestRawHandler(t *testing.T) {
 			&transport.Request{
 				Procedure: tt.procedure,
 				Headers:   tt.headers,
+				Encoding:  "raw",
 				Body:      chunkReader,
 			},
 			resw,

--- a/encoding/thrift/inbound.go
+++ b/encoding/thrift/inbound.go
@@ -41,8 +41,9 @@ type thriftHandler struct {
 }
 
 func (t thriftHandler) Handle(ctx context.Context, opts transport.Options, treq *transport.Request, rw transport.ResponseWriter) error {
-	treq.Encoding = Encoding
-	// TODO(abg): Should we fail requests if Rpc-Encoding does not match?
+	if err := encoding.Expect(treq, Encoding); err != nil {
+		return err
+	}
 
 	body, err := ioutil.ReadAll(treq.Body)
 	if err != nil {

--- a/internal/encoding/server.go
+++ b/internal/encoding/server.go
@@ -108,3 +108,29 @@ func ResponseHeadersEncodeError(req *transport.Request, err error) error {
 	e.IsHeader = true
 	return e
 }
+
+// Expect verifies that the given request has the given encoding or it returns
+// an error.
+func Expect(req *transport.Request, want transport.Encoding) error {
+	got := req.Encoding
+	if want == got {
+		return nil
+	}
+
+	return serverEncodingError{
+		Encoding:  want,
+		Caller:    req.Caller,
+		Service:   req.Service,
+		Procedure: req.Procedure,
+		Reason:    encodingMismatchError{Want: want, Got: got},
+	}
+}
+
+// encodingMismatchError represenst a encoding mismatch
+type encodingMismatchError struct {
+	Want, Got transport.Encoding
+}
+
+func (e encodingMismatchError) Error() string {
+	return fmt.Sprintf("expected encoding %q but got %q", e.Want, e.Got)
+}

--- a/internal/request/validator.go
+++ b/internal/request/validator.go
@@ -104,6 +104,9 @@ func (v *Validator) Validate(ctx context.Context) (*transport.Request, error) {
 	if !hasDeadline && v.lateErr == nil {
 		missingParams = append(missingParams, "TTL")
 	}
+	if v.Request.Encoding == "" {
+		missingParams = append(missingParams, "encoding")
+	}
 	if len(missingParams) > 0 {
 		return nil, missingParametersError{Parameters: missingParams}
 	}

--- a/internal/request/validator_test.go
+++ b/internal/request/validator_test.go
@@ -56,11 +56,16 @@ func TestValidator(t *testing.T) {
 				Procedure: "hello",
 			},
 			ttl: time.Second,
+			wantErr: missingParametersError{
+				Parameters: []string{"encoding"},
+			},
+			wantMessage: "missing encoding",
 		},
 		{
 			req: &transport.Request{
 				Service:   "service",
 				Procedure: "hello",
+				Encoding:  "raw",
 			},
 			ttl: time.Second,
 			wantErr: missingParametersError{
@@ -72,6 +77,7 @@ func TestValidator(t *testing.T) {
 			req: &transport.Request{
 				Caller:    "caller",
 				Procedure: "hello",
+				Encoding:  "raw",
 			},
 			ttl: time.Second,
 			wantErr: missingParametersError{
@@ -81,8 +87,9 @@ func TestValidator(t *testing.T) {
 		},
 		{
 			req: &transport.Request{
-				Caller:  "caller",
-				Service: "service",
+				Caller:   "caller",
+				Service:  "service",
+				Encoding: "raw",
 			},
 			ttl: time.Second,
 			wantErr: missingParametersError{
@@ -95,6 +102,7 @@ func TestValidator(t *testing.T) {
 				Caller:    "caller",
 				Service:   "service",
 				Procedure: "hello",
+				Encoding:  "raw",
 			},
 			wantErr: missingParametersError{
 				Parameters: []string{"TTL"},
@@ -105,10 +113,10 @@ func TestValidator(t *testing.T) {
 			req: &transport.Request{},
 			wantErr: missingParametersError{
 				Parameters: []string{
-					"service name", "procedure", "caller name", "TTL",
+					"service name", "procedure", "caller name", "TTL", "encoding",
 				},
 			},
-			wantMessage: "missing service name, procedure, caller name, and TTL",
+			wantMessage: "missing service name, procedure, caller name, TTL, and encoding",
 		},
 		{
 			req: &transport.Request{

--- a/transport/http/handler_test.go
+++ b/transport/http/handler_test.go
@@ -220,7 +220,7 @@ func TestHandlerFailures(t *testing.T) {
 			&http.Request{
 				Method: "POST",
 			},
-			"BadRequest: missing service name, procedure, caller name, and TTL\n",
+			"BadRequest: missing service name, procedure, caller name, TTL, and encoding\n",
 		},
 		{
 			&http.Request{


### PR DESCRIPTION
This changes yarpc-go to require the encoding over the wire. Incoming requests
are considered bad requests if they don't have an encoding or if the encoding
does not match the encoding on the handler.

Resolves #238