### PR TITLE
[PeerList][Part 3] Adding a http PeerAgent

### DIFF
--- a/internal/errors/peers.go
+++ b/internal/errors/peers.go
@@ -1,0 +1,13 @@
+package errors
+
+import "fmt"
+
+// ErrAgentHasNoReferenceToPeer is called when an agent is expected to operate on a Peer it has no reference to
+type ErrAgentHasNoReferenceToPeer struct {
+	Agent          interface{}
+	PeerIdentifier interface{}
+}
+
+func (e ErrAgentHasNoReferenceToPeer) Error() string {
+	return fmt.Sprintf("agent (%v) has no reference to peer (%v)", e.Agent, e.PeerIdentifier)
+}

--- a/internal/errors/peers.go
+++ b/internal/errors/peers.go
@@ -2,6 +2,16 @@ package errors
 
 import "fmt"
 
+// ErrPeerHasNoReferenceToSubscriber is called when a Peer is expected to operate on a PeerSubscriber it has no reference to
+type ErrPeerHasNoReferenceToSubscriber struct {
+	Peer           interface{}
+	PeerSubscriber interface{}
+}
+
+func (e ErrPeerHasNoReferenceToSubscriber) Error() string {
+	return fmt.Sprintf("peer (%v) has no reference to peer subscriber (%v)", e.Peer, e.PeerSubscriber)
+}
+
 // ErrAgentHasNoReferenceToPeer is called when an agent is expected to operate on a Peer it has no reference to
 type ErrAgentHasNoReferenceToPeer struct {
 	Agent          interface{}

--- a/internal/errors/peers.go
+++ b/internal/errors/peers.go
@@ -4,12 +4,12 @@ import "fmt"
 
 // ErrPeerHasNoReferenceToSubscriber is called when a Peer is expected to operate on a PeerSubscriber it has no reference to
 type ErrPeerHasNoReferenceToSubscriber struct {
-	Peer           interface{}
+	PeerIdentifier interface{}
 	PeerSubscriber interface{}
 }
 
 func (e ErrPeerHasNoReferenceToSubscriber) Error() string {
-	return fmt.Sprintf("peer (%v) has no reference to peer subscriber (%v)", e.Peer, e.PeerSubscriber)
+	return fmt.Sprintf("peer (%v) has no reference to peer subscriber (%v)", e.PeerIdentifier, e.PeerSubscriber)
 }
 
 // ErrAgentHasNoReferenceToPeer is called when an agent is expected to operate on a Peer it has no reference to
@@ -20,4 +20,14 @@ type ErrAgentHasNoReferenceToPeer struct {
 
 func (e ErrAgentHasNoReferenceToPeer) Error() string {
 	return fmt.Sprintf("agent (%v) has no reference to peer (%v)", e.Agent, e.PeerIdentifier)
+}
+
+// ErrInvalidPeerType is when a specfic peer type is required, but was not passed in
+type ErrInvalidPeerType struct {
+	ExpectedType   string
+	PeerIdentifier interface{}
+}
+
+func (e ErrInvalidPeerType) Error() string {
+	return fmt.Sprintf("expected peer type (%s) but got peer (%v)", e.ExpectedType, e.PeerIdentifier)
 }

--- a/transport/http/agent.go
+++ b/transport/http/agent.go
@@ -3,48 +3,63 @@ package http
 import (
 	"net/http"
 	"sync"
+	"time"
 
 	"go.uber.org/yarpc/transport"
 	"go.uber.org/yarpc/transport/internal/errors"
 	"go.uber.org/yarpc/transport/peer/hostport"
 )
 
+type agentConfig struct {
+	keepAlive time.Duration
+}
+
+var defaultAgentConfig = agentConfig{keepAlive: 30 * time.Second}
+
+// AgentOption customizes the behavior of an HTTP agent.
+type AgentOption func(*agentConfig)
+
+// AgentKeepAlive specifies the keep-alive period for the network connection. If
+// zero, keep-alives are disabled.
+//
+// Defaults to 30 seconds.
+func AgentKeepAlive(t time.Duration) AgentOption {
+	return func(c *agentConfig) {
+		c.keepAlive = t
+	}
+}
+
+// NewAgent creates a new http agent for managing peers and sending requests
+func NewAgent(opts ...AgentOption) *Agent {
+	cfg := defaultAgentConfig
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	return &Agent{
+		client:    buildAgentClient(&cfg),
+		peerNodes: make(map[string]*peerNode),
+	}
+}
+
 // Agent keeps track of http peers and the associated client with which the peer will call into.
 type Agent struct {
-	sync.Mutex
+	lock sync.RWMutex
 
 	client    *http.Client
 	peerNodes map[string]*peerNode
 }
 
-// peerNode keeps track of a HostPortPeer and any subscribers referencing it
+// peerNode keeps track of a HostPortPeer and any subscribers retaining it
 type peerNode struct {
-	peer       *hostport.Peer
-	references map[transport.PeerSubscriber]struct{}
-}
-
-// NewDefaultAgent creates an http agent with the default parameters
-func NewDefaultAgent() *Agent {
-	return NewAgent(&defaultConfig)
-}
-
-// NewAgent creates a new http agent for managing peers and sending requests
-func NewAgent(cfg *outboundConfig) *Agent {
-	return &Agent{
-		client:    buildClient(cfg),
-		peerNodes: make(map[string]*peerNode),
-	}
-}
-
-// GetClient gets the http client that should be used for making requests
-func (a *Agent) GetClient() *http.Client {
-	return a.client
+	peer        *hostport.Peer
+	subscribers map[transport.PeerSubscriber]struct{}
 }
 
 // RetainPeer gets or creates a Peer for the specificed PeerList
 func (a *Agent) RetainPeer(pid transport.PeerIdentifier, sub transport.PeerSubscriber) (transport.Peer, error) {
-	a.Mutex.Lock()
-	defer a.Mutex.Unlock()
+	a.lock.Lock()
+	defer a.lock.Unlock()
 
 	hppid, ok := pid.(hostport.PeerIdentifier)
 	if !ok {
@@ -55,21 +70,22 @@ func (a *Agent) RetainPeer(pid transport.PeerIdentifier, sub transport.PeerSubsc
 	}
 
 	node := a.getOrCreatePeerNode(hppid)
-
-	node.references[sub] = struct{}{}
-
+	node.subscribers[sub] = struct{}{}
 	return node.peer, nil
 }
 
+// **NOTE** should only be called while the lock write mutex is acquired
 func (a *Agent) getOrCreatePeerNode(pid hostport.PeerIdentifier) *peerNode {
 	if node, ok := a.peerNodes[pid.Identifier()]; ok {
 		return node
 	}
 
-	peer := hostport.NewPeer(pid, a, a)
+	peer := hostport.NewPeer(pid, a)
+	peer.SetStatus(transport.PeerAvailable)
+
 	node := &peerNode{
-		peer:       peer,
-		references: make(map[transport.PeerSubscriber]struct{}),
+		peer:        peer,
+		subscribers: make(map[transport.PeerSubscriber]struct{}),
 	}
 	a.peerNodes[peer.Identifier()] = node
 
@@ -78,8 +94,8 @@ func (a *Agent) getOrCreatePeerNode(pid hostport.PeerIdentifier) *peerNode {
 
 // ReleasePeer releases a peer from the PeerSubscriber and removes that peer from the Agent if nothing is listening to it
 func (a *Agent) ReleasePeer(pid transport.PeerIdentifier, sub transport.PeerSubscriber) error {
-	a.Mutex.Lock()
-	defer a.Mutex.Unlock()
+	a.lock.Lock()
+	defer a.lock.Unlock()
 
 	node, ok := a.peerNodes[pid.Identifier()]
 	if !ok {
@@ -89,17 +105,16 @@ func (a *Agent) ReleasePeer(pid transport.PeerIdentifier, sub transport.PeerSubs
 		}
 	}
 
-	_, ok = node.references[sub]
-	if !ok {
+	if _, ok = node.subscribers[sub]; !ok {
 		return errors.ErrPeerHasNoReferenceToSubscriber{
 			PeerIdentifier: pid,
 			PeerSubscriber: sub,
 		}
 	}
 
-	delete(node.references, sub)
+	delete(node.subscribers, sub)
 
-	if len(node.references) == 0 {
+	if len(node.subscribers) == 0 {
 		delete(a.peerNodes, pid.Identifier())
 	}
 
@@ -108,8 +123,8 @@ func (a *Agent) ReleasePeer(pid transport.PeerIdentifier, sub transport.PeerSubs
 
 // NotifyStatusChanged Notifies peer subscribers the peer's status changes.
 func (a *Agent) NotifyStatusChanged(peer transport.Peer) {
-	a.Mutex.Lock()
-	defer a.Mutex.Unlock()
+	a.lock.RLock()
+	defer a.lock.RUnlock()
 
 	node, ok := a.peerNodes[peer.Identifier()]
 	if !ok {
@@ -117,7 +132,7 @@ func (a *Agent) NotifyStatusChanged(peer transport.Peer) {
 		return
 	}
 
-	for sub := range node.references {
+	for sub := range node.subscribers {
 		sub.NotifyStatusChanged(peer)
 	}
 }

--- a/transport/http/agent.go
+++ b/transport/http/agent.go
@@ -1,0 +1,83 @@
+package http
+
+import (
+	"net/http"
+	"sync"
+
+	"go.uber.org/yarpc/internal/errors"
+	"go.uber.org/yarpc/transport"
+	"go.uber.org/yarpc/transport/peers"
+)
+
+// Agent keeps track of http peers and the associated client with which the peer will call into.
+type Agent struct {
+	sync.Mutex
+
+	client *http.Client
+	peers  map[string]*peers.HostPortPeer
+}
+
+// NewDefaultAgent creates an http agent with the default parameters
+func NewDefaultAgent() *Agent {
+	return NewAgent(&defaultConfig)
+}
+
+// NewAgent creates a new http agent for managing peers and sending requests
+func NewAgent(cfg *outboundConfig) *Agent {
+	return &Agent{
+		client: buildClient(cfg),
+		peers:  make(map[string]*peers.HostPortPeer),
+	}
+}
+
+// GetClient gets the http client that should be used for making requests
+func (a *Agent) GetClient() *http.Client {
+	return a.client
+}
+
+// RetainPeer gets or creates a Peer for the specificed PeerList
+func (a *Agent) RetainPeer(id transport.PeerIdentifier, list transport.PeerSubscriber) (transport.Peer, error) {
+	a.Mutex.Lock()
+	defer a.Mutex.Unlock()
+
+	p := a.getOrCreatePeer(id)
+
+	p.OnRetain(list)
+	return p, nil
+}
+
+func (a *Agent) getOrCreatePeer(pid transport.PeerIdentifier) *peers.HostPortPeer {
+	if p, ok := a.peers[pid.Identifier()]; ok {
+		return p
+	}
+
+	p := peers.NewPeer(pid, a)
+
+	a.peers[p.Identifier()] = p
+	return p
+}
+
+// ReleasePeer removes a peer from the PeerList and removes that peer from the Agent if nothing is using it
+func (a *Agent) ReleasePeer(id transport.PeerIdentifier, list transport.PeerSubscriber) error {
+	a.Mutex.Lock()
+	defer a.Mutex.Unlock()
+
+	p, ok := a.peers[id.Identifier()]
+	if !ok {
+		return errors.ErrAgentHasNoReferenceToPeer{
+			Agent:          a,
+			PeerIdentifier: id,
+		}
+	}
+
+	err := p.OnRelease(list)
+	if err != nil {
+		return err
+	}
+
+	if p.References() == 0 {
+		delete(a.peers, id.Identifier())
+	}
+
+	return nil
+}

--- a/transport/http/agent.go
+++ b/transport/http/agent.go
@@ -13,8 +13,14 @@ import (
 type Agent struct {
 	sync.Mutex
 
-	client *http.Client
-	peers  map[string]*peers.HostPortPeer
+	client    *http.Client
+	peerNodes map[string]*peerNode
+}
+
+// peerNode keeps track of a HostPortPeer and any subscribers referencing it
+type peerNode struct {
+	peer       *peers.HostPortPeer
+	references map[transport.PeerSubscriber]bool
 }
 
 // NewDefaultAgent creates an http agent with the default parameters
@@ -25,8 +31,8 @@ func NewDefaultAgent() *Agent {
 // NewAgent creates a new http agent for managing peers and sending requests
 func NewAgent(cfg *outboundConfig) *Agent {
 	return &Agent{
-		client: buildClient(cfg),
-		peers:  make(map[string]*peers.HostPortPeer),
+		client:    buildClient(cfg),
+		peerNodes: make(map[string]*peerNode),
 	}
 }
 
@@ -36,33 +42,38 @@ func (a *Agent) GetClient() *http.Client {
 }
 
 // RetainPeer gets or creates a Peer for the specificed PeerList
-func (a *Agent) RetainPeer(id transport.PeerIdentifier, list transport.PeerSubscriber) (transport.Peer, error) {
+func (a *Agent) RetainPeer(pid transport.PeerIdentifier, sub transport.PeerSubscriber) (transport.Peer, error) {
 	a.Mutex.Lock()
 	defer a.Mutex.Unlock()
 
-	p := a.getOrCreatePeer(id)
+	node := a.getOrCreatePeerNode(pid)
 
-	p.OnRetain(list)
-	return p, nil
+	node.references[sub] = true
+
+	return node.peer, nil
 }
 
-func (a *Agent) getOrCreatePeer(pid transport.PeerIdentifier) *peers.HostPortPeer {
-	if p, ok := a.peers[pid.Identifier()]; ok {
-		return p
+func (a *Agent) getOrCreatePeerNode(pid transport.PeerIdentifier) *peerNode {
+	if node, ok := a.peerNodes[pid.Identifier()]; ok {
+		return node
 	}
 
-	p := peers.NewPeer(pid, a)
+	peer := peers.NewPeer(pid, a, a)
+	node := &peerNode{
+		peer:       peer,
+		references: make(map[transport.PeerSubscriber]bool),
+	}
+	a.peerNodes[peer.Identifier()] = node
 
-	a.peers[p.Identifier()] = p
-	return p
+	return node
 }
 
-// ReleasePeer removes a peer from the PeerList and removes that peer from the Agent if nothing is using it
-func (a *Agent) ReleasePeer(id transport.PeerIdentifier, list transport.PeerSubscriber) error {
+// ReleasePeer releases a peer from the peersubscriber and removes that peer from the Agent if nothing is listening to it
+func (a *Agent) ReleasePeer(id transport.PeerIdentifier, sub transport.PeerSubscriber) error {
 	a.Mutex.Lock()
 	defer a.Mutex.Unlock()
 
-	p, ok := a.peers[id.Identifier()]
+	node, ok := a.peerNodes[id.Identifier()]
 	if !ok {
 		return errors.ErrAgentHasNoReferenceToPeer{
 			Agent:          a,
@@ -70,14 +81,48 @@ func (a *Agent) ReleasePeer(id transport.PeerIdentifier, list transport.PeerSubs
 		}
 	}
 
-	err := p.OnRelease(list)
-	if err != nil {
-		return err
+	_, ok = node.references[sub]
+	if !ok {
+		return errors.ErrPeerHasNoReferenceToSubscriber{
+			Peer:           node.peer,
+			PeerSubscriber: sub,
+		}
 	}
 
-	if p.References() == 0 {
-		delete(a.peers, id.Identifier())
+	delete(node.references, sub)
+
+	if len(node.references) == 0 {
+		delete(a.peerNodes, id.Identifier())
 	}
 
 	return nil
+}
+
+func (a *Agent) NotifyAvailable(peer transport.Peer) error {
+	return nil
+}
+
+func (a *Agent) NotifyConnecting(peer transport.Peer) error {
+	return nil
+}
+
+// The Peer Notifies the PeerSubscriber that it is ineligible for requests
+func (a *Agent) NotifyUnavailable(peer transport.Peer) error {
+	return nil
+}
+
+// The Peer Notifies the PeerSubscriber when its pending request count changes (maybe to 0).
+func (a *Agent) NotifyPendingUpdate(peer transport.Peer) {
+	a.Mutex.Lock()
+	defer a.Mutex.Unlock()
+
+	node, ok := a.peerNodes[peer.Identifier()]
+	if !ok {
+		// The peer has probably been released already and this is a request finishing, ignore
+		return
+	}
+
+	for sub, _ := range node.references {
+		sub.NotifyPendingUpdate(peer)
+	}
 }

--- a/transport/http/agent.go
+++ b/transport/http/agent.go
@@ -56,7 +56,7 @@ type peerNode struct {
 	subscribers map[transport.PeerSubscriber]struct{}
 }
 
-// RetainPeer gets or creates a Peer for the specificed PeerList
+// RetainPeer gets or creates a Peer for the specified PeerSubscriber (usually a PeerList)
 func (a *Agent) RetainPeer(pid transport.PeerIdentifier, sub transport.PeerSubscriber) (transport.Peer, error) {
 	a.lock.Lock()
 	defer a.lock.Unlock()

--- a/transport/http/agent_client.go
+++ b/transport/http/agent_client.go
@@ -1,0 +1,22 @@
+package http
+
+import (
+	"net"
+	"net/http"
+	"time"
+)
+
+func buildAgentClient(cfg *agentConfig) *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			// options lifted from https://golang.org/src/net/http/transport.go
+			Proxy: http.ProxyFromEnvironment,
+			Dial: (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: cfg.keepAlive,
+			}).Dial,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+		},
+	}
+}

--- a/transport/http/agent_test.go
+++ b/transport/http/agent_test.go
@@ -18,6 +18,9 @@ type peerExpectation struct {
 	subscribers []*transporttest.MockPeerSubscriber
 }
 
+// createPeerExpectations creates a slice of peerExpectation structs for the
+// peers that are expected to be contained in the agent.  It will also add a
+// number of expected subscribers for each Peer
 func createPeerExpectations(
 	mockCtrl *gomock.Controller,
 	hostports []string,
@@ -53,7 +56,7 @@ func (pim peerIdentifierMatcher) Matches(x interface{}) bool {
 
 // String describes what the matcher matches.
 func (pim peerIdentifierMatcher) String() string {
-	return string(hostport.PeerIdentifier(pim).Identifier())
+	return hostport.PeerIdentifier(pim).Identifier()
 }
 
 func TestAgent(t *testing.T) {

--- a/transport/http/agent_test.go
+++ b/transport/http/agent_test.go
@@ -3,14 +3,57 @@ package http
 import (
 	"testing"
 
-	"go.uber.org/yarpc/internal/errors"
 	"go.uber.org/yarpc/transport"
-	"go.uber.org/yarpc/transport/peers"
 	"go.uber.org/yarpc/transport/transporttest"
 
 	"github.com/crossdock/crossdock-go/assert"
 	"github.com/golang/mock/gomock"
+	"go.uber.org/yarpc/internal/errors"
+	"go.uber.org/yarpc/transport/peer/hostport"
 )
+
+type peerExpectation struct {
+	identifier  hostport.PeerIdentifier
+	subscribers []*transporttest.MockPeerSubscriber
+}
+
+func createPeerExpectations(
+	mockCtrl *gomock.Controller,
+	hostports []string,
+	subscribers int,
+) []peerExpectation {
+	expectations := make([]peerExpectation, 0, len(hostports))
+	for _, hp := range hostports {
+		hpid := hostport.NewPeerIdentifier(hp)
+		subs := make([]*transporttest.MockPeerSubscriber, 0, subscribers)
+		for i := 0; i < subscribers; i++ {
+			subs = append(subs, transporttest.NewMockPeerSubscriber(mockCtrl))
+		}
+		expectations = append(expectations, peerExpectation{
+			identifier:  hpid,
+			subscribers: subs,
+		})
+	}
+	return expectations
+}
+
+// peerIdentifierMatcher allows us to compare peerIdentifiers with Peers through gomock
+type peerIdentifierMatcher hostport.PeerIdentifier
+
+// Matches returns whether x is a match.
+func (pim peerIdentifierMatcher) Matches(x interface{}) bool {
+	res, ok := x.(transport.PeerIdentifier)
+	if !ok {
+		return false
+	}
+
+	return res.Identifier() == hostport.PeerIdentifier(pim).Identifier()
+}
+
+// String describes what the matcher matches.
+func (pim peerIdentifierMatcher) String() string {
+	return string(hostport.PeerIdentifier(pim).Identifier())
+}
 
 func TestAgent(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
@@ -19,123 +62,299 @@ func TestAgent(t *testing.T) {
 	type testStruct struct {
 		msg           string
 		agent         *Agent
-		appliedFunc   func(*Agent)
-		expectedPeers []peerNode
+		appliedFunc   func(*Agent) error
+		expectedPeers []peerExpectation
+		expectedErr   error
 	}
 	tests := []testStruct{
 		func() (s testStruct) {
-			msg := "one retain"
+			s.msg = "one retain"
 			s.agent = NewDefaultAgent()
-			pid := peers.NewPeerIdentifier("localhost:1234")
-			s.appliedFunc = func(a transport.PeerAgent) {
-				sub := transporttest.NewMockPeerSubscriber(mockCtrl)
-				a.RetainPeer(pid, sub)
+			s.expectedPeers = createPeerExpectations(
+				mockCtrl,
+				[]string{"localhost:1234"},
+				1,
+			)
+			s.appliedFunc = func(a *Agent) error {
+				_, err := a.RetainPeer(s.expectedPeers[0].identifier, s.expectedPeers[0].subscribers[0])
+				return err
 			}
-			s.assertFunc = func(a *Agent) {
-				assert.Len(t, a.peers, 1, msg)
+			return
+		}(),
+		func() (s testStruct) {
+			s.msg = "one retain on release"
+			s.agent = NewDefaultAgent()
+			s.expectedPeers = []peerExpectation{}
+			s.appliedFunc = func(a *Agent) error {
+				pid := hostport.NewPeerIdentifier("localhost:1234")
 
-				peer := a.peers[pid.Identifier()]
-				assert.Equal(t, pid.Identifier(), peer.Identifier(), msg)
-				assert.Equal(t, 1, peer.References(), msg)
+				sub := transporttest.NewMockPeerSubscriber(mockCtrl)
+
+				_, err := a.RetainPeer(pid, sub)
+				if err != nil {
+					return err
+				}
+				err = a.ReleasePeer(pid, sub)
+
+				return err
 			}
 			return
 		}(),
 		func() (s testStruct) {
-			msg := "three retains"
+			s.msg = "one retain on release using peer"
 			s.agent = NewDefaultAgent()
-			pid := peers.NewPeerIdentifier("localhost:1234")
-			s.appliedFunc = func(a transport.PeerAgent) {
+			s.expectedPeers = []peerExpectation{}
+			s.appliedFunc = func(a *Agent) error {
+				pid := hostport.NewPeerIdentifier("localhost:1234")
+
 				sub := transporttest.NewMockPeerSubscriber(mockCtrl)
-				sub2 := transporttest.NewMockPeerSubscriber(mockCtrl)
-				sub3 := transporttest.NewMockPeerSubscriber(mockCtrl)
-				a.RetainPeer(pid, sub)
-				a.RetainPeer(pid, sub2)
-				a.RetainPeer(pid, sub3)
-			}
-			s.assertFunc = func(a *Agent) {
-				assert.Len(t, a.peers, 1, msg)
-				peer := a.peers[pid.Identifier()]
-				assert.Equal(t, 3, peer.References(), msg)
+
+				peer, err := a.RetainPeer(pid, sub)
+				if err != nil {
+					return err
+				}
+				err = a.ReleasePeer(peer, sub)
+
+				return err
 			}
 			return
 		}(),
 		func() (s testStruct) {
-			msg := "three retains, one release"
+			s.msg = "three retains"
 			s.agent = NewDefaultAgent()
-			pid := peers.NewPeerIdentifier("localhost:1234")
-			s.appliedFunc = func(a transport.PeerAgent) {
-				sub := transporttest.NewMockPeerSubscriber(mockCtrl)
-				sub2 := transporttest.NewMockPeerSubscriber(mockCtrl)
-				sub3 := transporttest.NewMockPeerSubscriber(mockCtrl)
-				a.RetainPeer(pid, sub)
-				a.RetainPeer(pid, sub2)
-				a.ReleasePeer(pid, sub)
-				a.RetainPeer(pid, sub3)
-			}
-			s.assertFunc = func(a *Agent) {
-				assert.Len(t, a.peers, 1, msg)
-				peer := a.peers[pid.Identifier()]
-				assert.Equal(t, 2, peer.References(), msg)
+			s.expectedPeers = createPeerExpectations(
+				mockCtrl,
+				[]string{"localhost:1234"},
+				3,
+			)
+			s.appliedFunc = func(a *Agent) error {
+				a.RetainPeer(s.expectedPeers[0].identifier, s.expectedPeers[0].subscribers[0])
+				a.RetainPeer(s.expectedPeers[0].identifier, s.expectedPeers[0].subscribers[1])
+				_, err := a.RetainPeer(s.expectedPeers[0].identifier, s.expectedPeers[0].subscribers[2])
+				return err
 			}
 			return
 		}(),
 		func() (s testStruct) {
-			msg := "three retains, three release"
+			s.msg = "three retains, one release"
 			s.agent = NewDefaultAgent()
-			pid := peers.NewPeerIdentifier("localhost:1234")
-			s.appliedFunc = func(a transport.PeerAgent) {
+			s.expectedPeers = createPeerExpectations(
+				mockCtrl,
+				[]string{"localhost:1234"},
+				2,
+			)
+			s.appliedFunc = func(a *Agent) error {
+				unSub := transporttest.NewMockPeerSubscriber(mockCtrl)
+				a.RetainPeer(s.expectedPeers[0].identifier, unSub)
+				a.RetainPeer(s.expectedPeers[0].identifier, s.expectedPeers[0].subscribers[0])
+				a.ReleasePeer(s.expectedPeers[0].identifier, unSub)
+				a.RetainPeer(s.expectedPeers[0].identifier, s.expectedPeers[0].subscribers[1])
+
+				return nil
+			}
+			return
+		}(),
+		func() (s testStruct) {
+			s.msg = "three retains, three release"
+			s.agent = NewDefaultAgent()
+			s.expectedPeers = []peerExpectation{}
+			s.appliedFunc = func(a *Agent) error {
+				pid := hostport.NewPeerIdentifier("localhost:123")
+
 				sub := transporttest.NewMockPeerSubscriber(mockCtrl)
 				sub2 := transporttest.NewMockPeerSubscriber(mockCtrl)
 				sub3 := transporttest.NewMockPeerSubscriber(mockCtrl)
+
 				a.RetainPeer(pid, sub)
 				a.RetainPeer(pid, sub2)
 				a.ReleasePeer(pid, sub)
 				a.RetainPeer(pid, sub3)
 				a.ReleasePeer(pid, sub2)
 				a.ReleasePeer(pid, sub3)
-			}
-			s.assertFunc = func(a *Agent) {
-				assert.Len(t, a.peers, 0, msg)
-			}
-			return
-		}(),
-		func() (s testStruct) {
-			msg := "no retains, one release"
-			s.agent = NewDefaultAgent()
-			pid := peers.NewPeerIdentifier("localhost:1234")
-			var err error
-			s.appliedFunc = func(a transport.PeerAgent) {
-				sub := transporttest.NewMockPeerSubscriber(mockCtrl)
-				err = a.ReleasePeer(pid, sub)
-			}
-			s.assertFunc = func(a *Agent) {
-				assert.NotNil(t, err, msg)
 
-				errAgent, ok := err.(errors.ErrAgentHasNoReferenceToPeer)
-				assert.True(t, ok, msg)
-				assert.Equal(t, a, errAgent.Agent, msg)
-				assert.Equal(t, pid, errAgent.PeerIdentifier, msg)
+				return nil
 			}
 			return
 		}(),
 		func() (s testStruct) {
-			msg := "one retains, one release (from different subscriber)"
+			s.msg = "no retains, one release"
 			s.agent = NewDefaultAgent()
-			var err error
-			pid := peers.NewPeerIdentifier("localhost:1234")
+			s.expectedPeers = []peerExpectation{}
+
+			pid := hostport.NewPeerIdentifier("localhost:1234")
+			s.expectedErr = errors.ErrAgentHasNoReferenceToPeer{
+				Agent:          s.agent,
+				PeerIdentifier: pid,
+			}
+
+			s.appliedFunc = func(a *Agent) error {
+				return a.ReleasePeer(pid, transporttest.NewMockPeerSubscriber(mockCtrl))
+			}
+			return
+		}(),
+		func() (s testStruct) {
+			s.msg = "retain with invalid identifier"
+			s.agent = NewDefaultAgent()
+			s.expectedPeers = []peerExpectation{}
+
+			pid := transporttest.NewMockPeerIdentifier(mockCtrl)
+			s.expectedErr = errors.ErrInvalidPeerType{
+				ExpectedType:   "hostport.PeerIdentifier",
+				PeerIdentifier: pid,
+			}
+
+			s.appliedFunc = func(a *Agent) error {
+				_, err := a.RetainPeer(pid, transporttest.NewMockPeerSubscriber(mockCtrl))
+				return err
+			}
+			return
+		}(),
+		func() (s testStruct) {
+			s.msg = "one retains, one release (from different subscriber)"
+			s.agent = NewDefaultAgent()
+			s.expectedPeers = createPeerExpectations(
+				mockCtrl,
+				[]string{"localhost:1234"},
+				1,
+			)
+
 			invalidSub := transporttest.NewMockPeerSubscriber(mockCtrl)
-			s.appliedFunc = func(a transport.PeerAgent) {
-				sub1 := transporttest.NewMockPeerSubscriber(mockCtrl)
-				a.RetainPeer(pid, sub1)
-				err = a.ReleasePeer(pid, invalidSub)
+			s.expectedErr = errors.ErrPeerHasNoReferenceToSubscriber{
+				PeerIdentifier: s.expectedPeers[0].identifier,
+				PeerSubscriber: invalidSub,
 			}
-			s.assertFunc = func(a *Agent) {
-				assert.NotNil(t, err, msg)
 
-				errRef, ok := err.(errors.ErrPeerHasNoReferenceToSubscriber)
-				assert.True(t, ok, msg)
-				assert.Equal(t, a.peers[pid.Identifier()], errRef.Peer, msg)
-				assert.Equal(t, invalidSub, errRef.PeerSubscriber, msg)
+			s.appliedFunc = func(a *Agent) error {
+				a.RetainPeer(s.expectedPeers[0].identifier, s.expectedPeers[0].subscribers[0])
+				return a.ReleasePeer(s.expectedPeers[0].identifier, invalidSub)
+			}
+			return
+		}(),
+		func() (s testStruct) {
+			s.msg = "multi peer retain/release"
+			s.agent = NewDefaultAgent()
+			s.expectedPeers = createPeerExpectations(
+				mockCtrl,
+				[]string{"localhost:1234", "localhost:1111", "localhost:2222"},
+				2,
+			)
+
+			s.appliedFunc = func(a *Agent) error {
+				expP1 := s.expectedPeers[0]
+				expP2 := s.expectedPeers[1]
+				expP3 := s.expectedPeers[2]
+				rndP1 := hostport.NewPeerIdentifier("localhost:9888")
+				rndP2 := hostport.NewPeerIdentifier("localhost:9883")
+				rndSub1 := transporttest.NewMockPeerSubscriber(mockCtrl)
+				rndSub2 := transporttest.NewMockPeerSubscriber(mockCtrl)
+				rndSub3 := transporttest.NewMockPeerSubscriber(mockCtrl)
+
+				// exp1: Defer a bunch of Releases
+				a.RetainPeer(expP1.identifier, rndSub1)
+				defer a.ReleasePeer(expP1.identifier, rndSub1)
+				a.RetainPeer(expP1.identifier, expP1.subscribers[0])
+				a.RetainPeer(expP1.identifier, rndSub2)
+				defer a.ReleasePeer(expP1.identifier, rndSub2)
+				a.RetainPeer(expP1.identifier, expP1.subscribers[1])
+
+				// exp2: Retain a subscriber, release it, then retain it again
+				a.RetainPeer(expP2.identifier, expP2.subscribers[0])
+				a.RetainPeer(expP2.identifier, expP2.subscribers[1])
+				a.ReleasePeer(expP2.identifier, expP2.subscribers[0])
+				a.ReleasePeer(expP2.identifier, expP2.subscribers[1])
+				a.RetainPeer(expP2.identifier, expP2.subscribers[0])
+				a.RetainPeer(expP2.identifier, expP2.subscribers[1])
+
+				// exp3: Retain release a Peer
+				a.RetainPeer(expP3.identifier, rndSub3)
+				a.ReleasePeer(expP3.identifier, rndSub3)
+				a.RetainPeer(expP3.identifier, expP3.subscribers[0])
+				a.RetainPeer(expP3.identifier, expP3.subscribers[1])
+
+				// rnd1: retain/release on random sub
+				a.RetainPeer(rndP1, rndSub1)
+				a.ReleasePeer(rndP1, rndSub1)
+
+				// rnd2: retain/release on already used subscriber
+				a.RetainPeer(rndP2, expP1.subscribers[0])
+				a.ReleasePeer(rndP2, expP1.subscribers[0])
+
+				return nil
+			}
+			return
+		}(),
+		func() (s testStruct) {
+			s.msg = "notification verification"
+			s.agent = NewDefaultAgent()
+			s.expectedPeers = createPeerExpectations(
+				mockCtrl,
+				[]string{"localhost:1234"},
+				2,
+			)
+
+			s.expectedPeers[0].subscribers[0].EXPECT().NotifyStatusChanged(
+				peerIdentifierMatcher(s.expectedPeers[0].identifier),
+			).Times(3)
+			s.expectedPeers[0].subscribers[1].EXPECT().NotifyStatusChanged(
+				peerIdentifierMatcher(s.expectedPeers[0].identifier),
+			).Times(3)
+
+			s.appliedFunc = func(a *Agent) error {
+				peer, _ := a.RetainPeer(s.expectedPeers[0].identifier, s.expectedPeers[0].subscribers[0])
+				a.RetainPeer(s.expectedPeers[0].identifier, s.expectedPeers[0].subscribers[1])
+
+				a.NotifyStatusChanged(peer)
+				a.NotifyStatusChanged(peer)
+				a.NotifyStatusChanged(peer)
+
+				return nil
+			}
+			return
+		}(),
+		func() (s testStruct) {
+			s.msg = "no notification after release"
+			s.agent = NewDefaultAgent()
+			s.expectedPeers = []peerExpectation{}
+
+			sub := transporttest.NewMockPeerSubscriber(mockCtrl)
+			sub.EXPECT().NotifyStatusChanged(gomock.Any()).Times(0)
+
+			pid := hostport.NewPeerIdentifier("localhost:1234")
+
+			s.appliedFunc = func(a *Agent) error {
+				peer, _ := a.RetainPeer(pid, sub)
+				a.ReleasePeer(pid, sub)
+
+				a.NotifyStatusChanged(peer)
+				a.NotifyStatusChanged(peer)
+				a.NotifyStatusChanged(peer)
+
+				return nil
+			}
+			return
+		}(),
+		func() (s testStruct) {
+			s.msg = "notification before versus after release"
+			s.agent = NewDefaultAgent()
+			s.expectedPeers = []peerExpectation{}
+
+			pid := hostport.NewPeerIdentifier("localhost:1234")
+
+			sub := transporttest.NewMockPeerSubscriber(mockCtrl)
+			sub.EXPECT().NotifyStatusChanged(peerIdentifierMatcher(pid)).Times(1)
+
+			s.appliedFunc = func(a *Agent) error {
+				peer, _ := a.RetainPeer(pid, sub)
+
+				a.NotifyStatusChanged(peer)
+
+				a.ReleasePeer(pid, sub)
+
+				a.NotifyStatusChanged(peer)
+				a.NotifyStatusChanged(peer)
+				a.NotifyStatusChanged(peer)
+
+				return nil
 			}
 			return
 		}(),
@@ -144,8 +363,27 @@ func TestAgent(t *testing.T) {
 	for _, tt := range tests {
 		agent := tt.agent
 
-		tt.appliedFunc(agent)
+		err := tt.appliedFunc(agent)
 
-		tt.assertFunc(agent)
+		assert.Equal(t, tt.expectedErr, err, tt.msg)
+		assert.Equal(t, len(tt.expectedPeers), len(agent.peerNodes), tt.msg)
+		for _, expectedPeerNode := range tt.expectedPeers {
+			peerNode, ok := agent.peerNodes[expectedPeerNode.identifier.Identifier()]
+			assert.True(t, ok, tt.msg)
+
+			assert.Equal(t, expectedPeerNode.identifier.Identifier(), peerNode.peer.Identifier(), tt.msg)
+
+			assert.Equal(t, len(expectedPeerNode.subscribers), len(peerNode.references), tt.msg)
+			for _, expectedSubscriber := range expectedPeerNode.subscribers {
+				subExists, ok := peerNode.references[expectedSubscriber]
+				assert.True(t, ok && subExists, "subscriber (%v) not in list (%v). %s", expectedSubscriber, peerNode.references, tt.msg)
+			}
+		}
 	}
+}
+
+func TestAgentClient(t *testing.T) {
+	agent := NewDefaultAgent()
+
+	assert.NotNil(t, agent.GetClient())
 }

--- a/transport/http/agent_test.go
+++ b/transport/http/agent_test.go
@@ -1,0 +1,150 @@
+package http
+
+import (
+	"testing"
+
+	"go.uber.org/yarpc/internal/errors"
+	"go.uber.org/yarpc/transport"
+	"go.uber.org/yarpc/transport/peers"
+	"go.uber.org/yarpc/transport/transporttest"
+
+	"github.com/crossdock/crossdock-go/assert"
+	"github.com/golang/mock/gomock"
+)
+
+func TestAgent(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	type testStruct struct {
+		agent       *Agent
+		appliedFunc func(transport.PeerAgent)
+		assertFunc  func(*Agent)
+	}
+	tests := []testStruct{
+		func() (s testStruct) {
+			msg := "one retain"
+			s.agent = NewDefaultAgent()
+			pid := peers.NewPeerIdentifier("localhost:1234")
+			s.appliedFunc = func(a transport.PeerAgent) {
+				sub := transporttest.NewMockPeerSubscriber(mockCtrl)
+				a.RetainPeer(pid, sub)
+			}
+			s.assertFunc = func(a *Agent) {
+				assert.Len(t, a.peers, 1, msg)
+
+				peer := a.peers[pid.Identifier()]
+				assert.Equal(t, pid.Identifier(), peer.Identifier(), msg)
+				assert.Equal(t, 1, peer.References(), msg)
+			}
+			return
+		}(),
+		func() (s testStruct) {
+			msg := "three retains"
+			s.agent = NewDefaultAgent()
+			pid := peers.NewPeerIdentifier("localhost:1234")
+			s.appliedFunc = func(a transport.PeerAgent) {
+				sub := transporttest.NewMockPeerSubscriber(mockCtrl)
+				sub2 := transporttest.NewMockPeerSubscriber(mockCtrl)
+				sub3 := transporttest.NewMockPeerSubscriber(mockCtrl)
+				a.RetainPeer(pid, sub)
+				a.RetainPeer(pid, sub2)
+				a.RetainPeer(pid, sub3)
+			}
+			s.assertFunc = func(a *Agent) {
+				assert.Len(t, a.peers, 1, msg)
+				peer := a.peers[pid.Identifier()]
+				assert.Equal(t, 3, peer.References(), msg)
+			}
+			return
+		}(),
+		func() (s testStruct) {
+			msg := "three retains, one release"
+			s.agent = NewDefaultAgent()
+			pid := peers.NewPeerIdentifier("localhost:1234")
+			s.appliedFunc = func(a transport.PeerAgent) {
+				sub := transporttest.NewMockPeerSubscriber(mockCtrl)
+				sub2 := transporttest.NewMockPeerSubscriber(mockCtrl)
+				sub3 := transporttest.NewMockPeerSubscriber(mockCtrl)
+				a.RetainPeer(pid, sub)
+				a.RetainPeer(pid, sub2)
+				a.ReleasePeer(pid, sub)
+				a.RetainPeer(pid, sub3)
+			}
+			s.assertFunc = func(a *Agent) {
+				assert.Len(t, a.peers, 1, msg)
+				peer := a.peers[pid.Identifier()]
+				assert.Equal(t, 2, peer.References(), msg)
+			}
+			return
+		}(),
+		func() (s testStruct) {
+			msg := "three retains, three release"
+			s.agent = NewDefaultAgent()
+			pid := peers.NewPeerIdentifier("localhost:1234")
+			s.appliedFunc = func(a transport.PeerAgent) {
+				sub := transporttest.NewMockPeerSubscriber(mockCtrl)
+				sub2 := transporttest.NewMockPeerSubscriber(mockCtrl)
+				sub3 := transporttest.NewMockPeerSubscriber(mockCtrl)
+				a.RetainPeer(pid, sub)
+				a.RetainPeer(pid, sub2)
+				a.ReleasePeer(pid, sub)
+				a.RetainPeer(pid, sub3)
+				a.ReleasePeer(pid, sub2)
+				a.ReleasePeer(pid, sub3)
+			}
+			s.assertFunc = func(a *Agent) {
+				assert.Len(t, a.peers, 0, msg)
+			}
+			return
+		}(),
+		func() (s testStruct) {
+			msg := "no retains, one release"
+			s.agent = NewDefaultAgent()
+			pid := peers.NewPeerIdentifier("localhost:1234")
+			var err error
+			s.appliedFunc = func(a transport.PeerAgent) {
+				sub := transporttest.NewMockPeerSubscriber(mockCtrl)
+				err = a.ReleasePeer(pid, sub)
+			}
+			s.assertFunc = func(a *Agent) {
+				assert.NotNil(t, err, msg)
+
+				errAgent, ok := err.(errors.ErrAgentHasNoReferenceToPeer)
+				assert.True(t, ok, msg)
+				assert.Equal(t, a, errAgent.Agent, msg)
+				assert.Equal(t, pid, errAgent.PeerIdentifier, msg)
+			}
+			return
+		}(),
+		func() (s testStruct) {
+			msg := "one retains, one release (from different subscriber)"
+			s.agent = NewDefaultAgent()
+			var err error
+			pid := peers.NewPeerIdentifier("localhost:1234")
+			invalidSub := transporttest.NewMockPeerSubscriber(mockCtrl)
+			s.appliedFunc = func(a transport.PeerAgent) {
+				sub1 := transporttest.NewMockPeerSubscriber(mockCtrl)
+				a.RetainPeer(pid, sub1)
+				err = a.ReleasePeer(pid, invalidSub)
+			}
+			s.assertFunc = func(a *Agent) {
+				assert.NotNil(t, err, msg)
+
+				errRef, ok := err.(errors.ErrPeerHasNoReferenceToSubscriber)
+				assert.True(t, ok, msg)
+				assert.Equal(t, a.peers[pid.Identifier()], errRef.Peer, msg)
+				assert.Equal(t, invalidSub, errRef.PeerSubscriber, msg)
+			}
+			return
+		}(),
+	}
+
+	for _, tt := range tests {
+		agent := tt.agent
+
+		tt.appliedFunc(agent)
+
+		tt.assertFunc(agent)
+	}
+}

--- a/transport/http/agent_test.go
+++ b/transport/http/agent_test.go
@@ -17,9 +17,10 @@ func TestAgent(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	type testStruct struct {
-		agent       *Agent
-		appliedFunc func(transport.PeerAgent)
-		assertFunc  func(*Agent)
+		msg           string
+		agent         *Agent
+		appliedFunc   func(*Agent)
+		expectedPeers []peerNode
 	}
 	tests := []testStruct{
 		func() (s testStruct) {

--- a/transport/http/agent_test.go
+++ b/transport/http/agent_test.go
@@ -3,8 +3,8 @@ package http
 import (
 	"testing"
 
-	"go.uber.org/yarpc/internal/errors"
 	"go.uber.org/yarpc/transport"
+	"go.uber.org/yarpc/transport/internal/errors"
 	"go.uber.org/yarpc/transport/peer/hostport"
 	"go.uber.org/yarpc/transport/transporttest"
 
@@ -375,8 +375,8 @@ func TestAgent(t *testing.T) {
 
 			assert.Equal(t, len(expectedPeerNode.subscribers), len(peerNode.references), tt.msg)
 			for _, expectedSubscriber := range expectedPeerNode.subscribers {
-				subExists, ok := peerNode.references[expectedSubscriber]
-				assert.True(t, ok && subExists, "subscriber (%v) not in list (%v). %s", expectedSubscriber, peerNode.references, tt.msg)
+				_, ok := peerNode.references[expectedSubscriber]
+				assert.True(t, ok, "subscriber (%v) not in list (%v). %s", expectedSubscriber, peerNode.references, tt.msg)
 			}
 		}
 	}

--- a/transport/http/agent_test.go
+++ b/transport/http/agent_test.go
@@ -3,13 +3,13 @@ package http
 import (
 	"testing"
 
+	"go.uber.org/yarpc/internal/errors"
 	"go.uber.org/yarpc/transport"
+	"go.uber.org/yarpc/transport/peer/hostport"
 	"go.uber.org/yarpc/transport/transporttest"
 
 	"github.com/crossdock/crossdock-go/assert"
 	"github.com/golang/mock/gomock"
-	"go.uber.org/yarpc/internal/errors"
-	"go.uber.org/yarpc/transport/peer/hostport"
 )
 
 type peerExpectation struct {

--- a/transport/internal/errors/peers.go
+++ b/transport/internal/errors/peers.go
@@ -19,7 +19,7 @@ func (e ErrPeerHasNoReferenceToSubscriber) Error() string {
 // ErrAgentHasNoReferenceToPeer is called when an agent is expected to
 // operate on a Peer it has no reference to
 type ErrAgentHasNoReferenceToPeer struct {
-	Agent          transport.PeerAgent
+	Agent          transport.Agent
 	PeerIdentifier transport.PeerIdentifier
 }
 

--- a/transport/internal/errors/peers.go
+++ b/transport/internal/errors/peers.go
@@ -1,31 +1,37 @@
 package errors
 
-import "fmt"
+import (
+	"fmt"
+	"go.uber.org/yarpc/transport"
+)
 
-// ErrPeerHasNoReferenceToSubscriber is called when a Peer is expected to operate on a PeerSubscriber it has no reference to
+// ErrPeerHasNoReferenceToSubscriber is called when a Peer is expected
+// to operate on a PeerSubscriber it has no reference to
 type ErrPeerHasNoReferenceToSubscriber struct {
-	PeerIdentifier interface{}
-	PeerSubscriber interface{}
+	PeerIdentifier transport.PeerIdentifier
+	PeerSubscriber transport.PeerSubscriber
 }
 
 func (e ErrPeerHasNoReferenceToSubscriber) Error() string {
 	return fmt.Sprintf("peer (%v) has no reference to peer subscriber (%v)", e.PeerIdentifier, e.PeerSubscriber)
 }
 
-// ErrAgentHasNoReferenceToPeer is called when an agent is expected to operate on a Peer it has no reference to
+// ErrAgentHasNoReferenceToPeer is called when an agent is expected to
+// operate on a Peer it has no reference to
 type ErrAgentHasNoReferenceToPeer struct {
-	Agent          interface{}
-	PeerIdentifier interface{}
+	Agent          transport.PeerAgent
+	PeerIdentifier transport.PeerIdentifier
 }
 
 func (e ErrAgentHasNoReferenceToPeer) Error() string {
 	return fmt.Sprintf("agent (%v) has no reference to peer (%v)", e.Agent, e.PeerIdentifier)
 }
 
-// ErrInvalidPeerType is when a specfic peer type is required, but was not passed in
+// ErrInvalidPeerType is when a specfic peer type is required, but
+// was not passed in
 type ErrInvalidPeerType struct {
 	ExpectedType   string
-	PeerIdentifier interface{}
+	PeerIdentifier transport.PeerIdentifier
 }
 
 func (e ErrInvalidPeerType) Error() string {


### PR DESCRIPTION
Summary: This diff introduces the concept of an http "PeerAgent".
Instances of this agent have the ability to create hostportpeers for
peerlists so they can be used in downstream calls. It controls the whole
lifecycle of a peer, as PeerLists should call retain/release during the
lifecycle of their peers.