### PR TITLE
lifecycle: 3.5: Add sync.Once and sync.LifecycleOnce

### DIFF
--- a/internal/sync/lifecycle.go
+++ b/internal/sync/lifecycle.go
@@ -1,6 +1,7 @@
 package sync
 
-// LifecycleOnce is an abstraction around a lifecycle interface
+// LifecycleOnce is a helper for implementing transport.Lifecycles
+// with similar behavior.
 type LifecycleOnce struct {
 	start Once
 	stop  Once
@@ -11,19 +12,9 @@ func (l *LifecycleOnce) Start(f func() error) error {
 	return l.start.Do(f)
 }
 
-// SetStarted will set the start `Once` flag to true
-func (l *LifecycleOnce) SetStarted() {
-	l.start.SetDone()
-}
-
 // Stop will run the `f` function once and return the error
 func (l *LifecycleOnce) Stop(f func() error) error {
 	return l.stop.Do(f)
-}
-
-// SetStopped will set the stop `Once` flag to true
-func (l *LifecycleOnce) SetStopped() {
-	l.stop.SetDone()
 }
 
 // IsRunning will return true if the start has been run, and the stop has not

--- a/internal/sync/lifecycle.go
+++ b/internal/sync/lifecycle.go
@@ -1,0 +1,32 @@
+package sync
+
+// LifecycleOnce is an abstraction around a lifecycle interface
+type LifecycleOnce struct {
+	start Once
+	stop  Once
+}
+
+// Start will run the `f` function once and return the error
+func (l *LifecycleOnce) Start(f func() error) error {
+	return l.start.Do(f)
+}
+
+// SetStarted will set the start `Once` flag to true
+func (l *LifecycleOnce) SetStarted() {
+	l.start.SetDone()
+}
+
+// Stop will run the `f` function once and return the error
+func (l *LifecycleOnce) Stop(f func() error) error {
+	return l.stop.Do(f)
+}
+
+// SetStopped will set the stop `Once` flag to true
+func (l *LifecycleOnce) SetStopped() {
+	l.stop.SetDone()
+}
+
+// IsRunning will return true if the start has been run, and the stop has not
+func (l *LifecycleOnce) IsRunning() bool {
+	return l.start.Done() && !l.stop.Done()
+}

--- a/internal/sync/once.go
+++ b/internal/sync/once.go
@@ -1,0 +1,38 @@
+package sync
+
+import (
+	"sync"
+
+	"github.com/uber-go/atomic"
+)
+
+// Once is a wrapper around sync.Once in order to simplify returning the
+// same error multiple times from the same function
+type Once struct {
+	done atomic.Bool
+	once sync.Once
+	err  error
+}
+
+// Do is a wrapper around the sync.Once `Do` method. This version takes a function that
+// returns an error, and every subsequent call to the `Do` function will be returned the
+// `err` of the `f` func
+func (o *Once) Do(f func() error) error {
+	o.once.Do(func() {
+		o.err = f()
+		o.done.Store(true)
+	})
+
+	return o.err
+}
+
+// SetDone will complete the `once` sync and will set the `done` flag to true
+func (o *Once) SetDone() {
+	o.once.Do(func() {})
+	o.done.Store(true)
+}
+
+// Done returns whether the finished flag has been set and thus sync.Once has been run
+func (o *Once) Done() bool {
+	return o.done.Load()
+}

--- a/internal/sync/once.go
+++ b/internal/sync/once.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Once is a wrapper around sync.Once in order to simplify returning the
-// same error multiple times from the same function
+// same error multiple times from the same function.
 type Once struct {
 	done atomic.Bool
 	once sync.Once
@@ -16,8 +16,13 @@ type Once struct {
 
 // Do is a wrapper around the sync.Once `Do` method. This version takes a function that
 // returns an error, and every subsequent call to the `Do` function will be returned the
-// `err` of the `f` func
+// `err` of the `f` func.
+// If f is nil we will replace it with a noop function.
 func (o *Once) Do(f func() error) error {
+	if f == nil {
+		f = func() error { return nil }
+	}
+
 	o.once.Do(func() {
 		o.err = f()
 		o.done.Store(true)
@@ -26,13 +31,7 @@ func (o *Once) Do(f func() error) error {
 	return o.err
 }
 
-// SetDone will complete the `once` sync and will set the `done` flag to true
-func (o *Once) SetDone() {
-	o.once.Do(func() {})
-	o.done.Store(true)
-}
-
-// Done returns whether the finished flag has been set and thus sync.Once has been run
+// Done returns whether the finished flag has been set and thus sync.Once has been run.
 func (o *Once) Done() bool {
 	return o.done.Load()
 }

--- a/internal/sync/once_test.go
+++ b/internal/sync/once_test.go
@@ -9,11 +9,11 @@ import (
 )
 
 func TestOnce(t *testing.T) {
-	once := Once{}
+	var once Once
 	onceCalls := atomic.NewInt32(0)
 	expectedErr := errors.New("test error")
 
-	wait := ErrorWaiter{}
+	var wait ErrorWaiter
 	for i := 0; i < 10; i++ {
 		wait.Submit(func() error {
 			return once.Do(func() error {
@@ -32,15 +32,15 @@ func TestOnce(t *testing.T) {
 }
 
 func TestOnceNotFinished(t *testing.T) {
-	once := Once{}
+	var once Once
 
 	assert.False(t, once.Done())
 }
 
-func TestOnceSetDone(t *testing.T) {
-	once := Once{}
+func TestOnceDoWithNil(t *testing.T) {
+	var once Once
 
-	once.SetDone()
+	once.Do(nil)
 
 	assert.True(t, once.Done())
 }

--- a/internal/sync/once_test.go
+++ b/internal/sync/once_test.go
@@ -1,0 +1,46 @@
+package sync
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uber-go/atomic"
+)
+
+func TestOnce(t *testing.T) {
+	once := Once{}
+	onceCalls := atomic.NewInt32(0)
+	expectedErr := errors.New("test error")
+
+	wait := ErrorWaiter{}
+	for i := 0; i < 10; i++ {
+		wait.Submit(func() error {
+			return once.Do(func() error {
+				onceCalls.Inc()
+				return expectedErr
+			})
+		})
+	}
+	errs := wait.Wait()
+
+	assert.Equal(t, 1, int(onceCalls.Load()), "number of executions of once was not 1")
+	for _, err := range errs {
+		assert.Equal(t, expectedErr, err)
+	}
+	assert.True(t, once.Done())
+}
+
+func TestOnceNotFinished(t *testing.T) {
+	once := Once{}
+
+	assert.False(t, once.Done())
+}
+
+func TestOnceSetDone(t *testing.T) {
+	once := Once{}
+
+	once.SetDone()
+
+	assert.True(t, once.Done())
+}


### PR DESCRIPTION
Summary: This diff adds a custom sync.Once and sync.LifecycleOnce.  These
are convenience structs for adding idempotent start/stop functions for
lifecycle objects.