### PR TITLE
[GRPC][Part 9] Add support for Baggage Headers

### DIFF
--- a/crossdock/client/dispatcher/dispatcher.go
+++ b/crossdock/client/dispatcher/dispatcher.go
@@ -26,6 +26,7 @@ import (
 	"github.com/yarpc/yarpc-go"
 	"github.com/yarpc/yarpc-go/crossdock/client/params"
 	"github.com/yarpc/yarpc-go/transport"
+	grpc "github.com/yarpc/yarpc-go/transport/grpc"
 	ht "github.com/yarpc/yarpc-go/transport/http"
 	tch "github.com/yarpc/yarpc-go/transport/tchannel"
 
@@ -49,6 +50,8 @@ func Create(t crossdock.T) yarpc.Dispatcher {
 		ch, err := tchannel.NewChannel("client", nil)
 		fatals.NoError(err, "couldn't create tchannel")
 		outbound = tch.NewOutbound(ch, tch.HostPort(server+":8082"))
+	case "grpc":
+		outbound = grpc.NewOutbound(fmt.Sprintf("%s:8089", server))
 	default:
 		fatals.Fail("", "unknown transport %q", trans)
 	}

--- a/crossdock/client/dispatcher/dispatcher_test.go
+++ b/crossdock/client/dispatcher/dispatcher_test.go
@@ -41,6 +41,10 @@ func TestCreate(t *testing.T) {
 			"server is required",
 		},
 		{
+			crossdock.Params{"transport": "grpc"},
+			"server is required",
+		},
+		{
 			crossdock.Params{"server": "localhost", "transport": "foo"},
 			`unknown transport "foo"`,
 		},
@@ -54,6 +58,12 @@ func TestCreate(t *testing.T) {
 			params: crossdock.Params{
 				"server":    "localhost",
 				"transport": "tchannel",
+			},
+		},
+		{
+			params: crossdock.Params{
+				"server":    "localhost",
+				"transport": "grpc",
 			},
 		},
 	}

