### PR TITLE
Move TChannel NewInboundFromChannel aside

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,7 +96,7 @@ v1.0.0-dev (unreleased)
     Before:
 
     ```go
-    inbound := tchannel.NewInbound(...)
+    inbound := tchannel.NewInbound(ch)
     err := inbound.Start(
         transport.ServiceDetail{
             Name: "service",
@@ -109,7 +109,8 @@ v1.0.0-dev (unreleased)
     Now:
 
     ```go
-    inbound := tchannel.NewInbound(...).WithRegistry(registry)
+    inbound := tchannel.NewInboundFromChannel(ch).
+        WithRegistry(registry)
     err := inbound.Start()
     ```
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -197,7 +197,7 @@ func Benchmark_TChannel_YARPCToYARPC(b *testing.B) {
 
 	serverCfg := yarpc.Config{
 		Name:     "server",
-		Inbounds: yarpc.Inbounds{ytchannel.NewInbound(serverCh)},
+		Inbounds: yarpc.Inbounds{ytchannel.NewInboundFromChannel(serverCh)},
 	}
 
 	clientCh, err := tchannel.NewChannel("client", nil)
@@ -258,7 +258,7 @@ func Benchmark_TChannel_TChannelToYARPC(b *testing.B) {
 
 	serverCfg := yarpc.Config{
 		Name:     "server",
-		Inbounds: yarpc.Inbounds{ytchannel.NewInbound(serverCh)},
+		Inbounds: yarpc.Inbounds{ytchannel.NewInboundFromChannel(serverCh)},
 	}
 
 	withDispatcher(b, serverCfg, func(server yarpc.Dispatcher) {

--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -44,7 +44,7 @@ func basicDispatcher(t *testing.T) Dispatcher {
 	return NewDispatcher(Config{
 		Name: "test",
 		Inbounds: Inbounds{
-			tch.NewInbound(ch).WithListenAddr(":0"),
+			tch.NewInboundFromChannel(ch).WithListenAddr(":0"),
 			http.NewInbound(":0"),
 		},
 	})

--- a/internal/crossdock/client/ctxpropagation/behavior.go
+++ b/internal/crossdock/client/ctxpropagation/behavior.go
@@ -349,7 +349,7 @@ func buildDispatcher(t crossdock.T) (dispatcher yarpc.Dispatcher, tconfig server
 	dispatcher = yarpc.NewDispatcher(yarpc.Config{
 		Name: "ctxclient",
 		Inbounds: yarpc.Inbounds{
-			tch.NewInbound(ch).WithListenAddr(":8087"),
+			tch.NewInboundFromChannel(ch).WithListenAddr(":8087"),
 			http.NewInbound(":8086"),
 		},
 		Outbounds: yarpc.Outbounds{

--- a/internal/crossdock/server/yarpc/server.go
+++ b/internal/crossdock/server/yarpc/server.go
@@ -50,7 +50,7 @@ func Start() {
 		Name: "yarpc-test",
 		Inbounds: yarpc.Inbounds{
 			http.NewInbound(":8081"),
-			tch.NewInbound(ch).WithListenAddr(":8082"),
+			tch.NewInboundFromChannel(ch).WithListenAddr(":8082"),
 		},
 	})
 

--- a/internal/examples/json/server/main.go
+++ b/internal/examples/json/server/main.go
@@ -80,7 +80,7 @@ func main() {
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name: "keyvalue",
 		Inbounds: yarpc.Inbounds{
-			tch.NewInbound(channel).WithListenAddr(":28941"),
+			tch.NewInboundFromChannel(channel).WithListenAddr(":28941"),
 			http.NewInbound(":24034"),
 		},
 		InboundMiddleware: yarpc.InboundMiddleware{

--- a/internal/examples/thrift/keyvalue/server/main.go
+++ b/internal/examples/thrift/keyvalue/server/main.go
@@ -68,7 +68,7 @@ func main() {
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name: "keyvalue",
 		Inbounds: yarpc.Inbounds{
-			tch.NewInbound(channel).WithListenAddr(":28941"),
+			tch.NewInboundFromChannel(channel).WithListenAddr(":28941"),
 			http.NewInbound(":24034"),
 		},
 	})

--- a/transport/roundtrip_test.go
+++ b/transport/roundtrip_test.go
@@ -143,7 +143,7 @@ func (tt tchannelTransport) WithRegistry(r transport.Registry, f func(transport.
 	serverOpts := testutils.NewOpts().SetServiceName(testService)
 	clientOpts := testutils.NewOpts().SetServiceName(testCaller)
 	testutils.WithServer(tt.t, serverOpts, func(ch *tchannel.Channel, hostPort string) {
-		i := tch.NewInbound(ch).WithRegistry(r)
+		i := tch.NewInboundFromChannel(ch).WithRegistry(r)
 		require.NoError(tt.t, i.Start(), "failed to start")
 
 		defer i.Stop()

--- a/transport/tchannel/inbound.go
+++ b/transport/tchannel/inbound.go
@@ -30,10 +30,10 @@ import (
 	"github.com/uber/tchannel-go"
 )
 
-// NewInbound builds a new TChannel inbound from the given Channel. Existing
+// NewInboundFromChannel builds a new TChannel inbound from the given Channel. Existing
 // methods registered on the channel remain registered and are preferred when
 // a call is received.
-func NewInbound(ch Channel) *Inbound {
+func NewInboundFromChannel(ch Channel) *Inbound {
 	return &Inbound{
 		ch:     ch,
 		tracer: opentracing.GlobalTracer(),
@@ -52,8 +52,8 @@ type Inbound struct {
 // WithListenAddr changes the address on which the TChannel server will listen
 // for connections. By default, the server listens on an OS-assigned port.
 //
-// This option has no effect if the Chanel provided to NewInbound is already
-// listening for connections when Start() is called.
+// This option has no effect if the Chanel provided to NewInboundFromChannel is
+// already listening for connections when Start() is called.
 func (i *Inbound) WithListenAddr(addr string) *Inbound {
 	i.addr = addr
 	return i

--- a/transport/tchannel/inbound_test.go
+++ b/transport/tchannel/inbound_test.go
@@ -38,7 +38,7 @@ func TestInboundStartNew(t *testing.T) {
 	}{
 		{
 			func(ch *tchannel.Channel, f func(*Inbound)) {
-				i := NewInbound(ch)
+				i := NewInboundFromChannel(ch)
 				i.SetRegistry(new(transporttest.MockRegistry))
 				// Can't do Equal because we want to match the pointer, not a
 				// DeepEqual.
@@ -51,7 +51,7 @@ func TestInboundStartNew(t *testing.T) {
 		},
 		{
 			func(ch *tchannel.Channel, f func(*Inbound)) {
-				i := NewInbound(ch).WithListenAddr(":0")
+				i := NewInboundFromChannel(ch).WithListenAddr(":0")
 				i.SetRegistry(new(transporttest.MockRegistry))
 				assert.True(t, ch == i.Channel(), "channel does not match")
 				require.NoError(t, i.Start())
@@ -80,7 +80,7 @@ func TestInboundStartAlreadyListening(t *testing.T) {
 	require.NoError(t, ch.ListenAndServe(":0"))
 	assert.Equal(t, tchannel.ChannelListening, ch.State())
 
-	i := NewInbound(ch)
+	i := NewInboundFromChannel(ch)
 
 	i.SetRegistry(new(transporttest.MockRegistry))
 	require.NoError(t, i.Start())
@@ -94,14 +94,14 @@ func TestInboundStopWithoutStarting(t *testing.T) {
 	ch, err := tchannel.NewChannel("foo", nil)
 	require.NoError(t, err)
 
-	i := NewInbound(ch)
+	i := NewInboundFromChannel(ch)
 	assert.NoError(t, i.Stop())
 }
 
 func TestInboundInvalidAddress(t *testing.T) {
 	ch, err := tchannel.NewChannel("foo", nil)
 	require.NoError(t, err)
-	i := NewInbound(ch).WithListenAddr("not valid")
+	i := NewInboundFromChannel(ch).WithListenAddr("not valid")
 	i.SetRegistry(new(transporttest.MockRegistry))
 	assert.Error(t, i.Start())
 }
@@ -116,7 +116,7 @@ func TestInboundExistingMethods(t *testing.T) {
 		},
 	}, nil)
 
-	i := NewInbound(ch)
+	i := NewInboundFromChannel(ch)
 	i.SetRegistry(new(transporttest.MockRegistry))
 	require.NoError(t, i.Start())
 	defer i.Stop()

--- a/transport/tracer_test.go
+++ b/transport/tracer_test.go
@@ -152,7 +152,7 @@ func createTChannelDispatcher(tracer opentracing.Tracer, t *testing.T) yarpc.Dis
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name: "yarpc-test",
 		Inbounds: yarpc.Inbounds{
-			ytchannel.NewInbound(ch).WithTracer(tracer),
+			ytchannel.NewInboundFromChannel(ch).WithTracer(tracer),
 		},
 		Outbounds: yarpc.Outbounds{
 			"yarpc-test": {


### PR DESCRIPTION
The rationale for this change is that tchannel.NewInbound should be reserved for tchannel.NewInbound(chooser) in a future version.