### PR TITLE
[GRPC][Part 8] Propagate Application Headers

### DIFF
--- a/crossdock/main_test.go
+++ b/crossdock/main_test.go
@@ -71,7 +71,7 @@ func TestCrossdock(t *testing.T) {
 		{
 			name: "headers",
 			axes: axes{
-				"transport": []string{"http", "tchannel"},
+				"transport": []string{"http", "tchannel", "grpc"},
 				"encoding":  []string{"raw", "json", "thrift"},
 			},
 		},

--- a/transport/grpc/constants.go
+++ b/transport/grpc/constants.go
@@ -1,6 +1,10 @@
 package grpc
 
 const (
+	// ApplicationHeaderPrefix is the prefix added to application headers over
+	// the wire.
+	ApplicationHeaderPrefix = "rpc-header-"
+
 	// CallerHeader is the HTTP header used to indiate the service doing the calling
 	CallerHeader = "rpc-caller"
 

--- a/transport/grpc/handler.go
+++ b/transport/grpc/handler.go
@@ -65,6 +65,8 @@ func getTRequest(ctx context.Context, msgBodyDecoder func(interface{}) error) (*
 		return nil, err
 	}
 
+	appHeaders := applicationHeaders.FromGRPCMetadata(ctxMetadata, transport.Headers{})
+
 	requestBody, err := getMsgBody(msgBodyDecoder)
 	if err != nil {
 		return nil, err
@@ -75,6 +77,7 @@ func getTRequest(ctx context.Context, msgBodyDecoder func(interface{}) error) (*
 		Procedure: procedure,
 		Caller:    caller,
 		Encoding:  transport.Encoding(encoding),
+		Headers:   appHeaders,
 		Body:      requestBody,
 	}
 	return treq, nil
@@ -163,13 +166,16 @@ func callHandler(
 
 	err = internal.SafelyCallHandler(ctx, handler, start, grpcOptions, treq, rw)
 
+	// Sends the headers back on the request
+	grpc.SendHeader(ctx, r.headers)
 	responseBody := r.body.Bytes()
 	return &responseBody, err
 }
 
 // The response object contains response information from the YARPC handler
 type response struct {
-	body bytes.Buffer
+	body    bytes.Buffer
+	headers metadata.MD
 }
 
 // Wrapper to control writes to the response object
@@ -186,7 +192,7 @@ func (rw responseWriter) Write(s []byte) (int, error) {
 }
 
 func (rw responseWriter) AddHeaders(h transport.Headers) {
-	// TODO support Headers
+	rw.r.headers = applicationHeaders.ToGRPCMetadata(h, rw.r.headers)
 }
 
 func (responseWriter) SetApplicationError() {

--- a/transport/grpc/handler.go
+++ b/transport/grpc/handler.go
@@ -65,7 +65,7 @@ func getTRequest(ctx context.Context, msgBodyDecoder func(interface{}) error) (*
 		return nil, err
 	}
 
-	appHeaders := applicationHeaders.FromGRPCMetadata(ctxMetadata, transport.Headers{})
+	appHeaders := applicationHeaders.fromMetadata(ctxMetadata, transport.Headers{})
 
 	requestBody, err := getMsgBody(msgBodyDecoder)
 	if err != nil {
@@ -192,7 +192,7 @@ func (rw responseWriter) Write(s []byte) (int, error) {
 }
 
 func (rw responseWriter) AddHeaders(h transport.Headers) {
-	rw.r.headers = applicationHeaders.ToGRPCMetadata(h, rw.r.headers)
+	rw.r.headers = applicationHeaders.toMetadata(h, rw.r.headers)
 }
 
 func (responseWriter) SetApplicationError() {

--- a/transport/grpc/handler_test.go
+++ b/transport/grpc/handler_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"testing"
 
+	"go.uber.org/yarpc/transport"
+
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/metadata"
@@ -150,4 +152,33 @@ func TestResponseWriter_Write(t *testing.T) {
 	assert.Equal(t, len(byteMsg), changed)
 	assert.Equal(t, error(nil), err)
 	assert.Equal(t, strMsg, string(r.body.Bytes()))
+}
+
+func TestResponseWriter_AddHeaders(t *testing.T) {
+	caller := "teeeeest"
+	encoding := "raw"
+	inputHeaders := transport.HeadersFromMap(map[string]string{
+		CallerHeader:   caller,
+		EncodingHeader: encoding,
+	})
+	expectedHeaders := metadata.New(map[string]string{
+		ApplicationHeaderPrefix + CallerHeader:   caller,
+		ApplicationHeaderPrefix + EncodingHeader: encoding,
+	})
+
+	var r response
+	rw := newResponseWriter(&r)
+
+	rw.AddHeaders(inputHeaders)
+
+	assert.Equal(t, expectedHeaders, r.headers)
+}
+
+func TestResponseWriter_SetApplicationError(t *testing.T) {
+	var r response
+	rw := newResponseWriter(&r)
+
+	rw.SetApplicationError()
+
+	// No action on Application Error
 }

--- a/transport/grpc/handler_test.go
+++ b/transport/grpc/handler_test.go
@@ -141,7 +141,7 @@ func TestExtractMetadataHeader(t *testing.T) {
 	}
 }
 
-func TestResponseWriter_Write(t *testing.T) {
+func TestResponseWriter(t *testing.T) {
 	strMsg := "this is a test"
 	byteMsg := []byte(strMsg)
 	var r response
@@ -154,7 +154,7 @@ func TestResponseWriter_Write(t *testing.T) {
 	assert.Equal(t, strMsg, string(r.body.Bytes()))
 }
 
-func TestResponseWriter_AddHeaders(t *testing.T) {
+func TestResponseWriterWithHeaders(t *testing.T) {
 	caller := "teeeeest"
 	encoding := "raw"
 	inputHeaders := transport.HeadersFromMap(map[string]string{
@@ -172,13 +172,4 @@ func TestResponseWriter_AddHeaders(t *testing.T) {
 	rw.AddHeaders(inputHeaders)
 
 	assert.Equal(t, expectedHeaders, r.headers)
-}
-
-func TestResponseWriter_SetApplicationError(t *testing.T) {
-	var r response
-	rw := newResponseWriter(&r)
-
-	rw.SetApplicationError()
-
-	// No action on Application Error
 }

--- a/transport/grpc/header.go
+++ b/transport/grpc/header.go
@@ -1,0 +1,86 @@
+package grpc
+
+import (
+	"strings"
+
+	"go.uber.org/yarpc/transport"
+
+	"google.golang.org/grpc/metadata"
+)
+
+// headerMapper converts gRCP Metadata to and from transport headers.
+type headerMapper struct{ Prefix string }
+
+var (
+	applicationHeaders = headerMapper{ApplicationHeaderPrefix}
+)
+
+// toGRPCMetadata converts transport headers into gRPC Metadata.
+//
+// Headers are read from 'from' and written to 'to'. The final header collection
+// is returned.
+//
+// If 'to' is nil, a new map will be assigned.
+func (hm headerMapper) ToGRPCMetadata(from transport.Headers, to metadata.MD) metadata.MD {
+	if to == nil {
+		to = make(metadata.MD, from.Len())
+	}
+	for k, v := range from.Items() {
+		Headers(to).Add(hm.Prefix+k, v)
+	}
+	return to
+}
+
+// fromGRPCMetadata converts GRPC Metadata to transport headers.
+//
+// Headers are read from 'from' and written to 'to'. The final header collection
+// is returned.
+//
+// If 'to' is nil, a new map will be assigned.
+func (hm headerMapper) FromGRPCMetadata(from metadata.MD, to transport.Headers) transport.Headers {
+	prefixLen := len(hm.Prefix)
+	for k := range from {
+		if strings.HasPrefix(k, hm.Prefix) {
+			key := k[prefixLen:]
+			to = to.With(key, Headers(from).Get(k))
+		}
+		// Note: undefined behavior for multiple occurrences of the same header
+	}
+	return to
+}
+
+// Headers is a convenience type for converting Header information safely
+type Headers map[string][]string
+
+// Add adds the key, value pair to the header.
+// It appends to any existing values associated with key.
+func (h Headers) Add(key, value string) {
+	h[key] = append(h[key], value)
+}
+
+// Set sets the header entries associated with key to
+// the single element value. It replaces any existing
+// values associated with key.
+func (h Headers) Set(key, value string) {
+	h[key] = []string{value}
+}
+
+// Get gets the first value associated with the given key.
+// If there are no values associated with the key, Get returns "".
+// Get is a convenience method. For more complex queries,
+// access the map directly.
+func (h Headers) Get(key string) string {
+	if h == nil {
+		return ""
+	}
+	v := h[key]
+	if len(v) == 0 {
+		return ""
+	}
+	return v[0]
+}
+
+// Del deletes the values associated with key.
+func (h Headers) Del(key string) {
+	delete(h, key)
+}

--- a/transport/grpc/header.go
+++ b/transport/grpc/header.go
@@ -8,14 +8,14 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-// headerMapper converts gRCP Metadata to and from transport headers.
+// headerMapper converts gRPC Metadata to and from transport headers.
 type headerMapper struct{ Prefix string }
 
 var (
 	applicationHeaders = headerMapper{ApplicationHeaderPrefix}
 )
 
-// toGRPCMetadata converts transport headers into gRPC Metadata.
+// toMetadata converts transport headers into gRPC Metadata.
 //
 // Headers are read from 'from' and written to 'to'. The final header collection
 // is returned.
@@ -31,7 +31,7 @@ func (hm headerMapper) toMetadata(from transport.Headers, to metadata.MD) metada
 	return to
 }
 
-// fromGRPCMetadata converts GRPC Metadata to transport headers.
+// fromMetadata converts GRPC Metadata to transport headers.
 //
 // Headers are read from 'from' and written to 'to'. The final header collection
 // is returned.

--- a/transport/grpc/header.go
+++ b/transport/grpc/header.go
@@ -21,12 +21,12 @@ var (
 // is returned.
 //
 // If 'to' is nil, a new map will be assigned.
-func (hm headerMapper) ToGRPCMetadata(from transport.Headers, to metadata.MD) metadata.MD {
+func (hm headerMapper) toMetadata(from transport.Headers, to metadata.MD) metadata.MD {
 	if to == nil {
 		to = make(metadata.MD, from.Len())
 	}
 	for k, v := range from.Items() {
-		Headers(to).Add(hm.Prefix+k, v)
+		headers(to).add(hm.Prefix+k, v)
 	}
 	return to
 }
@@ -37,31 +37,31 @@ func (hm headerMapper) ToGRPCMetadata(from transport.Headers, to metadata.MD) me
 // is returned.
 //
 // If 'to' is nil, a new map will be assigned.
-func (hm headerMapper) FromGRPCMetadata(from metadata.MD, to transport.Headers) transport.Headers {
+func (hm headerMapper) fromMetadata(from metadata.MD, to transport.Headers) transport.Headers {
 	prefixLen := len(hm.Prefix)
 	for k := range from {
 		if strings.HasPrefix(k, hm.Prefix) {
 			key := k[prefixLen:]
-			to = to.With(key, Headers(from).Get(k))
+			to = to.With(key, headers(from).get(k))
 		}
 		// Note: undefined behavior for multiple occurrences of the same header
 	}
 	return to
 }
 
-// Headers is a convenience type for converting Header information safely
-type Headers map[string][]string
+// headers is a convenience type for converting Header information safely
+type headers map[string][]string
 
 // Add adds the key, value pair to the header.
 // It appends to any existing values associated with key.
-func (h Headers) Add(key, value string) {
+func (h headers) add(key, value string) {
 	h[key] = append(h[key], value)
 }
 
 // Set sets the header entries associated with key to
 // the single element value. It replaces any existing
 // values associated with key.
-func (h Headers) Set(key, value string) {
+func (h headers) set(key, value string) {
 	h[key] = []string{value}
 }
 
@@ -69,7 +69,7 @@ func (h Headers) Set(key, value string) {
 // If there are no values associated with the key, Get returns "".
 // Get is a convenience method. For more complex queries,
 // access the map directly.
-func (h Headers) Get(key string) string {
+func (h headers) get(key string) string {
 	if h == nil {
 		return ""
 	}
@@ -81,6 +81,6 @@ func (h Headers) Get(key string) string {
 }
 
 // Del deletes the values associated with key.
-func (h Headers) Del(key string) {
+func (h headers) del(key string) {
 	delete(h, key)
 }

--- a/transport/grpc/header.go
+++ b/transport/grpc/header.go
@@ -11,9 +11,7 @@ import (
 // headerMapper converts gRPC Metadata to and from transport headers.
 type headerMapper struct{ Prefix string }
 
-var (
-	applicationHeaders = headerMapper{ApplicationHeaderPrefix}
-)
+var applicationHeaders = headerMapper{ApplicationHeaderPrefix}
 
 // toMetadata converts transport headers into gRPC Metadata.
 //
@@ -49,12 +47,13 @@ func (hm headerMapper) fromMetadata(from metadata.MD, to transport.Headers) tran
 	return to
 }
 
-// headers is a convenience type for converting Header information safely
+// headers is a convenience type for converting Header information safely (all GRPC headers need to be lowercase)
 type headers map[string][]string
 
 // Add adds the key, value pair to the header.
 // It appends to any existing values associated with key.
 func (h headers) add(key, value string) {
+	key = strings.ToLower(key)
 	h[key] = append(h[key], value)
 }
 
@@ -62,6 +61,7 @@ func (h headers) add(key, value string) {
 // the single element value. It replaces any existing
 // values associated with key.
 func (h headers) set(key, value string) {
+	key = strings.ToLower(key)
 	h[key] = []string{value}
 }
 
@@ -70,6 +70,7 @@ func (h headers) set(key, value string) {
 // Get is a convenience method. For more complex queries,
 // access the map directly.
 func (h headers) get(key string) string {
+	key = strings.ToLower(key)
 	if h == nil {
 		return ""
 	}
@@ -82,5 +83,6 @@ func (h headers) get(key string) string {
 
 // Del deletes the values associated with key.
 func (h headers) del(key string) {
+	key = strings.ToLower(key)
 	delete(h, key)
 }

--- a/transport/grpc/header_test.go
+++ b/transport/grpc/header_test.go
@@ -9,122 +9,292 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-func TestHeaderMapper_ToMetadata(t *testing.T) {
-	prefix := "test-"
-	testMapper := headerMapper{prefix}
+func TestHeaderMapperToMetadata(t *testing.T) {
+	type testStruct struct {
+		mapper       headerMapper
+		inputHeaders transport.Headers
+		inputMD      metadata.MD
+		expectedMD   metadata.MD
+	}
+	tests := []testStruct{
+		func() (s testStruct) {
+			prefix := "test-"
+			s.mapper = headerMapper{prefix}
+			s.inputHeaders = transport.HeadersFromMap(map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			})
+			s.inputMD = metadata.New(map[string]string{
+				"key": "value",
+			})
+			s.expectedMD = metadata.New(map[string]string{
+				"key":           "value",
+				prefix + "key1": "value1",
+				prefix + "key2": "value2",
+			})
+			return
+		}(),
+		func() (s testStruct) {
+			prefix := "test-"
+			s.mapper = headerMapper{prefix}
+			s.inputHeaders = transport.HeadersFromMap(map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			})
+			s.inputMD = nil
+			s.expectedMD = metadata.New(map[string]string{
+				prefix + "key1": "value1",
+				prefix + "key2": "value2",
+			})
+			return
+		}(),
+	}
 
-	inputHeaders := transport.HeadersFromMap(map[string]string{
-		"key1": "value1",
-		"key2": "value2",
-	})
-	expectedMetadata := metadata.New(map[string]string{
-		"key":           "value",
-		prefix + "key1": "value1",
-		prefix + "key2": "value2",
-	})
+	for _, tt := range tests {
+		md := tt.mapper.toMetadata(tt.inputHeaders, tt.inputMD)
 
-	md := metadata.New(map[string]string{
-		"key": "value",
-	})
-	actualMetadata := testMapper.toMetadata(inputHeaders, md)
-
-	assert.Equal(t, expectedMetadata, actualMetadata)
+		assert.Equal(t, tt.expectedMD, md)
+	}
 }
 
-func TestHeaderMapper_ToMetadata_fromNil(t *testing.T) {
-	prefix := "test-"
-	testMapper := headerMapper{prefix}
+func TestHeaderMapperFromMetadata(t *testing.T) {
+	type testStruct struct {
+		mapper          headerMapper
+		inputMD         metadata.MD
+		inputHeaders    transport.Headers
+		expectedHeaders transport.Headers
+	}
+	tests := []testStruct{
+		func() (s testStruct) {
+			prefix := "test-"
+			s.mapper = headerMapper{prefix}
+			s.inputMD = metadata.New(map[string]string{
+				"key10":         "value10",
+				prefix + "key1": "value1",
+				prefix + "key2": "value2",
+			})
+			s.inputHeaders = transport.HeadersFromMap(map[string]string{
+				"key": "value",
+			})
+			s.expectedHeaders = transport.HeadersFromMap(map[string]string{
+				"key":  "value",
+				"key1": "value1",
+				"key2": "value2",
+			})
+			return
+		}(),
+		func() (s testStruct) {
+			prefix := "test-"
+			s.mapper = headerMapper{prefix}
+			s.inputMD = metadata.New(map[string]string{
+				"key10":         "value10",
+				prefix + "key1": "value1",
+				prefix + "key2": "value2",
+			})
+			s.inputHeaders = transport.Headers{}
+			s.expectedHeaders = transport.HeadersFromMap(map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			})
+			return
+		}(),
+	}
 
-	inputHeaders := transport.HeadersFromMap(map[string]string{
-		"key1": "value1",
-		"key2": "value2",
-	})
-	expectedMetadata := metadata.New(map[string]string{
-		prefix + "key1": "value1",
-		prefix + "key2": "value2",
-	})
+	for _, tt := range tests {
+		headers := tt.mapper.fromMetadata(tt.inputMD, tt.inputHeaders)
 
-	actualMetadata := testMapper.toMetadata(inputHeaders, nil)
-
-	assert.Equal(t, expectedMetadata, actualMetadata)
+		assert.Equal(t, tt.expectedHeaders, headers)
+	}
 }
 
-func TestHeaderMapper_FromMetadata(t *testing.T) {
-	prefix := "test-"
-	testMapper := headerMapper{prefix}
+func TestHeadersAdd(t *testing.T) {
+	type testStruct struct {
+		inputHeaders    headers
+		addKeys         []string
+		addValues       []string
+		expectedHeaders headers
+	}
+	tests := []testStruct{
+		{
+			inputHeaders: map[string][]string{"key": {"value"}},
+			addKeys:      []string{"key1", "key2"},
+			addValues:    []string{"value1", "value2"},
+			expectedHeaders: map[string][]string{
+				"key":  {"value"},
+				"key1": {"value1"},
+				"key2": {"value2"},
+			},
+		},
+		{
+			inputHeaders: map[string][]string{"key": {"value"}},
+			addKeys:      []string{"KEY1", "KEY2"},
+			addValues:    []string{"VALUE1", "VALUE2"},
+			expectedHeaders: map[string][]string{
+				"key":  {"value"},
+				"key1": {"VALUE1"},
+				"key2": {"VALUE2"},
+			},
+		},
+		{
+			inputHeaders: map[string][]string{"key": {"value"}},
+			addKeys:      []string{"key"},
+			addValues:    []string{"value2"},
+			expectedHeaders: map[string][]string{
+				"key": {"value", "value2"},
+			},
+		},
+	}
 
-	inputMetadata := metadata.New(map[string]string{
-		"key":           "value",
-		prefix + "key1": "value1",
-		prefix + "key2": "value2",
-	})
-	expectedHeaders := transport.HeadersFromMap(map[string]string{
-		"key1": "value1",
-		"key2": "value2",
-	})
-
-	actualHeaders := testMapper.fromMetadata(inputMetadata, transport.Headers{})
-
-	assert.Equal(t, expectedHeaders, actualHeaders)
+	for _, tt := range tests {
+		headers := tt.inputHeaders
+		for i := range tt.addKeys {
+			headers.add(tt.addKeys[i], tt.addValues[i])
+		}
+		assert.Equal(t, tt.expectedHeaders, headers)
+	}
 }
 
-func TestHeaders_Add(t *testing.T) {
-	headers := headers{}
-	headers["key1"] = []string{"value1"}
-	headers["key2"] = []string{"value2"}
+func TestHeadersDel(t *testing.T) {
+	type testStruct struct {
+		inputHeaders    headers
+		delKeys         []string
+		expectedHeaders headers
+	}
+	tests := []testStruct{
+		{
+			inputHeaders: map[string][]string{
+				"key":  {"value"},
+				"key1": {"value1"},
+				"key2": {"value2"},
+			},
+			delKeys: []string{"key1", "key2"},
+			expectedHeaders: map[string][]string{
+				"key": {"value"},
+			},
+		},
+		{
+			inputHeaders: map[string][]string{
+				"key":  {"value"},
+				"key1": {"value1"},
+				"key2": {"value2"},
+			},
+			delKeys: []string{"KEY1", "KEY2"},
+			expectedHeaders: map[string][]string{
+				"key": {"value"},
+			},
+		},
+	}
 
-	headers.add("testkey", "testvalue")
-
-	assert.Equal(t, "value1", headers["key1"][0])
-	assert.Equal(t, "value2", headers["key2"][0])
-	assert.Equal(t, "testvalue", headers["testkey"][0])
+	for _, tt := range tests {
+		headers := tt.inputHeaders
+		for _, key := range tt.delKeys {
+			headers.del(key)
+		}
+		assert.Equal(t, tt.expectedHeaders, headers)
+	}
 }
 
-func TestHeaders_Del(t *testing.T) {
-	headers := headers{}
-	headers["key1"] = []string{"value1"}
-	headers["key2"] = []string{"value2"}
+func TestHeadersGet(t *testing.T) {
+	type testStruct struct {
+		inputHeaders   headers
+		keys           []string
+		expectedValues []string
+	}
+	tests := []testStruct{
+		{
+			inputHeaders: map[string][]string{
+				"key":  {"value"},
+				"key1": {"value1"},
+				"key2": {"value2"},
+			},
+			keys:           []string{"key1", "key2"},
+			expectedValues: []string{"value1", "value2"},
+		},
+		{
+			inputHeaders: map[string][]string{
+				"key":  {"value"},
+				"key1": {"value1"},
+				"key2": {"value2"},
+			},
+			keys:           []string{"KEY1"},
+			expectedValues: []string{"value1"},
+		},
+		{
+			inputHeaders:   nil,
+			keys:           []string{"key1"},
+			expectedValues: []string{""},
+		},
+		{
+			inputHeaders: map[string][]string{
+				"key": {"value"},
+			},
+			keys:           []string{"key1"},
+			expectedValues: []string{""},
+		},
+		{
+			inputHeaders:   map[string][]string{},
+			keys:           []string{"key1"},
+			expectedValues: []string{""},
+		},
+	}
 
-	headers.del("key2")
-
-	assert.Equal(t, 1, len(headers))
-	assert.Equal(t, "value1", headers["key1"][0])
-	assert.Equal(t, []string(nil), headers["key2"])
+	for _, tt := range tests {
+		headers := tt.inputHeaders
+		for i := range tt.keys {
+			value := headers.get(tt.keys[i])
+			assert.Equal(t, tt.expectedValues[i], value)
+		}
+		assert.Equal(t, tt.inputHeaders, headers) // Ensure there were no mutations on get commands
+	}
 }
 
-func TestHeaders_Get(t *testing.T) {
-	headers := headers{}
-	headers["key1"] = []string{"value1"}
-	headers["key2"] = []string{"value2"}
+func TestHeadersSet(t *testing.T) {
+	type testStruct struct {
+		inputHeaders    headers
+		setKeys         []string
+		setValues       []string
+		expectedHeaders headers
+	}
+	tests := []testStruct{
+		{
+			inputHeaders: map[string][]string{
+				"key": {"value"},
+			},
+			setKeys:   []string{"key1", "key2"},
+			setValues: []string{"value1", "value2"},
+			expectedHeaders: map[string][]string{
+				"key":  {"value"},
+				"key1": {"value1"},
+				"key2": {"value2"},
+			},
+		},
+		{
+			inputHeaders: map[string][]string{
+				"key": {"value", "value1"},
+			},
+			setKeys:   []string{"key"},
+			setValues: []string{"value4"},
+			expectedHeaders: map[string][]string{
+				"key": {"value4"},
+			},
+		},
+		{
+			inputHeaders: map[string][]string{
+				"key": {"value", "value1"},
+			},
+			setKeys:   []string{"KEY"},
+			setValues: []string{"value4"},
+			expectedHeaders: map[string][]string{
+				"key": {"value4"},
+			},
+		},
+	}
 
-	value := headers.get("key2")
-
-	assert.Equal(t, "value2", value)
-}
-
-func TestHeaders_Get_Nil(t *testing.T) {
-	headers := headers(nil)
-
-	value := headers.get("key2")
-
-	assert.Equal(t, "", value)
-}
-
-func TestHeaders_Get_EmptyList(t *testing.T) {
-	headers := headers{}
-	headers["key1"] = []string{}
-
-	value := headers.get("key1")
-
-	assert.Equal(t, "", value)
-}
-
-func TestHeaders_Set(t *testing.T) {
-	headers := headers{}
-	headers["key1"] = []string{"value1"}
-	headers["key2"] = []string{"value2"}
-
-	headers.set("key2", "newValue")
-
-	assert.Equal(t, []string{"newValue"}, headers["key2"])
+	for _, tt := range tests {
+		headers := tt.inputHeaders
+		for i := range tt.setKeys {
+			headers.set(tt.setKeys[i], tt.setValues[i])
+		}
+		assert.Equal(t, tt.expectedHeaders, headers)
+	}
 }

--- a/transport/grpc/header_test.go
+++ b/transport/grpc/header_test.go
@@ -1,0 +1,130 @@
+package grpc
+
+import (
+	"testing"
+
+	"go.uber.org/yarpc/transport"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestHeaderMapper_ToGRPCMetadata(t *testing.T) {
+	prefix := "test-"
+	testMapper := headerMapper{prefix}
+
+	inputHeaders := transport.HeadersFromMap(map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+	})
+	expectedMetadata := metadata.New(map[string]string{
+		"key":           "value",
+		prefix + "key1": "value1",
+		prefix + "key2": "value2",
+	})
+
+	md := metadata.New(map[string]string{
+		"key": "value",
+	})
+	actualMetadata := testMapper.ToGRPCMetadata(inputHeaders, md)
+
+	assert.Equal(t, expectedMetadata, actualMetadata)
+}
+
+func TestHeaderMapper_ToGRPCMetadata_fromNil(t *testing.T) {
+	prefix := "test-"
+	testMapper := headerMapper{prefix}
+
+	inputHeaders := transport.HeadersFromMap(map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+	})
+	expectedMetadata := metadata.New(map[string]string{
+		prefix + "key1": "value1",
+		prefix + "key2": "value2",
+	})
+
+	actualMetadata := testMapper.ToGRPCMetadata(inputHeaders, nil)
+
+	assert.Equal(t, expectedMetadata, actualMetadata)
+}
+
+func TestHeaderMapper_FromGRPCMetadata(t *testing.T) {
+	prefix := "test-"
+	testMapper := headerMapper{prefix}
+
+	inputMetadata := metadata.New(map[string]string{
+		"key":           "value",
+		prefix + "key1": "value1",
+		prefix + "key2": "value2",
+	})
+	expectedHeaders := transport.HeadersFromMap(map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+	})
+
+	actualHeaders := testMapper.FromGRPCMetadata(inputMetadata, transport.Headers{})
+
+	assert.Equal(t, expectedHeaders, actualHeaders)
+}
+
+func TestHeaders_Add(t *testing.T) {
+	headers := Headers{}
+	headers["key1"] = []string{"value1"}
+	headers["key2"] = []string{"value2"}
+
+	headers.Add("testkey", "testvalue")
+
+	assert.Equal(t, "value1", headers["key1"][0])
+	assert.Equal(t, "value2", headers["key2"][0])
+	assert.Equal(t, "testvalue", headers["testkey"][0])
+}
+
+func TestHeaders_Del(t *testing.T) {
+	headers := Headers{}
+	headers["key1"] = []string{"value1"}
+	headers["key2"] = []string{"value2"}
+
+	headers.Del("key2")
+
+	assert.Equal(t, 1, len(headers))
+	assert.Equal(t, "value1", headers["key1"][0])
+	assert.Equal(t, []string(nil), headers["key2"])
+}
+
+func TestHeaders_Get(t *testing.T) {
+	headers := Headers{}
+	headers["key1"] = []string{"value1"}
+	headers["key2"] = []string{"value2"}
+
+	value := headers.Get("key2")
+
+	assert.Equal(t, "value2", value)
+}
+
+func TestHeaders_Get_Nil(t *testing.T) {
+	headers := Headers(nil)
+
+	value := headers.Get("key2")
+
+	assert.Equal(t, "", value)
+}
+
+func TestHeaders_Get_EmptyList(t *testing.T) {
+	headers := Headers{}
+	headers["key1"] = []string{}
+
+	value := headers.Get("key1")
+
+	assert.Equal(t, "", value)
+}
+
+func TestHeaders_Set(t *testing.T) {
+	headers := Headers{}
+	headers["key1"] = []string{"value1"}
+	headers["key2"] = []string{"value2"}
+
+	headers.Set("key2", "newValue")
+
+	assert.Equal(t, []string{"newValue"}, headers["key2"])
+}

--- a/transport/grpc/header_test.go
+++ b/transport/grpc/header_test.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-func TestHeaderMapper_ToGRPCMetadata(t *testing.T) {
+func TestHeaderMapper_ToMetadata(t *testing.T) {
 	prefix := "test-"
 	testMapper := headerMapper{prefix}
 
@@ -31,7 +31,7 @@ func TestHeaderMapper_ToGRPCMetadata(t *testing.T) {
 	assert.Equal(t, expectedMetadata, actualMetadata)
 }
 
-func TestHeaderMapper_ToGRPCMetadata_fromNil(t *testing.T) {
+func TestHeaderMapper_ToMetadata_fromNil(t *testing.T) {
 	prefix := "test-"
 	testMapper := headerMapper{prefix}
 
@@ -49,7 +49,7 @@ func TestHeaderMapper_ToGRPCMetadata_fromNil(t *testing.T) {
 	assert.Equal(t, expectedMetadata, actualMetadata)
 }
 
-func TestHeaderMapper_FromGRPCMetadata(t *testing.T) {
+func TestHeaderMapper_FromMetadata(t *testing.T) {
 	prefix := "test-"
 	testMapper := headerMapper{prefix}
 

--- a/transport/grpc/header_test.go
+++ b/transport/grpc/header_test.go
@@ -26,7 +26,7 @@ func TestHeaderMapper_ToGRPCMetadata(t *testing.T) {
 	md := metadata.New(map[string]string{
 		"key": "value",
 	})
-	actualMetadata := testMapper.ToGRPCMetadata(inputHeaders, md)
+	actualMetadata := testMapper.toMetadata(inputHeaders, md)
 
 	assert.Equal(t, expectedMetadata, actualMetadata)
 }
@@ -44,7 +44,7 @@ func TestHeaderMapper_ToGRPCMetadata_fromNil(t *testing.T) {
 		prefix + "key2": "value2",
 	})
 
-	actualMetadata := testMapper.ToGRPCMetadata(inputHeaders, nil)
+	actualMetadata := testMapper.toMetadata(inputHeaders, nil)
 
 	assert.Equal(t, expectedMetadata, actualMetadata)
 }
@@ -63,17 +63,17 @@ func TestHeaderMapper_FromGRPCMetadata(t *testing.T) {
 		"key2": "value2",
 	})
 
-	actualHeaders := testMapper.FromGRPCMetadata(inputMetadata, transport.Headers{})
+	actualHeaders := testMapper.fromMetadata(inputMetadata, transport.Headers{})
 
 	assert.Equal(t, expectedHeaders, actualHeaders)
 }
 
 func TestHeaders_Add(t *testing.T) {
-	headers := Headers{}
+	headers := headers{}
 	headers["key1"] = []string{"value1"}
 	headers["key2"] = []string{"value2"}
 
-	headers.Add("testkey", "testvalue")
+	headers.add("testkey", "testvalue")
 
 	assert.Equal(t, "value1", headers["key1"][0])
 	assert.Equal(t, "value2", headers["key2"][0])
@@ -81,11 +81,11 @@ func TestHeaders_Add(t *testing.T) {
 }
 
 func TestHeaders_Del(t *testing.T) {
-	headers := Headers{}
+	headers := headers{}
 	headers["key1"] = []string{"value1"}
 	headers["key2"] = []string{"value2"}
 
-	headers.Del("key2")
+	headers.del("key2")
 
 	assert.Equal(t, 1, len(headers))
 	assert.Equal(t, "value1", headers["key1"][0])
@@ -93,38 +93,38 @@ func TestHeaders_Del(t *testing.T) {
 }
 
 func TestHeaders_Get(t *testing.T) {
-	headers := Headers{}
+	headers := headers{}
 	headers["key1"] = []string{"value1"}
 	headers["key2"] = []string{"value2"}
 
-	value := headers.Get("key2")
+	value := headers.get("key2")
 
 	assert.Equal(t, "value2", value)
 }
 
 func TestHeaders_Get_Nil(t *testing.T) {
-	headers := Headers(nil)
+	headers := headers(nil)
 
-	value := headers.Get("key2")
+	value := headers.get("key2")
 
 	assert.Equal(t, "", value)
 }
 
 func TestHeaders_Get_EmptyList(t *testing.T) {
-	headers := Headers{}
+	headers := headers{}
 	headers["key1"] = []string{}
 
-	value := headers.Get("key1")
+	value := headers.get("key1")
 
 	assert.Equal(t, "", value)
 }
 
 func TestHeaders_Set(t *testing.T) {
-	headers := Headers{}
+	headers := headers{}
 	headers["key1"] = []string{"value1"}
 	headers["key2"] = []string{"value2"}
 
-	headers.Set("key2", "newValue")
+	headers.set("key2", "newValue")
 
 	assert.Equal(t, []string{"newValue"}, headers["key2"])
 }

--- a/transport/grpc/outbound.go
+++ b/transport/grpc/outbound.go
@@ -60,10 +60,7 @@ func getRequestHeaders(ctx context.Context, req *transport.Request) metadata.MD 
 		CallerHeader:   req.Caller,
 		EncodingHeader: string(req.Encoding),
 	})
-
-	md = applicationHeaders.ToGRPCMetadata(req.Headers, md)
-
-	return md
+	return applicationHeaders.toMetadata(req.Headers, md)
 }
 
 func callDownstream(
@@ -81,6 +78,6 @@ func callDownstream(
 
 	buf := bytes.NewBuffer(responseBody)
 	closer := ioutil.NopCloser(buf)
-	headers := applicationHeaders.FromGRPCMetadata(responseHeaders, transport.Headers{})
+	headers := applicationHeaders.fromMetadata(responseHeaders, transport.Headers{})
 	return &transport.Response{Body: closer, Headers: headers}, nil
 }

--- a/transport/grpc/outbound.go
+++ b/transport/grpc/outbound.go
@@ -61,6 +61,8 @@ func getRequestHeaders(ctx context.Context, req *transport.Request) metadata.MD 
 		EncodingHeader: string(req.Encoding),
 	})
 
+	md = applicationHeaders.ToGRPCMetadata(req.Headers, md)
+
 	return md
 }
 
@@ -71,12 +73,14 @@ func callDownstream(
 	connection *grpc.ClientConn,
 ) (*transport.Response, error) {
 	var responseBody []byte
+	var responseHeaders metadata.MD
 
-	if err := grpc.Invoke(ctx, uri, requestBody, &responseBody, connection); err != nil {
+	if err := grpc.Invoke(ctx, uri, requestBody, &responseBody, connection, grpc.Header(&responseHeaders)); err != nil {
 		return nil, err
 	}
 
 	buf := bytes.NewBuffer(responseBody)
 	closer := ioutil.NopCloser(buf)
-	return &transport.Response{Body: closer}, nil
+	headers := applicationHeaders.FromGRPCMetadata(responseHeaders, transport.Headers{})
+	return &transport.Response{Body: closer, Headers: headers}, nil
 }


### PR DESCRIPTION
Summary: Adds the ability for GRPC to send application headers.  Adds a
header file for containing the process of converting headers between
grpc and yarpc

Test Plan: Wrote tests, added to crossdock header test, ran
yclient/yserver
