### PR TITLE
Simplify propagation APIs

### DIFF
--- a/api/transport/propagation.go
+++ b/api/transport/propagation.go
@@ -28,11 +28,11 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 )
 
-// CreateOpenTracingSpan is used to create a new context with a started span
+// CreateOpenTracingSpan creates a new context with a started span
 type CreateOpenTracingSpan struct {
 	Tracer        opentracing.Tracer
 	TransportName string
-	Start         time.Time
+	StartTime     time.Time
 }
 
 // Do creates a new context that has a reference to the started span.
@@ -48,7 +48,7 @@ func (c *CreateOpenTracingSpan) Do(
 
 	span := c.Tracer.StartSpan(
 		req.Procedure,
-		opentracing.StartTime(c.Start),
+		opentracing.StartTime(c.StartTime),
 		opentracing.ChildOf(parent),
 		opentracing.Tags{
 			"rpc.caller":    req.Caller,
@@ -64,12 +64,12 @@ func (c *CreateOpenTracingSpan) Do(
 	return ctx, span
 }
 
-// ExtractOpenTracingSpan is used to derive a context and associated span
+// ExtractOpenTracingSpan derives a context and associated span
 type ExtractOpenTracingSpan struct {
-	ParentSpanCtx opentracing.SpanContext
-	Tracer        opentracing.Tracer
-	TransportName string
-	Start         time.Time
+	ParentSpanContext opentracing.SpanContext
+	Tracer            opentracing.Tracer
+	TransportName     string
+	StartTime         time.Time
 }
 
 // Do derives a new context from SpanContext. The created context has a
@@ -81,7 +81,7 @@ func (e *ExtractOpenTracingSpan) Do(
 ) (context.Context, opentracing.Span) {
 	span := e.Tracer.StartSpan(
 		req.Procedure,
-		opentracing.StartTime(e.Start),
+		opentracing.StartTime(e.StartTime),
 		opentracing.Tags{
 			"rpc.caller":    req.Caller,
 			"rpc.service":   req.Service,
@@ -90,7 +90,7 @@ func (e *ExtractOpenTracingSpan) Do(
 		},
 		// parentSpanCtx may be nil
 		// this implies ChildOf
-		ext.RPCServerOption(e.ParentSpanCtx),
+		ext.RPCServerOption(e.ParentSpanContext),
 	)
 	ext.PeerService.Set(span, req.Caller)
 	ext.SpanKindRPCServer.Set(span)

--- a/serialize/serialize.go
+++ b/serialize/serialize.go
@@ -26,12 +26,12 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"go.uber.org/thriftrw/protocol"
-	"go.uber.org/thriftrw/wire"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/serialize/internal"
 
 	"github.com/opentracing/opentracing-go"
+	"go.uber.org/thriftrw/protocol"
+	"go.uber.org/thriftrw/wire"
 )
 
 // version indicates which underlying serialization method will be used

--- a/serialize/serialize_test.go
+++ b/serialize/serialize_test.go
@@ -105,12 +105,16 @@ func TestContextSerialization(t *testing.T) {
 		":)":    ":(",
 	}
 
-	_, span := transport.CreateOpenTracingSpan(
+	createOpenTracingSpan := transport.CreateOpenTracingSpan{
+		Tracer:        tracer,
+		TransportName: "fake-transport",
+		Start:         time.Now(),
+	}
+
+	_, span := createOpenTracingSpan.Do(
 		context.Background(),
 		req,
-		tracer,
-		"fake-transport",
-		time.Now())
+	)
 	addBaggage(span, baggage)
 	span.Finish()
 
@@ -122,13 +126,14 @@ func TestContextSerialization(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, span)
 
-	_, span = transport.ExtractOpenTracingSpan(
-		context.Background(),
-		spanContext,
-		req,
-		tracer,
-		"fake-transport",
-		time.Now())
+	extractOpenTracingSpan := transport.ExtractOpenTracingSpan{
+		ParentSpanCtx: spanContext,
+		Tracer:        tracer,
+		TransportName: "fake-transport",
+		Start:         time.Now(),
+	}
+
+	_, span = extractOpenTracingSpan.Do(context.Background(), req)
 	defer span.Finish()
 
 	assert.Equal(t, baggage, getBaggage(span))

--- a/serialize/serialize_test.go
+++ b/serialize/serialize_test.go
@@ -108,13 +108,10 @@ func TestContextSerialization(t *testing.T) {
 	createOpenTracingSpan := transport.CreateOpenTracingSpan{
 		Tracer:        tracer,
 		TransportName: "fake-transport",
-		Start:         time.Now(),
+		StartTime:     time.Now(),
 	}
 
-	_, span := createOpenTracingSpan.Do(
-		context.Background(),
-		req,
-	)
+	_, span := createOpenTracingSpan.Do(context.Background(), req)
 	addBaggage(span, baggage)
 	span.Finish()
 
@@ -127,10 +124,10 @@ func TestContextSerialization(t *testing.T) {
 	assert.NotNil(t, span)
 
 	extractOpenTracingSpan := transport.ExtractOpenTracingSpan{
-		ParentSpanCtx: spanContext,
-		Tracer:        tracer,
-		TransportName: "fake-transport",
-		Start:         time.Now(),
+		ParentSpanContext: spanContext,
+		Tracer:            tracer,
+		TransportName:     "fake-transport",
+		StartTime:         time.Now(),
 	}
 
 	_, span = extractOpenTracingSpan.Do(context.Background(), req)

--- a/transport/x/redis/inbound.go
+++ b/transport/x/redis/inbound.go
@@ -142,10 +142,10 @@ func (i *Inbound) handle() error {
 	}
 
 	extractOpenTracingSpan := transport.ExtractOpenTracingSpan{
-		ParentSpanCtx: spanContext,
-		Tracer:        i.tracer,
-		TransportName: transportName,
-		Start:         start,
+		ParentSpanContext: spanContext,
+		Tracer:            i.tracer,
+		TransportName:     transportName,
+		StartTime:         start,
 	}
 	ctx, span := extractOpenTracingSpan.Do(context.Background(), req)
 	defer span.Finish()

--- a/transport/x/redis/inbound.go
+++ b/transport/x/redis/inbound.go
@@ -141,7 +141,13 @@ func (i *Inbound) handle() error {
 		return err
 	}
 
-	ctx, span := transport.ExtractOpenTracingSpan(context.Background(), spanContext, req, i.tracer, transportName, start)
+	extractOpenTracingSpan := transport.ExtractOpenTracingSpan{
+		ParentSpanCtx: spanContext,
+		Tracer:        i.tracer,
+		TransportName: transportName,
+		Start:         start,
+	}
+	ctx, span := extractOpenTracingSpan.Do(context.Background(), req)
 	defer span.Finish()
 
 	v := request.Validator{Request: req}

--- a/transport/x/redis/outbound.go
+++ b/transport/x/redis/outbound.go
@@ -88,7 +88,12 @@ func (o *Outbound) CallOneway(ctx context.Context, req *transport.Request) (tran
 		return nil, errOutboundNotStarted
 	}
 
-	ctx, span := transport.CreateOpenTracingSpan(ctx, req, o.tracer, transportName, time.Now())
+	createOpenTracingSpan := transport.CreateOpenTracingSpan{
+		Tracer:        o.tracer,
+		TransportName: transportName,
+		Start:         time.Now(),
+	}
+	ctx, span := createOpenTracingSpan.Do(ctx, req)
 	defer span.Finish()
 
 	marshalledRPC, err := serialize.ToBytes(o.tracer, span.Context(), req)

--- a/transport/x/redis/outbound.go
+++ b/transport/x/redis/outbound.go
@@ -91,7 +91,7 @@ func (o *Outbound) CallOneway(ctx context.Context, req *transport.Request) (tran
 	createOpenTracingSpan := transport.CreateOpenTracingSpan{
 		Tracer:        o.tracer,
 		TransportName: transportName,
-		Start:         time.Now(),
+		StartTime:     time.Now(),
 	}
 	ctx, span := createOpenTracingSpan.Do(ctx, req)
 	defer span.Finish()


### PR DESCRIPTION
This reduces the number of arguments given to `CreateOpenTracingSpan`
and `ExtractOpenTracingSpan` to simplify the experience for transport
authors by introducing companion structs.

Fixes #572