### PR TITLE
[PeerList][Part 8] Block the ChoosePeer function when there is no peer available

### DIFF
--- a/transport/internal/errors/peers.go
+++ b/transport/internal/errors/peers.go
@@ -115,5 +115,5 @@ func (e ErrPeerRemoveNotInList) Error() string {
 type ErrChooseContextHasNoDeadline string
 
 func (e ErrChooseContextHasNoDeadline) Error() string {
-	return fmt.Sprintf("can't wait for peer without a context deadline for peerlist %s", string(e))
+	return fmt.Sprintf("can't wait for peer without a context deadline for peerlist %q", string(e))
 }

--- a/transport/internal/errors/peers.go
+++ b/transport/internal/errors/peers.go
@@ -95,13 +95,6 @@ func (e ErrInvalidAgentConversion) Error() string {
 	return fmt.Sprintf("cannot convert agent (%v) to type %s", e.Agent, e.ExpectedType)
 }
 
-// ErrNoPeerToSelect is used when a peerlist doesn't have any peers to return
-type ErrNoPeerToSelect string
-
-func (e ErrNoPeerToSelect) Error() string {
-	return fmt.Sprintf("could not find a peer to select in peerlist %q", string(e))
-}
-
 // ErrPeerAddAlreadyInList is returned to peer providers if the
 // peerlist is already tracking a peer for the added identifier
 type ErrPeerAddAlreadyInList string
@@ -116,4 +109,11 @@ type ErrPeerRemoveNotInList string
 
 func (e ErrPeerRemoveNotInList) Error() string {
 	return fmt.Sprintf("can't remove peer (%s) because it is not in peerlist", string(e))
+}
+
+// ErrChooseContextHasNoDeadline is returned when a context is sent to a peerlist with no deadline
+type ErrChooseContextHasNoDeadline string
+
+func (e ErrChooseContextHasNoDeadline) Error() string {
+	return fmt.Sprintf("can't wait for peer without a context deadline for peerlist %s", string(e))
 }

--- a/transport/peer/x/peerlist/roundrobin/roundrobin.go
+++ b/transport/peer/x/peerlist/roundrobin/roundrobin.go
@@ -33,8 +33,9 @@ import (
 // New creates a new round robin PeerList using
 func New(peerIDs []transport.PeerIdentifier, agent transport.Agent) (*RoundRobin, error) {
 	rr := &RoundRobin{
-		pr:    NewPeerRing(len(peerIDs)),
-		agent: agent,
+		pr:             NewPeerRing(len(peerIDs)),
+		agent:          agent,
+		peerAddedEvent: make(chan struct{}, 1),
 	}
 
 	err := rr.addAll(peerIDs)
@@ -43,9 +44,10 @@ func New(peerIDs []transport.PeerIdentifier, agent transport.Agent) (*RoundRobin
 
 // RoundRobin is a PeerList which rotates which peers are to be selected in a circle
 type RoundRobin struct {
-	pr      *PeerRing
-	agent   transport.Agent
-	started atomic.Bool
+	pr             *PeerRing
+	peerAddedEvent chan struct{}
+	agent          transport.Agent
+	started        atomic.Bool
 }
 
 func (pl *RoundRobin) addAll(peerIDs []transport.PeerIdentifier) error {
@@ -59,6 +61,32 @@ func (pl *RoundRobin) addAll(peerIDs []transport.PeerIdentifier) error {
 	}
 
 	return yerrors.MultiError(errs)
+}
+
+// Add a peer identifier to the round robin
+func (pl *RoundRobin) Add(pid transport.PeerIdentifier) error {
+	return pl.addPeer(pid)
+}
+
+func (pl *RoundRobin) addPeer(pid transport.PeerIdentifier) error {
+	p, err := pl.agent.RetainPeer(pid, pl)
+	if err != nil {
+		return err
+	}
+
+	if err = pl.pr.Add(p); err != nil {
+		return err
+	}
+
+	pl.notifyPeerAddedEvent()
+	return nil
+}
+
+func (pl *RoundRobin) notifyPeerAddedEvent() {
+	select {
+	case pl.peerAddedEvent <- struct{}{}:
+	default:
+	}
 }
 
 // Start notifies the RoundRobin that requests will start coming
@@ -90,33 +118,6 @@ func (pl *RoundRobin) clearPeers() error {
 	return yerrors.MultiError(errs)
 }
 
-// ChoosePeer selects the next available peer in the round robin
-func (pl *RoundRobin) ChoosePeer(context.Context, *transport.Request) (transport.Peer, error) {
-	if !pl.started.Load() {
-		return nil, errors.ErrPeerListNotStarted("RoundRobinList")
-	}
-
-	nextPeer := pl.pr.Next()
-	if nextPeer == nil {
-		return nil, errors.ErrNoPeerToSelect("RoundRobinList")
-	}
-	return nextPeer, nil
-}
-
-// Add a peer identifier to the round robin
-func (pl *RoundRobin) Add(pid transport.PeerIdentifier) error {
-	return pl.addPeer(pid)
-}
-
-func (pl *RoundRobin) addPeer(pid transport.PeerIdentifier) error {
-	p, err := pl.agent.RetainPeer(pid, pl)
-	if err != nil {
-		return err
-	}
-
-	return pl.pr.Add(p)
-}
-
 // Remove a peer identifier from the round robin
 func (pl *RoundRobin) Remove(pid transport.PeerIdentifier) error {
 	if err := pl.pr.Remove(pid); err != nil {
@@ -125,6 +126,38 @@ func (pl *RoundRobin) Remove(pid transport.PeerIdentifier) error {
 	}
 
 	return pl.agent.ReleasePeer(pid, pl)
+}
+
+// ChoosePeer selects the next available peer in the round robin
+func (pl *RoundRobin) ChoosePeer(ctx context.Context, req *transport.Request) (transport.Peer, error) {
+	if !pl.started.Load() {
+		return nil, errors.ErrPeerListNotStarted("RoundRobinList")
+	}
+
+	for {
+		if nextPeer := pl.pr.Next(); nextPeer != nil {
+			return nextPeer, nil
+		}
+
+		if err := pl.waitForPeerAddedEvent(ctx); err != nil {
+			return nil, err
+		}
+	}
+}
+
+// waitForPeerAddedEvent waits until a peer is added to the peer list or the
+// given context finishes.
+func (pl *RoundRobin) waitForPeerAddedEvent(ctx context.Context) error {
+	if _, ok := ctx.Deadline(); !ok {
+		return errors.ErrChooseContextHasNoDeadline("RoundRobinList")
+	}
+
+	select {
+	case <-pl.peerAddedEvent:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // NotifyStatusChanged when the peer's status changes

--- a/transport/peer/x/peerlist/roundrobin/roundrobin_test.go
+++ b/transport/peer/x/peerlist/roundrobin/roundrobin_test.go
@@ -344,6 +344,34 @@ func TestRoundRobinList(t *testing.T) {
 			expectedStarted: true,
 		},
 		{
+			msg:               "multiple blocking until add",
+			retainedPeerIDs:   []string{"1"},
+			expectedRingPeers: []string{"1"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				ConcurrentAction{
+					Actions: []PeerListAction{
+						ChooseAction{
+							InputContextTimeout: 200 * time.Millisecond,
+							ExpectedPeer:        "1",
+						},
+						ChooseAction{
+							InputContextTimeout: 200 * time.Millisecond,
+							ExpectedPeer:        "1",
+						},
+						ChooseAction{
+							InputContextTimeout: 200 * time.Millisecond,
+							ExpectedPeer:        "1",
+						},
+						AddAction{InputPeerID: "1"},
+					},
+					Wait: 10 * time.Millisecond,
+				},
+				ChooseAction{ExpectedPeer: "1"},
+			},
+			expectedStarted: true,
+		},
+		{
 			msg:               "block but added too late",
 			retainedPeerIDs:   []string{"1"},
 			expectedRingPeers: []string{"1"},

--- a/transport/peer/x/peerlist/roundrobin/roundrobin_test.go
+++ b/transport/peer/x/peerlist/roundrobin/roundrobin_test.go
@@ -1,8 +1,10 @@
 package roundrobin
 
 import (
+	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	yerrors "go.uber.org/yarpc/internal/errors"
 	"go.uber.org/yarpc/transport/internal/errors"
@@ -129,16 +131,16 @@ func TestRoundRobinList(t *testing.T) {
 			msg:                "start retain error",
 			inputPeerIDs:       []string{"1"},
 			errRetainedPeerIDs: []string{"1"},
-			retainErr:          errors.ErrNoPeerToSelect("Test!!"),
-			expectedCreateErr:  errors.ErrNoPeerToSelect("Test!!"),
+			retainErr:          errors.ErrInvalidPeerType{},
+			expectedCreateErr:  errors.ErrInvalidPeerType{},
 		},
 		{
 			msg:                "start retain multiple errors",
 			inputPeerIDs:       []string{"1", "2", "3"},
 			retainedPeerIDs:    []string{"2"},
 			errRetainedPeerIDs: []string{"1", "3"},
-			retainErr:          errors.ErrNoPeerToSelect("Test!!"),
-			expectedCreateErr:  yerrors.ErrorGroup{errors.ErrNoPeerToSelect("Test!!"), errors.ErrNoPeerToSelect("Test!!")},
+			retainErr:          errors.ErrInvalidPeerType{},
+			expectedCreateErr:  yerrors.ErrorGroup{errors.ErrInvalidPeerType{}, errors.ErrInvalidPeerType{}},
 			expectedRingPeers:  []string{"2"},
 		},
 		{
@@ -193,10 +195,8 @@ func TestRoundRobinList(t *testing.T) {
 			peerListActions: []PeerListAction{
 				StartAction{},
 				ChooseAction{
-					ExpectedErr: errors.ErrNoPeerToSelect("RoundRobinList"),
-				},
-				ChooseAction{
-					ExpectedErr: errors.ErrNoPeerToSelect("RoundRobinList"),
+					InputContextTimeout: 20 * time.Millisecond,
+					ExpectedErr:         context.DeadlineExceeded,
 				},
 			},
 			expectedStarted: true,
@@ -320,6 +320,80 @@ func TestRoundRobinList(t *testing.T) {
 				},
 				ChooseAction{ExpectedPeer: "1"},
 				ChooseAction{ExpectedPeer: "1"},
+			},
+			expectedStarted: true,
+		},
+		{
+			msg:               "block until add",
+			retainedPeerIDs:   []string{"1"},
+			expectedRingPeers: []string{"1"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				ConcurrentAction{
+					Actions: []PeerListAction{
+						ChooseAction{
+							InputContextTimeout: 200 * time.Millisecond,
+							ExpectedPeer:        "1",
+						},
+						AddAction{InputPeerID: "1"},
+					},
+					Wait: 20 * time.Millisecond,
+				},
+				ChooseAction{ExpectedPeer: "1"},
+			},
+			expectedStarted: true,
+		},
+		{
+			msg:               "block but added too late",
+			retainedPeerIDs:   []string{"1"},
+			expectedRingPeers: []string{"1"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				ConcurrentAction{
+					Actions: []PeerListAction{
+						ChooseAction{
+							InputContextTimeout: 10 * time.Millisecond,
+							ExpectedErr:         context.DeadlineExceeded,
+						},
+						AddAction{InputPeerID: "1"},
+					},
+					Wait: 20 * time.Millisecond,
+				},
+				ChooseAction{ExpectedPeer: "1"},
+			},
+			expectedStarted: true,
+		},
+		{
+			msg:               "block until new peer after removal of only peer",
+			inputPeerIDs:      []string{"1"},
+			retainedPeerIDs:   []string{"1", "2"},
+			releasedPeerIDs:   []string{"1"},
+			expectedRingPeers: []string{"2"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				RemoveAction{InputPeerID: "1"},
+				ConcurrentAction{
+					Actions: []PeerListAction{
+						ChooseAction{
+							InputContextTimeout: 200 * time.Millisecond,
+							ExpectedPeer:        "2",
+						},
+						AddAction{InputPeerID: "2"},
+					},
+					Wait: 20 * time.Millisecond,
+				},
+				ChooseAction{ExpectedPeer: "2"},
+			},
+			expectedStarted: true,
+		},
+		{
+			msg: "no blocking with no context deadline",
+			peerListActions: []PeerListAction{
+				StartAction{},
+				ChooseAction{
+					InputContext: context.Background(),
+					ExpectedErr:  errors.ErrChooseContextHasNoDeadline("RoundRobinList"),
+				},
 			},
 			expectedStarted: true,
 		},


### PR DESCRIPTION
Summary: This diff changes the functionality of ChoosePeer to block
until either:

1) A new Peer is added to the list
2) The context deadline is passed (if there is no context deadline
return an error immediately)

This is done using a channel of size one on the roundrobin that will get
filled when a new "add" is run on the peerList. Since the add could
already be filled, the checking/waiting functionality is run in a loop