### PR TITLE
travis: Split crossdock and linter out

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,7 @@ before_install:
 install:
 - |
   set -ex
+  make install
   case "$TYPE" in
     lint)
       go get -u -f github.com/golang/lint/golint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-sudo: required
-
+sudo: false
 language: go
 
 go:
@@ -13,6 +12,7 @@ services:
 
 env:
   global:
+    - CROSSDOCK=0
     - GO15VENDOREXPERIMENT=1
     - DOCKER_COMPOSE_VERSION=1.8.0
     - COMMIT=${TRAVIS_COMMIT::8}
@@ -20,33 +20,59 @@ env:
     - secure: Vg1mnR5Eu98dQ30rNb2fFblehh71a6goJz/Crhh+kae1z1Ec6NuQ6b0mNrzZMIXg6QktZ9gK0bJHjg1t90QpDfWHtSqAhQ0Z5yI4xH7Dt7jEMSYhGQ+YSmG6qo4c6Rh7CrIYXFRenS+qzhA8h7m48O8j1Z5G24qfen3y9cs7TNWKi43kGY8kSue3+xMi8hVErFLhfyhLNkOMJzWes+22apwEWIYwZWALYLpkmpYmgK8+nw+cZrI/r1WX5f6tdyZ/CRD/BAMgCwJYo7SNMuqTzsKTdqlHr7p2j7vcZtBSk5SJwzeChNJQwy94k+HF79R0WX8T8wuvxZKGtRqo7kf5bHAg2NRNDEL1KjBjV8tCJoh7FHLmQenQKfAt7x/eQu9r/+3do9Wvyan5MV3zYpDlCFZrRua9BL+cuSQaDAvGDAfqbzuDdlqUJLmn+t2+yyrxJS1NX5fLi6MX8cyh/11JkcIXifM9HqD1yM9S99MA8M3/O2g71oEbvcktkRCMOGga68sap+GzavVElyuutzHDGrPSvSqFw42yBAEKbnEJDbsMYL/6xxN/Xd3ez3YuwRs4R1m2NRN4Nq53ERozW8k7uVxmaEBioGfO+e5n0MfDQXY6uvdCx/R32ub4QDYOAovvoxhg042pYMbxWJkO73RMWTQzJvY8dbrxdMkw4xyq3Ic=
     - secure: dhvshW7GvphJ6xvS8MxEtJGN+4C4d64hqOcaCKXXXVqyeunJ1gH/Cb6v1RcETgtRxOIHyyHo218j0cs0hNtIWCZq5YVbXMAJ5Sret+cKA3aZNMCbgwPNS48WdVZsCHurW22abq41ejfKuuFqSI+ooMprrsGeRjHMbJZM86k7UuEqxdvqGjotYugGcfiCjxnNtMHd1M6AQ9fPFzhg8TUeqPy7eDIdKTcqwa/h7ZsYn/WJp1LkUtwyHsfpweIv6JBQ9/xUDzjcoz5MA6Nj75/Mk4bJzzLEem3EKs1TTZOqV1NVt7VJ887NPe4fLIxP1/jQLzsh6kShTcctLszc70NgrowdwhdIqN/3TUmxkVbGP2JzbQ4yR6LVKCDDeWpKGiPsIKy75kEiW4ZlEZhnwCOKaR94FyBy1HEnhyoD9OJD6Gq/u4UdEw/QuNfE89gbr47LA4z487AzYGzH+1J3MlEbTNgTCmWduC0ghTx33vItrYMXXabGDe7XwfdJKTnMjfXVv+CVBdMAZVtDL27sEmbbAzIrRjP+JOFm7ZRYfzvxu5vCWlB/3wMMt7DzcutjxR4tyYs71Ec5zdUH/16wSvjQR1laJZCujlNSA/3FZUizCzW3qFVsBkaWRF+/C/cksi6cR83xIrc4y4WRLttAcbfqmsXaigL5Iz4GbLg62vmFP88=
 
+matrix:
+  # Fail the build as soon as the first job fails
+  fast_finish: true
+
+  include:
+    - go: 1.7
+      env: CROSSDOCK=1
+      sudo: required
+
 before_install:
-  - docker version
-  - sudo rm -f /usr/local/bin/docker-compose
-  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
-  - chmod +x docker-compose
-  - sudo mv docker-compose /usr/local/bin
-  - docker-compose version
+- go version
+- |
+  set -ex
+  if [ -n "$CROSSDOCK" ]; then
+    docker version
+    sudo rm -f /usr/local/bin/docker-compose
+    curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+    chmod +x docker-compose
+    sudo mv docker-compose /usr/local/bin
+    docker-compose version
+  fi
+  set +ex
 
 install:
-  - make install_ci
+- make install_ci
 
 script:
