### PR TITLE
Split peer StartRequest and EndRequest

### DIFF
--- a/peer/hostport/hostport.go
+++ b/peer/hostport/hostport.go
@@ -102,23 +102,25 @@ func (p *Peer) Status() peer.Status {
 // SetStatus sets the status of the Peer (to be used by the peer.Agent)
 func (p *Peer) SetStatus(status peer.ConnectionStatus) {
 	p.connectionStatus = status
-	p.notifyStatusChanged()
+	p.notifyStatusChanged(nil)
 }
 
 // StartRequest runs at the beginning of a request and returns a callback for when the request finished
-func (p *Peer) StartRequest() {
+func (p *Peer) StartRequest(s peer.Subscriber) {
 	p.pending.Inc()
-	p.notifyStatusChanged()
+	p.notifyStatusChanged(s)
 }
 
 // EndRequest should be run after a request has finished.
-func (p *Peer) EndRequest() {
+func (p *Peer) EndRequest(s peer.Subscriber) {
 	p.pending.Dec()
-	p.notifyStatusChanged()
+	p.notifyStatusChanged(s)
 }
 
-func (p *Peer) notifyStatusChanged() {
+func (p *Peer) notifyStatusChanged(dontNotify peer.Subscriber) {
 	for sub := range p.subscribers {
-		sub.NotifyStatusChanged(p)
+		if sub != dontNotify {
+			sub.NotifyStatusChanged(p)
+		}
 	}
 }

--- a/peer/hostport/hostport.go
+++ b/peer/hostport/hostport.go
@@ -106,14 +106,13 @@ func (p *Peer) SetStatus(status peer.ConnectionStatus) {
 }
 
 // StartRequest runs at the beginning of a request and returns a callback for when the request finished
-func (p *Peer) StartRequest() func() {
+func (p *Peer) StartRequest() {
 	p.pending.Inc()
 	p.notifyStatusChanged()
-	return p.endRequest
 }
 
-// endRequest should be run after a request has finished
-func (p *Peer) endRequest() {
+// EndRequest should be run after a request has finished.
+func (p *Peer) EndRequest() {
 	p.pending.Dec()
 	p.notifyStatusChanged()
 }

--- a/peer/hostport/peeraction_test.go
+++ b/peer/hostport/peeraction_test.go
@@ -43,16 +43,16 @@ type PeerAction interface {
 	Apply(*testing.T, *Peer, *Dependencies)
 }
 
-// StartStopReqAction will run a StartRequest and (optionally) a stop request
+// StartStopReqAction will run a StartRequest and (optionally) EndRequest
 type StartStopReqAction struct {
 	Stop bool
 }
 
-// Apply will run StartRequest and (optionally) the end closure
+// Apply will run StartRequest and (optionally) EndRequest
 func (sa StartStopReqAction) Apply(t *testing.T, p *Peer, d *Dependencies) {
-	end := p.StartRequest()
+	p.StartRequest()
 	if sa.Stop {
-		end()
+		p.EndRequest()
 	}
 }
 

--- a/peer/hostport/peeraction_test.go
+++ b/peer/hostport/peeraction_test.go
@@ -50,9 +50,9 @@ type StartStopReqAction struct {
 
 // Apply will run StartRequest and (optionally) EndRequest
 func (sa StartStopReqAction) Apply(t *testing.T, p *Peer, d *Dependencies) {
-	p.StartRequest()
+	p.StartRequest(nil)
 	if sa.Stop {
-		p.EndRequest()
+		p.EndRequest(nil)
 	}
 }
 

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -59,10 +59,9 @@ type Peer interface {
 	// Get the status of the Peer
 	Status() Status
 
-	// Tell the peer that a request is starting/ending
-	// The callsite should look like:
-	//   done := peer.StartRequest()
-	//   defer done()
-	//   // Do request
-	StartRequest() (finish func())
+	// Tell the peer that a request is starting
+	StartRequest()
+
+	// Tell the peer that a request has finished
+	EndRequest()
 }

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -60,8 +60,8 @@ type Peer interface {
 	Status() Status
 
 	// Tell the peer that a request is starting
-	StartRequest()
+	StartRequest(dontNotify Subscriber)
 
 	// Tell the peer that a request has finished
-	EndRequest()
+	EndRequest(dontNotify Subscriber)
 }

--- a/peer/peertest/peer.go
+++ b/peer/peertest/peer.go
@@ -80,6 +80,14 @@ func (_m *MockPeer) EXPECT() *_MockPeerRecorder {
 	return _m.recorder
 }
 
+func (_m *MockPeer) EndRequest() {
+	_m.ctrl.Call(_m, "EndRequest")
+}
+
+func (_mr *_MockPeerRecorder) EndRequest() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "EndRequest")
+}
+
 func (_m *MockPeer) Identifier() string {
 	ret := _m.ctrl.Call(_m, "Identifier")
 	ret0, _ := ret[0].(string)
@@ -90,10 +98,8 @@ func (_mr *_MockPeerRecorder) Identifier() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Identifier")
 }
 
-func (_m *MockPeer) StartRequest() func() {
-	ret := _m.ctrl.Call(_m, "StartRequest")
-	ret0, _ := ret[0].(func())
-	return ret0
+func (_m *MockPeer) StartRequest() {
+	_m.ctrl.Call(_m, "StartRequest")
 }
 
 func (_mr *_MockPeerRecorder) StartRequest() *gomock.Call {

--- a/peer/peertest/peers.go
+++ b/peer/peertest/peers.go
@@ -63,13 +63,12 @@ func (p *LightMockPeer) Status() peer.Status {
 }
 
 // StartRequest is run when a Request starts
-func (p *LightMockPeer) StartRequest() func() {
+func (p *LightMockPeer) StartRequest() {
 	p.PeerStatus.PendingRequestCount++
-	return p.endRequest
 }
 
-// endRequest should be run after a MockPeer request has finished
-func (p *LightMockPeer) endRequest() {
+// EndRequest should be run after a MockPeer request has finished
+func (p *LightMockPeer) EndRequest() {
 	p.PeerStatus.PendingRequestCount--
 }
 

--- a/peer/peertest/peers.go
+++ b/peer/peertest/peers.go
@@ -63,12 +63,12 @@ func (p *LightMockPeer) Status() peer.Status {
 }
 
 // StartRequest is run when a Request starts
-func (p *LightMockPeer) StartRequest() {
+func (p *LightMockPeer) StartRequest(_ peer.Subscriber) {
 	p.PeerStatus.PendingRequestCount++
 }
 
 // EndRequest should be run after a MockPeer request has finished
-func (p *LightMockPeer) EndRequest() {
+func (p *LightMockPeer) EndRequest(_ peer.Subscriber) {
 	p.PeerStatus.PendingRequestCount--
 }
 

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -130,8 +130,8 @@ func (o *Outbound) Call(ctx context.Context, treq *transport.Request) (*transpor
 	if err != nil {
 		return nil, err
 	}
-	p.StartRequest()
-	defer p.EndRequest()
+	p.StartRequest(nil)
+	defer p.EndRequest(nil)
 
 	req, err := o.createRequest(p, treq)
 	if err != nil {
@@ -202,8 +202,8 @@ func (o *Outbound) CallOneway(ctx context.Context, treq *transport.Request) (tra
 	if err != nil {
 		return nil, err
 	}
-	p.StartRequest()
-	defer p.EndRequest()
+	p.StartRequest(nil)
+	defer p.EndRequest(nil)
 
 	req, err := o.createRequest(p, treq)
 	if err != nil {

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -130,8 +130,8 @@ func (o *Outbound) Call(ctx context.Context, treq *transport.Request) (*transpor
 	if err != nil {
 		return nil, err
 	}
-	endRequest := p.StartRequest()
-	defer endRequest()
+	p.StartRequest()
+	defer p.EndRequest()
 
 	req, err := o.createRequest(p, treq)
 	if err != nil {
@@ -202,8 +202,8 @@ func (o *Outbound) CallOneway(ctx context.Context, treq *transport.Request) (tra
 	if err != nil {
 		return nil, err
 	}
-	endRequest := p.StartRequest()
-	defer endRequest()
+	p.StartRequest()
+	defer p.EndRequest()
 
 	req, err := o.createRequest(p, treq)
 	if err != nil {


### PR DESCRIPTION
This pivots the end request closure to an end request notification method and adds an argument to suppress the notification to the subscriber that originates the message.