### PR TITLE
yarpc.InjectClients: automatic client injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Releases
 v0.4.0 (unreleased)
 -------------------
 
--   No changes yet.
+-   Add `yarpc.InjectClients` to automatically instantiate and inject clients
+    into structs that need them.
 
 
 v0.3.1 (2016-09-31)

--- a/crossdock/thrift/echo/service/echo/echo.go
+++ b/crossdock/thrift/echo/service/echo/echo.go
@@ -26,8 +26,8 @@ package echo
 import (
 	"errors"
 	"fmt"
-	"go.uber.org/yarpc/crossdock/thrift/echo"
 	"go.uber.org/thriftrw/wire"
+	"go.uber.org/yarpc/crossdock/thrift/echo"
 	"strings"
 )
 

--- a/crossdock/thrift/echo/yarpc/echoclient/client.go
+++ b/crossdock/thrift/echo/yarpc/echoclient/client.go
@@ -55,7 +55,7 @@ func New(c transport.Channel, opts ...thrift.ClientOption) Interface {
 }
 
 func init() {
-	yarpc.RegisterClientFactory(func(c transport.Channel) Interface {
+	yarpc.RegisterClientBuilder(func(c transport.Channel) Interface {
 		return New(c)
 	})
 }

--- a/crossdock/thrift/echo/yarpc/echoclient/client.go
+++ b/crossdock/thrift/echo/yarpc/echoclient/client.go
@@ -24,14 +24,14 @@
 package echoclient
 
 import (
-	yarpc "go.uber.org/yarpc"
-	"golang.org/x/net/context"
 	"go.uber.org/thriftrw/protocol"
-	"go.uber.org/thriftrw/wire"
+	"golang.org/x/net/context"
 	"go.uber.org/yarpc/crossdock/thrift/echo"
 	"go.uber.org/yarpc/transport"
 	"go.uber.org/yarpc/encoding/thrift"
 	echo2 "go.uber.org/yarpc/crossdock/thrift/echo/service/echo"
+	"go.uber.org/yarpc"
+	"go.uber.org/thriftrw/wire"
 )
 
 // Interface is a client for the Echo service.
@@ -52,6 +52,12 @@ func New(c transport.Channel, opts ...thrift.ClientOption) Interface {
 		Channel:  c,
 		Protocol: protocol.Binary,
 	}, opts...)}
+}
+
+func init() {
+	yarpc.RegisterClientFactory(func(c transport.Channel) Interface {
+		return New(c)
+	})
 }
 
 type client struct{ c thrift.Client }

--- a/crossdock/thrift/echo/yarpc/echoserver/server.go
+++ b/crossdock/thrift/echo/yarpc/echoserver/server.go
@@ -24,13 +24,13 @@
 package echoserver
 
 import (
-	yarpc "go.uber.org/yarpc"
-	"golang.org/x/net/context"
 	"go.uber.org/thriftrw/protocol"
-	"go.uber.org/thriftrw/wire"
+	"golang.org/x/net/context"
 	"go.uber.org/yarpc/crossdock/thrift/echo"
 	"go.uber.org/yarpc/encoding/thrift"
 	echo2 "go.uber.org/yarpc/crossdock/thrift/echo/service/echo"
+	"go.uber.org/yarpc"
+	"go.uber.org/thriftrw/wire"
 )
 
 // Interface is the server-side interface for the Echo service.

--- a/crossdock/thrift/gauntlet/service/thrifttest/testenum.go
+++ b/crossdock/thrift/gauntlet/service/thrifttest/testenum.go
@@ -26,8 +26,8 @@ package thrifttest
 import (
 	"errors"
 	"fmt"
-	"go.uber.org/yarpc/crossdock/thrift/gauntlet"
 	"go.uber.org/thriftrw/wire"
+	"go.uber.org/yarpc/crossdock/thrift/gauntlet"
 	"strings"
 )
 

--- a/crossdock/thrift/gauntlet/service/thrifttest/testexception.go
+++ b/crossdock/thrift/gauntlet/service/thrifttest/testexception.go
@@ -26,8 +26,8 @@ package thrifttest
 import (
 	"errors"
 	"fmt"
-	"go.uber.org/yarpc/crossdock/thrift/gauntlet"
 	"go.uber.org/thriftrw/wire"
+	"go.uber.org/yarpc/crossdock/thrift/gauntlet"
 	"strings"
 )
 