-  - make lint_ci
-  - make test_ci
-  - make test-examples
-  - travis_retry goveralls -coverprofile=cover.out -service=travis-ci || true
-  - make crossdock
-  - docker-compose logs
+- |
+  set -ex
+  if [ -n "$CROSSDOCK" ]; then
+    make crossdock
+    docker-compose logs
+  else
+    make lint_ci
+    make test_ci
+    make test-examples
+    travis_retry goveralls -coverprofile=cover.out -service=travis-ci || true
+  fi
+  set +ex
 
 after_success:
-  - export REPO=yarpc/yarpc-go
-  - export PR=https://api.github.com/repos/$TRAVIS_REPO_SLUG/pulls/$TRAVIS_PULL_REQUEST
-  - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo `curl -s $PR | jq -r .head.ref`; fi)
-  - export TAG=`if [ "$BRANCH" == "master" ]; then echo "latest"; else echo $BRANCH; fi`
-  - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, REPO=$REPO, PR=$PR, BRANCH=$BRANCH, TAG=$TAG"
-  - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
-  - docker build -f Dockerfile -t $REPO:$COMMIT .
-  - docker tag $REPO:$COMMIT $REPO:$TAG
-  - docker tag $REPO:$COMMIT $REPO:travis-$TRAVIS_BUILD_NUMBER
-  - docker push $REPO
+- export REPO=yarpc/yarpc-go
+- export PR=https://api.github.com/repos/$TRAVIS_REPO_SLUG/pulls/$TRAVIS_PULL_REQUEST
+- export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo `curl -s $PR | jq -r .head.ref`; fi)
+- export TAG=`if [ "$BRANCH" == "master" ]; then echo "latest"; else echo $BRANCH; fi`
+- echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, REPO=$REPO, PR=$PR, BRANCH=$BRANCH, TAG=$TAG"
+- |
+  set -ex
+  if [ -n "$CROSSDOCK" ]; then
+    docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+    docker build -f Dockerfile -t $REPO:$COMMIT .
+    docker tag $REPO:$COMMIT $REPO:$TAG
+    docker tag $REPO:$COMMIT $REPO:travis-$TRAVIS_BUILD_NUMBER
+    docker push $REPO
+  fi
+  set +ex

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
 
   include:
     - go: 1.7
-      env: CROSSDOCK=1
+      env: CROSSDOCK=true
       services: [docker]
       sudo: required
 
@@ -30,7 +30,7 @@ before_install:
 - go version
 - |
   set -ex
-  if [ "$CROSSDOCK" == 1 ]; then
+  if [ "$CROSSDOCK" == true ]; then
     docker version
     sudo rm -f /usr/local/bin/docker-compose
     curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
@@ -46,7 +46,7 @@ install:
 script:
 - |
   set -ex
-  if [ "$CROSSDOCK"  == 1 ]; then
+  if [ "$CROSSDOCK"  == true ]; then
     make crossdock
     docker-compose logs
   else
@@ -65,7 +65,7 @@ after_success:
 - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, REPO=$REPO, PR=$PR, BRANCH=$BRANCH, TAG=$TAG"
 - |
   set -ex
-  if [ "$CROSSDOCK"  == 1 ]; then
+  if [ "$CROSSDOCK"  == true ]; then
     docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
     docker build -f Dockerfile -t $REPO:$COMMIT .
     docker tag $REPO:$COMMIT $REPO:$TAG

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,6 @@
 sudo: false
 language: go
 
-go:
-  - 1.5
-  - 1.6
-  - 1.7
-  - tip
-
-addons:
-  apt:
-    packages: [python-virtualenv]
-
 env:
   global:
     - GO15VENDOREXPERIMENT=1
@@ -25,8 +15,29 @@ matrix:
   fast_finish: true
 
   include:
+    # Lint
     - go: 1.7
-      env: CROSSDOCK=true
+      env: TYPE=lint
+
+    # Tests
+    #
+    # Need virtualenv for example tests
+    - go: 1.5
+      env: TYPE=test
+      addons: {apt: {packages: [python-virtualenv]}}
+    - go: 1.6
+      env: TYPE=test
+      addons: {apt: {packages: [python-virtualenv]}}
+    - go: 1.7
+      env: TYPE=test
+      addons: {apt: {packages: [python-virtualenv]}}
+    - go: tip
+      env: TYPE=test
+      addons: {apt: {packages: [python-virtualenv]}}
+
+    # Crossdock
+    - go: 1.7
+      env: TYPE=crossdock
       services: [docker]
       sudo: required
 
@@ -34,31 +45,49 @@ before_install:
 - go version
 - |
   set -ex
-  if [ "$CROSSDOCK" == true ]; then
-    docker version
-    sudo rm -f /usr/local/bin/docker-compose
-    curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
-    chmod +x docker-compose
-    sudo mv docker-compose /usr/local/bin
-    docker-compose version
-  fi
+  case "$TYPE" in
+    crossdock)
+      docker version
+      sudo rm -f /usr/local/bin/docker-compose
+      curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+      chmod +x docker-compose
+      sudo mv docker-compose /usr/local/bin
+      docker-compose version
+      ;;
+  esac
   set +ex
 
 install:
