### PR TITLE
Remove call to Github API to get current branch name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,8 +98,8 @@ after_success:
   case "$TYPE" in
     crossdock)
       export REPO=yarpc/yarpc-go
-      export TAG=`if [ "$TRAVIS_PULL_REQUEST_BRANCH" == "master" ]; then echo "latest"; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi`
-
+      export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
+      export TAG=`if [ "$BRANCH" == "master" ]; then echo "latest"; else echo $BRANCH; fi`
       docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       docker build -f Dockerfile -t $REPO:$COMMIT .
       docker tag $REPO:$COMMIT $REPO:$TAG

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,9 +98,7 @@ after_success:
   case "$TYPE" in
     crossdock)
       export REPO=yarpc/yarpc-go
-      export PR=https://api.github.com/repos/$TRAVIS_REPO_SLUG/pulls/$TRAVIS_PULL_REQUEST
-      export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo `curl -s $PR | jq -r .head.ref`; fi)
-      export TAG=`if [ "$BRANCH" == "master" ]; then echo "latest"; else echo $BRANCH; fi`
+      export TAG=`if [ "$TRAVIS_PULL_REQUEST_BRANCH" == "master" ]; then echo "latest"; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi`
 
       docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       docker build -f Dockerfile -t $REPO:$COMMIT .

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,6 @@ matrix:
 before_install:
 - go version
 - |
-  set -ex
   case "$TYPE" in
     crossdock)
       docker version
@@ -56,11 +55,9 @@ before_install:
       docker-compose version
       ;;
   esac
-  set +ex
 
 install:
 - |
-  set -ex
   make install
   case "$TYPE" in
     lint)
@@ -75,7 +72,6 @@ install:
 
 script:
 - |
-  set -ex
   case "$TYPE" in
     lint)
       make lint
@@ -90,7 +86,6 @@ script:
       docker-compose logs
       ;;
   esac
-  set +ex
 
 after_success:
 - |
@@ -99,8 +94,6 @@ after_success:
       export REPO=yarpc/yarpc-go
       export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
       export TAG=`if [ "$BRANCH" == "master" ]; then echo "latest"; else echo $BRANCH; fi`
-
-      echo "TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST, TRAVIS_BRANCH=$TRAVIS_BRANCH, TRAVIS_PULL_REQUEST_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH, BRANCH=$BRANCH, TAG=$TAG"
 
       docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       docker build -f Dockerfile -t $REPO:$COMMIT .

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,21 +94,18 @@ script:
 
 after_success:
 - |
-  set -ex
   case "$TYPE" in
     crossdock)
       export REPO=yarpc/yarpc-go
       export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
       export TAG=`if [ "$BRANCH" == "master" ]; then echo "latest"; else echo $BRANCH; fi`
 
-      set +x
-      docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
-      set -x
+      echo "TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST, TRAVIS_BRANCH=$TRAVIS_BRANCH, TRAVIS_PULL_REQUEST_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH, BRANCH=$BRANCH, TAG=$TAG"
 
+      docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       docker build -f Dockerfile -t $REPO:$COMMIT .
       docker tag $REPO:$COMMIT $REPO:$TAG
       docker tag $REPO:$COMMIT $REPO:travis-$TRAVIS_BUILD_NUMBER
       docker push $REPO
       ;;
   esac
-  set +ex


### PR DESCRIPTION
Now that Travis has shipped https://github.com/travis-ci/travis-ci/issues/1633, we don't need to make a call to the Github API to get the current branch name from both PUSH and PR builds.