### PR TITLE
Add canonical import path to go.uber.org/yarpc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: go
+go_import_path: go.uber.org/yarpc
 
 env:
   global:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Releases
 ========
 
+v0.3.1 (2016-09-31)
+-------------------
+
+-   Fix missing canonical import path to `go.uber.org/yarpc`.
+
+
 v0.3.0 (2016-09-30)
 -------------------
 

--- a/version.go
+++ b/version.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package yarpc
+package yarpc // import "go.uber.org/yarpc"
 
 // Version is the current version of YARPC.
 const Version = "0.3.0"

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package yarpc // import "go.uber.org/yarpc"
 
 // Version is the current version of YARPC.
-const Version = "0.3.0"
+const Version = "0.3.1"


### PR DESCRIPTION
This should be a patch since installing the library from github.com/yarpc/yarpc-go will not work.