### PR TITLE
Use OpenTracing ^1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Releases
 v0.3.0 (unreleased)
 -------------------
 
--   No changes yet.
+-   Update opentracing-go to `>= 1, < 2`.
 
 
 v0.2.0 (2016-09-19)

--- a/glide.lock
+++ b/glide.lock
@@ -1,14 +1,17 @@
-hash: 2b8aab8d2a172ddb714303aac6e77607f787f41b7fff1664898d72dd6d956ee8
-updated: 2016-09-19T10:04:06.378128281-07:00
+hash: 88025999cb77e2388355a000730fcd8fa5eea1b457385286706658db8db08e23
+updated: 2016-09-27T14:50:58.395609946-07:00
 imports:
 - name: github.com/apache/thrift
-  version: 5a3f855b4e6882184f13c698855c877241144a12
+  version: 2df9c20dc76c044e502861a2111b90cbdcbbb957
   subpackages:
   - lib/go/thrift
 - name: github.com/crossdock/crossdock-go
-  version: 9a20d202853d1322cb1d440821ff60dcebfb9323
+  version: 049aabb0122b03bc9bd30cab8f3f91fb60166361
+  subpackages:
+  - assert
+  - require
 - name: github.com/davecgh/go-spew
-  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
   subpackages:
   - spew
 - name: github.com/golang/mock
@@ -16,35 +19,37 @@ imports:
   subpackages:
   - gomock
 - name: github.com/opentracing/opentracing-go
-  version: 77a31d686003349e89c89e58408aafcd20003f41
+  version: 0c3154a3c2ce79d3271985848659870599dfb77c
   subpackages:
   - ext
+  - log
+  - mocktracer
 - name: github.com/pmezard/go-difflib
   version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: d77da356e56a7428ad25149ca77381849a6a5232
+  version: 976c720a22c8eb4eb6a0b4348ad85ad12491a506
   subpackages:
   - assert
   - require
 - name: github.com/thriftrw/thriftrw-go
-  version: 0edcedc6665a0c7805587c5cab2fd3d31e720a10
+  version: 486fe6340c8acc600a44a3a698becb9725d578fb
   subpackages:
-  - ptr
-  - wire
-  - protocol
   - envelope
-  - plugin
-  - plugin/api
-  - protocol/binary
-  - internal/envelope/exception
   - internal/envelope
+  - internal/envelope/exception
   - internal/frame
   - internal/goast
   - internal/multiplex
+  - plugin
+  - plugin/api
   - plugin/api/service/plugin
   - plugin/api/service/servicegenerator
+  - protocol
+  - protocol/binary
+  - ptr
+  - wire
 - name: github.com/uber-go/atomic
   version: 0c9e689d64f004564b79d9a663634756df322902
 - name: github.com/uber/tchannel-go
@@ -52,19 +57,23 @@ imports:
   subpackages:
   - json
   - raw
-  - thrift
   - relay
+  - relay/relaytest
+  - testutils
+  - testutils/goroutines
+  - testutils/testreader
+  - thrift
+  - thrift/gen-go/meta
   - tnet
   - trand
   - typed
-  - thrift/gen-go/meta
 - name: golang.org/x/net
-  version: 3797cd8864994d713d909eda5e61ede8683fdc12
+  version: f09c4662a0bd6bd8943ac7b4931e185df9471da4
   subpackages:
   - context
   - context/ctxhttp
 - name: golang.org/x/tools
-  version: f1a397bba50dee815e8c73f3ec94ffc0e8df1a09
+  version: fc2b74b64ef08c618146ebc92062f6499db5314c
   subpackages:
   - go/ast/astutil
-devImports: []
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -19,7 +19,7 @@ import:
 - package: github.com/uber/tchannel-go
   version: ^1.2
 - package: github.com/opentracing/opentracing-go
-  version: ~0.9
+  version: ^1
 - package: github.com/crossdock/crossdock-go
   version: master
 - package: github.com/uber-go/atomic


### PR DESCRIPTION
Now that opentracing-go has released a major 1.0, let's pin to `>= 1, < 2`.

Fixes #308 cc @yarpc/golang 