### PR TITLE
Refactor Transport Constructors for chained configuration instead of options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,29 @@ v1.0.0-dev (unreleased)
     previously transport specific Inbound and Outbound interfaces.
     This eliminates unnecessary polymorphism in some cases.
 
+-   **Breaking**: the HTTP and TChannel Inbound and Outbound transports no longer
+    support optional arguments.  Instead, you must chain `With*` methods.
+
+    Before:
+
+    ```go
+    tchannel.NewOutbound(channel, tchannel.HostPort("127.0.0.1:4040")
+    ```
+
+    Now:
+
+    ```go
+    tchannel.NewOutbound(channel).WithHostPort("127.0.0.1:4040")
+    ```
+
+    This change applies to:
+
+    -   WithHostPort on TChannel outbound
+    -   WithListenAddr on TChannel inbound
+    -   WithMux on HTTP inbound
+    -   WithURLTemplate on HTTP outbounds **new**
+    -   WithTracer on all transports **new**
+
 v1.0.0-rc1 (2016-11-23)
 -----------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ v1.0.0-dev (unreleased)
     understanding where they come from.
 
 
+-   **Breaking**: TChannel inbound and outbound constructors now return
+    pointers to Inbound and Outbound structs with private state satisfying the
+    `transport.Inbound` and `transport.Outbound` interfaces.  These were
+    previously transport specific Inbound and Outbound interfaces.
+    This eliminates unnecessary polymorphism in some cases.
+
 v1.0.0-rc1 (2016-11-23)
 -----------------------
 

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ build:
 
 .PHONY: generate
 generate:
+	go install ./vendor/golang.org/x/tools/cmd/stringer
 	go install ./vendor/go.uber.org/thriftrw
 	go install ./encoding/thrift/thriftrw-plugin-yarpc
 	go generate $(PACKAGES)

--- a/bench_test.go
+++ b/bench_test.go
@@ -205,7 +205,8 @@ func Benchmark_TChannel_YARPCToYARPC(b *testing.B) {
 			Name: "client",
 			Outbounds: yarpc.Outbounds{
 				"server": {
-					Unary: ytchannel.NewOutbound(clientCh, ytchannel.HostPort(serverCh.PeerInfo().HostPort)),
+					Unary: ytchannel.NewOutbound(clientCh).
+						WithHostPort(serverCh.PeerInfo().HostPort),
 				},
 			},
 		}
@@ -231,7 +232,8 @@ func Benchmark_TChannel_YARPCToTChannel(b *testing.B) {
 		Name: "client",
 		Outbounds: yarpc.Outbounds{
 			"server": {
-				Unary: ytchannel.NewOutbound(clientCh, ytchannel.HostPort(serverCh.PeerInfo().HostPort)),
+				Unary: ytchannel.NewOutbound(clientCh).
+					WithHostPort(serverCh.PeerInfo().HostPort),
 			},
 		},
 	}

