### PR TITLE
Strict service name validation

### DIFF
--- a/dispatcher.go
+++ b/dispatcher.go
@@ -27,6 +27,7 @@ import (
 
 	"go.uber.org/yarpc/api/middleware"
 	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal"
 	"go.uber.org/yarpc/internal/clientconfig"
 	"go.uber.org/yarpc/internal/errors"
 	"go.uber.org/yarpc/internal/request"
@@ -72,7 +73,10 @@ type InboundMiddleware struct {
 // NewDispatcher builds a new Dispatcher using the specified Config.
 func NewDispatcher(cfg Config) *Dispatcher {
 	if cfg.Name == "" {
-		panic("a service name is required")
+		panic("yarpc.NewDispatcher expects a service name")
+	}
+	if err := internal.ValidateServiceName(cfg.Name); err != nil {
+		panic("yarpc.NewDispatcher expects a valid service name: %s" + err.Error())
 	}
 
 	return &Dispatcher{

--- a/internal/servicename.go
+++ b/internal/servicename.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package internal
+
+import (
+	"fmt"
+	"regexp"
+)
+
+var (
+	// Must starts with [a-z].
+	// Can contain [a-z] and 0-9] with non-consecutive dashes.
+	validNameRegex = regexp.MustCompile("^[a-z]+([a-z0-9]|[^-]-)*[^-]$")
+
+	// We disallow UUIDs explicitly (they would be accepted by validNameRegex alone)
+	uuidRegex = regexp.MustCompile("[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}")
+)
+
+// ValidateServiceName returns an error if the given name is not a valid
+// service name.
+func ValidateServiceName(name string) error {
+	if !validNameRegex.MatchString(name) {
+		return fmt.Errorf("service name must begin with a letter and consist only of dash-delimited lower-case ASCII alphanumeric words")
+	}
+	if uuidRegex.MatchString(name) {
+		return fmt.Errorf("service name must not contain a UUID")
+	}
+	return nil
+}

--- a/internal/servicename_test.go
+++ b/internal/servicename_test.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidServiceNames(t *testing.T) {
+	tests := []string{
+		"superskipper",
+		"supper-skipper",
+		"supperskipper83",
+		"supper-skipper83",
+	}
+	for _, n := range tests {
+		assert.NoError(t, ValidateServiceName(n), n)
+	}
+}
+
+func TestInvalidServiceNames(t *testing.T) {
+	tests := []string{
+		"a77ab7e4-51cb-4808-a9ef-875568bde54a",
+		"urn:uuid:a77ab7e4-51cb-4808-a9ef-875568bde54a",
+		"26695a10-a384-48e7-8867-6d48b7fae80a",
+		"eviluuid26695a10-a384-48e7-8867-6d48b7fae80a",
+		"a77ab7e4-51cb-4808-a9ef-875568bde54aeviluuid",
+		"superSkipper",
+		"SuperSkipper",
+		"super_skipper",
+		"083superskipper",
+		"茶",
+		"super skipper",
+		"100",
+		"10-09-2016",
+		"",
+		"    ",
+		"-",
+		"no--duplication",
+		"no---duplication",
+		"endswithadash-",
+	}
+	for _, n := range tests {
+		assert.Error(t, ValidateServiceName(n), n)
+	}
+}

--- a/internal/servicename_test.go
+++ b/internal/servicename_test.go
@@ -32,6 +32,9 @@ func TestValidServiceNames(t *testing.T) {
 		"supper-skipper",
 		"supperskipper83",
 		"supper-skipper83",
+		"a77ab7g4-51cb-4808-a9ef-875568bde54a",         // not valid UUID
+		"eviluuid26695g10-a384-48e7-8867-6d48b7fae80a", // not valid UUID
+		"a77gb7e4-51cb-4808-a9ef-875568bde54aeviluuid", // not valid UUID
 	}
 	for _, n := range tests {
 		assert.NoError(t, ValidateServiceName(n), n)
@@ -45,6 +48,7 @@ func TestInvalidServiceNames(t *testing.T) {
 		"26695a10-a384-48e7-8867-6d48b7fae80a",
 		"eviluuid26695a10-a384-48e7-8867-6d48b7fae80a",
 		"a77ab7e4-51cb-4808-a9ef-875568bde54aeviluuid",
+		"26695g10-a384-48e7-8867-6d48b7fae80a", // not valid UUID, but starts with a number.
 		"superSkipper",
 		"SuperSkipper",
 		"super_skipper",


### PR DESCRIPTION
See #313 for the rules.
I have disallowed UUIDs appearing anywhere in the name, but you can still have
names looking strangely like UUIDs.

fixes #313