### PR TITLE
Allow Call with nil reqMeta

### DIFF
--- a/encoding/thrift/outbound_test.go
+++ b/encoding/thrift/outbound_test.go
@@ -27,7 +27,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/yarpc/yarpc-go"
 	"github.com/yarpc/yarpc-go/transport"
 	"github.com/yarpc/yarpc-go/transport/transporttest"
 
@@ -183,8 +182,7 @@ func TestClient(t *testing.T) {
 			Protocol: proto,
 		})
 
-		// TODO can we pass nil instead of reqmeta?
-		_, _, err := c.Call(ctx, yarpc.NewReqMeta(), tt.giveRequestBody)
+		_, _, err := c.Call(ctx, nil, tt.giveRequestBody)
 		if tt.wantError != "" {
 			if assert.Error(t, err, "%v: expected failure", tt.desc) {
 				assert.Contains(t, err.Error(), tt.wantError, "%v: error mismatch", tt.desc)

--- a/internal/meta/req.go
+++ b/internal/meta/req.go
@@ -33,6 +33,9 @@ func FromTransportRequest(req *transport.Request) yarpc.ReqMeta {
 // ToTransportRequest fills the given transport request with information from
 // the given ReqMeta.
 func ToTransportRequest(reqMeta yarpc.CallReqMeta, req *transport.Request) {
+	if reqMeta == nil {
+		return
+	}
 	req.Procedure = reqMeta.GetProcedure()
 	req.Headers = transport.Headers(reqMeta.GetHeaders())
 }


### PR DESCRIPTION
This makes it possible to make a `Call` with a `nil` reqMeta in encodings that don't request `Procedure` to be set, like Thrift.