### PR TITLE
clients: Resolve channel outbounds per-request

### DIFF
--- a/crossdock/client/dispatcher/dispatcher_test.go
+++ b/crossdock/client/dispatcher/dispatcher_test.go
@@ -64,8 +64,8 @@ func TestCreate(t *testing.T) {
 
 			// should get here only if the request succeeded
 			ch := dispatcher.Channel("yarpc-test")
-			assert.Equal(t, "client", ch.Caller)
-			assert.Equal(t, "yarpc-test", ch.Service)
+			assert.Equal(t, "client", ch.Caller())
+			assert.Equal(t, "yarpc-test", ch.Service())
 		})
 
 		if tt.errOut != "" && assert.Len(t, entries, 1) {

--- a/crossdock/server/yarpc/phone.go
+++ b/crossdock/server/yarpc/phone.go
@@ -95,7 +95,7 @@ func Phone(reqMeta yarpc.ReqMeta, body *PhoneRequest) (*PhoneResponse, yarpc.Res
 	defer outbound.Stop()
 
 	// TODO use reqMeta.Service for caller
-	client := json.New(transport.SimpleChannel("yarpc-test", body.Service, outbound))
+	client := json.New(transport.IdentityChannel("yarpc-test", body.Service, outbound))
 	resBody := PhoneResponse{
 		Service:   "yarpc-test", // TODO use reqMeta.Service
 		Procedure: reqMeta.Procedure(),

--- a/crossdock/server/yarpc/phone.go
+++ b/crossdock/server/yarpc/phone.go
@@ -94,12 +94,8 @@ func Phone(reqMeta yarpc.ReqMeta, body *PhoneRequest) (*PhoneResponse, yarpc.Res
 	}
 	defer outbound.Stop()
 
-	client := json.New(transport.Channel{
-		Caller:   "yarpc-test", // TODO use reqMeta.Service,
-		Service:  body.Service,
-		Outbound: outbound,
-	})
-
+	// TODO use reqMeta.Service for caller
+	client := json.New(transport.SimpleChannel("yarpc-test", body.Service, outbound))
 	resBody := PhoneResponse{
 		Service:   "yarpc-test", // TODO use reqMeta.Service
 		Procedure: reqMeta.Procedure(),

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -110,19 +110,10 @@ func (d dispatcher) Inbounds() []transport.Inbound {
 }
 
 func (d dispatcher) Channel(service string) transport.Channel {
-	// TODO keep map[string]*Channel instead of Outbound when New is called. The
-	// channels will allow persisting service-specific settings like "always
-	// use this TTL for this service."
-
 	if out, ok := d.Outbounds[service]; ok {
-		// we can eventually write an outbound that load balances between
-		// known outbounds for a service.
 		out = transport.ApplyFilter(out, d.Filter)
-		return transport.Channel{
-			Outbound: request.ValidatorOutbound{Outbound: out},
-			Caller:   d.Name,
-			Service:  service,
-		}
+		out = request.ValidatorOutbound{Outbound: out}
+		return transport.SimpleChannel(d.Name, service, out)
 	}
 	panic(noOutboundForService{Service: service})
 }

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -113,7 +113,7 @@ func (d dispatcher) Channel(service string) transport.Channel {
 	if out, ok := d.Outbounds[service]; ok {
 		out = transport.ApplyFilter(out, d.Filter)
 		out = request.ValidatorOutbound{Outbound: out}
-		return transport.SimpleChannel(d.Name, service, out)
+		return transport.IdentityChannel(d.Name, service, out)
 	}
 	panic(noOutboundForService{Service: service})
 }

--- a/encoding/json/outbound_test.go
+++ b/encoding/json/outbound_test.go
@@ -98,11 +98,7 @@ func TestCall(t *testing.T) {
 
 	for _, tt := range tests {
 		outbound := transporttest.NewMockOutbound(mockCtrl)
-		client := New(transport.Channel{
-			Caller:   caller,
-			Service:  service,
-			Outbound: outbound,
-		})
+		client := New(transport.SimpleChannel(caller, service, outbound))
 
 		if !tt.noCall {
 			outbound.EXPECT().Call(gomock.Any(),

--- a/encoding/json/outbound_test.go
+++ b/encoding/json/outbound_test.go
@@ -98,7 +98,7 @@ func TestCall(t *testing.T) {
 
 	for _, tt := range tests {
 		outbound := transporttest.NewMockOutbound(mockCtrl)
-		client := New(transport.SimpleChannel(caller, service, outbound))
+		client := New(transport.IdentityChannel(caller, service, outbound))
 
 		if !tt.noCall {
 			outbound.EXPECT().Call(gomock.Any(),

--- a/encoding/raw/outbound_test.go
+++ b/encoding/raw/outbound_test.go
@@ -78,11 +78,7 @@ func TestCall(t *testing.T) {
 
 	for _, tt := range tests {
 		outbound := transporttest.NewMockOutbound(mockCtrl)
-		client := New(transport.Channel{
-			Caller:   caller,
-			Service:  service,
-			Outbound: outbound,
-		})
+		client := New(transport.SimpleChannel(caller, service, outbound))
 
 		writer, responseBody := testreader.ChunkReader()
 		for _, chunk := range tt.responseBody {

--- a/encoding/raw/outbound_test.go
+++ b/encoding/raw/outbound_test.go
@@ -78,7 +78,7 @@ func TestCall(t *testing.T) {
 
 	for _, tt := range tests {
 		outbound := transporttest.NewMockOutbound(mockCtrl)
-		client := New(transport.SimpleChannel(caller, service, outbound))
+		client := New(transport.IdentityChannel(caller, service, outbound))
 
 		writer, responseBody := testreader.ChunkReader()
 		for _, chunk := range tt.responseBody {

--- a/encoding/thrift/outbound_test.go
+++ b/encoding/thrift/outbound_test.go
@@ -39,16 +39,23 @@ import (
 	"golang.org/x/net/context"
 )
 
+func valueptr(v wire.Value) *wire.Value { return &v }
+
 func TestClient(t *testing.T) {
 	tests := []struct {
+		desc                 string
 		giveRequestBody      envelope.Enveloper // outgoing request body
-		giveResponseEnvelope *wire.Envelope     // returned response envelope
+		giveResponseEnvelope *wire.Envelope     // returned on DecodeEnveloped()
+		giveResponseBody     *wire.Value        // return on Decode()
+		transportOptions     transport.Options  // options for the outbound
 
 		expectCall          bool           // whether outbound.Call is expected
-		wantRequestEnvelope *wire.Envelope // expected envelope to encode
+		wantRequestEnvelope *wire.Envelope // expect EncodeEnveloped(x)
+		wantRequestBody     *wire.Value    // expect Encode(x)
 		wantError           string         // whether an error is expected
 	}{
 		{
+			desc:            "happy case",
 			giveRequestBody: fakeEnveloper(wire.Call),
 			wantRequestEnvelope: &wire.Envelope{
 				Name:  "someMethod",
@@ -65,11 +72,21 @@ func TestClient(t *testing.T) {
 			},
 		},
 		{
+			desc:             "happy case without enveloping",
+			giveRequestBody:  fakeEnveloper(wire.Call),
+			wantRequestBody:  valueptr(wire.NewValueStruct(wire.Struct{})),
+			expectCall:       true,
+			giveResponseBody: valueptr(wire.NewValueStruct(wire.Struct{})),
+			transportOptions: DisableEnvelopingForTransport,
+		},
+		{
+			desc:            "wrong envelope type for request",
 			giveRequestBody: fakeEnveloper(wire.Reply),
 			wantError: `failed to encode "thrift" request body for procedure ` +
 				`"MyService::someMethod" of service "service": unexpected envelope type: Reply`,
 		},
 		{
+			desc:            "TApplicationException",
 			giveRequestBody: fakeEnveloper(wire.Call),
 			wantRequestEnvelope: &wire.Envelope{
 				Name:  "someMethod",
@@ -92,6 +109,7 @@ func TestClient(t *testing.T) {
 				"TApplicationException{Message: great sadness, Type: ProtocolError}",
 		},
 		{
+			desc:            "wrong envelope type for response",
 			giveRequestBody: fakeEnveloper(wire.Call),
 			wantRequestEnvelope: &wire.Envelope{
 				Name:  "someMethod",
@@ -116,6 +134,7 @@ func TestClient(t *testing.T) {
 		defer mockCtrl.Finish()
 
 		proto := NewMockProtocol(mockCtrl)
+
 		if tt.wantRequestEnvelope != nil {
 			proto.EXPECT().EncodeEnveloped(*tt.wantRequestEnvelope, gomock.Any()).
 				Do(func(_ wire.Envelope, w io.Writer) {
@@ -124,9 +143,18 @@ func TestClient(t *testing.T) {
 				}).Return(nil)
 		}
 
+		if tt.wantRequestBody != nil {
+			proto.EXPECT().Encode(*tt.wantRequestBody, gomock.Any()).
+				Do(func(_ wire.Value, w io.Writer) {
+					_, err := w.Write([]byte("irrelevant"))
+					require.NoError(t, err, "Write() failed")
+				}).Return(nil)
+		}
+
 		ctx, _ := context.WithTimeout(context.Background(), time.Second)
 
 		trans := transporttest.NewMockOutbound(mockCtrl)
+		trans.EXPECT().Options().Return(tt.transportOptions).AnyTimes()
 		if tt.expectCall {
 			trans.EXPECT().Call(ctx,
 				transporttest.NewRequestMatcher(t, &transport.Request{
@@ -145,21 +173,23 @@ func TestClient(t *testing.T) {
 			proto.EXPECT().DecodeEnveloped(gomock.Any()).Return(*tt.giveResponseEnvelope, nil)
 		}
 
-		c := thriftClient{
-			t:             trans,
-			p:             proto,
-			thriftService: "MyService",
-			caller:        "caller",
-			service:       "service",
+		if tt.giveResponseBody != nil {
+			proto.EXPECT().Decode(gomock.Any(), wire.TStruct).Return(*tt.giveResponseBody, nil)
 		}
+
+		c := New(Config{
+			Service:  "MyService",
+			Channel:  transport.SimpleChannel("caller", "service", trans),
+			Protocol: proto,
+		})
 
 		_, _, err := c.Call(yarpc.NewReqMeta(ctx), tt.giveRequestBody)
 		if tt.wantError != "" {
-			if assert.Error(t, err, "expected failure") {
-				assert.Contains(t, err.Error(), tt.wantError)
+			if assert.Error(t, err, "%v: expected failure", tt.desc) {
+				assert.Contains(t, err.Error(), tt.wantError, "%v: error mismatch", tt.desc)
 			}
 		} else {
-			assert.NoError(t, err, "expected success")
+			assert.NoError(t, err, "%v: expected success", tt.desc)
 		}
 	}
 }

--- a/encoding/thrift/outbound_test.go
+++ b/encoding/thrift/outbound_test.go
@@ -179,7 +179,7 @@ func TestClient(t *testing.T) {
 
 		c := New(Config{
 			Service:  "MyService",
-			Channel:  transport.SimpleChannel("caller", "service", trans),
+			Channel:  transport.IdentityChannel("caller", "service", trans),
 			Protocol: proto,
 		})
 

--- a/transport/channel.go
+++ b/transport/channel.go
@@ -18,52 +18,34 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package raw
+package transport
 
-import (
-	"bytes"
-	"io/ioutil"
+// Channel scopes outbounds to a single caller-service pair.
+type Channel interface {
+	// Name of the service making the request.
+	Caller() string
 
-	"github.com/yarpc/yarpc-go"
-	"github.com/yarpc/yarpc-go/internal/meta"
-	"github.com/yarpc/yarpc-go/transport"
-)
+	// Name of the service to which the request is being made.
+	Service() string
 
-// Client makes Raw requests to a single service.
-type Client interface {
-	// Call performs an outbound Raw request.
-	Call(reqMeta yarpc.CallReqMeta, body []byte) ([]byte, yarpc.CallResMeta, error)
+	// Returns an outbound to send the request through.
+	//
+	// MAY be called multiple times for a request. MAY return different outbounds
+	// for each call. The returned outbound MUST have already been started.
+	GetOutbound() Outbound
 }
 
-// New builds a new Raw client.
-func New(c transport.Channel) Client {
-	return rawClient{ch: c}
+// SimpleChannel constructs a Channel which always returns the same outbound.
+func SimpleChannel(caller, service string, out Outbound) Channel {
+	return simpleChannel{caller: caller, service: service, outbound: out}
 }
 
-type rawClient struct {
-	ch transport.Channel
+type simpleChannel struct {
+	caller   string
+	service  string
+	outbound Outbound
 }
 
-func (c rawClient) Call(reqMeta yarpc.CallReqMeta, body []byte) ([]byte, yarpc.CallResMeta, error) {
-	treq := transport.Request{
-		Caller:   c.ch.Caller(),
-		Service:  c.ch.Service(),
-		Encoding: Encoding,
-		Body:     bytes.NewReader(body),
-	}
-	ctx := meta.ToTransportRequest(reqMeta, &treq)
-
-	tres, err := c.ch.GetOutbound().Call(ctx, &treq)
-	if err != nil {
-		return nil, nil, err
-	}
-	defer tres.Body.Close()
-
-	resBody, err := ioutil.ReadAll(tres.Body)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// TODO: when transport returns response context, use that here.
-	return resBody, meta.FromTransportResponse(ctx, tres), nil
-}
+func (s simpleChannel) Caller() string        { return s.caller }
+func (s simpleChannel) Service() string       { return s.service }
+func (s simpleChannel) GetOutbound() Outbound { return s.outbound }

--- a/transport/channel.go
+++ b/transport/channel.go
@@ -35,17 +35,18 @@ type Channel interface {
 	GetOutbound() Outbound
 }
 
-// SimpleChannel constructs a Channel which always returns the same outbound.
-func SimpleChannel(caller, service string, out Outbound) Channel {
-	return simpleChannel{caller: caller, service: service, outbound: out}
+// IdentityChannel constructs a simple Channel for the given caller-service pair
+// which always returns the given Outbound.
+func IdentityChannel(caller, service string, out Outbound) Channel {
+	return identityChannel{caller: caller, service: service, outbound: out}
 }
 
-type simpleChannel struct {
+type identityChannel struct {
 	caller   string
 	service  string
 	outbound Outbound
 }
 
-func (s simpleChannel) Caller() string        { return s.caller }
-func (s simpleChannel) Service() string       { return s.service }
-func (s simpleChannel) GetOutbound() Outbound { return s.outbound }
+func (s identityChannel) Caller() string        { return s.caller }
+func (s identityChannel) Service() string       { return s.service }
+func (s identityChannel) GetOutbound() Outbound { return s.outbound }

--- a/transport/outbound.go
+++ b/transport/outbound.go
@@ -51,18 +51,3 @@ type Outbound interface {
 
 // Outbounds is a map of service name to Outbound for that service.
 type Outbounds map[string]Outbound
-
-// Channel scopes an Outbound to a single caller-service pair.
-type Channel struct {
-	// Caller is the name of the service making the request.
-	Caller string
-
-	// Service is the name of the service to which the request is being made.
-	Service string
-
-	// Outbound is the transport used to send the request.
-	Outbound Outbound
-
-	// TODO: Can add caller-service-specific TTLs here. These can be inherited
-	//from the YARPC otherwise.
-}


### PR DESCRIPTION
This changes `transport.Channel` into an interface and YARPC clients to
resolve outbounds associated with channels on a per-request basis.

This will make it possible to have stateful channels (a load balancing
channel, for example).

Resolves #260

CC @yarpc/golang