### PR TITLE
Add basic benchmarks for HTTP/TChannel

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -33,9 +33,7 @@ func httpEcho(t testing.TB) http.HandlerFunc {
 		defer r.Body.Close()
 		hs := w.Header()
 		for k, vs := range r.Header {
-			for _, v := range vs {
-				hs.Set(k, v)
-			}
+			hs[k] = vs
 		}
 
 		_, err := io.Copy(w, r.Body)
@@ -75,12 +73,13 @@ func runHTTPClient(b *testing.B, c *http.Client, url string) {
 		req, err := http.NewRequest("POST", url, bytes.NewReader(_reqBody))
 		require.NoError(b, err, "failed to build request %d", i+1)
 
-		req.Header.Add("Context-TTL-MS", "100")
-		req.Header.Add("Rpc-Caller", "http-client")
-		req.Header.Add("Rpc-Encoding", "raw")
-		req.Header.Add("Rpc-Procedure", "echo")
-		req.Header.Add("Rpc-Service", "server")
-
+		req.Header = http.Header{
+			"Context-TTL-MS": {"100"},
+			"Rpc-Caller":     {"http-client"},
+			"Rpc-Encoding":   {"raw"},
+			"Rpc-Procedure":  {"echo"},
+			"Rpc-Service":    {"server"},
+		}
 		res, err := ctxhttp.Do(ctx, c, req)
 		require.NoError(b, err, "request %d failed", i+1)
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -75,9 +75,9 @@ func runHTTPClient(b *testing.B, c *http.Client, url string) {
 		req, err := http.NewRequest("POST", url, bytes.NewReader(_reqBody))
 		require.NoError(b, err, "failed to build request %d", i+1)
 
+		req.Header.Add("Context-TTL-MS", "100")
 		req.Header.Add("Rpc-Caller", "http-client")
 		req.Header.Add("Rpc-Encoding", "raw")
-		req.Header.Add("Context-TTL-MS", "100")
 		req.Header.Add("Rpc-Procedure", "echo")
 		req.Header.Add("Rpc-Service", "server")
 


### PR DESCRIPTION
This compares {net/http, tchannel-go, yarpc} to/from {net/http, tchannel-go, yarpc} for both protocols.

Results on my laptop:

```
$ go test -bench=. -benchtime=15s -benchmem
PASS
Benchmark_HTTP_YARPCToYARPC-8          	  200000	     98514 ns/op	    7516 B/op	     107 allocs/op
Benchmark_HTTP_YARPCToNetHTTP-8        	  200000	    122506 ns/op	    8480 B/op	     119 allocs/op
Benchmark_HTTP_NetHTTPToYARPC-8        	  200000	    119336 ns/op	    7377 B/op	     106 allocs/op
Benchmark_HTTP_NetHTTPToNetHTTP-8      	  200000	     95684 ns/op	    8359 B/op	     118 allocs/op
Benchmark_TChannel_YARPCToYARPC-8      	  300000	     90701 ns/op	   12765 B/op	     132 allocs/op
Benchmark_TChannel_YARPCToTChannel-8   	  200000	     84215 ns/op	   12798 B/op	     127 allocs/op
Benchmark_TChannel_TChannelToYARPC-8   	  300000	     83985 ns/op	   13024 B/op	     126 allocs/op
Benchmark_TChannel_TChannelToTChannel-8	  300000	     73950 ns/op	   13034 B/op	     121 allocs/op
ok  	github.com/yarpc/yarpc-go	186.535s
```

CC @prashantv @breerly @bombela