### PR TITLE
WIP Thread sk, rk, and rd through reqmeta to transports

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: 8df58d37862bf74d2815e0eeef9ad586cfbf78852bc5326ca24f2e2f0e723d6c
-updated: 2016-09-02T10:41:58.381069719-07:00
+hash: e24184530c3c74558539331977b541aaa6c3d1604fbd14c6465fb1ce9e72bfe8
+updated: 2016-09-15T14:29:36.127581945-07:00
 imports:
 - name: github.com/apache/thrift
-  version: aa4312ef5ff8ae4965cc779fe73d2375aba0c2dc
+  version: ddc53c32486cc23dfa63ed4e5abb19923b8d13e6
   subpackages:
   - lib/go/thrift
 - name: github.com/crossdock/crossdock-go
@@ -11,7 +11,7 @@ imports:
   - assert
   - require
 - name: github.com/davecgh/go-spew
-  version: 6cf5744a041a0022271cefed95ba843f6d87fd51
+  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
   subpackages:
   - spew
 - name: github.com/golang/mock
@@ -38,12 +38,20 @@ imports:
   - wire
   - protocol
   - envelope
+  - plugin
+  - plugin/api
   - protocol/binary
   - internal/envelope/exception
+  - internal/envelope
+  - internal/frame
+  - internal/goast
+  - internal/multiplex
+  - plugin/api/service/plugin
+  - plugin/api/service/servicegenerator
 - name: github.com/uber-go/atomic
   version: 0c9e689d64f004564b79d9a663634756df322902
 - name: github.com/uber/tchannel-go
-  version: 1a0e35378f6f721bc07f6c4466bc9701ed70b506
+  version: f57e644626dbf4d87ee2b36571600c21f8255f1f
   subpackages:
   - json
   - raw
@@ -58,8 +66,12 @@ imports:
   - relay/relaytest
   - testutils/goroutines
 - name: golang.org/x/net
-  version: 1358eff22f0dd0c54fc521042cc607f6ff4b531a
+  version: de35ec43e7a9aabd6a9c54d2898220ea7e44de7d
   subpackages:
   - context
   - context/ctxhttp
+- name: golang.org/x/tools
+  version: f1a397bba50dee815e8c73f3ec94ffc0e8df1a09
+  subpackages:
+  - go/ast/astutil
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -17,7 +17,7 @@ import:
   subpackages:
   - gomock
 - package: github.com/uber/tchannel-go
-  version: ^1.1.0
+  version: ^1.2
 - package: github.com/opentracing/opentracing-go
   version: ~0.9
 - package: github.com/crossdock/crossdock-go

--- a/internal/meta/req.go
+++ b/internal/meta/req.go
@@ -37,6 +37,9 @@ func ToTransportRequest(reqMeta yarpc.CallReqMeta, req *transport.Request) {
 		return
 	}
 	req.Procedure = reqMeta.GetProcedure()
+	req.ShardKey = reqMeta.GetShardKey()
+	req.RoutingKey = reqMeta.GetRoutingKey()
+	req.RoutingDelegate = reqMeta.GetRoutingDelegate()
 	req.Headers = transport.Headers(reqMeta.GetHeaders())
 }
 

--- a/req_meta.go
+++ b/req_meta.go
@@ -26,9 +26,15 @@ import "github.com/yarpc/yarpc-go/transport"
 type CallReqMeta interface {
 	Procedure(string) CallReqMeta
 	Headers(Headers) CallReqMeta
+	ShardKey(string) CallReqMeta
+	RoutingKey(string) CallReqMeta
+	RoutingDelegate(string) CallReqMeta
 
 	GetProcedure() string
 	GetHeaders() Headers
+	GetShardKey() string
+	GetRoutingKey() string
+	GetRoutingDelegate() string
 }
 
 // ReqMeta contains information about an incoming YARPC request.
