### PR TITLE
[Idempotent Start/Stop][Part 0.5] Create wrapper around sync.Once for ease of use

### DIFF
--- a/internal/sync/once.go
+++ b/internal/sync/once.go
@@ -1,0 +1,32 @@
+package sync
+
+import (
+	"sync"
+
+	"github.com/uber-go/atomic"
+)
+
+// OnceWithError is a wrapper around sync.Once in order to simplify returning the
+// same error multiple times from the same function
+type OnceWithError struct {
+	finished    atomic.Bool
+	once        sync.Once
+	returnedErr error
+}
+
+// IsFinished returns whether the finished flag has been set and thus sync.Once has been run
+func (o *OnceWithError) IsFinished() bool {
+	return o.finished.Load()
+}
+
+// Do is a wrapper around the sync.Once `Do` method. This version takes a function that
+// returns an error, and every subsequent call to the `Do` function will be returned the
+// `returnedErr` of the `Do` func
+func (o *OnceWithError) Do(f func() error) error {
+	o.once.Do(func() {
+		o.finished.Swap(true)
+		o.returnedErr = f()
+	})
+
+	return o.returnedErr
+}

--- a/internal/sync/once_test.go
+++ b/internal/sync/once_test.go
@@ -1,0 +1,38 @@
+package sync
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uber-go/atomic"
+)
+
+func TestOnceWithError(t *testing.T) {
+	once := OnceWithError{}
+	onceCalls := atomic.NewInt32(0)
+	expectedErr := errors.New("test error")
+
+	wait := ErrorWaiter{}
+	for i := 0; i < 10; i++ {
+		wait.Submit(func() error {
+			return once.Do(func() error {
+				onceCalls.Inc()
+				return expectedErr
+			})
+		})
+	}
+	errs := wait.Wait()
+
+	assert.Equal(t, 1, int(onceCalls.Load()), "number of executions of once was not 1")
+	for _, err := range errs {
+		assert.Equal(t, expectedErr, err)
+	}
+	assert.True(t, once.IsFinished())
+}
+
+func TestOnceWithErrorNotFinished(t *testing.T) {
+	once := OnceWithError{}
+
+	assert.False(t, once.IsFinished())
+}


### PR DESCRIPTION
Summary: As I worked on part 1 and beyond of moving the lists &&
outbounds to be idempotent I realized there was a common pattern across
all the diffs

1) sync.Once in order to make sure the start/stop functionality is only
called once
2) a started/stopped bool to check to see if start/stop had already been
run
3) a stopErr/startErr to return multiple times if start/stop are called
multiple times

I've consolidated these into this internal sync struct which should
handle this logic for us