### PR TITLE
Drop support for golang 1.5 and 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,6 @@ matrix:
     # Tests
     #
     # Need virtualenv for example tests
-    - go: 1.5
-      env: TYPE=test
-      addons: {apt: {packages: [python-virtualenv]}}
-    - go: 1.6
-      env: TYPE=test
-      addons: {apt: {packages: [python-virtualenv]}}
     - go: 1.7
       env: TYPE=test
       addons: {apt: {packages: [python-virtualenv]}}

--- a/bench_test.go
+++ b/bench_test.go
@@ -19,8 +19,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go"
 	traw "github.com/uber/tchannel-go/raw"
-	"golang.org/x/net/context"
-	"golang.org/x/net/context/ctxhttp"
+	"context"
+	"context/ctxhttp"
 )
 
 var _reqBody = []byte("hello")

--- a/context.go
+++ b/context.go
@@ -23,7 +23,7 @@ package yarpc
 import (
 	"github.com/yarpc/yarpc-go/internal/baggage"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 // WithBaggage returns a copy of the context with the given baggage attached to

--- a/context_test.go
+++ b/context_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/thriftrw/thriftrw-go/ptr"
-	"golang.org/x/net/context"
+	"context"
 )
 
 func TestContextHeaders(t *testing.T) {

--- a/crossdock/client/ctxpropagation/behavior.go
+++ b/crossdock/client/ctxpropagation/behavior.go
@@ -36,7 +36,7 @@ import (
 	tch "github.com/yarpc/yarpc-go/transport/tchannel"
 
 	"github.com/uber/tchannel-go"
-	"golang.org/x/net/context"
+	"context"
 )
 
 // Run verifies that context is propagated across multiple hops.

--- a/crossdock/client/echo/json.go
+++ b/crossdock/client/echo/json.go
@@ -29,7 +29,7 @@ import (
 	"github.com/yarpc/yarpc-go/encoding/json"
 
 	"github.com/crossdock/crossdock-go"
-	"golang.org/x/net/context"
+	"context"
 )
 
 // jsonEcho contains an echo request or response for the JSON echo endpoint.

--- a/crossdock/client/echo/raw.go
+++ b/crossdock/client/echo/raw.go
@@ -30,7 +30,7 @@ import (
 	"github.com/yarpc/yarpc-go/encoding/raw"
 
 	"github.com/crossdock/crossdock-go"
-	"golang.org/x/net/context"
+	"context"
 )
 
 // Raw implements the 'raw' behavior.

--- a/crossdock/client/echo/thrift.go
+++ b/crossdock/client/echo/thrift.go
@@ -31,7 +31,7 @@ import (
 	"github.com/yarpc/yarpc-go/encoding/thrift"
 
 	"github.com/crossdock/crossdock-go"
-	"golang.org/x/net/context"
+	"context"
 )
 
 // Thrift implements the 'thrift' behavior.

--- a/crossdock/client/gauntlet/behavior.go
+++ b/crossdock/client/gauntlet/behavior.go
@@ -37,7 +37,7 @@ import (
 
 	"github.com/crossdock/crossdock-go"
 	"github.com/thriftrw/thriftrw-go/ptr"
-	"golang.org/x/net/context"
+	"context"
 )
 
 const serverName = "yarpc-test"

--- a/crossdock/client/headers/behavior.go
+++ b/crossdock/client/headers/behavior.go
@@ -34,7 +34,7 @@ import (
 	"github.com/yarpc/yarpc-go/encoding/thrift"
 
 	"github.com/crossdock/crossdock-go"
-	"golang.org/x/net/context"
+	"context"
 )
 
 func createHeadersT(t crossdock.T) crossdock.T {

--- a/crossdock/client/httpserver/behavior.go
+++ b/crossdock/client/httpserver/behavior.go
@@ -32,7 +32,7 @@ import (
 	ht "github.com/yarpc/yarpc-go/transport/http"
 
 	crossdock "github.com/crossdock/crossdock-go"
-	"golang.org/x/net/context"
+	"context"
 )
 
 // Run exercise a yarpc client against a rigged httpserver.

--- a/crossdock/client/tchclient/raw.go
+++ b/crossdock/client/tchclient/raw.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/crossdock/crossdock-go"
 	"github.com/uber/tchannel-go/raw"
-	"golang.org/x/net/context"
+	"context"
 )
 
 func runRaw(t crossdock.T, call call) {

--- a/crossdock/client/tchserver/json.go
+++ b/crossdock/client/tchserver/json.go
@@ -28,7 +28,7 @@ import (
 	"github.com/yarpc/yarpc-go/encoding/json"
 
 	"github.com/crossdock/crossdock-go"
-	"golang.org/x/net/context"
+	"context"
 )
 
 func runJSON(t crossdock.T, dispatcher yarpc.Dispatcher) {

--- a/crossdock/client/tchserver/raw.go
+++ b/crossdock/client/tchserver/raw.go
@@ -30,7 +30,7 @@ import (
 	"github.com/yarpc/yarpc-go/transport"
 
 	"github.com/crossdock/crossdock-go"
-	"golang.org/x/net/context"
+	"context"
 )
 
 func runRaw(t crossdock.T, dispatcher yarpc.Dispatcher) {

--- a/crossdock/client/tchserver/thrift.go
+++ b/crossdock/client/tchserver/thrift.go
@@ -32,7 +32,7 @@ import (
 	"github.com/yarpc/yarpc-go/encoding/thrift"
 
 	"github.com/crossdock/crossdock-go"
-	"golang.org/x/net/context"
+	"context"
 )
 
 func runThrift(t crossdock.T, dispatcher yarpc.Dispatcher) {

--- a/crossdock/client/timeout/behavior.go
+++ b/crossdock/client/timeout/behavior.go
@@ -31,7 +31,7 @@ import (
 	"github.com/yarpc/yarpc-go/transport"
 
 	"github.com/crossdock/crossdock-go"
-	"golang.org/x/net/context"
+	"context"
 )
 
 // Run tests if a yarpc client returns correctly a client timeout error behind

--- a/crossdock/server/tch/echo.go
+++ b/crossdock/server/tch/echo.go
@@ -26,7 +26,7 @@ import (
 	"github.com/uber/tchannel-go/json"
 	"github.com/uber/tchannel-go/raw"
 	"github.com/uber/tchannel-go/thrift"
-	"golang.org/x/net/context"
+	"context"
 )
 
 type echoRawHandler struct{}

--- a/crossdock/server/tch/server.go
+++ b/crossdock/server/tch/server.go
@@ -21,7 +21,7 @@
 package tch
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/json"

--- a/crossdock/server/tch/timeout.go
+++ b/crossdock/server/tch/timeout.go
@@ -23,7 +23,7 @@ package tch
 import (
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/raw"

--- a/crossdock/server/yarpc/echo.go
+++ b/crossdock/server/yarpc/echo.go
@@ -23,7 +23,7 @@ package yarpc
 import (
 	"github.com/yarpc/yarpc-go"
 	"github.com/yarpc/yarpc-go/crossdock/thrift/echo"
-	"golang.org/x/net/context"
+	"context"
 )
 
 // EchoRaw implements the echo/raw procedure.

--- a/crossdock/server/yarpc/error.go
+++ b/crossdock/server/yarpc/error.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/yarpc/yarpc-go"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 // UnexpectedError fails with an unexpected error.

--- a/crossdock/server/yarpc/gauntlet.go
+++ b/crossdock/server/yarpc/gauntlet.go
@@ -26,7 +26,7 @@ import (
 	"github.com/yarpc/yarpc-go"
 	"github.com/yarpc/yarpc-go/crossdock/thrift/gauntlet"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 func resMetaFromReqMeta(reqMeta yarpc.ReqMeta) yarpc.ResMeta {

--- a/crossdock/server/yarpc/phone.go
+++ b/crossdock/server/yarpc/phone.go
@@ -32,7 +32,7 @@ import (
 	tch "github.com/yarpc/yarpc-go/transport/tchannel"
 
 	"github.com/uber/tchannel-go"
-	"golang.org/x/net/context"
+	"context"
 )
 
 // HTTPTransport contains information about an HTTP transport.

--- a/crossdock/server/yarpc/second_service.go
+++ b/crossdock/server/yarpc/second_service.go
@@ -23,7 +23,7 @@ package yarpc
 import (
 	"github.com/yarpc/yarpc-go"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 // secondService implements the SecondService.

--- a/crossdock/server/yarpc/sleep.go
+++ b/crossdock/server/yarpc/sleep.go
@@ -24,7 +24,7 @@ import (
 	"fmt"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/yarpc/yarpc-go"
 )

--- a/crossdock/thrift/echo/yarpc/echoclient/client.go
+++ b/crossdock/thrift/echo/yarpc/echoclient/client.go
@@ -25,7 +25,7 @@ package echoclient
 
 import (
 	"github.com/thriftrw/thriftrw-go/protocol"
-	"golang.org/x/net/context"
+	"context"
 	"github.com/yarpc/yarpc-go"
 	"github.com/yarpc/yarpc-go/crossdock/thrift/echo"
 	"github.com/yarpc/yarpc-go/transport"

--- a/crossdock/thrift/echo/yarpc/echoserver/server.go
+++ b/crossdock/thrift/echo/yarpc/echoserver/server.go
@@ -25,7 +25,7 @@ package echoserver
 
 import (
 	"github.com/thriftrw/thriftrw-go/protocol"
-	"golang.org/x/net/context"
+	"context"
 	"github.com/yarpc/yarpc-go"
 	"github.com/yarpc/yarpc-go/crossdock/thrift/echo"
 	"github.com/yarpc/yarpc-go/encoding/thrift"

--- a/crossdock/thrift/gauntlet/yarpc/secondserviceclient/client.go
+++ b/crossdock/thrift/gauntlet/yarpc/secondserviceclient/client.go
@@ -25,7 +25,7 @@ package secondserviceclient
 
 import (
 	"github.com/thriftrw/thriftrw-go/protocol"
-	"golang.org/x/net/context"
+	"context"
 	"github.com/yarpc/yarpc-go"
 	"github.com/yarpc/yarpc-go/crossdock/thrift/gauntlet/service/secondservice"
 	"github.com/yarpc/yarpc-go/transport"

--- a/crossdock/thrift/gauntlet/yarpc/secondserviceserver/server.go
+++ b/crossdock/thrift/gauntlet/yarpc/secondserviceserver/server.go
@@ -25,7 +25,7 @@ package secondserviceserver
 
 import (
 	"github.com/thriftrw/thriftrw-go/protocol"
-	"golang.org/x/net/context"
+	"context"
 	"github.com/yarpc/yarpc-go"
 	"github.com/yarpc/yarpc-go/crossdock/thrift/gauntlet/service/secondservice"
 	"github.com/yarpc/yarpc-go/encoding/thrift"

--- a/crossdock/thrift/gauntlet/yarpc/thrifttestclient/client.go
+++ b/crossdock/thrift/gauntlet/yarpc/thrifttestclient/client.go
@@ -25,7 +25,7 @@ package thrifttestclient
 
 import (
 	"github.com/thriftrw/thriftrw-go/protocol"
-	"golang.org/x/net/context"
+	"context"
 	"github.com/yarpc/yarpc-go"
 	"github.com/yarpc/yarpc-go/crossdock/thrift/gauntlet"
 	"github.com/yarpc/yarpc-go/transport"

--- a/crossdock/thrift/gauntlet/yarpc/thrifttestserver/server.go
+++ b/crossdock/thrift/gauntlet/yarpc/thrifttestserver/server.go
@@ -25,7 +25,7 @@ package thrifttestserver
 
 import (
 	"github.com/thriftrw/thriftrw-go/protocol"
-	"golang.org/x/net/context"
+	"context"
 	"github.com/yarpc/yarpc-go"
 	"github.com/yarpc/yarpc-go/crossdock/thrift/gauntlet"
 	"github.com/yarpc/yarpc-go/encoding/thrift"

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -26,7 +26,7 @@ import (
 	"github.com/yarpc/yarpc-go/transport"
 
 	"github.com/opentracing/opentracing-go"
-	"golang.org/x/net/context"
+	"context"
 )
 
 // Dispatcher object is used to configure a YARPC application; it is used by

--- a/encoding/json/inbound.go
+++ b/encoding/json/inbound.go
@@ -29,7 +29,7 @@ import (
 	"github.com/yarpc/yarpc-go/internal/meta"
 	"github.com/yarpc/yarpc-go/transport"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 // jsonHandler adapts a user-provided high-level handler into a transport-level

--- a/encoding/json/inbound_test.go
+++ b/encoding/json/inbound_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
+	"context"
 )
 
 type simpleRequest struct {

--- a/encoding/json/outbound.go
+++ b/encoding/json/outbound.go
@@ -24,7 +24,7 @@ import (
 	"bytes"
 	"encoding/json"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/yarpc/yarpc-go"
 	"github.com/yarpc/yarpc-go/internal/encoding"

--- a/encoding/json/outbound_test.go
+++ b/encoding/json/outbound_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
+	"context"
 )
 
 var _typeOfMapInterface = reflect.TypeOf(map[string]interface{}{})

--- a/encoding/json/register.go
+++ b/encoding/json/register.go
@@ -27,7 +27,7 @@ import (
 	"github.com/yarpc/yarpc-go"
 	"github.com/yarpc/yarpc-go/transport"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 var (

--- a/encoding/json/register_test.go
+++ b/encoding/json/register_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/yarpc/yarpc-go"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
+	"context"
 )
 
 func TestWrapHandlerInvalid(t *testing.T) {

--- a/encoding/raw/inbound.go
+++ b/encoding/raw/inbound.go
@@ -27,7 +27,7 @@ import (
 	"github.com/yarpc/yarpc-go/internal/meta"
 	"github.com/yarpc/yarpc-go/transport"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 // rawHandler adapts a Handler into a transport.Handler

--- a/encoding/raw/inbound_test.go
+++ b/encoding/raw/inbound_test.go
@@ -30,7 +30,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/uber/tchannel-go/testutils/testreader"
-	"golang.org/x/net/context"
+	"context"
 )
 
 func TestRawHandler(t *testing.T) {

--- a/encoding/raw/outbound.go
+++ b/encoding/raw/outbound.go
@@ -24,7 +24,7 @@ import (
 	"bytes"
 	"io/ioutil"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/yarpc/yarpc-go"
 	"github.com/yarpc/yarpc-go/internal/meta"

--- a/encoding/raw/outbound_test.go
+++ b/encoding/raw/outbound_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/uber/tchannel-go/testutils/testreader"
-	"golang.org/x/net/context"
+	"context"
 )
 
 func TestCall(t *testing.T) {

--- a/encoding/raw/register.go
+++ b/encoding/raw/register.go
@@ -24,7 +24,7 @@ import (
 	"github.com/yarpc/yarpc-go"
 	"github.com/yarpc/yarpc-go/transport"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 // Registrant is used for types that define or know about different Raw

--- a/encoding/thrift/inbound.go
+++ b/encoding/thrift/inbound.go
@@ -30,7 +30,7 @@ import (
 
 	"github.com/thriftrw/thriftrw-go/protocol"
 	"github.com/thriftrw/thriftrw-go/wire"
-	"golang.org/x/net/context"
+	"context"
 )
 
 // thriftHandler wraps a Thrift Handler into a transport.Handler

--- a/encoding/thrift/inbound_test.go
+++ b/encoding/thrift/inbound_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/thriftrw/thriftrw-go/wire"
-	"golang.org/x/net/context"
+	"context"
 )
 
 //go:generate mockgen -destination=mock_handler_test.go -package=thrift github.com/yarpc/yarpc-go/encoding/thrift Handler

--- a/encoding/thrift/mock_handler_test.go
+++ b/encoding/thrift/mock_handler_test.go
@@ -7,7 +7,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	wire "github.com/thriftrw/thriftrw-go/wire"
 	yarpc_go "github.com/yarpc/yarpc-go"
-	context "golang.org/x/net/context"
+	context "context"
 )
 
 // Mock of Handler interface

--- a/encoding/thrift/outbound.go
+++ b/encoding/thrift/outbound.go
@@ -34,7 +34,7 @@ import (
 	"github.com/thriftrw/thriftrw-go/envelope"
 	"github.com/thriftrw/thriftrw-go/protocol"
 	"github.com/thriftrw/thriftrw-go/wire"
-	"golang.org/x/net/context"
+	"context"
 )
 
 // Client is a generic Thrift client. It speaks in raw Thrift payloads.

--- a/encoding/thrift/outbound_test.go
+++ b/encoding/thrift/outbound_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/thriftrw/thriftrw-go/envelope"
 	"github.com/thriftrw/thriftrw-go/wire"
-	"golang.org/x/net/context"
+	"context"
 )
 
 func valueptr(v wire.Value) *wire.Value { return &v }

--- a/encoding/thrift/register.go
+++ b/encoding/thrift/register.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/thriftrw/thriftrw-go/protocol"
 	"github.com/thriftrw/thriftrw-go/wire"
-	"golang.org/x/net/context"
+	"context"
 )
 
 // Handler represents a Thrift request handler. It speaks in raw Thrift payloads.

--- a/encoding/thrift/thriftrw-plugin-yarpc/main.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/main.go
@@ -42,7 +42,7 @@ package <$pkgname>
 <$yarpc    := import "github.com/yarpc/yarpc-go">
 <$thrift   := import "github.com/yarpc/yarpc-go/encoding/thrift">
 <$protocol := import "github.com/thriftrw/thriftrw-go/protocol">
-<$context  := import "golang.org/x/net/context">
+<$context  := import "context">
 
 // Interface is the server-side interface for the <.Service.Name> service.
 type Interface interface {
@@ -136,7 +136,7 @@ package <$pkgname>
 <$transport := import "github.com/yarpc/yarpc-go/transport">
 <$thrift    := import "github.com/yarpc/yarpc-go/encoding/thrift">
 <$protocol  := import "github.com/thriftrw/thriftrw-go/protocol">
-<$context   := import "golang.org/x/net/context">
+<$context   := import "context">
 
 // Interface is a client for the <.Service.Name> service.
 type Interface interface {

--- a/examples/json/client/logger.go
+++ b/examples/json/client/logger.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/yarpc/yarpc-go/transport"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 type requestLogFilter struct{}

--- a/examples/json/client/main.go
+++ b/examples/json/client/main.go
@@ -36,7 +36,7 @@ import (
 	tch "github.com/yarpc/yarpc-go/transport/tchannel"
 
 	"github.com/uber/tchannel-go"
-	"golang.org/x/net/context"
+	"context"
 )
 
 type getRequest struct {

--- a/examples/json/server/logger.go
+++ b/examples/json/server/logger.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/yarpc/yarpc-go/transport"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 type requestLogInterceptor struct{}

--- a/examples/json/server/main.go
+++ b/examples/json/server/main.go
@@ -33,7 +33,7 @@ import (
 	tch "github.com/yarpc/yarpc-go/transport/tchannel"
 
 	"github.com/uber/tchannel-go"
-	"golang.org/x/net/context"
+	"context"
 )
 
 type getRequest struct {

--- a/examples/thrift/hello/main.go
+++ b/examples/thrift/hello/main.go
@@ -33,7 +33,7 @@ import (
 	"github.com/yarpc/yarpc-go/encoding/thrift"
 	"github.com/yarpc/yarpc-go/transport"
 	"github.com/yarpc/yarpc-go/transport/http"
-	"golang.org/x/net/context"
+	"context"
 )
 
 //go:generate thriftrw-go --out thrift --plugin=yarpc hello.thrift

--- a/examples/thrift/keyvalue/client/cache.go
+++ b/examples/thrift/keyvalue/client/cache.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/yarpc/yarpc-go/transport"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 // CacheFilter is a filter

--- a/examples/thrift/keyvalue/client/main.go
+++ b/examples/thrift/keyvalue/client/main.go
@@ -36,7 +36,7 @@ import (
 	tch "github.com/yarpc/yarpc-go/transport/tchannel"
 
 	"github.com/uber/tchannel-go"
-	"golang.org/x/net/context"
+	"context"
 )
 
 func main() {

--- a/examples/thrift/keyvalue/kv/yarpc/keyvalueclient/client.go
+++ b/examples/thrift/keyvalue/kv/yarpc/keyvalueclient/client.go
@@ -25,7 +25,7 @@ package keyvalueclient
 
 import (
 	"github.com/thriftrw/thriftrw-go/protocol"
-	"golang.org/x/net/context"
+	"context"
 	"github.com/yarpc/yarpc-go"
 	"github.com/yarpc/yarpc-go/encoding/thrift"
 	"github.com/yarpc/yarpc-go/transport"

--- a/examples/thrift/keyvalue/kv/yarpc/keyvalueserver/server.go
+++ b/examples/thrift/keyvalue/kv/yarpc/keyvalueserver/server.go
@@ -25,7 +25,7 @@ package keyvalueserver
 
 import (
 	"github.com/thriftrw/thriftrw-go/protocol"
-	"golang.org/x/net/context"
+	"context"
 	"github.com/yarpc/yarpc-go"
 	"github.com/yarpc/yarpc-go/encoding/thrift"
 	"github.com/yarpc/yarpc-go/examples/thrift/keyvalue/kv/service/keyvalue"

--- a/examples/thrift/keyvalue/server/main.go
+++ b/examples/thrift/keyvalue/server/main.go
@@ -34,7 +34,7 @@ import (
 	tch "github.com/yarpc/yarpc-go/transport/tchannel"
 
 	"github.com/uber/tchannel-go"
-	"golang.org/x/net/context"
+	"context"
 )
 
 type handler struct {

--- a/internal/baggage/context.go
+++ b/internal/baggage/context.go
@@ -23,7 +23,7 @@ package baggage
 import (
 	"github.com/yarpc/yarpc-go/transport"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 type baggageKey struct{}

--- a/internal/baggage/context_test.go
+++ b/internal/baggage/context_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/yarpc/yarpc-go/transport"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
+	"context"
 )
 
 type pair struct{ Key, Value string }

--- a/internal/filter/chain.go
+++ b/internal/filter/chain.go
@@ -23,7 +23,7 @@ package filter
 import (
 	"github.com/yarpc/yarpc-go/transport"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 // Chain combines a series of filters into a single Filter.

--- a/internal/filter/chain_test.go
+++ b/internal/filter/chain_test.go
@@ -32,7 +32,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
+	"context"
 )
 
 var retryFilter transport.FilterFunc = func(

--- a/internal/interceptor/chain.go
+++ b/internal/interceptor/chain.go
@@ -23,7 +23,7 @@ package interceptor
 import (
 	"github.com/yarpc/yarpc-go/transport"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 // Chain combines a series of Interceptors into a single Interceptor.

--- a/internal/interceptor/chain_test.go
+++ b/internal/interceptor/chain_test.go
@@ -31,7 +31,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
+	"context"
 )
 
 var retryInterceptor transport.InterceptorFunc = func(

--- a/internal/request/validator.go
+++ b/internal/request/validator.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/yarpc/yarpc-go/transport"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 // Validator helps validate requests.

--- a/internal/request/validator_outbound.go
+++ b/internal/request/validator_outbound.go
@@ -23,7 +23,7 @@ package request
 import (
 	"github.com/yarpc/yarpc-go/transport"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 // ValidatorOutbound wraps an Outbound to validate all outgoing requests.

--- a/internal/request/validator_test.go
+++ b/internal/request/validator_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/yarpc/yarpc-go/transport"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
+	"context"
 )
 
 func TestValidator(t *testing.T) {

--- a/transport/filter.go
+++ b/transport/filter.go
@@ -20,7 +20,7 @@
 
 package transport
 
-import "golang.org/x/net/context"
+import "context"
 
 // Filter defines transport-level middleware for Outbounds.
 //

--- a/transport/filter_test.go
+++ b/transport/filter_test.go
@@ -32,7 +32,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
+	"context"
 )
 
 func TestNopFilter(t *testing.T) {

--- a/transport/handler.go
+++ b/transport/handler.go
@@ -20,7 +20,7 @@
 
 package transport
 
-import "golang.org/x/net/context"
+import "context"
 
 // Handler handles a single transport-level request.
 type Handler interface {

--- a/transport/http/handler.go
+++ b/transport/http/handler.go
@@ -32,7 +32,7 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
-	"golang.org/x/net/context"
+	"context"
 )
 
 var httpOptions transport.Options

--- a/transport/http/handler_test.go
+++ b/transport/http/handler_test.go
@@ -37,7 +37,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
+	"context"
 )
 
 func TestHandlerSucces(t *testing.T) {

--- a/transport/http/inbound_test.go
+++ b/transport/http/inbound_test.go
@@ -37,7 +37,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
+	"context"
 )
 
 func TestStartAddrInUse(t *testing.T) {

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -34,8 +34,8 @@ import (
 	"github.com/yarpc/yarpc-go/transport"
 
 	"github.com/uber-go/atomic"
-	"golang.org/x/net/context"
-	"golang.org/x/net/context/ctxhttp"
+	"context"
+	"context/ctxhttp"
 )
 
 var (

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -35,7 +35,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
+	"context"
 )
 
 func TestCallSuccess(t *testing.T) {

--- a/transport/interceptor.go
+++ b/transport/interceptor.go
@@ -20,7 +20,7 @@
 
 package transport
 
-import "golang.org/x/net/context"
+import "context"
 
 // Interceptor defines a transport-level middleware for Inbounds.
 //

--- a/transport/interceptor_test.go
+++ b/transport/interceptor_test.go
@@ -32,7 +32,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
+	"context"
 )
 
 func TestNopInterceptor(t *testing.T) {

--- a/transport/internal/safelycallhandler.go
+++ b/transport/internal/safelycallhandler.go
@@ -29,7 +29,7 @@ import (
 	"github.com/yarpc/yarpc-go/internal/errors"
 	"github.com/yarpc/yarpc-go/transport"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 // SafelyCallHandler calls the handler h, recovering panics and timeout errors,

--- a/transport/outbound.go
+++ b/transport/outbound.go
@@ -20,7 +20,7 @@
 
 package transport
 
-import "golang.org/x/net/context"
+import "context"
 
 //go:generate mockgen -destination=transporttest/outbound.go -package=transporttest github.com/yarpc/yarpc-go/transport Outbound
 

--- a/transport/roundtrip_test.go
+++ b/transport/roundtrip_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/yarpc/yarpc-go/encoding/raw"
 	"github.com/yarpc/yarpc-go/internal/errors"

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -31,7 +31,7 @@ import (
 	"github.com/yarpc/yarpc-go/transport/internal"
 
 	"github.com/uber/tchannel-go"
-	"golang.org/x/net/context"
+	"context"
 )
 
 // inboundCall provides an interface similiar tchannel.InboundCall.

--- a/transport/tchannel/handler_test.go
+++ b/transport/tchannel/handler_test.go
@@ -37,7 +37,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go"
-	"golang.org/x/net/context"
+	"context"
 )
 
 func TestHandlerErrors(t *testing.T) {

--- a/transport/tchannel/header.go
+++ b/transport/tchannel/header.go
@@ -31,7 +31,7 @@ import (
 	"github.com/yarpc/yarpc-go/transport/tchannel/internal"
 
 	"github.com/uber/tchannel-go"
-	"golang.org/x/net/context"
+	"context"
 )
 
 // pullBaggage pulls the context headers from the given transport.Headers,

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/uber-go/atomic"
 	"github.com/uber/tchannel-go"
-	"golang.org/x/net/context"
+	"context"
 )
 
 var (

--- a/transport/tchannel/outbound_test.go
+++ b/transport/tchannel/outbound_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/testutils"
-	"golang.org/x/net/context"
+	"context"
 )
 
 // Different ways in which outbounds can be constructed from a client Channel

--- a/transport/tracer_test.go
+++ b/transport/tracer_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/mocktracer"
 	"github.com/uber/tchannel-go"
-	"golang.org/x/net/context"
+	"context"
 )
 
 type echoReqBody struct{}

--- a/transport/transporttest/context.go
+++ b/transport/transporttest/context.go
@@ -29,7 +29,7 @@ import (
 	"github.com/yarpc/yarpc-go/internal/baggage"
 	"github.com/yarpc/yarpc-go/transport"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 // ContextMatcher is a Matcher for verifying that a context's deadline is

--- a/transport/transporttest/outbound.go
+++ b/transport/transporttest/outbound.go
@@ -26,7 +26,7 @@ package transporttest
 import (
 	gomock "github.com/golang/mock/gomock"
 	transport "github.com/yarpc/yarpc-go/transport"
-	context "golang.org/x/net/context"
+	context "context"
 )
 
 // Mock of Outbound interface

--- a/transport/transporttest/register.go
+++ b/transport/transporttest/register.go
@@ -26,7 +26,7 @@ package transporttest
 import (
 	gomock "github.com/golang/mock/gomock"
 	transport "github.com/yarpc/yarpc-go/transport"
-	context "golang.org/x/net/context"
+	context "context"
 )
 
 // Mock of Handler interface


### PR DESCRIPTION
Seeing how production is moving to Go 1.7 now, and we are planning GA late Q4, I see no reason to keep around support for Golang 1.5 and 1.6. 

This commit vastly reduces the platform surface area of our library, and removes an external dependency.

- [x] remove go 1.5 and 1.6 from `.travis.yml`
- [x] use `context` instead of `golang.org/x/net/context`
- [ ] use [Request.WithContext](https://tip.golang.org/pkg/net/http/#Request.WithContext) in place of `golang.org/x/net/ctxhttp`
- [ ] remove dependency on `golang.org/x/net/context` from `glide.yaml` and `glide.lock`