### PR TITLE
Extract `Dispatcher.Channel` to `ChannelProvider`

### DIFF
--- a/dispatcher.go
+++ b/dispatcher.go
@@ -35,12 +35,7 @@ import (
 type Dispatcher interface {
 	transport.Handler
 	transport.Registry
-
-	// Retrieves a new Outbound transport that will make requests to the given
-	// service.
-	//
-	// This panics if the given service is unknown.
-	Channel(service string) transport.Channel
+	transport.ChannelProvider
 
 	// Inbounds returns a copy of the list of inbounds for this RPC object.
 	//

--- a/transport/channel.go
+++ b/transport/channel.go
@@ -20,7 +20,16 @@
 
 package transport
 
-// Channel scopes outbounds to a single caller-service pair.
+// ChannelProvider builds channels from the current service to other services.
+type ChannelProvider interface {
+	// Retrieves a new Channel that will make requests to the given service.
+	//
+	// This MAY panic if the given service is unknown.
+	Channel(service string) Channel
+}
+
+// A Channel is a stream of communication between a single caller-service
+// pair.
 type Channel interface {
 	// Name of the service making the request.
 	Caller() string


### PR DESCRIPTION
This extracts the `Channel(string) transport.Channel` function from
`yarpc.Dispatcher` into the `transport.ChannelProvider` interface.

CC @yarpc/golang