### PR TITLE
crossdock - Explicitly use Go 1.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM golang
-ENV GO15VENDOREXPERIMENT 1
+FROM golang:1.7
 ADD . /go/src/go.uber.org/yarpc
 RUN go install go.uber.org/yarpc/crossdock
 ENTRYPOINT /go/bin/crossdock


### PR DESCRIPTION
Docker is very stateful - this forces the right version so that you don't have to pull images locally.