-- make install_ci
+- |
+  set -ex
+  case "$TYPE" in
+    lint)
+      go get -u -f github.com/golang/lint/golint
+      ;;
+    test)
+      go get github.com/wadey/gocovmerge
+      go get github.com/mattn/goveralls
+      go get golang.org/x/tools/cmd/cover
+      ;;
+  esac
 
 script:
 - |
   set -ex
-  if [ "$CROSSDOCK"  == true ]; then
-    make crossdock
-    docker-compose logs
-  else
-    make lint_ci
-    make test_ci
-    make test-examples
-    travis_retry goveralls -coverprofile=cover.out -service=travis-ci || true
-  fi
+  case "$TYPE" in
+    lint)
+      make lint
+      ;;
+    test)
+      make test_ci
+      make test-examples
+      travis_retry goveralls -coverprofile=cover.out -service=travis-ci || true
+      ;;
+    crossdock)
+      make crossdock
+      docker-compose logs
+      ;;
+  esac
   set +ex
 
 after_success:
@@ -69,11 +98,13 @@ after_success:
 - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, REPO=$REPO, PR=$PR, BRANCH=$BRANCH, TAG=$TAG"
 - |
   set -ex
-  if [ "$CROSSDOCK"  == true ]; then
-    docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
-    docker build -f Dockerfile -t $REPO:$COMMIT .
-    docker tag $REPO:$COMMIT $REPO:$TAG
-    docker tag $REPO:$COMMIT $REPO:travis-$TRAVIS_BUILD_NUMBER
-    docker push $REPO
-  fi
+  case "$TYPE" in
+    crossdock)
+      docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+      docker build -f Dockerfile -t $REPO:$COMMIT .
+      docker tag $REPO:$COMMIT $REPO:$TAG
+      docker tag $REPO:$COMMIT $REPO:travis-$TRAVIS_BUILD_NUMBER
+      docker push $REPO
+    ;;
+  esac
   set +ex

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ go:
   - 1.7
   - tip
 
-services:
-  - docker
-
 env:
   global:
     - CROSSDOCK=0
@@ -27,6 +24,7 @@ matrix:
   include:
     - go: 1.7
       env: CROSSDOCK=1
+      services: [docker]
       sudo: required
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,18 @@ matrix:
   fast_finish: true
 
   include:
