### PR TITLE
[PeerRenames][Part 6] Move RoundRobin to 'x/roundrobin' package

### DIFF
--- a/peer/x/roundrobin/list_test.go
+++ b/peer/x/roundrobin/list_test.go
@@ -1,4 +1,4 @@
-package list
+package roundrobin
 
 import (
 	"context"
@@ -633,7 +633,7 @@ func TestRoundRobinList(t *testing.T) {
 			ExpectPeerRetainsWithError(agent, tt.errRetainedPeerIDs, tt.retainErr)
 			ExpectPeerReleases(agent, tt.errReleasedPeerIDs, tt.releaseErr)
 
-			pl, err := NewRoundRobin(pids, agent)
+			pl, err := New(pids, agent)
 			assert.Equal(t, tt.expectedCreateErr, err)
 
 			deps := ListActionDeps{

--- a/peer/x/roundrobin/peerring.go
+++ b/peer/x/roundrobin/peerring.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package list
+package roundrobin
 
 import (
 	"container/ring"


### PR DESCRIPTION
Summary: In following with our rename of list/single.go to
/single/list.go this diff updates the roundrobin outbound to do the same