### PR TITLE
make generate: Always use vendored dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules
 /cover.html
 /cover.out
 /TAGS
+/.tmp

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,11 @@
 # lint results.
 LINT_EXCLUDES_EXTRAS =
 
+# List of executables needed for 'make generate'
+GENERATE_DEPENDENCIES = \
+	golang.org/x/tools/cmd/stringer \
+	go.uber.org/thriftrw
+
 ##############################################################################
 export GO15VENDOREXPERIMENT=1
 
@@ -24,6 +29,25 @@ FILTER_LINT := grep -v $(patsubst %,-e %, $(LINT_EXCLUDES))
 
 CHANGELOG_VERSION = $(shell grep '^v[0-9]' CHANGELOG.md | head -n1 | cut -d' ' -f1)
 INTHECODE_VERSION = $(shell perl -ne '/^const Version.*"([^"]+)".*$$/ && print "v$$1\n"' version.go)
+
+##############################################################################
+
+_GENERATE_DEPS_DIR = $(shell pwd)/.tmp
+$(_GENERATE_DEPS_DIR):
+	mkdir $(_GENERATE_DEPS_DIR)
+
+# Full paths to executables needed for 'make generate'
+_GENERATE_DEPS_EXECUTABLES =
+
+define generatedeprule
+_GENERATE_DEPS_EXECUTABLES += $(_GENERATE_DEPS_DIR)/$(shell basename $1)
+
+$(_GENERATE_DEPS_DIR)/$(shell basename $1): vendor/$1/*.go glide.lock $(_GENERATE_DEPS_DIR)
+	./scripts/vendor-build.sh $(_GENERATE_DEPS_DIR) $1
+endef
+
+$(foreach i,$(GENERATE_DEPENDENCIES),$(eval $(call generatedeprule,$(i))))
+
 ##############################################################################
 
 .PHONY: build
@@ -31,11 +55,9 @@ build:
 	go build $(PACKAGES)
 
 .PHONY: generate
-generate:
-	go install ./vendor/golang.org/x/tools/cmd/stringer
-	go install ./vendor/go.uber.org/thriftrw
+generate: $(_GENERATE_DEPS_EXECUTABLES)
 	go install ./encoding/thrift/thriftrw-plugin-yarpc
-	go generate $(PACKAGES)
+	PATH=$(_GENERATE_DEPS_DIR):$$PATH go generate $(PACKAGES)
 
 .PHONY: lint
 lint:

--- a/scripts/vendor-build.sh
+++ b/scripts/vendor-build.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+if [[ "$VERBOSE" == "1" ]]; then
+	set -x
+fi
+
+if [[ -z "$2" ]]; then
+	echo "USAGE: $0 DIR IMPORTPATH"
+	echo ""
+	echo "The binary at IMPORTPATH will be built and saved to DIR."
+	exit 1
+fi
+
+if [[ ! -d vendor ]]; then
+	echo "Must be run from a directory containing vendored code."
+	exit 1
+fi
+
+function die() {
+	echo "$1"
+	exit 1
+}
+
+# findGlideLock dir looks for glide.lock in dir or any of its parent
+# directories.
+#
+# Returns the full path to glide.lock or an empty string.
+function findGlideLock() {
+	if [[ -e "$1/glide.lock" ]]; then
+		echo "$1/glide.lock"
+		return
+	fi
+
+	if [[ src == "$(basename "$1")" ]]; then
+		return
+	fi
+
+	findGlideLock "$(realpath --no-symlinks "$1/..")"
+}
+
+outputDir="$1"
+importPath="$2"
+
+# not an absolute path
+if [[ "${outputDir#/}" == "$outputDir" ]]; then
+	outputDir="$(pwd)/$outputDir"
+fi
+
+GOPATH=$(mktemp -d)
+export GOPATH
+
+ln -s "$PWD/vendor" "$GOPATH/src" || die "Failed to symlink vendor"
+cd "$GOPATH/src/$importPath" || die "Cannot find $importPath"
+
+# We have dependencies
+glideLock=$(findGlideLock "$GOPATH/src/$importPath")
+if [[ -n "$glideLock" ]]; then
+	glide install || die "Could not install dependencies"
+	trap 'rm -rf $(dirname $glideLock)/vendor' EXIT
+fi
+
+go build -o "$outputDir/$(basename "$importPath")" . || dir "Failed to build"


### PR DESCRIPTION
This changes the `make generate` target to build and use executables from
vendored dependencies.

It does so by essentially doing,

    export GOPATH=`mktemp -d`
    ln -s vendor $GOPATH/src

And building all executables there, installing any dependencies if necessary.

@yarpc/golang