--- a/crossdock/thrift/gauntlet/service/thrifttest/testinsanity.go
+++ b/crossdock/thrift/gauntlet/service/thrifttest/testinsanity.go
@@ -26,8 +26,8 @@ package thrifttest
 import (
 	"errors"
 	"fmt"
-	"go.uber.org/yarpc/crossdock/thrift/gauntlet"
 	"go.uber.org/thriftrw/wire"
+	"go.uber.org/yarpc/crossdock/thrift/gauntlet"
 	"strings"
 )
 

--- a/crossdock/thrift/gauntlet/service/thrifttest/testmulti.go
+++ b/crossdock/thrift/gauntlet/service/thrifttest/testmulti.go
@@ -26,8 +26,8 @@ package thrifttest
 import (
 	"errors"
 	"fmt"
-	"go.uber.org/yarpc/crossdock/thrift/gauntlet"
 	"go.uber.org/thriftrw/wire"
+	"go.uber.org/yarpc/crossdock/thrift/gauntlet"
 	"strings"
 )
 

--- a/crossdock/thrift/gauntlet/service/thrifttest/testmultiexception.go
+++ b/crossdock/thrift/gauntlet/service/thrifttest/testmultiexception.go
@@ -26,8 +26,8 @@ package thrifttest
 import (
 	"errors"
 	"fmt"
-	"go.uber.org/yarpc/crossdock/thrift/gauntlet"
 	"go.uber.org/thriftrw/wire"
+	"go.uber.org/yarpc/crossdock/thrift/gauntlet"
 	"strings"
 )
 

--- a/crossdock/thrift/gauntlet/service/thrifttest/testnest.go
+++ b/crossdock/thrift/gauntlet/service/thrifttest/testnest.go
@@ -26,8 +26,8 @@ package thrifttest
 import (
 	"errors"
 	"fmt"
-	"go.uber.org/yarpc/crossdock/thrift/gauntlet"
 	"go.uber.org/thriftrw/wire"
+	"go.uber.org/yarpc/crossdock/thrift/gauntlet"
 	"strings"
 )
 

--- a/crossdock/thrift/gauntlet/service/thrifttest/teststruct.go
+++ b/crossdock/thrift/gauntlet/service/thrifttest/teststruct.go
@@ -26,8 +26,8 @@ package thrifttest
 import (
 	"errors"
 	"fmt"
-	"go.uber.org/yarpc/crossdock/thrift/gauntlet"
 	"go.uber.org/thriftrw/wire"
+	"go.uber.org/yarpc/crossdock/thrift/gauntlet"
 	"strings"
 )
 

--- a/crossdock/thrift/gauntlet/service/thrifttest/testtypedef.go
+++ b/crossdock/thrift/gauntlet/service/thrifttest/testtypedef.go
@@ -26,8 +26,8 @@ package thrifttest
 import (
 	"errors"
 	"fmt"
-	"go.uber.org/yarpc/crossdock/thrift/gauntlet"
 	"go.uber.org/thriftrw/wire"
+	"go.uber.org/yarpc/crossdock/thrift/gauntlet"
 	"strings"
 )
 

--- a/crossdock/thrift/gauntlet/yarpc/secondserviceclient/client.go
+++ b/crossdock/thrift/gauntlet/yarpc/secondserviceclient/client.go
@@ -24,13 +24,13 @@
 package secondserviceclient
 
 import (
-	yarpc "go.uber.org/yarpc"
-	"golang.org/x/net/context"
 	"go.uber.org/thriftrw/protocol"
-	"go.uber.org/thriftrw/wire"
+	"golang.org/x/net/context"
 	"go.uber.org/yarpc/crossdock/thrift/gauntlet/service/secondservice"
 	"go.uber.org/yarpc/transport"
 	"go.uber.org/yarpc/encoding/thrift"
+	"go.uber.org/yarpc"
+	"go.uber.org/thriftrw/wire"
 )
 
 // Interface is a client for the SecondService service.
@@ -56,6 +56,12 @@ func New(c transport.Channel, opts ...thrift.ClientOption) Interface {
 		Channel:  c,
 		Protocol: protocol.Binary,
 	}, opts...)}
+}
+
+func init() {
+	yarpc.RegisterClientFactory(func(c transport.Channel) Interface {
+		return New(c)
+	})
 }
 
 type client struct{ c thrift.Client }