+    # Crossdock
+    - go: 1.7
+      services: [docker]
+      sudo: required
+      env:
+        - TYPE=crossdock
+        - DOCKER_COMPOSE_VERSION=1.8.0
+        - COMMIT=${TRAVIS_COMMIT::8}
+        - secure: rZOVU0zQTkPvaG43IIt/guPoq3EAE6/So/+elGcmHF14PsfPcPQ6MyexqdwRkVPd/fAuNwiXXwTXHkjI8ECYz5LF+m+g2VwvrhE9H1wfLuGbtgXSSXqB+dqylHGUz4ksm4q1gwiet8fpVHlNfbSfu+lhTpbl4+SUfFK+s9LqnAKbm+Hi8vKzyhGhvlTngi0Y2O4Z2FLUgU2fkUm5fesdUyW0H2/Bn5KRqJRtcyTmmj4eD/qMq5WDe8n5Sy9J+kuCpweC8vBZQzAGuPpGdj8jvbPCO+N2xM26Y7DNKMsgj6IU49D6sbmLvyVMbI1pBeAQ54TCJx5LySuZpLAzyaaqHEDwOs4+cRolZSQwpd7Q8/wOxZ13KqMhYOokBIcDlLs0yB9J3KOTS1lxU8YC6A3j+Wenw9/JjL0sXSSeOAvNkAeVtEu3dqXg326HJjzXgIQbci83TTtWv4MsQKIXMADOgMnQdgd4JRaGyfxM2hswsE2/Y5OlyXqrqtFHvgKy6MpLTB26r3aRA22VY6p5hFhuEGLClbHidyeHgkNI2iHOXZqoEdmno33Eq7WicH64bezmq+Z4nwyjBOLTblcG7V79s9hI296zGdAN+KLXezlS00qhWH3UVmsi/hYTyXbWXay3S0Hc5jB+YUrHZ1y+OM6fm442qzz+M5q+MdtCfRad7ZM=
+        - secure: Vg1mnR5Eu98dQ30rNb2fFblehh71a6goJz/Crhh+kae1z1Ec6NuQ6b0mNrzZMIXg6QktZ9gK0bJHjg1t90QpDfWHtSqAhQ0Z5yI4xH7Dt7jEMSYhGQ+YSmG6qo4c6Rh7CrIYXFRenS+qzhA8h7m48O8j1Z5G24qfen3y9cs7TNWKi43kGY8kSue3+xMi8hVErFLhfyhLNkOMJzWes+22apwEWIYwZWALYLpkmpYmgK8+nw+cZrI/r1WX5f6tdyZ/CRD/BAMgCwJYo7SNMuqTzsKTdqlHr7p2j7vcZtBSk5SJwzeChNJQwy94k+HF79R0WX8T8wuvxZKGtRqo7kf5bHAg2NRNDEL1KjBjV8tCJoh7FHLmQenQKfAt7x/eQu9r/+3do9Wvyan5MV3zYpDlCFZrRua9BL+cuSQaDAvGDAfqbzuDdlqUJLmn+t2+yyrxJS1NX5fLi6MX8cyh/11JkcIXifM9HqD1yM9S99MA8M3/O2g71oEbvcktkRCMOGga68sap+GzavVElyuutzHDGrPSvSqFw42yBAEKbnEJDbsMYL/6xxN/Xd3ez3YuwRs4R1m2NRN4Nq53ERozW8k7uVxmaEBioGfO+e5n0MfDQXY6uvdCx/R32ub4QDYOAovvoxhg042pYMbxWJkO73RMWTQzJvY8dbrxdMkw4xyq3Ic=
+        - secure: dhvshW7GvphJ6xvS8MxEtJGN+4C4d64hqOcaCKXXXVqyeunJ1gH/Cb6v1RcETgtRxOIHyyHo218j0cs0hNtIWCZq5YVbXMAJ5Sret+cKA3aZNMCbgwPNS48WdVZsCHurW22abq41ejfKuuFqSI+ooMprrsGeRjHMbJZM86k7UuEqxdvqGjotYugGcfiCjxnNtMHd1M6AQ9fPFzhg8TUeqPy7eDIdKTcqwa/h7ZsYn/WJp1LkUtwyHsfpweIv6JBQ9/xUDzjcoz5MA6Nj75/Mk4bJzzLEem3EKs1TTZOqV1NVt7VJ887NPe4fLIxP1/jQLzsh6kShTcctLszc70NgrowdwhdIqN/3TUmxkVbGP2JzbQ4yR6LVKCDDeWpKGiPsIKy75kEiW4ZlEZhnwCOKaR94FyBy1HEnhyoD9OJD6Gq/u4UdEw/QuNfE89gbr47LA4z487AzYGzH+1J3MlEbTNgTCmWduC0ghTx33vItrYMXXabGDe7XwfdJKTnMjfXVv+CVBdMAZVtDL27sEmbbAzIrRjP+JOFm7ZRYfzvxu5vCWlB/3wMMt7DzcutjxR4tyYs71Ec5zdUH/16wSvjQR1laJZCujlNSA/3FZUizCzW3qFVsBkaWRF+/C/cksi6cR83xIrc4y4WRLttAcbfqmsXaigL5Iz4GbLg62vmFP88=
+
     # Lint
     - go: 1.7
       env: TYPE=lint
@@ -29,18 +41,6 @@ matrix:
     - go: tip
       env: TYPE=test
       addons: {apt: {packages: [python-virtualenv]}}
