### PR TITLE
Kill top-level symlinks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.7
 ADD . /go/src/go.uber.org/yarpc
-RUN go install go.uber.org/yarpc/crossdock
+RUN go install go.uber.org/yarpc/internal/crossdock
 ENTRYPOINT /go/bin/crossdock
 EXPOSE 8080-8087

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ cover:
 # down.
 .PHONY: test-examples
 test-examples: build
-	make -C examples
+	make -C internal/examples
 
 
 .PHONY: crossdock

--- a/crossdock
+++ b/crossdock
@@ -1,1 +1,0 @@
-internal/crossdock

--- a/examples
+++ b/examples
@@ -1,1 +1,0 @@
-internal/examples


### PR DESCRIPTION
This kills the symlinks for examples/ and crossdock/ to keep the godocs clean.

GitHub doesn't follow symlinks anyway so this doesn't help with
discoverability.

@yarpc/golang