### PR TITLE
[PeerList][Part 11] Differentiating between Available/Unavailable Peers in RoundRobin

### DIFF
--- a/transport/peer/peerlist/single.go
+++ b/transport/peer/peerlist/single.go
@@ -92,4 +92,4 @@ func (pl *single) ChoosePeer(context.Context, *transport.Request) (transport.Pee
 }
 
 // NotifyStatusChanged when the Peer status changes
-func (pl *single) NotifyStatusChanged(transport.Peer) {}
+func (pl *single) NotifyStatusChanged(transport.PeerIdentifier) {}

--- a/transport/peer/x/peerlist/roundrobin/internal/peerlistaction.go
+++ b/transport/peer/x/peerlist/roundrobin/internal/peerlistaction.go
@@ -67,7 +67,7 @@ func (a StopAction) Apply(t *testing.T, pl transport.PeerList, deps Dependencies
 }
 
 // ChooseMultiAction will run ChoosePeer multiple times on the PeerList
-// It will assert if there is ANY failures
+// It will assert if there are ANY failures
 type ChooseMultiAction struct {
 	ExpectedPeers []string
 }
@@ -176,7 +176,8 @@ func (a ConcurrentAction) Apply(t *testing.T, pl transport.PeerList, deps Depend
 	wg.Wait()
 }
 
