### PR TITLE
validator: Clean up request validation API

### DIFF
--- a/internal/request/validator_outbound.go
+++ b/internal/request/validator_outbound.go
@@ -34,13 +34,7 @@ type OnewayValidatorOutbound struct{ transport.OnewayOutbound }
 
 // Call performs the given request, failing early if the request is invalid.
 func (o UnaryValidatorOutbound) Call(ctx context.Context, request *transport.Request) (*transport.Response, error) {
-	request, err := Validate(ctx, request)
-	if err != nil {
-		return nil, err
-	}
-
-	request, err = ValidateUnary(ctx, request)
-	if err != nil {
+	if err := ValidateUnary(ctx, request); err != nil {
 		return nil, err
 	}
 
@@ -49,13 +43,7 @@ func (o UnaryValidatorOutbound) Call(ctx context.Context, request *transport.Req
 
 // CallOneway performs the given request, failing early if the request is invalid.
 func (o OnewayValidatorOutbound) CallOneway(ctx context.Context, request *transport.Request) (transport.Ack, error) {
-	request, err := Validate(ctx, request)
-	if err != nil {
-		return nil, err
-	}
-
-	request, err = ValidateOneway(ctx, request)
-	if err != nil {
+	if err := ValidateOneway(ctx, request); err != nil {
 		return nil, err
 	}
 

--- a/internal/request/validator_test.go
+++ b/internal/request/validator_test.go
@@ -156,10 +156,10 @@ func TestValidator(t *testing.T) {
 		v := Validator{Request: tt.req}
 
 		ctx := context.Background()
-		_, err := v.Validate(ctx)
+		err := v.ValidateCommon(ctx)
 
 		if err == nil && tt.transportType == transport.Oneway {
-			_, err = v.ValidateOneway(ctx)
+			err = v.ValidateOneway(ctx)
 		} else if err == nil { // default to unary
 			var cancel func()
 
@@ -173,7 +173,7 @@ func TestValidator(t *testing.T) {
 				defer cancel()
 			}
 
-			_, err = v.ValidateUnary(ctx)
+			err = v.ValidateUnary(ctx)
 		}
 
 		if tt.wantErr != nil {

--- a/transport/http/handler.go
+++ b/transport/http/handler.go
@@ -92,7 +92,7 @@ func (h handler) callHandler(w http.ResponseWriter, req *http.Request, start tim
 
 	ctx, span := h.createSpan(ctx, req, treq, start)
 
-	treq, err := v.Validate(ctx)
+	err := v.ValidateCommon(ctx)
 	if err != nil {
 		return err
 	}
@@ -106,18 +106,13 @@ func (h handler) callHandler(w http.ResponseWriter, req *http.Request, start tim
 	case transport.Unary:
 		defer span.Finish()
 
-		ctx, cancel := v.ParseTTL(ctx, popHeader(req.Header, TTLMSHeader))
-		defer cancel()
-
-		treq, err = v.ValidateUnary(ctx)
-		if err != nil {
+		if err := v.ValidateUnary(ctx); err != nil {
 			return err
 		}
 		err = transport.DispatchUnaryHandler(ctx, spec.Unary(), start, treq, newResponseWriter(w))
 
 	case transport.Oneway:
-		treq, err = v.ValidateOneway(ctx)
-		if err != nil {
+		if err := v.ValidateOneway(ctx); err != nil {
 			return err
 		}
 		err = handleOnewayRequest(span, treq, spec.Oneway())

--- a/transport/x/redis/inbound.go
+++ b/transport/x/redis/inbound.go
@@ -151,8 +151,7 @@ func (i *Inbound) handle() error {
 	defer span.Finish()
 
 	v := request.Validator{Request: req}
-	req, err = v.Validate(ctx)
-	if err != nil {
+	if err := v.ValidateCommon(ctx); err != nil {
 		return transport.UpdateSpanWithErr(span, err)
 	}
 
@@ -166,8 +165,7 @@ func (i *Inbound) handle() error {
 		return transport.UpdateSpanWithErr(span, err)
 	}
 
-	req, err = v.ValidateOneway(ctx)
-	if err != nil {
+	if err := v.ValidateOneway(ctx); err != nil {
 		return transport.UpdateSpanWithErr(span, err)
 	}
 


### PR DESCRIPTION
This simplifies the request validation APIs slightly. The intention is to
expose `ValidateUnary` and `ValidateOneway` as public-facing APIs in a
different diff so that transport authors can perform validation easily.

@yarpc/golang