### PR TITLE
validator: Remove ValidateOnewayContext

### DIFF
--- a/api/transport/request_test.go
+++ b/api/transport/request_test.go
@@ -102,9 +102,7 @@ func TestValidator(t *testing.T) {
 		ctx := context.Background()
 		err := transport.ValidateRequest(tt.req)
 
-		if err == nil && tt.transportType == transport.Oneway {
-			err = request.ValidateOnewayContext(ctx)
-		} else if err == nil { // default to unary
+		if err == nil && tt.transportType == transport.Unary {
 			var cancel func()
 
 			if tt.ttl != 0 {

--- a/internal/request/validator.go
+++ b/internal/request/validator.go
@@ -35,10 +35,3 @@ func ValidateUnaryContext(ctx context.Context) error {
 
 	return nil
 }
-
-// ValidateOnewayContext validates that a context for a oneway request is
-// valid.
-func ValidateOnewayContext(ctx context.Context) error {
-	// Currently, no extra checks for oneway requests are required
-	return nil
-}

--- a/internal/request/validator_outbound.go
+++ b/internal/request/validator_outbound.go
@@ -51,9 +51,5 @@ func (o OnewayValidatorOutbound) CallOneway(ctx context.Context, request *transp
 		return nil, err
 	}
 
-	if err := ValidateOnewayContext(ctx); err != nil {
-		return nil, err
-	}
-
 	return o.OnewayOutbound.CallOneway(ctx, request)
 }

--- a/transport/http/handler.go
+++ b/transport/http/handler.go
@@ -111,9 +111,6 @@ func (h handler) callHandler(w http.ResponseWriter, req *http.Request, start tim
 		err = transport.DispatchUnaryHandler(ctx, spec.Unary(), start, treq, newResponseWriter(w))
 
 	case transport.Oneway:
-		if err := request.ValidateOnewayContext(ctx); err != nil {
-			return err
-		}
 		err = handleOnewayRequest(span, treq, spec.Oneway())
 
 	default:

--- a/transport/x/redis/inbound.go
+++ b/transport/x/redis/inbound.go
@@ -26,7 +26,6 @@ import (
 
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/errors"
-	"go.uber.org/yarpc/internal/request"
 	"go.uber.org/yarpc/serialize"
 
 	"github.com/opentracing/opentracing-go"
@@ -161,10 +160,6 @@ func (i *Inbound) handle() error {
 
 	if spec.Type() != transport.Oneway {
 		err = errors.UnsupportedTypeError{Transport: transportName, Type: string(spec.Type())}
-		return transport.UpdateSpanWithErr(span, err)
-	}
-
-	if err := request.ValidateOnewayContext(ctx); err != nil {
 		return transport.UpdateSpanWithErr(span, err)
 	}
 


### PR DESCRIPTION
This is a no-op and it's an internal API. We can add it back if necessary.

@yarpc/golang