### PR TITLE
Make outbounds idempotent

### DIFF
--- a/internal/errors/outbound.go
+++ b/internal/errors/outbound.go
@@ -22,14 +22,6 @@ package errors
 
 import "fmt"
 
-// ErrOutboundAlreadyStarted represents a failure because Start() was already
-// called on the outbound.
-type ErrOutboundAlreadyStarted string
-
-func (e ErrOutboundAlreadyStarted) Error() string {
-	return fmt.Sprintf("%s has already been started", string(e))
-}
-
 // ErrOutboundNotStarted represents a failure because Start() was not called
 // on an outbound or if Stop() was called.
 type ErrOutboundNotStarted string

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -190,20 +190,19 @@ func TestCallFailures(t *testing.T) {
 	}
 }
 
-func TestStartTwice(t *testing.T) {
+func TestStartMultiple(t *testing.T) {
 	out := NewOutbound("http://localhost:9999")
-	if assert.NoError(t, out.Start(transport.NoDeps)) {
+	for i := 0; i < 10; i++ {
 		err := out.Start(transport.NoDeps)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "http.Outbound has already been started")
+		assert.NoError(t, err)
 	}
 }
 
-func TestStopWithoutStarting(t *testing.T) {
+func TestStopMultiple(t *testing.T) {
 	out := NewOutbound("http://localhost:9999")
-	err := out.Stop()
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "http.Outbound has not been started")
+	for i := 0; i < 10; i++ {
+		assert.NoError(t, out.Stop())
+	}
 }
 
 func TestCallWithoutStarting(t *testing.T) {

--- a/transport/outbound.go
+++ b/transport/outbound.go
@@ -30,10 +30,8 @@ type Outbound interface {
 	// Sets up the outbound to start making calls.
 	//
 	// This MUST block until the outbound is ready to start sending requests.
-	// This MUST be idempotent and thread-safe. If call multiple times, only
-	// the first arguments given (deps) are considered valid
-	//
-	// Implementations can assume that this function is called at most once.
+	// This MUST be idempotent and thread-safe. If called multiple times, only
+	// the first call's dependencies are used
 	Start(deps Deps) error
 
 	// Stops the outbound, cleaning up any resources held by the Outbound.

--- a/transport/outbound.go
+++ b/transport/outbound.go
@@ -30,11 +30,15 @@ type Outbound interface {
 	// Sets up the outbound to start making calls.
 	//
 	// This MUST block until the outbound is ready to start sending requests.
+	// This MUST be idempotent and thread-safe. If call multiple times, only
+	// the first arguments given (deps) are considered valid
 	//
 	// Implementations can assume that this function is called at most once.
 	Start(deps Deps) error
 
 	// Stops the outbound, cleaning up any resources held by the Outbound.
+	//
+	// This MUST be idempotent and thread-safe. This MAY be called more than once
 	Stop() error
 
 	// Call sends the given request through this transport and returns its

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -32,10 +32,7 @@ import (
 	"github.com/uber/tchannel-go"
 )
 
-var (
-	errOutboundAlreadyStarted = errors.ErrOutboundAlreadyStarted("tchannel.Outbound")
-	errOutboundNotStarted     = errors.ErrOutboundNotStarted("tchannel.Outbound")
-)
+var errOutboundNotStarted = errors.ErrOutboundNotStarted("tchannel.Outbound")
 
 // OutboundOption configures Outbound.
 type OutboundOption func(*outbound)
@@ -73,17 +70,14 @@ type outbound struct {
 func (o outbound) Start(d transport.Deps) error {
 	// TODO: Should we create the connection to HostPort (if specified) here or
 	// wait for the first call?
-	if o.started.Swap(true) {
-		return errOutboundAlreadyStarted
-	}
+	o.started.Swap(true)
 	return nil
 }
 
 func (o outbound) Stop() error {
 	if !o.started.Swap(false) {
-		return errOutboundNotStarted
+		o.Channel.Close()
 	}
-	o.Channel.Close()
 	return nil
 }
 

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -75,7 +75,7 @@ func (o outbound) Start(d transport.Deps) error {
 }
 
 func (o outbound) Stop() error {
-	if !o.started.Swap(false) {
+	if o.started.Swap(false) {
 		o.Channel.Close()
 	}
 	return nil

--- a/transport/tchannel/outbound_test.go
+++ b/transport/tchannel/outbound_test.go
@@ -266,7 +266,7 @@ func TestCallFailures(t *testing.T) {
 	}
 }
 
-func TestStartTwice(t *testing.T) {
+func TestStartMultiple(t *testing.T) {
 	for _, getOutbound := range newOutbounds {
 		out := getOutbound(testutils.NewClient(t, &testutils.ChannelOpts{
 			ServiceName: "caller",
@@ -274,25 +274,10 @@ func TestStartTwice(t *testing.T) {
 		// TODO: If we change Start() to establish a connection to the host, this
 		// hostport will have to be changed to a real server.
 
-		if assert.NoError(t, out.Start(transport.NoDeps)) {
+		for i := 0; i < 10; i++ {
 			err := out.Start(transport.NoDeps)
-			assert.Error(t, err)
-			assert.Contains(t, err.Error(), "tchannel.Outbound has already been started")
+			assert.NoError(t, err)
 		}
-	}
-}
-
-func TestStopWithoutStarting(t *testing.T) {
-	for _, getOutbound := range newOutbounds {
-		out := getOutbound(testutils.NewClient(t, &testutils.ChannelOpts{
-			ServiceName: "caller",
-		}), "localhost:4040")
-		// TODO: If we change Start() to establish a connection to the host, this
-		// hostport will have to be changed to a real server.
-
-		err := out.Stop()
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "tchannel.Outbound has not been started")
 	}
 }
 


### PR DESCRIPTION
This changes HTTP and TChannel outbounds such that Start() and Stop() may be called multiple times. This is necessary in the case of one outbound implementing multiple outbound types (eg oneway and unary).