### PR TITLE
[GRPC][Part 3] Sample GRPC server and client

### DIFF
--- a/examples/grpc/client/main.go
+++ b/examples/grpc/client/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	gr "github.com/yarpc/yarpc-go/transport/grpc"
+
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+const (
+	address = "localhost:50054"
+)
+
+func main() {
+	// In the "true" requests from gRPC to YARPC (as opposed to YARPC to YARPC) we will likely get a
+	// protobuf encoding, for now, using the PassThroughCodec is necessary to test (though it won't be used
+	// in production)
+	conn, err := grpc.Dial(address, grpc.WithInsecure(), grpc.WithCodec(gr.PassThroughCodec{}))
+	if err != nil {
+		log.Fatalf("did not connect: %v", err)
+	}
+	defer conn.Close()
+
+	// Adds the necessary YARPC Headers to the request
+	md := metadata.New(map[string]string{
+		"rpc-caller":   "clientgo",
+		"rpc-encoding": "raw",
+	})
+	ctx := metadata.NewContext(context.Background(), md)
+
+	// typically called by generated code
+	strReq := "hello from client.go!"
+	req := []byte(strReq)
+
+	var res []byte
+
+	err = grpc.Invoke(ctx, "/foo/bar", &req, &res, conn) // @generated
+	if err != nil {
+		log.Fatalf("could not greet: %v", err)
+	}
+
+	fmt.Println("GOT RESP: ", string(res))
+}

