### PR TITLE
tchannel: Introduce Channel interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ Releases
 v0.5.0 (unreleased)
 -------------------
 
--   Upgrade to ThriftRW 1.0.
 -   **Breaking**: A detail of inbound transports has changed.
     Starting an inbound transport accepts a ServiceDetail, including
     the service name and a Registry. The Registry now must
@@ -12,6 +11,10 @@ v0.5.0 (unreleased)
     instead of `GetHandler(service, procedure string) (HandlerSpec, error)`.
     Note that in the prior release, `Handler` became `HandleSpec` to
     accommodate oneway handlers.
+-   Upgrade to ThriftRW 1.0.
+-   TChannel: `NewInbound` and `NewOutbound` now accept any object satisfying
+    the `Channel` interface. This should work with existing `*tchannel.Channel`
+    objects without any changes.
 
 
 v0.4.0 (2016-11-11)

--- a/transport/tchannel/channel.go
+++ b/transport/tchannel/channel.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tchannel
+
+import (
+	"github.com/uber/tchannel-go"
+	"golang.org/x/net/context"
+)
+
+// Channel is top-level TChannel.
+//
+// See https://godoc.org/github.com/uber/tchannel-go#Channel for more
+// information.
+type Channel interface {
+	BeginCall(
+		ctx context.Context,
+		hostPort, serviceName, methodName string,
+		callOptions *tchannel.CallOptions,
+	) (*tchannel.OutboundCall, error)
+	Close()
+	GetSubChannel(serviceName string, opts ...tchannel.SubChannelOption) *tchannel.SubChannel
+	ListenAndServe(hostPort string) error
+	PeerInfo() tchannel.LocalPeerInfo
+	ServiceName() string
+	State() tchannel.ChannelState
+}
+
+var _ Channel = (*tchannel.Channel)(nil)

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -50,7 +50,7 @@ func HostPort(hostPort string) OutboundOption {
 
 // NewOutbound builds a new TChannel outbound which uses the given Channel to
 // make requests.
-func NewOutbound(ch *tchannel.Channel, options ...OutboundOption) transport.UnaryOutbound {
+func NewOutbound(ch Channel, options ...OutboundOption) transport.UnaryOutbound {
 	o := outbound{Channel: ch, started: atomic.NewBool(false)}
 	for _, opt := range options {
 		opt(&o)
@@ -60,7 +60,7 @@ func NewOutbound(ch *tchannel.Channel, options ...OutboundOption) transport.Unar
 
 type outbound struct {
 	started *atomic.Bool
-	Channel *tchannel.Channel
+	Channel Channel
 
 	// If specified, this is the address to which the request will be made.
 	// Otherwise, the global peer list of the Channel will be used.


### PR DESCRIPTION
This introduces a new `Channel` interface for the TChannel transport. TChannel
Go's `*Channel` object satisfies this interface. This is needed to allow
customization of TChannel behavior from wrapper libraries that call YARPC Go.

@yarpc/golang