### PR TITLE
[Peers][RoundRobin] Remove Initial Peer List from RoundRobin Peerlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Releases
 v1.0.0-dev (unreleased)
 -----------------------
 
+-   **Breaking** Update `roundrobin.New` function to stop accepting an initial peer list.
+    Use `list.Update` to initialize the peers in the list instead.
 -   **Breaking**: Rename `Channel` to `ClientConfig` for both the dispatcher
     method and the interface. `mydispatcher.Channel("myservice")` becomes
     `mydispatcher.ClientConfig("myservice")`. The `ClientConfig` object can

--- a/peer/peertest/peerlistaction.go
+++ b/peer/peertest/peerlistaction.go
@@ -121,33 +121,29 @@ func (a ChooseAction) Apply(t *testing.T, pl peer.Chooser, deps ListActionDeps) 
 	}
 }
 
-// AddAction is an action for adding a peer to the peerlist
-type AddAction struct {
-	InputPeerID string
-	ExpectedErr error
+// UpdateAction is an action for adding/removing multiple peers on the PeerList
+type UpdateAction struct {
+	AddedPeerIDs   []string
+	RemovedPeerIDs []string
+	ExpectedErr    error
 }
 
-// Apply runs "Add" on the peer.Chooser after casting it to a peer.List
+// Apply runs "Update" on the peer.Chooser after casting it to a peer.List
 // and validates the error
-func (a AddAction) Apply(t *testing.T, pl peer.Chooser, deps ListActionDeps) {
+func (a UpdateAction) Apply(t *testing.T, pl peer.Chooser, deps ListActionDeps) {
 	list := pl.(peer.List)
 
-	err := list.Update([]peer.Identifier{MockPeerIdentifier(a.InputPeerID)}, nil)
-	assert.Equal(t, a.ExpectedErr, err)
-}
+	added := make([]peer.Identifier, 0, len(a.AddedPeerIDs))
+	for _, peerID := range a.AddedPeerIDs {
+		added = append(added, MockPeerIdentifier(peerID))
+	}
 
-// RemoveAction is an action for adding a peer to the peerlist
-type RemoveAction struct {
-	InputPeerID string
-	ExpectedErr error
-}
+	removed := make([]peer.Identifier, 0, len(a.RemovedPeerIDs))
+	for _, peerID := range a.RemovedPeerIDs {
+		removed = append(removed, MockPeerIdentifier(peerID))
+	}
 
-// Apply runs "Remove" on the peer.Chooser after casting it to a peer.List
-// and validates the error
-func (a RemoveAction) Apply(t *testing.T, pl peer.Chooser, deps ListActionDeps) {
-	list := pl.(peer.List)
-
-	err := list.Update(nil, []peer.Identifier{MockPeerIdentifier(a.InputPeerID)})
+	err := list.Update(added, removed)
 	assert.Equal(t, a.ExpectedErr, err)
 }
 

--- a/peer/x/roundrobin/list.go
+++ b/peer/x/roundrobin/list.go
@@ -31,17 +31,17 @@ import (
 	"go.uber.org/atomic"
 )
 
+const defaultCapacity = 10
+
 // New creates a new round robin PeerList
-func New(peerIDs []peer.Identifier, transport peer.Transport) (*List, error) {
+func New(transport peer.Transport) *List {
 	rr := &List{
-		unavailablePeers:   make(map[string]peer.Peer, len(peerIDs)),
-		availablePeerRing:  NewPeerRing(len(peerIDs)),
+		unavailablePeers:   make(map[string]peer.Peer, defaultCapacity),
+		availablePeerRing:  NewPeerRing(defaultCapacity),
 		transport:          transport,
 		peerAvailableEvent: make(chan struct{}, 1),
 	}
-
-	err := rr.Update(peerIDs, nil)
-	return rr, err
+	return rr
 }
 
 // List is a PeerList which rotates which peers are to be selected in a circle


### PR DESCRIPTION
Summary: We Initially passed this in to seed the peer list with initial
values.  Instead, we should run

```
pl := roundrobin.New(agent)
pl.Update(newPeerIDs, nil)
```

Which is what this diff does