### PR TITLE
WIP: Make http request building into pluggable function

### DIFF
--- a/transport/http/handler_test.go
+++ b/transport/http/handler_test.go
@@ -54,7 +54,7 @@ func TestHandlerSucces(t *testing.T) {
 	headers.Set(BaggageHeaderPrefix+"BAR", "baz")
 
 	rpcHandler := transporttest.NewMockHandler(mockCtrl)
-	httpHandler := handler{Handler: rpcHandler}
+	httpHandler := handler{Handler: rpcHandler, Extractor: DefaultExtractor}
 
 	rpcHandler.EXPECT().Handle(
 		transporttest.NewContextMatcher(t,
@@ -129,7 +129,7 @@ func TestHandlerHeaders(t *testing.T) {
 
 	for _, tt := range tests {
 		rpcHandler := transporttest.NewMockHandler(mockCtrl)
-		httpHandler := handler{Handler: rpcHandler}
+		httpHandler := handler{Handler: rpcHandler, Extractor: DefaultExtractor}
 
 		rpcHandler.EXPECT().Handle(
 			transporttest.NewContextMatcher(t,
@@ -189,7 +189,7 @@ func TestHandlerFailures(t *testing.T) {
 		req *http.Request
 		msg string
 	}{
-		{&http.Request{Method: "GET"}, "404 page not found\n"},
+		{&http.Request{Method: "GET"}, "BadRequest: must use the POST method when making requests\n"},
 		{
 			&http.Request{
 				Method: "POST",
@@ -239,7 +239,7 @@ func TestHandlerFailures(t *testing.T) {
 			req.Body = ioutil.NopCloser(bytes.NewReader([]byte{}))
 		}
 
-		h := handler{Handler: transporttest.NewMockHandler(mockCtrl)}
+		h := handler{Handler: transporttest.NewMockHandler(mockCtrl), Extractor: DefaultExtractor}
 		rw := httptest.NewRecorder()
 		h.ServeHTTP(rw, tt.req)
 
@@ -282,7 +282,7 @@ func TestHandlerInternalFailure(t *testing.T) {
 		gomock.Any(),
 	).Return(fmt.Errorf("great sadness"))
 
-	httpHandler := handler{Handler: rpcHandler}
+	httpHandler := handler{Handler: rpcHandler, Extractor: DefaultExtractor}
 	httpResponse := httptest.NewRecorder()
 	httpHandler.ServeHTTP(httpResponse, &request)
 


### PR DESCRIPTION
Tbe current http transport requires a specific
set of http headers for building a transport.Request. 
This limits the flexibility of the http.Inbound
 for those callers that want to take a different
approach to service and procedure extraction. By
making the http -> transport.Request a pluggable
function, service owners can decide how they want
to invoke their handlers without the transport requiring
any knowledge of the http request itself (in essence, 
the http entity becomes an encoding).

This will allow service providers to invoke handler
methods without requiring an HTTP POST, to use url
patterns for method selection and/or embed method
selection in the body of the http request. The latter
will allow GraphQL to be used as an encoding.

I'm not sure if the YARPC team is interested in this,
but wanted to get a conversation going.

NB: I did not focus on enhancing test coverage, and 
expect this PR to require modifications, etc. 