### PR TITLE
[Oneway Crossdock][Part 1] Support oneway in crossdock

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,9 @@ services:
             - AXIS_APACHETHRIFTSERVER=go
             - AXIS_GAUNTLET=go
             - AXIS_HTTPSERVER=go
+            - AXIS_CLIENT_ONEWAY=go
+            - AXIS_SERVER_ONEWAY=go
+            - AXIS_TRANSPORT_ONEWAY=http
 
             - BEHAVIOR_RAW=client,server,transport
             - BEHAVIOR_JSON=client,server,transport
@@ -45,6 +48,8 @@ services:
             # BEHAVIOR_INBOUNDTTL TODO
             - BEHAVIOR_CTXPROPAGATION=ctxclient,ctxserver,transport
             - BEHAVIOR_APACHETHRIFT=apachethriftclient,apachethriftserver
+            - BEHAVIOR_ONEWAY=client_oneway,server_oneway,transport_oneway,encoding
+
             - REPORT=compact
 
     go:

--- a/internal/crossdock/client/dispatcher/dispatcher.go
+++ b/internal/crossdock/client/dispatcher/dispatcher.go
@@ -76,9 +76,9 @@ func Create(t crossdock.T) yarpc.Dispatcher {
 	})
 }
 
-// CreateOneway returns a started dispatcher and returns the address the
+// CreateOnewayDispatcher returns a started dispatcher and returns the address the
 // server should call back to (ie this host)
-func CreateOneway(t crossdock.T, handler raw.OnewayHandler) (yarpc.Dispatcher, string) {
+func CreateOnewayDispatcher(t crossdock.T, handler raw.OnewayHandler) (yarpc.Dispatcher, string) {
 	fatals := crossdock.Fatals(t)
 
 	server := t.Param("server_oneway")

--- a/internal/crossdock/client/dispatcher/dispatcher.go
+++ b/internal/crossdock/client/dispatcher/dispatcher.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 
 	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/encoding/raw"
 	"go.uber.org/yarpc/internal/crossdock/client/params"
 	"go.uber.org/yarpc/peer/hostport"
 	"go.uber.org/yarpc/peer/single"
@@ -73,4 +74,42 @@ func Create(t crossdock.T) yarpc.Dispatcher {
 			},
 		},
 	})
+}
+
+// CreateOneway returns a started dispatcher and returns the address the
+// server should call back to (ie this host)
+func CreateOneway(t crossdock.T, handler raw.OnewayHandler) (yarpc.Dispatcher, string) {
+	fatals := crossdock.Fatals(t)
+
+	server := t.Param("server_oneway")
+	fatals.NotEmpty(server, "oneway server is required")
+
+	var outbound transport.OnewayOutbound
+
+	trans := t.Param("transport_oneway")
+	switch trans {
+	case "http":
+		outbound = http.NewOutbound(
+			single.New(
+				hostport.PeerIdentifier(fmt.Sprintf("%s:8084", server)),
+				http.NewTransport(),
+			))
+	default:
+		fatals.Fail("", "unknown transport %q", trans)
+	}
+
+	callBackInbound := http.NewInbound(":0")
+	dispatcher := yarpc.NewDispatcher(yarpc.Config{
+		Name: "oneway-client",
+		Outbounds: yarpc.Outbounds{
+			"oneway-server": {Oneway: outbound},
+		},
+		Inbounds: yarpc.Inbounds{callBackInbound},
+	})
+
+	// register procedure for server to call us back on
+	dispatcher.Register(raw.OnewayProcedure("call-back", raw.OnewayHandler(handler)))
+	fatals.NoError(dispatcher.Start(), "could not start Dispatcher")
+
+	return dispatcher, callBackInbound.Addr().String()
 }