@@ -46,8 +52,11 @@ func NewReqMeta() CallReqMeta {
 }
 
 type callReqMeta struct {
-	procedure string
-	headers   Headers
+	procedure     string
+	headers       Headers
+	shardKey      string
+	routeKey      string
+	routeDelegate string
 }
 
 func (r *callReqMeta) Procedure(p string) CallReqMeta {
@@ -60,10 +69,37 @@ func (r *callReqMeta) Headers(h Headers) CallReqMeta {
 	return r
 }
 
+func (r *callReqMeta) ShardKey(sk string) CallReqMeta {
+	r.shardKey = sk
+	return r
+}
+
+func (r *callReqMeta) RoutingKey(rk string) CallReqMeta {
+	r.routeKey = rk
+	return r
+}
+
+func (r *callReqMeta) RoutingDelegate(rd string) CallReqMeta {
+	r.routeDelegate = rd
+	return r
+}
+
 func (r *callReqMeta) GetProcedure() string {
 	return r.procedure
 }
 
 func (r *callReqMeta) GetHeaders() Headers {
 	return r.headers
+}
+
+func (r *callReqMeta) GetShardKey() string {
+	return r.shardKey
+}
+
+func (r *callReqMeta) GetRoutingKey() string {
+	return r.routeKey
+}
+
+func (r *callReqMeta) GetRoutingDelegate() string {
+	return r.routeDelegate
 }

--- a/req_meta.go
+++ b/req_meta.go
@@ -41,8 +41,6 @@ type ReqMeta interface {
 }
 
 // NewReqMeta constructs a CallReqMeta with the given Context.
-//
-// The context MUST NOT be nil.
 func NewReqMeta() CallReqMeta {
 	return &callReqMeta{}
 }

--- a/transport/http/constants.go
+++ b/transport/http/constants.go
@@ -45,4 +45,18 @@ const (
 
 	// ServiceHeader is the HTTP header used to indicate the service
 	ServiceHeader = "Rpc-Service"
+
+	// ShardKeyHeader is the HTTP header used by a clustered service to
+	// identify the node responsible for handling the request.
+	ShardKeyHeader = "Rpc-Shard-Key"
+
+	// RoutingKeyHeader is the HTTP header used by a relay to identify
+	// the traffic group responsible for handling the request, overriding the
+	// service name when available.
+	RoutingKeyHeader = "Rpc-Routing-Key"
+
+	// RoutingDelegateHeader is the HTTP header used by a relay to identify a
+	// service that can proxy for the destined service and perform
+	// application-specific routing.
+	RoutingDelegateHeader = "Rpc-Routing-Delegate"
 )

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -164,6 +164,15 @@ func (o *outbound) Call(ctx context.Context, treq *transport.Request) (*transpor
 	req.Header.Set(ServiceHeader, treq.Service)
 	req.Header.Set(ProcedureHeader, treq.Procedure)
 	req.Header.Set(TTLMSHeader, fmt.Sprintf("%d", ttl/time.Millisecond))
+	if treq.ShardKey != "" {
+		req.Header.Set(ShardKeyHeader, treq.ShardKey)
+	}
+	if treq.RoutingKey != "" {
+		req.Header.Set(RoutingKeyHeader, treq.RoutingKey)
+	}
+	if treq.RoutingDelegate != "" {
+		req.Header.Set(RoutingDelegateHeader, treq.RoutingDelegate)
+	}
 
 	encoding := string(treq.Encoding)
 	if encoding != "" {

--- a/transport/request.go
+++ b/transport/request.go
@@ -28,6 +28,7 @@ type Request struct {
 	Caller string
 
 	// Name of the service to which the request is being made.
+	// The service refers to the canonical traffic group for the service.
 	Service string
 
 	// Name of the encoding used for the request body.
@@ -38,6 +39,20 @@ type Request struct {
 
 	// Headers for the request.
 	Headers Headers
+
+	// ShardKey is an opaque string that is meaningful to the destined service
+	// for how to relay a request within a cluster to the shard that owns the
+	// key.
+	ShardKey string
+
+	// RoutingKey refers to a traffic group for the destined service, and when
+	// present may override the service name for purposes of routing.
+	RoutingKey string
+
+	// RoutingDelegate refers to the traffic group for a service that proxies
+	// for the destined service for routing purposes. The routing delegate may
+	// override the routing key and service.
+	RoutingDelegate string
 
 	// Request payload.
 	Body io.Reader

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -104,7 +104,12 @@ func (o outbound) Call(ctx context.Context, req *transport.Request) (*transport.
 	var err error
 
 	format := tchannel.Format(req.Encoding)
-	callOptions := tchannel.CallOptions{Format: format}
+	callOptions := tchannel.CallOptions{
+		Format:          format,
+		ShardKey:        req.ShardKey,
+		RoutingKey:      req.RoutingKey,
+		RoutingDelegate: req.RoutingDelegate,
+	}
 	if o.HostPort != "" {
 		// If the hostport is given, we use the BeginCall on the channel
 		// instead of the subchannel.


### PR DESCRIPTION
This adds support for three RPC request properties: shard key, routing key, and routing delegate, writing them to the wire in the way appropriate per transport.

r @prashantv @breerly 