### PR TITLE
validator: Move ParseTTL to http

### DIFF
--- a/internal/request/errors.go
+++ b/internal/request/errors.go
@@ -57,22 +57,3 @@ func (e missingParametersError) Error() string {
 	s += fmt.Sprintf(", and %s", ps[len(ps)-1])
 	return s
 }
-
-// invalidTTLError is a failure to process a request because the TTL was in an
-// invalid format.
-type invalidTTLError struct {
-	Service   string
-	Procedure string
-	TTL       string
-}
-
-func (e invalidTTLError) AsHandlerError() errors.HandlerError {
-	return errors.HandlerBadRequestError(e)
-}
-
-func (e invalidTTLError) Error() string {
-	return fmt.Sprintf(
-		`invalid TTL %q for procedure %q of service %q: must be positive integer`,
-		e.TTL, e.Procedure, e.Service,
-	)
-}

--- a/internal/request/validator_test.go
+++ b/internal/request/validator_test.go
@@ -34,9 +34,7 @@ func TestValidator(t *testing.T) {
 	tests := []struct {
 		req           *transport.Request
 		transportType transport.Type
-
-		ttl       time.Duration
-		ttlString string // set to try parseTTL
+		ttl           time.Duration
 
 		wantErr     error
 		wantMessage string
@@ -118,38 +116,6 @@ func TestValidator(t *testing.T) {
 			},
 			wantMessage: "missing service name, procedure, caller name, and encoding",
 		},
-		{
-			req: &transport.Request{
-				Caller:    "caller",
-				Service:   "service",
-				Encoding:  "raw",
-				Procedure: "hello",
-			},
-			transportType: transport.Unary,
-			ttlString:     "-1000",
-			wantErr: invalidTTLError{
-				Service:   "service",
-				Procedure: "hello",
-				TTL:       "-1000",
-			},
-			wantMessage: `invalid TTL "-1000" for procedure "hello" of service "service": must be positive integer`,
-		},
-		{
-			req: &transport.Request{
-				Caller:    "caller",
-				Service:   "service",
-				Encoding:  "raw",
-				Procedure: "hello",
-			},
-			transportType: transport.Unary,
-			ttlString:     "not an integer",
-			wantErr: invalidTTLError{
-				Service:   "service",
-				Procedure: "hello",
-				TTL:       "not an integer",
-			},
-			wantMessage: `invalid TTL "not an integer" for procedure "hello" of service "service": must be positive integer`,
-		},
 	}
 
 	for _, tt := range tests {
@@ -165,11 +131,6 @@ func TestValidator(t *testing.T) {
 
 			if tt.ttl != 0 {
 				ctx, cancel = context.WithTimeout(ctx, tt.ttl)
-				defer cancel()
-			}
-
-			if tt.ttlString != "" {
-				ctx, cancel = v.ParseTTL(ctx, tt.ttlString)
 				defer cancel()
 			}
 

--- a/transport/http/handler_test.go
+++ b/transport/http/handler_test.go
@@ -265,7 +265,7 @@ func TestHandlerFailures(t *testing.T) {
 
 		code := rw.Code
 		assert.True(t, code >= 400 && code < 500, "expected 400 level code")
-		assert.Equal(t, rw.Body.String(), tt.msg)
+		assert.Equal(t, tt.msg, rw.Body.String())
 	}
 }
 

--- a/transport/http/ttl.go
+++ b/transport/http/ttl.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package http
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/errors"
+)
+
+// parseTTL takes a context parses the given TTL, clamping the context to that
+// TTL and as a side-effect, tracking any errors encountered while attempting
+// to parse and validate that TTL.
+//
+// Leaves the context unchanged if the TTL is empty.
+func parseTTL(ctx context.Context, req *transport.Request, ttl string) (_ context.Context, cancel func(), _ error) {
+	if ttl == "" {
+		return ctx, func() {}, nil
+	}
+
+	ttlms, err := strconv.Atoi(ttl)
+	if err != nil {
+		return ctx, func() {}, invalidTTLError{
+			Service:   req.Service,
+			Procedure: req.Procedure,
+			TTL:       ttl,
+		}
+	}
+
+	// negative TTLs are invalid
+	if ttlms < 0 {
+		return ctx, func() {}, invalidTTLError{
+			Service:   req.Service,
+			Procedure: req.Procedure,
+			TTL:       fmt.Sprint(ttlms),
+		}
+	}
+
+	ctx, cancel = context.WithTimeout(ctx, time.Duration(ttlms)*time.Millisecond)
+	return ctx, cancel, nil
+}
+
+// invalidTTLError is a failure to process a request because the TTL was in an
+// invalid format.
+type invalidTTLError struct {
+	Service   string
+	Procedure string
+	TTL       string
+}
+
+func (e invalidTTLError) AsHandlerError() errors.HandlerError {
+	return errors.HandlerBadRequestError(e)
+}
+
+func (e invalidTTLError) Error() string {
+	return fmt.Sprintf(
+		`invalid TTL %q for procedure %q of service %q: must be positive integer`,
+		e.TTL, e.Procedure, e.Service,
+	)
+}

