### PR TITLE
Replace HTTP outbound with construction from peer.Chooser

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -133,7 +133,7 @@ func Benchmark_HTTP_YARPCToYARPC(b *testing.B) {
 		Name: "client",
 		Outbounds: yarpc.Outbounds{
 			"server": {
-				Unary: yhttp.NewChooserOutbound(
+				Unary: yhttp.NewOutbound(
 					single.New(hostport.PeerIdentifier("http://localhost:8999"), httpTransport),
 				),
 			},
@@ -155,7 +155,7 @@ func Benchmark_HTTP_YARPCToNetHTTP(b *testing.B) {
 		Name: "client",
 		Outbounds: yarpc.Outbounds{
 			"server": {
-				Unary: yhttp.NewChooserOutbound(
+				Unary: yhttp.NewOutbound(
 					single.New(hostport.PeerIdentifier("http://localhost:8998"), httpTransport),
 				),
 			},

--- a/internal/crossdock/client/apachethrift/behavior.go
+++ b/internal/crossdock/client/apachethrift/behavior.go
@@ -48,11 +48,11 @@ func Run(t crossdock.T) {
 	httpTransport := http.NewTransport()
 	hostPort := hostport.PeerIdentifier(fmt.Sprintf("%v:%v", server, serverPort))
 
-	thriftOutbound := http.NewChooserOutbound(single.New(hostPort, httpTransport)).
+	thriftOutbound := http.NewOutbound(single.New(hostPort, httpTransport)).
 		WithURLTemplate("http://host:port/thrift/ThriftTest")
-	secondOutbound := http.NewChooserOutbound(single.New(hostPort, httpTransport)).
+	secondOutbound := http.NewOutbound(single.New(hostPort, httpTransport)).
 		WithURLTemplate("http://host:port/thrift/SecondService")
-	multiplexOutbound := http.NewChooserOutbound(single.New(hostPort, httpTransport)).
+	multiplexOutbound := http.NewOutbound(single.New(hostPort, httpTransport)).
 		WithURLTemplate("http://host:port/thrift/multiplexed")
 
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{

--- a/internal/crossdock/client/ctxpropagation/behavior.go
+++ b/internal/crossdock/client/ctxpropagation/behavior.go
@@ -332,7 +332,7 @@ func buildDispatcher(t crossdock.T) (dispatcher yarpc.Dispatcher, tconfig server
 		if httpTransport == nil {
 			httpTransport = http.NewTransport()
 		}
-		outbound = http.NewChooserOutbound(
+		outbound = http.NewOutbound(
 			single.New(
 				hostport.PeerIdentifier(fmt.Sprintf("%s:8081", subject)),
 				httpTransport,

--- a/internal/crossdock/client/dispatcher/dispatcher.go
+++ b/internal/crossdock/client/dispatcher/dispatcher.go
@@ -51,7 +51,7 @@ func Create(t crossdock.T) yarpc.Dispatcher {
 		if httpTransport == nil {
 			httpTransport = http.NewTransport()
 		}
-		unaryOutbound = http.NewChooserOutbound(
+		unaryOutbound = http.NewOutbound(
 			single.New(
 				hostport.PeerIdentifier(fmt.Sprintf("%s:8081", server)),
 				httpTransport,

--- a/internal/crossdock/client/httpserver/behavior.go
+++ b/internal/crossdock/client/httpserver/behavior.go
@@ -51,7 +51,7 @@ func Run(t crossdock.T) {
 		Name: "client",
 		Outbounds: yarpc.Outbounds{
 			"yarpc-test": {
-				Unary: http.NewChooserOutbound(
+				Unary: http.NewOutbound(
 					single.New(
 						hostport.PeerIdentifier(fmt.Sprintf("%s:8085", server)),
 						httpTransport,

--- a/internal/crossdock/client/oneway/oneway.go
+++ b/internal/crossdock/client/oneway/oneway.go
@@ -73,7 +73,7 @@ func newDispatcher(t crossdock.T) yarpc.Dispatcher {
 		Name: "client",
 		Outbounds: yarpc.Outbounds{
 			"oneway-test": {
-				Oneway: http.NewChooserOutbound(single.New(
+				Oneway: http.NewOutbound(single.New(
 					hostport.PeerIdentifier(fmt.Sprintf("%s:8084", server)),
 					httpTransport,
 				)),

--- a/internal/crossdock/server/oneway/server.go
+++ b/internal/crossdock/server/oneway/server.go
@@ -39,7 +39,7 @@ var dispatcher yarpc.Dispatcher
 func Start() {
 	httpTransport := http.NewTransport()
 	h := onewayHandler{
-		Outbound: http.NewChooserOutbound(
+		Outbound: http.NewOutbound(
 			single.New(
 				hostport.PeerIdentifier("127.0.0.1:8089"),
 				httpTransport,

--- a/internal/crossdock/server/yarpc/phone.go
+++ b/internal/crossdock/server/yarpc/phone.go
@@ -78,7 +78,7 @@ func Phone(ctx context.Context, reqMeta yarpc.ReqMeta, body *PhoneRequest) (*Pho
 	switch {
 	case body.Transport.HTTP != nil:
 		t := body.Transport.HTTP
-		outbound = http.NewChooserOutbound(
+		outbound = http.NewOutbound(
 			single.New(
 				hostport.PeerIdentifier(fmt.Sprintf("%s:%d", t.Host, t.Port)),
 				http.NewTransport(), // TODO transport lifecycle

--- a/internal/examples/json/client/main.go
+++ b/internal/examples/json/client/main.go
@@ -100,7 +100,7 @@ func main() {
 		if httpTransport == nil {
 			httpTransport = http.NewTransport()
 		}
-		outbound = http.NewChooserOutbound(
+		outbound = http.NewOutbound(
 			single.New(
 				hostport.PeerIdentifier("127.0.0.1:24034"),
 				httpTransport,

--- a/internal/examples/thrift/hello/main.go
+++ b/internal/examples/thrift/hello/main.go
@@ -49,7 +49,7 @@ func main() {
 		},
 		Outbounds: yarpc.Outbounds{
 			"hello": {
-				Unary: http.NewChooserOutbound(
+				Unary: http.NewOutbound(
 					single.New(
 						hostport.PeerIdentifier("127.0.0.1:8086"),
 						httpTransport,

--- a/internal/examples/thrift/keyvalue/client/main.go
+++ b/internal/examples/thrift/keyvalue/client/main.go
@@ -58,7 +58,7 @@ func main() {
 		if httpTransport == nil {
 			httpTransport = http.NewTransport()
 		}
-		outbound = http.NewChooserOutbound(
+		outbound = http.NewOutbound(
 			single.New(
 				hostport.PeerIdentifier("127.0.0.1:24034"),
 				httpTransport,

--- a/transport/http/handler_test.go
+++ b/transport/http/handler_test.go
@@ -351,7 +351,7 @@ func TestHandlerPanic(t *testing.T) {
 		Name: "yarpc-test-client",
 		Outbounds: yarpc.Outbounds{
 			"yarpc-test": {
-				Unary: NewChooserOutbound(
+				Unary: NewOutbound(
 					single.New(
 						hostport.PeerIdentifier(inbound.Addr().String()),
 						httpTransport,

--- a/transport/http/inbound_test.go
+++ b/transport/http/inbound_test.go
@@ -125,7 +125,7 @@ func TestInboundMux(t *testing.T) {
 	}
 
 	// this should fail
-	o := NewChooserOutbound(
+	o := NewOutbound(
 		single.New(
 			hostport.PeerIdentifier(i.Addr().String()),
 			httpTransport,

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -93,6 +93,18 @@ func NewChooserOutbound(chooser peer.Chooser) *Outbound {
 	}
 }
 
+// NewSingleOutbound creates an outbound from a single URL.
+// This form defers to the underlying HTTP agent's peer selection and load
+// balancing, using DNS.
+func NewSingleOutbound(u string, t *Transport) *Outbound {
+	parsedURL, err := url.Parse(u)
+	if err != nil {
+		panic(err.Error())
+	}
+	return NewChooserOutbound(single.New(hostport.PeerIdentifier(parsedURL.Host), t)).
+		WithURLTemplate(u)
+}
+
 // Outbound is an HTTP UnaryOutbound and OnewayOutbound
 type Outbound struct {
 	started     *atomic.Bool

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -51,40 +51,11 @@ var (
 
 var defaultURLTemplate, _ = url.Parse("http://localhost")
 
-// NewOutbound builds a new HTTP outbound that sends requests to the given
-// URL.
-//
-// Deprecated: create outbounds through NewPeerListOutbound instead
-func NewOutbound(urlStr string, opts ...TransportOption) *Outbound {
-	transport := NewTransport(opts...)
-
-	_, hp := parseURL(urlStr)
-	peerID := hostport.PeerIdentifier(hp)
-	c := single.New(peerID, transport)
-
-	err := c.Start()
-	if err != nil {
-		// This should never happen, single shouldn't return an error here
-		panic(fmt.Sprintf("could not start single peerChooser, err: %s", err))
-	}
-
-	return NewChooserOutbound(c).WithURLTemplate(urlStr)
-}
-
-func parseURL(urlStr string) (*url.URL, string) {
-	parsedURL, err := url.Parse(urlStr)
-	if err != nil {
-		panic(fmt.Sprintf("invalid url: %s, err: %s", urlStr, err))
-	}
-
-	return parsedURL, parsedURL.Host
-}
-
-// NewChooserOutbound builds a new HTTP outbound built around a peer.Chooser
+// NewOutbound builds a new HTTP outbound built around a peer.Chooser
 // for getting potential downstream hosts.
 // Chooser.Choose MUST return *hostport.Peer objects.
 // Chooser.Start MUST be called before Outbound.Start
-func NewChooserOutbound(chooser peer.Chooser) *Outbound {
+func NewOutbound(chooser peer.Chooser) *Outbound {
 	return &Outbound{
 		started:     atomic.NewBool(false),
 		chooser:     chooser,
@@ -101,7 +72,7 @@ func NewSingleOutbound(u string, t *Transport) *Outbound {
 	if err != nil {
 		panic(err.Error())
 	}
-	return NewChooserOutbound(single.New(hostport.PeerIdentifier(parsedURL.Host), t)).
+	return NewOutbound(single.New(hostport.PeerIdentifier(parsedURL.Host), t)).
 		WithURLTemplate(u)
 }
 

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -72,7 +72,7 @@ func TestCallSuccess(t *testing.T) {
 	// TODO transport lifecycle
 
 	parsedURL, _ := url.Parse(successServer.URL)
-	out := NewChooserOutbound(
+	out := NewOutbound(
 		single.New(
 			hostport.PeerIdentifier(parsedURL.Host),
 			httpTransport,
@@ -234,7 +234,7 @@ func TestStopMultiple(t *testing.T) {
 	httpTransport := NewTransport()
 	// TODO transport lifecycle
 
-	out := NewChooserOutbound(
+	out := NewOutbound(
 		single.New(
 			hostport.PeerIdentifier("127.0.0.1:9999"),
 			httpTransport,
@@ -265,7 +265,7 @@ func TestCallWithoutStarting(t *testing.T) {
 	httpTransport := NewTransport()
 	// TODO transport lifecycle
 
-	out := NewChooserOutbound(
+	out := NewOutbound(
 		single.New(
 			hostport.PeerIdentifier("127.0.0.1:9999"),
 			httpTransport,

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -121,6 +121,9 @@ func TestOutboundHeaders(t *testing.T) {
 		},
 	}
 
+	httpTransport := NewTransport()
+	// TODO transport lifecycle
+
 	for _, tt := range tests {
 		server := httptest.NewServer(http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
@@ -140,7 +143,8 @@ func TestOutboundHeaders(t *testing.T) {
 			defer cancel()
 		}
 
-		out := NewOutbound(server.URL)
+		out := NewSingleOutbound(server.URL, httpTransport)
+
 		require.NoError(t, out.Start(), "failed to start outbound")
 		defer out.Stop()
 
@@ -173,6 +177,8 @@ func TestCallFailures(t *testing.T) {
 		}))
 	defer internalErrorServer.Close()
 
+	httpTransport := NewTransport()
+
 	tests := []struct {
 		url      string
 		messages []string
@@ -183,7 +189,7 @@ func TestCallFailures(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		out := NewOutbound(tt.url)
+		out := NewSingleOutbound(tt.url, httpTransport)
 		require.NoError(t, out.Start(), "failed to start outbound")
 		defer out.Stop()
 
@@ -204,7 +210,8 @@ func TestCallFailures(t *testing.T) {
 }
 
 func TestStartMultiple(t *testing.T) {
-	out := NewOutbound("http://localhost:9999")
+	httpTransport := NewTransport()
+	out := NewSingleOutbound("http://localhost:9999", httpTransport)
 
 	var wg sync.WaitGroup
 	signal := make(chan struct{})

--- a/transport/roundtrip_test.go
+++ b/transport/roundtrip_test.go
@@ -106,7 +106,7 @@ func (ht httpTransport) WithRegistry(r transport.Registry, f func(transport.Unar
 	require.NoError(ht.t, i.Start(), "failed to start")
 	defer i.Stop()
 
-	o := http.NewChooserOutbound(
+	o := http.NewOutbound(
 		single.New(
 			hostport.PeerIdentifier(i.Addr().String()),
 			httpTransport,
@@ -125,7 +125,7 @@ func (ht httpTransport) WithRegistryOneway(r transport.Registry, f func(transpor
 	require.NoError(ht.t, i.Start(), "failed to start")
 	defer i.Stop()
 
-	o := http.NewChooserOutbound(
+	o := http.NewOutbound(
 		single.New(
 			hostport.PeerIdentifier(i.Addr().String()),
 			httpTransport,

--- a/transport/tracer_test.go
+++ b/transport/tracer_test.go
@@ -126,7 +126,7 @@ func createHTTPDispatcher(tracer opentracing.Tracer) yarpc.Dispatcher {
 		},
 		Outbounds: yarpc.Outbounds{
 			"yarpc-test": {
-				Unary: http.NewChooserOutbound(
+				Unary: http.NewOutbound(
 					single.New(
 						hostport.PeerIdentifier("127.0.0.1:18080"),
 						httpTransport,

--- a/yarpctest/recorder/recorder_test.go
+++ b/yarpctest/recorder/recorder_test.go
@@ -168,7 +168,7 @@ func withDisconnectedClient(t *testing.T, recorder *Recorder, f func(raw.Client)
 		Name: "client",
 		Outbounds: yarpc.Outbounds{
 			"server": {
-				Unary: http.NewChooserOutbound(
+				Unary: http.NewOutbound(
 					single.New(
 						hostport.PeerIdentifier("127.0.0.1:65535"),
 						httpTransport,
@@ -210,7 +210,7 @@ func withConnectedClient(t *testing.T, recorder *Recorder, f func(raw.Client)) {
 		Name: "client",
 		Outbounds: yarpc.Outbounds{
 			"server": {
-				Unary: http.NewChooserOutbound(
+				Unary: http.NewOutbound(
 					single.New(
 						hostport.PeerIdentifier(serverHTTP.Addr().String()),
 						httpTransport,


### PR DESCRIPTION
Last time, on #507, I eliminated all usage of the old http.NewOutbound. In this stunning episode of “Days on our Githubs”, http.NewChooserOutbound becomes the new http.NewOutbound. In the exciting conclusion, TChannel will see similar treatment.

r @AlexAPB 