-
-    # Crossdock
-    - go: 1.7
-      services: [docker]
-      sudo: required
-      env:
-        - DOCKER_COMPOSE_VERSION=1.8.0
-        - COMMIT=${TRAVIS_COMMIT::8}
-        - TYPE=crossdock
-        - secure: rZOVU0zQTkPvaG43IIt/guPoq3EAE6/So/+elGcmHF14PsfPcPQ6MyexqdwRkVPd/fAuNwiXXwTXHkjI8ECYz5LF+m+g2VwvrhE9H1wfLuGbtgXSSXqB+dqylHGUz4ksm4q1gwiet8fpVHlNfbSfu+lhTpbl4+SUfFK+s9LqnAKbm+Hi8vKzyhGhvlTngi0Y2O4Z2FLUgU2fkUm5fesdUyW0H2/Bn5KRqJRtcyTmmj4eD/qMq5WDe8n5Sy9J+kuCpweC8vBZQzAGuPpGdj8jvbPCO+N2xM26Y7DNKMsgj6IU49D6sbmLvyVMbI1pBeAQ54TCJx5LySuZpLAzyaaqHEDwOs4+cRolZSQwpd7Q8/wOxZ13KqMhYOokBIcDlLs0yB9J3KOTS1lxU8YC6A3j+Wenw9/JjL0sXSSeOAvNkAeVtEu3dqXg326HJjzXgIQbci83TTtWv4MsQKIXMADOgMnQdgd4JRaGyfxM2hswsE2/Y5OlyXqrqtFHvgKy6MpLTB26r3aRA22VY6p5hFhuEGLClbHidyeHgkNI2iHOXZqoEdmno33Eq7WicH64bezmq+Z4nwyjBOLTblcG7V79s9hI296zGdAN+KLXezlS00qhWH3UVmsi/hYTyXbWXay3S0Hc5jB+YUrHZ1y+OM6fm442qzz+M5q+MdtCfRad7ZM=
-        - secure: Vg1mnR5Eu98dQ30rNb2fFblehh71a6goJz/Crhh+kae1z1Ec6NuQ6b0mNrzZMIXg6QktZ9gK0bJHjg1t90QpDfWHtSqAhQ0Z5yI4xH7Dt7jEMSYhGQ+YSmG6qo4c6Rh7CrIYXFRenS+qzhA8h7m48O8j1Z5G24qfen3y9cs7TNWKi43kGY8kSue3+xMi8hVErFLhfyhLNkOMJzWes+22apwEWIYwZWALYLpkmpYmgK8+nw+cZrI/r1WX5f6tdyZ/CRD/BAMgCwJYo7SNMuqTzsKTdqlHr7p2j7vcZtBSk5SJwzeChNJQwy94k+HF79R0WX8T8wuvxZKGtRqo7kf5bHAg2NRNDEL1KjBjV8tCJoh7FHLmQenQKfAt7x/eQu9r/+3do9Wvyan5MV3zYpDlCFZrRua9BL+cuSQaDAvGDAfqbzuDdlqUJLmn+t2+yyrxJS1NX5fLi6MX8cyh/11JkcIXifM9HqD1yM9S99MA8M3/O2g71oEbvcktkRCMOGga68sap+GzavVElyuutzHDGrPSvSqFw42yBAEKbnEJDbsMYL/6xxN/Xd3ez3YuwRs4R1m2NRN4Nq53ERozW8k7uVxmaEBioGfO+e5n0MfDQXY6uvdCx/R32ub4QDYOAovvoxhg042pYMbxWJkO73RMWTQzJvY8dbrxdMkw4xyq3Ic=
-        - secure: dhvshW7GvphJ6xvS8MxEtJGN+4C4d64hqOcaCKXXXVqyeunJ1gH/Cb6v1RcETgtRxOIHyyHo218j0cs0hNtIWCZq5YVbXMAJ5Sret+cKA3aZNMCbgwPNS48WdVZsCHurW22abq41ejfKuuFqSI+ooMprrsGeRjHMbJZM86k7UuEqxdvqGjotYugGcfiCjxnNtMHd1M6AQ9fPFzhg8TUeqPy7eDIdKTcqwa/h7ZsYn/WJp1LkUtwyHsfpweIv6JBQ9/xUDzjcoz5MA6Nj75/Mk4bJzzLEem3EKs1TTZOqV1NVt7VJ887NPe4fLIxP1/jQLzsh6kShTcctLszc70NgrowdwhdIqN/3TUmxkVbGP2JzbQ4yR6LVKCDDeWpKGiPsIKy75kEiW4ZlEZhnwCOKaR94FyBy1HEnhyoD9OJD6Gq/u4UdEw/QuNfE89gbr47LA4z487AzYGzH+1J3MlEbTNgTCmWduC0ghTx33vItrYMXXabGDe7XwfdJKTnMjfXVv+CVBdMAZVtDL27sEmbbAzIrRjP+JOFm7ZRYfzvxu5vCWlB/3wMMt7DzcutjxR4tyYs71Ec5zdUH/16wSvjQR1laJZCujlNSA/3FZUizCzW3qFVsBkaWRF+/C/cksi6cR83xIrc4y4WRLttAcbfqmsXaigL5Iz4GbLg62vmFP88=
 
 before_install:
 - go version

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ go:
   - 1.7
   - tip
 
+addons:
+  apt:
+    packages: [python-virtualenv]
+
 env:
   global:
     - GO15VENDOREXPERIMENT=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ go:
 
 env:
   global:
-    - CROSSDOCK=0
     - GO15VENDOREXPERIMENT=1
     - DOCKER_COMPOSE_VERSION=1.8.0
     - COMMIT=${TRAVIS_COMMIT::8}
@@ -31,7 +30,7 @@ before_install:
 - go version
 - |
   set -ex
-  if [ -n "$CROSSDOCK" ]; then
+  if [ "$CROSSDOCK" == 1 ]; then
     docker version
     sudo rm -f /usr/local/bin/docker-compose
     curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
@@ -47,7 +46,7 @@ install:
 script:
 - |
   set -ex
-  if [ -n "$CROSSDOCK" ]; then
+  if [ "$CROSSDOCK"  == 1 ]; then
     make crossdock
     docker-compose logs
   else
@@ -66,7 +65,7 @@ after_success:
 - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, REPO=$REPO, PR=$PR, BRANCH=$BRANCH, TAG=$TAG"
 - |
   set -ex
-  if [ -n "$CROSSDOCK" ]; then
+  if [ "$CROSSDOCK"  == 1 ]; then
     docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
     docker build -f Dockerfile -t $REPO:$COMMIT .
     docker tag $REPO:$COMMIT $REPO:$TAG

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,6 @@ language: go
 env:
   global:
     - GO15VENDOREXPERIMENT=1