--- a/crossdock/thrift/gauntlet/yarpc/secondserviceclient/client.go
+++ b/crossdock/thrift/gauntlet/yarpc/secondserviceclient/client.go
@@ -59,7 +59,7 @@ func New(c transport.Channel, opts ...thrift.ClientOption) Interface {
 }
 
 func init() {
-	yarpc.RegisterClientFactory(func(c transport.Channel) Interface {
+	yarpc.RegisterClientBuilder(func(c transport.Channel) Interface {
 		return New(c)
 	})
 }

--- a/crossdock/thrift/gauntlet/yarpc/secondserviceserver/server.go
+++ b/crossdock/thrift/gauntlet/yarpc/secondserviceserver/server.go
@@ -24,12 +24,12 @@
 package secondserviceserver
 
 import (
-	yarpc "go.uber.org/yarpc"
-	"golang.org/x/net/context"
 	"go.uber.org/thriftrw/protocol"
-	"go.uber.org/thriftrw/wire"
+	"golang.org/x/net/context"
 	"go.uber.org/yarpc/crossdock/thrift/gauntlet/service/secondservice"
 	"go.uber.org/yarpc/encoding/thrift"
+	"go.uber.org/yarpc"
+	"go.uber.org/thriftrw/wire"
 )
 
 // Interface is the server-side interface for the SecondService service.

--- a/crossdock/thrift/gauntlet/yarpc/thrifttestclient/client.go
+++ b/crossdock/thrift/gauntlet/yarpc/thrifttestclient/client.go
@@ -174,7 +174,7 @@ func New(c transport.Channel, opts ...thrift.ClientOption) Interface {
 }
 
 func init() {
-	yarpc.RegisterClientFactory(func(c transport.Channel) Interface {
+	yarpc.RegisterClientBuilder(func(c transport.Channel) Interface {
 		return New(c)
 	})
 }

--- a/crossdock/thrift/gauntlet/yarpc/thrifttestclient/client.go
+++ b/crossdock/thrift/gauntlet/yarpc/thrifttestclient/client.go
@@ -24,14 +24,14 @@
 package thrifttestclient
 
 import (
-	yarpc "go.uber.org/yarpc"
-	"golang.org/x/net/context"
 	"go.uber.org/thriftrw/protocol"
-	"go.uber.org/thriftrw/wire"
+	"golang.org/x/net/context"
 	"go.uber.org/yarpc/crossdock/thrift/gauntlet"
 	"go.uber.org/yarpc/transport"
 	"go.uber.org/yarpc/encoding/thrift"
 	"go.uber.org/yarpc/crossdock/thrift/gauntlet/service/thrifttest"
+	"go.uber.org/yarpc"
+	"go.uber.org/thriftrw/wire"
 )
 
 // Interface is a client for the ThriftTest service.
@@ -171,6 +171,12 @@ func New(c transport.Channel, opts ...thrift.ClientOption) Interface {
 		Channel:  c,
 		Protocol: protocol.Binary,
 	}, opts...)}
+}
+
+func init() {
+	yarpc.RegisterClientFactory(func(c transport.Channel) Interface {
+		return New(c)
+	})
 }
 
 type client struct{ c thrift.Client }

--- a/crossdock/thrift/gauntlet/yarpc/thrifttestserver/server.go
+++ b/crossdock/thrift/gauntlet/yarpc/thrifttestserver/server.go
@@ -24,13 +24,13 @@
 package thrifttestserver
 
 import (
-	yarpc "go.uber.org/yarpc"
-	"golang.org/x/net/context"
 	"go.uber.org/thriftrw/protocol"
-	"go.uber.org/thriftrw/wire"
+	"golang.org/x/net/context"
 	"go.uber.org/yarpc/crossdock/thrift/gauntlet"
 	"go.uber.org/yarpc/encoding/thrift"
 	"go.uber.org/yarpc/crossdock/thrift/gauntlet/service/thrifttest"
+	"go.uber.org/yarpc"
+	"go.uber.org/thriftrw/wire"
 )
 
 // Interface is the server-side interface for the ThriftTest service.

--- a/encoding/json/outbound.go
+++ b/encoding/json/outbound.go
@@ -48,6 +48,10 @@ func New(c transport.Channel) Client {
 	return jsonClient{ch: c}
 }
 
+func init() {
+	yarpc.RegisterClientFactory(New)
+}
+
 type jsonClient struct {
 	ch transport.Channel
 }

--- a/encoding/json/outbound.go
+++ b/encoding/json/outbound.go
@@ -49,7 +49,7 @@ func New(c transport.Channel) Client {
 }
 
 func init() {
-	yarpc.RegisterClientFactory(New)
+	yarpc.RegisterClientBuilder(New)
 }
 
 type jsonClient struct {

--- a/encoding/raw/outbound.go
+++ b/encoding/raw/outbound.go
@@ -42,6 +42,10 @@ func New(c transport.Channel) Client {
 	return rawClient{ch: c}
 }
 
+func init() {
+	yarpc.RegisterClientFactory(New)
+}
+
 type rawClient struct {
 	ch transport.Channel
 }

--- a/encoding/raw/outbound.go
+++ b/encoding/raw/outbound.go
@@ -43,7 +43,7 @@ func New(c transport.Channel) Client {
 }
 
 func init() {
-	yarpc.RegisterClientFactory(New)
+	yarpc.RegisterClientBuilder(New)
 }
 
 type rawClient struct {

--- a/encoding/thrift/thriftrw-plugin-yarpc/main.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/main.go
@@ -170,7 +170,7 @@ func New(c <$transport>.Channel, opts ...<$thrift>.ClientOption) Interface {
 }
 
 func init() {
-	<$yarpc>.RegisterClientFactory(func(c <$transport>.Channel) Interface {
+	<$yarpc>.RegisterClientBuilder(func(c <$transport>.Channel) Interface {
 		return New(c)
 	})
 }

--- a/encoding/thrift/thriftrw-plugin-yarpc/main.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/main.go
@@ -169,6 +169,12 @@ func New(c <$transport>.Channel, opts ...<$thrift>.ClientOption) Interface {
 	}, opts...)}
 }
 
+func init() {
+	<$yarpc>.RegisterClientFactory(func(c <$transport>.Channel) Interface {
+		return New(c)
+	})
+}
+
 type client struct{ c <$thrift>.Client }
 
 <$service := .Service>

--- a/examples/thrift/hello/thrift/hello/service/hello/echo.go
+++ b/examples/thrift/hello/thrift/hello/service/hello/echo.go
@@ -26,8 +26,8 @@ package hello
 import (
 	"errors"
 	"fmt"
-	"go.uber.org/yarpc/examples/thrift/hello/thrift/hello"
 	"go.uber.org/thriftrw/wire"
+	"go.uber.org/yarpc/examples/thrift/hello/thrift/hello"
 	"strings"
 )
 

--- a/examples/thrift/hello/thrift/hello/yarpc/helloclient/client.go
+++ b/examples/thrift/hello/thrift/hello/yarpc/helloclient/client.go
@@ -55,7 +55,7 @@ func New(c transport.Channel, opts ...thrift.ClientOption) Interface {
 }
 
 func init() {
-	yarpc.RegisterClientFactory(func(c transport.Channel) Interface {
+	yarpc.RegisterClientBuilder(func(c transport.Channel) Interface {
 		return New(c)
 	})
 }

--- a/examples/thrift/hello/thrift/hello/yarpc/helloclient/client.go
+++ b/examples/thrift/hello/thrift/hello/yarpc/helloclient/client.go
@@ -24,14 +24,14 @@
 package helloclient
 
 import (
-	yarpc "go.uber.org/yarpc"
-	"golang.org/x/net/context"
 	"go.uber.org/thriftrw/protocol"
-	"go.uber.org/thriftrw/wire"
+	"golang.org/x/net/context"
 	"go.uber.org/yarpc/encoding/thrift"
 	"go.uber.org/yarpc/transport"
 	"go.uber.org/yarpc/examples/thrift/hello/thrift/hello"
 	hello2 "go.uber.org/yarpc/examples/thrift/hello/thrift/hello/service/hello"
+	"go.uber.org/yarpc"
+	"go.uber.org/thriftrw/wire"
 )
 
 // Interface is a client for the Hello service.
@@ -52,6 +52,12 @@ func New(c transport.Channel, opts ...thrift.ClientOption) Interface {
 		Channel:  c,
 		Protocol: protocol.Binary,
 	}, opts...)}
+}
+
+func init() {
+	yarpc.RegisterClientFactory(func(c transport.Channel) Interface {
+		return New(c)
+	})
 }
 
 type client struct{ c thrift.Client }

--- a/examples/thrift/hello/thrift/hello/yarpc/helloserver/server.go
+++ b/examples/thrift/hello/thrift/hello/yarpc/helloserver/server.go
@@ -24,13 +24,13 @@
 package helloserver
 
 import (
-	yarpc "go.uber.org/yarpc"
-	"golang.org/x/net/context"
 	"go.uber.org/thriftrw/protocol"
-	"go.uber.org/thriftrw/wire"
+	"golang.org/x/net/context"
 	"go.uber.org/yarpc/encoding/thrift"
 	"go.uber.org/yarpc/examples/thrift/hello/thrift/hello"
 	hello2 "go.uber.org/yarpc/examples/thrift/hello/thrift/hello/service/hello"
+	"go.uber.org/yarpc"
+	"go.uber.org/thriftrw/wire"
 )
 
 // Interface is the server-side interface for the Hello service.

--- a/examples/thrift/keyvalue/kv/service/keyvalue/getvalue.go
+++ b/examples/thrift/keyvalue/kv/service/keyvalue/getvalue.go
@@ -26,8 +26,8 @@ package keyvalue
 import (
 	"errors"
 	"fmt"
-	"go.uber.org/yarpc/examples/thrift/keyvalue/kv"
 	"go.uber.org/thriftrw/wire"
+	"go.uber.org/yarpc/examples/thrift/keyvalue/kv"
 	"strings"
 )
 

--- a/examples/thrift/keyvalue/kv/yarpc/keyvalueclient/client.go
+++ b/examples/thrift/keyvalue/kv/yarpc/keyvalueclient/client.go
@@ -24,13 +24,13 @@
 package keyvalueclient
 
 import (
-	yarpc "go.uber.org/yarpc"
-	"golang.org/x/net/context"
 	"go.uber.org/thriftrw/protocol"
-	"go.uber.org/thriftrw/wire"
+	"golang.org/x/net/context"
 	"go.uber.org/yarpc/encoding/thrift"
 	"go.uber.org/yarpc/transport"
 	"go.uber.org/yarpc/examples/thrift/keyvalue/kv/service/keyvalue"
+	"go.uber.org/yarpc"
+	"go.uber.org/thriftrw/wire"
 )
 
 // Interface is a client for the KeyValue service.
@@ -58,6 +58,12 @@ func New(c transport.Channel, opts ...thrift.ClientOption) Interface {
 		Channel:  c,
 		Protocol: protocol.Binary,
 	}, opts...)}
