### PR TITLE
[Oneway][Part 6] Encoding layers and http use CallOneway

### DIFF
--- a/crossdock/thrift/echo/yarpc/echoclient/client.go
+++ b/crossdock/thrift/echo/yarpc/echoclient/client.go
@@ -65,6 +65,7 @@ func (c client) Echo(
 	reqMeta yarpc.CallReqMeta,
 	_Ping *echo.Ping,
 ) (success *echo.Pong, resMeta yarpc.CallResMeta, err error) {
+
 	args := echo2.EchoHelper.Args(_Ping)
 
 	var body wire.Value

--- a/crossdock/thrift/echo/yarpc/echoserver/server.go
+++ b/crossdock/thrift/echo/yarpc/echoserver/server.go
@@ -54,6 +54,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Registrant {
 		Methods: map[string]thrift.UnaryHandler{
 			"echo": thrift.UnaryHandlerFunc(h.Echo),
 		},
+		OnewayMethods: map[string]thrift.OnewayHandler{},
 	}
 	return thrift.BuildRegistrants(service, opts...)
 }

--- a/crossdock/thrift/gauntlet/yarpc/secondserviceclient/client.go
+++ b/crossdock/thrift/gauntlet/yarpc/secondserviceclient/client.go
@@ -68,6 +68,7 @@ func (c client) BlahBlah(
 	ctx context.Context,
 	reqMeta yarpc.CallReqMeta,
 ) (resMeta yarpc.CallResMeta, err error) {
+
 	args := secondservice.BlahBlahHelper.Args()
 
 	var body wire.Value
@@ -90,6 +91,7 @@ func (c client) SecondtestString(
 	reqMeta yarpc.CallReqMeta,
 	_Thing *string,
 ) (success string, resMeta yarpc.CallResMeta, err error) {
+
 	args := secondservice.SecondtestStringHelper.Args(_Thing)
 
 	var body wire.Value

--- a/crossdock/thrift/gauntlet/yarpc/secondserviceserver/server.go
+++ b/crossdock/thrift/gauntlet/yarpc/secondserviceserver/server.go
@@ -59,6 +59,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Registrant {
 			"blahBlah":         thrift.UnaryHandlerFunc(h.BlahBlah),
 			"secondtestString": thrift.UnaryHandlerFunc(h.SecondtestString),
 		},
+		OnewayMethods: map[string]thrift.OnewayHandler{},
 	}
 	return thrift.BuildRegistrants(service, opts...)
 }

