### PR TITLE
[Oneway][Part 5] Validation occurs in two steps

### DIFF
--- a/crossdock/client/errorshttpclient/behavior.go
+++ b/crossdock/client/errorshttpclient/behavior.go
@@ -117,19 +117,28 @@ func Run(t crossdock.T) {
 		headers map[string]string
 		body    string
 
-		wantStatus         int
+		wantStatus int
+		skipStatus int
+
 		skipBody           string
 		wantBody           string
 		wantBodyStartsWith string
-		skipStatus         int
+
+		// hack to get java/python/node crossdock tests passing for now :(
+		// this is because we're changing when we validate the TTL
+		wantBodyOneOf []string
 	}{
 		{
 			name:       "no service",
 			headers:    map[string]string{},
 			body:       "{}",
 			wantStatus: 400,
-			wantBody: "BadRequest: missing service name, procedure, " +
-				"caller name, TTL, and encoding\n",
+			wantBodyOneOf: []string{
+				"BadRequest: missing service name, procedure, " +
+					"caller name, and encoding\n",
+				"BadRequest: missing service name, procedure, " +
+					"caller name, TTL, and encoding\n",
+			},
 		},
 		{
 			name: "wrong service",
@@ -152,7 +161,10 @@ func Run(t crossdock.T) {
 			},
 			body:       "{}",
 			wantStatus: 400,
-			wantBody:   "BadRequest: missing procedure, caller name, TTL, and encoding\n",
+			wantBodyOneOf: []string{
+				"BadRequest: missing procedure, caller name, and encoding\n",
+				"BadRequest: missing procedure, caller name, TTL, and encoding\n",
+			},
 		},
 		{
 			name: "no caller",
@@ -162,7 +174,10 @@ func Run(t crossdock.T) {
 			},
 			body:       "{}",
 			wantStatus: 400,
-			wantBody:   "BadRequest: missing caller name, TTL, and encoding\n",
+			wantBodyOneOf: []string{
+				"BadRequest: missing caller name and encoding\n",
+				"BadRequest: missing caller name, TTL, and encoding\n",
+			},
 		},
 		{
 			name: "no handler",
@@ -187,7 +202,10 @@ func Run(t crossdock.T) {
 			},
 			body:       "{}",
 			wantStatus: 400,
-			wantBody:   "BadRequest: missing TTL and encoding\n",
+			wantBodyOneOf: []string{
+				"BadRequest: missing encoding\n",
+				"BadRequest: missing TTL and encoding\n",
+			},
 		},
 		{
 			name: "no encoding",

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -105,11 +105,12 @@ func convertOutbounds(outbounds Outbounds, filter transport.Filter) Outbounds {
 		// apply filters and create ValidatorOutbounds
 		if outs.Unary != nil {
 			unaryOutbound = transport.ApplyFilter(outs.Unary, filter)
-			unaryOutbound = request.ValidatorOutbound{UnaryOutbound: unaryOutbound}
+			unaryOutbound = request.UnaryValidatorOutbound{UnaryOutbound: unaryOutbound}
 		}
 
+		// TODO(apb): apply oneway outbound filter
 		if outs.Oneway != nil {
-			// TODO(apb): apply oneway outbound filter & validation
+			onewayOutbound = request.OnewayValidatorOutbound{OnewayOutbound: outs.Oneway}
 		}
 
 		convertedOutbounds[service] = transport.Outbounds{

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
             - AXIS_SERVER=go,node,java,python
             - AXIS_TRANSPORT=http,tchannel
             - AXIS_ENCODING=raw,json,thrift
-            - AXIS_ERRORS_HTTPCLIENT=node,go
+            - AXIS_ERRORS_HTTPCLIENT=go # pending update to node test
             # AXIS_ERRORS_HTTPSERVER TODO
             - AXIS_ERRORS_TCHCLIENT=go
             # AXIS_ERRORS_TCHSERVER TODO

--- a/internal/request/validator.go
+++ b/internal/request/validator.go
@@ -31,25 +31,38 @@ import (
 
 // Validator helps validate requests.
 //
-// 	v := Validator{Request: request}
-// 	v.ParseTTL(ttlstring)
-// 	request, err := v.Validate()
+//	v := Validator{Request: request}
+//	v.Validate()
+//	...
+//	v.ParseTTL(ttlstring)
+//	request, err := v.ValidateUnary()
 type Validator struct {
-	Request  *transport.Request
-	earlyErr error
-	lateErr  error
+	Request *transport.Request
+	errTTL  error
 }
 
 // Validate is a shortcut for the case where a request needs to be validated
-// without changing the TTL.
+// without changing the TTL. This should be used to validate all request types
 func Validate(ctx context.Context, req *transport.Request) (*transport.Request, error) {
 	v := Validator{Request: req}
 	return v.Validate(ctx)
 }
 
+// ValidateUnary validates a unary request. This should be used after a successful Validate()
+func ValidateUnary(ctx context.Context, req *transport.Request) (*transport.Request, error) {
+	v := Validator{Request: req}
+	return v.ValidateUnary(ctx)
+}
+
+// ValidateOneway validates a oneway request. This should be used after a successful Validate()
+func ValidateOneway(ctx context.Context, req *transport.Request) (*transport.Request, error) {
+	v := Validator{Request: req}
+	return v.ValidateOneway(ctx)
+}
+
 // ParseTTL takes a context parses the given TTL, clamping the context to that TTL
 // and as a side-effect, tracking any errors encountered while attempting to
-// parse and validate that TTL.
+// parse and validate that TTL. Should only be used for unary requests
 func (v *Validator) ParseTTL(ctx context.Context, ttl string) (context.Context, func()) {
 	if ttl == "" {
 		// The TTL is missing so set it to 0 and let Validate() fail with the
@@ -59,7 +72,7 @@ func (v *Validator) ParseTTL(ctx context.Context, ttl string) (context.Context, 
 
 	ttlms, err := strconv.Atoi(ttl)
 	if err != nil {
-		v.earlyErr = invalidTTLError{
+		v.errTTL = invalidTTLError{
 			Service:   v.Request.Service,
 			Procedure: v.Request.Procedure,
 			TTL:       ttl,
@@ -68,7 +81,7 @@ func (v *Validator) ParseTTL(ctx context.Context, ttl string) (context.Context, 
 	}
 	// negative TTLs are invalid
 	if ttlms < 0 {
-		v.lateErr = invalidTTLError{
+		v.errTTL = invalidTTLError{
 			Service:   v.Request.Service,
 			Procedure: v.Request.Procedure,
 			TTL:       fmt.Sprint(ttlms),
@@ -80,15 +93,9 @@ func (v *Validator) ParseTTL(ctx context.Context, ttl string) (context.Context, 
 }
 
 // Validate checks that the request inside this validator is valid and returns
-// either the validated request or an error.
+// either the validated request or an error. This should be used to check all
+// requests, prior to the RPC type specifc validation.
 func (v *Validator) Validate(ctx context.Context) (*transport.Request, error) {
-	// already failed
-	if v.earlyErr != nil {
-		return nil, v.earlyErr
-	}
-
-	_, hasDeadline := ctx.Deadline()
-
 	// check missing params
 	var missingParams []string
 	if v.Request.Service == "" {
@@ -100,9 +107,6 @@ func (v *Validator) Validate(ctx context.Context) (*transport.Request, error) {
 	if v.Request.Caller == "" {
 		missingParams = append(missingParams, "caller name")
 	}
-	if !hasDeadline && v.lateErr == nil {
-		missingParams = append(missingParams, "TTL")
-	}
 	if v.Request.Encoding == "" {
 		missingParams = append(missingParams, "encoding")
 	}
@@ -110,9 +114,26 @@ func (v *Validator) Validate(ctx context.Context) (*transport.Request, error) {
 		return nil, missingParametersError{Parameters: missingParams}
 	}
 
-	if v.lateErr != nil {
-		return nil, v.lateErr
+	return v.Request, nil
+}
+
+// ValidateUnary validates a unary request. This should be used after a successful v.Validate()
+func (v *Validator) ValidateUnary(ctx context.Context) (*transport.Request, error) {
+	if v.errTTL != nil {
+		return nil, v.errTTL
 	}
 
+	_, hasDeadline := ctx.Deadline()
+
+	if !hasDeadline {
+		return nil, missingParametersError{Parameters: []string{"TTL"}}
+	}
+
+	return v.Request, nil
+}
+
+// ValidateOneway validates a oneway request. This should be used after a successful Validate()
+func (v *Validator) ValidateOneway(ctx context.Context) (*transport.Request, error) {
+	// Currently, no extra checks for oneway requests are required
 	return v.Request, nil
 }

--- a/internal/request/validator_outbound.go
+++ b/internal/request/validator_outbound.go
@@ -26,15 +26,38 @@ import (
 	"go.uber.org/yarpc/transport"
 )
 
-// ValidatorOutbound wraps an Outbound to validate all outgoing requests.
-type ValidatorOutbound struct{ transport.UnaryOutbound }
+// UnaryValidatorOutbound wraps an Outbound to validate all outgoing unary requests.
+type UnaryValidatorOutbound struct{ transport.UnaryOutbound }
+
+// OnewayValidatorOutbound wraps an Outbound to validate all outgoing oneway requests.
+type OnewayValidatorOutbound struct{ transport.OnewayOutbound }
 
 // Call performs the given request, failing early if the request is invalid.
-func (o ValidatorOutbound) Call(ctx context.Context, request *transport.Request) (*transport.Response, error) {
+func (o UnaryValidatorOutbound) Call(ctx context.Context, request *transport.Request) (*transport.Response, error) {
 	request, err := Validate(ctx, request)
 	if err != nil {
 		return nil, err
 	}
 
+	request, err = ValidateUnary(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+
 	return o.UnaryOutbound.Call(ctx, request)
+}
+
+// CallOneway performs the given request, failing early if the request is invalid.
+func (o OnewayValidatorOutbound) CallOneway(ctx context.Context, request *transport.Request) (transport.Ack, error) {
+	request, err := Validate(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+
+	request, err = ValidateOneway(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+
+	return o.OnewayOutbound.CallOneway(ctx, request)
 }

--- a/internal/request/validator_test.go
+++ b/internal/request/validator_test.go
@@ -32,9 +32,12 @@ import (
 
 func TestValidator(t *testing.T) {
 	tests := []struct {
-		req         *transport.Request
-		ttl         time.Duration
-		ttlString   string // set to try parseTTL
+		req           *transport.Request
+		transportType transport.Type
+
+		ttl       time.Duration
+		ttlString string // set to try parseTTL
+
 		wantErr     error
 		wantMessage string
 	}{
@@ -55,7 +58,6 @@ func TestValidator(t *testing.T) {
 				Service:   "service",
 				Procedure: "hello",
 			},
-			ttl: time.Second,
 			wantErr: missingParametersError{
 				Parameters: []string{"encoding"},
 			},
@@ -67,7 +69,6 @@ func TestValidator(t *testing.T) {
 				Procedure: "hello",
 				Encoding:  "raw",
 			},
-			ttl: time.Second,
 			wantErr: missingParametersError{
 				Parameters: []string{"caller name"},
 			},
@@ -79,7 +80,6 @@ func TestValidator(t *testing.T) {
 				Procedure: "hello",
 				Encoding:  "raw",
 			},
-			ttl: time.Second,
 			wantErr: missingParametersError{
 				Parameters: []string{"service name"},
 			},
@@ -91,7 +91,6 @@ func TestValidator(t *testing.T) {
 				Service:  "service",
 				Encoding: "raw",
 			},
-			ttl: time.Second,
 			wantErr: missingParametersError{
 				Parameters: []string{"procedure"},
 			},
@@ -104,6 +103,7 @@ func TestValidator(t *testing.T) {
 				Procedure: "hello",
 				Encoding:  "raw",
 			},
+			transportType: transport.Unary,
 			wantErr: missingParametersError{
 				Parameters: []string{"TTL"},
 			},
@@ -113,10 +113,10 @@ func TestValidator(t *testing.T) {
 			req: &transport.Request{},
 			wantErr: missingParametersError{
 				Parameters: []string{
-					"service name", "procedure", "caller name", "TTL", "encoding",
+					"service name", "procedure", "caller name", "encoding",
 				},
 			},
-			wantMessage: "missing service name, procedure, caller name, TTL, and encoding",
+			wantMessage: "missing service name, procedure, caller name, and encoding",
 		},
 		{
 			req: &transport.Request{
@@ -125,7 +125,8 @@ func TestValidator(t *testing.T) {
 				Encoding:  "raw",
 				Procedure: "hello",
 			},
-			ttlString: "-1000",
+			transportType: transport.Unary,
+			ttlString:     "-1000",
 			wantErr: invalidTTLError{
 				Service:   "service",
 				Procedure: "hello",
@@ -140,7 +141,8 @@ func TestValidator(t *testing.T) {
 				Encoding:  "raw",
 				Procedure: "hello",
 			},
-			ttlString: "not an integer",
+			transportType: transport.Unary,
+			ttlString:     "not an integer",
 			wantErr: invalidTTLError{
 				Service:   "service",
 				Procedure: "hello",
@@ -154,17 +156,26 @@ func TestValidator(t *testing.T) {
 		v := Validator{Request: tt.req}
 
 		ctx := context.Background()
-		if tt.ttl != 0 {
-			var cancel func()
-			ctx, cancel = context.WithTimeout(ctx, tt.ttl)
-			defer cancel()
-		}
-
-		if tt.ttlString != "" {
-			v.ParseTTL(ctx, tt.ttlString)
-		}
-
 		_, err := v.Validate(ctx)
+
+		if err == nil && tt.transportType == transport.Oneway {
+			_, err = v.ValidateOneway(ctx)
+		} else if err == nil { // default to unary
+			var cancel func()
+
+			if tt.ttl != 0 {
+				ctx, cancel = context.WithTimeout(ctx, tt.ttl)
+				defer cancel()
+			}
+
+			if tt.ttlString != "" {
+				ctx, cancel = v.ParseTTL(ctx, tt.ttlString)
+				defer cancel()
+			}
+
+			_, err = v.ValidateUnary(ctx)
+		}
+
 		if tt.wantErr != nil {
 			assert.Equal(t, tt.wantErr, err)
 			if tt.wantMessage != "" && err != nil {

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -159,7 +159,11 @@ func (h handler) callHandler(ctx context.Context, call inboundCall, start time.T
 
 	switch spec.Type() {
 	case transport.Unary:
-		err = internal.SafelyCallUnaryHandler(ctx, spec.Unary(), start, treq, rw)
+		treq, err = request.ValidateUnary(ctx, treq)
+		if err == nil {
+			err = internal.SafelyCallUnaryHandler(ctx, spec.Unary(), start, treq, rw)
+		}
+
 	default:
 		err = errors.UnsupportedTypeError{Transport: "TChannel", Type: string(spec.Type())}
 	}


### PR DESCRIPTION
Validation must occur in two steps now. The first validation step will be check general information standard across all RPC request types (procedure name, service name, etc) and the next validation step will be RPC type specific. In the case of unary requests, the second step will check for a valid TTL and oneway, currently, will be nothing.