### PR TITLE
Generalize GetHandler(ctx,req)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ v0.5.0 (unreleased)
 -------------------
 
 -   Upgrade to ThriftRW 1.0.
+-   **Breaking**: A detail of inbound transports has changed.
+    Starting an inbound transport accepts a ServiceDetail, including
+    the service name and a Registry. The Registry now must
+    implement `Choose(context.Context, transport.Request) (HandlerSpec, error)`
+    instead of `GetHandler(service, procedure string) (HandlerSpec, error)`.
+    Note that in the prior release, `Handler` became `HandleSpec` to
+    accommodate oneway handlers.
 
 
 v0.4.0 (2016-11-11)

--- a/internal/registrytest/matcher.go
+++ b/internal/registrytest/matcher.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package registrytest
+
+import "go.uber.org/yarpc/transport"
+
+// Criterion is an argument that adds criteria to a transport request and
+// context matcher.
+type Criterion func(*Matcher)
+
+// NewMatcher returns a pair of matchers corresponding to the arguments
+// of GetHandler(Context, Request), for verifying that GetHandler is called with
+// parameters that satisfy given constraints. Passing options like
+// WithService("foo") adds constraints to the matcher.
+func NewMatcher(criteria ...Criterion) *Matcher {
+	m := Matcher{
+		constraints: make([]choiceConstraint, 0, 5),
+	}
+	for _, criterion := range criteria {
+		criterion(&m)
+	}
+	return &m
+}
+
+type choiceConstraint func(*transport.Request) bool
+
+// Matcher is a gomock Matcher that validates transport requests with
+// given criteria.
+type Matcher struct {
+	constraints []choiceConstraint
+}
+
+// WithCaller adds a constraint that the request caller must match.
+func (m *Matcher) WithCaller(caller string) *Matcher {
+	m.constraints = append(m.constraints, func(r *transport.Request) bool {
+		return caller == r.Caller
+	})
+	return m
+}
+
+// WithService adds a constraint that the request callee must match.
+func (m *Matcher) WithService(service string) *Matcher {
+	m.constraints = append(m.constraints, func(r *transport.Request) bool {
+		return service == r.Service
+	})
+	return m
+}
+
+// WithProcedure adds a constraint that the request procedure must match.
+func (m *Matcher) WithProcedure(procedure string) *Matcher {
+	m.constraints = append(m.constraints, func(r *transport.Request) bool {
+		return procedure == r.Procedure
+	})
+	return m
+}
+
+// Matches returns whether a transport request matches the configured criteria
+// for the matcher.
+func (m *Matcher) Matches(got interface{}) bool {
+	req := got.(*transport.Request)
+	for _, check := range m.constraints {
+		if !check(req) {
+			return false
+		}
+	}
+	return true
+}
+
+func (m *Matcher) String() string {
+	return "choice matcher"
+}

--- a/transport/http/handler.go
+++ b/transport/http/handler.go
@@ -98,7 +98,7 @@ func (h handler) callHandler(w http.ResponseWriter, req *http.Request, start tim
 		return err
 	}
 
-	spec, err := h.Registry.GetHandlerSpec(treq.Service, treq.Procedure)
+	spec, err := h.Registry.Choose(ctx, treq)
 	if err != nil {
 		return updateSpanWithErr(span, err)
 	}

