### PR TITLE
Drop support for Go 1.5 and 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,6 @@ matrix:
     # Tests
     #
     # Need virtualenv for example tests
-    - go: 1.5
-      env: TYPE=test
-      addons: {apt: {packages: [python-virtualenv]}}
-    - go: 1.6
-      env: TYPE=test
-      addons: {apt: {packages: [python-virtualenv]}}
     - go: 1.7
       env: TYPE=test
       addons: {apt: {packages: [python-virtualenv]}}


### PR DESCRIPTION
This removes support for Go 1.5 and 1.6. 

Once we know exactly what customers are using in production, 
we can remove switch the use of `golang.org/x/net/context` for 
the `context` package.