### PR TITLE
Add `Is*Error` functions to yarpc package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ v1.0.0-dev (unreleased)
     interface.
 -   **Breaking**: `Peer.StartRequest` and `Peer.EndRequest` no longer accept a
     `dontNotify` argument.
+-   Added `yarpc.IsBadRequestError`, `yarpc.IsUnexpectedError` and
+    `yarpc.IsTimeoutError` functions.
 -   Added a `transport.BadRequestError` function to build errors which satisfy
     `transport.IsBadRequestError`.
 -   Added a `transport.ValidateRequest` function to validate

--- a/errors.go
+++ b/errors.go
@@ -22,6 +22,8 @@ package yarpc
 
 import (
 	"fmt"
+
+	"go.uber.org/yarpc/api/transport"
 )
 
 type noOutboundForService struct {
@@ -30,4 +32,21 @@ type noOutboundForService struct {
 
 func (e noOutboundForService) Error() string {
 	return fmt.Sprintf("no configured outbound transport for service %q", e.Service)
+}
+
+// IsBadRequestError returns true if the request could not be processed
+// because it was invalid.
+func IsBadRequestError(err error) bool {
+	return transport.IsBadRequestError(err)
+}
+
+// IsUnexpectedError returns true if the server panicked or failed to process
+// the request with an unhandled error.
+func IsUnexpectedError(err error) bool {
+	return transport.IsUnexpectedError(err)
+}
+
+// IsTimeoutError return true if the given error is a TimeoutError.
+func IsTimeoutError(err error) bool {
+	return transport.IsTimeoutError(err)
 }


### PR DESCRIPTION
This adds `yarpc.Is{BadRequest,Unexpected,Timeout}Error` functions to the
`yarpc` package so that users don't have to use `transport` when handling
these errors in their applications.

@yarpc/golang