-    - DOCKER_COMPOSE_VERSION=1.8.0
-    - COMMIT=${TRAVIS_COMMIT::8}
-    - secure: rZOVU0zQTkPvaG43IIt/guPoq3EAE6/So/+elGcmHF14PsfPcPQ6MyexqdwRkVPd/fAuNwiXXwTXHkjI8ECYz5LF+m+g2VwvrhE9H1wfLuGbtgXSSXqB+dqylHGUz4ksm4q1gwiet8fpVHlNfbSfu+lhTpbl4+SUfFK+s9LqnAKbm+Hi8vKzyhGhvlTngi0Y2O4Z2FLUgU2fkUm5fesdUyW0H2/Bn5KRqJRtcyTmmj4eD/qMq5WDe8n5Sy9J+kuCpweC8vBZQzAGuPpGdj8jvbPCO+N2xM26Y7DNKMsgj6IU49D6sbmLvyVMbI1pBeAQ54TCJx5LySuZpLAzyaaqHEDwOs4+cRolZSQwpd7Q8/wOxZ13KqMhYOokBIcDlLs0yB9J3KOTS1lxU8YC6A3j+Wenw9/JjL0sXSSeOAvNkAeVtEu3dqXg326HJjzXgIQbci83TTtWv4MsQKIXMADOgMnQdgd4JRaGyfxM2hswsE2/Y5OlyXqrqtFHvgKy6MpLTB26r3aRA22VY6p5hFhuEGLClbHidyeHgkNI2iHOXZqoEdmno33Eq7WicH64bezmq+Z4nwyjBOLTblcG7V79s9hI296zGdAN+KLXezlS00qhWH3UVmsi/hYTyXbWXay3S0Hc5jB+YUrHZ1y+OM6fm442qzz+M5q+MdtCfRad7ZM=
-    - secure: Vg1mnR5Eu98dQ30rNb2fFblehh71a6goJz/Crhh+kae1z1Ec6NuQ6b0mNrzZMIXg6QktZ9gK0bJHjg1t90QpDfWHtSqAhQ0Z5yI4xH7Dt7jEMSYhGQ+YSmG6qo4c6Rh7CrIYXFRenS+qzhA8h7m48O8j1Z5G24qfen3y9cs7TNWKi43kGY8kSue3+xMi8hVErFLhfyhLNkOMJzWes+22apwEWIYwZWALYLpkmpYmgK8+nw+cZrI/r1WX5f6tdyZ/CRD/BAMgCwJYo7SNMuqTzsKTdqlHr7p2j7vcZtBSk5SJwzeChNJQwy94k+HF79R0WX8T8wuvxZKGtRqo7kf5bHAg2NRNDEL1KjBjV8tCJoh7FHLmQenQKfAt7x/eQu9r/+3do9Wvyan5MV3zYpDlCFZrRua9BL+cuSQaDAvGDAfqbzuDdlqUJLmn+t2+yyrxJS1NX5fLi6MX8cyh/11JkcIXifM9HqD1yM9S99MA8M3/O2g71oEbvcktkRCMOGga68sap+GzavVElyuutzHDGrPSvSqFw42yBAEKbnEJDbsMYL/6xxN/Xd3ez3YuwRs4R1m2NRN4Nq53ERozW8k7uVxmaEBioGfO+e5n0MfDQXY6uvdCx/R32ub4QDYOAovvoxhg042pYMbxWJkO73RMWTQzJvY8dbrxdMkw4xyq3Ic=
-    - secure: dhvshW7GvphJ6xvS8MxEtJGN+4C4d64hqOcaCKXXXVqyeunJ1gH/Cb6v1RcETgtRxOIHyyHo218j0cs0hNtIWCZq5YVbXMAJ5Sret+cKA3aZNMCbgwPNS48WdVZsCHurW22abq41ejfKuuFqSI+ooMprrsGeRjHMbJZM86k7UuEqxdvqGjotYugGcfiCjxnNtMHd1M6AQ9fPFzhg8TUeqPy7eDIdKTcqwa/h7ZsYn/WJp1LkUtwyHsfpweIv6JBQ9/xUDzjcoz5MA6Nj75/Mk4bJzzLEem3EKs1TTZOqV1NVt7VJ887NPe4fLIxP1/jQLzsh6kShTcctLszc70NgrowdwhdIqN/3TUmxkVbGP2JzbQ4yR6LVKCDDeWpKGiPsIKy75kEiW4ZlEZhnwCOKaR94FyBy1HEnhyoD9OJD6Gq/u4UdEw/QuNfE89gbr47LA4z487AzYGzH+1J3MlEbTNgTCmWduC0ghTx33vItrYMXXabGDe7XwfdJKTnMjfXVv+CVBdMAZVtDL27sEmbbAzIrRjP+JOFm7ZRYfzvxu5vCWlB/3wMMt7DzcutjxR4tyYs71Ec5zdUH/16wSvjQR1laJZCujlNSA/3FZUizCzW3qFVsBkaWRF+/C/cksi6cR83xIrc4y4WRLttAcbfqmsXaigL5Iz4GbLg62vmFP88=
 
 matrix:
   # Fail the build as soon as the first job fails
