### PR TITLE
Revamp README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
-# yarpc-go
+# yarpc-go [![GoDoc][doc-img]][doc] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov]
 
-[![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov]
+## Installation
 
-  [ci-img]: https://travis-ci.org/yarpc/yarpc-go.svg?branch=master
-  [cov-img]: https://coveralls.io/repos/github/yarpc/yarpc-go/badge.svg?branch=master
-  [ci]: https://travis-ci.org/yarpc/yarpc-go
-  [cov]: https://coveralls.io/github/yarpc/yarpc-go?branch=master
+`go get -u go.uber.org/yarpc`
 
-**This project is currently WIP and not ready for use. Do not use it until this notice goes away.**
+## Development Status: Alpha
 
-Cheers
+Ready for adventurous users and early adopters, but there will likely be a few
+breaking changes and features required before releasing version 1.0.
+
+[doc-img]: https://godoc.org/go.uber.org/yarpc?status.svg
+[doc]: https://godoc.org/go.uber.org/yarpc
+[ci-img]: https://travis-ci.org/yarpc/yarpc-go.svg?branch=master
+[cov-img]: https://coveralls.io/repos/github/yarpc/yarpc-go/badge.svg?branch=master
+[ci]: https://travis-ci.org/yarpc/yarpc-go
+[cov]: https://coveralls.io/github/yarpc/yarpc-go?branch=master

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # yarpc-go [![GoDoc][doc-img]][doc] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov]
 
+A transport and encoding agnostic RPC framework.
+
 ## Installation
 
 `go get -u go.uber.org/yarpc`


### PR DESCRIPTION
I wanted to call out the right import path in the installation, so I revamped the README to reflect `go.uber.org/yarpc` - cc @abhinav @kriskowal 