### PR TITLE
dispatcher/Start: Stop everything if Start fails

### DIFF
--- a/dispatcher.go
+++ b/dispatcher.go
@@ -132,8 +132,7 @@ func (d dispatcher) Start() error {
 
 	startInbound := func(i transport.Inbound) func() error {
 		return func() error {
-			err := i.Start(service, d.deps)
-			if err != nil {
+			if err := i.Start(service, d.deps); err != nil {
 				return err
 			}
 
@@ -146,8 +145,7 @@ func (d dispatcher) Start() error {
 
 	startOutbound := func(o transport.Outbound) func() error {
 		return func() error {
-			err := o.Start(d.deps)
-			if err != nil {
+			if err := o.Start(d.deps); err != nil {
 				return err
 			}
 

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -21,8 +21,10 @@
 package yarpc
 
 import (
+	"sync"
+
 	"go.uber.org/yarpc/internal/request"
-	"go.uber.org/yarpc/internal/sync"
+	intsync "go.uber.org/yarpc/internal/sync"
 	"go.uber.org/yarpc/transport"
 
 	"github.com/opentracing/opentracing-go"
@@ -117,6 +119,12 @@ func (d dispatcher) Channel(service string) transport.Channel {
 }
 
 func (d dispatcher) Start() error {
+	var (
+		mu               sync.Mutex
+		startedInbounds  []transport.Inbound
+		startedOutbounds []transport.Outbound
+	)
+
 	service := transport.ServiceDetail{
 		Name:     d.Name,
 		Registry: d,
@@ -124,17 +132,33 @@ func (d dispatcher) Start() error {
 
 	startInbound := func(i transport.Inbound) func() error {
 		return func() error {
-			return i.Start(service, d.deps)
+			err := i.Start(service, d.deps)
+			if err != nil {
+				return err
+			}
+
+			mu.Lock()
+			startedInbounds = append(startedInbounds, i)
+			mu.Unlock()
+			return nil
 		}
 	}
 
 	startOutbound := func(o transport.Outbound) func() error {
 		return func() error {
-			return o.Start(d.deps)
+			err := o.Start(d.deps)
+			if err != nil {
+				return err
+			}
+
+			mu.Lock()
+			startedOutbounds = append(startedOutbounds, o)
+			mu.Unlock()
+			return nil
 		}
 	}
 
-	var wait sync.ErrorWaiter
+	var wait intsync.ErrorWaiter
 	for _, i := range d.inbounds {
 		wait.Submit(startInbound(i))
 	}
@@ -144,10 +168,25 @@ func (d dispatcher) Start() error {
 		wait.Submit(startOutbound(o))
 	}
 
-	if errors := wait.Wait(); len(errors) > 0 {
-		return errorGroup(errors)
+	errors := wait.Wait()
+	if len(errors) == 0 {
+		return nil
 	}
-	return nil
+
+	// Failed to start so stop everything that was started.
+	wait = intsync.ErrorWaiter{}
+	for _, i := range startedInbounds {
+		wait.Submit(i.Stop)
+	}
+	for _, o := range startedOutbounds {
+		wait.Submit(o.Stop)
+	}
+
+	if newErrors := wait.Wait(); len(newErrors) > 0 {
+		errors = append(errors, newErrors...)
+	}
+
+	return errorGroup(errors)
 }
 
 func (d dispatcher) Register(rs []transport.Registrant) {
@@ -159,7 +198,7 @@ func (d dispatcher) Register(rs []transport.Registrant) {
 }
 
 func (d dispatcher) Stop() error {
-	var wait sync.ErrorWaiter
+	var wait intsync.ErrorWaiter
 	for _, i := range d.inbounds {
 		wait.Submit(i.Stop)
 	}

--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -137,8 +137,8 @@ func TestStartStopFailures(t *testing.T) {
 						in.EXPECT().Start(gomock.Any(), gomock.Any()).Return(errors.New("great sadness"))
 					} else {
 						in.EXPECT().Start(gomock.Any(), gomock.Any()).Return(nil)
+						in.EXPECT().Stop().Return(nil)
 					}
-					// no Stop() because Start() failed
 					inbounds[i] = in
 				}
 				return inbounds
@@ -148,6 +148,7 @@ func TestStartStopFailures(t *testing.T) {
 				for i := 0; i < 10; i++ {
 					out := transporttest.NewMockOutbound(mockCtrl)
 					out.EXPECT().Start(gomock.Any()).Return(nil)
+					out.EXPECT().Stop().Return(nil)
 					outbounds[fmt.Sprintf("service-%v", i)] = out
 				}
 				return outbounds
@@ -189,6 +190,7 @@ func TestStartStopFailures(t *testing.T) {
 				for i := range inbounds {
 					in := transporttest.NewMockInbound(mockCtrl)
 					in.EXPECT().Start(gomock.Any(), gomock.Any()).Return(nil)
+					in.EXPECT().Stop().Return(nil)
 					inbounds[i] = in
 				}
 				return inbounds
@@ -201,6 +203,7 @@ func TestStartStopFailures(t *testing.T) {
 						out.EXPECT().Start(gomock.Any()).Return(errors.New("something went wrong"))
 					} else {
 						out.EXPECT().Start(gomock.Any()).Return(nil)
+						out.EXPECT().Stop().Return(nil)
 					}
 					outbounds[fmt.Sprintf("service-%v", i)] = out
 				}


### PR DESCRIPTION
Previously, if an inbound/outbound failed to start, we would fail the
dispatcher's start but leave the other inbounds and outbounds running. This
means that the failed dispatcher could continue to send/receive requests
on the transports that did not fail.

This changes the system to stop all the inbounds and outbounds that were
started successfully if any of them fails to start. This should ensure that
users are unable to send or receive requests through a broken dispatcher.

Resolves #380

CC @yarpc/golang