### PR TITLE
Thread application error bit through HTTP inbound and outbound

### DIFF
--- a/api/transport/response.go
+++ b/api/transport/response.go
@@ -24,8 +24,9 @@ import "io"
 
 // Response is the low level response representation.
 type Response struct {
-	Headers Headers
-	Body    io.ReadCloser
+	Headers          Headers
+	Body             io.ReadCloser
+	ApplicationError bool
 }
 
 // ResponseWriter allows Handlers to write responses in a streaming fashion.

--- a/transport/http/constants.go
+++ b/transport/http/constants.go
@@ -61,6 +61,10 @@ const (
 	// whether the response body represents an application error.
 	ApplicationStatusHeader = "Rpc-Status"
 
+	// ApplicationSuccessStatus is the value for ApplicationStatusHeader for
+	// successful requests.
+	ApplicationSuccessStatus = "success"
+
 	// ApplicationErrorStatus is the value for ApplicationStatusHeader for
 	// errant requests.
 	ApplicationErrorStatus = "error"

--- a/transport/http/constants.go
+++ b/transport/http/constants.go
@@ -56,4 +56,12 @@ const (
 	// service that can proxy for the destined service and perform
 	// application-specific routing.
 	RoutingDelegateHeader = "Rpc-Routing-Delegate"
+
+	// ApplicationStatusHeader is the HTTP response header used to express
+	// whether the response body represents an application error.
+	ApplicationStatusHeader = "Rpc-Status"
+
+	// ApplicationErrorStatus is the value for ApplicationStatusHeader for
+	// errant requests.
+	ApplicationErrorStatus = "error"
 )

--- a/transport/http/handler.go
+++ b/transport/http/handler.go
@@ -197,6 +197,6 @@ func (rw responseWriter) AddHeaders(h transport.Headers) {
 	applicationHeaders.ToHTTPHeaders(h, rw.w.Header())
 }
 
-func (responseWriter) SetApplicationError() {
-	// Nothing to do.
+func (rw responseWriter) SetApplicationError() {
+	rw.w.Header().Add(ApplicationStatusHeader, ApplicationErrorStatus)
 }

--- a/transport/http/handler.go
+++ b/transport/http/handler.go
@@ -186,6 +186,7 @@ type responseWriter struct {
 }
 
 func newResponseWriter(w http.ResponseWriter) responseWriter {
+	w.Header().Set(ApplicationStatusHeader, ApplicationSuccessStatus)
 	return responseWriter{w: w}
 }
 
@@ -198,5 +199,5 @@ func (rw responseWriter) AddHeaders(h transport.Headers) {
 }
 
 func (rw responseWriter) SetApplicationError() {
-	rw.w.Header().Add(ApplicationStatusHeader, ApplicationErrorStatus)
+	rw.w.Header().Set(ApplicationStatusHeader, ApplicationErrorStatus)
 }

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -241,9 +241,11 @@ func (o *Outbound) callWithPeer(
 	if response.StatusCode >= 200 && response.StatusCode < 300 {
 		appHeaders := applicationHeaders.FromHTTPHeaders(
 			response.Header, transport.NewHeaders())
+		appError := response.Header.Get(ApplicationStatusHeader) != ApplicationErrorStatus
 		return &transport.Response{
-			Headers: appHeaders,
-			Body:    response.Body,
+			Headers:          appHeaders,
+			Body:             response.Body,
+			ApplicationError: appError,
 		}, nil
 	}
 

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -241,7 +241,7 @@ func (o *Outbound) callWithPeer(
 	if response.StatusCode >= 200 && response.StatusCode < 300 {
 		appHeaders := applicationHeaders.FromHTTPHeaders(
 			response.Header, transport.NewHeaders())
-		appError := response.Header.Get(ApplicationStatusHeader) != ApplicationErrorStatus
+		appError := response.Header.Get(ApplicationStatusHeader) == ApplicationErrorStatus
 		return &transport.Response{
 			Headers:          appHeaders,
 			Body:             response.Body,

--- a/transport/tchannel/channel_outbound.go
+++ b/transport/tchannel/channel_outbound.go
@@ -170,7 +170,11 @@ func (o *ChannelOutbound) Call(ctx context.Context, req *transport.Request) (*tr
 		return nil, err
 	}
 
-	return &transport.Response{Headers: headers, Body: resBody}, nil
+	return &transport.Response{
+		Headers:          headers,
+		Body:             resBody,
+		ApplicationError: res.ApplicationError(),
+	}, nil
 }
 
 func writeBody(body io.Reader, call *tchannel.OutboundCall) error {


### PR DESCRIPTION
This adds support for the application error bit on call responses for both TChannel and HTTP. For TChannel, this bit already transited, but for HTTP, it is necessary to add an HTTP response header, Rpc-Status, which can carry the value "error". I left the header absent in the success case for simplicity, but any value other than error lifts to "not error".