### PR TITLE
Add transport.BadRequestError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ v1.0.0-dev (unreleased)
     interface.
 -   **Breaking**: `Peer.StartRequest` and `Peer.EndRequest` no longer accept a
     `dontNotify` argument.
+-   Added a `transport.BadRequestError` function to build errors which satisfy
+    `transport.IsBadRequestError`.
 
 
 v1.0.0-rc3 (2016-12-09)

--- a/api/transport/errors.go
+++ b/api/transport/errors.go
@@ -22,6 +22,14 @@ package transport
 
 import "go.uber.org/yarpc/internal/errors"
 
+// BadRequestError builds an error which indicates a bad request with the
+// given error as the reason.
+//
+// Transport implementations treat BadRequestErrors as user errors.
+func BadRequestError(err error) error {
+	return errors.HandlerBadRequestError(err)
+}
+
 // IsBadRequestError returns true if the request could not be processed
 // because it was invalid.
 func IsBadRequestError(err error) bool {
@@ -29,11 +37,9 @@ func IsBadRequestError(err error) bool {
 	return ok
 }
 
-// IsUnexpectedError returns true if the server failed to process the request
-// because of an unhandled error.
+// IsUnexpectedError returns true if the server panicked or failed to process
+// the request with an unhandled error.
 func IsUnexpectedError(err error) bool {
-	// TODO: Add "or it panicked while processing the request." to the doc when
-	// #111 is resolved.
 	_, ok := err.(errors.UnexpectedError)
 	return ok
 }

--- a/api/transport/errors_test.go
+++ b/api/transport/errors_test.go
@@ -1,0 +1,15 @@
+package transport
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBadRequestError(t *testing.T) {
+	err := errors.New("derp")
+	err = BadRequestError(err)
+	assert.True(t, IsBadRequestError(err))
+	assert.Equal(t, "BadRequest: derp", err.Error())
+}


### PR DESCRIPTION
This may be used by encoding implementations outside the YARPC library to
build errors that are handled correctly in transport implementations.

@yarpc/golang