-// NotifyStatusChangeAction will run the NotifyStatusChange function on a PeerList with a specified Peer
+// NotifyStatusChangeAction will run the NotifyStatusChange function on a PeerList
+// with a specified Peer after changing the peer's ConnectionStatus
 type NotifyStatusChangeAction struct {
 	// PeerID is a unique identifier to the Peer we want use in the notification
 	PeerID string

--- a/transport/peer/x/peerlist/roundrobin/internal/peerlistaction.go
+++ b/transport/peer/x/peerlist/roundrobin/internal/peerlistaction.go
@@ -188,7 +188,7 @@ type NotifyStatusChangeAction struct {
 
 // Apply will run the NotifyStatusChanged function on the PeerList with the provided Peer
 func (a NotifyStatusChangeAction) Apply(t *testing.T, pl transport.PeerList, deps Dependencies) {
-	deps.Peers[a.PeerID].StatusObj.ConnectionStatus = a.NewConnectionStatus
+	deps.Peers[a.PeerID].PeerStatus.ConnectionStatus = a.NewConnectionStatus
 
 	plSub := pl.(transport.PeerSubscriber)
 

--- a/transport/peer/x/peerlist/roundrobin/internal/peerlistaction.go
+++ b/transport/peer/x/peerlist/roundrobin/internal/peerlistaction.go
@@ -32,10 +32,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Dependencies are passed through PeerListActions' Apply methods in order
+// to allow the PeerListAction to modify state other than just the PeerList
+type Dependencies struct {
+	Peers map[string]*MockPeer
+}
+
 // PeerListAction defines actions that can be applied to a PeerList
 type PeerListAction interface {
 	// Apply runs a function on the PeerList and asserts the result
-	Apply(*testing.T, transport.PeerList)
+	Apply(*testing.T, transport.PeerList, Dependencies)
 }
 
 // StartAction is an action for testing PeerList.Start
@@ -44,7 +50,7 @@ type StartAction struct {
 }
 
 // Apply runs "Start" on the peerList and validates the error
-func (a StartAction) Apply(t *testing.T, pl transport.PeerList) {
+func (a StartAction) Apply(t *testing.T, pl transport.PeerList, deps Dependencies) {
 	err := pl.Start()
 	assert.Equal(t, a.ExpectedErr, err)
 }
@@ -55,9 +61,25 @@ type StopAction struct {
 }
 
 // Apply runs "Stop" on the peerList and validates the error
-func (a StopAction) Apply(t *testing.T, pl transport.PeerList) {
+func (a StopAction) Apply(t *testing.T, pl transport.PeerList, deps Dependencies) {
 	err := pl.Stop()
 	assert.Equal(t, a.ExpectedErr, err)
+}
+
+// ChooseMultiAction will run ChoosePeer multiple times on the PeerList
+// It will assert if there is ANY failures
+type ChooseMultiAction struct {
+	ExpectedPeers []string
+}
+
+// Apply runs "ChoosePeer" on the peerList for every ExpectedPeer
+func (a ChooseMultiAction) Apply(t *testing.T, pl transport.PeerList, deps Dependencies) {
+	for _, expectedPeer := range a.ExpectedPeers {
+		action := ChooseAction{
+			ExpectedPeer: expectedPeer,
+		}
+		action.Apply(t, pl, deps)
+	}
 }
 
 // ChooseAction is an action for choosing a peer from the peerlist
@@ -70,7 +92,7 @@ type ChooseAction struct {
 }
 
 // Apply runs "ChoosePeer" on the peerList and validates the peer && error
-func (a ChooseAction) Apply(t *testing.T, pl transport.PeerList) {
+func (a ChooseAction) Apply(t *testing.T, pl transport.PeerList, deps Dependencies) {
 	ctx := a.InputContext
 	if ctx == nil {
 		ctx = context.Background()
@@ -106,7 +128,7 @@ type AddAction struct {
 
 // Apply runs "Add" on the peerList after casting it to a PeerChangeListener
 // and validates the error
-func (a AddAction) Apply(t *testing.T, pl transport.PeerList) {
+func (a AddAction) Apply(t *testing.T, pl transport.PeerList, deps Dependencies) {
 	changeListener := pl.(transport.PeerChangeListener)
 
 	err := changeListener.Add(MockPeerIdentifier(a.InputPeerID))
@@ -121,7 +143,7 @@ type RemoveAction struct {
 
 // Apply runs "Remove" on the peerList after casting it to a PeerChangeListener
 // and validates the error
-func (a RemoveAction) Apply(t *testing.T, pl transport.PeerList) {
+func (a RemoveAction) Apply(t *testing.T, pl transport.PeerList, deps Dependencies) {
 	changeListener := pl.(transport.PeerChangeListener)
 
 	err := changeListener.Remove(MockPeerIdentifier(a.InputPeerID))
@@ -136,14 +158,14 @@ type ConcurrentAction struct {
 
 // Apply runs all the ConcurrentAction's actions in goroutines with a delay of `Wait`
 // between each action. Returns when all actions have finished executing
-func (a ConcurrentAction) Apply(t *testing.T, pl transport.PeerList) {
+func (a ConcurrentAction) Apply(t *testing.T, pl transport.PeerList, deps Dependencies) {
 	var wg sync.WaitGroup
 
 	wg.Add(len(a.Actions))
 	for _, action := range a.Actions {
 		go func(ac PeerListAction) {
 			defer wg.Done()
-			ac.Apply(t, pl)
+			ac.Apply(t, pl, deps)
 		}(action)
 
 		if a.Wait > 0 {
@@ -154,11 +176,29 @@ func (a ConcurrentAction) Apply(t *testing.T, pl transport.PeerList) {
 	wg.Wait()
 }
 
+// NotifyStatusChangeAction will run the NotifyStatusChange function on a PeerList with a specified Peer
+type NotifyStatusChangeAction struct {
+	// PeerID is a unique identifier to the Peer we want use in the notification
+	PeerID string
+
+	// NewConnectionStatus is the new ConnectionStatus of the Peer
+	NewConnectionStatus transport.PeerConnectionStatus
+}
+
+// Apply will run the NotifyStatusChanged function on the PeerList with the provided Peer
+func (a NotifyStatusChangeAction) Apply(t *testing.T, pl transport.PeerList, deps Dependencies) {
+	deps.Peers[a.PeerID].StatusObj.ConnectionStatus = a.NewConnectionStatus
+
+	plSub := pl.(transport.PeerSubscriber)
+
+	plSub.NotifyStatusChanged(deps.Peers[a.PeerID])
+}
+
 // ApplyPeerListActions runs all the PeerListActions on the PeerList
-func ApplyPeerListActions(t *testing.T, pl transport.PeerList, actions []PeerListAction) {
+func ApplyPeerListActions(t *testing.T, pl transport.PeerList, actions []PeerListAction, deps Dependencies) {
 	for i, action := range actions {
 		t.Run(fmt.Sprintf("action #%d: %T", i, action), func(t *testing.T) {
-			action.Apply(t, pl)
+			action.Apply(t, pl, deps)
 		})
 	}
 }

--- a/transport/peer/x/peerlist/roundrobin/internal/peers.go
+++ b/transport/peer/x/peerlist/roundrobin/internal/peers.go
@@ -42,7 +42,7 @@ func (pid MockPeerIdentifier) Identifier() string {
 func NewMockPeer(pid MockPeerIdentifier, conStatus transport.PeerConnectionStatus) *MockPeer {
 	return &MockPeer{
 		MockPeerIdentifier: pid,
-		StatusObj: transport.PeerStatus{
+		PeerStatus: transport.PeerStatus{
 			ConnectionStatus:    conStatus,
 			PendingRequestCount: 0,
 		},
@@ -55,23 +55,23 @@ func NewMockPeer(pid MockPeerIdentifier, conStatus transport.PeerConnectionStatu
 type MockPeer struct {
 	MockPeerIdentifier
 
-	StatusObj transport.PeerStatus
+	PeerStatus transport.PeerStatus
 }
 
 // Status returns the Status Object of the MockPeer
 func (p *MockPeer) Status() transport.PeerStatus {
-	return p.StatusObj
+	return p.PeerStatus
 }
 
 // StartRequest is run when a Request starts
 func (p *MockPeer) StartRequest() func() {
-	p.StatusObj.PendingRequestCount++
+	p.PeerStatus.PendingRequestCount++
 	return p.endRequest
 }
 
 // endRequest should be run after a MockPeer request has finished
 func (p *MockPeer) endRequest() {
-	p.StatusObj.PendingRequestCount--
+	p.PeerStatus.PendingRequestCount--
 }
 
 // PeerIdentifierMatcher is used to match a Peer/PeerIdentifier by comparing

--- a/transport/peer/x/peerlist/roundrobin/internal/peers.go
+++ b/transport/peer/x/peerlist/roundrobin/internal/peers.go
@@ -38,6 +38,42 @@ func (pid MockPeerIdentifier) Identifier() string {
 	return string(pid)
 }
 
+// NewMockPeer returns a new MockPeer
+func NewMockPeer(pid MockPeerIdentifier, conStatus transport.PeerConnectionStatus) *MockPeer {
+	return &MockPeer{
+		MockPeerIdentifier: pid,
+		StatusObj: transport.PeerStatus{
+			ConnectionStatus:    conStatus,
+			PendingRequestCount: 0,
+		},
+	}
+}
+
+// MockPeer is a small simple wrapper around the Peer interface for mocking and changing
+// a peer's attributes
+// MockPeer is NOT thread safe
+type MockPeer struct {
+	MockPeerIdentifier
+
+	StatusObj transport.PeerStatus
+}
+
+// Status returns the Status Object of the MockPeer
+func (p *MockPeer) Status() transport.PeerStatus {
+	return p.StatusObj
+}
+
+// StartRequest is run when a Request starts
+func (p *MockPeer) StartRequest() func() {
+	p.StatusObj.PendingRequestCount++
+	return p.endRequest
+}
+
+// endRequest should be run after a MockPeer request has finished
+func (p *MockPeer) endRequest() {
+	p.StatusObj.PendingRequestCount--
+}
+
 // PeerIdentifierMatcher is used to match a Peer/PeerIdentifier by comparing
 // The peer's .Identifier function with the Matcher string
 type PeerIdentifierMatcher string
@@ -67,21 +103,33 @@ func CreatePeerIDs(peerIDStrs []string) []transport.PeerIdentifier {
 
 // ExpectPeerRetains registers expectations on a MockAgent to generate peers on the RetainPeer function
 func ExpectPeerRetains(
-	mockCtrl *gomock.Controller,
+	agent *transporttest.MockAgent,
+	availablePeerStrs []string,
+	unavailablePeerStrs []string,
+) map[string]*MockPeer {
+	peers := make(map[string]*MockPeer, len(availablePeerStrs)+len(unavailablePeerStrs))
+	for _, peerStr := range availablePeerStrs {
+		peer := NewMockPeer(MockPeerIdentifier(peerStr), transport.PeerAvailable)
+		agent.EXPECT().RetainPeer(PeerIdentifierMatcher(peerStr), gomock.Any()).Return(peer, nil)
+		peers[peer.Identifier()] = peer
+	}
+	for _, peerStr := range unavailablePeerStrs {
+		peer := NewMockPeer(MockPeerIdentifier(peerStr), transport.PeerUnavailable)
+		agent.EXPECT().RetainPeer(PeerIdentifierMatcher(peerStr), gomock.Any()).Return(peer, nil)
+		peers[peer.Identifier()] = peer
+	}
+	return peers
+}
+
+// ExpectPeerRetainsWithError registers expectations on a MockAgent return errors
+func ExpectPeerRetainsWithError(
 	agent *transporttest.MockAgent,
 	peerStrs []string,
 	err error, // Will be returned from the MockAgent on the Retains of these Peers
-) []transport.Peer {
-	peers := make([]transport.Peer, 0, len(peerStrs))
+) {
 	for _, peerStr := range peerStrs {
-		peer := transporttest.NewMockPeer(mockCtrl)
-		peer.EXPECT().Identifier().Return(peerStr).AnyTimes()
-
-		agent.EXPECT().RetainPeer(PeerIdentifierMatcher(peerStr), gomock.Any()).Return(peer, err)
-
-		peers = append(peers, peer)
+		agent.EXPECT().RetainPeer(PeerIdentifierMatcher(peerStr), gomock.Any()).Return(nil, err)
 	}
-	return peers
 }
 
 // ExpectPeerReleases registers expectations on a MockAgent to release peers through the ReleasePeer function

--- a/transport/peer/x/peerlist/roundrobin/peerring.go
+++ b/transport/peer/x/peerlist/roundrobin/peerring.go
@@ -42,6 +42,16 @@ type PeerRing struct {
 	nextNode   *ring.Ring
 }
 
+// GetPeer returns the Peer from the Ring or Nil
+func (pr *PeerRing) GetPeer(pid transport.PeerIdentifier) transport.Peer {
+	node, ok := pr.peerToNode[pid.Identifier()]
+	if !ok {
+		return nil
+	}
+
+	return getPeerForRingNode(node)
+}
+
 // Add a transport.Peer to the end of the PeerRing, if the ring is empty
 // it initializes the nextNode marker
 func (pr *PeerRing) Add(peer transport.Peer) error {
@@ -69,13 +79,13 @@ func newPeerRingNode(peer transport.Peer) *ring.Ring {
 	return newNode
 }
 
-// Remove a peer PeerIdentifier from the PeerRing, if the PeerID is not
+// Remove a peer Peer from the PeerRing, if the PeerID is not
 // in the ring return an error
-func (pr *PeerRing) Remove(pid transport.PeerIdentifier) error {
-	node, ok := pr.peerToNode[pid.Identifier()]
+func (pr *PeerRing) Remove(p transport.Peer) error {
+	node, ok := pr.peerToNode[p.Identifier()]
 	if !ok {
 		// Peer doesn't exist in the list
-		return errors.ErrPeerRemoveNotInList(pid.Identifier())
+		return errors.ErrPeerRemoveNotInList(p.Identifier())
 	}
 
 	pr.popNode(node)

--- a/transport/peer/x/peerlist/roundrobin/roundrobin.go
+++ b/transport/peer/x/peerlist/roundrobin/roundrobin.go
@@ -190,22 +190,12 @@ func (pl *RoundRobin) removeByPeerIdentifier(pid transport.PeerIdentifier) error
 		return pl.availablePeerRing.Remove(peer)
 	}
 
-	if peer := pl.getUnavailablePeer(pid); peer != nil {
+	if peer, ok := pl.nonAvailablePeers[pid.Identifier()]; ok && peer != nil {
 		pl.removeFromUnavailablePeers(peer)
 		return nil
 	}
 
 	return errors.ErrPeerRemoveNotInList(pid.Identifier())
-}
-
-// getUnavailablePeer returns a Peer from the unavailable peer map or nil
-// Must be run in a mutex.Lock()
-func (pl *RoundRobin) getUnavailablePeer(pid transport.PeerIdentifier) transport.Peer {
-	p, ok := pl.nonAvailablePeers[pid.Identifier()]
-	if !ok {
-		return nil
-	}
-	return p
 }
 
 // removeFromUnavailablePeers remove a peer from the Unavailable Peers list
@@ -277,13 +267,11 @@ func (pl *RoundRobin) NotifyStatusChanged(pid transport.PeerIdentifier) {
 		return
 	}
 
-	if peer := pl.getUnavailablePeer(pid); peer != nil {
+	if peer, ok := pl.nonAvailablePeers[pid.Identifier()]; ok && peer != nil {
 		pl.handleUnavailablePeerStatusChange(peer)
 		return
 	}
-
 	// No action required
-	return
 }
 
 // handleAvailablePeerStatusChange checks the connection status of a connected peer to potentially

--- a/transport/peer/x/peerlist/roundrobin/roundrobin_test.go
+++ b/transport/peer/x/peerlist/roundrobin/roundrobin_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	yerrors "go.uber.org/yarpc/internal/errors"
+	"go.uber.org/yarpc/transport"
 	"go.uber.org/yarpc/transport/internal/errors"
 	. "go.uber.org/yarpc/transport/peer/x/peerlist/roundrobin/internal"
 	"go.uber.org/yarpc/transport/transporttest"
@@ -22,8 +23,11 @@ func TestRoundRobinList(t *testing.T) {
 		// PeerIDs that will be inserted into the PeerList at creation time
 		inputPeerIDs []string
 
-		// PeerIDs that will be returned from the agent's OnRetain
-		retainedPeerIDs []string
+		// PeerIDs that will be returned from the agent's OnRetain with "Available" status
+		retainedAvailablePeerIDs []string
+
+		// PeerIDs that will be returned from the agent's OnRetain with "Unavailable" status
+		retainedUnavailablePeerIDs []string
 
 		// PeerIDs that will be released from the agent
 		releasedPeerIDs []string
@@ -42,24 +46,35 @@ func TestRoundRobinList(t *testing.T) {
 		// Expected Error to be returned from the PeerList's creation function
 		expectedCreateErr error
 
-		// PeerIDs expected to be in the PeerList's PeerRing after the actions have been applied
-		expectedRingPeers []string
+		// PeerIDs expected to be in the PeerList's "Available" list after the actions have been applied
+		expectedAvailablePeers []string
+
+		// PeerIDs expected to be in the PeerList's "Unavailable" list after the actions have been applied
+		expectedUnavailablePeers []string
 
 		// Boolean indicating whether the PeerList is "started" after the actions have been applied
 		expectedStarted bool
 	}
 	tests := []testStruct{
 		{
-			msg:               "setup",
-			inputPeerIDs:      []string{"1"},
-			retainedPeerIDs:   []string{"1"},
-			expectedRingPeers: []string{"1"},
+			msg:                      "setup",
+			inputPeerIDs:             []string{"1"},
+			retainedAvailablePeerIDs: []string{"1"},
+			expectedAvailablePeers:   []string{"1"},
 		},
 		{
-			msg:               "start",
-			inputPeerIDs:      []string{"1"},
-			retainedPeerIDs:   []string{"1"},
-			expectedRingPeers: []string{"1"},
+			msg:                        "setup with disconnected",
+			inputPeerIDs:               []string{"1", "2"},
+			retainedAvailablePeerIDs:   []string{"1"},
+			retainedUnavailablePeerIDs: []string{"2"},
+			expectedAvailablePeers:     []string{"1"},
+			expectedUnavailablePeers:   []string{"2"},
+		},
+		{
+			msg:                      "start",
+			inputPeerIDs:             []string{"1"},
+			retainedAvailablePeerIDs: []string{"1"},
+			expectedAvailablePeers:   []string{"1"},
 			peerListActions: []PeerListAction{
 				StartAction{},
 				ChooseAction{
@@ -69,10 +84,11 @@ func TestRoundRobinList(t *testing.T) {
 			expectedStarted: true,
 		},
 		{
-			msg:             "start stop",
-			inputPeerIDs:    []string{"1", "2", "3", "4", "5", "6"},
-			retainedPeerIDs: []string{"1", "2", "3", "4", "5", "6"},
-			releasedPeerIDs: []string{"1", "2", "3", "4", "5", "6"},
+			msg:                        "start stop",
+			inputPeerIDs:               []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"},
+			retainedAvailablePeerIDs:   []string{"1", "2", "3", "4", "5", "6"},
+			retainedUnavailablePeerIDs: []string{"7", "8", "9"},
+			releasedPeerIDs:            []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"},
 			peerListActions: []PeerListAction{
 				StartAction{},
 				StopAction{},
@@ -83,10 +99,10 @@ func TestRoundRobinList(t *testing.T) {
 			expectedStarted: false,
 		},
 		{
-			msg:               "start many and choose",
-			inputPeerIDs:      []string{"1", "2", "3", "4", "5", "6"},
-			retainedPeerIDs:   []string{"1", "2", "3", "4", "5", "6"},
-			expectedRingPeers: []string{"1", "2", "3", "4", "5", "6"},
+			msg:                      "start many and choose",
+			inputPeerIDs:             []string{"1", "2", "3", "4", "5", "6"},
+			retainedAvailablePeerIDs: []string{"1", "2", "3", "4", "5", "6"},
+			expectedAvailablePeers:   []string{"1", "2", "3", "4", "5", "6"},
 			peerListActions: []PeerListAction{
 				StartAction{},
 				ChooseAction{ExpectedPeer: "1"},
@@ -100,10 +116,10 @@ func TestRoundRobinList(t *testing.T) {
 			expectedStarted: true,
 		},
 		{
-			msg:               "start twice",
-			inputPeerIDs:      []string{"1"},
-			retainedPeerIDs:   []string{"1"},
-			expectedRingPeers: []string{"1"},
+			msg:                      "start twice",
+			inputPeerIDs:             []string{"1"},
+			retainedAvailablePeerIDs: []string{"1"},
+			expectedAvailablePeers:   []string{"1"},
 			peerListActions: []PeerListAction{
 				StartAction{},
 				StartAction{
@@ -116,10 +132,10 @@ func TestRoundRobinList(t *testing.T) {
 			expectedStarted: true,
 		},
 		{
-			msg:               "stop no start",
-			inputPeerIDs:      []string{"1"},
-			retainedPeerIDs:   []string{"1"},
-			expectedRingPeers: []string{"1"},
+			msg:                      "stop no start",
+			inputPeerIDs:             []string{"1"},
+			retainedAvailablePeerIDs: []string{"1"},
+			expectedAvailablePeers:   []string{"1"},
 			peerListActions: []PeerListAction{
 				StopAction{
 					ExpectedErr: errors.ErrPeerListNotStarted("RoundRobinList"),
@@ -135,20 +151,20 @@ func TestRoundRobinList(t *testing.T) {
 			expectedCreateErr:  errors.ErrInvalidPeerType{},
 		},
 		{
-			msg:                "start retain multiple errors",
-			inputPeerIDs:       []string{"1", "2", "3"},
-			retainedPeerIDs:    []string{"2"},
-			errRetainedPeerIDs: []string{"1", "3"},
-			retainErr:          errors.ErrInvalidPeerType{},
-			expectedCreateErr:  yerrors.ErrorGroup{errors.ErrInvalidPeerType{}, errors.ErrInvalidPeerType{}},
-			expectedRingPeers:  []string{"2"},
+			msg:                      "start retain multiple errors",
+			inputPeerIDs:             []string{"1", "2", "3"},
+			retainedAvailablePeerIDs: []string{"2"},
+			errRetainedPeerIDs:       []string{"1", "3"},
+			retainErr:                errors.ErrInvalidPeerType{},
+			expectedCreateErr:        yerrors.ErrorGroup{errors.ErrInvalidPeerType{}, errors.ErrInvalidPeerType{}},
+			expectedAvailablePeers:   []string{"2"},
 		},
 		{
-			msg:                "start stop release error",
-			inputPeerIDs:       []string{"1"},
-			retainedPeerIDs:    []string{"1"},
-			errReleasedPeerIDs: []string{"1"},
-			releaseErr:         errors.ErrAgentHasNoReferenceToPeer{},
+			msg:                      "start stop release error",
+			inputPeerIDs:             []string{"1"},
+			retainedAvailablePeerIDs: []string{"1"},
+			errReleasedPeerIDs:       []string{"1"},
+			releaseErr:               errors.ErrAgentHasNoReferenceToPeer{},
 			peerListActions: []PeerListAction{
 				StartAction{},
 				StopAction{
@@ -158,12 +174,12 @@ func TestRoundRobinList(t *testing.T) {
 			expectedStarted: false,
 		},
 		{
-			msg:                "start stop release multiple errors",
-			inputPeerIDs:       []string{"1", "2", "3"},
-			retainedPeerIDs:    []string{"1", "2", "3"},
-			releasedPeerIDs:    []string{"2"},
-			errReleasedPeerIDs: []string{"1", "3"},
-			releaseErr:         errors.ErrAgentHasNoReferenceToPeer{},
+			msg:                      "start stop release multiple errors",
+			inputPeerIDs:             []string{"1", "2", "3"},
+			retainedAvailablePeerIDs: []string{"1", "2", "3"},
+			releasedPeerIDs:          []string{"2"},
+			errReleasedPeerIDs:       []string{"1", "3"},
+			releaseErr:               errors.ErrAgentHasNoReferenceToPeer{},
 			peerListActions: []PeerListAction{
 				StartAction{},
 				StopAction{
@@ -176,10 +192,10 @@ func TestRoundRobinList(t *testing.T) {
 			expectedStarted: false,
 		},
 		{
-			msg:               "choose before start",
-			inputPeerIDs:      []string{"1"},
-			retainedPeerIDs:   []string{"1"},
-			expectedRingPeers: []string{"1"},
+			msg:                      "choose before start",
+			inputPeerIDs:             []string{"1"},
+			retainedAvailablePeerIDs: []string{"1"},
+			expectedAvailablePeers:   []string{"1"},
 			peerListActions: []PeerListAction{
 				ChooseAction{
 					ExpectedErr: errors.ErrPeerListNotStarted("RoundRobinList"),
@@ -202,10 +218,10 @@ func TestRoundRobinList(t *testing.T) {
 			expectedStarted: true,
 		},
 		{
-			msg:               "start add",
-			inputPeerIDs:      []string{"1"},
-			retainedPeerIDs:   []string{"1", "2"},
-			expectedRingPeers: []string{"1", "2"},
+			msg:                      "start add",
+			inputPeerIDs:             []string{"1"},
+			retainedAvailablePeerIDs: []string{"1", "2"},
+			expectedAvailablePeers:   []string{"1", "2"},
 			peerListActions: []PeerListAction{
 				StartAction{},
 				AddAction{InputPeerID: "2"},
@@ -216,11 +232,11 @@ func TestRoundRobinList(t *testing.T) {
 			expectedStarted: true,
 		},
 		{
-			msg:               "start remove",
-			inputPeerIDs:      []string{"1", "2"},
-			retainedPeerIDs:   []string{"1", "2"},
-			expectedRingPeers: []string{"2"},
-			releasedPeerIDs:   []string{"1"},
+			msg:                      "start remove",
+			inputPeerIDs:             []string{"1", "2"},
+			retainedAvailablePeerIDs: []string{"1", "2"},
+			expectedAvailablePeers:   []string{"2"},
+			releasedPeerIDs:          []string{"1"},
 			peerListActions: []PeerListAction{
 				StartAction{},
 				RemoveAction{InputPeerID: "1"},
@@ -229,11 +245,11 @@ func TestRoundRobinList(t *testing.T) {
 			expectedStarted: true,
 		},
 		{
-			msg:               "start add many and remove many",
-			inputPeerIDs:      []string{"1", "2", "3-r", "4-r"},
-			retainedPeerIDs:   []string{"1", "2", "3-r", "4-r", "5-a-r", "6-a-r", "7-a", "8-a"},
-			releasedPeerIDs:   []string{"3-r", "4-r", "5-a-r", "6-a-r"},
-			expectedRingPeers: []string{"1", "2", "7-a", "8-a"},
+			msg:                      "start add many and remove many",
+			inputPeerIDs:             []string{"1", "2", "3-r", "4-r"},
+			retainedAvailablePeerIDs: []string{"1", "2", "3-r", "4-r", "5-a-r", "6-a-r", "7-a", "8-a"},
+			releasedPeerIDs:          []string{"3-r", "4-r", "5-a-r", "6-a-r"},
+			expectedAvailablePeers:   []string{"1", "2", "7-a", "8-a"},
 			peerListActions: []PeerListAction{
 				StartAction{},
 				AddAction{InputPeerID: "5-a-r"},
@@ -253,12 +269,12 @@ func TestRoundRobinList(t *testing.T) {
 			expectedStarted: true,
 		},
 		{
-			msg:                "add retain error",
-			inputPeerIDs:       []string{"1", "2"},
-			retainedPeerIDs:    []string{"1", "2"},
-			expectedRingPeers:  []string{"1", "2"},
-			errRetainedPeerIDs: []string{"3"},
-			retainErr:          errors.ErrInvalidPeerType{},
+			msg:                      "add retain error",
+			inputPeerIDs:             []string{"1", "2"},
+			retainedAvailablePeerIDs: []string{"1", "2"},
+			expectedAvailablePeers:   []string{"1", "2"},
+			errRetainedPeerIDs:       []string{"3"},
+			retainErr:                errors.ErrInvalidPeerType{},
 			peerListActions: []PeerListAction{
 				StartAction{},
 				AddAction{
@@ -272,10 +288,10 @@ func TestRoundRobinList(t *testing.T) {
 			expectedStarted: true,
 		},
 		{
-			msg:               "add duplicate peer",
-			inputPeerIDs:      []string{"1", "2"},
-			retainedPeerIDs:   []string{"1", "2", "2"},
-			expectedRingPeers: []string{"1", "2"},
+			msg:                      "add duplicate peer",
+			inputPeerIDs:             []string{"1", "2"},
+			retainedAvailablePeerIDs: []string{"1", "2", "2"},
+			expectedAvailablePeers:   []string{"1", "2"},
 			peerListActions: []PeerListAction{
 				StartAction{},
 				AddAction{
@@ -289,10 +305,10 @@ func TestRoundRobinList(t *testing.T) {
 			expectedStarted: true,
 		},
 		{
-			msg:               "remove peer not in list",
-			inputPeerIDs:      []string{"1", "2"},
-			retainedPeerIDs:   []string{"1", "2"},
-			expectedRingPeers: []string{"1", "2"},
+			msg:                      "remove peer not in list",
+			inputPeerIDs:             []string{"1", "2"},
+			retainedAvailablePeerIDs: []string{"1", "2"},
+			expectedAvailablePeers:   []string{"1", "2"},
 			peerListActions: []PeerListAction{
 				StartAction{},
 				RemoveAction{
@@ -306,12 +322,12 @@ func TestRoundRobinList(t *testing.T) {
 			expectedStarted: true,
 		},
 		{
-			msg:                "remove release error",
-			inputPeerIDs:       []string{"1", "2"},
-			retainedPeerIDs:    []string{"1", "2"},
-			errReleasedPeerIDs: []string{"2"},
-			releaseErr:         errors.ErrAgentHasNoReferenceToPeer{},
-			expectedRingPeers:  []string{"1"},
+			msg:                      "remove release error",
+			inputPeerIDs:             []string{"1", "2"},
+			retainedAvailablePeerIDs: []string{"1", "2"},
+			errReleasedPeerIDs:       []string{"2"},
+			releaseErr:               errors.ErrAgentHasNoReferenceToPeer{},
+			expectedAvailablePeers:   []string{"1"},
 			peerListActions: []PeerListAction{
 				StartAction{},
 				RemoveAction{
@@ -324,9 +340,9 @@ func TestRoundRobinList(t *testing.T) {
 			expectedStarted: true,
 		},
 		{
-			msg:               "block until add",
-			retainedPeerIDs:   []string{"1"},
-			expectedRingPeers: []string{"1"},
+			msg: "block until add",
+			retainedAvailablePeerIDs: []string{"1"},
+			expectedAvailablePeers:   []string{"1"},
 			peerListActions: []PeerListAction{
 				StartAction{},
 				ConcurrentAction{
@@ -344,9 +360,9 @@ func TestRoundRobinList(t *testing.T) {
 			expectedStarted: true,
 		},
 		{
-			msg:               "multiple blocking until add",
-			retainedPeerIDs:   []string{"1"},
-			expectedRingPeers: []string{"1"},
+			msg: "multiple blocking until add",
+			retainedAvailablePeerIDs: []string{"1"},
+			expectedAvailablePeers:   []string{"1"},
 			peerListActions: []PeerListAction{
 				StartAction{},
 				ConcurrentAction{
@@ -372,9 +388,9 @@ func TestRoundRobinList(t *testing.T) {
 			expectedStarted: true,
 		},
 		{
-			msg:               "block but added too late",
-			retainedPeerIDs:   []string{"1"},
-			expectedRingPeers: []string{"1"},
+			msg: "block but added too late",
+			retainedAvailablePeerIDs: []string{"1"},
+			expectedAvailablePeers:   []string{"1"},
 			peerListActions: []PeerListAction{
 				StartAction{},
 				ConcurrentAction{
@@ -392,11 +408,11 @@ func TestRoundRobinList(t *testing.T) {
 			expectedStarted: true,
 		},
 		{
-			msg:               "block until new peer after removal of only peer",
-			inputPeerIDs:      []string{"1"},
-			retainedPeerIDs:   []string{"1", "2"},
-			releasedPeerIDs:   []string{"1"},
-			expectedRingPeers: []string{"2"},
+			msg:                      "block until new peer after removal of only peer",
+			inputPeerIDs:             []string{"1"},
+			retainedAvailablePeerIDs: []string{"1", "2"},
+			releasedPeerIDs:          []string{"1"},
+			expectedAvailablePeers:   []string{"2"},
 			peerListActions: []PeerListAction{
 				StartAction{},
 				RemoveAction{InputPeerID: "1"},
@@ -425,41 +441,225 @@ func TestRoundRobinList(t *testing.T) {
 			},
 			expectedStarted: true,
 		},
+		{
+			msg:                        "add unavailable peer",
+			inputPeerIDs:               []string{"1"},
+			retainedAvailablePeerIDs:   []string{"1"},
+			retainedUnavailablePeerIDs: []string{"2"},
+			expectedAvailablePeers:     []string{"1"},
+			expectedUnavailablePeers:   []string{"2"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				AddAction{InputPeerID: "2"},
+				ChooseAction{ExpectedPeer: "1"},
+				ChooseAction{ExpectedPeer: "1"},
+			},
+			expectedStarted: true,
+		},
+		{
+			msg:                        "remove unavailable peer",
+			inputPeerIDs:               []string{"1"},
+			retainedUnavailablePeerIDs: []string{"1"},
+			releasedPeerIDs:            []string{"1"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				RemoveAction{InputPeerID: "1"},
+				ChooseAction{
+					InputContextTimeout: 10 * time.Millisecond,
+					ExpectedErr:         context.DeadlineExceeded,
+				},
+			},
+			expectedStarted: true,
+		},
+		{
+			msg:                        "notify peer is now available",
+			inputPeerIDs:               []string{"1"},
+			retainedUnavailablePeerIDs: []string{"1"},
+			expectedAvailablePeers:     []string{"1"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				ChooseAction{
+					InputContextTimeout: 10 * time.Millisecond,
+					ExpectedErr:         context.DeadlineExceeded,
+				},
+				NotifyStatusChangeAction{PeerID: "1", NewConnectionStatus: transport.PeerAvailable},
+				ChooseAction{ExpectedPeer: "1"},
+			},
+			expectedStarted: true,
+		},
+		{
+			msg:                      "notify peer is still available",
+			inputPeerIDs:             []string{"1"},
+			retainedAvailablePeerIDs: []string{"1"},
+			expectedAvailablePeers:   []string{"1"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				ChooseAction{ExpectedPeer: "1"},
+				NotifyStatusChangeAction{PeerID: "1", NewConnectionStatus: transport.PeerAvailable},
+				ChooseAction{ExpectedPeer: "1"},
+			},
+			expectedStarted: true,
+		},
+		{
+			msg:                      "notify peer is now unavailable",
+			inputPeerIDs:             []string{"1"},
+			retainedAvailablePeerIDs: []string{"1"},
+			expectedUnavailablePeers: []string{"1"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				ChooseAction{ExpectedPeer: "1"},
+				NotifyStatusChangeAction{PeerID: "1", NewConnectionStatus: transport.PeerUnavailable},
+				ChooseAction{
+					InputContextTimeout: 10 * time.Millisecond,
+					ExpectedErr:         context.DeadlineExceeded,
+				},
+			},
+			expectedStarted: true,
+		},
+		{
+			msg:                        "notify peer is still unavailable",
+			inputPeerIDs:               []string{"1"},
+			retainedUnavailablePeerIDs: []string{"1"},
+			expectedUnavailablePeers:   []string{"1"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				NotifyStatusChangeAction{PeerID: "1", NewConnectionStatus: transport.PeerUnavailable},
+				ChooseAction{
+					InputContextTimeout: 10 * time.Millisecond,
+					ExpectedErr:         context.DeadlineExceeded,
+				},
+			},
+			expectedStarted: true,
+		},
+		{
+			msg:                      "notify invalid peer",
+			inputPeerIDs:             []string{"1"},
+			retainedAvailablePeerIDs: []string{"1"},
+			releasedPeerIDs:          []string{"1"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				RemoveAction{InputPeerID: "1"},
+				NotifyStatusChangeAction{PeerID: "1", NewConnectionStatus: transport.PeerAvailable},
+			},
+			expectedStarted: true,
+		},
+		{
+			// v: Available, u: Unavailable, a: Added, r: Removed
+			msg:                        "notify peer stress test",
+			inputPeerIDs:               []string{"1v", "6u"},
+			retainedAvailablePeerIDs:   []string{"1v", "2va", "3vau", "4var", "5vaur"},
+			retainedUnavailablePeerIDs: []string{"6u", "7ua", "8uav", "9uar", "10uavr"},
+			releasedPeerIDs:            []string{"4var", "5vaur", "9uar", "10uavr"},
+			expectedAvailablePeers:     []string{"1v", "2va", "8uav"},
+			expectedUnavailablePeers:   []string{"3vau", "6u", "7ua"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				// Added Peers
+				AddAction{InputPeerID: "2va"},
+				AddAction{InputPeerID: "3vau"},
+				AddAction{InputPeerID: "4var"},
+				AddAction{InputPeerID: "5vaur"},
+				AddAction{InputPeerID: "7ua"},
+				AddAction{InputPeerID: "8uav"},
+				AddAction{InputPeerID: "9uar"},
+				AddAction{InputPeerID: "10uavr"},
+
+				ChooseMultiAction{ExpectedPeers: []string{"1v", "2va", "3vau", "4var", "5vaur"}},
+				ChooseMultiAction{ExpectedPeers: []string{"1v", "2va", "3vau", "4var", "5vaur"}},
+
+				// Change Status to Unavailable
+				NotifyStatusChangeAction{PeerID: "3vau", NewConnectionStatus: transport.PeerUnavailable},
+				NotifyStatusChangeAction{PeerID: "5vaur", NewConnectionStatus: transport.PeerUnavailable},
+
+				ChooseMultiAction{ExpectedPeers: []string{"1v", "2va", "4var"}},
+				ChooseMultiAction{ExpectedPeers: []string{"1v", "2va", "4var"}},
+
+				// Change Status to Available
+				NotifyStatusChangeAction{PeerID: "8uav", NewConnectionStatus: transport.PeerAvailable},
+				NotifyStatusChangeAction{PeerID: "10uavr", NewConnectionStatus: transport.PeerAvailable},
+
+				ChooseMultiAction{ExpectedPeers: []string{"1v", "2va", "4var", "8uav", "10uavr"}},
+				ChooseMultiAction{ExpectedPeers: []string{"1v", "2va", "4var", "8uav", "10uavr"}},
+
+				// Remove Peers
+				RemoveAction{InputPeerID: "4var"},
+				RemoveAction{InputPeerID: "5vaur"},
+				RemoveAction{InputPeerID: "9uar"},
+				RemoveAction{InputPeerID: "10uavr"},
+
+				ChooseMultiAction{ExpectedPeers: []string{"1v", "2va", "8uav"}},
+				ChooseMultiAction{ExpectedPeers: []string{"1v", "2va", "8uav"}},
+			},
+			expectedStarted: true,
+		},
+		{
+			msg:                        "block until notify available",
+			inputPeerIDs:               []string{"1"},
+			retainedUnavailablePeerIDs: []string{"1"},
+			expectedAvailablePeers:     []string{"1"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				ConcurrentAction{
+					Actions: []PeerListAction{
+						ChooseAction{
+							InputContextTimeout: 200 * time.Millisecond,
+							ExpectedPeer:        "1",
+						},
+						NotifyStatusChangeAction{PeerID: "1", NewConnectionStatus: transport.PeerAvailable},
+					},
+					Wait: 20 * time.Millisecond,
+				},
+				ChooseAction{ExpectedPeer: "1"},
+			},
+			expectedStarted: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.msg, func(t *testing.T) {
-			// Due to a deadlock that occurs when an Expectation on the Peers
-			// relies on the MockController we need to use separate controllers
-			// for the MockPeers and MockAgents
-			agentMockCtrl := gomock.NewController(t)
-			defer agentMockCtrl.Finish()
-			peerMockCtrl := gomock.NewController(t)
-			defer peerMockCtrl.Finish()
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
 
 			pids := CreatePeerIDs(tt.inputPeerIDs)
-			agent := transporttest.NewMockAgent(agentMockCtrl)
+			agent := transporttest.NewMockAgent(mockCtrl)
 
 			// Healthy Agent Retain/Release
-			ExpectPeerRetains(peerMockCtrl, agent, tt.retainedPeerIDs, nil)
+			peerMap := ExpectPeerRetains(
+				agent,
+				tt.retainedAvailablePeerIDs,
+				tt.retainedUnavailablePeerIDs,
+			)
 			ExpectPeerReleases(agent, tt.releasedPeerIDs, nil)
 
 			// Unhealthy Agent Retain/Release
-			ExpectPeerRetains(peerMockCtrl, agent, tt.errRetainedPeerIDs, tt.retainErr)
+			ExpectPeerRetainsWithError(agent, tt.errRetainedPeerIDs, tt.retainErr)
 			ExpectPeerReleases(agent, tt.errReleasedPeerIDs, tt.releaseErr)
 
 			pl, err := New(pids, agent)
 			assert.Equal(t, tt.expectedCreateErr, err)
 
-			ApplyPeerListActions(t, pl, tt.peerListActions)
+			deps := Dependencies{
+				Peers: peerMap,
+			}
+			ApplyPeerListActions(t, pl, tt.peerListActions, deps)
 
-			assert.Equal(t, len(tt.expectedRingPeers), len(pl.pr.peerToNode))
-			for _, expectedRingPeer := range tt.expectedRingPeers {
-				node, ok := pl.pr.peerToNode[expectedRingPeer]
-				assert.True(t, ok, fmt.Sprintf("expected peer: %s was not in peerlist", expectedRingPeer))
+			assert.Len(t, pl.availablePeerRing.peerToNode, len(tt.expectedAvailablePeers), "invalid available peerlist size")
+			for _, expectedRingPeer := range tt.expectedAvailablePeers {
+				node, ok := pl.availablePeerRing.peerToNode[expectedRingPeer]
+				assert.True(t, ok, fmt.Sprintf("expected peer: %s was not in available peerlist", expectedRingPeer))
+				if ok {
+					actualPeer := getPeerForRingNode(node)
+					assert.Equal(t, expectedRingPeer, actualPeer.Identifier())
+				}
+			}
 
-				actualPeer := getPeerForRingNode(node)
-				assert.Equal(t, expectedRingPeer, actualPeer.Identifier())
+			assert.Len(t, pl.nonAvailablePeers, len(tt.expectedUnavailablePeers), "invalid unavailable peerlist size")
+			for _, expectedUnavailablePeer := range tt.expectedUnavailablePeers {
+				peer, ok := pl.nonAvailablePeers[expectedUnavailablePeer]
+				assert.True(t, ok, fmt.Sprintf("expected peer: %s was not in unavailable peerlist", expectedUnavailablePeer))
+				if ok {
+					assert.Equal(t, expectedUnavailablePeer, peer.Identifier())
+				}
 			}
 
 			assert.Equal(t, tt.expectedStarted, pl.started.Load())

--- a/transport/peeragent.go
+++ b/transport/peeragent.go
@@ -25,7 +25,7 @@ package transport
 // PeerSubscriber listens to changes of a Peer over time.
 type PeerSubscriber interface {
 	// The Peer Notifies the PeerSubscriber when its status changes (e.g. connections status, pending requests)
-	NotifyStatusChanged(Peer)
+	NotifyStatusChanged(PeerIdentifier)
 }
 
 // Agent manages Peers across different PeerSubscribers.  A PeerSubscriber will request a Peer for a specific

--- a/transport/transporttest/peeragent.go
+++ b/transport/transporttest/peeragent.go
@@ -91,7 +91,7 @@ func (_m *MockPeerSubscriber) EXPECT() *_MockPeerSubscriberRecorder {
 	return _m.recorder
 }
 
-func (_m *MockPeerSubscriber) NotifyStatusChanged(_param0 transport.Peer) {
+func (_m *MockPeerSubscriber) NotifyStatusChanged(_param0 transport.PeerIdentifier) {
 	_m.ctrl.Call(_m, "NotifyStatusChanged", _param0)
 }
 


### PR DESCRIPTION
Summary: In order to have a more powerful PeerList in the round robin,
we need to be able to distinguish between a Peer that cannot accept
requests and one that can.  This PR adds a distinction in the RoundRobin
PeerList that will only return Available Peers from the ChoosePeer
method.

In the process of doing this, I realized it would be a bad idea to trust
the Peer we pass in the NotifyStatusChanged function, so I changed it
from a Peer to a PeerIdentifier so that the lists need to look up their
own object so we don't get an issue of duplicate peers getting passed
around with different state.

Test Plan: I've upgraded the PeerListAction tests to have a
NotifyStatusChangeAction which will update a Peer's Status and run the
NotifyStatusChange function on the PeerList with the provided Peer.
This required weaving a list of available MockPeers in the Apply
function.
Additionally, the gomock MockPeer was not very flexible with changing
the returned result from an Expectation, so I ended up creating a thin
mock of Peer instead.