### PR TITLE
Ensure crossdock HTTP servers are stopped

### DIFF
--- a/crossdock/server/start.go
+++ b/crossdock/server/start.go
@@ -39,4 +39,9 @@ func Start() {
 func Stop() {
 	tch.Stop()
 	yarpc.Stop()
+	http.Stop()
+	apachethrift.Stop()
 }
+
+// TODO(abg): We should probably use defers to ensure things that started up
+// successfully are stopped before we exit.

--- a/glide.lock
+++ b/glide.lock
@@ -1,17 +1,14 @@
-hash: 695b7dc863d581ff72b38fc8631b095bc5b2c5bf212b03128f35b35a39e7f13b
-updated: 2016-09-16T12:47:00.231813202-07:00
+hash: 2b8aab8d2a172ddb714303aac6e77607f787f41b7fff1664898d72dd6d956ee8
+updated: 2016-09-19T10:04:06.378128281-07:00
 imports:
 - name: github.com/apache/thrift
-  version: 205dc19556eac3c0ab2d1965c4636b78f8922fae
+  version: 5a3f855b4e6882184f13c698855c877241144a12
   subpackages:
   - lib/go/thrift
 - name: github.com/crossdock/crossdock-go
-  version: 049aabb0122b03bc9bd30cab8f3f91fb60166361
-  subpackages:
-  - assert
-  - require
+  version: 9a20d202853d1322cb1d440821ff60dcebfb9323
 - name: github.com/davecgh/go-spew
-  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
   - spew
 - name: github.com/golang/mock
@@ -22,7 +19,6 @@ imports:
   version: 77a31d686003349e89c89e58408aafcd20003f41
   subpackages:
   - ext
-  - mocktracer
 - name: github.com/pmezard/go-difflib
   version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
@@ -35,20 +31,20 @@ imports:
 - name: github.com/thriftrw/thriftrw-go
   version: 0edcedc6665a0c7805587c5cab2fd3d31e720a10
   subpackages:
+  - ptr
+  - wire
+  - protocol
   - envelope
-  - internal/envelope
+  - plugin
+  - plugin/api
+  - protocol/binary
   - internal/envelope/exception
+  - internal/envelope
   - internal/frame
   - internal/goast
   - internal/multiplex
-  - plugin
-  - plugin/api
   - plugin/api/service/plugin
   - plugin/api/service/servicegenerator
-  - protocol
-  - protocol/binary
-  - ptr
-  - wire
 - name: github.com/uber-go/atomic
   version: 0c9e689d64f004564b79d9a663634756df322902
 - name: github.com/uber/tchannel-go
@@ -56,18 +52,14 @@ imports:
   subpackages:
   - json
   - raw
-  - relay
-  - relay/relaytest
-  - testutils
-  - testutils/goroutines
-  - testutils/testreader
   - thrift
-  - thrift/gen-go/meta
+  - relay
   - tnet
   - trand
   - typed
+  - thrift/gen-go/meta
 - name: golang.org/x/net
-  version: 71a035914f99bb58fe82eac0f1289f10963d876c
+  version: 3797cd8864994d713d909eda5e61ede8683fdc12
   subpackages:
   - context
   - context/ctxhttp
@@ -75,4 +67,4 @@ imports:
   version: f1a397bba50dee815e8c73f3ec94ffc0e8df1a09
   subpackages:
   - go/ast/astutil
-testImports: []
+devImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -22,3 +22,5 @@ import:
   version: ~0.9
 - package: github.com/crossdock/crossdock-go
   version: master
+- package: github.com/uber-go/atomic
+  version: ^1.0.0

--- a/internal/net/httpserver.go
+++ b/internal/net/httpserver.go
@@ -82,7 +82,7 @@ func (h *HTTPServer) ListenAndServe() error {
 		return errAlreadyListening
 	}
 
-	listener, err := net.Listen("tcp", h.Server.Addr)
+	listener, err := net.Listen("tcp", addr)
 	if err != nil {
 		return err
 	}

--- a/internal/net/httpserver.go
+++ b/internal/net/httpserver.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package net
+
+import (
+	"errors"
+	"net"
+	"net/http"
+	"sync"
+	"sync/atomic"
+)
+
+// HTTPServer wraps an http.Server to listen asynchronously and allow stopping
+// it.
+type HTTPServer struct {
+	*http.Server
+
+	lock     sync.Mutex
+	listener net.Listener
+	done     chan error
+	stopped  uint32
+}
+
+// NewHTTPServer wraps the given http.Server into an HTTPServer.
+func NewHTTPServer(s *http.Server) *HTTPServer {
+	return &HTTPServer{Server: s}
+}
+
+// Listener returns the listener for this server or nil if the server isn't
+// yet listening.
+func (h *HTTPServer) Listener() net.Listener {
+	return h.listener
+}
+
+// ListenAndServe starts the given HTTP server up in the background and
+// returns immediately. The server listens on the configured Addr or ":http"
+// if unconfigured.
+//
+// An error is returned if the server failed to start up, if the server was
+// already listening, or if the server was stopped with Stop().
+func (h *HTTPServer) ListenAndServe() error {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+
+	if atomic.LoadUint32(&h.stopped) == 1 {
+		return errors.New("the server has been stopped")
+	}
+
+	if h.listener != nil {
+		return errors.New("the server is already listening")
+	}
+
+	addr := h.Server.Addr
+	if addr == "" {
+		addr = ":http"
+	}
+
+	done := make(chan error, 1)
+	listener, err := net.Listen("tcp", h.Server.Addr)
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		// Serve always returns a non-nil error. For us, it's an error only if
+		// we didn't call Stop().
+		err := h.Server.Serve(listener)
+		if atomic.LoadUint32(&h.stopped) == 0 {
+			done <- err
+		} else {
+			done <- nil
+		}
+	}()
+
+	h.done = done
+	h.listener = listener
+	return nil
+}
+
+// Stop stops the server. An error is returned if the server stopped
+// unexpectedly.
+//
+// Once a server is stopped, it cannot be started again with ListenAndServe.
+func (h *HTTPServer) Stop() error {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+
+	if !atomic.CompareAndSwapUint32(&h.stopped, 0, 1) {
+		return nil
+	}
+
+	if h.listener == nil {
+		return nil
+	}
+
+	closeErr := h.listener.Close()
+	h.listener = nil
+	serveErr := <-h.done // wait until Serve() stops
+	if closeErr != nil {
+		return closeErr
+	}
+	return serveErr
+}

