### PR TITLE
[GRPC][Part 2] Create passthrough codec for GRPC

### DIFF
--- a/transport/grpc/codec.go
+++ b/transport/grpc/codec.go
@@ -3,10 +3,10 @@ package grpc
 import "fmt"
 
 // PassThroughCodec passes bytes to/from the wire without modification
-type PassThroughCodec struct{}
+type passThroughCodec struct{}
 
 // Marshal takes a []byte pointer and passes it through as a []byte
-func (PassThroughCodec) Marshal(v interface{}) ([]byte, error) {
+func (passThroughCodec) Marshal(v interface{}) ([]byte, error) {
 	bs, ok := v.(*[]byte)
 	if !ok {
 		return nil, fmt.Errorf("expected sender of type *[]byte but got %T", v)
@@ -15,7 +15,7 @@ func (PassThroughCodec) Marshal(v interface{}) ([]byte, error) {
 }
 
 // Unmarshal takes a byte slice and writes it to v
-func (PassThroughCodec) Unmarshal(data []byte, v interface{}) error {
+func (passThroughCodec) Unmarshal(data []byte, v interface{}) error {
 	bs, ok := v.(*[]byte)
 	if !ok {
 		return fmt.Errorf("expected receiver of type *[]byte but got %T", v)
@@ -24,6 +24,6 @@ func (PassThroughCodec) Unmarshal(data []byte, v interface{}) error {
 	return nil
 }
 
-func (PassThroughCodec) String() string {
+func (passThroughCodec) String() string {
 	return "passthrough"
 }

--- a/transport/grpc/codec.go
+++ b/transport/grpc/codec.go
@@ -1,0 +1,29 @@
+package grpc
+
+import "fmt"
+
+// PassThroughCodec passes bytes to/from the wire without modification
+type PassThroughCodec struct{}
+
+// Marshal takes a []byte pointer and passes it through as a []byte
+func (PassThroughCodec) Marshal(v interface{}) ([]byte, error) {
+	bs, ok := v.(*[]byte)
+	if !ok {
+		return nil, fmt.Errorf("expected sender of type *[]byte but got %T", v)
+	}
+	return *(bs), nil
+}
+
+// Unmarshal takes a byte slice and writes it to v
+func (PassThroughCodec) Unmarshal(data []byte, v interface{}) error {
+	bs, ok := v.(*[]byte)
+	if !ok {
+		return fmt.Errorf("expected receiver of type *[]byte but got %T", v)
+	}
+	*bs = data
+	return nil
+}
+
+func (PassThroughCodec) String() string {
+	return "raw"
+}

--- a/transport/grpc/codec.go
+++ b/transport/grpc/codec.go
@@ -2,7 +2,7 @@ package grpc
 
 import "fmt"
 
-// PassThroughCodec passes bytes to/from the wire without modification
+// passThroughCodec passes bytes to/from the wire without modification
 type passThroughCodec struct{}
 
 // Marshal takes a []byte pointer and passes it through as a []byte

--- a/transport/grpc/codec.go
+++ b/transport/grpc/codec.go
@@ -25,5 +25,5 @@ func (PassThroughCodec) Unmarshal(data []byte, v interface{}) error {
 }
 
 func (PassThroughCodec) String() string {
-	return "raw"
+	return "passthrough"
 }

--- a/transport/grpc/codec_test.go
+++ b/transport/grpc/codec_test.go
@@ -1,0 +1,58 @@
+package grpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPassThroughCodecMarshal(t *testing.T) {
+	codec := PassThroughCodec{}
+	strMsg := "this is a test"
+	byteSender := []byte(strMsg)
+
+	result, err := codec.Marshal(&byteSender)
+
+	assert.Equal(t, strMsg, string(result))
+	assert.Equal(t, error(nil), err)
+}
+
+func TestPassThroughCodecMarshalError(t *testing.T) {
+	codec := PassThroughCodec{}
+	strMsg := "this is a test"
+
+	result, err := codec.Marshal(&strMsg)
+
+	assert.Equal(t, []byte(nil), result)
+	assert.Equal(t, "expected sender of type *[]byte but got *string", err.Error())
+}
+
+func TestPassThroughCodecUnmarshal(t *testing.T) {
+	codec := PassThroughCodec{}
+	strMsg := "this is a test"
+	data := []byte(strMsg)
+	var receiver []byte
+
+	err := codec.Unmarshal(data, &receiver)
+
+	assert.Equal(t, strMsg, string(receiver))
+	assert.Equal(t, error(nil), err)
+}
+
+func TestPassThroughCodecUnmarshalError(t *testing.T) {
+	codec := PassThroughCodec{}
+	strMsg := "this is a test"
+	data := []byte(strMsg)
+	var receiver string
+
+	err := codec.Unmarshal(data, &receiver)
+
+	assert.Equal(t, "", receiver)
+	assert.Equal(t, "expected receiver of type *[]byte but got *string", err.Error())
+}
+
+func TestPassThroughCodecString(t *testing.T) {
+	codec := PassThroughCodec{}
+
+	assert.Equal(t, "raw", codec.String())
+}

--- a/transport/grpc/codec_test.go
+++ b/transport/grpc/codec_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestPassThroughCodecMarshal(t *testing.T) {
-	codec := PassThroughCodec{}
+	codec := passThroughCodec{}
 	strMsg := "this is a test"
 	byteSender := []byte(strMsg)
 
@@ -18,7 +18,7 @@ func TestPassThroughCodecMarshal(t *testing.T) {
 }
 
 func TestPassThroughCodecMarshalError(t *testing.T) {
-	codec := PassThroughCodec{}
+	codec := passThroughCodec{}
 	strMsg := "this is a test"
 
 	result, err := codec.Marshal(&strMsg)
@@ -28,7 +28,7 @@ func TestPassThroughCodecMarshalError(t *testing.T) {
 }
 
 func TestPassThroughCodecUnmarshal(t *testing.T) {
-	codec := PassThroughCodec{}
+	codec := passThroughCodec{}
 	strMsg := "this is a test"
 	data := []byte(strMsg)
 	var receiver []byte
@@ -40,7 +40,7 @@ func TestPassThroughCodecUnmarshal(t *testing.T) {
 }
 
 func TestPassThroughCodecUnmarshalError(t *testing.T) {
-	codec := PassThroughCodec{}
+	codec := passThroughCodec{}
 	strMsg := "this is a test"
 	data := []byte(strMsg)
 	var receiver string
@@ -52,7 +52,7 @@ func TestPassThroughCodecUnmarshalError(t *testing.T) {
 }
 
 func TestPassThroughCodecString(t *testing.T) {
-	codec := PassThroughCodec{}
+	codec := passThroughCodec{}
 
 	assert.Equal(t, "passthrough", codec.String())
 }

--- a/transport/grpc/codec_test.go
+++ b/transport/grpc/codec_test.go
@@ -54,5 +54,5 @@ func TestPassThroughCodecUnmarshalError(t *testing.T) {
 func TestPassThroughCodecString(t *testing.T) {
 	codec := PassThroughCodec{}
 
-	assert.Equal(t, "raw", codec.String())
+	assert.Equal(t, "passthrough", codec.String())
 }


### PR DESCRIPTION
Summary: By default, GRPC requires a codec to convert requests over the
wire into protobufs/json/thrift/etc.  Since we want to use the YARPC
encoders to perform the conversions, we need a passthrough Codec to pass
to GRPC, so GRPC can perform the transport, and we'll pick the encoding
based on the YARPC configuration.

*Note* The "String" function is applied in gRPC as a content header e.g.
"-protobuf" or "-raw".  For now we put everything into "raw" but
conceivably in the future we'll want to customize the Codec "name" we
use to have compatibility with regular GRPC servers/clients

Test Plan: Wrote tests