--- a/crossdock/main_test.go
+++ b/crossdock/main_test.go
@@ -52,7 +52,7 @@ func TestCrossdock(t *testing.T) {
 		{
 			name: "raw",
 
-			axes: axes{"transport": []string{"http", "tchannel"}},
+			axes: axes{"transport": []string{"http", "tchannel", "grpc"}},
 		},
 		{
 			name: "json",

--- a/crossdock/main_test.go
+++ b/crossdock/main_test.go
@@ -108,7 +108,7 @@ func TestCrossdock(t *testing.T) {
 		{
 			name: "ctxpropagation",
 			axes: axes{
-				"transport": []string{"http", "tchannel"},
+				"transport": []string{"http", "tchannel", "grpc"},
 			},
 			params: params{
 				"ctxserver": "127.0.0.1",

--- a/crossdock/main_test.go
+++ b/crossdock/main_test.go
@@ -56,11 +56,11 @@ func TestCrossdock(t *testing.T) {
 		},
 		{
 			name: "json",
-			axes: axes{"transport": []string{"http", "tchannel"}},
+			axes: axes{"transport": []string{"http", "tchannel", "grpc"}},
 		},
 		{
 			name: "thrift",
-			axes: axes{"transport": []string{"http", "tchannel"}},
+			axes: axes{"transport": []string{"http", "tchannel", "grpc"}},
 		},
 		{
 			name: "errors_httpclient",
@@ -96,7 +96,7 @@ func TestCrossdock(t *testing.T) {
 		{
 			name: "thriftgauntlet",
 			axes: axes{
-				"transport": []string{"http", "tchannel"},
+				"transport": []string{"http", "tchannel", "grpc"},
 			},
 		},
 		{

--- a/crossdock/main_test.go
+++ b/crossdock/main_test.go
@@ -71,7 +71,7 @@ func TestCrossdock(t *testing.T) {
 		{
 			name: "headers",
 			axes: axes{
-				"transport": []string{"http", "tchannel"},
+				"transport": []string{"http", "tchannel", "grpc"},
 				"encoding":  []string{"raw", "json", "thrift"},
 			},
 		},

--- a/crossdock/server/yarpc/phone.go
+++ b/crossdock/server/yarpc/phone.go
@@ -28,6 +28,7 @@ import (
 	"github.com/yarpc/yarpc-go"
 	"github.com/yarpc/yarpc-go/encoding/json"
 	"github.com/yarpc/yarpc-go/transport"
+	"github.com/yarpc/yarpc-go/transport/grpc"
 	ht "github.com/yarpc/yarpc-go/transport/http"
 	tch "github.com/yarpc/yarpc-go/transport/tchannel"
 
@@ -47,10 +48,17 @@ type TChannelTransport struct {
 	Port int    `json:"port"`
 }
 
+// GRPCTransport contains information about a gRPC transport.
+type GRPCTransport struct {
+	Host string `json:"host"`
+	Port int    `json:"port"`
+}
+
 // TransportConfig contains the transport configuration for the phone request.
 type TransportConfig struct {
 	HTTP     *HTTPTransport     `json:"http"`
 	TChannel *TChannelTransport `json:"tchannel"`
+	GRPC     *GRPCTransport     `json:"grpc"`
 }
 
 // PhoneRequest is a request to make another request to a different service.
@@ -85,6 +93,9 @@ func Phone(ctx context.Context, reqMeta yarpc.ReqMeta, body *PhoneRequest) (*Pho
 			return nil, nil, fmt.Errorf("failed to build TChannel: %v", err)
 		}
 		outbound = tch.NewOutbound(ch, tch.HostPort(hostport))
+	case body.Transport.GRPC != nil:
+		t := body.Transport.GRPC
+		outbound = grpc.NewOutbound(fmt.Sprintf("%s:%d", t.Host, t.Port))
 	default:
 		return nil, nil, fmt.Errorf("unconfigured transport")
 	}

--- a/crossdock/server/yarpc/server.go
+++ b/crossdock/server/yarpc/server.go
@@ -32,6 +32,7 @@ import (
 	"github.com/yarpc/yarpc-go/encoding/raw"
 	"github.com/yarpc/yarpc-go/encoding/thrift"
 	"github.com/yarpc/yarpc-go/transport"
+	grpc "github.com/yarpc/yarpc-go/transport/grpc"
 	"github.com/yarpc/yarpc-go/transport/http"
 	tch "github.com/yarpc/yarpc-go/transport/tchannel"
 
@@ -52,6 +53,7 @@ func Start() {
 		Inbounds: []transport.Inbound{
 			http.NewInbound(":8081"),
 			tch.NewInbound(ch, tch.ListenAddr(":8082")),
+			grpc.NewInbound(8089),
 		},
 	})
 

--- a/examples/grpc/client/main.go
+++ b/examples/grpc/client/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	gr "github.com/yarpc/yarpc-go/transport/grpc"
+
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+const (
+	address = "localhost:50054"
+)
+
+func main() {
+	// In the "true" requests from gRPC to YARPC (as opposed to YARPC to YARPC) we will likely get a
+	// protobuf encoding, for now, using the PassThroughCodec is necessary to test (though it won't be used
+	// in production)
+	conn, err := grpc.Dial(address, grpc.WithInsecure(), grpc.WithCodec(gr.PassThroughCodec{}))
+	if err != nil {
+		log.Fatalf("did not connect: %v", err)
+	}
+	defer conn.Close()
+
+	// Adds the necessary YARPC Headers to the request
+	md := metadata.New(map[string]string{
+		"rpc-caller":   "clientgo",
+		"rpc-encoding": "raw",
+	})
+	ctx := metadata.NewContext(context.Background(), md)
+
+	// typically called by generated code
+	strReq := "hello from client.go!"
+	req := []byte(strReq)
+
+	var res []byte
+
+	err = grpc.Invoke(ctx, "/foo/bar", &req, &res, conn) // @generated
+	if err != nil {
+		log.Fatalf("could not greet: %v", err)
+	}
+
+	fmt.Println("GOT RESP: ", string(res))
+}

--- a/examples/grpc/server/main.go
+++ b/examples/grpc/server/main.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net"
+
+	gr "github.com/yarpc/yarpc-go/transport/grpc"
+
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+)
+
+const (
+	port = ":50054"
+)
+
+// @generated
+type service interface {
+	Bar(ctx context.Context, in *[]byte) (*[]byte, error)
+}
+
+// @generated
+// dec is testCodec.Unmarshal
+func handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	fmt.Println("grpc.methodHandler::main.handler")
+	var in []byte
+	if err := dec(&in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(service).Bar(ctx, &in) // &in
+	}
+	// TODO this path hasn't been exercised
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/foo/bar",
+	}
+	// this is a grpc.UnaryHandler
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		fmt.Println("grpc.UnaryHandler::main.handler")
+
+		// call the users handler, casting the req to the right type
+		return srv.(service).Bar(ctx, req.(*[]byte))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+// @generated
+var serviceDesc = grpc.ServiceDesc{
+	ServiceName: "foo",
+	HandlerType: (*service)(nil),
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "bar",
+			Handler:    handler, // grpc.methodHandler
+		},
+	},
+	Streams: []grpc.StreamDesc{},
+}
+
+type server struct{}
+
+func (server) Bar(ctx context.Context, in *[]byte) (*[]byte, error) {
+	fmt.Println("main.server::Bar")
+	res := []byte("server says hi")
+	if in != nil {
+		res = []byte(fmt.Sprintf("server got request body: %s", string(*in)))
+	}
+	return &res, nil
+}
+
+func main() {
+	lis, err := net.Listen("tcp", port)
+	if err != nil {
+		log.Fatalf("failed to listen: %v", err)
+	}
+
+	// TODO only 1 codec is supported at the moment, https://github.com/grpc/grpc-go/issues/803
+	s := grpc.NewServer(grpc.CustomCodec(gr.PassThroughCodec{}))
+	s.RegisterService(&serviceDesc, server{}) // @generated
+	s.Serve(lis)
+}

--- a/examples/grpc/thrift/main.go
+++ b/examples/grpc/thrift/main.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/yarpc/yarpc-go/examples/thrift/hello/thrift/hello"
+	"github.com/yarpc/yarpc-go/examples/thrift/hello/thrift/hello/yarpc/helloclient"
+	"github.com/yarpc/yarpc-go/examples/thrift/hello/thrift/hello/yarpc/helloserver"
+
+	"github.com/yarpc/yarpc-go"
+	"github.com/yarpc/yarpc-go/encoding/thrift"
+	"github.com/yarpc/yarpc-go/transport"
+	"github.com/yarpc/yarpc-go/transport/grpc"
+	"golang.org/x/net/context"
+)
+
+//go:generate thriftrw-go --out thrift --plugin=yarpc hello.thrift
+
+func main() {
+	dispatcher := yarpc.NewDispatcher(yarpc.Config{
+		Name: "hello",
+		Inbounds: []transport.Inbound{
+			grpc.NewInbound(8086),
+		},
+		Outbounds: transport.Outbounds{
+			"hello": grpc.NewOutbound("localhost:8086"),
+		},
+	})
+
+	thrift.Register(dispatcher, helloserver.New(&helloHandler{}))
+	client := helloclient.New(dispatcher.Channel("hello"))
+
+	if err := dispatcher.Start(); err != nil {
+		log.Fatal(err)
+	}
+	defer dispatcher.Stop()
+
+	response, headers := call(client, "Hi There")
+	fmt.Println(response, headers)
+
+	select {}
+}
+
+type helloHandler struct{}
+
+func (h helloHandler) Echo(ctx context.Context, reqMeta yarpc.ReqMeta, echo *hello.EchoRequest) (*hello.EchoResponse, yarpc.ResMeta, error) {
+	return &hello.EchoResponse{Message: echo.Message, Count: echo.Count + 1},
+		yarpc.NewResMeta().Headers(reqMeta.Headers()),
+		nil
+}
+
+func call(client helloclient.Interface, message string) (*hello.EchoResponse, yarpc.Headers) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	resBody, resMeta, err := client.Echo(
+		ctx,
+		yarpc.NewReqMeta(),
+		&hello.EchoRequest{Message: message, Count: 1},
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return resBody, resMeta.Headers()
+}

--- a/examples/grpc/yclient/main.go
+++ b/examples/grpc/yclient/main.go
@@ -50,6 +50,8 @@ func sendRequest(client raw.Client, procedure, msgBody string) {
 	fmt.Println("Body: ", msgBody)
 
 	ctx, _ := context.WithTimeout(context.Background(), randTimeout)
+	ctx = yarpc.WithBaggage(ctx, "token", "42")
+
 	resBody, resMeta, err := client.Call(
 		ctx,
 		yarpc.NewReqMeta().Procedure(procedure).Headers(headers),

--- a/examples/grpc/yclient/main.go
+++ b/examples/grpc/yclient/main.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"golang.org/x/net/context"
+
+	yarpc "github.com/yarpc/yarpc-go"
+	"github.com/yarpc/yarpc-go/encoding/raw"
+	"github.com/yarpc/yarpc-go/transport"
+	"github.com/yarpc/yarpc-go/transport/grpc"
+)
+
+func main() {
+	dispatcher := yarpc.NewDispatcher(yarpc.Config{
+		Name: "hello",
+		Outbounds: transport.Outbounds{
+			"yarpc": grpc.NewOutbound("localhost:50054"),
+		},
+	})
+
+	if err := dispatcher.Start(); err != nil {
+		log.Fatal(err)
+	}
+	defer dispatcher.Stop()
+
+	client := raw.New(dispatcher.Channel("yarpc"))
+
+	yarpcReqBody := fmt.Sprintf("Request to yarpc with value %d", time.Now().Unix())
+	sendRequest(client, "yarpc", yarpcReqBody)
+}
+
+func sendRequest(client raw.Client, procedure, msgBody string) {
+	randDuration := time.Now().Unix()%100 + 1
+	randTimeout := time.Duration(randDuration) * time.Second
+	headers := yarpc.NewHeaders().With("from", "self")
+
+	fmt.Println("---Sending a request---")
+	fmt.Println("Timeout: ", randTimeout)
+	fmt.Println("Caller: hello")
+	fmt.Println("Encoding: raw")
+	fmt.Println("Service: yarpc")
+	fmt.Println("Procedure: ", procedure)
+	fmt.Println("headers: ", headers)
+	fmt.Println("Body: ", msgBody)
+
+	ctx, _ := context.WithTimeout(context.Background(), randTimeout)
+	resBody, resMeta, err := client.Call(
+		ctx,
+		yarpc.NewReqMeta().Procedure(procedure).Headers(headers),
+		[]byte(msgBody),
+	)
+	if err != nil {
+		log.Fatalf("call failed: %v", err)
+	}
+
+	fmt.Println("SUCCESS! Got response: ", string(resBody))
+	fmt.Println("With Headers: ", resMeta.Headers())
+	fmt.Println("---Finished request---")
+}

--- a/examples/grpc/yclient/main.go
+++ b/examples/grpc/yclient/main.go
@@ -17,7 +17,7 @@ func main() {
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name: "hello",
 		Outbounds: transport.Outbounds{
-			"yarpc": grpc.NewOutbound("localhost:50054"),
+			"foo": grpc.NewOutbound("localhost:50054"),
 		},
 	})
 
@@ -26,10 +26,13 @@ func main() {
 	}
 	defer dispatcher.Stop()
 
-	client := raw.New(dispatcher.Channel("yarpc"))
+	client := raw.New(dispatcher.Channel("foo"))
 
-	yarpcReqBody := fmt.Sprintf("Request to yarpc with value %d", time.Now().Unix())
-	sendRequest(client, "yarpc", yarpcReqBody)
+	barReqBody := fmt.Sprintf("Request to bar with value %d", time.Now().Unix())
+	sendRequest(client, "bar", barReqBody)
+
+	mooReqBody := fmt.Sprintf("Request to moo with value %d", time.Now().Unix())
+	sendRequest(client, "moo", mooReqBody)
 }
 
 func sendRequest(client raw.Client, procedure, msgBody string) {
@@ -41,7 +44,7 @@ func sendRequest(client raw.Client, procedure, msgBody string) {
 	fmt.Println("Timeout: ", randTimeout)
 	fmt.Println("Caller: hello")
 	fmt.Println("Encoding: raw")
-	fmt.Println("Service: yarpc")
+	fmt.Println("Service: foo")
 	fmt.Println("Procedure: ", procedure)
 	fmt.Println("headers: ", headers)
 	fmt.Println("Body: ", msgBody)

--- a/examples/grpc/yserver/main.go
+++ b/examples/grpc/yserver/main.go
@@ -8,6 +8,7 @@ import (
 
 	yarpc "github.com/yarpc/yarpc-go"
 	"github.com/yarpc/yarpc-go/encoding/raw"
+	"github.com/yarpc/yarpc-go/internal/baggage"
 	"github.com/yarpc/yarpc-go/transport"
 	"github.com/yarpc/yarpc-go/transport/grpc"
 	"golang.org/x/net/context"
@@ -53,6 +54,7 @@ func printReqInfo(ctx context.Context, reqMeta yarpc.ReqMeta, body []byte) {
 	fmt.Println("Procedure: ", reqMeta.Procedure())
 	fmt.Println("Service: ", reqMeta.Service())
 	fmt.Println("Headers: ", reqMeta.Headers())
+	fmt.Println("Baggage: ", baggage.FromContext(ctx))
 	fmt.Println("Body: ", string(body))
 }
 

--- a/examples/grpc/yserver/main.go
+++ b/examples/grpc/yserver/main.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"log"
+
+	"fmt"
+	"time"
+
+	"github.com/yarpc/yarpc-go"
+	"github.com/yarpc/yarpc-go/encoding/raw"
+	"github.com/yarpc/yarpc-go/transport"
+	"github.com/yarpc/yarpc-go/transport/grpc"
+	"golang.org/x/net/context"
+)
+
+func yarpcFunc(ctx context.Context, reqMeta yarpc.ReqMeta, body []byte) ([]byte, yarpc.ResMeta, error) {
+	fmt.Println("---NEW REQUEST TO YARPC---")
+
+	printReqInfo(ctx, reqMeta, body)
+
+	res := []byte(fmt.Sprintf("server got request body: %s for YARPC", string(body)))
+
+	fmt.Println("---END OF REQUEST TO YARPC---")
+	return res, nil, nil
+}
+
+func printReqInfo(ctx context.Context, reqMeta yarpc.ReqMeta, body []byte) {
+	if dl, ok := ctx.Deadline(); ok {
+		fmt.Println("Timeout: ", dl.Sub(time.Now()))
+	} else {
+		fmt.Println("no deadline")
+	}
+
+	fmt.Println("Caller: ", reqMeta.Caller())
+	fmt.Println("Encoding: ", reqMeta.Encoding())
+	fmt.Println("Procedure: ", reqMeta.Procedure())
+	fmt.Println("Service: ", reqMeta.Service())
+	fmt.Println("Headers: ", reqMeta.Headers())
+	fmt.Println("Body: ", string(body))
+}
+
+func main() {
+	dispatcher := yarpc.NewDispatcher(yarpc.Config{
+		Name: "yarpc",
+		Inbounds: []transport.Inbound{
+			grpc.NewInbound(50054),
+		},
+	})
+
+	// TODO support non-default procedure names
+	raw.Register(dispatcher, raw.Procedure("yarpc", yarpcFunc))
+
+	if err := dispatcher.Start(); err != nil {
+		log.Fatal(err)
+	}
+	defer dispatcher.Stop()
+
+	select {}
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: 88025999cb77e2388355a000730fcd8fa5eea1b457385286706658db8db08e23
-updated: 2016-09-27T14:50:58.395609946-07:00
+hash: 54f6258557827460214fe5360d3f2b30eaa25e46f9a08cf0e42f9434ae9cd8a7
+updated: 2016-09-28T12:53:42.621983921-07:00
 imports:
 - name: github.com/apache/thrift
-  version: 2df9c20dc76c044e502861a2111b90cbdcbbb957
+  version: 8ccf5a645c8e34e0abb6f31b216dbf77f0ac2a43
   subpackages:
   - lib/go/thrift
 - name: github.com/crossdock/crossdock-go
@@ -18,6 +18,10 @@ imports:
   version: bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
   subpackages:
   - gomock
+- name: github.com/golang/protobuf
+  version: 87c000235d3d852c1628dc9490cd21ab36a7d69f
+  subpackages:
+  - proto
 - name: github.com/opentracing/opentracing-go
   version: 0c3154a3c2ce79d3271985848659870599dfb77c
   subpackages:
@@ -72,8 +76,25 @@ imports:
   subpackages:
   - context
   - context/ctxhttp
+  - http2
+  - http2/hpack
+  - idna
+  - internal/timeseries
+  - lex/httplex
+  - trace
 - name: golang.org/x/tools
   version: fc2b74b64ef08c618146ebc92062f6499db5314c
   subpackages:
   - go/ast/astutil
+- name: google.golang.org/grpc
+  version: 0032a855ba5c8a3c8e0d71c2deef354b70af1584
+  subpackages:
+  - codes
+  - credentials
+  - grpclog
+  - internal
+  - metadata
+  - naming
+  - peer
+  - transport
 testImports: []

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 54f6258557827460214fe5360d3f2b30eaa25e46f9a08cf0e42f9434ae9cd8a7
-updated: 2016-09-28T12:53:42.621983921-07:00
+hash: dd2f75e3a8d86f54baa5090f3f777c1db5320afcb6c0e3b3ce5766bcc2dae70b
+updated: 2016-09-28T18:27:48.799105702-07:00
 imports:
 - name: github.com/apache/thrift
   version: 8ccf5a645c8e34e0abb6f31b216dbf77f0ac2a43
@@ -72,7 +72,7 @@ imports:
   - trand
   - typed
 - name: golang.org/x/net
-  version: f09c4662a0bd6bd8943ac7b4931e185df9471da4
+  version: 9f0e377a8a39bb99ff03459d77c135a0042878f0
   subpackages:
   - context
   - context/ctxhttp

--- a/glide.yaml
+++ b/glide.yaml
@@ -23,5 +23,6 @@ import:
 - package: github.com/crossdock/crossdock-go
   version: master
 - package: github.com/uber-go/atomic
-- package: google.golang.org/grpc
   version: ^1.0.0
+- package: google.golang.org/grpc
+  version: ^1

--- a/glide.yaml
+++ b/glide.yaml
@@ -23,4 +23,5 @@ import:
 - package: github.com/crossdock/crossdock-go
   version: master
 - package: github.com/uber-go/atomic
+- package: google.golang.org/grpc
   version: ^1.0.0

--- a/transport/grpc/codec.go
+++ b/transport/grpc/codec.go
@@ -1,0 +1,29 @@
+package grpc
+
+import "fmt"
+
+// PassThroughCodec passes bytes to/from the wire without modification
+type PassThroughCodec struct{}
+
+// Marshal takes a []byte pointer and passes it through as a []byte
+func (PassThroughCodec) Marshal(v interface{}) ([]byte, error) {
+	bs, ok := v.(*[]byte)
+	if !ok {
+		return nil, fmt.Errorf("expected sender of type *[]byte but got %T", v)
+	}
+	return *(bs), nil
+}
+
+// Unmarshal takes a byte slice and writes it to v
+func (PassThroughCodec) Unmarshal(data []byte, v interface{}) error {
+	bs, ok := v.(*[]byte)
+	if !ok {
+		return fmt.Errorf("expected receiver of type *[]byte but got %T", v)
+	}
+	*bs = data
+	return nil
+}
+
+func (PassThroughCodec) String() string {
+	return "raw"
+}

--- a/transport/grpc/codec.go
+++ b/transport/grpc/codec.go
@@ -25,5 +25,5 @@ func (PassThroughCodec) Unmarshal(data []byte, v interface{}) error {
 }
 
 func (PassThroughCodec) String() string {
-	return "raw"
+	return "passthrough"
 }

--- a/transport/grpc/codec_test.go
+++ b/transport/grpc/codec_test.go
@@ -1,0 +1,58 @@
+package grpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPassThroughCodecMarshal(t *testing.T) {
+	codec := PassThroughCodec{}
+	strMsg := "this is a test"
+	byteSender := []byte(strMsg)
+
+	result, err := codec.Marshal(&byteSender)
+
+	assert.Equal(t, strMsg, string(result))
+	assert.Equal(t, error(nil), err)
+}
+
+func TestPassThroughCodecMarshalError(t *testing.T) {
+	codec := PassThroughCodec{}
+	strMsg := "this is a test"
+
+	result, err := codec.Marshal(&strMsg)
+
+	assert.Equal(t, []byte(nil), result)
+	assert.Equal(t, "expected sender of type *[]byte but got *string", err.Error())
+}
+
+func TestPassThroughCodecUnmarshal(t *testing.T) {
+	codec := PassThroughCodec{}
+	strMsg := "this is a test"
+	data := []byte(strMsg)
+	var receiver []byte
+
+	err := codec.Unmarshal(data, &receiver)
+
+	assert.Equal(t, strMsg, string(receiver))
+	assert.Equal(t, error(nil), err)
+}
+
+func TestPassThroughCodecUnmarshalError(t *testing.T) {
+	codec := PassThroughCodec{}
+	strMsg := "this is a test"
+	data := []byte(strMsg)
+	var receiver string
+
+	err := codec.Unmarshal(data, &receiver)
+
+	assert.Equal(t, "", receiver)
+	assert.Equal(t, "expected receiver of type *[]byte but got *string", err.Error())
+}
+
+func TestPassThroughCodecString(t *testing.T) {
+	codec := PassThroughCodec{}
+
+	assert.Equal(t, "raw", codec.String())
+}

--- a/transport/grpc/codec_test.go
+++ b/transport/grpc/codec_test.go
@@ -54,5 +54,5 @@ func TestPassThroughCodecUnmarshalError(t *testing.T) {
 func TestPassThroughCodecString(t *testing.T) {
 	codec := PassThroughCodec{}
 
-	assert.Equal(t, "raw", codec.String())
+	assert.Equal(t, "passthrough", codec.String())
 }

--- a/transport/grpc/constants.go
+++ b/transport/grpc/constants.go
@@ -5,6 +5,9 @@ const (
 	// the wire.
 	ApplicationHeaderPrefix = "rpc-header-"
 
+	// BaggageHeaderPrefix is the prefix added to context headers over the wire.
+	BaggageHeaderPrefix = "context-"
+
 	// CallerHeader is the HTTP header used to indiate the service doing the calling
 	CallerHeader = "rpc-caller"
 

--- a/transport/grpc/constants.go
+++ b/transport/grpc/constants.go
@@ -1,0 +1,10 @@
+package grpc
+
+const (
+	// CallerHeader is the HTTP header used to indiate the service doing the calling
+	CallerHeader = "rpc-caller"
+
+	// EncodingHeader is the HTTP header used to specify the name of the
+	// encoding (raw, json, thrift, etc).
+	EncodingHeader = "rpc-encoding"
+)

--- a/transport/grpc/constants.go
+++ b/transport/grpc/constants.go
@@ -1,6 +1,10 @@
 package grpc
 
 const (
+	// ApplicationHeaderPrefix is the prefix added to application headers over
+	// the wire.
+	ApplicationHeaderPrefix = "rpc-header-"
+
 	// CallerHeader is the HTTP header used to indiate the service doing the calling
 	CallerHeader = "rpc-caller"
 

--- a/transport/grpc/handler.go
+++ b/transport/grpc/handler.go
@@ -1,0 +1,154 @@
+package grpc
+
+import (
+	"bytes"
+	"time"
+
+	"github.com/yarpc/yarpc-go/transport"
+	"github.com/yarpc/yarpc-go/transport/internal"
+
+	"strings"
+
+	"fmt"
+
+	"io"
+
+	"errors"
+
+	"net/url"
+
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	gtransport "google.golang.org/grpc/transport"
+)
+
+var grpcOptions transport.Options
+
+type handler struct {
+	Handler transport.Handler
+	Deps    transport.Deps
+}
+
+// Handle the grpc request and convert it into a YARPC request
+// dec ('decode') will pass through the request body in raw bytes using the PassThroughCodec
+func (h handler) Handle(
+	srv interface{},
+	ctx context.Context,
+	dec func(interface{}) error,
+	interceptor grpc.UnaryServerInterceptor,
+) (interface{}, error) {
+	treq, extractErr := getTRequest(ctx, dec)
+	if extractErr != nil {
+		return nil, extractErr
+	}
+
+	// TODO handle deadlines
+	// TODO handle validation
+
+	start := time.Now()
+
+	return callHandler(h, start, ctx, treq)
+}
+
+func getTRequest(ctx context.Context, msgBodyDecoder func(interface{}) error) (*transport.Request, error) {
+	service, procedure, err := getServiceAndProcedure(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	requestBody, err := getMsgBody(msgBodyDecoder)
+	if err != nil {
+		return nil, err
+	}
+
+	treq := &transport.Request{
+		Service:   service,
+		Procedure: procedure,
+		Caller:    "yarpc",
+		Encoding:  transport.Encoding("raw"),
+		Body:      requestBody,
+	}
+
+	return treq, nil
+}
+
+func getServiceAndProcedure(ctx context.Context) (service, procedure string, err error) {
+	stream, ok := gtransport.StreamFromContext(ctx)
+	if !ok {
+		return "", "", errors.New("Could not extract stream information from context")
+	}
+
+	streamMethod := stream.Method()
+
+	return getServiceAndProcedureFromMethod(streamMethod)
+}
+
+func getServiceAndProcedureFromMethod(streamMethod string) (service, procedure string, err error) {
+	if streamMethod != "" && streamMethod[0] == '/' {
+		streamMethod = streamMethod[1:]
+	}
+	splitPos := strings.LastIndex(streamMethod, "/")
+
+	service, err = url.QueryUnescape(streamMethod[:splitPos])
+	if err != nil {
+		return "", "", fmt.Errorf("Could not parse service for request: %s, error: %v", streamMethod[:splitPos], err)
+	}
+
+	procedure, err = url.QueryUnescape(streamMethod[splitPos+1:])
+	if err != nil {
+		return "", "", fmt.Errorf("Could not parse procedure for request: %s, error: %v", streamMethod[splitPos+1:], err)
+	}
+	return
+}
+
+func getMsgBody(msgBodyDecoder func(interface{}) error) (io.Reader, error) {
+	var requestBody []byte
+	if err := msgBodyDecoder(&requestBody); err != nil {
+		return nil, err
+	}
+
+	requestBodyBuffer := bytes.NewBuffer(requestBody)
+
+	return requestBodyBuffer, nil
+}
+
+func callHandler(
+	h handler,
+	start time.Time,
+	ctx context.Context,
+	treq *transport.Request,
+) (interface{}, error) {
+	var r response
+	rw := newResponseWriter(&r)
+
+	err := internal.SafelyCallHandler(h.Handler, start, ctx, grpcOptions, treq, rw)
+
+	responseBody := r.body.Bytes()
+	return &responseBody, err
+}
+
+// The response object contains response information from the YARPC handler
+type response struct {
+	body bytes.Buffer
+}
+
+// Wrapper to control writes to the response object
+type responseWriter struct {
+	r *response
+}
+
+func newResponseWriter(r *response) responseWriter {
+	return responseWriter{r: r}
+}
+
+func (rw responseWriter) Write(s []byte) (int, error) {
+	return rw.r.body.Write(s)
+}
+
+func (rw responseWriter) AddHeaders(h transport.Headers) {
+	// TODO support Headers
+}
+
+func (responseWriter) SetApplicationError() {
+	// Nothing to do.
+}

--- a/transport/grpc/handler.go
+++ b/transport/grpc/handler.go
@@ -19,6 +19,7 @@ import (
 
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 	gtransport "google.golang.org/grpc/transport"
 )
 
@@ -56,6 +57,21 @@ func getTRequest(ctx context.Context, msgBodyDecoder func(interface{}) error) (*
 		return nil, err
 	}
 
+	ctxMetadata, err := getContextMetadata(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	caller, err := getCaller(ctxMetadata)
+	if err != nil {
+		return nil, err
+	}
+
+	encoding, err := getEncoding(ctxMetadata)
+	if err != nil {
+		return nil, err
+	}
+
 	requestBody, err := getMsgBody(msgBodyDecoder)
 	if err != nil {
 		return nil, err
@@ -64,8 +80,8 @@ func getTRequest(ctx context.Context, msgBodyDecoder func(interface{}) error) (*
 	treq := &transport.Request{
 		Service:   service,
 		Procedure: procedure,
-		Caller:    "yarpc",
-		Encoding:  transport.Encoding("raw"),
+		Caller:    caller,
+		Encoding:  transport.Encoding(encoding),
 		Body:      requestBody,
 	}
 
@@ -99,6 +115,35 @@ func getServiceAndProcedureFromMethod(streamMethod string) (service, procedure s
 		return "", "", fmt.Errorf("Could not parse procedure for request: %s, error: %v", streamMethod[splitPos+1:], err)
 	}
 	return
+}
+
+func getContextMetadata(ctx context.Context) (metadata.MD, error) {
+	contextMetadata, ok := metadata.FromContext(ctx)
+	if !ok || contextMetadata == nil {
+		return nil, errors.New("Could not extract metadata information from context")
+	}
+	return contextMetadata, nil
+}
+
+func getCaller(ctxMetadata metadata.MD) (string, error) {
+	// TODO Make a gRPC outbounds require a header for caller and enforce it at inbounds
+	return extractMetadataHeader(ctxMetadata, CallerHeader)
+}
+
+func getEncoding(ctxMetadata metadata.MD) (string, error) {
+	// TODO Add a pull request to gRPC to add encoding via content-type to contexts so we don't have to set it manually ourselves
+	return extractMetadataHeader(ctxMetadata, EncodingHeader)
+}
+
+func extractMetadataHeader(ctxMetadata metadata.MD, header string) (string, error) {
+	headerList, ok := ctxMetadata[header]
+	if !ok {
+		return "", fmt.Errorf("Couldn't extract header:(%s) from Context Metadata (%v)", header, ctxMetadata)
+	}
+	if len(headerList) != 1 {
+		return "", fmt.Errorf("Invalid number of headers for %s, expected 1, got %d", header, len(headerList))
+	}
+	return headerList[0], nil
 }
 
 func getMsgBody(msgBodyDecoder func(interface{}) error) (io.Reader, error) {

--- a/transport/grpc/handler_test.go
+++ b/transport/grpc/handler_test.go
@@ -3,10 +3,13 @@ package grpc
 import (
 	"testing"
 
+	"google.golang.org/grpc/metadata"
+
 	"fmt"
 	"net/url"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/yarpc/yarpc-go/transport"
 )
 
 func TestGetServiceAndProcedureFromMethod_Base(t *testing.T) {
@@ -70,4 +73,33 @@ func TestResponseWriter_Write(t *testing.T) {
 	assert.Equal(t, len(byteMsg), changed)
 	assert.Equal(t, error(nil), err)
 	assert.Equal(t, strMsg, string(r.body.Bytes()))
+}
+
+func TestResponseWriter_AddHeaders(t *testing.T) {
+	caller := "teeeeest"
+	encoding := "raw"
+	inputHeaders := transport.HeadersFromMap(map[string]string{
+		CallerHeader:   caller,
+		EncodingHeader: encoding,
+	})
+	expectedHeaders := metadata.New(map[string]string{
+		ApplicationHeaderPrefix + CallerHeader:   caller,
+		ApplicationHeaderPrefix + EncodingHeader: encoding,
+	})
+
+	var r response
+	rw := newResponseWriter(&r)
+
+	rw.AddHeaders(inputHeaders)
+
+	assert.Equal(t, expectedHeaders, r.headers)
+}
+
+func TestResponseWriter_SetApplicationError(t *testing.T) {
+	var r response
+	rw := newResponseWriter(&r)
+
+	rw.SetApplicationError()
+
+	// No action on Application Error
 }

--- a/transport/grpc/handler_test.go
+++ b/transport/grpc/handler_test.go
@@ -1,0 +1,73 @@
+package grpc
+
+import (
+	"testing"
+
+	"fmt"
+	"net/url"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetServiceAndProcedureFromMethod_Base(t *testing.T) {
+	method := "foo/bar"
+
+	service, procedure, err := getServiceAndProcedureFromMethod(method)
+
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "foo", service)
+	assert.Equal(t, "bar", procedure)
+}
+
+func TestGetServiceAndProcedureFromMethod_ExtraSlash(t *testing.T) {
+	method := "/foo/bar"
+
+	service, procedure, err := getServiceAndProcedureFromMethod(method)
+
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "foo", service)
+	assert.Equal(t, "bar", procedure)
+}
+
+func TestGetServiceAndProcedureFromMethod_URLEncoded(t *testing.T) {
+	expectedService := "foo/la"
+	expectedProcedure := "bar/moo"
+	method := fmt.Sprintf("/%s/%s", url.QueryEscape(expectedService), url.QueryEscape(expectedProcedure))
+
+	service, procedure, err := getServiceAndProcedureFromMethod(method)
+
+	assert.Equal(t, nil, err)
+	assert.Equal(t, expectedService, service)
+	assert.Equal(t, expectedProcedure, procedure)
+}
+
+func TestGetServiceAndProcedureFromMethod_ServiceDecodeError(t *testing.T) {
+	invalidService := "foo%"
+	method := fmt.Sprintf("/%s/bar", invalidService)
+
+	_, _, err := getServiceAndProcedureFromMethod(method)
+
+	assert.NotNil(t, err, "Invalid service encoding did not cause an error")
+}
+
+func TestGetServiceAndProcedureFromMethod_ProcedureDecodeError(t *testing.T) {
+	invalidProcedure := "bar%"
+	method := fmt.Sprintf("/foo/%s", invalidProcedure)
+
+	_, _, err := getServiceAndProcedureFromMethod(method)
+
+	assert.NotNil(t, err, "Invalid procedure encoding did not cause an error")
+}
+
+func TestResponseWriter_Write(t *testing.T) {
+	strMsg := "this is a test"
+	byteMsg := []byte(strMsg)
+	var r response
+	rw := newResponseWriter(&r)
+
+	changed, err := rw.Write(byteMsg)
+
+	assert.Equal(t, len(byteMsg), changed)
+	assert.Equal(t, error(nil), err)
+	assert.Equal(t, strMsg, string(r.body.Bytes()))
+}

--- a/transport/grpc/header.go
+++ b/transport/grpc/header.go
@@ -1,0 +1,85 @@
+package grpc
+
+import (
+	"strings"
+
+	"github.com/yarpc/yarpc-go/transport"
+	"google.golang.org/grpc/metadata"
+)
+
+// headerMapper converts gRCP Metadata to and from transport headers.
+type headerMapper struct{ Prefix string }
+
+var (
+	applicationHeaders = headerMapper{ApplicationHeaderPrefix}
+)
+
+// toGRPCMetadata converts transport headers into gRPC Metadata.
+//
+// Headers are read from 'from' and written to 'to'. The final header collection
+// is returned.
+//
+// If 'to' is nil, a new map will be assigned.
+func (hm headerMapper) ToGRPCMetadata(from transport.Headers, to metadata.MD) metadata.MD {
+	if to == nil {
+		to = make(metadata.MD, from.Len())
+	}
+	for k, v := range from.Items() {
+		Headers(to).Add(hm.Prefix+k, v)
+	}
+	return to
+}
+
+// fromGRPCMetadata converts GRPC Metadata to transport headers.
+//
+// Headers are read from 'from' and written to 'to'. The final header collection
+// is returned.
+//
+// If 'to' is nil, a new map will be assigned.
+func (hm headerMapper) FromGRPCMetadata(from metadata.MD, to transport.Headers) transport.Headers {
+	prefixLen := len(hm.Prefix)
+	for k := range from {
+		if strings.HasPrefix(k, hm.Prefix) {
+			key := k[prefixLen:]
+			to = to.With(key, Headers(from).Get(k))
+		}
+		// Note: undefined behavior for multiple occurrences of the same header
+	}
+	return to
+}
+
+// Headers is a convenience type for converting Header information safely
+type Headers map[string][]string
+
+// Add adds the key, value pair to the header.
+// It appends to any existing values associated with key.
+func (h Headers) Add(key, value string) {
+	h[key] = append(h[key], value)
+}
+
+// Set sets the header entries associated with key to
+// the single element value. It replaces any existing
+// values associated with key.
+func (h Headers) Set(key, value string) {
+	h[key] = []string{value}
+}
+
+// Get gets the first value associated with the given key.
+// If there are no values associated with the key, Get returns "".
+// Get is a convenience method. For more complex queries,
+// access the map directly.
+func (h Headers) Get(key string) string {
+	if h == nil {
+		return ""
+	}
+	v := h[key]
+	if len(v) == 0 {
+		return ""
+	}
+	return v[0]
+}
+
+// Del deletes the values associated with key.
+func (h Headers) Del(key string) {
+	delete(h, key)
+}

--- a/transport/grpc/header.go
+++ b/transport/grpc/header.go
@@ -12,6 +12,7 @@ type headerMapper struct{ Prefix string }
 
 var (
 	applicationHeaders = headerMapper{ApplicationHeaderPrefix}
+	baggageHeaders     = headerMapper{BaggageHeaderPrefix}
 )
 
 // toGRPCMetadata converts transport headers into gRPC Metadata.

--- a/transport/grpc/header_test.go
+++ b/transport/grpc/header_test.go
@@ -1,0 +1,129 @@
+package grpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/yarpc/yarpc-go/transport"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestHeaderMapper_ToGRPCMetadata(t *testing.T) {
+	prefix := "test-"
+	testMapper := headerMapper{prefix}
+
+	inputHeaders := transport.HeadersFromMap(map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+	})
+	expectedMetadata := metadata.New(map[string]string{
+		"key":           "value",
+		prefix + "key1": "value1",
+		prefix + "key2": "value2",
+	})
+
+	md := metadata.New(map[string]string{
+		"key": "value",
+	})
+	actualMetadata := testMapper.ToGRPCMetadata(inputHeaders, md)
+
+	assert.Equal(t, expectedMetadata, actualMetadata)
+}
+
+func TestHeaderMapper_ToGRPCMetadata_fromNil(t *testing.T) {
+	prefix := "test-"
+	testMapper := headerMapper{prefix}
+
+	inputHeaders := transport.HeadersFromMap(map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+	})
+	expectedMetadata := metadata.New(map[string]string{
+		prefix + "key1": "value1",
+		prefix + "key2": "value2",
+	})
+
+	actualMetadata := testMapper.ToGRPCMetadata(inputHeaders, nil)
+
+	assert.Equal(t, expectedMetadata, actualMetadata)
+}
+
+func TestHeaderMapper_FromGRPCMetadata(t *testing.T) {
+	prefix := "test-"
+	testMapper := headerMapper{prefix}
+
+	inputMetadata := metadata.New(map[string]string{
+		"key":           "value",
+		prefix + "key1": "value1",
+		prefix + "key2": "value2",
+	})
+	expectedHeaders := transport.HeadersFromMap(map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+	})
+
+	actualHeaders := testMapper.FromGRPCMetadata(inputMetadata, transport.Headers{})
+
+	assert.Equal(t, expectedHeaders, actualHeaders)
+}
+
+func TestHeaders_Add(t *testing.T) {
+	headers := Headers{}
+	headers["key1"] = []string{"value1"}
+	headers["key2"] = []string{"value2"}
+
+	headers.Add("testkey", "testvalue")
+
+	assert.Equal(t, "value1", headers["key1"][0])
+	assert.Equal(t, "value2", headers["key2"][0])
+	assert.Equal(t, "testvalue", headers["testkey"][0])
+}
+
+func TestHeaders_Del(t *testing.T) {
+	headers := Headers{}
+	headers["key1"] = []string{"value1"}
+	headers["key2"] = []string{"value2"}
+
+	headers.Del("key2")
+
+	assert.Equal(t, 1, len(headers))
+	assert.Equal(t, "value1", headers["key1"][0])
+	assert.Equal(t, []string(nil), headers["key2"])
+}
+
+func TestHeaders_Get(t *testing.T) {
+	headers := Headers{}
+	headers["key1"] = []string{"value1"}
+	headers["key2"] = []string{"value2"}
+
+	value := headers.Get("key2")
+
+	assert.Equal(t, "value2", value)
+}
+
+func TestHeaders_Get_Nil(t *testing.T) {
+	headers := Headers(nil)
+
+	value := headers.Get("key2")
+
+	assert.Equal(t, "", value)
+}
+
+func TestHeaders_Get_EmptyList(t *testing.T) {
+	headers := Headers{}
+	headers["key1"] = []string{}
+
+	value := headers.Get("key1")
+
+	assert.Equal(t, "", value)
+}
+
+func TestHeaders_Set(t *testing.T) {
+	headers := Headers{}
+	headers["key1"] = []string{"value1"}
+	headers["key2"] = []string{"value2"}
+
+	headers.Set("key2", "newValue")
+
+	assert.Equal(t, []string{"newValue"}, headers["key2"])
+}

--- a/transport/grpc/inbound.go
+++ b/transport/grpc/inbound.go
@@ -1,0 +1,94 @@
+package grpc
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/yarpc/yarpc-go/transport"
+
+	"net/url"
+
+	"google.golang.org/grpc"
+)
+
+// Inbound is a gRPC Inbound.
+type Inbound interface {
+	transport.Inbound
+
+	Server() *grpc.Server
+}
+
+// NewInbound builds a new gRPC Inbound.
+func NewInbound(port int) Inbound {
+	i := &inbound{port: port}
+	return i
+}
+
+type inbound struct {
+	port   int
+	server *grpc.Server
+}
+
+func (i *inbound) Server() *grpc.Server {
+	if i.server == nil {
+		return nil
+	}
+	return i.server
+}
+
+// gRPC expects a service and a server to have the same interface when it's configured.
+// For our purposes, we are faking the interfaces and forwarding all requests directly to
+// the YARPC gRPC Handle instead
+type passThroughService interface{}
+type passThroughServer struct{}
+
+func (i *inbound) Start(h transport.Handler, d transport.Deps) error {
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%v", i.port))
+	if err != nil {
+		return err
+	}
+
+	// Use a codec that passes through the bytes from gRPC requests to YARPC encoders
+	// TODO customize the Codec.String() function which is used for the Content-Type header
+	i.server = grpc.NewServer(grpc.CustomCodec(PassThroughCodec{}))
+
+	gHandler := handler{
+		Handler: h,
+		Deps:    d,
+	}
+
+	var serviceDescs []grpc.ServiceDesc
+
+	// TODO generate serviceDescs from yarpc registration info
+	serviceDescs = append(serviceDescs, grpc.ServiceDesc{
+		ServiceName: url.QueryEscape("yarpc"),
+		HandlerType: (*passThroughService)(nil),
+		Methods: []grpc.MethodDesc{
+			{
+				MethodName: url.QueryEscape("yarpc"), // TODO: Is this what we want here?
+				Handler:    gHandler.Handle,          // grpc.methodHandler
+			},
+		},
+		Streams: []grpc.StreamDesc{},
+	})
+
+	// TODO Generate the serviceDesc from the configuration of the dispatcher name and procedure names
+
+	// Register Services
+	for _, desc := range serviceDescs {
+		i.server.RegisterService(&desc, passThroughServer{})
+	}
+
+	// TODO should block until ready to accept requests
+	go i.server.Serve(lis)
+
+	return nil
+}
+
+func (i *inbound) Stop() error {
+	if i.server == nil {
+		return nil
+	}
+	i.server.GracefulStop()
+	return nil
+}

--- a/transport/grpc/inbound.go
+++ b/transport/grpc/inbound.go
@@ -58,21 +58,19 @@ func (i *inbound) Start(h transport.Handler, d transport.Deps) error {
 	}
 
 	var serviceDescs []grpc.ServiceDesc
+	if reg, ok := h.(transport.Registry); ok {
+		serviceProcedures := make(map[string][]string)
+		for _, sp := range reg.ServiceProcedures() {
+			serviceProcedures[sp.Service] = append(serviceProcedures[sp.Service], sp.Procedure)
+		}
 
-	// TODO generate serviceDescs from yarpc registration info
-	serviceDescs = append(serviceDescs, grpc.ServiceDesc{
-		ServiceName: url.QueryEscape("yarpc"),
-		HandlerType: (*passThroughService)(nil),
-		Methods: []grpc.MethodDesc{
-			{
-				MethodName: url.QueryEscape("yarpc"), // TODO: Is this what we want here?
-				Handler:    gHandler.Handle,          // grpc.methodHandler
-			},
-		},
-		Streams: []grpc.StreamDesc{},
-	})
-
-	// TODO Generate the serviceDesc from the configuration of the dispatcher name and procedure names
+		for service, procs := range serviceProcedures {
+			serviceDescs = append(serviceDescs, *createServiceDesc(gHandler, service, procs))
+		}
+	} else {
+		// Called with a plain Handler instead of Dispatcher. Fall back to no meaningful service description.
+		serviceDescs = append(serviceDescs, *createServiceDesc(gHandler, "yarpc", []string{"yarpc"}))
+	}
 
 	// Register Services
 	for _, desc := range serviceDescs {
@@ -83,6 +81,23 @@ func (i *inbound) Start(h transport.Handler, d transport.Deps) error {
 	go i.server.Serve(lis)
 
 	return nil
+}
+
+func createServiceDesc(gHandler handler, service string, procedures []string) *grpc.ServiceDesc {
+	methodDescs := make([]grpc.MethodDesc, 0, len(procedures))
+	for _, proc := range procedures {
+		methodDescs = append(methodDescs, grpc.MethodDesc{
+			MethodName: url.QueryEscape(proc),
+			Handler:    gHandler.Handle,
+		})
+	}
+
+	return &grpc.ServiceDesc{
+		ServiceName: url.QueryEscape(service),
+		HandlerType: (*passThroughService)(nil),
+		Methods:     methodDescs,
+		Streams:     []grpc.StreamDesc{},
+	}
 }
 
 func (i *inbound) Stop() error {

--- a/transport/grpc/inbound_test.go
+++ b/transport/grpc/inbound_test.go
@@ -1,0 +1,56 @@
+package grpc
+
+import (
+	"net"
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yarpc/yarpc-go/transport"
+	"github.com/yarpc/yarpc-go/transport/transporttest"
+)
+
+func TestStartAddrInUse(t *testing.T) {
+	i1 := NewInbound(50099)
+	i2 := NewInbound(50099)
+
+	require.NoError(t, i1.Start(new(transporttest.MockHandler), transport.NoDeps))
+	err := i2.Start(new(transporttest.MockHandler), transport.NoDeps)
+
+	require.Error(t, err)
+	opErr, ok := err.(*net.OpError)
+	assert.True(t, ok && opErr.Op == "listen", "expected a listen error")
+	if ok {
+		sysErr, ok := opErr.Err.(*os.SyscallError)
+		assert.True(t, ok && sysErr.Syscall == "bind" && sysErr.Err == syscall.EADDRINUSE, "expected a EADDRINUSE bind error")
+	}
+
+	assert.NoError(t, i1.Stop())
+}
+
+func TestInboundStartAndStop(t *testing.T) {
+	i := NewInbound(0)
+
+	require.NoError(t, i.Start(new(transporttest.MockHandler), transport.NoDeps))
+
+	serviceInfo := i.Server().GetServiceInfo()
+	assert.Equal(t, 1, len(serviceInfo["yarpc"].Methods))
+	assert.Equal(t, "yarpc", serviceInfo["yarpc"].Methods[0].Name)
+
+	assert.NoError(t, i.Stop())
+}
+
+func TestInboundStartError(t *testing.T) {
+	err := NewInbound(-100).Start(new(transporttest.MockHandler), transport.NoDeps)
+	// Verify that two inbounds started on the same port
+	assert.Error(t, err, "expected failure")
+}
+
+func TestInboundStopWithoutStarting(t *testing.T) {
+	i := NewInbound(8000)
+
+	assert.Nil(t, i.Server())
+	assert.NoError(t, i.Stop())
+}

--- a/transport/grpc/outbound.go
+++ b/transport/grpc/outbound.go
@@ -9,6 +9,7 @@ import (
 
 	"net/url"
 
+	"github.com/yarpc/yarpc-go/internal/baggage"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -65,6 +66,10 @@ func getRequestHeaders(ctx context.Context, req *transport.Request) metadata.MD 
 	})
 
 	md = applicationHeaders.ToGRPCMetadata(req.Headers, md)
+
+	if bagHeaders := baggage.FromContext(ctx); bagHeaders.Len() > 0 {
+		md = baggageHeaders.ToGRPCMetadata(bagHeaders, md)
+	}
 
 	return md
 }

--- a/transport/grpc/outbound.go
+++ b/transport/grpc/outbound.go
@@ -1,0 +1,72 @@
+package grpc
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/yarpc/yarpc-go/transport"
+
+	"net/url"
+
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+)
+
+// NewOutbound builds a new GRPC outbound.
+func NewOutbound(address string) transport.Outbound {
+	return &outbound{address: address}
+}
+
+type outbound struct {
+	address string
+	conn    *grpc.ClientConn
+}
+
+func (o *outbound) Start(d transport.Deps) error {
+	conn, err := grpc.Dial(o.address, grpc.WithInsecure(), grpc.WithCodec(PassThroughCodec{}))
+	if err != nil {
+		return err
+	}
+	o.conn = conn
+
+	return nil
+}
+
+func (o *outbound) Stop() error {
+	o.conn.Close()
+	return nil
+}
+
+func (outbound) Options() (o transport.Options) {
+	return o
+}
+
+func (o outbound) Call(ctx context.Context, req *transport.Request) (*transport.Response, error) {
+	requestBody, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	uri := fmt.Sprintf("/%s/%s", url.QueryEscape(req.Service), url.QueryEscape(req.Procedure))
+
+	return callDownstream(ctx, uri, &requestBody, o.conn)
+}
+
+func callDownstream(
+	ctx context.Context,
+	uri string,
+	requestBody *[]byte,
+	connection *grpc.ClientConn,
+) (*transport.Response, error) {
+	var responseBody []byte
+
+	if err := grpc.Invoke(ctx, uri, requestBody, &responseBody, connection); err != nil {
+		return nil, err
+	}
+
+	buf := bytes.NewBuffer(responseBody)
+	closer := ioutil.NopCloser(buf)
+
+	return &transport.Response{Body: closer}, nil
+}

--- a/transport/grpc/outbound.go
+++ b/transport/grpc/outbound.go
@@ -11,6 +11,7 @@ import (
 
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 )
 
 // NewOutbound builds a new GRPC outbound.
@@ -48,9 +49,22 @@ func (o outbound) Call(ctx context.Context, req *transport.Request) (*transport.
 		return nil, err
 	}
 
+	metadataHeaders := getRequestHeaders(ctx, req)
+	ctx = metadata.NewContext(ctx, metadataHeaders)
+
 	uri := fmt.Sprintf("/%s/%s", url.QueryEscape(req.Service), url.QueryEscape(req.Procedure))
 
 	return callDownstream(ctx, uri, &requestBody, o.conn)
+}
+
+func getRequestHeaders(ctx context.Context, req *transport.Request) metadata.MD {
+	// 'Headers' in gRPC are known as 'Metadata'
+	md := metadata.New(map[string]string{
+		CallerHeader:   req.Caller,
+		EncodingHeader: string(req.Encoding),
+	})
+
+	return md
 }
 
 func callDownstream(


### PR DESCRIPTION
Summary: Adds support for Baggage Headers in GRPC by storing/grabbing them on the
context on inbounds and outbounds.  Added the crossdock configuration
required for the change as well.  Unfortunately I needed to move the
dispatcher.Start() in the ctxpropagation behaviour to be after the
registers on that same dispatcher (not sure if that's a behaviour we
want to support).

Test Plan: Added crossdock tests, ran yclient/yserver with baggage