--- a/internal/net/httpserver.go
+++ b/internal/net/httpserver.go
@@ -70,13 +70,13 @@ func (h *HTTPServer) ListenAndServe() error {
 		return errServerStopped
 	}
 
+	h.lock.Lock()
+	defer h.lock.Unlock()
+
 	addr := h.Server.Addr
 	if addr == "" {
 		addr = ":http"
 	}
-
-	h.lock.Lock()
-	defer h.lock.Unlock()
 
 	if h.listener != nil {
 		return errAlreadyListening

--- a/internal/net/httpserver_test.go
+++ b/internal/net/httpserver_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package net
+
+import (
+	"net"
+	"net/http"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartAndStop(t *testing.T) {
+	server := NewHTTPServer(&http.Server{Addr: ":0"})
+	require.NoError(t, server.ListenAndServe())
+
+	require.NotNil(t, server.Listener())
+	addr := server.Listener().Addr().String()
+
+	conn, err := net.Dial("tcp", addr)
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	require.NoError(t, server.Stop())
+	_, err = net.Dial("tcp", addr)
+	require.Error(t, err)
+}
+
+func TestStartAddrInUse(t *testing.T) {
+	s1 := NewHTTPServer(&http.Server{Addr: ":0"})
+	require.NoError(t, s1.ListenAndServe())
+	defer s1.Stop()
+
+	s2 := NewHTTPServer(&http.Server{Addr: s1.Listener().Addr().String()})
+	err := s2.ListenAndServe()
+
+	require.Error(t, err)
+	oe, ok := err.(*net.OpError)
+	assert.True(t, ok && oe.Op == "listen", "expected a listen error")
+	if ok {
+		se, ok := oe.Err.(*os.SyscallError)
+		assert.True(t, ok && se.Syscall == "bind" && se.Err == syscall.EADDRINUSE, "expected a EADDRINUSE bind error")
+	}
+}
+func TestStopAndListen(t *testing.T) {
+	server := NewHTTPServer(&http.Server{Addr: ":0"})
+	require.NoError(t, server.ListenAndServe())
+	require.NoError(t, server.Stop())
+	require.Error(t, server.ListenAndServe())
+}
+
+func TestStopWithoutStart(t *testing.T) {
+	server := NewHTTPServer(&http.Server{Addr: ":0"})
+	require.NoError(t, server.Stop())
+}
+
+func TestStartTwice(t *testing.T) {
+	server := NewHTTPServer(&http.Server{Addr: ":0"})
+	require.NoError(t, server.ListenAndServe())
+	require.Error(t, server.ListenAndServe())
+	require.NoError(t, server.Stop())
+}
+
+func TestStopTwice(t *testing.T) {
+	server := NewHTTPServer(&http.Server{Addr: ":0"})
+	require.NoError(t, server.ListenAndServe())
+	require.NoError(t, server.Stop())
+	require.NoError(t, server.Stop())
+}
+
+func TestListenFail(t *testing.T) {
+	server := NewHTTPServer(&http.Server{Addr: "invalid"})
+	require.Error(t, server.ListenAndServe())
+}
+
+func TestStopError(t *testing.T) {
+	server := NewHTTPServer(&http.Server{Addr: ":0"})
+	require.NoError(t, server.ListenAndServe())
+	require.NoError(t, server.Listener().Close())
+	time.Sleep(5 * time.Millisecond)
+	require.Error(t, server.Stop())
+}

--- a/transport/http/inbound_test.go
+++ b/transport/http/inbound_test.go
@@ -57,16 +57,6 @@ func TestStartAddrInUse(t *testing.T) {
 	assert.NoError(t, i1.Stop())
 }
 
-func TestCloseError(t *testing.T) {
-	i := NewInbound(":0")
-	require.NoError(t, i.Start(new(transporttest.MockHandler), transport.NoDeps))
-	require.NoError(t, i.(*inbound).listener.Close())
-	err := i.Stop()
-	require.Error(t, err)
-	oe, ok := err.(*net.OpError)
-	assert.True(t, ok && oe.Op == "close", "expected a close error")
-}
-
 func TestNilAddrAfterStop(t *testing.T) {
 	i := NewInbound(":0")
 	require.NoError(t, i.Start(new(transporttest.MockHandler), transport.NoDeps))


### PR DESCRIPTION
-   Pull out logic for stoppable `net/http` servers from HTTP inbound into a
    separate package.
-   Implement `Stop()` functions for the crossdock HTTP and Apache Thrift
    servers by using the stoppable HTTP server.

CC @prashantv @breerly @kriskowal @bombela