### PR TITLE
Create base interfaces for inbounds/outbounds

### DIFF
--- a/transport/inbound.go
+++ b/transport/inbound.go
@@ -22,17 +22,8 @@ package transport
 
 //go:generate mockgen -destination=transporttest/inbound.go -package=transporttest go.uber.org/yarpc/transport Inbound
 
-// Inbound is a transport that knows how to receive requests for procedure
-// calls.
-type Inbound interface {
-	// Starts accepting new requests and dispatches them to the given Handler.
-	//
-	// The function MUST return immediately, although it SHOULD block until
-	// the inbound is ready to start accepting new requests.
-	//
-	// Implementations can assume that this function is called at most once.
-	Start(handler Handler, deps Deps) error
-
+// BaseInbound is the commone interface for all inbounds
+type BaseInbound interface {
 	// Stops the inbound. No new requests will be processed.
 	//
 	// This MAY block while the server drains ongoing requests.
@@ -40,4 +31,18 @@ type Inbound interface {
 
 	// TODO some way for the inbound to expose the host and port it's
 	// listening on
+}
+
+// Inbound is a transport that knows how to receive requests for procedure
+// calls.
+type Inbound interface {
+	BaseInbound
+
+	// Starts accepting new requests and dispatches them to the given Handler.
+	//
+	// The function MUST return immediately, although it SHOULD block until
+	// the inbound is ready to start accepting new requests.
+	//
+	// Implementations can assume that this function is called at most once.
+	Start(handler Handler, deps Deps) error
 }

--- a/transport/outbound.go
+++ b/transport/outbound.go
@@ -24,9 +24,8 @@ import "golang.org/x/net/context"
 
 //go:generate mockgen -destination=transporttest/outbound.go -package=transporttest go.uber.org/yarpc/transport Outbound
 
-// Outbound is a transport that knows how to send requests for procedure
-// calls.
-type Outbound interface {
+// BaseOutbound is the common interface for all outbounds
+type BaseOutbound interface {
 	// Sets up the outbound to start making calls.
 	//
 	// This MUST block until the outbound is ready to start sending requests.
@@ -39,6 +38,12 @@ type Outbound interface {
 
 	// Options for all requests made through this Outbound.
 	Options() Options
+}
+
+// Outbound is a unary transport that knows how to send requests for procedure
+// calls.
+type Outbound interface {
+	BaseOutbound
 
 	// Call sends the given request through this transport and returns its
 	// response.


### PR DESCRIPTION
This creates the base Inbound/Outbound interfaces that other RPC types such as oneway will use.
http://t.uber.com/yarpc-oneway-rfc