### PR TITLE
Factor Registrar out of Registry

### DIFF
--- a/crossdock/server/yarpc/server.go
+++ b/crossdock/server/yarpc/server.go
@@ -71,7 +71,7 @@ func Stop() {
 	}
 }
 
-func register(reg transport.Registry) {
+func register(reg transport.Registrar) {
 	reg.Register(raw.Procedure("echo/raw", EchoRaw))
 	reg.Register(json.Procedure("echo", EchoJSON))
 

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -34,7 +34,7 @@ import (
 // Clients to send RPCs, and by Procedures to recieve them. This object is what
 // enables an application to be transport-agnostic.
 type Dispatcher interface {
-	transport.Registry
+	transport.Registrar
 	transport.ChannelProvider
 
 	// Inbounds returns a copy of the list of inbounds for this RPC object.
@@ -79,7 +79,7 @@ func NewDispatcher(cfg Config) Dispatcher {
 
 	return dispatcher{
 		Name:        cfg.Name,
-		Registry:    transport.NewMapRegistry(cfg.Name),
+		Registrar:   transport.NewMapRegistry(cfg.Name),
 		inbounds:    cfg.Inbounds,
 		Outbounds:   cfg.Outbounds,
 		Filter:      cfg.Filter,
@@ -92,7 +92,7 @@ func NewDispatcher(cfg Config) Dispatcher {
 //
 // It allows use of multiple Inbounds and Outbounds together.
 type dispatcher struct {
-	transport.Registry
+	transport.Registrar
 
 	Name        string
 	Outbounds   transport.Outbounds
@@ -192,7 +192,7 @@ func (d dispatcher) Register(rs []transport.Registrant) {
 		r.Handler = transport.ApplyInterceptor(r.Handler, d.Interceptor)
 		rs[i] = r
 	}
-	d.Registry.Register(rs)
+	d.Registrar.Register(rs)
 }
 
 func (d dispatcher) Stop() error {

--- a/encoding/json/register.go
+++ b/encoding/json/register.go
@@ -37,13 +37,13 @@ var (
 	_interfaceEmptyType = reflect.TypeOf((*interface{})(nil)).Elem()
 )
 
-// Register calls the Registry's Register method.
+// Register calls the Registrar's Register method.
 //
 // This function exists for backwards compatibility only. It will be removed
 // in a future version.
 //
-// Deprecated: Use the Registry's Register method directly.
-func Register(r transport.Registry, rs []transport.Registrant) {
+// Deprecated: Use the Registrar's Register method directly.
+func Register(r transport.Registrar, rs []transport.Registrant) {
 	r.Register(rs)
 }
 

--- a/encoding/raw/register.go
+++ b/encoding/raw/register.go
@@ -27,13 +27,13 @@ import (
 	"go.uber.org/yarpc/transport"
 )
 
-// Register calls the Registry's Register method.
+// Register calls the Registrar's Register method.
 //
 // This function exists for backwards compatibility only. It will be removed
 // in a future version.
 //
-// Deprecated: Use the Registry's Register method directly.
-func Register(r transport.Registry, rs []transport.Registrant) {
+// Deprecated: Use the Registrar's Register method directly.
+func Register(r transport.Registrar, rs []transport.Registrant) {
 	r.Register(rs)
 }
 

--- a/encoding/thrift/register.go
+++ b/encoding/thrift/register.go
@@ -30,13 +30,13 @@ import (
 	"go.uber.org/thriftrw/wire"
 )
 
-// Register calls the Registry's Register method.
+// Register calls the Registrar's Register method.
 //
 // This function exists for backwards compatibility only. It will be removed
 // in a future version.
 //
-// Deprecated: Use the Registry's Register method directly.
-func Register(r transport.Registry, rs []transport.Registrant) {
+// Deprecated: Use the Registrar's Register method directly.
+func Register(r transport.Registrar, rs []transport.Registrant) {
 	r.Register(rs)
 }
 

--- a/transport/register.go
+++ b/transport/register.go
@@ -53,9 +53,6 @@ type Registrant struct {
 // Registry maintains and provides access to a collection of procedures and
 // their handlers.
 type Registry interface {
-	// Registers zero or more registrants with the registry.
-	Register([]Registrant)
-
 	// ServiceProcedures returns a list of services and their procedures that
 	// have been registered so far.
 	ServiceProcedures() []ServiceProcedure
@@ -67,6 +64,14 @@ type Registry interface {
 	// service may be empty to indicate that the default service name should
 	// be used.
 	GetHandler(service, procedure string) (Handler, error)
+}
+
+// Registrar provides access to a collection of procedures and their handlers.
+type Registrar interface {
+	Registry
+
+	// Registers zero or more registrants with the registry.
+	Register([]Registrant)
 }
 
 // MapRegistry is a Registry that maintains a map of the registered


### PR DESCRIPTION
This change factors the registry (accessor) from the registrar (mutator) interfaces, since only the registry interface is needed for inbound service details, so we have less surface area for registry adapters. The next step is to shift from GetHandler(sn, pn) to Choose(ctx,req) in registries.

r @abhinav @willhug @AlexAPB 