### PR TITLE
[PeerRenames][Part 4] Rename single names from pl to s

### DIFF
--- a/peer/single/chooser.go
+++ b/peer/single/chooser.go
@@ -46,50 +46,50 @@ func New(pid peer.Identifier, agent peer.Agent) peer.Chooser {
 	}
 }
 
-func (pl *single) Start() error {
-	pl.lock.Lock()
-	defer pl.lock.Unlock()
-	if pl.started {
+func (s *single) Start() error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if s.started {
 		return peer.ErrPeerListAlreadyStarted("single")
 	}
-	pl.started = true
+	s.started = true
 
-	p, err := pl.agent.RetainPeer(pl.initialPeerID, pl)
+	p, err := s.agent.RetainPeer(s.initialPeerID, s)
 	if err != nil {
-		pl.started = false
+		s.started = false
 		return err
 	}
-	pl.p = p
+	s.p = p
 	return nil
 }
 
-func (pl *single) Stop() error {
-	pl.lock.Lock()
-	defer pl.lock.Unlock()
+func (s *single) Stop() error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
 
-	if !pl.started {
+	if !s.started {
 		return peer.ErrPeerListNotStarted("single")
 	}
-	pl.started = false
+	s.started = false
 
-	err := pl.agent.ReleasePeer(pl.initialPeerID, pl)
+	err := s.agent.ReleasePeer(s.initialPeerID, s)
 	if err != nil {
 		return err
 	}
 
-	pl.p = nil
+	s.p = nil
 	return nil
 }
 
-func (pl *single) ChoosePeer(context.Context, *transport.Request) (peer.Peer, error) {
-	pl.lock.RLock()
-	defer pl.lock.RUnlock()
+func (s *single) ChoosePeer(context.Context, *transport.Request) (peer.Peer, error) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
 
-	if !pl.started {
+	if !s.started {
 		return nil, peer.ErrPeerListNotStarted("single")
 	}
-	return pl.p, nil
+	return s.p, nil
 }
 
 // NotifyStatusChanged when the Peer status changes
-func (pl *single) NotifyStatusChanged(peer.Identifier) {}
+func (s *single) NotifyStatusChanged(peer.Identifier) {}

--- a/peer/single/chooser_test.go
+++ b/peer/single/chooser_test.go
@@ -148,18 +148,18 @@ func TestSingleChooser(t *testing.T) {
 				ExpectPeerReleases(agent, []string{tt.releasedPeerID}, tt.releasedErr)
 			}
 
-			pl := New(MockPeerIdentifier(tt.inputPeerID), agent).(*single)
+			s := New(MockPeerIdentifier(tt.inputPeerID), agent).(*single)
 
-			ApplyPeerListActions(t, pl, tt.actions, ListActionDeps{})
+			ApplyPeerListActions(t, s, tt.actions, ListActionDeps{})
 
-			assert.Equal(t, agent, pl.agent)
-			assert.Equal(t, tt.expectedPeerID, pl.initialPeerID.Identifier())
+			assert.Equal(t, agent, s.agent)
+			assert.Equal(t, tt.expectedPeerID, s.initialPeerID.Identifier())
 			if tt.expectedPeer != "" {
-				assert.Equal(t, tt.expectedPeer, pl.p.Identifier())
+				assert.Equal(t, tt.expectedPeer, s.p.Identifier())
 			} else {
-				assert.Nil(t, pl.p)
+				assert.Nil(t, s.p)
 			}
-			assert.Equal(t, tt.expectedStarted, pl.started)
+			assert.Equal(t, tt.expectedStarted, s.started)
 		})
 	}
 }


### PR DESCRIPTION
Summary: Renames the single file's use of 'pl' with the more accurate 's'