### PR TITLE
Update List.Update to take a ListUpdate struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Releases
 v1.0.0-dev (unreleased)
 -----------------------
 
+-   **Breaking**: Changed `peer.List.Update` to accept a `peer.ListUpdates`
+    struct instead of a list of additions and removals
 -   **Breaking**: yarpc.NewDispatcher now returns a pointer to a
     yarpc.Dispatcher. Previously, yarpc.Dispatcher was an interface, now a
     concrete struct.

--- a/api/peer/list.go
+++ b/api/peer/list.go
@@ -48,7 +48,7 @@ type List interface {
 	Update(updates ListUpdates) error
 }
 
-// ListUpdates is a wrapper around the list of additions and removals used in List.Update
+// ListUpdates specifies the updates to be made to a List
 type ListUpdates struct {
 	// Additions are the identifiers that should be added to the list
 	Additions []Identifier

--- a/api/peer/list.go
+++ b/api/peer/list.go
@@ -41,9 +41,18 @@ type Chooser interface {
 }
 
 // List listens to adds and removes of Peers from a PeerProvider
-// A Chooser will implement the PeerChangeListener interface in order to receive
+// A Chooser will implement the List interface in order to receive
 // updates to the list of Peers it is keeping track of
 type List interface {
 	// Update performs the additions and removals to the Peer List
-	Update(additions, removals []Identifier) error
+	Update(updates ListUpdates) error
+}
+
+// ListUpdates is a wrapper around the list of additions and removals used in List.Update
+type ListUpdates struct {
+	// Additions are the identifiers that should be added to the list
+	Additions []Identifier
+
+	// Removals are the identifiers that should be removed to the list
+	Removals []Identifier
 }

--- a/api/peer/peertest/peerlistaction.go
+++ b/api/peer/peertest/peerlistaction.go
@@ -143,7 +143,12 @@ func (a UpdateAction) Apply(t *testing.T, pl peer.Chooser, deps ListActionDeps) 
 		removed = append(removed, MockPeerIdentifier(peerID))
 	}
 
-	err := list.Update(added, removed)
+	err := list.Update(
+		peer.ListUpdates{
+			Additions: added,
+			Removals:  removed,
+		},
+	)
 	assert.Equal(t, a.ExpectedErr, err)
 }
 

--- a/peer/x/roundrobin/list.go
+++ b/peer/x/roundrobin/list.go
@@ -62,7 +62,10 @@ type List struct {
 // Update applies the additions and removals of peer Identifiers to the list
 // it returns a multi-error result of every failure that happened without
 // circuit breaking due to failures
-func (pl *List) Update(additions, removals []peer.Identifier) error {
+func (pl *List) Update(updates peer.ListUpdates) error {
+	additions := updates.Additions
+	removals := updates.Removals
+
 	if len(additions) == 0 && len(removals) == 0 {
 		return nil
 	}


### PR DESCRIPTION
Summary: This makes the callsite for List.Update much more explicit so
there is less chance that we'll accidentally switch the additions and
removals

Task: #570