### PR TITLE
Reduce test flakiness

### DIFF
--- a/transport/http/inbound_test.go
+++ b/transport/http/inbound_test.go
@@ -22,6 +22,7 @@ package http
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -93,12 +94,12 @@ func TestInboundMux(t *testing.T) {
 		w.Write([]byte("healthy"))
 	})
 
-	i := NewInbound(":8080", Mux("/rpc/v1", mux))
+	i := NewInbound(":0", Mux("/rpc/v1", mux))
 	h := transporttest.NewMockHandler(mockCtrl)
 	require.NoError(t, i.Start(h, transport.NoDeps))
 	defer i.Stop()
 
-	addr := "http://127.0.0.1:8080/"
+	addr := fmt.Sprintf("http://%v/", i.Addr().String())
 	resp, err := http.Get(addr + "health")
 	if assert.NoError(t, err, "/health failed") {
 		defer resp.Body.Close()

--- a/transport/tracer_test.go
+++ b/transport/tracer_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/encoding/json"
 	"go.uber.org/yarpc/transport"
@@ -111,13 +112,15 @@ func (h handler) assertBaggage(ctx context.Context) {
 }
 
 func createHTTPDispatcher(tracer opentracing.Tracer) yarpc.Dispatcher {
+	// TODO: Use port 0 once https://github.com/yarpc/yarpc-go/issues/381 is
+	// fixed.
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name: "yarpc-test",
 		Inbounds: []transport.Inbound{
-			http.NewInbound(":8080"),
+			http.NewInbound(":18080"),
 		},
 		Outbounds: transport.Outbounds{
-			"yarpc-test": http.NewOutbound("http://127.0.0.1:8080"),
+			"yarpc-test": http.NewOutbound("http://127.0.0.1:18080"),
 		},
 		Tracer: tracer,
 	})
@@ -156,7 +159,7 @@ func TestHTTPTracer(t *testing.T) {
 	handler := handler{client: client, t: t}
 	handler.register(dispatcher)
 
-	dispatcher.Start()
+	require.NoError(t, dispatcher.Start())
 	defer dispatcher.Stop()
 
 	ctx, cancel := handler.createContextWithBaggage(tracer)
@@ -176,7 +179,7 @@ func TestTChannelTracer(t *testing.T) {
 	handler := handler{client: client, t: t}
 	handler.register(dispatcher)
 
-	dispatcher.Start()
+	require.NoError(t, dispatcher.Start())
 	defer dispatcher.Stop()
 
 	ctx, cancel := handler.createContextWithBaggage(tracer)
@@ -213,7 +216,7 @@ func TestHTTPTracerDepth2(t *testing.T) {
 	handler := handler{client: client, t: t}
 	handler.register(dispatcher)
 
-	dispatcher.Start()
+	require.NoError(t, dispatcher.Start())
 	defer dispatcher.Stop()
 
 	ctx, cancel := handler.createContextWithBaggage(tracer)
@@ -233,7 +236,7 @@ func TestTChannelTracerDepth2(t *testing.T) {
 	handler := handler{client: client, t: t}
 	handler.register(dispatcher)
 
-	dispatcher.Start()
+	require.NoError(t, dispatcher.Start())
 	defer dispatcher.Stop()
 
 	ctx, cancel := handler.createContextWithBaggage(tracer)


### PR DESCRIPTION
-   `http/inbound`: use OS-assigned ports instead of a static port 8080.
-   `transport/tracer`: fail the test if `dispatcher.Start()` failed
-   `transport/tracer`: Don't use port 8080 since it conflicts with something
    else. For now, we're still using a static port but once #381 gets
    resolved, we can use OS-assigned ports.

CC @yarpc/golang