### PR TITLE
lifecycle: 4: Make start/stop idempotent in transport lifecycles

### DIFF
--- a/peer/x/roundrobin/list.go
+++ b/peer/x/roundrobin/list.go
@@ -123,8 +123,7 @@ func (pl *List) addToAvailablePeers(p peer.Peer) error {
 
 // Start notifies the List that requests will start coming
 func (pl *List) Start() error {
-	pl.once.SetStarted()
-	return nil
+	return pl.once.Start(nil)
 }
 
 // Stop notifies the List that requests will stop coming

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -28,18 +28,17 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"sync"
 	"time"
 
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/errors"
+	"go.uber.org/yarpc/internal/sync"
 	peerchooser "go.uber.org/yarpc/peer"
 	"go.uber.org/yarpc/peer/hostport"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
-	"go.uber.org/atomic"
 )
 
 var errOutboundNotStarted = errors.ErrOutboundNotStarted("http.Outbound")
@@ -116,12 +115,7 @@ type Outbound struct {
 	urlTemplate *url.URL
 	tracer      opentracing.Tracer
 
-	started   atomic.Bool
-	startOnce sync.Once
-	startErr  error
-	stopped   atomic.Bool
-	stopOnce  sync.Once
-	stopErr   error
+	once sync.LifecycleOnce
 }
 
 // setURLTemplate configures an alternate URL template.
@@ -143,32 +137,22 @@ func (o *Outbound) Transports() []transport.Transport {
 
 // Start the HTTP outbound
 func (o *Outbound) Start() error {
-	o.startOnce.Do(func() {
-		o.started.Store(true)
-		o.startErr = o.chooser.Start()
-	})
-
-	return o.startErr
+	return o.once.Start(o.chooser.Start)
 }
 
 // Stop the HTTP outbound
 func (o *Outbound) Stop() error {
-	o.stopOnce.Do(func() {
-		o.stopped.Store(true)
-		o.stopErr = o.chooser.Stop()
-	})
-
-	return o.stopErr
+	return o.once.Stop(o.chooser.Stop)
 }
 
 // IsRunning returns whether the Outbound is running.
 func (o *Outbound) IsRunning() bool {
-	return o.started.Load() && !o.stopped.Load()
+	return o.once.IsRunning()
 }
 
 // Call makes a HTTP request
 func (o *Outbound) Call(ctx context.Context, treq *transport.Request) (*transport.Response, error) {
-	if !o.started.Load() {
+	if !o.IsRunning() {
 		// TODO replace with "panicInDebug"
 		return nil, errOutboundNotStarted
 	}
@@ -181,7 +165,7 @@ func (o *Outbound) Call(ctx context.Context, treq *transport.Request) (*transpor
 
 // CallOneway makes a oneway request
 func (o *Outbound) CallOneway(ctx context.Context, treq *transport.Request) (transport.Ack, error) {
-	if !o.started.Load() {
+	if !o.IsRunning() {
 		// TODO replace with "panicInDebug"
 		return nil, errOutboundNotStarted
 	}

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -119,6 +119,7 @@ type Outbound struct {
 	started   atomic.Bool
 	startOnce sync.Once
 	startErr  error
+	stopped   atomic.Bool
 	stopOnce  sync.Once
 	stopErr   error
 }
@@ -153,7 +154,7 @@ func (o *Outbound) Start() error {
 // Stop the HTTP outbound
 func (o *Outbound) Stop() error {
 	o.stopOnce.Do(func() {
-		o.started.Store(false)
+		o.stopped.Store(true)
 		o.stopErr = o.chooser.Stop()
 	})
 
@@ -162,7 +163,7 @@ func (o *Outbound) Stop() error {
 
 // IsRunning returns whether the Outbound is running.
 func (o *Outbound) IsRunning() bool {
-	return o.started.Load()
+	return o.started.Load() && !o.stopped.Load()
 }
 
 // Call makes a HTTP request

--- a/transport/tchannel/channel_inbound.go
+++ b/transport/tchannel/channel_inbound.go
@@ -95,8 +95,7 @@ func (i *ChannelInbound) start() error {
 
 // Stop stops the TChannel outbound. This currently does nothing.
 func (i *ChannelInbound) Stop() error {
-	i.once.SetStopped()
-	return nil
+	return i.once.Stop(nil)
 }
 
 // IsRunning returns whether the ChannelInbound is running.

--- a/transport/tchannel/channel_outbound.go
+++ b/transport/tchannel/channel_outbound.go
@@ -72,8 +72,7 @@ func (o *ChannelOutbound) Transports() []transport.Transport {
 func (o *ChannelOutbound) Start() error {
 	// TODO: Should we create the connection to HostPort (if specified) here or
 	// wait for the first call?
-	o.once.SetStarted()
-	return nil
+	return o.once.Start(nil)
 }
 
 // Stop stops the TChannel outbound.


### PR DESCRIPTION
Summary: Inbound, Outbounds, Choosers and Transports will need to be
idempotent if we want to compose them.  This diff makes all our existing
implementations idempotent