+}
+
+func init() {
+	yarpc.RegisterClientFactory(func(c transport.Channel) Interface {
+		return New(c)
+	})
 }
 
 type client struct{ c thrift.Client }

--- a/examples/thrift/keyvalue/kv/yarpc/keyvalueclient/client.go
+++ b/examples/thrift/keyvalue/kv/yarpc/keyvalueclient/client.go
@@ -61,7 +61,7 @@ func New(c transport.Channel, opts ...thrift.ClientOption) Interface {
 }
 
 func init() {
-	yarpc.RegisterClientFactory(func(c transport.Channel) Interface {
+	yarpc.RegisterClientBuilder(func(c transport.Channel) Interface {
 		return New(c)
 	})
 }

--- a/examples/thrift/keyvalue/kv/yarpc/keyvalueserver/server.go
+++ b/examples/thrift/keyvalue/kv/yarpc/keyvalueserver/server.go
@@ -24,12 +24,12 @@
 package keyvalueserver
 
 import (
-	yarpc "go.uber.org/yarpc"
-	"golang.org/x/net/context"
 	"go.uber.org/thriftrw/protocol"
-	"go.uber.org/thriftrw/wire"
+	"golang.org/x/net/context"
 	"go.uber.org/yarpc/encoding/thrift"
 	"go.uber.org/yarpc/examples/thrift/keyvalue/kv/service/keyvalue"
+	"go.uber.org/yarpc"
+	"go.uber.org/thriftrw/wire"
 )
 
 // Interface is the server-side interface for the KeyValue service.

--- a/inject.go
+++ b/inject.go
@@ -114,9 +114,9 @@ func InjectClients(src transport.ChannelProvider, dest interface{}) {
 	structT := destT.Elem()
 	for i := 0; i < structV.NumField(); i++ {
 		fieldInfo := structT.Field(i)
+		fieldV := structV.Field(i)
 
-		service := fieldInfo.Tag.Get("service")
-		if service == "" {
+		if !fieldV.CanSet() {
 			continue
 		}
 
@@ -125,7 +125,11 @@ func InjectClients(src transport.ChannelProvider, dest interface{}) {
 			continue
 		}
 
-		fieldV := structV.Field(i)
+		service := fieldInfo.Tag.Get("service")
+		if service == "" {
+			continue
+		}
+
 		if !fieldV.IsNil() {
 			continue
 		}

--- a/inject.go
+++ b/inject.go
@@ -103,7 +103,7 @@ func RegisterClientFactory(f interface{}) (forget func()) {
 // Factory functions for different client types may be registered using the
 // RegisterClientFactory function. This function panics if an empty client
 // field without a registered constructor is encountered.
-func InjectClients(src Dispatcher, dest interface{}) {
+func InjectClients(src transport.ChannelProvider, dest interface{}) {
 	destV := reflect.ValueOf(dest)
 	destT := reflect.TypeOf(dest)
 	if destT.Kind() != reflect.Ptr || destT.Elem().Kind() != reflect.Struct {

--- a/inject.go
+++ b/inject.go
@@ -82,9 +82,9 @@ func RegisterClientFactory(f interface{}) (forget func()) {
 }
 
 // InjectClients injects clients from the given Dispatcher into the given
-// struct. dest must be a pointer to a struct with zero or more public fields
-// Thrift client fields. Only fields with nil values and a `service` tag will
-// be populated; everything else will be left unchanged.
+// struct. dest must be a pointer to a struct with zero or more exported
+// fields Thrift client fields. Only fields with nil values and a `service`
+// tag will be populated; everything else will be left unchanged.
 //
 // 	type Handler struct {
 // 		KeyValueClient keyvalueclient.Interface `service:"keyvalue"`

--- a/inject.go
+++ b/inject.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpc
+
+import (
+	"fmt"
+	"reflect"
+
+	"go.uber.org/yarpc/transport"
+)
+
+var (
+	_clientFactories = make(map[reflect.Type]reflect.Value)
+	_typeOfChannel   = reflect.TypeOf((*transport.Channel)(nil)).Elem()
+)
+
+func getFactoryType(f interface{}) reflect.Type {
+	if f == nil {
+		panic("f must not be nil")
+	}
+
+	fT := reflect.TypeOf(f)
+	if fT.Kind() != reflect.Func {
+		panic(fmt.Sprintf("f must be a function, not %T", f))
+	}
+
+	if fT.NumIn() != 1 || fT.In(0) != _typeOfChannel {
+		panic(fmt.Sprintf("%v must accept only a transport.Channel", fT))
+	}
+
+	if fT.NumOut() != 1 || fT.Out(0).Kind() != reflect.Interface {
+		panic(fmt.Sprintf("%v must return a single interface result", fT))
+	}
+
+	return fT.Out(0)
+}
+
+// RegisterClientFactory registers a factory function for a specific client
+// type.
+//
+// Functions must have the signature,
+//
+// 	func(transport.Channel) T
+//
+// Where T is the type of the client. T MUST be an interface.
+//
+// This function panics if a client for the given type has already been
+// registered.
+//
+// After a factory function for a client type is registered, these objects can
+// be instantiated automatically using InjectClients.
+//
+// A function to unregister the factory function is returned. Note that the
+// function will clear whatever the corresponding type's factory function is
+// at the time it is called, regardless of whether the value matches what was
+// passed to this function or not.
+func RegisterClientFactory(f interface{}) (forget func()) {
+	t := getFactoryType(f)
+	if _, conflict := _clientFactories[t]; conflict {
+		panic(fmt.Sprintf("a factory for %v has already been registered", t))
+	}
+	_clientFactories[t] = reflect.ValueOf(f)
+	return func() { delete(_clientFactories, t) }
+}
+
+// InjectClients injects clients from the given Dispatcher into the given
+// struct. dest must be a pointer to a struct with zero or more public fields
+// Thrift client fields. Only fields with nil values and a `service` tag will
+// be populated; everything else will be left unchanged.
+//
+// 	type Handler struct {
+// 		KeyValueClient keyvalueclient.Interface `service:"keyvalue"`
+// 		UserClient json.Client `service:"users"`
+// 		TagClient tagclient.Interface  // will not be changed
+// 	}
+//
+// 	var h Handler
+// 	yarpc.InjectClients(dispatcher, &h)
+//
+// 	// InjectClients above is equivalent to,
+//
+// 	h.KeyValueClient = keyvalueclient.New(dispatcher.Channel("keyvalue"))
+// 	h.UserClient = json.New(dispatcher.Channel("users"))
+//
+// Factory functions for different client types may be registered using the
+// RegisterClientFactory function. This function panics if an empty client
+// field without a registered constructor is encountered.
+func InjectClients(src Dispatcher, dest interface{}) {
+	destV := reflect.ValueOf(dest)
+	destT := reflect.TypeOf(dest)
+	if destT.Kind() != reflect.Ptr || destT.Elem().Kind() != reflect.Struct {
+		panic(fmt.Sprintf("dest must be a pointer to a struct, not %T", dest))
+	}
+
+	structV := destV.Elem()
+	structT := destT.Elem()
+	for i := 0; i < structV.NumField(); i++ {
+		fieldInfo := structT.Field(i)
+
+		service := fieldInfo.Tag.Get("service")
+		if service == "" {
+			continue
+		}
+
+		fieldT := fieldInfo.Type
+		if fieldT.Kind() != reflect.Interface {
+			continue
+		}
+
+		fieldV := structV.Field(i)
+		if !fieldV.IsNil() {
+			continue
+		}
+
+		channelV := reflect.ValueOf(src.Channel(service))
+		constructor, ok := _clientFactories[fieldT]
+		if !ok {
+			panic(fmt.Sprintf("a constructor for %v has not been registered", fieldT))
+		}
+
+		client := constructor.Call([]reflect.Value{channelV})[0]
+		fieldV.Set(client)
+	}
+}

--- a/inject.go
+++ b/inject.go
@@ -134,12 +134,12 @@ func InjectClients(src transport.ChannelProvider, dest interface{}) {
 			continue
 		}
 
-		channelV := reflect.ValueOf(src.Channel(service))
 		constructor, ok := _clientFactories[fieldT]
 		if !ok {
 			panic(fmt.Sprintf("a constructor for %v has not been registered", fieldT))
 		}
 
+		channelV := reflect.ValueOf(src.Channel(service))
 		client := constructor.Call([]reflect.Value{channelV})[0]
 		fieldV.Set(client)
 	}

--- a/inject_test.go
+++ b/inject_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRegisterClientFactoryPanics(t *testing.T) {
+func TestRegisterClientBuilderPanics(t *testing.T) {
 	tests := []struct {
 		name string
 		give interface{}
@@ -45,7 +45,7 @@ func TestRegisterClientFactoryPanics(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		assert.Panics(t, func() { yarpc.RegisterClientFactory(tt.give) }, tt.name)
+		assert.Panics(t, func() { yarpc.RegisterClientBuilder(tt.give) }, tt.name)
 	}
 }
 
@@ -97,7 +97,7 @@ func TestInjectClientSuccess(t *testing.T) {
 	type unknownClient interface{}
 
 	type knownClient interface{}
-	clear := yarpc.RegisterClientFactory(
+	clear := yarpc.RegisterClientBuilder(
 		func(transport.Channel) knownClient { return knownClient(struct{}{}) })
 	defer clear()
 

--- a/inject_test.go
+++ b/inject_test.go
@@ -1,0 +1,160 @@
+package yarpc_test
+
+import (
+	"testing"
+
+	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/encoding/json"
+	"go.uber.org/yarpc/encoding/raw"
+	"go.uber.org/yarpc/transport"
+	"go.uber.org/yarpc/transport/transporttest"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegisterClientFactoryPanics(t *testing.T) {
+	tests := []struct {
+		name string
+		give interface{}
+	}{
+		{name: "nil", give: nil},
+		{name: "wrong kind", give: 42},
+		{
+			name: "already registered",
+			give: func(transport.Channel) json.Client { return nil },
+		},
+		{
+			name: "wrong argument type",
+			give: func(int) json.Client { return nil },
+		},
+		{
+			name: "wrong return type",
+			give: func(transport.Channel) string { return "" },
+		},
+		{
+			name: "wrong number of arguments",
+			give: func(transport.Channel, ...string) json.Client { return nil },
+		},
+		{
+			name: "wrong number of returns",
+			give: func(transport.Channel) (json.Client, error) { return nil, nil },
+		},
+	}
+
+	for _, tt := range tests {
+		assert.Panics(t, func() { yarpc.RegisterClientFactory(tt.give) }, tt.name)
+	}
+}
+
+func TestInjectClientsPanics(t *testing.T) {
+	type unknownClient interface{}
+
+	tests := []struct {
+		name      string
+		outbounds []string
+		target    interface{}
+	}{
+		{
+			name:   "not a pointer to a struct",
+			target: struct{}{},
+		},
+		{
+			name: "unknown service",
+			target: &struct {
+				Client json.Client `service:"foo"`
+			}{},
+		},
+		{
+			name:      "unknown client",
+			outbounds: []string{"foo"},
+			target: &struct {
+				Client unknownClient `service:"foo"`
+			}{},
+		},
+	}
+
+	for _, tt := range tests {
+		dispatcherWithOutbounds(t, tt.outbounds, func(d yarpc.Dispatcher) {
+			assert.Panics(t, func() { yarpc.InjectClients(d, tt.target) }, tt.name)
+		})
+	}
+}
+
+func TestInjectClientSuccess(t *testing.T) {
+	type unknownClient interface{}
+
+	type knownClient interface{}
+	clear := yarpc.RegisterClientFactory(
+		func(transport.Channel) knownClient { return knownClient(struct{}{}) })
+	defer clear()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	tests := []struct {
+		name      string
+		outbounds []string
+		target    interface{}
+	}{
+		{
+			name:   "empty",
+			target: &struct{}{},
+		},
+		{
+			name: "unknown service non-nil",
+			target: &struct {
+				Client json.Client `service:"foo"`
+			}{
+				Client: json.New(transport.IdentityChannel(
+					"foo", "bar", transporttest.NewMockOutbound(mockCtrl))),
+			},
+		},
+		{
+			name: "unknown type untagged",
+			target: &struct {
+				Client unknownClient `notservice:"foo"`
+			}{},
+		},
+		{
+			name:      "unknown type non-nil",
+			outbounds: []string{"foo"},
+			target: &struct {
+				Client unknownClient `service:"foo"`
+			}{Client: unknownClient(struct{}{})},
+		},
+		{
+			name:      "known type",
+			outbounds: []string{"foo"},
+			target: &struct {
+				Client knownClient `service:"foo"`
+			}{},
+		},
+		{
+			name:      "default encodings",
+			outbounds: []string{"jsontest", "rawtest"},
+			target: &struct {
+				JSON json.Client `service:"jsontest"`
+				Raw  raw.Client  `service:"rawtest"`
+			}{},
+		},
+	}
+
+	for _, tt := range tests {
+		dispatcherWithOutbounds(t, tt.outbounds, func(d yarpc.Dispatcher) {
+			assert.NotPanics(t, func() { yarpc.InjectClients(d, tt.target) }, tt.name)
+		})
+	}
+}
+
+func dispatcherWithOutbounds(t *testing.T, outnames []string, f func(yarpc.Dispatcher)) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	outbounds := make(transport.Outbounds, len(outnames))
+	for _, name := range outnames {
+		outbounds[name] = transporttest.NewMockOutbound(mockCtrl)
+	}
+
+	f(yarpc.NewDispatcher(yarpc.Config{Name: "foo", Outbounds: outbounds}))
+}


### PR DESCRIPTION
This implements `yarpc.InjectClients` which provides a mechanism to
automatically fill clients into structs from a Dispatcher.

```go
type myHandler struct {
    Cache cacheclient.Interface `service:"memcached"`
}

var handler myHandler
yarpc.InjectClients(dispatcher, &handler)

// Is equivalent to

handler = myHandler{
    Cache: cacheclient.New(dispatcher.Channel("memcached")),
}
```

A global map of types and their constructors is maintained and reflection is
used to fill the target struct with clients. `{json, raw}.Client`s are
registered into that map by default and generated Thrift clients register
themselves into the map in `init()`.

Note that as suggested in the original issue, this DOES NOT recursively walk
the object tree, and only updates the fields in the top-level object. This
makes this feature less surprising and drops any concerns around
instantiating/modifying user-owned objects.

Resolves #330

CC @breerly @bombela @prashantv @kriskowal 