### PR TITLE
lifecycle: 2: Update Transport,Inbound,Outbound, and Chooser

### DIFF
--- a/api/peer/list.go
+++ b/api/peer/list.go
@@ -30,11 +30,7 @@ import (
 
 // Chooser is a collection of Peers.  Outbounds request peers from the peer.Chooser to determine where to send requests
 type Chooser interface {
-	// Notify the PeerList that it will start receiving requests
-	Start() error
-
-	// Notify the PeerList that it will stop receiving requests
-	Stop() error
+	transport.Lifecycle
 
 	// Choose a Peer for the next call, block until a peer is available (or timeout)
 	Choose(context.Context, *transport.Request) (peer Peer, onFinish func(error), err error)

--- a/api/transport/inbound.go
+++ b/api/transport/inbound.go
@@ -25,6 +25,8 @@ package transport
 // Inbound is a transport that knows how to receive requests for procedure
 // calls.
 type Inbound interface {
+	Lifecycle
+
 	// SetRouter configures the inbound to dispatch requests through a
 	// router, typically called by a Dispatcher with its RouteTable of handled
 	// procedures.
@@ -34,22 +36,4 @@ type Inbound interface {
 	// collected for lifecycle management, typically by a Dispatcher.
 	// An inbound may submit zero or more transports.
 	Transports() []Transport
-
-	// Starts accepting new requests.
-	//
-	// The inbound must have a configured router.
-	//
-	// The function MUST return immediately, although it SHOULD block until
-	// the inbound is ready to start accepting new requests.
-	//
-	// Implementations can assume that this function is called at most once.
-	Start() error
-
-	// Stops the inbound. No new requests will be processed.
-	//
-	// This MAY block while the server drains ongoing requests.
-	Stop() error
-
-	// TODO some way for the inbound to expose the host and port it's
-	// listening on
 }

--- a/api/transport/inbound.go
+++ b/api/transport/inbound.go
@@ -30,6 +30,7 @@ type Inbound interface {
 	// SetRouter configures the inbound to dispatch requests through a
 	// router, typically called by a Dispatcher with its RouteTable of handled
 	// procedures.
+	// Inbound.Start MAY panic if SetRouter was not called.
 	SetRouter(Router)
 
 	// Transport returns any transports that the inbound uses, so they can be

--- a/api/transport/outbound.go
+++ b/api/transport/outbound.go
@@ -26,6 +26,8 @@ import "context"
 
 // Outbound is the common interface for all outbounds
 type Outbound interface {
+	Lifecycle
+
 	// Transports returns the transports that used by this outbound, so they
 	// can be collected for lifecycle management, typically by a Dispatcher.
 	//
@@ -34,18 +36,6 @@ type Outbound interface {
 	// across multiple transport protocols during a transport protocol
 	// migration.
 	Transports() []Transport
-
-	// Sets up the outbound to start making calls.
-	//
-	// This MUST block until the outbound is ready to start sending requests.
-	// This MUST be idempotent and thread-safe. If called multiple times, only
-	// the first call's dependencies are used
-	Start() error
-
-	// Stops the outbound, cleaning up any resources held by the Outbound.
-	//
-	// This MUST be idempotent and thread-safe. This MAY be called more than once
-	Stop() error
 }
 
 // UnaryOutbound is a transport that knows how to send unary requests for procedure

--- a/api/transport/transport.go
+++ b/api/transport/transport.go
@@ -23,16 +23,5 @@ package transport
 // Transport is the interface needed by a Dispatcher to manage the life cycle
 // of a transport.
 type Transport interface {
-	// Start starts a transport, opening listening sockets and accepting
-	// inbound requests, and opening connections to retained outbound peers.
-	//
-	// Start should block until the transport is ready to receive inbound
-	// requests.
-	Start() error
-
-	// Stop stops a transport, closing listening sockets, rejecting inbound
-	// requests, and draining existing peers of all pending requests.
-	//
-	// Stop should block until all pending requests have drained.
-	Stop() error
+	Lifecycle
 }


### PR DESCRIPTION
Summary: Updates the start/stop interfaces so that they don't declare
their start/stop functions directly, but, instead do it through the
lifecycle interface