### PR TITLE
Remove With prefix from transport options

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -188,7 +188,7 @@ func Benchmark_HTTP_NetHTTPToNetHTTP(b *testing.B) {
 
 func Benchmark_TChannel_YARPCToYARPC(b *testing.B) {
 	serverTChannel := ytchannel.NewChannelTransport(
-		ytchannel.WithServiceName("server"),
+		ytchannel.ServiceName("server"),
 	)
 	serverCfg := yarpc.Config{
 		Name:     "server",
@@ -196,7 +196,7 @@ func Benchmark_TChannel_YARPCToYARPC(b *testing.B) {
 	}
 
 	clientTChannel := ytchannel.NewChannelTransport(
-		ytchannel.WithServiceName("client"),
+		ytchannel.ServiceName("client"),
 	)
 
 	// no defer close on channels because YARPC will take care of that
@@ -228,7 +228,7 @@ func Benchmark_TChannel_YARPCToTChannel(b *testing.B) {
 	serverCh.Register(traw.Wrap(tchannelEcho{t: b}), "echo")
 	require.NoError(b, serverCh.ListenAndServe(":0"), "failed to start up TChannel")
 
-	clientTChannel := ytchannel.NewChannelTransport(ytchannel.WithServiceName("client"))
+	clientTChannel := ytchannel.NewChannelTransport(ytchannel.ServiceName("client"))
 	clientCfg := yarpc.Config{
 		Name: "client",
 		Outbounds: yarpc.Outbounds{
@@ -246,7 +246,7 @@ func Benchmark_TChannel_YARPCToTChannel(b *testing.B) {
 
 func Benchmark_TChannel_TChannelToYARPC(b *testing.B) {
 	tchannelTransport := ytchannel.NewChannelTransport(
-		ytchannel.WithServiceName("server"),
+		ytchannel.ServiceName("server"),
 	)
 
 	serverCfg := yarpc.Config{

--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -38,7 +38,7 @@ import (
 
 func basicDispatcher(t *testing.T) Dispatcher {
 	httpTransport := http.NewTransport()
-	tchannelTransport := tchannel.NewChannelTransport(tchannel.WithServiceName("test"))
+	tchannelTransport := tchannel.NewChannelTransport(tchannel.ServiceName("test"))
 	return NewDispatcher(Config{
 		Name: "test",
 		Inbounds: Inbounds{

--- a/internal/crossdock/client/apachethrift/behavior.go
+++ b/internal/crossdock/client/apachethrift/behavior.go
@@ -46,12 +46,18 @@ func Run(t crossdock.T) {
 	httpTransport := http.NewTransport()
 	url := fmt.Sprintf("http://%v:%v/", server, serverPort)
 
-	thriftOutbound := httpTransport.NewSingleOutbound(url).
-		WithURLTemplate("http://host:port/thrift/ThriftTest")
-	secondOutbound := httpTransport.NewSingleOutbound(url).
-		WithURLTemplate("http://host:port/thrift/SecondService")
-	multiplexOutbound := httpTransport.NewSingleOutbound(url).
-		WithURLTemplate("http://host:port/thrift/multiplexed")
+	thriftOutbound := httpTransport.NewSingleOutbound(
+		url,
+		http.URLTemplate("http://host:port/thrift/ThriftTest"),
+	)
+	secondOutbound := httpTransport.NewSingleOutbound(
+		url,
+		http.URLTemplate("http://host:port/thrift/SecondService"),
+	)
+	multiplexOutbound := httpTransport.NewSingleOutbound(
+		url,
+		http.URLTemplate("http://host:port/thrift/multiplexed"),
+	)
 
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name: "apache-thrift-client",

--- a/internal/crossdock/client/ctxpropagation/behavior.go
+++ b/internal/crossdock/client/ctxpropagation/behavior.go
@@ -319,7 +319,7 @@ func buildDispatcher(t crossdock.T) (dispatcher yarpc.Dispatcher, tconfig server
 	fatals.NotEmpty(subject, "ctxserver is required")
 
 	httpTransport := http.NewTransport()
-	tchannelTransport := tch.NewChannelTransport(tch.WithListenAddr(":8087"), tch.WithServiceName("ctxclient"))
+	tchannelTransport := tch.NewChannelTransport(tch.ListenAddr(":8087"), tch.ServiceName("ctxclient"))
 
 	var outbound transport.UnaryOutbound
 	switch trans := t.Param(params.Transport); trans {

--- a/internal/crossdock/client/dispatcher/dispatcher.go
+++ b/internal/crossdock/client/dispatcher/dispatcher.go
@@ -47,7 +47,7 @@ func Create(t crossdock.T) yarpc.Dispatcher {
 		httpTransport := http.NewTransport()
 		unaryOutbound = httpTransport.NewSingleOutbound(fmt.Sprintf("http://%s:8081", server))
 	case "tchannel":
-		tchannelTransport := tchannel.NewChannelTransport(tchannel.WithServiceName("client"))
+		tchannelTransport := tchannel.NewChannelTransport(tchannel.ServiceName("client"))
 		unaryOutbound = tchannelTransport.NewSingleOutbound(server + ":8082")
 	default:
 		fatals.Fail("", "unknown transport %q", trans)

--- a/internal/crossdock/client/tchserver/behavior.go
+++ b/internal/crossdock/client/tchserver/behavior.go
@@ -43,7 +43,7 @@ func Run(t crossdock.T) {
 	server := t.Param(params.Server)
 	serverHostPort := fmt.Sprintf("%v:%v", server, serverPort)
 
-	tchannelTransport := tchannel.NewChannelTransport(tchannel.WithServiceName("yarpc-client"))
+	tchannelTransport := tchannel.NewChannelTransport(tchannel.ServiceName("yarpc-client"))
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name: "yarpc-client",
 		Outbounds: yarpc.Outbounds{

--- a/internal/crossdock/server/yarpc/phone.go
+++ b/internal/crossdock/server/yarpc/phone.go
@@ -72,7 +72,7 @@ func Phone(ctx context.Context, reqMeta yarpc.ReqMeta, body *PhoneRequest) (*Pho
 	var outbound transport.UnaryOutbound
 
 	httpTransport := http.NewTransport()
-	tchannelTransport := tchannel.NewChannelTransport(tchannel.WithServiceName("yarpc-test-client"))
+	tchannelTransport := tchannel.NewChannelTransport(tchannel.ServiceName("yarpc-test-client"))
 
 	switch {
 	case body.Transport.HTTP != nil:

--- a/internal/crossdock/server/yarpc/server.go
+++ b/internal/crossdock/server/yarpc/server.go
@@ -39,8 +39,8 @@ var dispatcher yarpc.Dispatcher
 // Start starts the test server that clients will make requests to
 func Start() {
 	tchannelTransport := tchannel.NewChannelTransport(
-		tchannel.WithListenAddr(":8082"),
-		tchannel.WithServiceName("yarpc-test"),
+		tchannel.ListenAddr(":8082"),
+		tchannel.ServiceName("yarpc-test"),
 	)
 	httpTransport := http.NewTransport()
 	dispatcher = yarpc.NewDispatcher(yarpc.Config{

--- a/internal/examples/json/client/main.go
+++ b/internal/examples/json/client/main.go
@@ -89,7 +89,7 @@ func main() {
 	flag.Parse()
 
 	httpTransport := http.NewTransport()
-	tchannelTransport := tchannel.NewChannelTransport(tchannel.WithServiceName("keyvalue-client"))
+	tchannelTransport := tchannel.NewChannelTransport(tchannel.ServiceName("keyvalue-client"))
 
 	var outbound transport.UnaryOutbound
 	switch strings.ToLower(outboundName) {

--- a/internal/examples/json/server/main.go
+++ b/internal/examples/json/server/main.go
@@ -70,8 +70,8 @@ func (h *handler) Set(ctx context.Context, reqMeta yarpc.ReqMeta, body *setReque
 
 func main() {
 	tchannelTransport := tchannel.NewChannelTransport(
-		tchannel.WithServiceName("keyvalue"),
-		tchannel.WithListenAddr(":28941"),
+		tchannel.ServiceName("keyvalue"),
+		tchannel.ListenAddr(":28941"),
 	)
 	httpTransport := http.NewTransport()
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{

--- a/internal/examples/thrift/keyvalue/client/main.go
+++ b/internal/examples/thrift/keyvalue/client/main.go
@@ -47,7 +47,7 @@ func main() {
 	flag.Parse()
 
 	httpTransport := http.NewTransport()
-	tchannelTransport := tchannel.NewChannelTransport(tchannel.WithServiceName("keyvalue-client"))
+	tchannelTransport := tchannel.NewChannelTransport(tchannel.ServiceName("keyvalue-client"))
 
 	var outbound transport.UnaryOutbound
 	switch strings.ToLower(outboundName) {

--- a/internal/examples/thrift/keyvalue/server/main.go
+++ b/internal/examples/thrift/keyvalue/server/main.go
@@ -58,8 +58,8 @@ func (h *handler) SetValue(ctx context.Context, reqMeta yarpc.ReqMeta, key *stri
 
 func main() {
 	tchannelTransport := tchannel.NewChannelTransport(
-		tchannel.WithServiceName("keyvalue"),
-		tchannel.WithListenAddr(":28941"),
+		tchannel.ServiceName("keyvalue"),
+		tchannel.ListenAddr(":28941"),
 	)
 	httpTransport := http.NewTransport()
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{

--- a/transport/http/inbound_test.go
+++ b/transport/http/inbound_test.go
@@ -110,7 +110,7 @@ func TestInboundMux(t *testing.T) {
 		w.Write([]byte("healthy"))
 	})
 
-	i := httpTransport.NewInbound(":0").WithMux("/rpc/v1", mux)
+	i := httpTransport.NewInbound(":0", Mux("/rpc/v1", mux))
 	h := transporttest.NewMockUnaryHandler(mockCtrl)
 	reg := transporttest.NewMockRegistry(mockCtrl)
 	i.SetRegistry(reg)
@@ -147,7 +147,7 @@ func TestInboundMux(t *testing.T) {
 		assert.Equal(t, err.Error(), "404 page not found")
 	}
 
-	o = o.WithURLTemplate("http://host:port/rpc/v1")
+	o.setURLTemplate("http://host:port/rpc/v1")
 	require.NoError(t, o.Start(), "failed to start outbound")
 	defer o.Stop()
 

--- a/transport/http/transport.go
+++ b/transport/http/transport.go
@@ -52,9 +52,9 @@ func KeepAlive(t time.Duration) TransportOption {
 	}
 }
 
-// WithTracer configures a tracer for the transport and all its inbounds and
+// Tracer configures a tracer for the transport and all its inbounds and
 // outbounds.
-func WithTracer(tracer opentracing.Tracer) TransportOption {
+func Tracer(tracer opentracing.Tracer) TransportOption {
 	return func(c *transportConfig) {
 		c.tracer = tracer
 	}

--- a/transport/tchannel/inbound_test.go
+++ b/transport/tchannel/inbound_test.go
@@ -110,7 +110,7 @@ func TestInboundStopWithoutStarting(t *testing.T) {
 }
 
 func TestInboundInvalidAddress(t *testing.T) {
-	x := NewChannelTransport(WithServiceName("foo"), WithListenAddr("not valid"))
+	x := NewChannelTransport(ServiceName("foo"), ListenAddr("not valid"))
 	i := x.NewInbound()
 	i.SetRegistry(new(transporttest.MockRegistry))
 	assert.Nil(t, i.Start())

--- a/transport/tchannel/options.go
+++ b/transport/tchannel/options.go
@@ -42,8 +42,8 @@ type transportConfig struct {
 // TransportOption will eventually also be suitable for passing to NewTransport.
 type TransportOption func(*transportConfig)
 
-// WithTracer is an option that configures the tracer for a TChannel transport.
-func WithTracer(tracer opentracing.Tracer) TransportOption {
+// Tracer is an option that configures the tracer for a TChannel transport.
+func Tracer(tracer opentracing.Tracer) TransportOption {
 	return func(t *transportConfig) {
 		t.tracer = tracer
 	}
@@ -60,19 +60,19 @@ func WithChannel(ch Channel) TransportOption {
 	}
 }
 
-// WithListenAddr informs a transport constructor what address (in the form of
+// ListenAddr informs a transport constructor what address (in the form of
 // host:port) to listen on. This option does not apply to NewChannelTransport
 // if it is called with WithChannel and a channel that is already listening.
-func WithListenAddr(addr string) TransportOption {
+func ListenAddr(addr string) TransportOption {
 	return func(t *transportConfig) {
 		t.addr = addr
 	}
 }
 
-// WithServiceName informs the NewChannelTransport constructor which service
+// ServiceName informs the NewChannelTransport constructor which service
 // name to use if it needs to construct a root Channel object, as when called
 // without the WithChannel option.
-func WithServiceName(name string) TransportOption {
+func ServiceName(name string) TransportOption {
 	return func(t *transportConfig) {
 		t.name = name
 	}

--- a/transport/tracer_test.go
+++ b/transport/tracer_test.go
@@ -113,7 +113,7 @@ func createHTTPDispatcher(tracer opentracing.Tracer) yarpc.Dispatcher {
 	// TODO: Use port 0 once https://github.com/yarpc/yarpc-go/issues/381 is
 	// fixed.
 
-	httpTransport := http.NewTransport(http.WithTracer(tracer))
+	httpTransport := http.NewTransport(http.Tracer(tracer))
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name: "yarpc-test",
 		Inbounds: yarpc.Inbounds{
@@ -134,9 +134,9 @@ func createTChannelDispatcher(tracer opentracing.Tracer, t *testing.T) yarpc.Dis
 	hp := "127.0.0.1:4040"
 
 	tchannelTransport := ytchannel.NewChannelTransport(
-		ytchannel.WithListenAddr(hp),
-		ytchannel.WithTracer(tracer),
-		ytchannel.WithServiceName("yarpc-test"),
+		ytchannel.ListenAddr(hp),
+		ytchannel.Tracer(tracer),
+		ytchannel.ServiceName("yarpc-test"),
 	)
 
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{


### PR DESCRIPTION
While updating the change log, it became obvious that I had invented these prefixes for options. I’m removing them to remain in keeping with the prior precedent, with the exception of WithChannel, which collides with the Channel interface.