### PR TITLE
Remove with registry

### DIFF
--- a/transport/http/inbound.go
+++ b/transport/http/inbound.go
@@ -66,13 +66,6 @@ func (i *Inbound) WithTracer(tracer opentracing.Tracer) *Inbound {
 	return i
 }
 
-// WithRegistry configures a registry to handle incoming requests,
-// as a chained method for convenience.
-func (i *Inbound) WithRegistry(registry transport.Registry) *Inbound {
-	i.registry = registry
-	return i
-}
-
 // SetRegistry configures a registry to handle incoming requests.
 // This satisfies the transport.Inbound interface, and would be called
 // by a dispatcher when it starts.

--- a/transport/http/inbound_test.go
+++ b/transport/http/inbound_test.go
@@ -85,9 +85,9 @@ func TestInboundStartAndStop(t *testing.T) {
 
 func TestInboundStartError(t *testing.T) {
 	x := NewTransport()
-	err := x.NewInbound("invalid").
-		WithRegistry(new(transporttest.MockRegistry)).
-		Start()
+	i := x.NewInbound("invalid")
+	i.SetRegistry(new(transporttest.MockRegistry))
+	err := i.Start()
 	assert.Error(t, err, "expected failure")
 }
 

--- a/transport/tchannel/inbound.go
+++ b/transport/tchannel/inbound.go
@@ -65,13 +65,6 @@ func (i *Inbound) WithTracer(tracer opentracing.Tracer) *Inbound {
 	return i
 }
 
-// WithRegistry configures a registry to handle incoming requests,
-// as a chained method for convenience.
-func (i *Inbound) WithRegistry(registry transport.Registry) *Inbound {
-	i.registry = registry
-	return i
-}
-
 // SetRegistry configures a registry to handle incoming requests.
 // This satisfies the transport.Inbound interface, and would be called
 // by a dispatcher when it starts.


### PR DESCRIPTION
Based on #540, just removes the WithRegistry method on inbounds, in favor of calling SetRegistry just like dispatcher, even in tests where the fluent API was convenient.