--- a/crossdock/thrift/gauntlet/yarpc/thrifttestclient/client.go
+++ b/crossdock/thrift/gauntlet/yarpc/thrifttestclient/client.go
@@ -184,6 +184,7 @@ func (c client) TestBinary(
 	reqMeta yarpc.CallReqMeta,
 	_Thing []byte,
 ) (success []byte, resMeta yarpc.CallResMeta, err error) {
+
 	args := thrifttest.TestBinaryHelper.Args(_Thing)
 
 	var body wire.Value
@@ -206,6 +207,7 @@ func (c client) TestByte(
 	reqMeta yarpc.CallReqMeta,
 	_Thing *int8,
 ) (success int8, resMeta yarpc.CallResMeta, err error) {
+
 	args := thrifttest.TestByteHelper.Args(_Thing)
 
 	var body wire.Value
@@ -228,6 +230,7 @@ func (c client) TestDouble(
 	reqMeta yarpc.CallReqMeta,
 	_Thing *float64,
 ) (success float64, resMeta yarpc.CallResMeta, err error) {
+
 	args := thrifttest.TestDoubleHelper.Args(_Thing)
 
 	var body wire.Value
@@ -250,6 +253,7 @@ func (c client) TestEnum(
 	reqMeta yarpc.CallReqMeta,
 	_Thing *gauntlet.Numberz,
 ) (success gauntlet.Numberz, resMeta yarpc.CallResMeta, err error) {
+
 	args := thrifttest.TestEnumHelper.Args(_Thing)
 
 	var body wire.Value
@@ -272,6 +276,7 @@ func (c client) TestException(
 	reqMeta yarpc.CallReqMeta,
 	_Arg *string,
 ) (resMeta yarpc.CallResMeta, err error) {
+
 	args := thrifttest.TestExceptionHelper.Args(_Arg)
 
 	var body wire.Value
@@ -294,6 +299,7 @@ func (c client) TestI32(
 	reqMeta yarpc.CallReqMeta,
 	_Thing *int32,
 ) (success int32, resMeta yarpc.CallResMeta, err error) {
+
 	args := thrifttest.TestI32Helper.Args(_Thing)
 
 	var body wire.Value
@@ -316,6 +322,7 @@ func (c client) TestI64(
 	reqMeta yarpc.CallReqMeta,
 	_Thing *int64,
 ) (success int64, resMeta yarpc.CallResMeta, err error) {
+
 	args := thrifttest.TestI64Helper.Args(_Thing)
 
 	var body wire.Value
@@ -338,6 +345,7 @@ func (c client) TestInsanity(
 	reqMeta yarpc.CallReqMeta,
 	_Argument *gauntlet.Insanity,
 ) (success map[gauntlet.UserId]map[gauntlet.Numberz]*gauntlet.Insanity, resMeta yarpc.CallResMeta, err error) {
+
 	args := thrifttest.TestInsanityHelper.Args(_Argument)
 
 	var body wire.Value
@@ -360,6 +368,7 @@ func (c client) TestList(
 	reqMeta yarpc.CallReqMeta,
 	_Thing []int32,
 ) (success []int32, resMeta yarpc.CallResMeta, err error) {
+
 	args := thrifttest.TestListHelper.Args(_Thing)
 
 	var body wire.Value
@@ -382,6 +391,7 @@ func (c client) TestMap(
 	reqMeta yarpc.CallReqMeta,
 	_Thing map[int32]int32,
 ) (success map[int32]int32, resMeta yarpc.CallResMeta, err error) {
+
 	args := thrifttest.TestMapHelper.Args(_Thing)
 
 	var body wire.Value
@@ -404,6 +414,7 @@ func (c client) TestMapMap(
 	reqMeta yarpc.CallReqMeta,
 	_Hello *int32,
 ) (success map[int32]map[int32]int32, resMeta yarpc.CallResMeta, err error) {
+
 	args := thrifttest.TestMapMapHelper.Args(_Hello)
 
 	var body wire.Value
@@ -431,6 +442,7 @@ func (c client) TestMulti(
 	_Arg4 *gauntlet.Numberz,
 	_Arg5 *gauntlet.UserId,
 ) (success *gauntlet.Xtruct, resMeta yarpc.CallResMeta, err error) {
+
 	args := thrifttest.TestMultiHelper.Args(_Arg0, _Arg1, _Arg2, _Arg3, _Arg4, _Arg5)
 
 	var body wire.Value
@@ -454,6 +466,7 @@ func (c client) TestMultiException(
 	_Arg0 *string,
 	_Arg1 *string,
 ) (success *gauntlet.Xtruct, resMeta yarpc.CallResMeta, err error) {
+
 	args := thrifttest.TestMultiExceptionHelper.Args(_Arg0, _Arg1)
 
 	var body wire.Value
@@ -476,6 +489,7 @@ func (c client) TestNest(
 	reqMeta yarpc.CallReqMeta,
 	_Thing *gauntlet.Xtruct2,
 ) (success *gauntlet.Xtruct2, resMeta yarpc.CallResMeta, err error) {
+
 	args := thrifttest.TestNestHelper.Args(_Thing)
 
 	var body wire.Value
@@ -498,6 +512,7 @@ func (c client) TestSet(
 	reqMeta yarpc.CallReqMeta,
 	_Thing map[int32]struct{},
 ) (success map[int32]struct{}, resMeta yarpc.CallResMeta, err error) {
+
 	args := thrifttest.TestSetHelper.Args(_Thing)
 
 	var body wire.Value
@@ -520,6 +535,7 @@ func (c client) TestString(
 	reqMeta yarpc.CallReqMeta,
 	_Thing *string,
 ) (success string, resMeta yarpc.CallResMeta, err error) {
+
 	args := thrifttest.TestStringHelper.Args(_Thing)
 
 	var body wire.Value
@@ -542,6 +558,7 @@ func (c client) TestStringMap(
 	reqMeta yarpc.CallReqMeta,
 	_Thing map[string]string,
 ) (success map[string]string, resMeta yarpc.CallResMeta, err error) {
+
 	args := thrifttest.TestStringMapHelper.Args(_Thing)
 
 	var body wire.Value
@@ -564,6 +581,7 @@ func (c client) TestStruct(
 	reqMeta yarpc.CallReqMeta,
 	_Thing *gauntlet.Xtruct,
 ) (success *gauntlet.Xtruct, resMeta yarpc.CallResMeta, err error) {
+
 	args := thrifttest.TestStructHelper.Args(_Thing)
 
 	var body wire.Value
@@ -586,6 +604,7 @@ func (c client) TestTypedef(
 	reqMeta yarpc.CallReqMeta,
 	_Thing *gauntlet.UserId,
 ) (success gauntlet.UserId, resMeta yarpc.CallResMeta, err error) {
+
 	args := thrifttest.TestTypedefHelper.Args(_Thing)
 
 	var body wire.Value
@@ -607,6 +626,7 @@ func (c client) TestVoid(
 	ctx context.Context,
 	reqMeta yarpc.CallReqMeta,
 ) (resMeta yarpc.CallResMeta, err error) {
+
 	args := thrifttest.TestVoidHelper.Args()
 
 	var body wire.Value

--- a/crossdock/thrift/gauntlet/yarpc/thrifttestserver/server.go
+++ b/crossdock/thrift/gauntlet/yarpc/thrifttestserver/server.go
@@ -192,6 +192,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Registrant {
 			"testTypedef":        thrift.UnaryHandlerFunc(h.TestTypedef),
 			"testVoid":           thrift.UnaryHandlerFunc(h.TestVoid),
 		},
+		OnewayMethods: map[string]thrift.OnewayHandler{},
 	}
 	return thrift.BuildRegistrants(service, opts...)
 }

--- a/encoding/json/outbound_test.go
+++ b/encoding/json/outbound_test.go
@@ -23,6 +23,7 @@ package json
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io/ioutil"
 	"reflect"
 	"testing"
@@ -148,6 +149,97 @@ func TestCall(t *testing.T) {
 				assert.Equal(t, tt.wantHeaders, res.Headers())
 				assert.Equal(t, tt.want, resBody)
 			}
+		}
+	}
+}
+
+type successAck struct{}
+
+func (a successAck) String() string {
+	return "success"
+}
+
+func TestCallOneway(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	ctx := context.Background()
+
+	caller := "caller"
+	service := "service"
+
+	tests := []struct {
+		procedure      string
+		headers        yarpc.Headers
+		body           interface{}
+		encodedRequest string
+
+		// whether the outbound receives the request
+		noCall bool
+
+		wantErr string // error message
+	}{
+		{
+			procedure:      "foo",
+			body:           []string{"foo", "bar"},
+			encodedRequest: `["foo","bar"]` + "\n",
+		},
+		{
+			procedure: "baz",
+			body:      func() {}, // funcs cannot be json.Marshal'ed
+			noCall:    true,
+			wantErr:   `failed to encode "json" request body for procedure "baz" of service "service"`,
+		},
+		{
+			procedure:      "requestHeaders",
+			headers:        yarpc.NewHeaders().With("user-id", "42"),
+			body:           map[string]interface{}{},
+			encodedRequest: "{}\n",
+		},
+	}
+
+	for _, tt := range tests {
+		outbound := transporttest.NewMockOnewayOutbound(mockCtrl)
+		client := New(channel.MultiOutbound(caller, service,
+			transport.Outbounds{
+				Oneway: outbound,
+			}))
+
+		if !tt.noCall {
+			reqMatcher := transporttest.NewRequestMatcher(t,
+				&transport.Request{
+					Caller:    caller,
+					Service:   service,
+					Procedure: tt.procedure,
+					Encoding:  Encoding,
+					Headers:   transport.Headers(tt.headers),
+					Body:      bytes.NewReader([]byte(tt.encodedRequest)),
+				})
+
+			if tt.wantErr != "" {
+				outbound.
+					EXPECT().
+					CallOneway(gomock.Any(), reqMatcher).
+					Return(nil, errors.New(tt.wantErr))
+			} else {
+				outbound.
+					EXPECT().
+					CallOneway(gomock.Any(), reqMatcher).
+					Return(&successAck{}, nil)
+			}
+		}
+
+		ack, err := client.CallOneway(
+			ctx,
+			yarpc.NewReqMeta().Procedure(tt.procedure).Headers(tt.headers),
+			tt.body)
+
+		if tt.wantErr != "" {
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		} else {
+			assert.NoError(t, err, "")
+			assert.Equal(t, ack.String(), "success")
 		}
 	}
 }

--- a/encoding/thrift/outbound_test.go
+++ b/encoding/thrift/outbound_test.go
@@ -23,6 +23,7 @@ package thrift
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"io/ioutil"
 	"testing"
@@ -197,6 +198,126 @@ func TestClient(t *testing.T) {
 			}
 		} else {
 			assert.NoError(t, err, "%v: expected success", tt.desc)
+		}
+	}
+}
+
+type successAck struct{}
+
+func (a successAck) String() string {
+	return "success"
+}
+
+func TestClientOneway(t *testing.T) {
+	caller, service, procedure := "caller", "MyService", "someMethod"
+
+	tests := []struct {
+		desc            string
+		giveRequestBody envelope.Enveloper // outgoing request body
+		clientOptions   []ClientOption
+
+		expectCall          bool           // whether outbound.Call is expected
+		wantRequestEnvelope *wire.Envelope // expect EncodeEnveloped(x)
+		wantRequestBody     *wire.Value    // expect Encode(x)
+		wantError           string         // whether an error is expected
+	}{
+		{
+			desc:            "happy case",
+			giveRequestBody: fakeEnveloper(wire.Call),
+			clientOptions:   []ClientOption{Enveloped},
+
+			expectCall: true,
+			wantRequestEnvelope: &wire.Envelope{
+				Name:  procedure,
+				SeqID: 1,
+				Type:  wire.Call,
+				Value: wire.NewValueStruct(wire.Struct{}),
+			},
+		},
+		{
+			desc:            "happy case without enveloping",
+			giveRequestBody: fakeEnveloper(wire.Call),
+
+			expectCall:      true,
+			wantRequestBody: valueptr(wire.NewValueStruct(wire.Struct{})),
+		},
+		{
+			desc:            "wrong envelope type for request",
+			giveRequestBody: fakeEnveloper(wire.Reply),
+			clientOptions:   []ClientOption{Enveloped},
+
+			wantError: `failed to encode "thrift" request body for procedure ` +
+				`"MyService::someMethod" of service "MyService": unexpected envelope type: Reply`,
+		},
+	}
+
+	for _, tt := range tests {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		proto := NewMockProtocol(mockCtrl)
+		bodyBytes := []byte("irrelevant")
+
+		if tt.wantRequestEnvelope != nil {
+			proto.EXPECT().EncodeEnveloped(*tt.wantRequestEnvelope, gomock.Any()).
+				Do(func(_ wire.Envelope, w io.Writer) {
+					_, err := w.Write(bodyBytes)
+					require.NoError(t, err, "Write() failed")
+				}).Return(nil)
+		}
+
+		if tt.wantRequestBody != nil {
+			proto.EXPECT().Encode(*tt.wantRequestBody, gomock.Any()).
+				Do(func(_ wire.Value, w io.Writer) {
+					_, err := w.Write(bodyBytes)
+					require.NoError(t, err, "Write() failed")
+				}).Return(nil)
+		}
+
+		ctx := context.Background()
+
+		onewayOutbound := transporttest.NewMockOnewayOutbound(mockCtrl)
+
+		requestMatcher := transporttest.NewRequestMatcher(t, &transport.Request{
+			Caller:    caller,
+			Service:   service,
+			Encoding:  Encoding,
+			Procedure: procedureName(service, procedure),
+			Body:      bytes.NewReader(bodyBytes),
+		})
+
+		if tt.expectCall {
+			if tt.wantError != "" {
+				onewayOutbound.
+					EXPECT().
+					CallOneway(ctx, requestMatcher).
+					Return(nil, errors.New(tt.wantError))
+			} else {
+				onewayOutbound.
+					EXPECT().
+					CallOneway(ctx, requestMatcher).
+					Return(&successAck{}, nil)
+			}
+		}
+		opts := tt.clientOptions
+		opts = append(opts, Protocol(proto))
+
+		c := New(Config{
+			Service: service,
+			Channel: channel.MultiOutbound(caller, service,
+				transport.Outbounds{
+					Oneway: onewayOutbound,
+				}),
+		}, opts...)
+
+		ack, err := c.CallOneway(ctx, nil, tt.giveRequestBody)
+		if tt.wantError != "" {
+			if assert.Error(t, err, "%v: expected failure", tt.desc) {
+				assert.Contains(t, err.Error(), tt.wantError, "%v: error mismatch", tt.desc)
+			}
+		} else {
+			assert.NoError(t, err, "%v: expected success", tt.desc)
+			assert.Equal(t, "success", ack.String())
 		}
 	}
 }

--- a/encoding/thrift/thriftrw-plugin-yarpc/main.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/main.go
@@ -56,7 +56,8 @@ type Interface interface {
 			ctx <$context>.Context,
 			reqMeta <$yarpc>.ReqMeta, <range .Arguments>
 			<.Name> <formatType .Type>,<end>
-		) <if .ReturnType> (<formatType .ReturnType>, <$yarpc>.ResMeta, error)
+		)<if .OneWay> error
+		<else if .ReturnType> (<formatType .ReturnType>, <$yarpc>.ResMeta, error)
 		<else> (<$yarpc>.ResMeta, error)
 		<end>
 	<end>
@@ -76,6 +77,9 @@ func New(impl Interface, opts ...<$thrift>.RegisterOption) []<$transport>.Regist
 		Methods: map[string]<$thrift>.UnaryHandler{
 			<range .Service.Functions><if not .OneWay>"<.ThriftName>": <$thrift>.UnaryHandlerFunc(h.<.Name>),<end>
 		<end>},
+		OnewayMethods: map[string]<$thrift>.OnewayHandler{
+			<range .Service.Functions><if .OneWay>"<.ThriftName>": <$thrift>.OnewayHandlerFunc(h.<.Name>),<end>
+		<end>},
 	}
 	return <$thrift>.BuildRegistrants(service, opts...)
 }
@@ -87,6 +91,20 @@ type handler struct{ impl Interface }
 <$servicePackage := import $service.ImportPath>
 <$wire := import "go.uber.org/thriftrw/wire">
 
+<if .OneWay>
+func (h handler) <.Name>(
+	ctx <$context>.Context,
+	reqMeta <$yarpc>.ReqMeta,
+	body <$wire>.Value,
+) error {
+	var args <$servicePackage>.<.Name>Args
+	if err := args.FromWire(body); err != nil {
+		return err
+	}
+
+	return h.impl.<.Name>(ctx, reqMeta, <range .Arguments>args.<.Name>,<end>)
+}
+<else>
 func (h handler) <.Name>(
 	ctx <$context>.Context,
 	reqMeta <$yarpc>.ReqMeta,
@@ -115,6 +133,7 @@ func (h handler) <.Name>(
 	return response, err
 }
 <end>
+<end>
 `
 
 const clientTemplate = `
@@ -141,7 +160,8 @@ type Interface interface {
 			ctx <$context>.Context,
 			reqMeta <$yarpc>.CallReqMeta, <range .Arguments>
 				<.Name> <formatType .Type>,<end>
-		) <if .ReturnType> (<formatType .ReturnType>, <$yarpc>.CallResMeta, error)
+		)<if .OneWay> (<$transport>.Ack, error)
+		<else if .ReturnType> (<formatType .ReturnType>, <$yarpc>.CallResMeta, error)
 		<else> (<$yarpc>.CallResMeta, error)
 		<end>
 	<end>
@@ -171,13 +191,17 @@ type client struct{ c <$thrift>.Client }
 <range .Service.Functions>
 
 <$servicePackage := import $service.ImportPath>
-<$wire := import "go.uber.org/thriftrw/wire">
 
 func (c client) <.Name>(
 	ctx <$context>.Context,
 	reqMeta <$yarpc>.CallReqMeta, <range .Arguments>
 	_<.Name> <formatType .Type>,<end>
-) (<if .ReturnType>success <formatType .ReturnType>,<end> resMeta <$yarpc>.CallResMeta, err error) {
+<if .OneWay>) (<$transport>.Ack, error) {
+	args := <$servicePackage>.<.Name>Helper.Args(<range .Arguments>_<.Name>, <end>)
+	return c.c.CallOneway(ctx, reqMeta, args)
+}
+<else>) (<if .ReturnType>success <formatType .ReturnType>,<end> resMeta <$yarpc>.CallResMeta, err error) {
+	<$wire := import "go.uber.org/thriftrw/wire">
 	args := <$servicePackage>.<.Name>Helper.Args(<range .Arguments>_<.Name>, <end>)
 
 	var body <$wire>.Value
@@ -194,6 +218,7 @@ func (c client) <.Name>(
 	<if .ReturnType>success, <end>err = <$servicePackage>.<.Name>Helper.UnwrapResponse(&result)
 	return
 }
+<end>
 <end>
 `
 

--- a/examples/thrift/hello/thrift/hello/yarpc/helloserver/server.go
+++ b/examples/thrift/hello/thrift/hello/yarpc/helloserver/server.go
@@ -25,13 +25,12 @@ package helloserver
 
 import (
 	"context"
-
 	"go.uber.org/thriftrw/wire"
-	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/encoding/thrift"
+	"go.uber.org/yarpc/transport"
 	"go.uber.org/yarpc/examples/thrift/hello/thrift/hello"
 	hello2 "go.uber.org/yarpc/examples/thrift/hello/thrift/hello/service/hello"
-	"go.uber.org/yarpc/transport"
+	"go.uber.org/yarpc"
 )
 
 // Interface is the server-side interface for the Hello service.
@@ -55,6 +54,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Registrant {
 		Methods: map[string]thrift.UnaryHandler{
 			"echo": thrift.UnaryHandlerFunc(h.Echo),
 		},
+		OnewayMethods: map[string]thrift.OnewayHandler{},
 	}
 	return thrift.BuildRegistrants(service, opts...)
 }

--- a/examples/thrift/keyvalue/kv/yarpc/keyvalueserver/server.go
+++ b/examples/thrift/keyvalue/kv/yarpc/keyvalueserver/server.go
@@ -25,12 +25,11 @@ package keyvalueserver
 
 import (
 	"context"
-
 	"go.uber.org/thriftrw/wire"
-	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/encoding/thrift"
-	"go.uber.org/yarpc/examples/thrift/keyvalue/kv/service/keyvalue"
 	"go.uber.org/yarpc/transport"
+	"go.uber.org/yarpc/examples/thrift/keyvalue/kv/service/keyvalue"
+	"go.uber.org/yarpc"
 )
 
 // Interface is the server-side interface for the KeyValue service.
@@ -62,6 +61,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Registrant {
 			"getValue": thrift.UnaryHandlerFunc(h.GetValue),
 			"setValue": thrift.UnaryHandlerFunc(h.SetValue),
 		},
+		OnewayMethods: map[string]thrift.OnewayHandler{},
 	}
 	return thrift.BuildRegistrants(service, opts...)
 }

--- a/transport/roundtrip_test.go
+++ b/transport/roundtrip_test.go
@@ -56,10 +56,12 @@ type roundTripTransport interface {
 	// Set up an Inbound serving Registry r, and call f with an Outbound that
 	// knows how to talk to that Inbound.
 	WithRegistry(r transport.Registry, f func(transport.UnaryOutbound))
+	WithRegistryOneway(r transport.Registry, f func(transport.OnewayOutbound))
 }
 
 type staticRegistry struct {
-	Handler transport.UnaryHandler
+	Handler       transport.UnaryHandler
+	OnewayHandler transport.OnewayHandler
 }
 
 func (r staticRegistry) Register([]transport.Registrant) {
@@ -71,7 +73,11 @@ func (r staticRegistry) ServiceProcedures() []transport.ServiceProcedure {
 }
 
 func (r staticRegistry) GetHandlerSpec(service string, procedure string) (transport.HandlerSpec, error) {
-	return transport.NewUnaryHandlerSpec(r.Handler), nil
+	if procedure == testProcedure {
+		return transport.NewUnaryHandlerSpec(r.Handler), nil
+	} else {
+		return transport.NewOnewayHandlerSpec(r.OnewayHandler), nil
+	}
 }
 
 // handlerFunc wraps a function into a transport.Registry
@@ -81,10 +87,29 @@ func (f unaryHandlerFunc) Handle(ctx context.Context, r *transport.Request, w tr
 	return f(ctx, r, w)
 }
 
+// onewayHandlerFunc wraps a function into a transport.Registry
+type onewayHandlerFunc func(context.Context, *transport.Request) error
+
+func (f onewayHandlerFunc) HandleOneway(ctx context.Context, r *transport.Request) error {
+	return f(ctx, r)
+}
+
 // httpTransport implements a roundTripTransport for HTTP.
 type httpTransport struct{ t *testing.T }
 
 func (ht httpTransport) WithRegistry(r transport.Registry, f func(transport.UnaryOutbound)) {
+	i := http.NewInbound("127.0.0.1:0")
+	require.NoError(ht.t, i.Start(transport.ServiceDetail{Name: testService, Registry: r}, transport.NoDeps), "failed to start")
+	defer i.Stop()
+
+	addr := fmt.Sprintf("http://%v/", i.Addr().String())
+	o := http.NewOutbound(addr)
+	require.NoError(ht.t, o.Start(transport.NoDeps), "failed to start outbound")
+	defer o.Stop()
+	f(o)
+}
+
+func (ht httpTransport) WithRegistryOneway(r transport.Registry, f func(transport.OnewayOutbound)) {
 	i := http.NewInbound("127.0.0.1:0")
 	require.NoError(ht.t, i.Start(transport.ServiceDetail{Name: testService, Registry: r}, transport.NoDeps), "failed to start")
 	defer i.Stop()
@@ -117,6 +142,10 @@ func (tt tchannelTransport) WithRegistry(r transport.Registry, f func(transport.
 
 		f(o)
 	})
+}
+
+func (tt tchannelTransport) WithRegistryOneway(r transport.Registry, f func(transport.OnewayOutbound)) {
+	panic("tchannel does not support oneway calls")
 }
 
 func TestSimpleRoundTrip(t *testing.T) {
@@ -247,5 +276,83 @@ func TestSimpleRoundTrip(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+func TestSimpleRoundTripOneway(t *testing.T) {
+	trans := httpTransport{t}
+
+	tests := []struct {
+		name           string
+		requestHeaders transport.Headers
+		requestBody    string
+	}{
+		{
+			name:           "hello world",
+			requestHeaders: transport.NewHeaders().With("foo", "bar"),
+			requestBody:    "hello world",
+		},
+		{
+			name:           "empty",
+			requestHeaders: transport.NewHeaders(),
+			requestBody:    "",
+		},
+	}
+
+	rootCtx := context.Background()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			requestMatcher := transporttest.NewRequestMatcher(t, &transport.Request{
+				Caller:    testCaller,
+				Service:   testService,
+				Procedure: testProcedureOneway,
+				Encoding:  raw.Encoding,
+				Headers:   tt.requestHeaders,
+				Body:      bytes.NewReader([]byte(tt.requestBody)),
+			})
+
+			handlerDone := make(chan struct{})
+
+			onewayHandler := onewayHandlerFunc(func(_ context.Context, r *transport.Request) error {
+				assert.True(t, requestMatcher.Matches(r), "request mismatch: received %v", r)
+
+				// Pretend to work: this delay should not slow down tests since it is a
+				// server-side operation
+				time.Sleep(5 * time.Second)
+
+				// close the channel, telling the client (which should not be waiting for
+				// a response) that the handler finished executing
+				close(handlerDone)
+
+				return nil
+			})
+
+			registry := staticRegistry{OnewayHandler: onewayHandler}
+
+			trans.WithRegistryOneway(registry, func(o transport.OnewayOutbound) {
+				ack, err := o.CallOneway(rootCtx, &transport.Request{
+					Caller:    testCaller,
+					Service:   testService,
+					Procedure: testProcedureOneway,
+					Encoding:  raw.Encoding,
+					Headers:   tt.requestHeaders,
+					Body:      bytes.NewReader([]byte(tt.requestBody)),
+				})
+
+				select {
+				case <-handlerDone:
+					// if the server filled the channel, it means we waited for the server
+					// to complete the request
+					assert.Fail(t, "client waited for server handler to finish executing")
+				default:
+				}
+
+				if assert.NoError(t, err, "%T: oneway call failed for test '%v'", trans, tt.name) {
+					assert.NotNil(t, ack)
+				}
+			})
+		})
 	}
 }


### PR DESCRIPTION
 All encoding layers implement CallOneway, which in turn call CallOneway on the appropriate OnewayOutbound given by the channel. Thrift code generation template now supports oneway calls. Additionally, a roundtrip test is added using HTTP.