### PR TITLE
[Peer][Renames][Part 2] Rename ChoosePeer to Choose

### DIFF
--- a/peer/list.go
+++ b/peer/list.go
@@ -37,7 +37,7 @@ type Chooser interface {
 	Stop() error
 
 	// Choose a Peer for the next call, block until a peer is available (or timeout)
-	ChoosePeer(context.Context, *transport.Request) (Peer, error)
+	Choose(context.Context, *transport.Request) (Peer, error)
 }
 
 // List listens to adds and removes of Peers from a PeerProvider

--- a/peer/peertest/list.go
+++ b/peer/peertest/list.go
@@ -51,15 +51,15 @@ func (_m *MockChooser) EXPECT() *_MockChooserRecorder {
 	return _m.recorder
 }
 
-func (_m *MockChooser) ChoosePeer(_param0 context.Context, _param1 *transport.Request) (peer.Peer, error) {
-	ret := _m.ctrl.Call(_m, "ChoosePeer", _param0, _param1)
+func (_m *MockChooser) Choose(_param0 context.Context, _param1 *transport.Request) (peer.Peer, error) {
+	ret := _m.ctrl.Call(_m, "Choose", _param0, _param1)
 	ret0, _ := ret[0].(peer.Peer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockChooserRecorder) ChoosePeer(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ChoosePeer", arg0, arg1)
+func (_mr *_MockChooserRecorder) Choose(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Choose", arg0, arg1)
 }
 
 func (_m *MockChooser) Start() error {

--- a/peer/peertest/peerlistaction.go
+++ b/peer/peertest/peerlistaction.go
@@ -67,13 +67,13 @@ func (a StopAction) Apply(t *testing.T, pl peer.Chooser, deps ListActionDeps) {
 	assert.Equal(t, a.ExpectedErr, err)
 }
 
-// ChooseMultiAction will run ChoosePeer multiple times on the PeerList
+// ChooseMultiAction will run Choose multiple times on the PeerList
 // It will assert if there are ANY failures
 type ChooseMultiAction struct {
 	ExpectedPeers []string
 }
 
-// Apply runs "ChoosePeer" on the peerList for every ExpectedPeer
+// Apply runs "Choose" on the peerList for every ExpectedPeer
 func (a ChooseMultiAction) Apply(t *testing.T, pl peer.Chooser, deps ListActionDeps) {
 	for _, expectedPeer := range a.ExpectedPeers {
 		action := ChooseAction{
@@ -92,7 +92,7 @@ type ChooseAction struct {
 	ExpectedErr         error
 }
 
-// Apply runs "ChoosePeer" on the peerList and validates the peer && error
+// Apply runs "Choose" on the peerList and validates the peer && error
 func (a ChooseAction) Apply(t *testing.T, pl peer.Chooser, deps ListActionDeps) {
 	ctx := a.InputContext
 	if ctx == nil {
@@ -104,7 +104,7 @@ func (a ChooseAction) Apply(t *testing.T, pl peer.Chooser, deps ListActionDeps) 
 		defer cancel()
 	}
 
-	p, err := pl.ChoosePeer(ctx, a.InputRequest)
+	p, err := pl.Choose(ctx, a.InputRequest)
 
 	if a.ExpectedErr != nil {
 		// Note that we're not verifying anything about ExpectedPeer here because

--- a/peer/single/chooser.go
+++ b/peer/single/chooser.go
@@ -42,8 +42,8 @@ func New(pid peer.Identifier, agent peer.Agent) *Single {
 	return s
 }
 
-// ChoosePeer returns the single peer
-func (s *Single) ChoosePeer(context.Context, *transport.Request) (peer.Peer, error) {
+// Choose returns the single peer
+func (s *Single) Choose(context.Context, *transport.Request) (peer.Peer, error) {
 	return s.p, s.err
 }
 

--- a/peer/x/roundrobin/list.go
+++ b/peer/x/roundrobin/list.go
@@ -208,8 +208,8 @@ func (pl *List) removeFromUnavailablePeers(p peer.Peer) {
 	delete(pl.unavailablePeers, p.Identifier())
 }
 
-// ChoosePeer selects the next available peer in the round robin
-func (pl *List) ChoosePeer(ctx context.Context, req *transport.Request) (peer.Peer, error) {
+// Choose selects the next available peer in the round robin
+func (pl *List) Choose(ctx context.Context, req *transport.Request) (peer.Peer, error) {
 	if !pl.started.Load() {
 		return nil, peer.ErrPeerListNotStarted("RoundRobinList")
 	}

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -82,7 +82,7 @@ func parseURL(urlStr string) (*url.URL, string) {
 
 // NewChooserOutbound builds a new HTTP outbound built around a PeerList
 // for getting potential downstream hosts.
-// Chooser.ChoosePeer MUST return *hostport.Peer objects.
+// Chooser.Choose MUST return *hostport.Peer objects.
 // Chooser.Start MUST be called before Outbound.Start
 func NewChooserOutbound(chooser peer.Chooser) *Outbound {
 	return &Outbound{
@@ -260,7 +260,7 @@ func (o *Outbound) CallOneway(ctx context.Context, treq *transport.Request) (tra
 }
 
 func (o *Outbound) getPeerForRequest(ctx context.Context, treq *transport.Request) (*hostport.Peer, error) {
-	p, err := o.chooser.ChoosePeer(ctx, treq)
+	p, err := o.chooser.Choose(ctx, treq)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Summary: It's a simpler interface name, why not?