### PR TITLE
internal/errors: Make NoRegsitryError a variable

### DIFF
--- a/internal/errors/transport.go
+++ b/internal/errors/transport.go
@@ -20,7 +20,10 @@
 
 package errors
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 // HandlerError represents handler errors on the handler side.
 //
@@ -136,10 +139,6 @@ func (e UnsupportedTypeError) Error() string {
 	return fmt.Sprintf(`unsupported RPC type %q for transport %q`, e.Type, e.Transport)
 }
 
-// NoRegistryError indicates that Start was called without first calling
+// ErrNoRegistry indicates that Start was called without first calling
 // SetRegistry for an inbound transport.
-type NoRegistryError struct{}
-
-func (e NoRegistryError) Error() string {
-	return `no registry configured for transport inbound`
-}
+var ErrNoRegistry = errors.New("no registry configured for transport inbound")

--- a/transport/http/inbound.go
+++ b/transport/http/inbound.go
@@ -91,9 +91,8 @@ func (i *Inbound) Transports() []transport.Transport {
 // Start starts the inbound with a given service detail, opening a listening
 // socket.
 func (i *Inbound) Start() error {
-
 	if i.registry == nil {
-		return errors.NoRegistryError{}
+		return errors.ErrNoRegistry
 	}
 
 	var httpHandler http.Handler = handler{

--- a/transport/tchannel/channel_inbound.go
+++ b/transport/tchannel/channel_inbound.go
@@ -73,7 +73,7 @@ func (i *ChannelInbound) Channel() Channel {
 // underlying ChannelTransport.
 func (i *ChannelInbound) Start() error {
 	if i.registry == nil {
-		return errors.NoRegistryError{}
+		return errors.ErrNoRegistry
 	}
 
 	// Set up handlers. This must occur after construction because the

--- a/transport/x/redis/inbound.go
+++ b/transport/x/redis/inbound.go
@@ -96,7 +96,7 @@ func (i *Inbound) SetRegistry(registry transport.Registry) {
 // Start starts the inbound, reading from the queueKey
 func (i *Inbound) Start() error {
 	if i.registry == nil {
-		return errors.NoRegistryError{}
+		return errors.ErrNoRegistry
 	}
 
 	err := i.client.Start()


### PR DESCRIPTION
NoRegsitryError doesn't need to be a type. It can be a top-level `var`.

I had to rename it to `ErrNoRegistry` because golint prefers that naming
convention for top-level error variables.

@yarpc/golang