### PR TITLE
thrift: Disable enveloping by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ This release requires regeneration of ThriftRW code.
     opentracing baggage instead
 -   **Breaking**: Transport options have been removed completely. Encoding
     values differently based on the transport is no longer supported.
+-   **Breaking**: Thrift requests and responses are no longer enveloped by
+    default. The `thrift.Enveloped` option may be used to turn enveloping on
+    when instantiating Thrift clients or registering handlers.
 
 
 v0.3.1 (2016-09-31)

--- a/crossdock/client/echo/thrift.go
+++ b/crossdock/client/echo/thrift.go
@@ -28,7 +28,6 @@ import (
 	"go.uber.org/yarpc/crossdock/client/random"
 	"go.uber.org/yarpc/crossdock/thrift/echo"
 	"go.uber.org/yarpc/crossdock/thrift/echo/yarpc/echoclient"
-	"go.uber.org/yarpc/encoding/thrift"
 
 	"github.com/crossdock/crossdock-go"
 	"golang.org/x/net/context"
@@ -43,9 +42,7 @@ func Thrift(t crossdock.T) {
 	fatals.NoError(dispatcher.Start(), "could not start Dispatcher")
 	defer dispatcher.Stop()
 
-	// NOTE(abg): Enveloping is disabled in old cross-language tests until the
-	// other YARPC implementations catch up.
-	client := echoclient.New(dispatcher.Channel("yarpc-test"), thrift.DisableEnveloping)
+	client := echoclient.New(dispatcher.Channel("yarpc-test"))
 	ctx, _ := context.WithTimeout(context.Background(), time.Second)
 
 	token := random.String(5)

--- a/crossdock/client/gauntlet/behavior.go
+++ b/crossdock/client/gauntlet/behavior.go
@@ -90,8 +90,6 @@ type Config struct {
 
 	// Whether requests should use Thrift envelopes. Defaults to false.
 	Envelope bool
-	// NOTE(abg): Enveloping is disabled by default until other YARPC
-	// implementations catch up. Only specific tests opt into this feature.
 
 	// Bit mask of the different services to call. Defaults to AllServices.
 	Services ServiceSet
@@ -451,8 +449,8 @@ func BuildDesc(tt TT) string {
 func buildClient(t crossdock.T, desc string, service string, c Config) reflect.Value {
 	channel := c.Dispatcher.Channel(c.ServerName)
 	opts := c.ClientOptions
-	if !c.Envelope {
-		opts = append(opts, thrift.DisableEnveloping)
+	if c.Envelope {
+		opts = append(opts, thrift.Enveloped)
 	}
 	switch service {
 	case "", "ThriftTest":

--- a/crossdock/client/headers/behavior.go
+++ b/crossdock/client/headers/behavior.go
@@ -31,7 +31,6 @@ import (
 	"go.uber.org/yarpc/crossdock/thrift/echo/yarpc/echoclient"
 	"go.uber.org/yarpc/encoding/json"
 	"go.uber.org/yarpc/encoding/raw"
-	"go.uber.org/yarpc/encoding/thrift"
 
 	"github.com/crossdock/crossdock-go"
 	"golang.org/x/net/context"
@@ -64,9 +63,7 @@ func Run(t crossdock.T) {
 	case "json":
 		caller = jsonCaller{json.New(dispatcher.Channel("yarpc-test"))}
 	case "thrift":
-		// NOTE(abg): Enveloping is disabled in old cross-language tests until the
-		// other YARPC implementations catch up.
-		caller = thriftCaller{echoclient.New(dispatcher.Channel("yarpc-test"), thrift.DisableEnveloping)}
+		caller = thriftCaller{echoclient.New(dispatcher.Channel("yarpc-test"))}
 	default:
 		fatals.Fail("", "unknown encoding %q", encoding)
 	}

--- a/crossdock/client/tchserver/thrift.go
+++ b/crossdock/client/tchserver/thrift.go
@@ -29,7 +29,6 @@ import (
 	"go.uber.org/yarpc/crossdock/client/random"
 	"go.uber.org/yarpc/crossdock/thrift/echo"
 	"go.uber.org/yarpc/crossdock/thrift/echo/yarpc/echoclient"
-	"go.uber.org/yarpc/encoding/thrift"
 
 	"github.com/crossdock/crossdock-go"
 	"golang.org/x/net/context"
@@ -59,9 +58,7 @@ func runThrift(t crossdock.T, dispatcher yarpc.Dispatcher) {
 }
 
 func thriftCall(dispatcher yarpc.Dispatcher, headers yarpc.Headers, token string) (string, yarpc.CallResMeta, error) {
-	// NOTE(abg): Enveloping is disabled in old cross-language tests until the
-	// other YARPC implementations catch up.
-	client := echoclient.New(dispatcher.Channel(serverName), thrift.DisableEnveloping)
+	client := echoclient.New(dispatcher.Channel(serverName))
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()

--- a/crossdock/server/yarpc/server.go
+++ b/crossdock/server/yarpc/server.go
@@ -30,7 +30,6 @@ import (
 	"go.uber.org/yarpc/crossdock/thrift/gauntlet/yarpc/thrifttestserver"
 	"go.uber.org/yarpc/encoding/json"
 	"go.uber.org/yarpc/encoding/raw"
-	"go.uber.org/yarpc/encoding/thrift"
 	"go.uber.org/yarpc/transport"
 	"go.uber.org/yarpc/transport/http"
 	tch "go.uber.org/yarpc/transport/tchannel"
@@ -76,11 +75,9 @@ func register(reg transport.Registry) {
 	reg.Register(raw.Procedure("echo/raw", EchoRaw))
 	reg.Register(json.Procedure("echo", EchoJSON))
 
-	// NOTE(abg): Enveloping is disabled in old cross-language tests until the
-	// other YARPC implementations catch up.
-	reg.Register(echoserver.New(EchoThrift{}, thrift.DisableEnveloping))
-	reg.Register(thrifttestserver.New(thriftTest{}, thrift.DisableEnveloping))
-	reg.Register(secondserviceserver.New(secondService{}, thrift.DisableEnveloping))
+	reg.Register(echoserver.New(EchoThrift{}))
+	reg.Register(thrifttestserver.New(thriftTest{}))
+	reg.Register(secondserviceserver.New(secondService{}))
 
 	reg.Register(json.Procedure("unexpected-error", UnexpectedError))
 	reg.Register(json.Procedure("bad-response", BadResponse))

--- a/encoding/thrift/inbound.go
+++ b/encoding/thrift/inbound.go
@@ -35,9 +35,9 @@ import (
 
 // thriftHandler wraps a Thrift Handler into a transport.Handler
 type thriftHandler struct {
-	Handler           Handler
-	Protocol          protocol.Protocol
-	DisableEnveloping bool
+	Handler    Handler
+	Protocol   protocol.Protocol
+	Enveloping bool
 }
 
 func (t thriftHandler) Handle(ctx context.Context, treq *transport.Request, rw transport.ResponseWriter) error {
@@ -52,7 +52,7 @@ func (t thriftHandler) Handle(ctx context.Context, treq *transport.Request, rw t
 
 	// We disable enveloping if either the client or the transport requires it.
 	proto := t.Protocol
-	if t.DisableEnveloping {
+	if !t.Enveloping {
 		proto = disableEnvelopingProtocol{
 			Protocol: proto,
 			Type:     wire.Call, // we only decode requests

--- a/encoding/thrift/inbound_test.go
+++ b/encoding/thrift/inbound_test.go
@@ -130,7 +130,7 @@ func TestThriftHandler(t *testing.T) {
 		ctx, _ := context.WithTimeout(context.Background(), time.Second)
 
 		handler := NewMockHandler(mockCtrl)
-		h := thriftHandler{Protocol: proto, Handler: handler}
+		h := thriftHandler{Protocol: proto, Handler: handler, Enveloping: true}
 
 		if tt.expectHandle {
 			reqMeta := fakeReqMeta{

--- a/encoding/thrift/options.go
+++ b/encoding/thrift/options.go
@@ -23,9 +23,9 @@ package thrift
 import "go.uber.org/thriftrw/protocol"
 
 type clientConfig struct {
-	Protocol          protocol.Protocol
-	DisableEnveloping bool
-	Multiplexed       bool
+	Protocol    protocol.Protocol
+	Enveloping  bool
+	Multiplexed bool
 }
 
 // ClientOption customizes the behavior of a Thrift client.
@@ -34,8 +34,8 @@ type ClientOption interface {
 }
 
 type registerConfig struct {
-	Protocol          protocol.Protocol
-	DisableEnveloping bool
+	Protocol   protocol.Protocol
+	Enveloping bool
 }
 
 // RegisterOption customizes the behavior of a Thrift handler during
@@ -50,26 +50,29 @@ type Option interface {
 	RegisterOption
 }
 
-// DisableEnveloping is an option that disables enveloping of Thrift requests
-// and responses.
+// Enveloped is an option that specifies that Thrift requests and responses
+// should be enveloped. It defaults to false.
 //
 // It may be specified on the client side when the client is constructed.
 //
-// 	client := myserviceclient.New(channel, thrift.DisableEnveloping)
+// 	client := myserviceclient.New(channel, thrift.Enveloped)
 //
 // It may be specified on the server side when the handler is registered.
 //
-// 	dispatcher.Register(myserviceserver.New(handler, thrift.DisableEnveloping))
-var DisableEnveloping Option = disableEnvelopingOption{}
+// 	dispatcher.Register(myserviceserver.New(handler, thrift.Enveloped))
+//
+// Note that you will need to enable enveloping to communicate with Apache
+// Thrift HTTP servers.
+var Enveloped Option = envelopedOption{}
 
-type disableEnvelopingOption struct{}
+type envelopedOption struct{}
 
-func (disableEnvelopingOption) applyClientOption(c *clientConfig) {
-	c.DisableEnveloping = true
+func (e envelopedOption) applyClientOption(c *clientConfig) {
+	c.Enveloping = true
 }
 
-func (disableEnvelopingOption) applyRegisterOption(c *registerConfig) {
-	c.DisableEnveloping = true
+func (e envelopedOption) applyRegisterOption(c *registerConfig) {
+	c.Enveloping = true
 }
 
 // Multiplexed is an option that specifies that requests from a client should

--- a/encoding/thrift/outbound.go
+++ b/encoding/thrift/outbound.go
@@ -91,10 +91,10 @@ func New(c Config, opts ...ClientOption) Client {
 	}
 
 	return thriftClient{
-		p:                 p,
-		ch:                c.Channel,
-		thriftService:     c.Service,
-		disableEnveloping: cc.DisableEnveloping,
+		p:             p,
+		ch:            c.Channel,
+		thriftService: c.Service,
+		Enveloping:    cc.Enveloping,
 	}
 }
 
@@ -103,8 +103,8 @@ type thriftClient struct {
 	p  protocol.Protocol
 
 	// name of the Thrift service
-	thriftService     string
-	disableEnveloping bool
+	thriftService string
+	Enveloping    bool
 }
 
 func (c thriftClient) Call(ctx context.Context, reqMeta yarpc.CallReqMeta, reqBody envelope.Enveloper) (wire.Value, yarpc.CallResMeta, error) {
@@ -123,7 +123,7 @@ func (c thriftClient) Call(ctx context.Context, reqMeta yarpc.CallReqMeta, reqBo
 	// 	}
 
 	proto := c.p
-	if c.disableEnveloping {
+	if !c.Enveloping {
 		proto = disableEnvelopingProtocol{
 			Protocol: proto,
 			Type:     wire.Reply, // we only decode replies with this instance

--- a/encoding/thrift/outbound_test.go
+++ b/encoding/thrift/outbound_test.go
@@ -55,6 +55,7 @@ func TestClient(t *testing.T) {
 	}{
 		{
 			desc:            "happy case",
+			clientOptions:   []ClientOption{Enveloped},
 			giveRequestBody: fakeEnveloper(wire.Call),
 			wantRequestEnvelope: &wire.Envelope{
 				Name:  "someMethod",
@@ -72,7 +73,6 @@ func TestClient(t *testing.T) {
 		},
 		{
 			desc:             "happy case without enveloping",
-			clientOptions:    []ClientOption{DisableEnveloping},
 			giveRequestBody:  fakeEnveloper(wire.Call),
 			wantRequestBody:  valueptr(wire.NewValueStruct(wire.Struct{})),
 			expectCall:       true,
@@ -80,12 +80,14 @@ func TestClient(t *testing.T) {
 		},
 		{
 			desc:            "wrong envelope type for request",
+			clientOptions:   []ClientOption{Enveloped},
 			giveRequestBody: fakeEnveloper(wire.Reply),
 			wantError: `failed to encode "thrift" request body for procedure ` +
 				`"MyService::someMethod" of service "service": unexpected envelope type: Reply`,
 		},
 		{
 			desc:            "TApplicationException",
+			clientOptions:   []ClientOption{Enveloped},
 			giveRequestBody: fakeEnveloper(wire.Call),
 			wantRequestEnvelope: &wire.Envelope{
 				Name:  "someMethod",
@@ -109,6 +111,7 @@ func TestClient(t *testing.T) {
 		},
 		{
 			desc:            "wrong envelope type for response",
+			clientOptions:   []ClientOption{Enveloped},
 			giveRequestBody: fakeEnveloper(wire.Call),
 			wantRequestEnvelope: &wire.Envelope{
 				Name:  "someMethod",

--- a/encoding/thrift/register.go
+++ b/encoding/thrift/register.go
@@ -81,9 +81,9 @@ func BuildRegistrants(s Service, opts ...RegisterOption) []transport.Registrant 
 		rs = append(rs, transport.Registrant{
 			Procedure: procedureName(s.Name, methodName),
 			Handler: thriftHandler{
-				Handler:           handler,
-				Protocol:          proto,
-				DisableEnveloping: rc.DisableEnveloping,
+				Handler:    handler,
+				Protocol:   proto,
+				Enveloping: rc.Enveloping,
 			},
 		})
 	}


### PR DESCRIPTION
Enveloping must now be explicitly enabled on a per-client or per-handler
basis using the `thrift.Enveloped` option.

@yarpc/golang