### PR TITLE
Add tracing all throughout the crossdock tests, update header checks

### DIFF
--- a/crossdock/client/ctxpropagation/behavior.go
+++ b/crossdock/client/ctxpropagation/behavior.go
@@ -36,7 +36,6 @@ import (
 
 	"github.com/crossdock/crossdock-go"
 	"github.com/opentracing/opentracing-go"
-	"github.com/uber/jaeger-client-go"
 	"github.com/uber/tchannel-go"
 )
 
@@ -58,10 +57,6 @@ func Run(t crossdock.T) {
 	checks := crossdock.Checks(t)
 	assert := crossdock.Assert(t)
 	fatals := crossdock.Fatals(t)
-
-	tracer, closer := jaeger.NewTracer("crossdock", jaeger.NewConstSampler(true), jaeger.NewNullReporter())
-	defer closer.Close()
-	opentracing.InitGlobalTracer(tracer)
 
 	tests := []struct {
 		desc      string

--- a/crossdock/client/headers/behavior.go
+++ b/crossdock/client/headers/behavior.go
@@ -28,6 +28,7 @@ import (
 	disp "go.uber.org/yarpc/crossdock/client/dispatcher"
 	"go.uber.org/yarpc/crossdock/client/params"
 	"go.uber.org/yarpc/crossdock/client/random"
+	"go.uber.org/yarpc/crossdock/internal"
 	"go.uber.org/yarpc/crossdock/thrift/echo"
 	"go.uber.org/yarpc/crossdock/thrift/echo/yarpc/echoclient"
 	"go.uber.org/yarpc/encoding/json"
@@ -121,16 +122,8 @@ func Run(t crossdock.T) {
 	for _, tt := range tests {
 		got, err := caller.Call(tt.give)
 		if checks.NoError(err, "%v: call failed", tt.desc) {
-			for _, header := range tt.want.Keys() {
-				expectedValue, _ := tt.want.Get(header)
-				actualValue, _ := got.Get(header)
-				assert.Equal(
-					expectedValue,
-					actualValue,
-					"%v: returns valid headers",
-					tt.desc,
-				)
-			}
+			gotHeaders := internal.RemoveVariableHeaderKeys(got)
+			assert.Equal(tt.want, gotHeaders, "%v: returns valid headers", tt.desc)
 		}
 	}
 }

--- a/crossdock/client/headers/behavior.go
+++ b/crossdock/client/headers/behavior.go
@@ -121,7 +121,16 @@ func Run(t crossdock.T) {
 	for _, tt := range tests {
 		got, err := caller.Call(tt.give)
 		if checks.NoError(err, "%v: call failed", tt.desc) {
-			assert.Equal(tt.want, got, "%v: returns valid headers", tt.desc)
+			for _, header := range tt.want.Keys() {
+				expectedValue, _ := tt.want.Get(header)
+				actualValue, _ := got.Get(header)
+				assert.Equal(
+					expectedValue,
+					actualValue,
+					"%v: returns valid headers",
+					tt.desc,
+				)
+			}
 		}
 	}
 }

--- a/crossdock/client/tchclient/json.go
+++ b/crossdock/client/tchclient/json.go
@@ -41,7 +41,13 @@ func runJSON(t crossdock.T, call call) {
 	resp, respHeaders, err := jsonCall(call, headers, token)
 	if checks.NoError(err, "json: call failed") {
 		assert.Equal(token, resp.Token, "body echoed")
-		assert.Equal(headers, respHeaders, "headers echoed")
+		for key, value := range headers {
+			assert.Equal(
+				value,
+				respHeaders[key],
+				"headers echoed",
+			)
+		}
 	}
 }
 

--- a/crossdock/client/tchclient/json.go
+++ b/crossdock/client/tchclient/json.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"go.uber.org/yarpc/crossdock/client/random"
+	"go.uber.org/yarpc/crossdock/internal"
 
 	"github.com/crossdock/crossdock-go"
 	"github.com/uber/tchannel-go/json"
@@ -41,13 +42,8 @@ func runJSON(t crossdock.T, call call) {
 	resp, respHeaders, err := jsonCall(call, headers, token)
 	if checks.NoError(err, "json: call failed") {
 		assert.Equal(token, resp.Token, "body echoed")
-		for key, value := range headers {
-			assert.Equal(
-				value,
-				respHeaders[key],
-				"headers echoed",
-			)
-		}
+		respHeaders = internal.RemoveVariableMapKeys(respHeaders)
+		assert.Equal(headers, respHeaders, "headers echoed")
 	}
 }
 

--- a/crossdock/client/tchclient/raw.go
+++ b/crossdock/client/tchclient/raw.go
@@ -41,12 +41,22 @@ func runRaw(t crossdock.T, call call) {
 		0x00, 0x03, // length = 3
 		'r', 'a', 'w',
 	}
+	expectedHeaderContains := []byte{
+		0x00, 0x05, // length = 5
+		'h', 'e', 'l', 'l', 'o',
+		0x00, 0x03, // length = 3
+		'r', 'a', 'w',
+	}
 	token := random.Bytes(5)
 
 	resp, respHeaders, err := rawCall(call, headers, token)
 	if checks.NoError(err, "raw: call failed") {
 		assert.Equal(token, resp, "body echoed")
-		assert.Equal(headers, respHeaders, "headers echoed")
+		assert.Contains(
+			string(respHeaders),
+			string(expectedHeaderContains),
+			"headers echoed",
+		)
 	}
 }
 

--- a/crossdock/client/tchclient/thrift.go
+++ b/crossdock/client/tchclient/thrift.go
@@ -27,6 +27,7 @@ import (
 
 	"go.uber.org/yarpc/crossdock/client/gauntlet"
 	"go.uber.org/yarpc/crossdock/client/random"
+	"go.uber.org/yarpc/crossdock/internal"
 	"go.uber.org/yarpc/crossdock/thrift/gen-go/echo"
 	"go.uber.org/yarpc/crossdock/thrift/gen-go/gauntlet_apache"
 
@@ -49,13 +50,8 @@ func runThrift(t crossdock.T, call call) {
 	resp, respHeaders, err := thriftCall(client, headers, token)
 	if checks.NoError(err, "thrift: call failed") {
 		assert.Equal(token, resp.Boop, "body echoed")
-		for key, value := range headers {
-			assert.Equal(
-				value,
-				respHeaders[key],
-				"headers echoed",
-			)
-		}
+		respHeaders = internal.RemoveVariableMapKeys(respHeaders)
+		assert.Equal(headers, respHeaders, "headers echoed")
 	}
 
 	runGauntlet(t, client)

--- a/crossdock/client/tchclient/thrift.go
+++ b/crossdock/client/tchclient/thrift.go
@@ -49,7 +49,13 @@ func runThrift(t crossdock.T, call call) {
 	resp, respHeaders, err := thriftCall(client, headers, token)
 	if checks.NoError(err, "thrift: call failed") {
 		assert.Equal(token, resp.Boop, "body echoed")
-		assert.Equal(headers, respHeaders, "headers echoed")
+		for key, value := range headers {
+			assert.Equal(
+				value,
+				respHeaders[key],
+				"headers echoed",
+			)
+		}
 	}
 
 	runGauntlet(t, client)

--- a/crossdock/client/tchserver/json.go
+++ b/crossdock/client/tchserver/json.go
@@ -44,7 +44,16 @@ func runJSON(t crossdock.T, dispatcher yarpc.Dispatcher) {
 	}
 	if checks.NoError(err, "json: call failed") {
 		assert.Equal(token, resBody, "body echoed")
-		assert.Equal(headers, resMeta.Headers(), "headers echoed")
+		assert.Equal(headers, resMeta.Headers())
+		for _, header := range headers.Keys() {
+			expectedValue, _ := headers.Get(header)
+			actualValue, _ := resMeta.Headers().Get(header)
+			assert.Equal(
+				expectedValue,
+				actualValue,
+				"headers echoed",
+			)
+		}
 	}
 }
 

--- a/crossdock/client/tchserver/json.go
+++ b/crossdock/client/tchserver/json.go
@@ -26,6 +26,7 @@ import (
 
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/crossdock/client/random"
+	"go.uber.org/yarpc/crossdock/internal"
 	"go.uber.org/yarpc/encoding/json"
 
 	"github.com/crossdock/crossdock-go"
@@ -44,16 +45,8 @@ func runJSON(t crossdock.T, dispatcher yarpc.Dispatcher) {
 	}
 	if checks.NoError(err, "json: call failed") {
 		assert.Equal(token, resBody, "body echoed")
-		assert.Equal(headers, resMeta.Headers())
-		for _, header := range headers.Keys() {
-			expectedValue, _ := headers.Get(header)
-			actualValue, _ := resMeta.Headers().Get(header)
-			assert.Equal(
-				expectedValue,
-				actualValue,
-				"headers echoed",
-			)
-		}
+		resHeaders := internal.RemoveVariableHeaderKeys(resMeta.Headers())
+		assert.Equal(headers, resHeaders, "headers echoed")
 	}
 }
 

--- a/crossdock/client/tchserver/raw.go
+++ b/crossdock/client/tchserver/raw.go
@@ -52,7 +52,15 @@ func hello(t crossdock.T, dispatcher yarpc.Dispatcher) {
 	}
 	if checks.NoError(err, "raw: call failed") {
 		assert.Equal(token, resBody, "body echoed")
-		assert.Equal(headers, resMeta.Headers(), "headers echoed")
+		for _, header := range headers.Keys() {
+			expectedValue, _ := headers.Get(header)
+			actualValue, _ := resMeta.Headers().Get(header)
+			assert.Equal(
+				expectedValue,
+				actualValue,
+				"headers echoed",
+			)
+		}
 	}
 }
 

--- a/crossdock/client/tchserver/raw.go
+++ b/crossdock/client/tchserver/raw.go
@@ -27,6 +27,7 @@ import (
 
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/crossdock/client/random"
+	"go.uber.org/yarpc/crossdock/internal"
 	"go.uber.org/yarpc/encoding/raw"
 	"go.uber.org/yarpc/transport"
 
@@ -52,15 +53,8 @@ func hello(t crossdock.T, dispatcher yarpc.Dispatcher) {
 	}
 	if checks.NoError(err, "raw: call failed") {
 		assert.Equal(token, resBody, "body echoed")
-		for _, header := range headers.Keys() {
-			expectedValue, _ := headers.Get(header)
-			actualValue, _ := resMeta.Headers().Get(header)
-			assert.Equal(
-				expectedValue,
-				actualValue,
-				"headers echoed",
-			)
-		}
+		resHeaders := internal.RemoveVariableHeaderKeys(resMeta.Headers())
+		assert.Equal(headers, resHeaders, "headers echoed")
 	}
 }
 

--- a/crossdock/client/tchserver/thrift.go
+++ b/crossdock/client/tchserver/thrift.go
@@ -47,7 +47,15 @@ func runThrift(t crossdock.T, dispatcher yarpc.Dispatcher) {
 	}
 	if checks.NoError(err, "thrift: call failed") {
 		assert.Equal(token, resBody, "body echoed")
-		assert.Equal(headers, resMeta.Headers(), "headers echoed")
+		for _, header := range headers.Keys() {
+			expectedValue, _ := headers.Get(header)
+			actualValue, _ := resMeta.Headers().Get(header)
+			assert.Equal(
+				expectedValue,
+				actualValue,
+				"headers echoed",
+			)
+		}
 	}
 
 	t.Tag("server", t.Param(params.Server))

--- a/crossdock/client/tchserver/thrift.go
+++ b/crossdock/client/tchserver/thrift.go
@@ -28,6 +28,7 @@ import (
 	"go.uber.org/yarpc/crossdock/client/gauntlet"
 	"go.uber.org/yarpc/crossdock/client/params"
 	"go.uber.org/yarpc/crossdock/client/random"
+	"go.uber.org/yarpc/crossdock/internal"
 	"go.uber.org/yarpc/crossdock/thrift/echo"
 	"go.uber.org/yarpc/crossdock/thrift/echo/yarpc/echoclient"
 
@@ -47,15 +48,8 @@ func runThrift(t crossdock.T, dispatcher yarpc.Dispatcher) {
 	}
 	if checks.NoError(err, "thrift: call failed") {
 		assert.Equal(token, resBody, "body echoed")
-		for _, header := range headers.Keys() {
-			expectedValue, _ := headers.Get(header)
-			actualValue, _ := resMeta.Headers().Get(header)
-			assert.Equal(
-				expectedValue,
-				actualValue,
-				"headers echoed",
-			)
-		}
+		resHeaders := internal.RemoveVariableHeaderKeys(resMeta.Headers())
+		assert.Equal(headers, resHeaders, "headers echoed")
 	}
 
 	t.Tag("server", t.Param(params.Server))

--- a/crossdock/internal/header.go
+++ b/crossdock/internal/header.go
@@ -2,6 +2,7 @@ package internal
 
 import "go.uber.org/yarpc"
 
+// RemoveVariableHeaderKeys removes any headers that might have been added by tracing
 func RemoveVariableHeaderKeys(headers yarpc.Headers) yarpc.Headers {
 	headers.Del("$tracing$uber-trace-id")
 	if headers.Len() == 0 {
@@ -10,6 +11,7 @@ func RemoveVariableHeaderKeys(headers yarpc.Headers) yarpc.Headers {
 	return headers
 }
 
+// RemoveVariableMapKeys removes any headers that might have been added by tracing
 func RemoveVariableMapKeys(headers map[string]string) map[string]string {
 	delete(headers, "$tracing$uber-trace-id")
 	return headers

--- a/crossdock/internal/header.go
+++ b/crossdock/internal/header.go
@@ -1,0 +1,16 @@
+package internal
+
+import "go.uber.org/yarpc"
+
+func RemoveVariableHeaderKeys(headers yarpc.Headers) yarpc.Headers {
+	headers.Del("$tracing$uber-trace-id")
+	if headers.Len() == 0 {
+		return yarpc.NewHeaders()
+	}
+	return headers
+}
+
+func RemoveVariableMapKeys(headers map[string]string) map[string]string {
+	delete(headers, "$tracing$uber-trace-id")
+	return headers
+}

--- a/crossdock/main.go
+++ b/crossdock/main.go
@@ -21,11 +21,16 @@
 package main
 
 import (
+	"github.com/opentracing/opentracing-go"
+	jaeger "github.com/uber/jaeger-client-go"
 	"go.uber.org/yarpc/crossdock/client"
 	"go.uber.org/yarpc/crossdock/server"
 )
 
 func main() {
+	tracer, _ := jaeger.NewTracer("crossdock", jaeger.NewConstSampler(true), jaeger.NewNullReporter())
+	opentracing.InitGlobalTracer(tracer)
+
 	server.Start()
 	client.Start()
 }

--- a/crossdock/main_test.go
+++ b/crossdock/main_test.go
@@ -28,11 +28,17 @@ import (
 	"go.uber.org/yarpc/crossdock/server"
 
 	"github.com/crossdock/crossdock-go"
+	"github.com/opentracing/opentracing-go"
+	jaeger "github.com/uber/jaeger-client-go"
 )
 
 const clientURL = "http://127.0.0.1:8080"
 
 func TestCrossdock(t *testing.T) {
+	tracer, closer := jaeger.NewTracer("crossdock", jaeger.NewConstSampler(true), jaeger.NewNullReporter())
+	defer closer.Close()
+	opentracing.InitGlobalTracer(tracer)
+
 	server.Start()
 	defer server.Stop()
 	go client.Start()


### PR DESCRIPTION
Summary: When we added jaeger support for passing baggage in the
ctxpropagation test we did not update the other tests to assume jaeger
tracers would be added.  Locally this was fine because we weren't
setting the jaeger tracer until the ctxpropagation test, so all the
headers were fine (they weren't setup in the dispatcher)
This diff moves the tracer setup to the very beginning so that tests
have to rely on the logic, it also fixes up the broken tests