### PR TITLE
Rename some behaviors with more obvious names.

### DIFF
--- a/crossdock/client/errors_httpclient/behavior.go
+++ b/crossdock/client/errors_httpclient/behavior.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package errors
+package errors_httpclient
 
 import (
 	"fmt"

--- a/crossdock/client/errors_tchclient/behavior.go
+++ b/crossdock/client/errors_tchclient/behavior.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package errorstchout
+package errors_tchclient
 
 import (
 	"fmt"

--- a/crossdock/client/start.go
+++ b/crossdock/client/start.go
@@ -23,8 +23,8 @@ package client
 import (
 	"github.com/yarpc/yarpc-go/crossdock/client/ctxpropagation"
 	"github.com/yarpc/yarpc-go/crossdock/client/echo"
-	"github.com/yarpc/yarpc-go/crossdock/client/errors"
-	"github.com/yarpc/yarpc-go/crossdock/client/errorstchout"
+	"github.com/yarpc/yarpc-go/crossdock/client/errors_httpclient"
+	"github.com/yarpc/yarpc-go/crossdock/client/errors_tchclient"
 	"github.com/yarpc/yarpc-go/crossdock/client/gauntlet"
 	"github.com/yarpc/yarpc-go/crossdock/client/headers"
 	"github.com/yarpc/yarpc-go/crossdock/client/httpserver"
@@ -36,18 +36,18 @@ import (
 )
 
 var behaviors = crossdock.Behaviors{
-	"raw":            echo.Raw,
-	"json":           echo.JSON,
-	"thrift":         echo.Thrift,
-	"headers":        headers.Run,
-	"errors":         errors.Run,
-	"errorstchout":   errorstchout.Run,
-	"tchclient":      tchclient.Run,
-	"tchserver":      tchserver.Run,
-	"thriftgauntlet": gauntlet.Run,
-	"timeout":        timeout.Run,
-	"ctxpropagation": ctxpropagation.Run,
-	"httpserver":     httpserver.Run,
+	"raw":               echo.Raw,
+	"json":              echo.JSON,
+	"thrift":            echo.Thrift,
+	"headers":           headers.Run,
+	"errors_httpclient": errors_httpclient.Run,
+	"errors_tchclient":  errors_tchclient.Run,
+	"tchclient":         tchclient.Run,
+	"tchserver":         tchserver.Run,
+	"thriftgauntlet":    gauntlet.Run,
+	"timeout":           timeout.Run,
+	"ctxpropagation":    ctxpropagation.Run,
+	"httpserver":        httpserver.Run,
 }
 
 // Start registers behaviors and begins the Crossdock client

--- a/crossdock/client/tchclient/behavior.go
+++ b/crossdock/client/tchclient/behavior.go
@@ -36,7 +36,7 @@ const (
 
 var log = tchannel.SimpleLogger
 
-// Run executes the tchclient test
+// Run exercises a YARPC server from a tchannel client.
 func Run(t crossdock.T) {
 	fatals := crossdock.Fatals(t)
 

--- a/crossdock/client/tchserver/behavior.go
+++ b/crossdock/client/tchserver/behavior.go
@@ -37,7 +37,7 @@ const (
 	serverName = "tchannel-server"
 )
 
-// Run executes the tchserver test
+// Run exercises a YARPC client against a tchannel server.
 func Run(t crossdock.T) {
 	fatals := crossdock.Fatals(t)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,10 +17,10 @@ services:
             - AXIS_SERVER=go,node,java,python
             - AXIS_TRANSPORT=http,tchannel
             - AXIS_ENCODING=raw,json,thrift
-            - AXIS_ERRORSHTTPOUT=node,go
-            # AXIS_ERRORSHTTPIN TODO
-            - AXIS_ERRORSTCHOUT=go
-            # AXIS_ERRORSTCHIN TODO
+            - AXIS_ERRORS_HTTPCLIENT=node,go
+            # AXIS_ERRORS_HTTPSERVER TODO
+            - AXIS_ERRORS_TCHCLIENT=go
+            # AXIS_ERRORS_TCHSERVER TODO
             - AXIS_CTXCLIENT=go
             - AXIS_CTXSERVER=go
             - AXIS_GAUNTLET=go
@@ -30,9 +30,9 @@ services:
             - BEHAVIOR_JSON=client,server,transport
             - BEHAVIOR_THRIFT=client,server,transport
             - BEHAVIOR_HEADERS=client,server,transport,encoding
-            - BEHAVIOR_ERRORS=errorshttpout,server
+            - BEHAVIOR_ERRORS_HTTPCLIENT=errors_httpclient,server
             # BEHAVIOR_ERRORSHTTPIN TODO
-            - BEHAVIOR_ERRORSTCHOUT=errorstchout,server
+            - BEHAVIOR_ERRORS_TCHCLIENT=errors_tchclient,server
             # BEHAVIOR_ERRORSTCHIN TODO
             - BEHAVIOR_TCHCLIENT=client,server,encoding
             - BEHAVIOR_TCHSERVER=client,server,encoding


### PR DESCRIPTION
I find that some behaviors are confusingly named. This PR renames few behaviors
to what I believe to be easier to understand.

 - `errors` becomes `errors_httpclient`
 - `errorstchout` becomes `errors_tchclient`

This achieves symmetry with `httpserver`, `tchclient` and `tchserver`.