### PR TITLE
Update outboundttl to timeout and add httpserver test in crossdock/main_test.go

### DIFF
--- a/crossdock/main_test.go
+++ b/crossdock/main_test.go
@@ -88,13 +88,19 @@ func TestCrossdock(t *testing.T) {
 			},
 		},
 		{
+			name: "httpserver",
+			params: params{
+				"httpserver": "127.0.0.1",
+			},
+		},
+		{
 			name: "thriftgauntlet",
 			axes: axes{
 				"transport": []string{"http", "tchannel"},
 			},
 		},
 		{
-			name: "outboundttl",
+			name: "timeout",
 			axes: axes{
 				"transport": []string{"http", "tchannel"},
 			},


### PR DESCRIPTION
Noticed that the main_test.go file was out of sync while I was adding gRPC code to crossdock tests.  Added the configurations to main_test.go and ran the tests locally.