### PR TITLE
context - Remove ResMeta Context

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -26,7 +26,7 @@ import (
 var _reqBody = []byte("hello")
 
 func yarpcEcho(reqMeta yarpc.ReqMeta, body []byte) ([]byte, yarpc.ResMeta, error) {
-	return body, yarpc.NewResMeta(reqMeta.Context()).Headers(reqMeta.Headers()), nil
+	return body, yarpc.NewResMeta().Headers(reqMeta.Headers()), nil
 }
 
 func httpEcho(t testing.TB) http.HandlerFunc {

--- a/crossdock/client/ctxpropagation/behavior.go
+++ b/crossdock/client/ctxpropagation/behavior.go
@@ -222,7 +222,7 @@ func (*singleHopHandler) SetTransport(server.TransportConfig) {}
 
 func (h *singleHopHandler) Handle(reqMeta yarpc.ReqMeta, body interface{}) (interface{}, yarpc.ResMeta, error) {
 	assertBaggageMatches(h.t, reqMeta.Context(), h.wantBaggage)
-	resMeta := yarpc.NewResMeta(reqMeta.Context()).Headers(reqMeta.Headers())
+	resMeta := yarpc.NewResMeta().Headers(reqMeta.Headers())
 	return map[string]interface{}{}, resMeta, nil
 }
 
@@ -271,8 +271,7 @@ func (h *multiHopHandler) Handle(reqMeta yarpc.ReqMeta, body interface{}) (inter
 			Body:      &js.RawMessage{'{', '}'},
 		}, &resp)
 
-	resMeta := yarpc.NewResMeta(phoneResMeta.Context()).
-		Headers(phoneResMeta.Headers())
+	resMeta := yarpc.NewResMeta().Headers(phoneResMeta.Headers())
 	return map[string]interface{}{}, resMeta, err
 }
 