--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -44,7 +44,7 @@ func basicDispatcher(t *testing.T) Dispatcher {
 	return NewDispatcher(Config{
 		Name: "test",
 		Inbounds: Inbounds{
-			tch.NewInbound(ch, tch.ListenAddr(":0")),
+			tch.NewInbound(ch).WithListenAddr(":0"),
 			http.NewInbound(":0"),
 		},
 	})

--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -75,8 +75,9 @@ func TestInboundsOrderIsMaintained(t *testing.T) {
 	// Order must be maintained
 	assert.Implements(t,
 		(*tch.Inbound)(nil), dispatcher.Inbounds()[0], "first inbound must be TChannel")
-	assert.Implements(t,
-		(*http.Inbound)(nil), dispatcher.Inbounds()[1], "second inbound must be HTTP")
+
+	_, ok := dispatcher.Inbounds()[1].(*http.Inbound)
+	assert.True(t, ok, "second inbound must be HTTP")
 }
 
 func TestInboundsOrderAfterStart(t *testing.T) {
@@ -90,7 +91,7 @@ func TestInboundsOrderAfterStart(t *testing.T) {
 	tchInbound := inbounds[0].(tch.Inbound)
 	assert.NotEqual(t, "0.0.0.0:0", tchInbound.Channel().PeerInfo().HostPort)
 
-	httpInbound := inbounds[1].(http.Inbound)
+	httpInbound := inbounds[1].(*http.Inbound)
 	assert.NotNil(t, httpInbound.Addr(), "expected an HTTP addr")
 }
 

--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -73,10 +73,10 @@ func TestInboundsOrderIsMaintained(t *testing.T) {
 	dispatcher := basicDispatcher(t)
 
 	// Order must be maintained
-	assert.Implements(t,
-		(*tch.Inbound)(nil), dispatcher.Inbounds()[0], "first inbound must be TChannel")
+	_, ok := dispatcher.Inbounds()[0].(*tch.Inbound)
+	assert.True(t, ok, "first inbound must be TChannel")
 
-	_, ok := dispatcher.Inbounds()[1].(*http.Inbound)
+	_, ok = dispatcher.Inbounds()[1].(*http.Inbound)
 	assert.True(t, ok, "second inbound must be HTTP")
 }
 
@@ -88,7 +88,7 @@ func TestInboundsOrderAfterStart(t *testing.T) {
 
 	inbounds := dispatcher.Inbounds()
 
-	tchInbound := inbounds[0].(tch.Inbound)
+	tchInbound := inbounds[0].(*tch.Inbound)
 	assert.NotEqual(t, "0.0.0.0:0", tchInbound.Channel().PeerInfo().HostPort)
 
 	httpInbound := inbounds[1].(*http.Inbound)

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,6 +5,8 @@ import:
   subpackages:
   - context
   - context/ctxhttp
+- package: golang.org/x/tools
+  version: master
 - package: github.com/opentracing/opentracing-go
   version: ^1
 - package: github.com/uber/tchannel-go

--- a/internal/crossdock/client/ctxpropagation/behavior.go
+++ b/internal/crossdock/client/ctxpropagation/behavior.go
@@ -337,7 +337,7 @@ func buildDispatcher(t crossdock.T) (dispatcher yarpc.Dispatcher, tconfig server
 	dispatcher = yarpc.NewDispatcher(yarpc.Config{
 		Name: "ctxclient",
 		Inbounds: yarpc.Inbounds{
-			tch.NewInbound(ch, tch.ListenAddr(":8087")),
+			tch.NewInbound(ch).WithListenAddr(":8087"),
 			ht.NewInbound(":8086"),
 		},
 		Outbounds: yarpc.Outbounds{

--- a/internal/crossdock/client/ctxpropagation/behavior.go
+++ b/internal/crossdock/client/ctxpropagation/behavior.go
@@ -328,7 +328,7 @@ func buildDispatcher(t crossdock.T) (dispatcher yarpc.Dispatcher, tconfig server
 		outbound = ht.NewOutbound(fmt.Sprintf("http://%s:8081", subject))
 		tconfig.TChannel = &server.TChannelTransport{Host: self, Port: 8087}
 	case "tchannel":
-		outbound = tch.NewOutbound(ch, tch.HostPort(fmt.Sprintf("%s:8082", subject)))
+		outbound = tch.NewOutbound(ch).WithHostPort(fmt.Sprintf("%s:8082", subject))
 		tconfig.HTTP = &server.HTTPTransport{Host: self, Port: 8086}
 	default:
 		fatals.Fail("", "unknown transport %q", trans)

--- a/internal/crossdock/client/dispatcher/dispatcher.go
+++ b/internal/crossdock/client/dispatcher/dispatcher.go
@@ -48,7 +48,7 @@ func Create(t crossdock.T) yarpc.Dispatcher {
 	case "tchannel":
 		ch, err := tchannel.NewChannel("client", nil)
 		fatals.NoError(err, "couldn't create tchannel")
-		unaryOutbound = tch.NewOutbound(ch, tch.HostPort(server+":8082"))
+		unaryOutbound = tch.NewOutbound(ch).WithHostPort(server + ":8082")
 	default:
 		fatals.Fail("", "unknown transport %q", trans)
 	}

--- a/internal/crossdock/client/tchserver/behavior.go
+++ b/internal/crossdock/client/tchserver/behavior.go
@@ -51,7 +51,7 @@ func Run(t crossdock.T) {
 		Name: "yarpc-client",
 		Outbounds: yarpc.Outbounds{
 			serverName: {
-				Unary: tch.NewOutbound(ch, tch.HostPort(serverHostPort)),
+				Unary: tch.NewOutbound(ch).WithHostPort(serverHostPort),
 			},
 		},
 	})

--- a/internal/crossdock/server/yarpc/phone.go
+++ b/internal/crossdock/server/yarpc/phone.go
@@ -85,7 +85,7 @@ func Phone(ctx context.Context, reqMeta yarpc.ReqMeta, body *PhoneRequest) (*Pho
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to build TChannel: %v", err)
 		}
-		outbound = tch.NewOutbound(ch, tch.HostPort(hostport))
+		outbound = tch.NewOutbound(ch).WithHostPort(hostport)
 	default:
 		return nil, nil, fmt.Errorf("unconfigured transport")
 	}

--- a/internal/crossdock/server/yarpc/server.go
+++ b/internal/crossdock/server/yarpc/server.go
@@ -50,7 +50,7 @@ func Start() {
 		Name: "yarpc-test",
 		Inbounds: yarpc.Inbounds{
 			http.NewInbound(":8081"),
-			tch.NewInbound(ch, tch.ListenAddr(":8082")),
+			tch.NewInbound(ch).WithListenAddr(":8082"),
 		},
 	})
 

--- a/internal/examples/json/client/main.go
+++ b/internal/examples/json/client/main.go
@@ -99,7 +99,7 @@ func main() {
 		if err != nil {
 			log.Fatalln(err)
 		}
-		outbound = tch.NewOutbound(channel, tch.HostPort("localhost:28941"))
+		outbound = tch.NewOutbound(channel).WithHostPort("localhost:28941")
 	default:
 		log.Fatalf("invalid outbound: %q\n", outboundName)
 	}

--- a/internal/examples/json/server/main.go
+++ b/internal/examples/json/server/main.go
@@ -80,7 +80,7 @@ func main() {
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name: "keyvalue",
 		Inbounds: yarpc.Inbounds{
-			tch.NewInbound(channel, tch.ListenAddr(":28941")),
+			tch.NewInbound(channel).WithListenAddr(":28941"),
 			http.NewInbound(":24034"),
 		},
 		InboundMiddleware: yarpc.InboundMiddleware{

--- a/internal/examples/thrift/keyvalue/client/main.go
+++ b/internal/examples/thrift/keyvalue/client/main.go
@@ -57,7 +57,7 @@ func main() {
 		if err != nil {
 			log.Fatalln(err)
 		}
-		outbound = tch.NewOutbound(channel, tch.HostPort("localhost:28941"))
+		outbound = tch.NewOutbound(channel).WithHostPort("localhost:28941")
 	default:
 		log.Fatalf("invalid outbound: %q\n", outboundName)
 	}

--- a/internal/examples/thrift/keyvalue/server/main.go
+++ b/internal/examples/thrift/keyvalue/server/main.go
@@ -68,7 +68,7 @@ func main() {
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name: "keyvalue",
 		Inbounds: yarpc.Inbounds{
-			tch.NewInbound(channel, tch.ListenAddr(":28941")),
+			tch.NewInbound(channel).WithListenAddr(":28941"),
 			http.NewInbound(":24034"),
 		},
 	})

--- a/transport/http/handler.go
+++ b/transport/http/handler.go
@@ -44,7 +44,7 @@ func popHeader(h http.Header, n string) string {
 
 // handler adapts a transport.Handler into a handler for net/http.
 type handler struct {
-	Registry transport.Registry
+	registry transport.Registry
 	tracer   opentracing.Tracer
 }
 
@@ -98,7 +98,7 @@ func (h handler) callHandler(w http.ResponseWriter, req *http.Request, start tim
 		return err
 	}
 
-	spec, err := h.Registry.Choose(ctx, treq)
+	spec, err := h.registry.Choose(ctx, treq)
 	if err != nil {
 		return updateSpanWithErr(span, err)
 	}

--- a/transport/http/handler_test.go
+++ b/transport/http/handler_test.go
@@ -78,7 +78,7 @@ func TestHandlerSucces(t *testing.T) {
 		gomock.Any(),
 	).Return(nil)
 
-	httpHandler := handler{Registry: registry, tracer: &opentracing.NoopTracer{}}
+	httpHandler := handler{registry: registry, tracer: &opentracing.NoopTracer{}}
 	req := &http.Request{
 		Method: "POST",
 		Header: headers,
@@ -131,7 +131,7 @@ func TestHandlerHeaders(t *testing.T) {
 			WithProcedure("hello"),
 		).Return(spec, nil)
 
-		httpHandler := handler{Registry: registry, tracer: &opentracing.NoopTracer{}}
+		httpHandler := handler{registry: registry, tracer: &opentracing.NoopTracer{}}
 
 		rpcHandler.EXPECT().Handle(
 			transporttest.NewContextMatcher(t,
@@ -258,7 +258,7 @@ func TestHandlerFailures(t *testing.T) {
 			).Return(spec, nil)
 		}
 
-		h := handler{Registry: reg, tracer: &opentracing.NoopTracer{}}
+		h := handler{registry: reg, tracer: &opentracing.NoopTracer{}}
 
 		rw := httptest.NewRecorder()
 		h.ServeHTTP(rw, tt.req)
@@ -309,7 +309,7 @@ func TestHandlerInternalFailure(t *testing.T) {
 		WithProcedure("hello"),
 	).Return(spec, nil)
 
-	httpHandler := handler{Registry: registry, tracer: &opentracing.NoopTracer{}}
+	httpHandler := handler{registry: registry, tracer: &opentracing.NoopTracer{}}
 	httpResponse := httptest.NewRecorder()
 	httpHandler.ServeHTTP(httpResponse, &request)
 

--- a/transport/http/inbound.go
+++ b/transport/http/inbound.go
@@ -70,6 +70,12 @@ type Inbound struct {
 	tracer     opentracing.Tracer
 }
 
+// WithTracer configures a tracer on this inbound.
+func (i *Inbound) WithTracer(tracer opentracing.Tracer) *Inbound {
+	i.tracer = tracer
+	return i
+}
+
 // Start starts the inbound with a given service detail and transport
 // dependencies, opening a listening socket.
 func (i *Inbound) Start(service transport.ServiceDetail, d transport.Deps) error {

--- a/transport/http/inbound.go
+++ b/transport/http/inbound.go
@@ -33,22 +33,6 @@ import (
 // InboundOption is an option for an HTTP inbound.
 type InboundOption func(*Inbound)
 
-// WithTracer is a NewInbound option that adds a tracer
-func WithTracer(tracer opentracing.Tracer) InboundOption {
-	return func(i *Inbound) {
-		i.tracer = tracer
-	}
-}
-
-// Mux specifies the ServeMux that the HTTP server should use and the pattern
-// under which the YARPC endpoint should be registered.
-func Mux(pattern string, mux *http.ServeMux) InboundOption {
-	return func(i *Inbound) {
-		i.mux = mux
-		i.muxPattern = pattern
-	}
-}
-
 // NewInbound builds a new HTTP inbound that listens on the given address.
 func NewInbound(addr string, opts ...InboundOption) *Inbound {
 	i := &Inbound{addr: addr}
@@ -68,6 +52,14 @@ type Inbound struct {
 	muxPattern string
 	server     *intnet.HTTPServer
 	tracer     opentracing.Tracer
+}
+
+// WithMux specifies the ServeMux that the HTTP server should use and the
+// pattern under which the YARPC endpoint should be registered.
+func (i *Inbound) WithMux(pattern string, mux *http.ServeMux) *Inbound {
+	i.mux = mux
+	i.muxPattern = pattern
+	return i
 }
 
 // WithTracer configures a tracer on this inbound.

--- a/transport/http/inbound.go
+++ b/transport/http/inbound.go
@@ -81,7 +81,7 @@ type inbound struct {
 func (i *inbound) Start(service transport.ServiceDetail, d transport.Deps) error {
 
 	var httpHandler http.Handler = handler{
-		Registry: service.Registry,
+		registry: service.Registry,
 		tracer:   i.tracer,
 	}
 	if i.mux != nil {

--- a/transport/http/inbound.go
+++ b/transport/http/inbound.go
@@ -30,17 +30,12 @@ import (
 	"github.com/opentracing/opentracing-go"
 )
 
-// InboundOption is an option for an HTTP inbound.
-type InboundOption func(*Inbound)
-
 // NewInbound builds a new HTTP inbound that listens on the given address.
-func NewInbound(addr string, opts ...InboundOption) *Inbound {
-	i := &Inbound{addr: addr}
-	i.tracer = opentracing.GlobalTracer()
-	for _, opt := range opts {
-		opt(i)
+func NewInbound(addr string) *Inbound {
+	return &Inbound{
+		addr:   addr,
+		tracer: opentracing.GlobalTracer(),
 	}
-	return i
 }
 
 // Inbound represents an HTTP Inbound. It is the same as the transport Inbound

--- a/transport/http/inbound_test.go
+++ b/transport/http/inbound_test.go
@@ -95,7 +95,7 @@ func TestInboundMux(t *testing.T) {
 		w.Write([]byte("healthy"))
 	})
 
-	i := NewInbound(":0", Mux("/rpc/v1", mux))
+	i := NewInbound(":0").WithMux("/rpc/v1", mux)
 	h := transporttest.NewMockUnaryHandler(mockCtrl)
 	reg := transporttest.NewMockRegistry(mockCtrl)
 	require.NoError(t, i.Start(transport.ServiceDetail{Name: "foo", Registry: reg}, transport.NoDeps))

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -48,10 +48,6 @@ var (
 	_ transport.OnewayOutbound = (*Outbound)(nil)
 )
 
-type outboundConfig struct {
-	keepAlive time.Duration
-}
-
 // NewOutbound builds a new HTTP outbound that sends requests to the given
 // URL.
 //

--- a/transport/roundtrip_test.go
+++ b/transport/roundtrip_test.go
@@ -135,7 +135,7 @@ func (tt tchannelTransport) WithRegistry(r transport.Registry, f func(transport.
 		// handler.
 
 		client := testutils.NewClient(tt.t, clientOpts)
-		o := tch.NewOutbound(client, tch.HostPort(hostPort))
+		o := tch.NewOutbound(client).WithHostPort(hostPort)
 		require.NoError(tt.t, o.Start(transport.NoDeps), "failed to start outbound")
 		defer o.Stop()
 

--- a/transport/tchannel/inbound.go
+++ b/transport/tchannel/inbound.go
@@ -29,19 +29,14 @@ import (
 	"github.com/uber/tchannel-go"
 )
 
-// InboundOption configures Inbound.
-type InboundOption func(*Inbound)
-
 // NewInbound builds a new TChannel inbound from the given Channel. Existing
 // methods registered on the channel remain registered and are preferred when
 // a call is received.
-func NewInbound(ch Channel, opts ...InboundOption) *Inbound {
-	i := &Inbound{ch: ch}
-	i.tracer = opentracing.GlobalTracer()
-	for _, opt := range opts {
-		opt(i)
+func NewInbound(ch Channel) *Inbound {
+	return &Inbound{
+		ch:     ch,
+		tracer: opentracing.GlobalTracer(),
 	}
-	return i
 }
 
 // Inbound is a TChannel Inbound.

--- a/transport/tchannel/inbound.go
+++ b/transport/tchannel/inbound.go
@@ -32,14 +32,6 @@ import (
 // InboundOption configures Inbound.
 type InboundOption func(*Inbound)
 
-// ListenAddr changes the address on which the TChannel server will listen for
-// connections. By default, the server listens on an OS-assigned port.
-//
-// This option has no effect if the Chanel provided to NewInbound is already
-// listening for connections when Start() is called.
-func ListenAddr(addr string) InboundOption {
-	return func(i *Inbound) { i.addr = addr }
-}
 
 // WithTracer adds a tracer to a TChannel inbound.
 func WithTracer(tracer opentracing.Tracer) InboundOption {
@@ -47,7 +39,6 @@ func WithTracer(tracer opentracing.Tracer) InboundOption {
 		i.tracer = tracer
 	}
 }
-
 // NewInbound builds a new TChannel inbound from the given Channel. Existing
 // methods registered on the channel remain registered and are preferred when
 // a call is received.
@@ -66,6 +57,16 @@ type Inbound struct {
 	addr     string
 	listener net.Listener
 	tracer   opentracing.Tracer
+}
+
+// WithListenAddr changes the address on which the TChannel server will listen
+// for connections. By default, the server listens on an OS-assigned port.
+//
+// This option has no effect if the Chanel provided to NewInbound is already
+// listening for connections when Start() is called.
+func (i *Inbound) WithListenAddr(addr string) *Inbound {
+	i.addr = addr
+	return i
 }
 
 // Channel returns the underlying Channel for this Inbound.

--- a/transport/tchannel/inbound.go
+++ b/transport/tchannel/inbound.go
@@ -32,13 +32,6 @@ import (
 // InboundOption configures Inbound.
 type InboundOption func(*Inbound)
 
-
-// WithTracer adds a tracer to a TChannel inbound.
-func WithTracer(tracer opentracing.Tracer) InboundOption {
-	return func(i *Inbound) {
-		i.tracer = tracer
-	}
-}
 // NewInbound builds a new TChannel inbound from the given Channel. Existing
 // methods registered on the channel remain registered and are preferred when
 // a call is received.
@@ -66,6 +59,12 @@ type Inbound struct {
 // listening for connections when Start() is called.
 func (i *Inbound) WithListenAddr(addr string) *Inbound {
 	i.addr = addr
+	return i
+}
+
+// WithTracer configures a tracer on the TChannel inbound.
+func (i *Inbound) WithTracer(tracer opentracing.Tracer) *Inbound {
+	i.tracer = tracer
 	return i
 }
 

--- a/transport/tchannel/inbound_test.go
+++ b/transport/tchannel/inbound_test.go
@@ -52,7 +52,7 @@ func TestInboundStartNew(t *testing.T) {
 		},
 		{
 			func(ch *tchannel.Channel, f func(*Inbound)) {
-				i := NewInbound(ch, ListenAddr(":0"))
+				i := NewInbound(ch).WithListenAddr(":0")
 				service := transport.ServiceDetail{Name: "derp", Registry: new(transporttest.MockRegistry)}
 				assert.True(t, ch == i.Channel(), "channel does not match")
 				require.NoError(t, i.Start(service, transport.NoDeps))
@@ -102,7 +102,7 @@ func TestInboundStopWithoutStarting(t *testing.T) {
 func TestInboundInvalidAddress(t *testing.T) {
 	ch, err := tchannel.NewChannel("foo", nil)
 	require.NoError(t, err)
-	i := NewInbound(ch, ListenAddr("not valid"))
+	i := NewInbound(ch).WithListenAddr("not valid")
 	service := transport.ServiceDetail{Name: "derp", Registry: new(transporttest.MockRegistry)}
 	assert.Error(t, i.Start(service, transport.NoDeps))
 }

--- a/transport/tchannel/inbound_test.go
+++ b/transport/tchannel/inbound_test.go
@@ -35,10 +35,10 @@ import (
 
 func TestInboundStartNew(t *testing.T) {
 	tests := []struct {
-		withInbound func(*tchannel.Channel, func(Inbound))
+		withInbound func(*tchannel.Channel, func(*Inbound))
 	}{
 		{
-			func(ch *tchannel.Channel, f func(Inbound)) {
+			func(ch *tchannel.Channel, f func(*Inbound)) {
 				i := NewInbound(ch)
 				service := transport.ServiceDetail{Name: "derp", Registry: new(transporttest.MockRegistry)}
 				// Can't do Equal because we want to match the pointer, not a
@@ -51,7 +51,7 @@ func TestInboundStartNew(t *testing.T) {
 			},
 		},
 		{
-			func(ch *tchannel.Channel, f func(Inbound)) {
+			func(ch *tchannel.Channel, f func(*Inbound)) {
 				i := NewInbound(ch, ListenAddr(":0"))
 				service := transport.ServiceDetail{Name: "derp", Registry: new(transporttest.MockRegistry)}
 				assert.True(t, ch == i.Channel(), "channel does not match")
@@ -66,7 +66,7 @@ func TestInboundStartNew(t *testing.T) {
 	for _, tt := range tests {
 		ch, err := tchannel.NewChannel("foo", nil)
 		require.NoError(t, err)
-		tt.withInbound(ch, func(i Inbound) {
+		tt.withInbound(ch, func(i *Inbound) {
 			assert.Equal(t, tchannel.ChannelListening, ch.State())
 			assert.NoError(t, i.Stop())
 			assert.Equal(t, tchannel.ChannelClosed, ch.State())

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -35,28 +35,10 @@ import (
 
 var errOutboundNotStarted = errors.ErrOutboundNotStarted("tchannel.Outbound")
 
-// OutboundOption configures Outbound.
-type OutboundOption func(*Outbound)
-
-// HostPort specifies that the requests made by this outbound should be to
-// the given address.
-//
-// By default, if HostPort was not specified, the Outbound will use the
-// TChannel global peer list.
-func HostPort(hostPort string) OutboundOption {
-	return func(o *Outbound) {
-		o.HostPort = hostPort
-	}
-}
-
 // NewOutbound builds a new TChannel outbound which uses the given Channel to
 // make requests.
-func NewOutbound(ch Channel, options ...OutboundOption) *Outbound {
-	o := &Outbound{channel: ch, started: atomic.NewBool(false)}
-	for _, opt := range options {
-		opt(o)
-	}
-	return o
+func NewOutbound(ch Channel) *Outbound {
+	return &Outbound{channel: ch, started: atomic.NewBool(false)}
 }
 
 // Outbound is a TChannel outbound transport.
@@ -67,6 +49,16 @@ type Outbound struct {
 	// If specified, this is the address to which the request will be made.
 	// Otherwise, the global peer list of the Channel will be used.
 	HostPort string
+}
+
+// WithHostPort specifies that the requests made by this outbound should be to
+// the given address.
+//
+// By default, if HostPort was not specified, the Outbound will use the
+// TChannel global peer list.
+func (o *Outbound) WithHostPort(hostPort string) *Outbound {
+	o.HostPort = hostPort
+	return o
 }
 
 // WithTracer configures a tracer for this outbound.

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -28,6 +28,7 @@ import (
 	"go.uber.org/yarpc/internal/errors"
 	"go.uber.org/yarpc/transport"
 
+	"github.com/opentracing/opentracing-go"
 	"github.com/uber/tchannel-go"
 	"go.uber.org/atomic"
 )
@@ -66,6 +67,12 @@ type Outbound struct {
 	// If specified, this is the address to which the request will be made.
 	// Otherwise, the global peer list of the Channel will be used.
 	HostPort string
+}
+
+// WithTracer configures a tracer for this outbound.
+func (o *Outbound) WithTracer(tracer opentracing.Tracer) *Outbound {
+	// At this time, we delegate tracing responsibility to the underlying TChannel.
+	return o
 }
 
 // Start starts the TChannel outbound.

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -35,7 +35,7 @@ import (
 var errOutboundNotStarted = errors.ErrOutboundNotStarted("tchannel.Outbound")
 
 // OutboundOption configures Outbound.
-type OutboundOption func(*outbound)
+type OutboundOption func(*Outbound)
 
 // HostPort specifies that the requests made by this outbound should be to
 // the given address.
@@ -43,45 +43,49 @@ type OutboundOption func(*outbound)
 // By default, if HostPort was not specified, the Outbound will use the
 // TChannel global peer list.
 func HostPort(hostPort string) OutboundOption {
-	return func(o *outbound) {
+	return func(o *Outbound) {
 		o.HostPort = hostPort
 	}
 }
 
 // NewOutbound builds a new TChannel outbound which uses the given Channel to
 // make requests.
-func NewOutbound(ch Channel, options ...OutboundOption) transport.UnaryOutbound {
-	o := outbound{Channel: ch, started: atomic.NewBool(false)}
+func NewOutbound(ch Channel, options ...OutboundOption) *Outbound {
+	o := &Outbound{channel: ch, started: atomic.NewBool(false)}
 	for _, opt := range options {
-		opt(&o)
+		opt(o)
 	}
 	return o
 }
 
-type outbound struct {
+// Outbound is a TChannel outbound transport.
+type Outbound struct {
 	started *atomic.Bool
-	Channel Channel
+	channel Channel
 
 	// If specified, this is the address to which the request will be made.
 	// Otherwise, the global peer list of the Channel will be used.
 	HostPort string
 }
 
-func (o outbound) Start(d transport.Deps) error {
+// Start starts the TChannel outbound.
+func (o *Outbound) Start(d transport.Deps) error {
 	// TODO: Should we create the connection to HostPort (if specified) here or
 	// wait for the first call?
 	o.started.Swap(true)
 	return nil
 }
 
-func (o outbound) Stop() error {
+// Stop stops the TChannel outbound.
+func (o *Outbound) Stop() error {
 	if o.started.Swap(false) {
-		o.Channel.Close()
+		o.channel.Close()
 	}
 	return nil
 }
 
-func (o outbound) Call(ctx context.Context, req *transport.Request) (*transport.Response, error) {
+// Call sends an RPC over this TChannel outbound.
+func (o *Outbound) Call(ctx context.Context, req *transport.Request) (*transport.Response, error) {
 	if !o.started.Load() {
 		// panic because there's no recovery from this
 		panic(errOutboundNotStarted)
@@ -103,7 +107,7 @@ func (o outbound) Call(ctx context.Context, req *transport.Request) (*transport.
 	if o.HostPort != "" {
 		// If the hostport is given, we use the BeginCall on the channel
 		// instead of the subchannel.
-		call, err = o.Channel.BeginCall(
+		call, err = o.channel.BeginCall(
 			// TODO(abg): Set TimeoutPerAttempt in the context's retry options if
 			// TTL is set.
 			// (kris): Consider instead moving TimeoutPerAttempt to an outer
@@ -115,7 +119,7 @@ func (o outbound) Call(ctx context.Context, req *transport.Request) (*transport.
 			&callOptions,
 		)
 	} else {
-		call, err = o.Channel.GetSubChannel(req.Service).BeginCall(
+		call, err = o.channel.GetSubChannel(req.Service).BeginCall(
 			// TODO(abg): Set TimeoutPerAttempt in the context's retry options if
 			// TTL is set.
 			ctx,

--- a/transport/tchannel/outbound_test.go
+++ b/transport/tchannel/outbound_test.go
@@ -45,7 +45,7 @@ var newOutbounds = []func(*tchannel.Channel, string) transport.UnaryOutbound{
 		return NewOutbound(ch)
 	},
 	func(ch *tchannel.Channel, hostPort string) transport.UnaryOutbound {
-		return NewOutbound(ch, HostPort(hostPort))
+		return NewOutbound(ch).WithHostPort(hostPort)
 	},
 }
 

--- a/transport/tracer_test.go
+++ b/transport/tracer_test.go
@@ -142,7 +142,7 @@ func createTChannelDispatcher(tracer opentracing.Tracer, t *testing.T) yarpc.Dis
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name: "yarpc-test",
 		Inbounds: yarpc.Inbounds{
-			ytchannel.NewInbound(ch, ytchannel.WithTracer(tracer)),
+			ytchannel.NewInbound(ch).WithTracer(tracer),
 		},
 		Outbounds: yarpc.Outbounds{
 			"yarpc-test": {

--- a/transport/tracer_test.go
+++ b/transport/tracer_test.go
@@ -121,7 +121,7 @@ func createHTTPDispatcher(tracer opentracing.Tracer) yarpc.Dispatcher {
 		},
 		Outbounds: yarpc.Outbounds{
 			"yarpc-test": {
-				Unary: http.NewOutbound("http://127.0.0.1:18080"),
+				Unary: http.NewOutbound("http://127.0.0.1:18080").WithTracer(tracer),
 			},
 		},
 		Tracer: tracer,

--- a/transport/tracer_test.go
+++ b/transport/tracer_test.go
@@ -117,7 +117,7 @@ func createHTTPDispatcher(tracer opentracing.Tracer) yarpc.Dispatcher {
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name: "yarpc-test",
 		Inbounds: yarpc.Inbounds{
-			http.NewInbound(":18080", http.WithTracer(tracer)),
+			http.NewInbound(":18080").WithTracer(tracer),
 		},
 		Outbounds: yarpc.Outbounds{
 			"yarpc-test": {

--- a/transport/tracer_test.go
+++ b/transport/tracer_test.go
@@ -146,7 +146,7 @@ func createTChannelDispatcher(tracer opentracing.Tracer, t *testing.T) yarpc.Dis
 		},
 		Outbounds: yarpc.Outbounds{
 			"yarpc-test": {
-				Unary: ytchannel.NewOutbound(ch, ytchannel.HostPort(hp)),
+				Unary: ytchannel.NewOutbound(ch).WithHostPort(hp),
 			},
 		},
 		Tracer: tracer,


### PR DESCRIPTION
WithTracer produced a conflict since there would need to be an inbound constructor option as well as an outbound constructor option. One way to solve this would be to create a subpackage for each of inbound and outbound, in each transport. This change alternately converts the options into chained methods, name spacing the With* method to the type.

This necessitates returning *Inbound and *Outbound pointers instead of a matching interface, which we arguably should do anyway since each inbound and outbound will satisfy multiple interfaces but does not necessarily need polymorphic method dispatch in usage.