### PR TITLE
[Peer][Renames][Part 1] Change List.Add/Remove to List.Update

### DIFF
--- a/peer/list.go
+++ b/peer/list.go
@@ -44,9 +44,6 @@ type Chooser interface {
 // A Chooser will implement the PeerChangeListener interface in order to receive
 // updates to the list of Peers it is keeping track of
 type List interface {
-	// Add a peer to the List (Called directly from a PeerProvider)
-	Add(Identifier) error
-
-	// Remove a peer from the List (Called directly from a PeerProvider)
-	Remove(Identifier) error
+	// Update performs the additions and removals to the Peer List
+	Update(additions, removals []Identifier) error
 }

--- a/peer/peertest/list.go
+++ b/peer/peertest/list.go
@@ -103,22 +103,12 @@ func (_m *MockList) EXPECT() *_MockListRecorder {
 	return _m.recorder
 }
 
-func (_m *MockList) Add(_param0 peer.Identifier) error {
-	ret := _m.ctrl.Call(_m, "Add", _param0)
+func (_m *MockList) Update(_param0 []peer.Identifier, _param1 []peer.Identifier) error {
+	ret := _m.ctrl.Call(_m, "Update", _param0, _param1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockListRecorder) Add(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Add", arg0)
-}
-
-func (_m *MockList) Remove(_param0 peer.Identifier) error {
-	ret := _m.ctrl.Call(_m, "Remove", _param0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-func (_mr *_MockListRecorder) Remove(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Remove", arg0)
+func (_mr *_MockListRecorder) Update(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Update", arg0, arg1)
 }

--- a/peer/peertest/peerlistaction.go
+++ b/peer/peertest/peerlistaction.go
@@ -130,9 +130,9 @@ type AddAction struct {
 // Apply runs "Add" on the peer.Chooser after casting it to a peer.List
 // and validates the error
 func (a AddAction) Apply(t *testing.T, pl peer.Chooser, deps ListActionDeps) {
-	changeListener := pl.(peer.List)
+	list := pl.(peer.List)
 
-	err := changeListener.Add(MockPeerIdentifier(a.InputPeerID))
+	err := list.Update([]peer.Identifier{MockPeerIdentifier(a.InputPeerID)}, nil)
 	assert.Equal(t, a.ExpectedErr, err)
 }
 
@@ -145,9 +145,9 @@ type RemoveAction struct {
 // Apply runs "Remove" on the peer.Chooser after casting it to a peer.List
 // and validates the error
 func (a RemoveAction) Apply(t *testing.T, pl peer.Chooser, deps ListActionDeps) {
-	changeListener := pl.(peer.List)
+	list := pl.(peer.List)
 
-	err := changeListener.Remove(MockPeerIdentifier(a.InputPeerID))
+	err := list.Update(nil, []peer.Identifier{MockPeerIdentifier(a.InputPeerID)})
 	assert.Equal(t, a.ExpectedErr, err)
 }
 

--- a/peer/x/roundrobin/list.go
+++ b/peer/x/roundrobin/list.go
@@ -59,19 +59,23 @@ type List struct {
 // it returns a multi-error result of every failure that happened without
 // circuit breaking due to failures
 func (pl *List) Update(additions, removals []peer.Identifier) error {
+	if len(additions) == 0 && len(removals) == 0 {
+		return nil
+	}
+
 	pl.lock.Lock()
 	defer pl.lock.Unlock()
 
 	var errs []error
 
-	for _, peerID := range additions {
-		if err := pl.addPeerIdentifier(peerID); err != nil {
+	for _, peerID := range removals {
+		if err := pl.removePeerIdentifier(peerID); err != nil {
 			errs = append(errs, err)
 		}
 	}
 
-	for _, peerID := range removals {
-		if err := pl.removePeerIdentifier(peerID); err != nil {
+	for _, peerID := range additions {
+		if err := pl.addPeerIdentifier(peerID); err != nil {
 			errs = append(errs, err)
 		}
 	}


### PR DESCRIPTION
Summary: in the soon-to-be world, in place of add/remove interfaces
we're going to have a single update func from potential peer providers,
this diff updates our Add/Remove functions into a single Update function

#460