### PR TITLE
thrift/outbound: Support TMultiplexedProtocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Releases
 ========
 
-v0.2.0 (2016-09-01)
+v0.2.0 (unreleased)
 -------------------
 
 -   Implemented a ThriftRW plugin. This should now be used instead of the
@@ -16,6 +16,8 @@ v0.2.0 (2016-09-01)
     carries the tracer and may eventually carry other dependencies.
 -   Panics from user handlers are recovered. The panic is logged (stderr), and
     an unexpected error is returned to the client about it.
+-   Thrift clients can now make requests to multiplexed Apache Thrift servers
+    using the `thrift.Multiplexed` client option.
 
 [opentracing]: http://opentracing.io/
 

--- a/encoding/thrift/multiplex.go
+++ b/encoding/thrift/multiplex.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package thrift
+
+import (
+	"io"
+	"strings"
+
+	"github.com/thriftrw/thriftrw-go/protocol"
+	"github.com/thriftrw/thriftrw-go/wire"
+)
+
+// multiplexedOutboundProtocol is a Protocol for outbound requests that adds
+// the name of the service to the envelope name for outbound requests and
+// strips it away for inbound responses.
+type multiplexedOutboundProtocol struct {
+	protocol.Protocol
+
+	// Name of the Thrift service
+	Service string
+}
+
+func (m multiplexedOutboundProtocol) EncodeEnveloped(e wire.Envelope, w io.Writer) error {
+	e.Name = m.Service + ":" + e.Name
+	return m.Protocol.EncodeEnveloped(e, w)
+}
+
+func (m multiplexedOutboundProtocol) DecodeEnveloped(r io.ReaderAt) (wire.Envelope, error) {
+	e, err := m.Protocol.DecodeEnveloped(r)
+	e.Name = strings.TrimPrefix(e.Name, m.Service+":")
+	return e, err
+}

--- a/encoding/thrift/multiplex_test.go
+++ b/encoding/thrift/multiplex_test.go
@@ -1,0 +1,97 @@
+package thrift
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/thriftrw/thriftrw-go/wire"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMultiplexedEncode(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	tests := []struct {
+		service  string
+		giveName string
+		wantName string
+	}{
+		{
+			service:  "Foo",
+			giveName: "bar",
+			wantName: "Foo:bar",
+		},
+		{
+			service:  "",
+			giveName: "y",
+			wantName: ":y",
+		},
+	}
+
+	for _, tt := range tests {
+		mockProto := NewMockProtocol(mockCtrl)
+		proto := multiplexedOutboundProtocol{
+			Protocol: mockProto,
+			Service:  tt.service,
+		}
+
+		giveEnvelope := wire.Envelope{
+			Value: wire.NewValueStruct(wire.Struct{Fields: []wire.Field{}}),
+			Type:  wire.Call,
+			Name:  tt.giveName,
+			SeqID: 42,
+		}
+
+		wantEnvelope := giveEnvelope
+		wantEnvelope.Name = tt.wantName
+		mockProto.EXPECT().EncodeEnveloped(wantEnvelope, gomock.Any()).Return(nil)
+
+		assert.NoError(t, proto.EncodeEnveloped(giveEnvelope, new(bytes.Buffer)))
+	}
+}
+
+func TestMultiplexedDecode(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	tests := []struct {
+		service  string
+		giveName string
+		wantName string
+	}{
+		{
+			service:  "Foo",
+			giveName: "Foo:bar",
+			wantName: "bar",
+		},
+		{
+			service:  "Foo",
+			giveName: "Bar:baz",
+			wantName: "Bar:baz",
+		},
+	}
+
+	for _, tt := range tests {
+		mockProto := NewMockProtocol(mockCtrl)
+		proto := multiplexedOutboundProtocol{
+			Protocol: mockProto,
+			Service:  tt.service,
+		}
+
+		mockProto.EXPECT().DecodeEnveloped(gomock.Any()).Return(
+			wire.Envelope{
+				Value: wire.NewValueStruct(wire.Struct{Fields: []wire.Field{}}),
+				Type:  wire.Call,
+				Name:  tt.giveName,
+				SeqID: 42,
+			}, nil)
+
+		gotEnvelope, err := proto.DecodeEnveloped(bytes.NewReader([]byte{}))
+		if assert.NoError(t, err) {
+			assert.Equal(t, tt.wantName, gotEnvelope.Name)
+		}
+	}
+}

--- a/encoding/thrift/options.go
+++ b/encoding/thrift/options.go
@@ -22,6 +22,7 @@ package thrift
 
 type clientConfig struct {
 	DisableEnveloping bool
+	Multiplexed       bool
 }
 
 // ClientOption customizes the behavior of a Thrift client.
@@ -65,4 +66,20 @@ func (disableEnvelopingOption) applyClientOption(c *clientConfig) {
 
 func (disableEnvelopingOption) applyRegisterOption(c *registerConfig) {
 	c.DisableEnveloping = true
+}
+
+// Multiplexed is an option that specifies that requests from a client should
+// use Thrift multiplexing. This option should be used if the remote server is
+// using Thrift's TMultiplexedProtocol. It includes the name of the service in
+// the envelope name for all outbound requests.
+//
+// Specify this option when constructing the Thrift client.
+//
+// 	client := myserviceclient.New(channel, thrift.Multiplexed)
+var Multiplexed ClientOption = multiplexedOption{}
+
+type multiplexedOption struct{}
+
+func (multiplexedOption) applyClientOption(c *clientConfig) {
+	c.Multiplexed = true
 }

--- a/encoding/thrift/outbound.go
+++ b/encoding/thrift/outbound.go
@@ -86,6 +86,13 @@ func New(c Config, opts ...ClientOption) Client {
 		opt.applyClientOption(&cc)
 	}
 
+	if cc.Multiplexed {
+		p = multiplexedOutboundProtocol{
+			Protocol: p,
+			Service:  c.Service,
+		}
+	}
+
 	return thriftClient{
 		p:                 p,
 		ch:                c.Channel,
@@ -122,6 +129,9 @@ func (c thriftClient) Call(ctx context.Context, reqMeta yarpc.CallReqMeta, reqBo
 
 	// We disable enveloping if either the client or the transport requires it.
 	disableEnveloping := c.disableEnveloping || isEnvelopingDisabled(out.Options())
+	// Note that we apply this thrift.Option here rather than in New because
+	// this can change on a per-transport basis in addition to the
+	// user-specifed option.
 
 	proto := c.p
 	if disableEnveloping {


### PR DESCRIPTION
This adds support for making a Thrift client multiplexed. You can simply pass
the `thrift.Multiplexed` option to your client when constructing it to make it
use TMultiplexedProtocol which changes the Thrift envelope name to
`$serviceName:$methodName`.