--- a/crossdock/server/yarpc/echo.go
+++ b/crossdock/server/yarpc/echo.go
@@ -27,13 +27,13 @@ import (
 
 // EchoRaw implements the echo/raw procedure.
 func EchoRaw(reqMeta yarpc.ReqMeta, body []byte) ([]byte, yarpc.ResMeta, error) {
-	resMeta := yarpc.NewResMeta(reqMeta.Context()).Headers(reqMeta.Headers())
+	resMeta := yarpc.NewResMeta().Headers(reqMeta.Headers())
 	return body, resMeta, nil
 }
 
 // EchoJSON implements the echo procedure.
 func EchoJSON(reqMeta yarpc.ReqMeta, body map[string]interface{}) (map[string]interface{}, yarpc.ResMeta, error) {
-	resMeta := yarpc.NewResMeta(reqMeta.Context()).Headers(reqMeta.Headers())
+	resMeta := yarpc.NewResMeta().Headers(reqMeta.Headers())
 	return body, resMeta, nil
 }
 
@@ -42,6 +42,6 @@ type EchoThrift struct{}
 
 // Echo endpoint for the Echo service.
 func (EchoThrift) Echo(reqMeta yarpc.ReqMeta, ping *echo.Ping) (*echo.Pong, yarpc.ResMeta, error) {
-	resMeta := yarpc.NewResMeta(reqMeta.Context()).Headers(reqMeta.Headers())
+	resMeta := yarpc.NewResMeta().Headers(reqMeta.Headers())
 	return &echo.Pong{Boop: ping.Beep}, resMeta, nil
 }

--- a/crossdock/server/yarpc/gauntlet.go
+++ b/crossdock/server/yarpc/gauntlet.go
@@ -28,7 +28,7 @@ import (
 )
 
 func resMetaFromReqMeta(reqMeta yarpc.ReqMeta) yarpc.ResMeta {
-	return yarpc.NewResMeta(reqMeta.Context()).Headers(reqMeta.Headers())
+	return yarpc.NewResMeta().Headers(reqMeta.Headers())
 }
 
 // thriftTest implements the ThriftTest service.

--- a/encoding/json/inbound.go
+++ b/encoding/json/inbound.go
@@ -61,9 +61,7 @@ func (h jsonHandler) Handle(ctx context.Context, _ transport.Options, treq *tran
 	}
 
 	if resMeta, ok := results[1].Interface().(yarpc.ResMeta); ok {
-		_ = meta.ToTransportResponseWriter(resMeta, rw)
-		// TODO(abg): once transports support response context, we'll have to
-		// propagate that here.
+		meta.ToTransportResponseWriter(resMeta, rw)
 	}
 
 	result := results[0].Interface()

--- a/encoding/json/inbound_test.go
+++ b/encoding/json/inbound_test.go
@@ -102,8 +102,7 @@ func TestHandleInterfaceEmptySuccess(t *testing.T) {
 
 func TestHandleSuccessWithResponseHeaders(t *testing.T) {
 	h := func(r yarpc.ReqMeta, _ *simpleRequest) (*simpleResponse, yarpc.ResMeta, error) {
-		resMeta := yarpc.NewResMeta(r.Context()).
-			Headers(yarpc.NewHeaders().With("foo", "bar"))
+		resMeta := yarpc.NewResMeta().Headers(yarpc.NewHeaders().With("foo", "bar"))
 		return &simpleResponse{Success: true}, resMeta, nil
 	}
 

--- a/encoding/json/outbound.go
+++ b/encoding/json/outbound.go
@@ -65,7 +65,6 @@ func (c jsonClient) Call(reqMeta yarpc.CallReqMeta, reqBody interface{}, resBody
 
 	treq.Body = bytes.NewReader(encoded)
 	tres, err := c.ch.GetOutbound().Call(ctx, &treq)
-	// TODO: transport must return response context
 
 	if err != nil {
 		return nil, err
@@ -80,6 +79,5 @@ func (c jsonClient) Call(reqMeta yarpc.CallReqMeta, reqBody interface{}, resBody
 		return nil, err
 	}
 
-	// TODO: when transport returns response context, use that here.
-	return meta.FromTransportResponse(ctx, tres), nil
+	return meta.FromTransportResponse(tres), nil
 }

--- a/encoding/raw/inbound.go
+++ b/encoding/raw/inbound.go
@@ -52,8 +52,7 @@ func (r rawHandler) Handle(ctx context.Context, _ transport.Options, treq *trans
 	}
 
 	if resMeta != nil {
-		_ = meta.ToTransportResponseWriter(resMeta, rw)
-		// TODO(abg): Propagate response context
+		meta.ToTransportResponseWriter(resMeta, rw)
 	}
 
 	if _, err := rw.Write(resBody); err != nil {

--- a/encoding/raw/inbound_test.go
+++ b/encoding/raw/inbound_test.go
@@ -88,8 +88,7 @@ func TestRawHandler(t *testing.T) {
 			procedure:  "responseHeaders",
 			bodyChunks: [][]byte{},
 			handler: func(reqMeta yarpc.ReqMeta, body []byte) ([]byte, yarpc.ResMeta, error) {
-				resMeta := yarpc.NewResMeta(reqMeta.Context()).
-					Headers(yarpc.NewHeaders().With("hello", "world"))
+				resMeta := yarpc.NewResMeta().Headers(yarpc.NewHeaders().With("hello", "world"))
 				return []byte{}, resMeta, nil
 			},
 			wantHeaders: transport.NewHeaders().With("hello", "world"),

--- a/encoding/raw/outbound.go
+++ b/encoding/raw/outbound.go
@@ -64,6 +64,5 @@ func (c rawClient) Call(reqMeta yarpc.CallReqMeta, body []byte) ([]byte, yarpc.C
 		return nil, nil, err
 	}
 
-	// TODO: when transport returns response context, use that here.
-	return resBody, meta.FromTransportResponse(ctx, tres), nil
+	return resBody, meta.FromTransportResponse(tres), nil
 }

--- a/encoding/thrift/inbound.go
+++ b/encoding/thrift/inbound.go
@@ -92,8 +92,7 @@ func (t thriftHandler) Handle(ctx context.Context, opts transport.Options, treq 
 
 	resMeta := res.Meta
 	if resMeta != nil {
-		_ = meta.ToTransportResponseWriter(resMeta, rw)
-		// TODO(abg): propagate response context
+		meta.ToTransportResponseWriter(resMeta, rw)
 	}
 
 	err = proto.EncodeEnveloped(wire.Envelope{

--- a/encoding/thrift/outbound.go
+++ b/encoding/thrift/outbound.go
@@ -187,8 +187,7 @@ func (c thriftClient) Call(
 
 	switch envelope.Type {
 	case wire.Reply:
-		// TODO(abg): when transport returns response context, use that here.
-		return envelope.Value, meta.FromTransportResponse(ctx, tres), nil
+		return envelope.Value, meta.FromTransportResponse(tres), nil
 	case wire.Exception:
 		var exc internal.TApplicationException
 		if err := exc.FromWire(envelope.Value); err != nil {

--- a/examples/thrift/hello/main.go
+++ b/examples/thrift/hello/main.go
@@ -67,7 +67,7 @@ type helloHandler struct{}
 
 func (h helloHandler) Echo(reqMeta yarpc.ReqMeta, echo *hello.EchoRequest) (*hello.EchoResponse, yarpc.ResMeta, error) {
 	return &hello.EchoResponse{Message: echo.Message, Count: echo.Count + 1},
-		yarpc.NewResMeta(reqMeta.Context()).Headers(reqMeta.Headers()),
+		yarpc.NewResMeta().Headers(reqMeta.Headers()),
 		nil
 }
 

--- a/internal/meta/res.go
+++ b/internal/meta/res.go
@@ -23,32 +23,23 @@ package meta
 import (
 	"github.com/yarpc/yarpc-go"
 	"github.com/yarpc/yarpc-go/transport"
-
-	"golang.org/x/net/context"
 )
 
 // FromTransportResponse builds a CallResMeta from a transport-level Response.
-func FromTransportResponse(ctx context.Context, res *transport.Response) yarpc.CallResMeta {
-	return callResMeta{ctx: ctx, res: res}
+func FromTransportResponse(res *transport.Response) yarpc.CallResMeta {
+	return callResMeta{res: res}
 }
 
 // ToTransportResponseWriter fills the given transport response with
-// information from the given ResMeta. The Context associated with the ResMeta
-// is returned.
-func ToTransportResponseWriter(resMeta yarpc.ResMeta, w transport.ResponseWriter) context.Context {
+// information from the given ResMeta.
+func ToTransportResponseWriter(resMeta yarpc.ResMeta, w transport.ResponseWriter) {
 	if hs := resMeta.GetHeaders(); hs.Len() > 0 {
 		w.AddHeaders(transport.Headers(resMeta.GetHeaders()))
 	}
-	return resMeta.GetContext()
 }
 
 type callResMeta struct {
-	ctx context.Context
 	res *transport.Response
-}
-
-func (r callResMeta) Context() context.Context {
-	return r.ctx
 }
 
 func (r callResMeta) Headers() yarpc.Headers {

--- a/res_meta.go
+++ b/res_meta.go
@@ -20,44 +20,29 @@
 
 package yarpc
 
-import "golang.org/x/net/context"
-
 // ResMeta contains information about an outgoing YARPC response.
 type ResMeta interface {
 	Headers(Headers) ResMeta
-
-	GetContext() context.Context
 	GetHeaders() Headers
 }
 
 // CallResMeta contains information about an incoming YARPC response.
 type CallResMeta interface {
-	Context() context.Context
 	Headers() Headers
 }
 
-// NewResMeta constructs a ResMeta with the given Context.
-//
-// The context MUST NOT be nil.
-func NewResMeta(ctx context.Context) ResMeta {
-	if ctx == nil {
-		panic("invalid usage of ResMeta: context cannot be nil")
-	}
-	return &resMeta{ctx: ctx}
+// NewResMeta constructs a ResMeta
+func NewResMeta() ResMeta {
+	return &resMeta{}
 }
 
 type resMeta struct {
-	ctx     context.Context
 	headers Headers
 }
 
 func (r *resMeta) Headers(h Headers) ResMeta {
 	r.headers = h
 	return r
-}
-
-func (r *resMeta) GetContext() context.Context {
-	return r.ctx
 }
 
 func (r *resMeta) GetHeaders() Headers {

--- a/yarpctest/fake_call_res_meta.go
+++ b/yarpctest/fake_call_res_meta.go
@@ -20,11 +20,7 @@
 
 package yarpctest
 
-import (
-	"github.com/yarpc/yarpc-go"
-
-	"golang.org/x/net/context"
-)
+import "github.com/yarpc/yarpc-go"
 
 // CallResMetaBuilder helps build fake yarpc.CallResMeta objects for testing.
 //
@@ -34,13 +30,12 @@ import (
 type CallResMetaBuilder struct {
 	singleUse
 
-	ctx     context.Context
 	headers yarpc.Headers
 }
 
 // NewCallResMetaBuilder builds a new fake ReqMeta for unit tests
-func NewCallResMetaBuilder(ctx context.Context) *CallResMetaBuilder {
-	return &CallResMetaBuilder{ctx: ctx}
+func NewCallResMetaBuilder() *CallResMetaBuilder {
+	return &CallResMetaBuilder{}
 }
 
 // Headers specifies the response headers for this CallResMeta.
@@ -61,10 +56,6 @@ func (f *CallResMetaBuilder) Build() yarpc.CallResMeta {
 }
 
 type fakeResMeta CallResMetaBuilder
-
-func (r fakeResMeta) Context() context.Context {
-	return CallResMetaBuilder(r).ctx
-}
 
 func (r fakeResMeta) Headers() yarpc.Headers {
 	return CallResMetaBuilder(r).headers

--- a/yarpctest/fake_call_res_meta_test.go
+++ b/yarpctest/fake_call_res_meta_test.go
@@ -22,11 +22,9 @@ package yarpctest
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	yarpc "github.com/yarpc/yarpc-go"
-	"golang.org/x/net/context"
 )
 
 func TestResMeta(t *testing.T) {
@@ -50,11 +48,7 @@ func TestResMeta(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-		defer cancel()
-
-		reqMeta := tt.build(NewCallResMetaBuilder(ctx)).Build()
-		assert.Equal(t, ctx, reqMeta.Context())
+		reqMeta := tt.build(NewCallResMetaBuilder()).Build()
 		assert.Equal(t, tt.wantHeaders, reqMeta.Headers())
 	}
 }


### PR DESCRIPTION
This removes Context from the ResMeta object - greatly simplifying the customer-facing experience.