### PR TITLE
WIP: transport: Expose error builders

### DIFF
--- a/api/transport/errors.go
+++ b/api/transport/errors.go
@@ -22,6 +22,13 @@ package transport
 
 import "go.uber.org/yarpc/internal/errors"
 
+// IsBadRequestError returns true if the request could not be processed
+// because it was invalid.
+func IsBadRequestError(err error) bool {
+	_, ok := err.(errors.BadRequestError)
+	return ok
+}
+
 // InboundBadRequestError builds an error which indicates that an inbound
 // cannot process a request because it is a bad request.
 //
@@ -30,11 +37,15 @@ func InboundBadRequestError(err error) error {
 	return errors.HandlerBadRequestError(err)
 }
 
-// IsBadRequestError returns true if the request could not be processed
-// because it was invalid.
-func IsBadRequestError(err error) bool {
-	_, ok := err.(errors.BadRequestError)
-	return ok
+// OutboundBadRequestError builds an error which indicates that an outbound
+// request failed because it is invalid.
+//
+// Outbound implementations should use this if the remote server refuses to
+// process the request.
+//
+// IsBadRequestError returns true for these errors.
+func OutboundBadRequestError(message string) error {
+	return errors.RemoteBadRequestError(message)
 }
 
 // IsUnexpectedError returns true if the server panicked or failed to process
@@ -44,8 +55,60 @@ func IsUnexpectedError(err error) bool {
 	return ok
 }
 
+// InboundUnexpectedError builds an error which indicates that an inbound
+// cannot process a request due to an unexpected failure.
+//
+// IsUnexpectedError returns true for these errors.
+func InboundUnexpectedError(err error) error {
+	return errors.HandlerUnexpectedError(err)
+}
+
+// OutboundUnexpectedError builds an error which indicates that an outbound
+// request failed due to an unexpected error.
+//
+// Outbound implementations should use this if the remote server responded
+// with a message indicating that it suffered an internal failure.
+//
+// IsUnexpectedError returns true for these errors.
+func OutboundUnexpectedError(message string) error {
+	return errors.RemoteUnexpectedError(message)
+}
+
 // IsTimeoutError return true if the given error is a TimeoutError.
 func IsTimeoutError(err error) bool {
 	_, ok := err.(errors.TimeoutError)
 	return ok
+}
+
+// OutboundTimeoutError builds an error which indicates that an outbound
+// request failed due to a timeout.
+//
+// Outbound implementations should use this if the remote server responded
+// with a message indicating that the request timed out. This should NOT be
+// used if the server did not send back a response within the request TTL.
+//
+// IsTimeoutError returns true for these errors.
+func OutboundTimeoutError(message string) error {
+	return errors.RemoteTimeoutError(message)
+}
+
+// ToInboundError converts an error into an inbound-level error. Inbound
+// implementations may use this with IsBadRequestError, IsUnexpectedError or
+// IsTimeoutError to behave differently for the different error cases. One
+// of the three functions is guaranteed to return true for an error returned
+// by this function.
+//
+// 	err := ToInboundError("myservice", "hello", err)
+// 	switch {
+// 	case IsBadRequestError(err):
+// 		return "User error"
+// 	case IsUnexpectedError(err):
+// 		return "Internal failure"
+// 	case IsTimeoutError(err):
+// 		return "Timeout"
+// 	default:
+// 		panic("Impossible!")
+// 	}
+func ToInboundError(service, procedure string, err error) error {
+	return errors.AsHandlerError(service, procedure, err)
 }

--- a/api/transport/handler.go
+++ b/api/transport/handler.go
@@ -92,7 +92,9 @@ type OnewayHandler interface {
 }
 
 // DispatchUnaryHandler calls the handler h, recovering panics and timeout errors,
-// converting them to yarpc errors. All other errors are passed trough.
+// converting them to YARPC errors. All other errors are passed through.
+//
+// IsTimeoutError returns true if the request timed out.
 func DispatchUnaryHandler(
 	ctx context.Context,
 	h UnaryHandler,
@@ -119,7 +121,7 @@ func DispatchUnaryHandler(
 }
 
 // DispatchOnewayHandler calls the oneway handler, recovering from panics as
-// errors
+// errors.
 func DispatchOnewayHandler(
 	ctx context.Context,
 	h OnewayHandler,


### PR DESCRIPTION
This adds, InboundBadRequestError, OutboundBadRequestError,
InboundUnexpectedError, OutboundUnexpectedError, OutboundTimeoutError, and
ToInboundError.

We will change uses of the `internal` functions to these.

- [x] BadRequest
- [x] Unexpected
- [ ] Timeout
- [ ] Rename internal references to handler and remote errors to inbound and
      outbound errors
- [ ] Changelog