--- a/transport/http/ttl_test.go
+++ b/transport/http/ttl_test.go
@@ -22,6 +22,7 @@ func TestParseTTL(t *testing.T) {
 		wantErr     error
 		wantMessage string
 	}{
+		{ttlString: "1"},
 		{
 			ttlString: "-1000",
 			wantErr: invalidTTLError{

--- a/transport/http/ttl_test.go
+++ b/transport/http/ttl_test.go
@@ -1,0 +1,58 @@
+package http
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/yarpc/api/transport"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseTTL(t *testing.T) {
+	req := &transport.Request{
+		Caller:    "caller",
+		Service:   "service",
+		Procedure: "hello",
+		Encoding:  "raw",
+	}
+
+	tests := []struct {
+		ttlString   string
+		wantErr     error
+		wantMessage string
+	}{
+		{
+			ttlString: "-1000",
+			wantErr: invalidTTLError{
+				Service:   "service",
+				Procedure: "hello",
+				TTL:       "-1000",
+			},
+			wantMessage: `invalid TTL "-1000" for procedure "hello" of service "service": must be positive integer`,
+		},
+		{
+			ttlString: "not an integer",
+			wantErr: invalidTTLError{
+				Service:   "service",
+				Procedure: "hello",
+				TTL:       "not an integer",
+			},
+			wantMessage: `invalid TTL "not an integer" for procedure "hello" of service "service": must be positive integer`,
+		},
+	}
+
+	for _, tt := range tests {
+		ctx, cancel, err := parseTTL(context.Background(), req, tt.ttlString)
+		defer cancel()
+
+		if tt.wantErr != nil && assert.Error(t, err) {
+			assert.Equal(t, tt.wantErr, err)
+			assert.Equal(t, tt.wantMessage, err.Error())
+		} else {
+			assert.NoError(t, err)
+			_, ok := ctx.Deadline()
+			assert.True(t, ok)
+		}
+	}
+}

--- a/transport/http/ttl_test.go
+++ b/transport/http/ttl_test.go
@@ -44,16 +44,18 @@ func TestParseTTL(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		ctx, cancel, err := parseTTL(context.Background(), req, tt.ttlString)
-		defer cancel()
+		t.Run(tt.ttlString, func(t *testing.T) {
+			ctx, cancel, err := parseTTL(context.Background(), req, tt.ttlString)
+			defer cancel()
 
-		if tt.wantErr != nil && assert.Error(t, err) {
-			assert.Equal(t, tt.wantErr, err)
-			assert.Equal(t, tt.wantMessage, err.Error())
-		} else {
-			assert.NoError(t, err)
-			_, ok := ctx.Deadline()
-			assert.True(t, ok)
-		}
+			if tt.wantErr != nil && assert.Error(t, err) {
+				assert.Equal(t, tt.wantErr, err)
+				assert.Equal(t, tt.wantMessage, err.Error())
+			} else {
+				assert.NoError(t, err)
+				_, ok := ctx.Deadline()
+				assert.True(t, ok)
+			}
+		})
 	}
 }


### PR DESCRIPTION
This removes ParseTTL functionality from the generic request validator. This
is needed for the HTTP transport only so it is implemented separately in the
http package, allowing us to simplify the validator further.

@yarpc/golang