--- a/transport/http/handler_test.go
+++ b/transport/http/handler_test.go
@@ -32,6 +32,7 @@ import (
 
 	yarpc "go.uber.org/yarpc"
 	"go.uber.org/yarpc/encoding/raw"
+	"go.uber.org/yarpc/internal/registrytest"
 	"go.uber.org/yarpc/transport"
 	"go.uber.org/yarpc/transport/transporttest"
 
@@ -55,7 +56,10 @@ func TestHandlerSucces(t *testing.T) {
 	rpcHandler := transporttest.NewMockUnaryHandler(mockCtrl)
 	spec := transport.NewUnaryHandlerSpec(rpcHandler)
 
-	registry.EXPECT().GetHandlerSpec("curly", "nyuck").Return(spec, nil)
+	registry.EXPECT().Choose(gomock.Any(), registrytest.NewMatcher().
+		WithService("curly").
+		WithProcedure("nyuck"),
+	).Return(spec, nil)
 
 	rpcHandler.EXPECT().Handle(
 		transporttest.NewContextMatcher(t,
@@ -121,7 +125,10 @@ func TestHandlerHeaders(t *testing.T) {
 		rpcHandler := transporttest.NewMockUnaryHandler(mockCtrl)
 		spec := transport.NewUnaryHandlerSpec(rpcHandler)
 
-		registry.EXPECT().GetHandlerSpec("service", "hello").Return(spec, nil)
+		registry.EXPECT().Choose(gomock.Any(), registrytest.NewMatcher().
+			WithService("service").
+			WithProcedure("hello"),
+		).Return(spec, nil)
 
 		httpHandler := handler{Registry: registry}
 
@@ -244,7 +251,10 @@ func TestHandlerFailures(t *testing.T) {
 			// since TTL is checked after we've determined the transport type, if we have an
 			// error with TTL it will be discovered after we read from the registry
 			spec := transport.NewUnaryHandlerSpec(panickedHandler{})
-			reg.EXPECT().GetHandlerSpec(service, procedure).Return(spec, nil)
+			reg.EXPECT().Choose(gomock.Any(), registrytest.NewMatcher().
+				WithService(service).
+				WithProcedure(procedure),
+			).Return(spec, nil)
 		}
 
 		h := handler{Registry: reg}
@@ -293,7 +303,10 @@ func TestHandlerInternalFailure(t *testing.T) {
 	registry := transporttest.NewMockRegistry(mockCtrl)
 	spec := transport.NewUnaryHandlerSpec(rpcHandler)
 
-	registry.EXPECT().GetHandlerSpec("fake", "hello").Return(spec, nil)
+	registry.EXPECT().Choose(gomock.Any(), registrytest.NewMatcher().
+		WithService("fake").
+		WithProcedure("hello"),
+	).Return(spec, nil)
 
 	httpHandler := handler{Registry: registry}
 	httpResponse := httptest.NewRecorder()

--- a/transport/http/inbound_test.go
+++ b/transport/http/inbound_test.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	"go.uber.org/yarpc/encoding/raw"
+	"go.uber.org/yarpc/internal/registrytest"
 	"go.uber.org/yarpc/transport"
 	"go.uber.org/yarpc/transport/transporttest"
 
@@ -135,7 +136,11 @@ func TestInboundMux(t *testing.T) {
 	defer o.Stop()
 
 	spec := transport.NewUnaryHandlerSpec(h)
-	reg.EXPECT().GetHandlerSpec("bar", "hello").Return(spec, nil)
+	reg.EXPECT().Choose(gomock.Any(), registrytest.NewMatcher().
+		WithCaller("foo").
+		WithService("bar").
+		WithProcedure("hello"),
+	).Return(spec, nil)
 
 	h.EXPECT().Handle(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 

--- a/transport/register.go
+++ b/transport/register.go
@@ -115,9 +115,9 @@ func (m MapRegistry) ServiceProcedures() []ServiceProcedure {
 	return procs
 }
 
-// GetHandlerSpec retrieves the HandlerSpec for the given Procedure or returns an
+// ChooseProcedure retrieves the HandlerSpec for the given Procedure or returns an
 // error.
-func (m MapRegistry) GetHandlerSpec(service, procedure string) (HandlerSpec, error) {
+func (m MapRegistry) ChooseProcedure(service, procedure string) (HandlerSpec, error) {
 	if service == "" {
 		service = m.defaultService
 	}
@@ -135,7 +135,7 @@ func (m MapRegistry) GetHandlerSpec(service, procedure string) (HandlerSpec, err
 // Choose retrives the HandlerSpec for the service and procedure noted on the
 // transport request, or returns an error.
 func (m MapRegistry) Choose(ctx context.Context, req *Request) (HandlerSpec, error) {
-	return m.GetHandlerSpec(req.Service, req.Procedure)
+	return m.ChooseProcedure(req.Service, req.Procedure)
 }
 
 type byServiceProcedure []ServiceProcedure

--- a/transport/register.go
+++ b/transport/register.go
@@ -58,14 +58,6 @@ type Registry interface {
 	// have been registered so far.
 	ServiceProcedures() []ServiceProcedure
 
-	// Gets the handler for the given service, procedure tuple. An
-	// UnrecognizedProcedureError will be returned if the handler does not
-	// exist.
-	//
-	// service may be empty to indicate that the default service name should
-	// be used.
-	GetHandlerSpec(service, procedure string) (HandlerSpec, error)
-
 	// Choose decides a handler based on a context and transport
 	// request metadata.  This is the interface for use in inbound transports
 	// to select a handler for a request.

--- a/transport/register.go
+++ b/transport/register.go
@@ -58,9 +58,10 @@ type Registry interface {
 	// have been registered so far.
 	ServiceProcedures() []ServiceProcedure
 
-	// Choose decides a handler based on a context and transport
-	// request metadata.  This is the interface for use in inbound transports
-	// to select a handler for a request.
+	// Choose decides a handler based on a context and transport request
+	// metadata, or returns an UnrecognizedProcedureError if no handler exists
+	// for the request.  This is the interface for use in inbound transports to
+	// select a handler for a request.
 	Choose(ctx context.Context, req *Request) (HandlerSpec, error)
 }
 

--- a/transport/register.go
+++ b/transport/register.go
@@ -21,6 +21,7 @@
 package transport
 
 import (
+	"context"
 	"sort"
 
 	"go.uber.org/yarpc/internal/errors"
@@ -64,6 +65,11 @@ type Registry interface {
 	// service may be empty to indicate that the default service name should
 	// be used.
 	GetHandlerSpec(service, procedure string) (HandlerSpec, error)
+
+	// Choose decides a handler based on a context and transport
+	// request metadata.  This is the interface for use in inbound transports
+	// to select a handler for a request.
+	Choose(ctx context.Context, req *Request) (HandlerSpec, error)
 }
 
 // Registrar provides access to a collection of procedures and their handlers.
@@ -132,6 +138,12 @@ func (m MapRegistry) GetHandlerSpec(service, procedure string) (HandlerSpec, err
 		Service:   service,
 		Procedure: procedure,
 	}
+}
+
+// Choose retrives the HandlerSpec for the service and procedure noted on the
+// transport request, or returns an error.
+func (m MapRegistry) Choose(ctx context.Context, req *Request) (HandlerSpec, error) {
+	return m.GetHandlerSpec(req.Service, req.Procedure)
 }
 
 type byServiceProcedure []ServiceProcedure

--- a/transport/register_test.go
+++ b/transport/register_test.go
@@ -63,12 +63,12 @@ func TestMapRegistry(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got, err := m.GetHandlerSpec(tt.service, tt.procedure)
+		got, err := m.ChooseProcedure(tt.service, tt.procedure)
 		if tt.want != nil {
 			assert.NoError(t, err,
-				"GetHandlerSpec(%q, %q) failed", tt.service, tt.procedure)
+				"ChooseProcedure(%q, %q) failed", tt.service, tt.procedure)
 			assert.True(t, tt.want == got.Unary(), // want == match, not deep equals
-				"GetHandlerSpec(%q, %q) did not match", tt.service, tt.procedure)
+				"ChooseProcedure(%q, %q) did not match", tt.service, tt.procedure)
 		} else {
 			assert.Error(t, err)
 		}

--- a/transport/roundtrip_test.go
+++ b/transport/roundtrip_test.go
@@ -72,14 +72,6 @@ func (r staticRegistry) ServiceProcedures() []transport.ServiceProcedure {
 	return []transport.ServiceProcedure{{Service: testService, Procedure: testProcedure}}
 }
 
-func (r staticRegistry) GetHandlerSpec(service string, procedure string) (transport.HandlerSpec, error) {
-	if procedure == testProcedure {
-		return transport.NewUnaryHandlerSpec(r.Handler), nil
-	} else {
-		return transport.NewOnewayHandlerSpec(r.OnewayHandler), nil
-	}
-}
-
 func (r staticRegistry) Choose(ctx context.Context, req *transport.Request) (transport.HandlerSpec, error) {
 	if req.Procedure == testProcedure {
 		return transport.NewUnaryHandlerSpec(r.Handler), nil

--- a/transport/roundtrip_test.go
+++ b/transport/roundtrip_test.go
@@ -80,6 +80,13 @@ func (r staticRegistry) GetHandlerSpec(service string, procedure string) (transp
 	}
 }
 
+func (r staticRegistry) Choose(ctx context.Context, req *transport.Request) (transport.HandlerSpec, error) {
+	if req.Procedure == testProcedure {
+		return transport.NewUnaryHandlerSpec(r.Handler), nil
+	}
+	return transport.NewOnewayHandlerSpec(r.OnewayHandler), nil
+}
+
 // handlerFunc wraps a function into a transport.Registry
 type unaryHandlerFunc func(context.Context, *transport.Request, transport.ResponseWriter) error
 

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -152,7 +152,7 @@ func (h handler) callHandler(ctx context.Context, call inboundCall, start time.T
 		return err
 	}
 
-	spec, err := h.Registry.GetHandlerSpec(treq.Service, treq.Procedure)
+	spec, err := h.Registry.Choose(ctx, treq)
 	if err != nil {
 		return err
 	}

--- a/transport/transporttest/register.go
+++ b/transport/transporttest/register.go
@@ -92,17 +92,6 @@ func (_mr *_MockRegistryRecorder) Choose(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Choose", arg0, arg1)
 }
 
-func (_m *MockRegistry) GetHandlerSpec(_param0 string, _param1 string) (transport.HandlerSpec, error) {
-	ret := _m.ctrl.Call(_m, "GetHandlerSpec", _param0, _param1)
-	ret0, _ := ret[0].(transport.HandlerSpec)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-func (_mr *_MockRegistryRecorder) GetHandlerSpec(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetHandlerSpec", arg0, arg1)
-}
-
 func (_m *MockRegistry) ServiceProcedures() []transport.ServiceProcedure {
 	ret := _m.ctrl.Call(_m, "ServiceProcedures")
 	ret0, _ := ret[0].([]transport.ServiceProcedure)

--- a/transport/transporttest/register.go
+++ b/transport/transporttest/register.go
@@ -81,6 +81,17 @@ func (_m *MockRegistry) EXPECT() *_MockRegistryRecorder {
 	return _m.recorder
 }
 
+func (_m *MockRegistry) Choose(_param0 context.Context, _param1 *transport.Request) (transport.HandlerSpec, error) {
+	ret := _m.ctrl.Call(_m, "Choose", _param0, _param1)
+	ret0, _ := ret[0].(transport.HandlerSpec)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockRegistryRecorder) Choose(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Choose", arg0, arg1)
+}
+
 func (_m *MockRegistry) GetHandlerSpec(_param0 string, _param1 string) (transport.HandlerSpec, error) {
 	ret := _m.ctrl.Call(_m, "GetHandlerSpec", _param0, _param1)
 	ret0, _ := ret[0].(transport.HandlerSpec)


### PR DESCRIPTION
Based on #418 

This factors Registry into Registry/Registrar, where the Registrar embeds Registry and adds the Register method for service, procedure pairs. Inbounds continue to use the narrower definition of Registry, and the Dispatcher retains the Registrar.

Additionally, this changes the registry’s GetHandler(service,procedure) to GetHandler(ctx,req) so alternate registry implementations can switch on anything in the baggage or request metadata.

The Registry does still expose an API that is specific to enumerating all locally handled procedures. Registry interceptors would have to proxy this. Knowing all procedures up front is a requirement for handling GRPC requests locally.