@@ -37,9 +32,15 @@ matrix:
 
     # Crossdock
     - go: 1.7
-      env: TYPE=crossdock
       services: [docker]
       sudo: required
+      env:
+        - DOCKER_COMPOSE_VERSION=1.8.0
+        - COMMIT=${TRAVIS_COMMIT::8}
+        - TYPE=crossdock
+        - secure: rZOVU0zQTkPvaG43IIt/guPoq3EAE6/So/+elGcmHF14PsfPcPQ6MyexqdwRkVPd/fAuNwiXXwTXHkjI8ECYz5LF+m+g2VwvrhE9H1wfLuGbtgXSSXqB+dqylHGUz4ksm4q1gwiet8fpVHlNfbSfu+lhTpbl4+SUfFK+s9LqnAKbm+Hi8vKzyhGhvlTngi0Y2O4Z2FLUgU2fkUm5fesdUyW0H2/Bn5KRqJRtcyTmmj4eD/qMq5WDe8n5Sy9J+kuCpweC8vBZQzAGuPpGdj8jvbPCO+N2xM26Y7DNKMsgj6IU49D6sbmLvyVMbI1pBeAQ54TCJx5LySuZpLAzyaaqHEDwOs4+cRolZSQwpd7Q8/wOxZ13KqMhYOokBIcDlLs0yB9J3KOTS1lxU8YC6A3j+Wenw9/JjL0sXSSeOAvNkAeVtEu3dqXg326HJjzXgIQbci83TTtWv4MsQKIXMADOgMnQdgd4JRaGyfxM2hswsE2/Y5OlyXqrqtFHvgKy6MpLTB26r3aRA22VY6p5hFhuEGLClbHidyeHgkNI2iHOXZqoEdmno33Eq7WicH64bezmq+Z4nwyjBOLTblcG7V79s9hI296zGdAN+KLXezlS00qhWH3UVmsi/hYTyXbWXay3S0Hc5jB+YUrHZ1y+OM6fm442qzz+M5q+MdtCfRad7ZM=
+        - secure: Vg1mnR5Eu98dQ30rNb2fFblehh71a6goJz/Crhh+kae1z1Ec6NuQ6b0mNrzZMIXg6QktZ9gK0bJHjg1t90QpDfWHtSqAhQ0Z5yI4xH7Dt7jEMSYhGQ+YSmG6qo4c6Rh7CrIYXFRenS+qzhA8h7m48O8j1Z5G24qfen3y9cs7TNWKi43kGY8kSue3+xMi8hVErFLhfyhLNkOMJzWes+22apwEWIYwZWALYLpkmpYmgK8+nw+cZrI/r1WX5f6tdyZ/CRD/BAMgCwJYo7SNMuqTzsKTdqlHr7p2j7vcZtBSk5SJwzeChNJQwy94k+HF79R0WX8T8wuvxZKGtRqo7kf5bHAg2NRNDEL1KjBjV8tCJoh7FHLmQenQKfAt7x/eQu9r/+3do9Wvyan5MV3zYpDlCFZrRua9BL+cuSQaDAvGDAfqbzuDdlqUJLmn+t2+yyrxJS1NX5fLi6MX8cyh/11JkcIXifM9HqD1yM9S99MA8M3/O2g71oEbvcktkRCMOGga68sap+GzavVElyuutzHDGrPSvSqFw42yBAEKbnEJDbsMYL/6xxN/Xd3ez3YuwRs4R1m2NRN4Nq53ERozW8k7uVxmaEBioGfO+e5n0MfDQXY6uvdCx/R32ub4QDYOAovvoxhg042pYMbxWJkO73RMWTQzJvY8dbrxdMkw4xyq3Ic=
+        - secure: dhvshW7GvphJ6xvS8MxEtJGN+4C4d64hqOcaCKXXXVqyeunJ1gH/Cb6v1RcETgtRxOIHyyHo218j0cs0hNtIWCZq5YVbXMAJ5Sret+cKA3aZNMCbgwPNS48WdVZsCHurW22abq41ejfKuuFqSI+ooMprrsGeRjHMbJZM86k7UuEqxdvqGjotYugGcfiCjxnNtMHd1M6AQ9fPFzhg8TUeqPy7eDIdKTcqwa/h7ZsYn/WJp1LkUtwyHsfpweIv6JBQ9/xUDzjcoz5MA6Nj75/Mk4bJzzLEem3EKs1TTZOqV1NVt7VJ887NPe4fLIxP1/jQLzsh6kShTcctLszc70NgrowdwhdIqN/3TUmxkVbGP2JzbQ4yR6LVKCDDeWpKGiPsIKy75kEiW4ZlEZhnwCOKaR94FyBy1HEnhyoD9OJD6Gq/u4UdEw/QuNfE89gbr47LA4z487AzYGzH+1J3MlEbTNgTCmWduC0ghTx33vItrYMXXabGDe7XwfdJKTnMjfXVv+CVBdMAZVtDL27sEmbbAzIrRjP+JOFm7ZRYfzvxu5vCWlB/3wMMt7DzcutjxR4tyYs71Ec5zdUH/16wSvjQR1laJZCujlNSA/3FZUizCzW3qFVsBkaWRF+/C/cksi6cR83xIrc4y4WRLttAcbfqmsXaigL5Iz4GbLg62vmFP88=
 
 before_install:
 - go version
