### PR TITLE
enforce at least one outbound for a service in the dispatcher

### DIFF
--- a/dispatcher.go
+++ b/dispatcher.go
@@ -109,10 +109,13 @@ func NewDispatcher(cfg Config) Dispatcher {
 
 // convertOutbounds applys outbound middleware and creates validator outbounds
 func convertOutbounds(outbounds Outbounds, middleware OutboundMiddleware) Outbounds {
-	//TODO(apb): ensure we're not given the same underlying outbound for each RPC type
 	convertedOutbounds := make(Outbounds, len(outbounds))
 
 	for service, outs := range outbounds {
+		if outs.Unary == nil && outs.Oneway == nil {
+			panic(fmt.Sprintf("no outbound set for service %q in dispatcher", service))
+		}
+
 		var (
 			unaryOutbound  transport.UnaryOutbound
 			onewayOutbound transport.OnewayOutbound

--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -297,12 +297,16 @@ func TestStartStopFailures(t *testing.T) {
 }
 
 func TestNoOutboundsForService(t *testing.T) {
-	assert.Panics(t, func() {
-		NewDispatcher(Config{
-			Name: "test",
-			Outbounds: Outbounds{
-				"my-test-service": {},
-			},
-		})
+	defer func() {
+		r := recover()
+		require.NotNil(t, r, "did not panic")
+		assert.Equal(t, r, `no outbound set for service "my-test-service" in dispatcher`)
+	}()
+
+	NewDispatcher(Config{
+		Name: "test",
+		Outbounds: Outbounds{
+			"my-test-service": {},
+		},
 	})
 }

--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -295,3 +295,14 @@ func TestStartStopFailures(t *testing.T) {
 		}
 	}
 }
+
+func TestNoOutboundsForService(t *testing.T) {
+	assert.Panics(t, func() {
+		NewDispatcher(Config{
+			Name: "test",
+			Outbounds: Outbounds{
+				"my-test-service": {},
+			},
+		})
+	})
+}


### PR DESCRIPTION
Currently, it's possible to configure a service with an empty transport.Outbounds object. This would blow up at the call site for users with a cryptic panic. This change enforces within the dispatcher that at least one outbound is given.

fixes #474