### PR TITLE
Don't panic

### DIFF
--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -162,8 +162,8 @@ func (o *Outbound) Stop() error {
 // Call makes a HTTP request
 func (o *Outbound) Call(ctx context.Context, treq *transport.Request) (*transport.Response, error) {
 	if !o.started.Load() {
-		// panic because there's no recovery from this
-		panic(errOutboundNotStarted)
+		// TODO replace with "panicInDebug"
+		return nil, errOutboundNotStarted
 	}
 	start := time.Now()
 	deadline, _ := ctx.Deadline()
@@ -175,8 +175,8 @@ func (o *Outbound) Call(ctx context.Context, treq *transport.Request) (*transpor
 // CallOneway makes a oneway request
 func (o *Outbound) CallOneway(ctx context.Context, treq *transport.Request) (transport.Ack, error) {
 	if !o.started.Load() {
-		// panic because there's no recovery from this
-		panic(errOutboundNotStarted)
+		// TODO replace with "panicInDebug"
+		return nil, errOutboundNotStarted
 	}
 	start := time.Now()
 	var ttl time.Duration

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -246,18 +246,19 @@ func TestStopMultiple(t *testing.T) {
 func TestCallWithoutStarting(t *testing.T) {
 	httpTransport := NewTransport()
 	out := httpTransport.NewSingleOutbound("http://127.0.0.1:9999")
-	assert.Panics(t, func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
-		defer cancel()
-		out.Call(
-			ctx,
-			&transport.Request{
-				Caller:    "caller",
-				Service:   "service",
-				Encoding:  raw.Encoding,
-				Procedure: "foo",
-				Body:      bytes.NewReader([]byte("sup")),
-			},
-		)
-	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	_, err := out.Call(
+		ctx,
+		&transport.Request{
+			Caller:    "caller",
+			Service:   "service",
+			Encoding:  raw.Encoding,
+			Procedure: "foo",
+			Body:      bytes.NewReader([]byte("sup")),
+		},
+	)
+
+	assert.Equal(t, errOutboundNotStarted, err)
 }

--- a/transport/tchannel/channel_outbound.go
+++ b/transport/tchannel/channel_outbound.go
@@ -86,8 +86,8 @@ func (o *ChannelOutbound) Stop() error {
 // Call sends an RPC over this TChannel outbound.
 func (o *ChannelOutbound) Call(ctx context.Context, req *transport.Request) (*transport.Response, error) {
 	if !o.started.Load() {
-		// panic because there's no recovery from this
-		panic(errOutboundNotStarted)
+		// TODO replace with "panicInDebug"
+		return nil, errOutboundNotStarted
 	}
 
 	// NB(abg): Under the current API, the local service's name is required

--- a/transport/tchannel/outbound_test.go
+++ b/transport/tchannel/outbound_test.go
@@ -332,19 +332,19 @@ func TestCallWithoutStarting(t *testing.T) {
 		// TODO: If we change Start() to establish a connection to the host, this
 		// hostport will have to be changed to a real server.
 
-		assert.Panics(t, func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
-			defer cancel()
-			out.Call(
-				ctx,
-				&transport.Request{
-					Caller:    "caller",
-					Service:   "service",
-					Encoding:  raw.Encoding,
-					Procedure: "foo",
-					Body:      bytes.NewReader([]byte("sup")),
-				},
-			)
-		})
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+		_, err := out.Call(
+			ctx,
+			&transport.Request{
+				Caller:    "caller",
+				Service:   "service",
+				Encoding:  raw.Encoding,
+				Procedure: "foo",
+				Body:      bytes.NewReader([]byte("sup")),
+			},
+		)
+
+		assert.Equal(t, errOutboundNotStarted, err)
 	}
 }


### PR DESCRIPTION
Summary: This diff removes the panics from Outbound calls.  We should
not be panicing in production