@@ -91,20 +92,20 @@ script:
   set +ex
 
 after_success:
-- export REPO=yarpc/yarpc-go
-- export PR=https://api.github.com/repos/$TRAVIS_REPO_SLUG/pulls/$TRAVIS_PULL_REQUEST
-- export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo `curl -s $PR | jq -r .head.ref`; fi)
-- export TAG=`if [ "$BRANCH" == "master" ]; then echo "latest"; else echo $BRANCH; fi`
-- echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, REPO=$REPO, PR=$PR, BRANCH=$BRANCH, TAG=$TAG"
 - |
   set -ex
   case "$TYPE" in
     crossdock)
+      export REPO=yarpc/yarpc-go
+      export PR=https://api.github.com/repos/$TRAVIS_REPO_SLUG/pulls/$TRAVIS_PULL_REQUEST
+      export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo `curl -s $PR | jq -r .head.ref`; fi)
+      export TAG=`if [ "$BRANCH" == "master" ]; then echo "latest"; else echo $BRANCH; fi`
+
       docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       docker build -f Dockerfile -t $REPO:$COMMIT .
       docker tag $REPO:$COMMIT $REPO:$TAG
       docker tag $REPO:$COMMIT $REPO:travis-$TRAVIS_BUILD_NUMBER
       docker push $REPO
-    ;;
+      ;;
   esac
   set +ex

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,9 @@
-# Minor versions of Go for which the lint check should be run.
-LINTABLE_MINOR_VERSIONS := 6
-
 # Paths besides auto-detected generated files that should be excluded from
 # lint results.
 LINT_EXCLUDES_EXTRAS =
 
 ##############################################################################
 export GO15VENDOREXPERIMENT=1
-
-GO_VERSION := $(shell go version | cut -d' ' -f3)   # e.g.: go1.6.2
-GO_MINOR_VERSION := $(word 2, $(subst ., , $(GO_VERSION)))
-
-ifneq ($(filter $(LINTABLE_MINOR_VERSIONS),$(GO_MINOR_VERSION)),)
-SHOULD_LINT := true
-endif
 
 PACKAGES := $(shell glide novendor)
 
@@ -40,7 +30,6 @@ build:
 
 .PHONY: lint
 lint:
-ifdef SHOULD_LINT
 	$(eval FMT_LOG := $(shell mktemp -t gofmt.XXXXX))
 	@gofmt -e -s -l $(GO_FILES) | $(FILTER_LINT) > $(FMT_LOG) || true
 	@[ ! -s "$(FMT_LOG)" ] || (echo "gofmt failed:" | cat - $(FMT_LOG) && false)
@@ -53,9 +42,6 @@ ifdef SHOULD_LINT
 	@cat /dev/null > $(LINT_LOG)
 	@$(foreach pkg, $(PACKAGES), golint $(pkg) | $(FILTER_LINT) >> $(LINT_LOG) || true;)
 	@[ ! -s "$(LINT_LOG)" ] || (echo "golint failed:" | cat - $(LINT_LOG) && false)
-else
-	@echo "Skipping linters for $(GO_VERSION)"
-endif
 
 .PHONY: install
 install:
@@ -96,19 +82,6 @@ crossdock-fresh: install
 	docker-compose pull
 	docker-compose build
 	docker-compose run crossdock
-
-
-.PHONY: install_ci
-install_ci: install
-ifdef SHOULD_LINT
-	go get -u -f github.com/golang/lint/golint
-endif
-	go get github.com/wadey/gocovmerge
-	go get github.com/mattn/goveralls
-	go get golang.org/x/tools/cmd/cover
-
-.PHONY: lint_ci
-lint_ci: lint
 
 .PHONY: test_ci
 test_ci:

--- a/scripts/cover.sh
+++ b/scripts/cover.sh
@@ -39,7 +39,7 @@ for pkg in "$@"; do
 		| map
 			( select(startswith("'"$ROOT_PKG"'"))
 			| select(contains("/vendor/") | not)
-			| select(in({'"$filter"'}) | not)
+			| select({'"$filter"'}[.] | not)
 			)
 		| join(",")
 	')


### PR DESCRIPTION
This changes our Travis configuration to,

-   Lint the source code only with Go 1.7
-   Run crossdock tests only with Go 1.7
-   Run tests, lint, and crossdock concurrently in separate jobs
-   Require sudo for crossdock tests only
-   Mark the build as failed as soon as any of the tests fails