### PR TITLE
HTTP transport constructors refactor

### DIFF
--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -41,11 +41,12 @@ func basicDispatcher(t *testing.T) Dispatcher {
 	ch, err := tchannel.NewChannel("test", nil)
 	require.NoError(t, err, "failed to create TChannel")
 
+	httpTransport := http.NewTransport()
 	return NewDispatcher(Config{
 		Name: "test",
 		Inbounds: Inbounds{
 			tch.NewInbound(ch).WithListenAddr(":0"),
-			http.NewInbound(":0"),
+			httpTransport.NewInbound(":0"),
 		},
 	})
 }

--- a/internal/crossdock/client/apachethrift/behavior.go
+++ b/internal/crossdock/client/apachethrift/behavior.go
@@ -26,8 +26,6 @@ import (
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/encoding/thrift"
 	"go.uber.org/yarpc/internal/crossdock/client/gauntlet"
-	"go.uber.org/yarpc/peer/hostport"
-	"go.uber.org/yarpc/peer/single"
 	"go.uber.org/yarpc/transport/http"
 
 	"github.com/crossdock/crossdock-go"
@@ -46,13 +44,13 @@ func Run(t crossdock.T) {
 	fatals.NotEmpty(server, "apachethriftserver is required")
 
 	httpTransport := http.NewTransport()
-	hostPort := hostport.PeerIdentifier(fmt.Sprintf("%v:%v", server, serverPort))
+	url := fmt.Sprintf("http://%v:%v/", server, serverPort)
 
-	thriftOutbound := http.NewOutbound(single.New(hostPort, httpTransport)).
+	thriftOutbound := httpTransport.NewSingleOutbound(url).
 		WithURLTemplate("http://host:port/thrift/ThriftTest")
-	secondOutbound := http.NewOutbound(single.New(hostPort, httpTransport)).
+	secondOutbound := httpTransport.NewSingleOutbound(url).
 		WithURLTemplate("http://host:port/thrift/SecondService")
-	multiplexOutbound := http.NewOutbound(single.New(hostPort, httpTransport)).
+	multiplexOutbound := httpTransport.NewSingleOutbound(url).
 		WithURLTemplate("http://host:port/thrift/multiplexed")
 
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{

--- a/internal/crossdock/client/httpserver/behavior.go
+++ b/internal/crossdock/client/httpserver/behavior.go
@@ -26,11 +26,9 @@ import (
 	"strings"
 	"time"
 
-	yarpc "go.uber.org/yarpc"
+	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/encoding/raw"
 	"go.uber.org/yarpc/internal/crossdock/client/params"
-	"go.uber.org/yarpc/peer/hostport"
-	"go.uber.org/yarpc/peer/single"
 	"go.uber.org/yarpc/transport"
 	"go.uber.org/yarpc/transport/http"
 
@@ -45,18 +43,11 @@ func Run(t crossdock.T) {
 	fatals.NotEmpty(server, "server is required")
 
 	httpTransport := http.NewTransport()
-	// TODO http transport lifecycle
-
 	disp := yarpc.NewDispatcher(yarpc.Config{
 		Name: "client",
 		Outbounds: yarpc.Outbounds{
 			"yarpc-test": {
-				Unary: http.NewOutbound(
-					single.New(
-						hostport.PeerIdentifier(fmt.Sprintf("%s:8085", server)),
-						httpTransport,
-					),
-				),
+				Unary: httpTransport.NewSingleOutbound(fmt.Sprintf("http://%s:8085", server)),
 			},
 		},
 	})

--- a/internal/crossdock/server/oneway/echo.go
+++ b/internal/crossdock/server/oneway/echo.go
@@ -30,8 +30,6 @@ import (
 	"go.uber.org/yarpc/encoding/json"
 	"go.uber.org/yarpc/encoding/raw"
 	"go.uber.org/yarpc/encoding/thrift"
-	"go.uber.org/yarpc/peer/hostport"
-	"go.uber.org/yarpc/peer/single"
 	"go.uber.org/yarpc/transport"
 	"go.uber.org/yarpc/transport/http"
 )
@@ -73,11 +71,7 @@ func (o *onewayHandler) callHome(ctx context.Context, reqMeta yarpc.ReqMeta, bod
 		panic("could not find callBackAddr in headers")
 	}
 
-	out := http.NewOutbound(
-		single.New(
-			hostport.PeerIdentifier(callBackAddr),
-			o.httpTransport))
-
+	out := o.httpTransport.NewSingleOutbound("http://" + callBackAddr)
 	out.Start()
 	defer out.Stop()
 

--- a/internal/crossdock/server/oneway/server.go
+++ b/internal/crossdock/server/oneway/server.go
@@ -35,7 +35,8 @@ var dispatcher yarpc.Dispatcher
 
 // Start starts the test server that clients will make requests to
 func Start() {
-	inbounds := []transport.Inbound{http.NewInbound(":8084")}
+	httpTransport := http.NewTransport()
+	inbounds := []transport.Inbound{httpTransport.NewInbound(":8084")}
 
 	dispatcher = yarpc.NewDispatcher(yarpc.Config{
 		Name:     "oneway-server",

--- a/internal/crossdock/server/yarpc/phone.go
+++ b/internal/crossdock/server/yarpc/phone.go
@@ -29,8 +29,6 @@ import (
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/encoding/json"
 	"go.uber.org/yarpc/internal/clientconfig"
-	"go.uber.org/yarpc/peer/hostport"
-	"go.uber.org/yarpc/peer/single"
 	"go.uber.org/yarpc/transport"
 	"go.uber.org/yarpc/transport/http"
 	tch "go.uber.org/yarpc/transport/tchannel"
@@ -75,15 +73,12 @@ type PhoneResponse struct {
 func Phone(ctx context.Context, reqMeta yarpc.ReqMeta, body *PhoneRequest) (*PhoneResponse, yarpc.ResMeta, error) {
 	var outbound transport.UnaryOutbound
 
+	httpTransport := http.NewTransport()
+
 	switch {
 	case body.Transport.HTTP != nil:
 		t := body.Transport.HTTP
-		outbound = http.NewOutbound(
-			single.New(
-				hostport.PeerIdentifier(fmt.Sprintf("%s:%d", t.Host, t.Port)),
-				http.NewTransport(), // TODO transport lifecycle
-			),
-		)
+		outbound = httpTransport.NewSingleOutbound(fmt.Sprintf("http://%s:%d", t.Host, t.Port))
 	case body.Transport.TChannel != nil:
 		t := body.Transport.TChannel
 		hostport := fmt.Sprintf("%s:%d", t.Host, t.Port)

--- a/internal/crossdock/server/yarpc/server.go
+++ b/internal/crossdock/server/yarpc/server.go
@@ -46,10 +46,11 @@ func Start() {
 		log.Fatalln("couldn't create tchannel: %v", err)
 	}
 
+	httpTransport := http.NewTransport()
 	dispatcher = yarpc.NewDispatcher(yarpc.Config{
 		Name: "yarpc-test",
 		Inbounds: yarpc.Inbounds{
-			http.NewInbound(":8081"),
+			httpTransport.NewInbound(":8081"),
 			tch.NewInbound(ch).WithListenAddr(":8082"),
 		},
 	})

--- a/internal/examples/json/client/main.go
+++ b/internal/examples/json/client/main.go
@@ -32,8 +32,6 @@ import (
 
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/encoding/json"
-	"go.uber.org/yarpc/peer/hostport"
-	"go.uber.org/yarpc/peer/single"
 	"go.uber.org/yarpc/transport"
 	"go.uber.org/yarpc/transport/http"
 	tch "go.uber.org/yarpc/transport/tchannel"
@@ -92,20 +90,12 @@ func main() {
 
 	flag.Parse()
 
-	var httpTransport *http.Transport
+	httpTransport := http.NewTransport()
 
 	var outbound transport.UnaryOutbound
 	switch strings.ToLower(outboundName) {
 	case "http":
-		if httpTransport == nil {
-			httpTransport = http.NewTransport()
-		}
-		outbound = http.NewOutbound(
-			single.New(
-				hostport.PeerIdentifier("127.0.0.1:24034"),
-				httpTransport,
-			),
-		)
+		outbound = httpTransport.NewSingleOutbound("http://127.0.0.1:24034")
 	case "tchannel":
 		channel, err := tchannel.NewChannel("keyvalue-client", nil)
 		if err != nil {

--- a/internal/examples/json/server/main.go
+++ b/internal/examples/json/server/main.go
@@ -77,11 +77,12 @@ func main() {
 		log.Fatalln(err)
 	}
 
+	httpTransport := http.NewTransport()
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name: "keyvalue",
 		Inbounds: yarpc.Inbounds{
 			tch.NewInbound(channel).WithListenAddr(":28941"),
-			http.NewInbound(":24034"),
+			httpTransport.NewInbound(":24034"),
 		},
 		InboundMiddleware: yarpc.InboundMiddleware{
 			Unary: requestLogInboundMiddleware{},

--- a/internal/examples/thrift/hello/main.go
+++ b/internal/examples/thrift/hello/main.go
@@ -29,8 +29,6 @@ import (
 	"go.uber.org/yarpc/internal/examples/thrift/hello/echo"
 	"go.uber.org/yarpc/internal/examples/thrift/hello/echo/yarpc/helloclient"
 	"go.uber.org/yarpc/internal/examples/thrift/hello/echo/yarpc/helloserver"
-	"go.uber.org/yarpc/peer/hostport"
-	"go.uber.org/yarpc/peer/single"
 
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/transport/http"
@@ -39,22 +37,15 @@ import (
 //go:generate thriftrw --plugin=yarpc echo.thrift
 
 func main() {
-
 	httpTransport := http.NewTransport()
-
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name: "hello",
 		Inbounds: yarpc.Inbounds{
-			http.NewInbound(":8086"),
+			httpTransport.NewInbound(":8086"),
 		},
 		Outbounds: yarpc.Outbounds{
 			"hello": {
-				Unary: http.NewOutbound(
-					single.New(
-						hostport.PeerIdentifier("127.0.0.1:8086"),
-						httpTransport,
-					),
-				),
+				Unary: httpTransport.NewSingleOutbound("http://127.0.0.1:8086"),
 			},
 		},
 	})

--- a/internal/examples/thrift/keyvalue/client/main.go
+++ b/internal/examples/thrift/keyvalue/client/main.go
@@ -32,8 +32,6 @@ import (
 
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/internal/examples/thrift/keyvalue/kv/yarpc/keyvalueclient"
-	"go.uber.org/yarpc/peer/hostport"
-	"go.uber.org/yarpc/peer/single"
 	"go.uber.org/yarpc/transport"
 	"go.uber.org/yarpc/transport/http"
 	tch "go.uber.org/yarpc/transport/tchannel"
@@ -50,20 +48,12 @@ func main() {
 
 	flag.Parse()
 
-	var httpTransport *http.Transport
+	httpTransport := http.NewTransport()
 
 	var outbound transport.UnaryOutbound
 	switch strings.ToLower(outboundName) {
 	case "http":
-		if httpTransport == nil {
-			httpTransport = http.NewTransport()
-		}
-		outbound = http.NewOutbound(
-			single.New(
-				hostport.PeerIdentifier("127.0.0.1:24034"),
-				httpTransport,
-			),
-		)
+		outbound = httpTransport.NewSingleOutbound("http://127.0.0.1:24034")
 	case "tchannel":
 		channel, err := tchannel.NewChannel("keyvalue-client", nil)
 		if err != nil {

--- a/internal/examples/thrift/keyvalue/server/main.go
+++ b/internal/examples/thrift/keyvalue/server/main.go
@@ -65,11 +65,12 @@ func main() {
 		log.Fatalln(err)
 	}
 
+	httpTransport := http.NewTransport()
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name: "keyvalue",
 		Inbounds: yarpc.Inbounds{
 			tch.NewInbound(channel).WithListenAddr(":28941"),
-			http.NewInbound(":24034"),
+			httpTransport.NewInbound(":24034"),
 		},
 	})
 

--- a/transport/http/inbound.go
+++ b/transport/http/inbound.go
@@ -31,11 +31,12 @@ import (
 	"github.com/opentracing/opentracing-go"
 )
 
-// NewInbound builds a new HTTP inbound that listens on the given address.
-func NewInbound(addr string) *Inbound {
+// NewInbound builds a new HTTP inbound that listens on the given address and
+// sharing this transport.
+func (t *Transport) NewInbound(addr string) *Inbound {
 	return &Inbound{
 		addr:   addr,
-		tracer: opentracing.GlobalTracer(),
+		tracer: t.tracer,
 	}
 }
 

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -143,7 +143,7 @@ func TestOutboundHeaders(t *testing.T) {
 			defer cancel()
 		}
 
-		out := NewSingleOutbound(server.URL, httpTransport)
+		out := httpTransport.NewSingleOutbound(server.URL)
 
 		require.NoError(t, out.Start(), "failed to start outbound")
 		defer out.Stop()
@@ -189,7 +189,7 @@ func TestCallFailures(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		out := NewSingleOutbound(tt.url, httpTransport)
+		out := httpTransport.NewSingleOutbound(tt.url)
 		require.NoError(t, out.Start(), "failed to start outbound")
 		defer out.Stop()
 
@@ -211,7 +211,7 @@ func TestCallFailures(t *testing.T) {
 
 func TestStartMultiple(t *testing.T) {
 	httpTransport := NewTransport()
-	out := NewSingleOutbound("http://localhost:9999", httpTransport)
+	out := httpTransport.NewSingleOutbound("http://localhost:9999")
 
 	var wg sync.WaitGroup
 	signal := make(chan struct{})
@@ -232,14 +232,7 @@ func TestStartMultiple(t *testing.T) {
 
 func TestStopMultiple(t *testing.T) {
 	httpTransport := NewTransport()
-	// TODO transport lifecycle
-
-	out := NewOutbound(
-		single.New(
-			hostport.PeerIdentifier("127.0.0.1:9999"),
-			httpTransport,
-		),
-	)
+	out := httpTransport.NewSingleOutbound("http://127.0.0.1:9999")
 
 	err := out.Start()
 	require.NoError(t, err)
@@ -263,14 +256,7 @@ func TestStopMultiple(t *testing.T) {
 
 func TestCallWithoutStarting(t *testing.T) {
 	httpTransport := NewTransport()
-	// TODO transport lifecycle
-
-	out := NewOutbound(
-		single.New(
-			hostport.PeerIdentifier("127.0.0.1:9999"),
-			httpTransport,
-		),
-	)
+	out := httpTransport.NewSingleOutbound("http://127.0.0.1:9999")
 	assert.Panics(t, func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 		defer cancel()


### PR DESCRIPTION
These changes, based on #529, pivot the HTTP transport away from using New* functions on the "transport/http" package to using http.NewTransport() and transport.New* methods for all construction needs. This includes the introduction of transport.NewSingleOutbound, which restores simplicity to the simple case. In all of these cases, the tracer gets threaded from the transport’s configuration into the creation of all dependent inbounds and outbounds. NewSingleOutbound benefits from being able to thread the transport into the single peer chooser behind the scenes.