### PR TITLE
Remove stuttering from Middleware API folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Releases
 v1.0.0-dev (unreleased)
 -----------------------
 
+-   **Breaking**: Rename `middleware.{Oneway,Unary}{Inbound,Outbound}Middleware`
+    to `middleware.{Oneway,Unary}{Inbound,Outbound}`
 -   **Breaking**: Changed `peer.List.Update` to accept a `peer.ListUpdates`
     struct instead of a list of additions and removals
 -   **Breaking**: yarpc.NewDispatcher now returns a pointer to a

--- a/api/middleware/inbound.go
+++ b/api/middleware/inbound.go
@@ -26,10 +26,10 @@ import (
 	"go.uber.org/yarpc/api/transport"
 )
 
-// UnaryInboundMiddleware defines a transport-level middleware for
+// UnaryInbound defines a transport-level middleware for
 // `UnaryHandler`s.
 //
-// UnaryInboundMiddleware MAY
+// UnaryInbound MAY
 //
 // - change the context
 // - change the request
@@ -38,99 +38,99 @@ import (
 // - handle the returned error
 // - call the given handler zero or more times
 //
-// UnaryInboundMiddleware MUST be thread-safe.
+// UnaryInbound MUST be thread-safe.
 //
-// UnaryInboundMiddleware is re-used across requests and MAY be called multiple times
+// UnaryInbound is re-used across requests and MAY be called multiple times
 // for the same request.
-type UnaryInboundMiddleware interface {
+type UnaryInbound interface {
 	Handle(ctx context.Context, req *transport.Request, resw transport.ResponseWriter, h transport.UnaryHandler) error
 }
 
-// NopUnaryInboundMiddleware is a inbound middleware that does not do anything special. It
+// NopUnaryInbound is a inbound middleware that does not do anything special. It
 // simply calls the underlying Handler.
-var NopUnaryInboundMiddleware UnaryInboundMiddleware = nopUnaryInboundMiddleware{}
+var NopUnaryInbound UnaryInbound = nopUnaryInbound{}
 
-// ApplyUnaryInboundMiddleware applies the given InboundMiddleware to the given Handler.
-func ApplyUnaryInboundMiddleware(h transport.UnaryHandler, i UnaryInboundMiddleware) transport.UnaryHandler {
+// ApplyUnaryInbound applies the given InboundMiddleware to the given Handler.
+func ApplyUnaryInbound(h transport.UnaryHandler, i UnaryInbound) transport.UnaryHandler {
 	if i == nil {
 		return h
 	}
 	return unaryHandlerWithMiddleware{h: h, i: i}
 }
 
-// UnaryInboundMiddlewareFunc adapts a function into an InboundMiddleware.
-type UnaryInboundMiddlewareFunc func(context.Context, *transport.Request, transport.ResponseWriter, transport.UnaryHandler) error
+// UnaryInboundFunc adapts a function into an InboundMiddleware.
+type UnaryInboundFunc func(context.Context, *transport.Request, transport.ResponseWriter, transport.UnaryHandler) error
 
-// Handle for UnaryInboundMiddlewareFunc
-func (f UnaryInboundMiddlewareFunc) Handle(ctx context.Context, req *transport.Request, resw transport.ResponseWriter, h transport.UnaryHandler) error {
+// Handle for UnaryInboundFunc
+func (f UnaryInboundFunc) Handle(ctx context.Context, req *transport.Request, resw transport.ResponseWriter, h transport.UnaryHandler) error {
 	return f(ctx, req, resw, h)
 }
 
 type unaryHandlerWithMiddleware struct {
 	h transport.UnaryHandler
-	i UnaryInboundMiddleware
+	i UnaryInbound
 }
 
 func (h unaryHandlerWithMiddleware) Handle(ctx context.Context, req *transport.Request, resw transport.ResponseWriter) error {
 	return h.i.Handle(ctx, req, resw, h.h)
 }
 
-type nopUnaryInboundMiddleware struct{}
+type nopUnaryInbound struct{}
 
-func (nopUnaryInboundMiddleware) Handle(ctx context.Context, req *transport.Request, resw transport.ResponseWriter, handler transport.UnaryHandler) error {
+func (nopUnaryInbound) Handle(ctx context.Context, req *transport.Request, resw transport.ResponseWriter, handler transport.UnaryHandler) error {
 	return handler.Handle(ctx, req, resw)
 }
 
-// OnewayInboundMiddleware defines a transport-level middleware for
+// OnewayInbound defines a transport-level middleware for
 // `OnewayHandler`s.
 //
-// OnewayInboundMiddleware MAY
+// OnewayInbound MAY
 //
 // - change the context
 // - change the request
 // - handle the returned error
 // - call the given handler zero or more times
 //
-// OnewayInboundMiddleware MUST be thread-safe.
+// OnewayInbound MUST be thread-safe.
 //
-// OnewayInboundMiddleware is re-used across requests and MAY be called
+// OnewayInbound is re-used across requests and MAY be called
 // multiple times for the same request.
-type OnewayInboundMiddleware interface {
+type OnewayInbound interface {
 	HandleOneway(ctx context.Context, req *transport.Request, h transport.OnewayHandler) error
 }
 
-// NopOnewayInboundMiddleware is an inbound middleware that does not do
+// NopOnewayInbound is an inbound middleware that does not do
 // anything special. It simply calls the underlying OnewayHandler.
-var NopOnewayInboundMiddleware OnewayInboundMiddleware = nopOnewayInboundMiddleware{}
+var NopOnewayInbound OnewayInbound = nopOnewayInbound{}
 
-// ApplyOnewayInboundMiddleware applies the given OnewayInboundMiddleware to
+// ApplyOnewayInbound applies the given OnewayInbound to
 // the given OnewayHandler.
-func ApplyOnewayInboundMiddleware(h transport.OnewayHandler, i OnewayInboundMiddleware) transport.OnewayHandler {
+func ApplyOnewayInbound(h transport.OnewayHandler, i OnewayInbound) transport.OnewayHandler {
 	if i == nil {
 		return h
 	}
 	return onewayHandlerWithMiddleware{h: h, i: i}
 }
 
-// OnewayInboundMiddlewareFunc adapts a function into a OnwayInboundMiddleware.
-type OnewayInboundMiddlewareFunc func(context.Context, *transport.Request, transport.OnewayHandler) error
+// OnewayInboundFunc adapts a function into a OnwayInboundMiddleware.
+type OnewayInboundFunc func(context.Context, *transport.Request, transport.OnewayHandler) error
 
-// HandleOneway for OnewayInboundMiddlewareFunc
-func (f OnewayInboundMiddlewareFunc) HandleOneway(ctx context.Context, req *transport.Request, h transport.OnewayHandler) error {
+// HandleOneway for OnewayInboundFunc
+func (f OnewayInboundFunc) HandleOneway(ctx context.Context, req *transport.Request, h transport.OnewayHandler) error {
 	return f(ctx, req, h)
 }
 
 type onewayHandlerWithMiddleware struct {
 	h transport.OnewayHandler
-	i OnewayInboundMiddleware
+	i OnewayInbound
 }
 
 func (h onewayHandlerWithMiddleware) HandleOneway(ctx context.Context, req *transport.Request) error {
 	return h.i.HandleOneway(ctx, req, h.h)
 }
 
-type nopOnewayInboundMiddleware struct{}
+type nopOnewayInbound struct{}
 
-func (nopOnewayInboundMiddleware) HandleOneway(ctx context.Context, req *transport.Request, handler transport.OnewayHandler) error {
+func (nopOnewayInbound) HandleOneway(ctx context.Context, req *transport.Request, handler transport.OnewayHandler) error {
 	return handler.HandleOneway(ctx, req)
 }

--- a/api/middleware/inbound.go
+++ b/api/middleware/inbound.go
@@ -29,7 +29,7 @@ import (
 // UnaryInbound defines a transport-level middleware for
 // `UnaryHandler`s.
 //
-// UnaryInbound MAY
+// UnaryInbound middleware MAY
 //
 // - change the context
 // - change the request
@@ -38,9 +38,9 @@ import (
 // - handle the returned error
 // - call the given handler zero or more times
 //
-// UnaryInbound MUST be thread-safe.
+// UnaryInbound middleware MUST be thread-safe.
 //
-// UnaryInbound is re-used across requests and MAY be called multiple times
+// UnaryInbound middleware is re-used across requests and MAY be called multiple times
 // for the same request.
 type UnaryInbound interface {
 	Handle(ctx context.Context, req *transport.Request, resw transport.ResponseWriter, h transport.UnaryHandler) error
@@ -84,16 +84,16 @@ func (nopUnaryInbound) Handle(ctx context.Context, req *transport.Request, resw 
 // OnewayInbound defines a transport-level middleware for
 // `OnewayHandler`s.
 //
-// OnewayInbound MAY
+// OnewayInbound middleware MAY
 //
 // - change the context
 // - change the request
 // - handle the returned error
 // - call the given handler zero or more times
 //
-// OnewayInbound MUST be thread-safe.
+// OnewayInbound middleware MUST be thread-safe.
 //
-// OnewayInbound is re-used across requests and MAY be called
+// OnewayInbound middleware is re-used across requests and MAY be called
 // multiple times for the same request.
 type OnewayInbound interface {
 	HandleOneway(ctx context.Context, req *transport.Request, h transport.OnewayHandler) error
@@ -103,7 +103,7 @@ type OnewayInbound interface {
 // anything special. It simply calls the underlying OnewayHandler.
 var NopOnewayInbound OnewayInbound = nopOnewayInbound{}
 
-// ApplyOnewayInbound applies the given OnewayInbound to
+// ApplyOnewayInbound applies the given OnewayInbound middleware to
 // the given OnewayHandler.
 func ApplyOnewayInbound(h transport.OnewayHandler, i OnewayInbound) transport.OnewayHandler {
 	if i == nil {
@@ -112,7 +112,7 @@ func ApplyOnewayInbound(h transport.OnewayHandler, i OnewayInbound) transport.On
 	return onewayHandlerWithMiddleware{h: h, i: i}
 }
 
-// OnewayInboundFunc adapts a function into a OnwayInboundMiddleware.
+// OnewayInboundFunc adapts a function into a OnewayInbound Middleware.
 type OnewayInboundFunc func(context.Context, *transport.Request, transport.OnewayHandler) error
 
 // HandleOneway for OnewayInboundFunc

--- a/api/middleware/outbound.go
+++ b/api/middleware/outbound.go
@@ -26,10 +26,10 @@ import (
 	"go.uber.org/yarpc/api/transport"
 )
 
-// UnaryOutboundMiddleware defines transport-level middleware for
+// UnaryOutbound defines transport-level middleware for
 // `UnaryOutbound`s.
 //
-// UnaryOutboundMiddleware MAY
+// UnaryOutbound MAY
 //
 // - change the context
 // - change the request
@@ -37,41 +37,41 @@ import (
 // - handle the returned error
 // - call the given outbound zero or more times
 //
-// UnaryOutboundMiddleware MUST
+// UnaryOutbound MUST
 //
 // - always return a non-nil Response or error.
 // - be thread-safe
 //
-// UnaryOutboundMiddleware is re-used across requests and MAY be called
+// UnaryOutbound is re-used across requests and MAY be called
 // multiple times on the same request.
-type UnaryOutboundMiddleware interface {
+type UnaryOutbound interface {
 	Call(ctx context.Context, request *transport.Request, out transport.UnaryOutbound) (*transport.Response, error)
 }
 
-// NopUnaryOutboundMiddleware is a unary outbound middleware that does not do
+// NopUnaryOutbound is a unary outbound middleware that does not do
 // anything special. It simply calls the underlying UnaryOutbound.
-var NopUnaryOutboundMiddleware UnaryOutboundMiddleware = nopUnaryOutboundMiddleware{}
+var NopUnaryOutbound UnaryOutbound = nopUnaryOutbound{}
 
-// ApplyUnaryOutboundMiddleware applies the given UnaryOutboundMiddleware to
+// ApplyUnaryOutbound applies the given UnaryOutbound to
 // the given UnaryOutbound.
-func ApplyUnaryOutboundMiddleware(o transport.UnaryOutbound, f UnaryOutboundMiddleware) transport.UnaryOutbound {
+func ApplyUnaryOutbound(o transport.UnaryOutbound, f UnaryOutbound) transport.UnaryOutbound {
 	if f == nil {
 		return o
 	}
 	return unaryOutboundWithMiddleware{o: o, f: f}
 }
 
-// UnaryOutboundMiddlewareFunc adapts a function into a UnaryOutboundMiddleware.
-type UnaryOutboundMiddlewareFunc func(context.Context, *transport.Request, transport.UnaryOutbound) (*transport.Response, error)
+// UnaryOutboundFunc adapts a function into a UnaryOutbound.
+type UnaryOutboundFunc func(context.Context, *transport.Request, transport.UnaryOutbound) (*transport.Response, error)
 
-// Call for UnaryOutboundMiddlewareFunc.
-func (f UnaryOutboundMiddlewareFunc) Call(ctx context.Context, request *transport.Request, out transport.UnaryOutbound) (*transport.Response, error) {
+// Call for UnaryOutboundFunc.
+func (f UnaryOutboundFunc) Call(ctx context.Context, request *transport.Request, out transport.UnaryOutbound) (*transport.Response, error) {
 	return f(ctx, request, out)
 }
 
 type unaryOutboundWithMiddleware struct {
 	o transport.UnaryOutbound
-	f UnaryOutboundMiddleware
+	f UnaryOutbound
 }
 
 func (fo unaryOutboundWithMiddleware) Transports() []transport.Transport {
@@ -90,15 +90,15 @@ func (fo unaryOutboundWithMiddleware) Call(ctx context.Context, request *transpo
 	return fo.f.Call(ctx, request, fo.o)
 }
 
-type nopUnaryOutboundMiddleware struct{}
+type nopUnaryOutbound struct{}
 
-func (nopUnaryOutboundMiddleware) Call(ctx context.Context, request *transport.Request, out transport.UnaryOutbound) (*transport.Response, error) {
+func (nopUnaryOutbound) Call(ctx context.Context, request *transport.Request, out transport.UnaryOutbound) (*transport.Response, error) {
 	return out.Call(ctx, request)
 }
 
-// OnewayOutboundMiddleware defines transport-level middleware for `OnewayOutbound`s.
+// OnewayOutbound defines transport-level middleware for `OnewayOutbound`s.
 //
-// OnewayOutboundMiddleware MAY
+// OnewayOutbound MAY
 //
 // - change the context
 // - change the request
@@ -106,41 +106,41 @@ func (nopUnaryOutboundMiddleware) Call(ctx context.Context, request *transport.R
 // - handle the returned error
 // - call the given outbound zero or more times
 //
-// OnewayOutboundMiddleware MUST
+// OnewayOutbound MUST
 //
 // - always return an Ack (nil or not) or an error.
 // - be thread-safe
 //
-// OnewayOutboundMiddleware is re-used across requests and MAY be called
+// OnewayOutbound is re-used across requests and MAY be called
 // multiple times on the same request.
-type OnewayOutboundMiddleware interface {
+type OnewayOutbound interface {
 	CallOneway(ctx context.Context, request *transport.Request, out transport.OnewayOutbound) (transport.Ack, error)
 }
 
-// NopOnewayOutboundMiddleware is a oneway outbound middleware that does not do
+// NopOnewayOutbound is a oneway outbound middleware that does not do
 // anything special. It simply calls the underlying OnewayOutbound.
-var NopOnewayOutboundMiddleware OnewayOutboundMiddleware = nopOnewayOutboundMiddleware{}
+var NopOnewayOutbound OnewayOutbound = nopOnewayOutbound{}
 
-// ApplyOnewayOutboundMiddleware applies the given OnewayOutboundMiddleware to
+// ApplyOnewayOutbound applies the given OnewayOutbound to
 // the given OnewayOutbound.
-func ApplyOnewayOutboundMiddleware(o transport.OnewayOutbound, f OnewayOutboundMiddleware) transport.OnewayOutbound {
+func ApplyOnewayOutbound(o transport.OnewayOutbound, f OnewayOutbound) transport.OnewayOutbound {
 	if f == nil {
 		return o
 	}
 	return onewayOutboundWithMiddleware{o: o, f: f}
 }
 
-// OnewayOutboundMiddlewareFunc adapts a function into a OnewayOutboundMiddleware.
-type OnewayOutboundMiddlewareFunc func(context.Context, *transport.Request, transport.OnewayOutbound) (transport.Ack, error)
+// OnewayOutboundFunc adapts a function into a OnewayOutbound.
+type OnewayOutboundFunc func(context.Context, *transport.Request, transport.OnewayOutbound) (transport.Ack, error)
 
-// CallOneway for OnewayOutboundMiddlewareFunc.
-func (f OnewayOutboundMiddlewareFunc) CallOneway(ctx context.Context, request *transport.Request, out transport.OnewayOutbound) (transport.Ack, error) {
+// CallOneway for OnewayOutboundFunc.
+func (f OnewayOutboundFunc) CallOneway(ctx context.Context, request *transport.Request, out transport.OnewayOutbound) (transport.Ack, error) {
 	return f(ctx, request, out)
 }
 
 type onewayOutboundWithMiddleware struct {
 	o transport.OnewayOutbound
-	f OnewayOutboundMiddleware
+	f OnewayOutbound
 }
 
 func (fo onewayOutboundWithMiddleware) Transports() []transport.Transport {
@@ -159,8 +159,8 @@ func (fo onewayOutboundWithMiddleware) CallOneway(ctx context.Context, request *
 	return fo.f.CallOneway(ctx, request, fo.o)
 }
 
-type nopOnewayOutboundMiddleware struct{}
+type nopOnewayOutbound struct{}
 
-func (nopOnewayOutboundMiddleware) CallOneway(ctx context.Context, request *transport.Request, out transport.OnewayOutbound) (transport.Ack, error) {
+func (nopOnewayOutbound) CallOneway(ctx context.Context, request *transport.Request, out transport.OnewayOutbound) (transport.Ack, error) {
 	return out.CallOneway(ctx, request)
 }

--- a/api/middleware/outbound.go
+++ b/api/middleware/outbound.go
@@ -29,7 +29,7 @@ import (
 // UnaryOutbound defines transport-level middleware for
 // `UnaryOutbound`s.
 //
-// UnaryOutbound MAY
+// UnaryOutbound middleware MAY
 //
 // - change the context
 // - change the request
@@ -37,12 +37,12 @@ import (
 // - handle the returned error
 // - call the given outbound zero or more times
 //
-// UnaryOutbound MUST
+// UnaryOutbound middleware MUST
 //
 // - always return a non-nil Response or error.
 // - be thread-safe
 //
-// UnaryOutbound is re-used across requests and MAY be called
+// UnaryOutbound middleware is re-used across requests and MAY be called
 // multiple times on the same request.
 type UnaryOutbound interface {
 	Call(ctx context.Context, request *transport.Request, out transport.UnaryOutbound) (*transport.Response, error)
@@ -52,8 +52,8 @@ type UnaryOutbound interface {
 // anything special. It simply calls the underlying UnaryOutbound.
 var NopUnaryOutbound UnaryOutbound = nopUnaryOutbound{}
 
-// ApplyUnaryOutbound applies the given UnaryOutbound to
-// the given UnaryOutbound.
+// ApplyUnaryOutbound applies the given UnaryOutbound middleware to
+// the given UnaryOutbound transport.
 func ApplyUnaryOutbound(o transport.UnaryOutbound, f UnaryOutbound) transport.UnaryOutbound {
 	if f == nil {
 		return o
@@ -61,7 +61,7 @@ func ApplyUnaryOutbound(o transport.UnaryOutbound, f UnaryOutbound) transport.Un
 	return unaryOutboundWithMiddleware{o: o, f: f}
 }
 
-// UnaryOutboundFunc adapts a function into a UnaryOutbound.
+// UnaryOutboundFunc adapts a function into a UnaryOutbound middleware.
 type UnaryOutboundFunc func(context.Context, *transport.Request, transport.UnaryOutbound) (*transport.Response, error)
 
 // Call for UnaryOutboundFunc.
@@ -98,7 +98,7 @@ func (nopUnaryOutbound) Call(ctx context.Context, request *transport.Request, ou
 
 // OnewayOutbound defines transport-level middleware for `OnewayOutbound`s.
 //
-// OnewayOutbound MAY
+// OnewayOutbound middleware MAY
 //
 // - change the context
 // - change the request
@@ -106,23 +106,23 @@ func (nopUnaryOutbound) Call(ctx context.Context, request *transport.Request, ou
 // - handle the returned error
 // - call the given outbound zero or more times
 //
-// OnewayOutbound MUST
+// OnewayOutbound middleware MUST
 //
 // - always return an Ack (nil or not) or an error.
 // - be thread-safe
 //
-// OnewayOutbound is re-used across requests and MAY be called
+// OnewayOutbound middleware is re-used across requests and MAY be called
 // multiple times on the same request.
 type OnewayOutbound interface {
 	CallOneway(ctx context.Context, request *transport.Request, out transport.OnewayOutbound) (transport.Ack, error)
 }
 
 // NopOnewayOutbound is a oneway outbound middleware that does not do
-// anything special. It simply calls the underlying OnewayOutbound.
+// anything special. It simply calls the underlying OnewayOutbound transport.
 var NopOnewayOutbound OnewayOutbound = nopOnewayOutbound{}
 
-// ApplyOnewayOutbound applies the given OnewayOutbound to
-// the given OnewayOutbound.
+// ApplyOnewayOutbound applies the given OnewayOutbound middleware to
+// the given OnewayOutbound transport.
 func ApplyOnewayOutbound(o transport.OnewayOutbound, f OnewayOutbound) transport.OnewayOutbound {
 	if f == nil {
 		return o
@@ -130,7 +130,7 @@ func ApplyOnewayOutbound(o transport.OnewayOutbound, f OnewayOutbound) transport
 	return onewayOutboundWithMiddleware{o: o, f: f}
 }
 
-// OnewayOutboundFunc adapts a function into a OnewayOutbound.
+// OnewayOutboundFunc adapts a function into a OnewayOutbound middleware.
 type OnewayOutboundFunc func(context.Context, *transport.Request, transport.OnewayOutbound) (transport.Ack, error)
 
 // CallOneway for OnewayOutboundFunc.

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -73,14 +73,14 @@ type Outbounds map[string]transport.Outbounds
 
 // OutboundMiddleware contains the different type of outbound middleware
 type OutboundMiddleware struct {
-	Unary  middleware.UnaryOutboundMiddleware
-	Oneway middleware.OnewayOutboundMiddleware
+	Unary  middleware.UnaryOutbound
+	Oneway middleware.OnewayOutbound
 }
 
 // InboundMiddleware contains the different type of inbound middleware
 type InboundMiddleware struct {
-	Unary  middleware.UnaryInboundMiddleware
-	Oneway middleware.OnewayInboundMiddleware
+	Unary  middleware.UnaryInbound
+	Oneway middleware.OnewayInbound
 }
 
 // NewDispatcher builds a new Dispatcher using the specified Config.
@@ -115,12 +115,12 @@ func convertOutbounds(outbounds Outbounds, mw OutboundMiddleware) Outbounds {
 
 		// apply outbound middleware and create ValidatorOutbounds
 		if outs.Unary != nil {
-			unaryOutbound = middleware.ApplyUnaryOutboundMiddleware(outs.Unary, mw.Unary)
+			unaryOutbound = middleware.ApplyUnaryOutbound(outs.Unary, mw.Unary)
 			unaryOutbound = request.UnaryValidatorOutbound{UnaryOutbound: unaryOutbound}
 		}
 
 		if outs.Oneway != nil {
-			onewayOutbound = middleware.ApplyOnewayOutboundMiddleware(outs.Oneway, mw.Oneway)
+			onewayOutbound = middleware.ApplyOnewayOutbound(outs.Oneway, mw.Oneway)
 			onewayOutbound = request.OnewayValidatorOutbound{OnewayOutbound: outs.Oneway}
 		}
 
@@ -209,11 +209,11 @@ func (d *Dispatcher) Register(rs []transport.Registrant) {
 	for _, r := range rs {
 		switch r.HandlerSpec.Type() {
 		case transport.Unary:
-			h := middleware.ApplyUnaryInboundMiddleware(r.HandlerSpec.Unary(),
+			h := middleware.ApplyUnaryInbound(r.HandlerSpec.Unary(),
 				d.InboundMiddleware.Unary)
 			r.HandlerSpec = transport.NewUnaryHandlerSpec(h)
 		case transport.Oneway:
-			h := middleware.ApplyOnewayInboundMiddleware(r.HandlerSpec.Oneway(),
+			h := middleware.ApplyOnewayInbound(r.HandlerSpec.Oneway(),
 				d.InboundMiddleware.Oneway)
 			r.HandlerSpec = transport.NewOnewayHandlerSpec(h)
 		default:

--- a/examples/json/client/main.go
+++ b/examples/json/client/main.go
@@ -109,7 +109,7 @@ func main() {
 			},
 		},
 		OutboundMiddleware: yarpc.OutboundMiddleware{
-			Unary: yarpc.UnaryOutboundMiddleware(requestLogOutboundMiddleware{}),
+			Unary: yarpc.UnaryOutbound(requestLogOutboundMiddleware{}),
 		},
 	})
 	if err := dispatcher.Start(); err != nil {

--- a/examples/json/client/main.go
+++ b/examples/json/client/main.go
@@ -109,7 +109,7 @@ func main() {
 			},
 		},
 		OutboundMiddleware: yarpc.OutboundMiddleware{
-			Unary: yarpc.UnaryOutbound(requestLogOutboundMiddleware{}),
+			Unary: yarpc.UnaryOutboundMiddleware(requestLogOutboundMiddleware{}),
 		},
 	})
 	if err := dispatcher.Start(); err != nil {

--- a/examples/thrift/keyvalue/client/cache.go
+++ b/examples/thrift/keyvalue/client/cache.go
@@ -32,7 +32,7 @@ import (
 
 // CacheOutboundMiddleware is a OutboundMiddleware
 type CacheOutboundMiddleware interface {
-	middleware.UnaryOutboundMiddleware
+	middleware.UnaryOutbound
 
 	Invalidate()
 }

--- a/internal/inboundmiddleware/chain.go
+++ b/internal/inboundmiddleware/chain.go
@@ -27,11 +27,11 @@ import (
 	"go.uber.org/yarpc/api/transport"
 )
 
-// UnaryChain combines a series of `UnaryInboundMiddleware`s into a single `InboundMiddleware`.
-func UnaryChain(mw ...middleware.UnaryInboundMiddleware) middleware.UnaryInboundMiddleware {
+// UnaryChain combines a series of `UnaryInbound`s into a single `InboundMiddleware`.
+func UnaryChain(mw ...middleware.UnaryInbound) middleware.UnaryInbound {
 	switch len(mw) {
 	case 0:
-		return middleware.NopUnaryInboundMiddleware
+		return middleware.NopUnaryInbound
 	case 1:
 		return mw[0]
 	default:
@@ -39,19 +39,19 @@ func UnaryChain(mw ...middleware.UnaryInboundMiddleware) middleware.UnaryInbound
 	}
 }
 
-type unaryChain []middleware.UnaryInboundMiddleware
+type unaryChain []middleware.UnaryInbound
 
 func (c unaryChain) Handle(ctx context.Context, req *transport.Request, resw transport.ResponseWriter, h transport.UnaryHandler) error {
 	return unaryChainExec{
-		Chain: []middleware.UnaryInboundMiddleware(c),
+		Chain: []middleware.UnaryInbound(c),
 		Final: h,
 	}.Handle(ctx, req, resw)
 }
 
-// unaryChainExec adapts a series of `UnaryInboundMiddleware`s into a UnaryHandler.
+// unaryChainExec adapts a series of `UnaryInbound`s into a UnaryHandler.
 // It is scoped to a single request to the `Handler` and is not thread-safe.
 type unaryChainExec struct {
-	Chain []middleware.UnaryInboundMiddleware
+	Chain []middleware.UnaryInbound
 	Final transport.UnaryHandler
 }
 
@@ -64,11 +64,11 @@ func (x unaryChainExec) Handle(ctx context.Context, req *transport.Request, resw
 	return next.Handle(ctx, req, resw, x)
 }
 
-// OnewayChain combines a series of `OnewayInboundMiddleware`s into a single `InboundMiddleware`.
-func OnewayChain(mw ...middleware.OnewayInboundMiddleware) middleware.OnewayInboundMiddleware {
+// OnewayChain combines a series of `OnewayInbound`s into a single `InboundMiddleware`.
+func OnewayChain(mw ...middleware.OnewayInbound) middleware.OnewayInbound {
 	switch len(mw) {
 	case 0:
-		return middleware.NopOnewayInboundMiddleware
+		return middleware.NopOnewayInbound
 	case 1:
 		return mw[0]
 	default:
@@ -76,19 +76,19 @@ func OnewayChain(mw ...middleware.OnewayInboundMiddleware) middleware.OnewayInbo
 	}
 }
 
-type onewayChain []middleware.OnewayInboundMiddleware
+type onewayChain []middleware.OnewayInbound
 
 func (c onewayChain) HandleOneway(ctx context.Context, req *transport.Request, h transport.OnewayHandler) error {
 	return onewayChainExec{
-		Chain: []middleware.OnewayInboundMiddleware(c),
+		Chain: []middleware.OnewayInbound(c),
 		Final: h,
 	}.HandleOneway(ctx, req)
 }
 
-// onewayChainExec adapts a series of `OnewayInboundMiddleware`s into a OnewayHandler.
+// onewayChainExec adapts a series of `OnewayInbound`s into a OnewayHandler.
 // It is scoped to a single request to the `Handler` and is not thread-safe.
 type onewayChainExec struct {
-	Chain []middleware.OnewayInboundMiddleware
+	Chain []middleware.OnewayInbound
 	Final transport.OnewayHandler
 }
 

--- a/internal/inboundmiddleware/chain_test.go
+++ b/internal/inboundmiddleware/chain_test.go
@@ -48,7 +48,7 @@ func (c *countInboundMiddleware) HandleOneway(ctx context.Context, req *transpor
 	return h.HandleOneway(ctx, req)
 }
 
-var retryUnaryInboundMiddleware middleware.UnaryInboundMiddlewareFunc = func(
+var retryUnaryInbound middleware.UnaryInboundFunc = func(
 	ctx context.Context, req *transport.Request, resw transport.ResponseWriter, h transport.UnaryHandler) error {
 	if err := h.Handle(ctx, req, resw); err != nil {
 		return h.Handle(ctx, req, resw)
@@ -78,8 +78,8 @@ func TestUnaryChain(t *testing.T) {
 
 	before := &countInboundMiddleware{}
 	after := &countInboundMiddleware{}
-	err := middleware.ApplyUnaryInboundMiddleware(
-		h, UnaryChain(before, retryUnaryInboundMiddleware, after),
+	err := middleware.ApplyUnaryInbound(
+		h, UnaryChain(before, retryUnaryInbound, after),
 	).Handle(ctx, req, resw)
 
 	assert.NoError(t, err, "expected success")
@@ -87,7 +87,7 @@ func TestUnaryChain(t *testing.T) {
 	assert.Equal(t, 2, after.Count, "expected inner inbound middleware to be called twice")
 }
 
-var retryOnewayInboundMiddleware middleware.OnewayInboundMiddlewareFunc = func(
+var retryOnewayInbound middleware.OnewayInboundFunc = func(
 	ctx context.Context, req *transport.Request, h transport.OnewayHandler) error {
 	if err := h.HandleOneway(ctx, req); err != nil {
 		return h.HandleOneway(ctx, req)
@@ -116,8 +116,8 @@ func TestOnewayChain(t *testing.T) {
 
 	before := &countInboundMiddleware{}
 	after := &countInboundMiddleware{}
-	err := middleware.ApplyOnewayInboundMiddleware(
-		h, OnewayChain(before, retryOnewayInboundMiddleware, after),
+	err := middleware.ApplyOnewayInbound(
+		h, OnewayChain(before, retryOnewayInbound, after),
 	).HandleOneway(ctx, req)
 
 	assert.NoError(t, err, "expected success")

--- a/internal/outboundmiddleware/chain.go
+++ b/internal/outboundmiddleware/chain.go
@@ -27,11 +27,11 @@ import (
 	"go.uber.org/yarpc/api/transport"
 )
 
-// UnaryChain combines a series of `UnaryOutboundMiddleware`s into a single `UnaryOutboundMiddleware`.
-func UnaryChain(mw ...middleware.UnaryOutboundMiddleware) middleware.UnaryOutboundMiddleware {
+// UnaryChain combines a series of `UnaryOutbound`s into a single `UnaryOutbound`.
+func UnaryChain(mw ...middleware.UnaryOutbound) middleware.UnaryOutbound {
 	switch len(mw) {
 	case 0:
-		return middleware.NopUnaryOutboundMiddleware
+		return middleware.NopUnaryOutbound
 	case 1:
 		return mw[0]
 	default:
@@ -39,19 +39,19 @@ func UnaryChain(mw ...middleware.UnaryOutboundMiddleware) middleware.UnaryOutbou
 	}
 }
 
-type unaryChain []middleware.UnaryOutboundMiddleware
+type unaryChain []middleware.UnaryOutbound
 
 func (c unaryChain) Call(ctx context.Context, request *transport.Request, out transport.UnaryOutbound) (*transport.Response, error) {
 	return unaryChainExec{
-		Chain: []middleware.UnaryOutboundMiddleware(c),
+		Chain: []middleware.UnaryOutbound(c),
 		Final: out,
 	}.Call(ctx, request)
 }
 
-// unaryChainExec adapts a series of `UnaryOutboundMiddleware`s into a `UnaryOutbound`. It
+// unaryChainExec adapts a series of `UnaryOutbound`s into a `UnaryOutbound`. It
 // is scoped to a single call of a UnaryOutbound and is not thread-safe.
 type unaryChainExec struct {
-	Chain []middleware.UnaryOutboundMiddleware
+	Chain []middleware.UnaryOutbound
 	Final transport.UnaryOutbound
 }
 
@@ -76,11 +76,11 @@ func (x unaryChainExec) Call(ctx context.Context, request *transport.Request) (*
 	return next.Call(ctx, request, x)
 }
 
-// OnewayChain combines a series of `OnewayOutboundMiddleware`s into a single `OnewayOutboundMiddleware`.
-func OnewayChain(mw ...middleware.OnewayOutboundMiddleware) middleware.OnewayOutboundMiddleware {
+// OnewayChain combines a series of `OnewayOutbound`s into a single `OnewayOutbound`.
+func OnewayChain(mw ...middleware.OnewayOutbound) middleware.OnewayOutbound {
 	switch len(mw) {
 	case 0:
-		return middleware.NopOnewayOutboundMiddleware
+		return middleware.NopOnewayOutbound
 	case 1:
 		return mw[0]
 	default:
@@ -88,19 +88,19 @@ func OnewayChain(mw ...middleware.OnewayOutboundMiddleware) middleware.OnewayOut
 	}
 }
 
-type onewayChain []middleware.OnewayOutboundMiddleware
+type onewayChain []middleware.OnewayOutbound
 
 func (c onewayChain) CallOneway(ctx context.Context, request *transport.Request, out transport.OnewayOutbound) (transport.Ack, error) {
 	return onewayChainExec{
-		Chain: []middleware.OnewayOutboundMiddleware(c),
+		Chain: []middleware.OnewayOutbound(c),
 		Final: out,
 	}.CallOneway(ctx, request)
 }
 
-// onewayChainExec adapts a series of `OnewayOutboundMiddleware`s into a `OnewayOutbound`. It
+// onewayChainExec adapts a series of `OnewayOutbound`s into a `OnewayOutbound`. It
 // is scoped to a single call of a OnewayOutbound and is not thread-safe.
 type onewayChainExec struct {
-	Chain []middleware.OnewayOutboundMiddleware
+	Chain []middleware.OnewayOutbound
 	Final transport.OnewayOutbound
 }
 

--- a/internal/outboundmiddleware/chain_test.go
+++ b/internal/outboundmiddleware/chain_test.go
@@ -49,7 +49,7 @@ func (c *countOutboundMiddleware) CallOneway(ctx context.Context, req *transport
 	return o.CallOneway(ctx, req)
 }
 
-var retryUnaryOutboundMiddleware middleware.UnaryOutboundMiddlewareFunc = func(
+var retryUnaryOutbound middleware.UnaryOutboundFunc = func(
 	ctx context.Context, req *transport.Request, o transport.UnaryOutbound) (*transport.Response, error) {
 	res, err := o.Call(ctx, req)
 	if err != nil {
@@ -82,8 +82,8 @@ func TestUnaryChain(t *testing.T) {
 
 	before := &countOutboundMiddleware{}
 	after := &countOutboundMiddleware{}
-	gotRes, err := middleware.ApplyUnaryOutboundMiddleware(
-		o, UnaryChain(before, retryUnaryOutboundMiddleware, after)).Call(ctx, req)
+	gotRes, err := middleware.ApplyUnaryOutbound(
+		o, UnaryChain(before, retryUnaryOutbound, after)).Call(ctx, req)
 
 	assert.NoError(t, err, "expected success")
 	assert.Equal(t, 1, before.Count, "expected outer middleware to be called once")
@@ -91,7 +91,7 @@ func TestUnaryChain(t *testing.T) {
 	assert.Equal(t, res, gotRes, "expected response to match")
 }
 
-var retryOnewayOutboundMiddleware middleware.OnewayOutboundMiddlewareFunc = func(
+var retryOnewayOutbound middleware.OnewayOutboundFunc = func(
 	ctx context.Context, req *transport.Request, o transport.OnewayOutbound) (transport.Ack, error) {
 	res, err := o.CallOneway(ctx, req)
 	if err != nil {
@@ -122,8 +122,8 @@ func TestOnewayChain(t *testing.T) {
 
 	before := &countOutboundMiddleware{}
 	after := &countOutboundMiddleware{}
-	gotRes, err := middleware.ApplyOnewayOutboundMiddleware(
-		o, OnewayChain(before, retryOnewayOutboundMiddleware, after)).CallOneway(ctx, req)
+	gotRes, err := middleware.ApplyOnewayOutbound(
+		o, OnewayChain(before, retryOnewayOutbound, after)).CallOneway(ctx, req)
 
 	assert.NoError(t, err, "expected success")
 	assert.Equal(t, 1, before.Count, "expected outer middleware to be called once")

--- a/middleware.go
+++ b/middleware.go
@@ -26,26 +26,26 @@ import (
 	"go.uber.org/yarpc/internal/outboundmiddleware"
 )
 
-// UnaryOutboundMiddleware combines the given collection of unary outbound
-// middleware in-order into a single UnaryOutboundMiddleware.
-func UnaryOutboundMiddleware(mw ...middleware.UnaryOutboundMiddleware) middleware.UnaryOutboundMiddleware {
+// UnaryOutbound combines the given collection of unary outbound
+// middleware in-order into a single UnaryOutbound.
+func UnaryOutbound(mw ...middleware.UnaryOutbound) middleware.UnaryOutbound {
 	return outboundmiddleware.UnaryChain(mw...)
 }
 
-// UnaryInboundMiddleware combines the given collection of unary inbound
-// middleware in-order into a single UnaryInboundMiddleware.
-func UnaryInboundMiddleware(mw ...middleware.UnaryInboundMiddleware) middleware.UnaryInboundMiddleware {
+// UnaryInbound combines the given collection of unary inbound
+// middleware in-order into a single UnaryInbound.
+func UnaryInbound(mw ...middleware.UnaryInbound) middleware.UnaryInbound {
 	return inboundmiddleware.UnaryChain(mw...)
 }
 
-// OnewayOutboundMiddleware combines the given collection of unary outbound
-// middleware in-order into a single OnewayOutboundMiddleware.
-func OnewayOutboundMiddleware(mw ...middleware.OnewayOutboundMiddleware) middleware.OnewayOutboundMiddleware {
+// OnewayOutbound combines the given collection of unary outbound
+// middleware in-order into a single OnewayOutbound.
+func OnewayOutbound(mw ...middleware.OnewayOutbound) middleware.OnewayOutbound {
 	return outboundmiddleware.OnewayChain(mw...)
 }
 
-// OnewayInboundMiddleware combines the given collection of unary inbound
-// middleware in-order into a single OnewayInboundMiddleware.
-func OnewayInboundMiddleware(mw ...middleware.OnewayInboundMiddleware) middleware.OnewayInboundMiddleware {
+// OnewayInbound combines the given collection of unary inbound
+// middleware in-order into a single OnewayInbound.
+func OnewayInbound(mw ...middleware.OnewayInbound) middleware.OnewayInbound {
 	return inboundmiddleware.OnewayChain(mw...)
 }

--- a/middleware.go
+++ b/middleware.go
@@ -26,26 +26,26 @@ import (
 	"go.uber.org/yarpc/internal/outboundmiddleware"
 )
 
-// UnaryOutbound combines the given collection of unary outbound
+// UnaryOutboundMiddleware combines the given collection of unary outbound
 // middleware in-order into a single UnaryOutbound.
-func UnaryOutbound(mw ...middleware.UnaryOutbound) middleware.UnaryOutbound {
+func UnaryOutboundMiddleware(mw ...middleware.UnaryOutbound) middleware.UnaryOutbound {
 	return outboundmiddleware.UnaryChain(mw...)
 }
 
-// UnaryInbound combines the given collection of unary inbound
+// UnaryInboundMiddleware combines the given collection of unary inbound
 // middleware in-order into a single UnaryInbound.
-func UnaryInbound(mw ...middleware.UnaryInbound) middleware.UnaryInbound {
+func UnaryInboundMiddleware(mw ...middleware.UnaryInbound) middleware.UnaryInbound {
 	return inboundmiddleware.UnaryChain(mw...)
 }
 
-// OnewayOutbound combines the given collection of unary outbound
+// OnewayOutboundMiddleware combines the given collection of unary outbound
 // middleware in-order into a single OnewayOutbound.
-func OnewayOutbound(mw ...middleware.OnewayOutbound) middleware.OnewayOutbound {
+func OnewayOutboundMiddleware(mw ...middleware.OnewayOutbound) middleware.OnewayOutbound {
 	return outboundmiddleware.OnewayChain(mw...)
 }
 
-// OnewayInbound combines the given collection of unary inbound
+// OnewayInboundMiddleware combines the given collection of unary inbound
 // middleware in-order into a single OnewayInbound.
-func OnewayInbound(mw ...middleware.OnewayInbound) middleware.OnewayInbound {
+func OnewayInboundMiddleware(mw ...middleware.OnewayInbound) middleware.OnewayInbound {
 	return inboundmiddleware.OnewayChain(mw...)
 }

--- a/middleware.go
+++ b/middleware.go
@@ -27,25 +27,25 @@ import (
 )
 
 // UnaryOutboundMiddleware combines the given collection of unary outbound
-// middleware in-order into a single UnaryOutbound.
+// middleware in-order into a single UnaryOutbound middleware.
 func UnaryOutboundMiddleware(mw ...middleware.UnaryOutbound) middleware.UnaryOutbound {
 	return outboundmiddleware.UnaryChain(mw...)
 }
 
 // UnaryInboundMiddleware combines the given collection of unary inbound
-// middleware in-order into a single UnaryInbound.
+// middleware in-order into a single UnaryInbound middleware.
 func UnaryInboundMiddleware(mw ...middleware.UnaryInbound) middleware.UnaryInbound {
 	return inboundmiddleware.UnaryChain(mw...)
 }
 
 // OnewayOutboundMiddleware combines the given collection of unary outbound
-// middleware in-order into a single OnewayOutbound.
+// middleware in-order into a single OnewayOutbound middleware.
 func OnewayOutboundMiddleware(mw ...middleware.OnewayOutbound) middleware.OnewayOutbound {
 	return outboundmiddleware.OnewayChain(mw...)
 }
 
 // OnewayInboundMiddleware combines the given collection of unary inbound
-// middleware in-order into a single OnewayInbound.
+// middleware in-order into a single OnewayInbound middleware.
 func OnewayInboundMiddleware(mw ...middleware.OnewayInbound) middleware.OnewayInbound {
 	return inboundmiddleware.OnewayChain(mw...)
 }


### PR DESCRIPTION
Summary: When we moved middleware out of transport we(I) didn't rename
the interfaces and structs, this diff updates the names

Task: #566