--- a/examples/grpc/server/main.go
+++ b/examples/grpc/server/main.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net"
+
+	gr "github.com/yarpc/yarpc-go/transport/grpc"
+
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+)
+
+const (
+	port = ":50054"
+)
+
+// @generated
+type service interface {
+	Bar(ctx context.Context, in *[]byte) (*[]byte, error)
+}
+
+// @generated
+// dec is testCodec.Unmarshal
+func handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	fmt.Println("grpc.methodHandler::main.handler")
+	var in []byte
+	if err := dec(&in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(service).Bar(ctx, &in) // &in
+	}
+	// TODO this path hasn't been exercised
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/foo/bar",
+	}
+	// this is a grpc.UnaryHandler
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		fmt.Println("grpc.UnaryHandler::main.handler")
+
+		// call the users handler, casting the req to the right type
+		return srv.(service).Bar(ctx, req.(*[]byte))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+// @generated
+var serviceDesc = grpc.ServiceDesc{
+	ServiceName: "foo",
+	HandlerType: (*service)(nil),
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "bar",
+			Handler:    handler, // grpc.methodHandler
+		},
+	},
+	Streams: []grpc.StreamDesc{},
+}
+
+type server struct{}
+
+func (server) Bar(ctx context.Context, in *[]byte) (*[]byte, error) {
+	fmt.Println("main.server::Bar")
+	res := []byte("server says hi")
+	if in != nil {
+		res = []byte(fmt.Sprintf("server got request body: %s", string(*in)))
+	}
+	return &res, nil
+}
+
+func main() {
+	lis, err := net.Listen("tcp", port)
+	if err != nil {
+		log.Fatalf("failed to listen: %v", err)
+	}
+
+	// TODO only 1 codec is supported at the moment, https://github.com/grpc/grpc-go/issues/803
+	s := grpc.NewServer(grpc.CustomCodec(gr.PassThroughCodec{}))
+	s.RegisterService(&serviceDesc, server{}) // @generated
+	s.Serve(lis)
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: 88025999cb77e2388355a000730fcd8fa5eea1b457385286706658db8db08e23
-updated: 2016-09-27T14:50:58.395609946-07:00
+hash: 54f6258557827460214fe5360d3f2b30eaa25e46f9a08cf0e42f9434ae9cd8a7
+updated: 2016-09-28T12:53:42.621983921-07:00
 imports:
 - name: github.com/apache/thrift
-  version: 2df9c20dc76c044e502861a2111b90cbdcbbb957
+  version: 8ccf5a645c8e34e0abb6f31b216dbf77f0ac2a43
   subpackages:
   - lib/go/thrift
 - name: github.com/crossdock/crossdock-go
@@ -18,6 +18,10 @@ imports:
   version: bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
   subpackages:
   - gomock
+- name: github.com/golang/protobuf
+  version: 87c000235d3d852c1628dc9490cd21ab36a7d69f
+  subpackages:
+  - proto
 - name: github.com/opentracing/opentracing-go
   version: 0c3154a3c2ce79d3271985848659870599dfb77c
   subpackages:
@@ -72,8 +76,25 @@ imports:
   subpackages:
   - context
   - context/ctxhttp
+  - http2
+  - http2/hpack
+  - idna
+  - internal/timeseries
+  - lex/httplex
+  - trace
 - name: golang.org/x/tools
   version: fc2b74b64ef08c618146ebc92062f6499db5314c
   subpackages:
   - go/ast/astutil
+- name: google.golang.org/grpc
+  version: 0032a855ba5c8a3c8e0d71c2deef354b70af1584
+  subpackages:
+  - codes
+  - credentials
+  - grpclog
+  - internal
+  - metadata
+  - naming
+  - peer
+  - transport
 testImports: []

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 54f6258557827460214fe5360d3f2b30eaa25e46f9a08cf0e42f9434ae9cd8a7
-updated: 2016-09-28T12:53:42.621983921-07:00
+hash: dd2f75e3a8d86f54baa5090f3f777c1db5320afcb6c0e3b3ce5766bcc2dae70b
+updated: 2016-09-28T18:27:48.799105702-07:00
 imports:
 - name: github.com/apache/thrift
   version: 8ccf5a645c8e34e0abb6f31b216dbf77f0ac2a43
@@ -72,7 +72,7 @@ imports:
   - trand
   - typed
 - name: golang.org/x/net
-  version: f09c4662a0bd6bd8943ac7b4931e185df9471da4
+  version: 9f0e377a8a39bb99ff03459d77c135a0042878f0
   subpackages:
   - context
   - context/ctxhttp

--- a/glide.yaml
+++ b/glide.yaml
@@ -23,5 +23,6 @@ import:
 - package: github.com/crossdock/crossdock-go
   version: master
 - package: github.com/uber-go/atomic
-- package: google.golang.org/grpc
   version: ^1.0.0
+- package: google.golang.org/grpc
+  version: ^1

--- a/glide.yaml
+++ b/glide.yaml
@@ -23,4 +23,5 @@ import:
 - package: github.com/crossdock/crossdock-go
   version: master
 - package: github.com/uber-go/atomic
+- package: google.golang.org/grpc
   version: ^1.0.0

--- a/transport/grpc/codec.go
+++ b/transport/grpc/codec.go
@@ -1,0 +1,29 @@
+package grpc
+
+import "fmt"
+
+// PassThroughCodec passes bytes to/from the wire without modification
+type PassThroughCodec struct{}
+
+// Marshal takes a []byte pointer and passes it through as a []byte
+func (PassThroughCodec) Marshal(v interface{}) ([]byte, error) {
+	bs, ok := v.(*[]byte)
+	if !ok {
+		return nil, fmt.Errorf("expected sender of type *[]byte but got %T", v)
+	}
+	return *(bs), nil
+}
+
+// Unmarshal takes a byte slice and writes it to v
+func (PassThroughCodec) Unmarshal(data []byte, v interface{}) error {
+	bs, ok := v.(*[]byte)
+	if !ok {
+		return fmt.Errorf("expected receiver of type *[]byte but got %T", v)
+	}
+	*bs = data
+	return nil
+}
+
+func (PassThroughCodec) String() string {
+	return "raw"
+}

--- a/transport/grpc/codec.go
+++ b/transport/grpc/codec.go
@@ -25,5 +25,5 @@ func (PassThroughCodec) Unmarshal(data []byte, v interface{}) error {
 }
 
 func (PassThroughCodec) String() string {
-	return "raw"
+	return "passthrough"
 }

--- a/transport/grpc/codec_test.go
+++ b/transport/grpc/codec_test.go
@@ -1,0 +1,58 @@
+package grpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPassThroughCodecMarshal(t *testing.T) {
+	codec := PassThroughCodec{}
+	strMsg := "this is a test"
+	byteSender := []byte(strMsg)
+
+	result, err := codec.Marshal(&byteSender)
+
+	assert.Equal(t, strMsg, string(result))
+	assert.Equal(t, error(nil), err)
+}
+
+func TestPassThroughCodecMarshalError(t *testing.T) {
+	codec := PassThroughCodec{}
+	strMsg := "this is a test"
+
+	result, err := codec.Marshal(&strMsg)
+
+	assert.Equal(t, []byte(nil), result)
+	assert.Equal(t, "expected sender of type *[]byte but got *string", err.Error())
+}
+
+func TestPassThroughCodecUnmarshal(t *testing.T) {
+	codec := PassThroughCodec{}
+	strMsg := "this is a test"
+	data := []byte(strMsg)
+	var receiver []byte
+
+	err := codec.Unmarshal(data, &receiver)
+
+	assert.Equal(t, strMsg, string(receiver))
+	assert.Equal(t, error(nil), err)
+}
+
+func TestPassThroughCodecUnmarshalError(t *testing.T) {
+	codec := PassThroughCodec{}
+	strMsg := "this is a test"
+	data := []byte(strMsg)
+	var receiver string
+
+	err := codec.Unmarshal(data, &receiver)
+
+	assert.Equal(t, "", receiver)
+	assert.Equal(t, "expected receiver of type *[]byte but got *string", err.Error())
+}
+
+func TestPassThroughCodecString(t *testing.T) {
+	codec := PassThroughCodec{}
+
+	assert.Equal(t, "raw", codec.String())
+}

--- a/transport/grpc/codec_test.go
+++ b/transport/grpc/codec_test.go
@@ -54,5 +54,5 @@ func TestPassThroughCodecUnmarshalError(t *testing.T) {
 func TestPassThroughCodecString(t *testing.T) {
 	codec := PassThroughCodec{}
 
-	assert.Equal(t, "raw", codec.String())
+	assert.Equal(t, "passthrough", codec.String())
 }


### PR DESCRIPTION
Summary: This diff creates a sample GRPC server and client (Not using
YARPC functionality).  This is for testing to ensure that requests from
GRPC can call into YARPC servers.

Test Plan: Started up the Server and had the client make a few calls