### PR TITLE
Inbound tracer options

### DIFF
--- a/transport/http/handler.go
+++ b/transport/http/handler.go
@@ -45,7 +45,7 @@ func popHeader(h http.Header, n string) string {
 // handler adapts a transport.Handler into a handler for net/http.
 type handler struct {
 	Registry transport.Registry
-	Deps     transport.Deps
+	tracer   opentracing.Tracer
 }
 
 func (h handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
@@ -166,7 +166,7 @@ func updateSpanWithErr(span opentracing.Span, err error) error {
 func (h handler) createSpan(ctx context.Context, req *http.Request, treq *transport.Request, start time.Time) (context.Context, opentracing.Span) {
 	// Extract opentracing etc baggage from headers
 	// Annotate the inbound context with a trace span
-	tracer := h.Deps.Tracer()
+	tracer := h.tracer
 	carrier := opentracing.HTTPHeadersCarrier(req.Header)
 	parentSpanCtx, _ := tracer.Extract(opentracing.HTTPHeaders, carrier)
 	// parentSpanCtx may be nil, ext.RPCServerOption handles a nil parent

--- a/transport/http/handler_test.go
+++ b/transport/http/handler_test.go
@@ -37,6 +37,7 @@ import (
 	"go.uber.org/yarpc/transport/transporttest"
 
 	"github.com/golang/mock/gomock"
+	"github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -77,7 +78,7 @@ func TestHandlerSucces(t *testing.T) {
 		gomock.Any(),
 	).Return(nil)
 
-	httpHandler := handler{Registry: registry}
+	httpHandler := handler{Registry: registry, tracer: &opentracing.NoopTracer{}}
 	req := &http.Request{
 		Method: "POST",
 		Header: headers,
@@ -130,7 +131,7 @@ func TestHandlerHeaders(t *testing.T) {
 			WithProcedure("hello"),
 		).Return(spec, nil)
 
-		httpHandler := handler{Registry: registry}
+		httpHandler := handler{Registry: registry, tracer: &opentracing.NoopTracer{}}
 
 		rpcHandler.EXPECT().Handle(
 			transporttest.NewContextMatcher(t,
@@ -257,7 +258,7 @@ func TestHandlerFailures(t *testing.T) {
 			).Return(spec, nil)
 		}
 
-		h := handler{Registry: reg}
+		h := handler{Registry: reg, tracer: &opentracing.NoopTracer{}}
 
 		rw := httptest.NewRecorder()
 		h.ServeHTTP(rw, tt.req)
@@ -308,7 +309,7 @@ func TestHandlerInternalFailure(t *testing.T) {
 		WithProcedure("hello"),
 	).Return(spec, nil)
 
-	httpHandler := handler{Registry: registry}
+	httpHandler := handler{Registry: registry, tracer: &opentracing.NoopTracer{}}
 	httpResponse := httptest.NewRecorder()
 	httpHandler.ServeHTTP(httpResponse, &request)
 

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -31,6 +31,7 @@ import (
 	"go.uber.org/yarpc/transport"
 	"go.uber.org/yarpc/transport/internal"
 
+	"github.com/opentracing/opentracing-go"
 	"github.com/uber/tchannel-go"
 	ncontext "golang.org/x/net/context"
 )
@@ -78,7 +79,7 @@ func (c tchannelCall) Response() inboundCallResponse {
 type handler struct {
 	existing map[string]tchannel.Handler
 	Registry transport.Registry
-	deps     transport.Deps
+	tracer   opentracing.Tracer
 }
 
 func (h handler) Handle(ctx ncontext.Context, call *tchannel.InboundCall) {
@@ -133,7 +134,7 @@ func (h handler) callHandler(ctx context.Context, call inboundCall, start time.T
 	treq.Headers = headers
 
 	if tcall, ok := call.(tchannelCall); ok {
-		tracer := h.deps.Tracer()
+		tracer := h.tracer
 		ctx = tchannel.ExtractInboundSpan(ctx, tcall.InboundCall, headers.Items(), tracer)
 	}
 

--- a/transport/tracer_test.go
+++ b/transport/tracer_test.go
@@ -117,7 +117,7 @@ func createHTTPDispatcher(tracer opentracing.Tracer) yarpc.Dispatcher {
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name: "yarpc-test",
 		Inbounds: yarpc.Inbounds{
-			http.NewInbound(":18080"),
+			http.NewInbound(":18080", http.WithTracer(tracer)),
 		},
 		Outbounds: yarpc.Outbounds{
 			"yarpc-test": {

--- a/transport/tracer_test.go
+++ b/transport/tracer_test.go
@@ -142,7 +142,7 @@ func createTChannelDispatcher(tracer opentracing.Tracer, t *testing.T) yarpc.Dis
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name: "yarpc-test",
 		Inbounds: yarpc.Inbounds{
-			ytchannel.NewInbound(ch),
+			ytchannel.NewInbound(ch, ytchannel.WithTracer(tracer)),
 		},
 		Outbounds: yarpc.Outbounds{
 			"yarpc-test": {


### PR DESCRIPTION
This change threads the tracer through a WithTracer option instead of through deps. Subsequent changes will address the factoring of outbounds regarding tracing, and later remove the dependencies argument from Start on both inbound and outbound transports.