### PR TITLE
[PeerList][Part 10] Move PeerSubscriber management functions into Peer

### DIFF
--- a/transport/http/agent.go
+++ b/transport/http/agent.go
@@ -64,7 +64,7 @@ func NewAgent(opts ...AgentOption) *Agent {
 
 // Agent keeps track of http peers and the associated client with which the peer will call into.
 type Agent struct {
-	lock sync.RWMutex
+	lock sync.Mutex
 
 	client *http.Client
 	peers  map[string]*hostport.Peer

--- a/transport/http/agent_test.go
+++ b/transport/http/agent_test.go
@@ -294,7 +294,7 @@ func TestAgent(t *testing.T) {
 
 				assert.Equal(t, expectedPeerNode.identifier.Identifier(), peer.Identifier())
 
-				assert.Equal(t, peer.NumSubscribers(), len(expectedPeerNode.subscribers))
+				assert.Len(t, expectedPeerNode.subscribers, peer.NumSubscribers())
 			}
 		})
 	}

--- a/transport/http/agent_test.go
+++ b/transport/http/agent_test.go
@@ -275,102 +275,28 @@ func TestAgent(t *testing.T) {
 			}
 			return
 		}(),
-		func() (s testStruct) {
-			s.msg = "notification verification"
-			s.expectedPeers = createPeerExpectations(
-				mockCtrl,
-				[]string{"localhost:1234"},
-				2,
-			)
-
-			s.expectedPeers[0].subscribers[0].EXPECT().NotifyStatusChanged(
-				peerIdentifierMatcher(s.expectedPeers[0].identifier),
-			).Times(3)
-			s.expectedPeers[0].subscribers[1].EXPECT().NotifyStatusChanged(
-				peerIdentifierMatcher(s.expectedPeers[0].identifier),
-			).Times(3)
-
-			s.appliedFunc = func(a *Agent) error {
-				peer, _ := a.RetainPeer(s.expectedPeers[0].identifier, s.expectedPeers[0].subscribers[0])
-				a.RetainPeer(s.expectedPeers[0].identifier, s.expectedPeers[0].subscribers[1])
-
-				a.NotifyStatusChanged(peer)
-				a.NotifyStatusChanged(peer)
-				a.NotifyStatusChanged(peer)
-
-				return nil
-			}
-			return
-		}(),
-		func() (s testStruct) {
-			s.msg = "no notification after release"
-			s.expectedPeers = []peerExpectation{}
-
-			sub := transporttest.NewMockPeerSubscriber(mockCtrl)
-			sub.EXPECT().NotifyStatusChanged(gomock.Any()).Times(0)
-
-			pid := hostport.PeerIdentifier("localhost:1234")
-
-			s.appliedFunc = func(a *Agent) error {
-				peer, _ := a.RetainPeer(pid, sub)
-				a.ReleasePeer(pid, sub)
-
-				a.NotifyStatusChanged(peer)
-				a.NotifyStatusChanged(peer)
-				a.NotifyStatusChanged(peer)
-
-				return nil
-			}
-			return
-		}(),
-		func() (s testStruct) {
-			s.msg = "notification before versus after release"
-			s.expectedPeers = []peerExpectation{}
-
-			pid := hostport.PeerIdentifier("localhost:1234")
-
-			sub := transporttest.NewMockPeerSubscriber(mockCtrl)
-			sub.EXPECT().NotifyStatusChanged(peerIdentifierMatcher(pid)).Times(1)
-
-			s.appliedFunc = func(a *Agent) error {
-				peer, _ := a.RetainPeer(pid, sub)
-
-				a.NotifyStatusChanged(peer)
-
-				a.ReleasePeer(pid, sub)
-
-				a.NotifyStatusChanged(peer)
-				a.NotifyStatusChanged(peer)
-				a.NotifyStatusChanged(peer)
-
-				return nil
-			}
-			return
-		}(),
 	}
 
 	for _, tt := range tests {
-		agent := tt.agent
-		if agent == nil {
-			agent = NewAgent()
-		}
-
-		err := tt.appliedFunc(agent)
-
-		assert.Equal(t, tt.expectedErr, err, tt.msg)
-		assert.Len(t, agent.peerNodes, len(tt.expectedPeers), tt.msg)
-		for _, expectedPeerNode := range tt.expectedPeers {
-			peerNode, ok := agent.peerNodes[expectedPeerNode.identifier.Identifier()]
-			assert.True(t, ok, tt.msg)
-
-			assert.Equal(t, expectedPeerNode.identifier.Identifier(), peerNode.peer.Identifier(), tt.msg)
-
-			assert.Len(t, peerNode.subscribers, len(expectedPeerNode.subscribers), tt.msg)
-			for _, expectedSubscriber := range expectedPeerNode.subscribers {
-				_, ok := peerNode.subscribers[expectedSubscriber]
-				assert.True(t, ok, "subscriber (%v) not in list (%v). %s", expectedSubscriber, peerNode.subscribers, tt.msg)
+		t.Run(tt.msg, func(t *testing.T) {
+			agent := tt.agent
+			if agent == nil {
+				agent = NewAgent()
 			}
-		}
+
+			err := tt.appliedFunc(agent)
+
+			assert.Equal(t, tt.expectedErr, err)
+			assert.Len(t, agent.peers, len(tt.expectedPeers))
+			for _, expectedPeerNode := range tt.expectedPeers {
+				peer, ok := agent.peers[expectedPeerNode.identifier.Identifier()]
+				assert.True(t, ok)
+
+				assert.Equal(t, expectedPeerNode.identifier.Identifier(), peer.Identifier())
+
+				assert.Equal(t, peer.NumSubscribers(), len(expectedPeerNode.subscribers))
+			}
+		})
 	}
 }
 