--- a/internal/crossdock/client/dispatcher/dispatcher_test.go
+++ b/internal/crossdock/client/dispatcher/dispatcher_test.go
@@ -103,7 +103,7 @@ func TestCreateOneway(t *testing.T) {
 
 	for _, tt := range tests {
 		entries := crossdock.Run(tt.params, func(ct crossdock.T) {
-			dispatcher, callBackAddr := CreateOneway(ct, nil)
+			dispatcher, callBackAddr := CreateOnewayDispatcher(ct, nil)
 
 			// should get here only if the request succeeded
 			clientConfig := dispatcher.ClientConfig("yarpc-test")

--- a/internal/crossdock/client/oneway/oneway.go
+++ b/internal/crossdock/client/oneway/oneway.go
@@ -35,7 +35,7 @@ import (
 // Run starts the oneway behavior, testing a combination of encodings and transports
 func Run(t crossdock.T) {
 	callBackHandler, serverCalledBack := newCallBackHandler()
-	dispatcher, callBackAddr := dispatcher.CreateOneway(t, callBackHandler)
+	dispatcher, callBackAddr := dispatcher.CreateOnewayDispatcher(t, callBackHandler)
 	defer dispatcher.Stop()
 
 	encoding := t.Param(params.Encoding)
@@ -51,8 +51,7 @@ func Run(t crossdock.T) {
 	}
 }
 
-// newCallBackHandler creates a oneway handler that fills a channel
-// with the received body
+// newCallBackHandler creates a oneway handler that fills a channel with the body
 func newCallBackHandler() (raw.OnewayHandler, <-chan []byte) {
 	serverCalledBack := make(chan []byte)
 	handler := func(ctx context.Context, reqMeta yarpc.ReqMeta, body []byte) error {

--- a/internal/crossdock/client/oneway/oneway.go
+++ b/internal/crossdock/client/oneway/oneway.go
@@ -22,78 +22,44 @@ package oneway
 
 import (
 	"context"
-	"fmt"
 
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/encoding/raw"
+	"go.uber.org/yarpc/internal/crossdock/client/dispatcher"
 	"go.uber.org/yarpc/internal/crossdock/client/params"
 	"go.uber.org/yarpc/internal/crossdock/client/random"
-	"go.uber.org/yarpc/peer/hostport"
-	"go.uber.org/yarpc/peer/single"
-	"go.uber.org/yarpc/transport/http"
 
 	"github.com/crossdock/crossdock-go"
 )
 
-var serverCalledBack chan []byte
-
-// Run starts an http run using encoding types
+// Run starts the oneway behavior, testing a combination of encodings and transports
 func Run(t crossdock.T) {
-	encoding := t.Param(params.Encoding)
-	t.Tag("encoding", encoding)
-	t.Tag("server", t.Param(params.Server))
-
-	fatals := crossdock.Fatals(t)
-	dispatcher := newDispatcher(t)
-
-	fatals.NoError(dispatcher.Start(), "could not start Dispatcher")
+	callBackHandler, serverCalledBack := newCallBackHandler()
+	dispatcher, callBackAddr := dispatcher.CreateOneway(t, callBackHandler)
 	defer dispatcher.Stop()
 
-	serverCalledBack = make(chan []byte)
-
+	encoding := t.Param(params.Encoding)
 	switch encoding {
 	case "raw":
-		Raw(t, dispatcher)
+		Raw(t, dispatcher, serverCalledBack, callBackAddr)
 	case "json":
-		JSON(t, dispatcher)
+		JSON(t, dispatcher, serverCalledBack, callBackAddr)
 	case "thrift":
-		Thrift(t, dispatcher)
+		Thrift(t, dispatcher, serverCalledBack, callBackAddr)
 	default:
-		fatals.Fail("unknown encoding", "%v", encoding)
+		crossdock.Fatals(t).Fail("unknown encoding", "%v", encoding)
 	}
 }
 
-func newDispatcher(t crossdock.T) yarpc.Dispatcher {
-	server := t.Param(params.Server)
-	crossdock.Fatals(t).NotEmpty(server, "server is required")
-
-	// TODO httpTransport lifecycle
-	httpTransport := http.NewTransport()
-	dispatcher := yarpc.NewDispatcher(yarpc.Config{
-		Name: "client",
-		Outbounds: yarpc.Outbounds{
-			"oneway-test": {
-				Oneway: http.NewOutbound(single.New(
-					hostport.PeerIdentifier(fmt.Sprintf("%s:8084", server)),
-					httpTransport,
-				)),
-			},
-		},
-		//for call back
-		Inbounds: yarpc.Inbounds{http.NewInbound(fmt.Sprintf("%s:8089", server))},
-	})
-
-	// register procedure for remote server to call us back on
-	dispatcher.Register(raw.OnewayProcedure("call-back", callBack))
-
-	return dispatcher
+// newCallBackHandler creates a oneway handler that fills a channel
+// with the received body
+func newCallBackHandler() (raw.OnewayHandler, <-chan []byte) {
+	serverCalledBack := make(chan []byte)
+	handler := func(ctx context.Context, reqMeta yarpc.ReqMeta, body []byte) error {
+		serverCalledBack <- body
+		return nil
+	}
+	return handler, serverCalledBack
 }
 
-func getRandomID() string {
-	return random.String(10)
-}
-
-func callBack(ctx context.Context, reqMeta yarpc.ReqMeta, body []byte) error {
-	serverCalledBack <- body
-	return nil
-}
+func getRandomID() string { return random.String(10) }

--- a/internal/crossdock/main_test.go
+++ b/internal/crossdock/main_test.go
@@ -56,14 +56,7 @@ func TestCrossdock(t *testing.T) {
 		axes   axes
 	}{
 		{
-			name: "oneway",
-			axes: axes{
-				"encoding": []string{"raw", "json", "thrift"},
-			},
-		},
-		{
 			name: "raw",
-
 			axes: axes{"transport": []string{"http", "tchannel"}},
 		},
 		{
@@ -132,6 +125,16 @@ func TestCrossdock(t *testing.T) {
 			params: params{
 				"apachethriftserver": "127.0.0.1",
 				"apachethriftclient": "127.0.0.1",
+			},
+		},
+		{
+			name: "oneway",
+			params: params{
+				"server_oneway": "127.0.0.1",
+			},
+			axes: axes{
+				"encoding":         []string{"raw", "json", "thrift"},
+				"transport_oneway": []string{"http"},
 			},
 		},
 	}


### PR DESCRIPTION
This allows
- the oneway client/server test to be run using crossdock (previously it was only run with `make test`)
- multiple oneway crossdock clients to be run simultaneously
- multiple oneway transports to be configured (previously defaulted to HTTP)

Brief overview of how this test works:
interaction can be diagramed as: `client -> server -> client`
- client creats an http.Inbound() that's listening on an on open port
- client makes 'echo' call to server with a token (and the listening address in the headers)
- server calls back to the client (using the call back address) with the same body it received
- client verifies the token it sent was encoded/decoded properly