### PR TITLE
Catch (recover) panics from user handlers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ v0.2.0 (2016-09-01)
 -   This also modifies the public interface for transport inbounds and
     outbounds, which must now accept a transport.Deps struct. The deps struct
     carries the tracer and may eventually carry other dependencies.
+-   Panics from user handlers are recovered. The panic is logged (stderr), and
+    an unexpected error is returned to the client about it.
 
 [opentracing]: http://opentracing.io/
 

--- a/transport/http/handler.go
+++ b/transport/http/handler.go
@@ -22,11 +22,10 @@ package http
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"runtime/debug"
 	"time"
-
-	"code.uber.internal/go-common.git/x/log"
 
 	"github.com/yarpc/yarpc-go/internal/baggage"
 	"github.com/yarpc/yarpc-go/internal/errors"
@@ -111,7 +110,7 @@ func (h handler) callHandler(w http.ResponseWriter, req *http.Request, start tim
 	// We recover panics from the user handler.
 	defer func() {
 		if r := recover(); r != nil {
-			log.Errorf("Handler panicked: %v\n%s", r, debug.Stack())
+			log.Printf("Handler panicked: %v\n%s", r, debug.Stack())
 			returnErr = fmt.Errorf("panic: %v", r)
 		}
 	}()

--- a/transport/http/handler.go
+++ b/transport/http/handler.go
@@ -23,7 +23,10 @@ package http
 import (
 	"fmt"
 	"net/http"
+	"runtime/debug"
 	"time"
+
+	"code.uber.internal/go-common.git/x/log"
 
 	"github.com/yarpc/yarpc-go/internal/baggage"
 	"github.com/yarpc/yarpc-go/internal/errors"
@@ -108,11 +111,8 @@ func (h handler) callHandler(w http.ResponseWriter, req *http.Request, start tim
 	// We recover panics from the user handler.
 	defer func() {
 		if r := recover(); r != nil {
-			if err, ok := r.(error); ok {
-				returnErr = err
-			} else {
-				returnErr = fmt.Errorf("%q", r)
-			}
+			log.Errorf("Handler panicked: %v\n%s", r, debug.Stack())
+			returnErr = fmt.Errorf("panic: %v", r)
 		}
 	}()
 

--- a/transport/http/handler_test.go
+++ b/transport/http/handler_test.go
@@ -29,8 +29,6 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
-
 	yarpc "github.com/yarpc/yarpc-go"
 	"github.com/yarpc/yarpc-go/encoding/raw"
 	"github.com/yarpc/yarpc-go/transport"
@@ -39,6 +37,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
 )
 
 func TestHandlerSucces(t *testing.T) {

--- a/transport/http/handler_test.go
+++ b/transport/http/handler_test.go
@@ -295,8 +295,7 @@ func TestHandlerInternalFailure(t *testing.T) {
 
 type panickedHandler struct{}
 
-func (th panickedHandler) Handle(context.Context, transport.Options,
-	*transport.Request, transport.ResponseWriter) error {
+func (th panickedHandler) Handle(context.Context, transport.Options, *transport.Request, transport.ResponseWriter) error {
 	panic("oops I panicked!")
 }
 

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -22,10 +22,9 @@ package tchannel
 
 import (
 	"fmt"
+	"log"
 	"runtime/debug"
 	"time"
-
-	"code.uber.internal/go-common.git/x/log"
 
 	"github.com/yarpc/yarpc-go/internal/encoding"
 	"github.com/yarpc/yarpc-go/internal/errors"
@@ -164,7 +163,7 @@ func (h handler) callHandler(ctx context.Context, call inboundCall, now time.Tim
 	// We recover panics from the user handler.
 	defer func() {
 		if r := recover(); r != nil {
-			log.Errorf("Handler panicked: %v\n%s", r, debug.Stack())
+			log.Printf("Handler panicked: %v\n%s", r, debug.Stack())
 			returnErr = fmt.Errorf("panic: %v", r)
 		}
 	}()

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -22,7 +22,10 @@ package tchannel
 
 import (
 	"fmt"
+	"runtime/debug"
 	"time"
+
+	"code.uber.internal/go-common.git/x/log"
 
 	"github.com/yarpc/yarpc-go/internal/encoding"
 	"github.com/yarpc/yarpc-go/internal/errors"
@@ -161,11 +164,8 @@ func (h handler) callHandler(ctx context.Context, call inboundCall, now time.Tim
 	// We recover panics from the user handler.
 	defer func() {
 		if r := recover(); r != nil {
-			if err, ok := r.(error); ok {
-				returnErr = err
-			} else {
-				returnErr = fmt.Errorf("%q", r)
-			}
+			log.Errorf("Handler panicked: %v\n%s", r, debug.Stack())
+			returnErr = fmt.Errorf("panic: %v", r)
 		}
 	}()
 

--- a/transport/tchannel/handler_test.go
+++ b/transport/tchannel/handler_test.go
@@ -322,7 +322,7 @@ func TestHandlerFailures(t *testing.T) {
 				})
 			},
 			wantErrors: []string{
-				`UnexpectedError: error for procedure "panic" of service "foo": "oops I panicked!"`,
+				`UnexpectedError: error for procedure "panic" of service "foo": panic: oops I panicked!`,
 			},
 			wantStatus: tchannel.ErrCodeUnexpected,
 		},

--- a/transport/tchannel/handler_test.go
+++ b/transport/tchannel/handler_test.go
@@ -288,6 +288,44 @@ func TestHandlerFailures(t *testing.T) {
 				`tchannel error ErrCodeTimeout: Timeout: call to procedure "waituntiltimeout" of service "foo" from caller "bar" timed out after `},
 			wantStatus: tchannel.ErrCodeTimeout,
 		},
+		{
+			desc: "handler panic",
+			sendCall: &fakeInboundCall{
+				service: "foo",
+				caller:  "bar",
+				method:  "panic",
+				format:  tchannel.Raw,
+				arg2:    []byte{0x00, 0x00},
+				arg3:    []byte{0x00},
+			},
+			expectCall: func(h *transporttest.MockHandler) {
+				req := &transport.Request{
+					Service:   "foo",
+					Caller:    "bar",
+					Procedure: "panic",
+					Encoding:  raw.Encoding,
+					Body:      bytes.NewReader([]byte{0x00}),
+				}
+				h.EXPECT().Handle(
+					transporttest.NewContextMatcher(
+						t, transporttest.ContextTTL(time.Second)),
+					transportOptions,
+					transporttest.NewRequestMatcher(t, req),
+					gomock.Any(),
+				).Do(func(
+					_ context.Context,
+					_ transport.Options,
+					_ *transport.Request,
+					_ transport.ResponseWriter,
+				) {
+					panic("oops I panicked!")
+				})
+			},
+			wantErrors: []string{
+				`UnexpectedError: error for procedure "panic" of service "foo": "oops I panicked!"`,
+			},
+			wantStatus: tchannel.ErrCodeUnexpected,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
For both http and tchannel, we catch any panics from the user handler. If we
recover a non `error` type, we simply format it via `%q`.

The `error` is then handled as any other user error: converted to an
`UnexpectedError`.