--- a/transport/internal/transporttest/subscriber.go
+++ b/transport/internal/transporttest/subscriber.go
@@ -18,22 +18,32 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package transport
+package transporttest
 
-//go:generate mockgen -destination=transporttest/peeragent.go -package=transporttest go.uber.org/yarpc/transport Agent,PeerSubscriber
+import (
+	"go.uber.org/yarpc/transport/transporttest"
 
-// PeerSubscriber listens to changes of a Peer over time.
-type PeerSubscriber interface {
-	// The Peer Notifies the PeerSubscriber when its status changes (e.g. connections status, pending requests)
-	NotifyStatusChanged(Peer)
+	"github.com/golang/mock/gomock"
+)
+
+// SubscriberDefinition is an abstraction for defining a PeerSubscriber with
+// an ID so it can be referenced later.
+type SubscriberDefinition struct {
+	ID                  string
+	ExpectedNotifyCount int
 }
 
-// Agent manages Peers across different PeerSubscribers.  A PeerSubscriber will request a Peer for a specific
-// PeerIdentifier and the Agent has the ability to create a new Peer or return an existing one.
-type Agent interface {
-	// Get or create a Peer for the PeerSubscriber
-	RetainPeer(PeerIdentifier, PeerSubscriber) (Peer, error)
-
-	// Unallocate a peer from the PeerSubscriber
-	ReleasePeer(PeerIdentifier, PeerSubscriber) error
+// CreateSubscriberMap will take a slice of SubscriberDefinitions and return
+// a map of IDs to MockPeerSubscribers
+func CreateSubscriberMap(
+	mockCtrl *gomock.Controller,
+	subDefinitions []SubscriberDefinition,
+) map[string]*transporttest.MockPeerSubscriber {
+	subscribers := make(map[string]*transporttest.MockPeerSubscriber, len(subDefinitions))
+	for _, subDef := range subDefinitions {
+		sub := transporttest.NewMockPeerSubscriber(mockCtrl)
+		sub.EXPECT().NotifyStatusChanged(gomock.Any()).Times(subDef.ExpectedNotifyCount)
+		subscribers[subDef.ID] = sub
+	}
+	return subscribers
 }

--- a/transport/peer/hostport/peer.go
+++ b/transport/peer/hostport/peer.go
@@ -67,13 +67,13 @@ func (p *Peer) Agent() transport.Agent {
 }
 
 // AddSubscriber adds a subscriber to the peer's subscriber map
-// Must be run in a Mutex.Lock from the transport.Agent
+// This function isn't thread safe
 func (p *Peer) AddSubscriber(sub transport.PeerSubscriber) {
 	p.subscribers[sub] = struct{}{}
 }
 
 // RemoveSubscriber removes a subscriber from the peer's subscriber map
-// Must be run in a Mutex.Lock from the transport.Agent
+// This function isn't thread safe
 func (p *Peer) RemoveSubscriber(sub transport.PeerSubscriber) error {
 	if _, ok := p.subscribers[sub]; !ok {
 		return errors.ErrPeerHasNoReferenceToSubscriber{
@@ -87,7 +87,7 @@ func (p *Peer) RemoveSubscriber(sub transport.PeerSubscriber) error {
 }
 
 // NumSubscribers returns the number of subscriptions attached to the peer
-// Must be run in a Mutex.Lock at the Agent level
+// This function isn't thread safe
 func (p *Peer) NumSubscribers() int {
 	return len(p.subscribers)
 }

--- a/transport/peer/hostport/peer_test.go
+++ b/transport/peer/hostport/peer_test.go
@@ -36,16 +36,29 @@ func TestPeerIdentifier(t *testing.T) {
 
 func TestPeer(t *testing.T) {
 	type testStruct struct {
-		msg         string
+		msg string
+
+		// PeerID for all the hostport.Peer initialization
 		inputPeerID string
 
-		// Map of subscriber id (used internally) to number of times notify will be called
-		SubDefinitions      []SubscriberDefinition
-		actions             []PeerAction
-		expectedIdentifier  string
-		expectedHostPort    string
-		expectedStatus      transport.PeerStatus
-		expectedAgent       transport.Agent
+		// List of "Subscribers" that we can define beforehand and reference in our PeerActions
+		// using the "ID" field in the subscriber definition, the "ExpectedNotifyCount" is the
+		// expected number of times the subscriber will be notified
+		SubDefinitions []SubscriberDefinition
+
+		// List of actions to be applied to the peer
+		actions []PeerAction
+
+		// Expected result from running Identifier() on the peer after the actions have been applied
+		expectedIdentifier string
+
+		// Expected result from running HostPort() on the peer after the actions have been applied
+		expectedHostPort string
+
+		// Expected result from running Status() on the peer after the actions have been applied
+		expectedStatus transport.PeerStatus
+
+		// Expected subscribers in the Peer's "subscribers" map after the actions have been applied
 		expectedSubscribers []string
 	}
 	tests := []testStruct{

--- a/transport/peer/hostport/peeraction_test.go
+++ b/transport/peer/hostport/peeraction_test.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package hostport
+
+import (
+	"fmt"
+	"testing"
+
+	"go.uber.org/yarpc/transport"
+	"go.uber.org/yarpc/transport/transporttest"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// There are no actual tests in this file, it contains a series of helper methods
+// for testing hostport.Peers
+
+// Dependences are passed through all the PeerActions in order to pass certain
+// state in between Actions
+type Dependencies struct {
+	Subscribers map[string]*transporttest.MockPeerSubscriber
+}
+
+// PeerAction defines actions that can be applied on a hostport.Peer
+type PeerAction interface {
+	Apply(*testing.T, *Peer, *Dependencies)
+}
+
+// StartStopReqAction will run a StartRequest and (optionally) a stop request
+type StartStopReqAction struct {
+	Stop bool
+}
+
+// Apply will run StartRequest and (optionally) the end closure
+func (sa StartStopReqAction) Apply(t *testing.T, p *Peer, d *Dependencies) {
+	end := p.StartRequest()
+	if sa.Stop {
+		end()
+	}
+}
+
+// SetStatusAction will run a SetStatus on a Peer
+type SetStatusAction struct {
+	InputStatus transport.PeerConnectionStatus
+}
+
+// Apply will run SetStatus on the Peer
+func (sa SetStatusAction) Apply(t *testing.T, p *Peer, d *Dependencies) {
+	p.SetStatus(sa.InputStatus)
+
+	assert.Equal(t, sa.InputStatus, p.Status().ConnectionStatus)
+}
+
+// SubscribeAction will run an AddSubscriber on a Peer
+type SubscribeAction struct {
+	// SubscriberID is a unique identifier for a subscriber that is
+	// contained in the Dependencies object passed in Apply
+	SubscriberID string
+
+	// ExpectedSubCount is the number of subscribers on the Peer after
+	// the subscription
+	ExpectedSubCount int
+}
+
+// Apply will run AddSubscriber on a Peer
+func (sa SubscribeAction) Apply(t *testing.T, p *Peer, d *Dependencies) {
+	sub, ok := d.Subscribers[sa.SubscriberID]
+	assert.True(t, ok, "referenced a subscriberID that does not exist %s", sa.SubscriberID)
+
+	p.AddSubscriber(sub)
+
+	assert.Equal(t, sa.ExpectedSubCount, p.NumSubscribers())
+}
+
+// UnsubscribeAction will run RemoveSubscriber on a Peer
+type UnsubscribeAction struct {
+	// SubscriberID is a unique identifier for a subscriber that is
+	// contained in the Dependencies object passed in Apply
+	SubscriberID string
+
+	// ExpectedErrType is the type of error that is expected to be returned
+	// from RemoveSubscriber
+	ExpectedErrType error
+
+	// ExpectedSubCount is the number of subscribers on the Peer after
+	// the subscription
+	ExpectedSubCount int
+}
+
+// Apply will run RemoveSubscriber from the Peer and assert on the result
+func (ua UnsubscribeAction) Apply(t *testing.T, p *Peer, d *Dependencies) {
+	sub, ok := d.Subscribers[ua.SubscriberID]
+	assert.True(t, ok, "referenced a subscriberID that does not exist %s", ua.SubscriberID)
+
+	err := p.RemoveSubscriber(sub)
+
+	assert.Equal(t, ua.ExpectedSubCount, p.NumSubscribers())
+	if err != nil {
+		assert.IsType(t, ua.ExpectedErrType, err)
+	} else {
+		assert.Nil(t, ua.ExpectedErrType)
+	}
+}
+
+// ApplyPeerActions runs all the PeerActions on the Peer
+func ApplyPeerActions(t *testing.T, p *Peer, actions []PeerAction, d *Dependencies) {
+	for i, action := range actions {
+		t.Run(fmt.Sprintf("action #%d: %T", i, action), func(t *testing.T) {
+			action.Apply(t, p, d)
+		})
+	}
+}

--- a/transport/transporttest/peeragent.go
+++ b/transport/transporttest/peeragent.go
@@ -49,14 +49,6 @@ func (_m *MockAgent) EXPECT() *_MockAgentRecorder {
 	return _m.recorder
 }
 
-func (_m *MockAgent) NotifyStatusChanged(_param0 transport.Peer) {
-	_m.ctrl.Call(_m, "NotifyStatusChanged", _param0)
-}
-
-func (_mr *_MockAgentRecorder) NotifyStatusChanged(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "NotifyStatusChanged", arg0)
-}
-
 func (_m *MockAgent) ReleasePeer(_param0 transport.PeerIdentifier, _param1 transport.PeerSubscriber) error {
 	ret := _m.ctrl.Call(_m, "ReleasePeer", _param0, _param1)
 	ret0, _ := ret[0].(error)


### PR DESCRIPTION
Summary: Due to a potential deadlock situation when a notification
action occurs in the Agent Lock at the same time an Add/Remove occurs in
the PeerList we needed to move the location of PeerSubscription
management into the Peer level.  This means that Notifications for peers
will not be entirely threadsafe, but that should be ok.  Since the only
actions that should affect the Peer's subscribers(lists) are Retain/Releases
(which should be triggered by the lists) most inconsistency situations
can safely be ignored (event after a release) or won't happen fast
enough to matter (If an action occurs on a peer while you are retaining
it, it won't matter because you're going to check it's state at the end
of the retaining anyway)

In the process of doing this I reworked the hostport.Peer tests, but,
only removed a couple of tests from the Agent tests, I'll look into
fixing the agent tests later, but since there was no new functionality
in the agent I didn't see a need for rewriting the tests yet.