### PR TITLE
[GRPC][Part 4.5] Fix Lint after golint upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # Paths besides auto-detected generated files that should be excluded from
 # lint results.
+# Exclude the handler_interface to grpc because their handler interface does not meet golint standards
 LINT_EXCLUDES_EXTRAS = transport/grpc/handler_interface.go
 
 ##############################################################################

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Paths besides auto-detected generated files that should be excluded from
 # lint results.
-LINT_EXCLUDES_EXTRAS =
+LINT_EXCLUDES_EXTRAS = transport/grpc/handler_interface.go
 
 ##############################################################################
 export GO15VENDOREXPERIMENT=1

--- a/transport/grpc/handler.go
+++ b/transport/grpc/handler.go
@@ -26,8 +26,7 @@ type handler struct {
 
 // Handle the grpc request and convert it into a YARPC request
 // dec ('decode') will pass through the request body in raw bytes using the passThroughCodec
-func (h handler) Handle(
-	srv interface{},
+func (h handler) handleImpl(
 	ctx context.Context,
 	dec func(interface{}) error,
 	interceptor grpc.UnaryServerInterceptor,
@@ -41,7 +40,7 @@ func (h handler) Handle(
 	// TODO handle validation
 
 	start := time.Now()
-	return callHandler(h, start, ctx, treq)
+	return callHandler(ctx, h, start, treq)
 }
 
 func getTRequest(ctx context.Context, msgBodyDecoder func(interface{}) error) (*transport.Request, error) {
@@ -107,9 +106,9 @@ func getMsgBody(msgBodyDecoder func(interface{}) error) (io.Reader, error) {
 }
 
 func callHandler(
+	ctx context.Context,
 	h handler,
 	start time.Time,
-	ctx context.Context,
 	treq *transport.Request,
 ) (interface{}, error) {
 	var r response
@@ -120,7 +119,7 @@ func callHandler(
 		return nil, err
 	}
 
-	err = internal.SafelyCallHandler(handler, start, ctx, grpcOptions, treq, rw)
+	err = internal.SafelyCallHandler(ctx, handler, start, grpcOptions, treq, rw)
 
 	responseBody := r.body.Bytes()
 	return &responseBody, err

--- a/transport/grpc/handler.go
+++ b/transport/grpc/handler.go
@@ -26,7 +26,7 @@ type handler struct {
 
 // Handle the grpc request and convert it into a YARPC request
 // dec ('decode') will pass through the request body in raw bytes using the passThroughCodec
-func (h handler) handleImpl(
+func (h handler) handle(
 	ctx context.Context,
 	dec func(interface{}) error,
 	interceptor grpc.UnaryServerInterceptor,

--- a/transport/grpc/handler_interface.go
+++ b/transport/grpc/handler_interface.go
@@ -1,8 +1,7 @@
 package grpc
 
 import (
-	"context"
-
+	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )
 

--- a/transport/grpc/handler_interface.go
+++ b/transport/grpc/handler_interface.go
@@ -1,0 +1,21 @@
+package grpc
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+)
+
+/*
+This needs to be in a separate file because the gRPC interface does not
+follow golint rules, so we put it in this file so we can ignore it when
+running go lint
+*/
+func (h handler) Handle(
+	srv interface{},
+	ctx context.Context,
+	dec func(interface{}) error,
+	interceptor grpc.UnaryServerInterceptor,
+) (interface{}, error) {
+	return h.handleImpl(ctx, dec, interceptor)
+}

--- a/transport/grpc/handler_interface.go
+++ b/transport/grpc/handler_interface.go
@@ -16,5 +16,5 @@ func (h handler) Handle(
 	dec func(interface{}) error,
 	interceptor grpc.UnaryServerInterceptor,
 ) (interface{}, error) {
-	return h.handleImpl(ctx, dec, interceptor)
+	return h.handle(ctx, dec, interceptor)
 }


### PR DESCRIPTION
Summary: In a recent commit to golint, there was a new rule added that
asserts that context.Context must be the first parameter in a function
definition.  This breaks some of GRPC's functionality since the handler
interface they require has ctx in the second position.  As a result, we
are fixing the cases where we have ctx in the second position, and we're
isolating the GRPC function we provide into it's own file and ignoring
it in our linting