### PR TITLE
Regenerate generated code with `make generate`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ build:
 generate: $(_GENERATE_DEPS_EXECUTABLES)
 	go install ./encoding/thrift/thriftrw-plugin-yarpc
 	PATH=$(_GENERATE_DEPS_DIR):$$PATH go generate $(PACKAGES)
+	./scripts/updateLicenses.sh
 
 .PHONY: lint
 lint:

--- a/internal/crossdock/thrift/echo/yarpc/echoclient/client.go
+++ b/internal/crossdock/thrift/echo/yarpc/echoclient/client.go
@@ -26,10 +26,10 @@ package echoclient
 import (
 	"context"
 	"go.uber.org/thriftrw/wire"
-	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/encoding/thrift"
 	"go.uber.org/yarpc/internal/crossdock/thrift/echo"
+	"go.uber.org/yarpc/encoding/thrift"
+	"go.uber.org/yarpc"
 )
 
 // Interface is a client for the Echo service.

--- a/internal/crossdock/thrift/echo/yarpc/echoserver/server.go
+++ b/internal/crossdock/thrift/echo/yarpc/echoserver/server.go
@@ -26,10 +26,10 @@ package echoserver
 import (
 	"context"
 	"go.uber.org/thriftrw/wire"
-	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/encoding/thrift"
 	"go.uber.org/yarpc/internal/crossdock/thrift/echo"
+	"go.uber.org/yarpc/encoding/thrift"
+	"go.uber.org/yarpc"
 )
 
 // Interface is the server-side interface for the Echo service.
@@ -51,6 +51,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 	service := thrift.Service{
 		Name: "Echo",
 		Methods: map[string]thrift.UnaryHandler{
+
 			"echo": thrift.UnaryHandlerFunc(h.Echo),
 		},
 		OnewayMethods: map[string]thrift.OnewayHandler{},

--- a/internal/crossdock/thrift/gauntlet/constants.go
+++ b/internal/crossdock/thrift/gauntlet/constants.go
@@ -23,4 +23,6 @@
 
 package gauntlet
 
+
+
 const MyNumberz Numberz = NumberzOne

--- a/internal/crossdock/thrift/gauntlet/yarpc/secondserviceclient/client.go
+++ b/internal/crossdock/thrift/gauntlet/yarpc/secondserviceclient/client.go
@@ -26,10 +26,10 @@ package secondserviceclient
 import (
 	"context"
 	"go.uber.org/thriftrw/wire"
-	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/encoding/thrift"
 	"go.uber.org/yarpc/internal/crossdock/thrift/gauntlet"
+	"go.uber.org/yarpc/encoding/thrift"
+	"go.uber.org/yarpc"
 )
 
 // Interface is a client for the SecondService service.

--- a/internal/crossdock/thrift/gauntlet/yarpc/secondserviceserver/server.go
+++ b/internal/crossdock/thrift/gauntlet/yarpc/secondserviceserver/server.go
@@ -26,10 +26,10 @@ package secondserviceserver
 import (
 	"context"
 	"go.uber.org/thriftrw/wire"
-	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/encoding/thrift"
 	"go.uber.org/yarpc/internal/crossdock/thrift/gauntlet"
+	"go.uber.org/yarpc/encoding/thrift"
+	"go.uber.org/yarpc"
 )
 
 // Interface is the server-side interface for the SecondService service.
@@ -56,7 +56,9 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 	service := thrift.Service{
 		Name: "SecondService",
 		Methods: map[string]thrift.UnaryHandler{
-			"blahBlah":         thrift.UnaryHandlerFunc(h.BlahBlah),
+
+			"blahBlah": thrift.UnaryHandlerFunc(h.BlahBlah),
+
 			"secondtestString": thrift.UnaryHandlerFunc(h.SecondtestString),
 		},
 		OnewayMethods: map[string]thrift.OnewayHandler{},

--- a/internal/crossdock/thrift/gauntlet/yarpc/thrifttestclient/client.go
+++ b/internal/crossdock/thrift/gauntlet/yarpc/thrifttestclient/client.go
@@ -26,10 +26,10 @@ package thrifttestclient
 import (
 	"context"
 	"go.uber.org/thriftrw/wire"
-	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/encoding/thrift"
 	"go.uber.org/yarpc/internal/crossdock/thrift/gauntlet"
+	"go.uber.org/yarpc/encoding/thrift"
+	"go.uber.org/yarpc"
 )
 
 // Interface is a client for the ThriftTest service.

--- a/internal/crossdock/thrift/gauntlet/yarpc/thrifttestserver/server.go
+++ b/internal/crossdock/thrift/gauntlet/yarpc/thrifttestserver/server.go
@@ -26,10 +26,10 @@ package thrifttestserver
 import (
 	"context"
 	"go.uber.org/thriftrw/wire"
-	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/encoding/thrift"
 	"go.uber.org/yarpc/internal/crossdock/thrift/gauntlet"
+	"go.uber.org/yarpc/encoding/thrift"
+	"go.uber.org/yarpc"
 )
 
 // Interface is the server-side interface for the ThriftTest service.
@@ -176,27 +176,46 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 	service := thrift.Service{
 		Name: "ThriftTest",
 		Methods: map[string]thrift.UnaryHandler{
-			"testBinary":         thrift.UnaryHandlerFunc(h.TestBinary),
-			"testByte":           thrift.UnaryHandlerFunc(h.TestByte),
-			"testDouble":         thrift.UnaryHandlerFunc(h.TestDouble),
-			"testEnum":           thrift.UnaryHandlerFunc(h.TestEnum),
-			"testException":      thrift.UnaryHandlerFunc(h.TestException),
-			"testI32":            thrift.UnaryHandlerFunc(h.TestI32),
-			"testI64":            thrift.UnaryHandlerFunc(h.TestI64),
-			"testInsanity":       thrift.UnaryHandlerFunc(h.TestInsanity),
-			"testList":           thrift.UnaryHandlerFunc(h.TestList),
-			"testMap":            thrift.UnaryHandlerFunc(h.TestMap),
-			"testMapMap":         thrift.UnaryHandlerFunc(h.TestMapMap),
-			"testMulti":          thrift.UnaryHandlerFunc(h.TestMulti),
-			"testMultiException": thrift.UnaryHandlerFunc(h.TestMultiException),
-			"testNest":           thrift.UnaryHandlerFunc(h.TestNest),
 
-			"testSet":       thrift.UnaryHandlerFunc(h.TestSet),
-			"testString":    thrift.UnaryHandlerFunc(h.TestString),
+			"testBinary": thrift.UnaryHandlerFunc(h.TestBinary),
+
+			"testByte": thrift.UnaryHandlerFunc(h.TestByte),
+
+			"testDouble": thrift.UnaryHandlerFunc(h.TestDouble),
+
+			"testEnum": thrift.UnaryHandlerFunc(h.TestEnum),
+
+			"testException": thrift.UnaryHandlerFunc(h.TestException),
+
+			"testI32": thrift.UnaryHandlerFunc(h.TestI32),
+
+			"testI64": thrift.UnaryHandlerFunc(h.TestI64),
+
+			"testInsanity": thrift.UnaryHandlerFunc(h.TestInsanity),
+
+			"testList": thrift.UnaryHandlerFunc(h.TestList),
+
+			"testMap": thrift.UnaryHandlerFunc(h.TestMap),
+
+			"testMapMap": thrift.UnaryHandlerFunc(h.TestMapMap),
+
+			"testMulti": thrift.UnaryHandlerFunc(h.TestMulti),
+
+			"testMultiException": thrift.UnaryHandlerFunc(h.TestMultiException),
+
+			"testNest": thrift.UnaryHandlerFunc(h.TestNest),
+
+			"testSet": thrift.UnaryHandlerFunc(h.TestSet),
+
+			"testString": thrift.UnaryHandlerFunc(h.TestString),
+
 			"testStringMap": thrift.UnaryHandlerFunc(h.TestStringMap),
-			"testStruct":    thrift.UnaryHandlerFunc(h.TestStruct),
-			"testTypedef":   thrift.UnaryHandlerFunc(h.TestTypedef),
-			"testVoid":      thrift.UnaryHandlerFunc(h.TestVoid),
+
+			"testStruct": thrift.UnaryHandlerFunc(h.TestStruct),
+
+			"testTypedef": thrift.UnaryHandlerFunc(h.TestTypedef),
+
+			"testVoid": thrift.UnaryHandlerFunc(h.TestVoid),
 		},
 		OnewayMethods: map[string]thrift.OnewayHandler{
 

--- a/internal/crossdock/thrift/gen.go
+++ b/internal/crossdock/thrift/gen.go
@@ -35,4 +35,4 @@ package thrift
 
 // Run this last
 
-//go:generate ../../scripts/updateLicenses.sh
+//go:generate ../../../scripts/updateLicenses.sh

--- a/internal/crossdock/thrift/oneway/yarpc/onewayclient/client.go
+++ b/internal/crossdock/thrift/oneway/yarpc/onewayclient/client.go
@@ -27,8 +27,8 @@ import (
 	"context"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/encoding/thrift"
 	"go.uber.org/yarpc/internal/crossdock/thrift/oneway"
+	"go.uber.org/yarpc/encoding/thrift"
 )
 
 // Interface is a client for the Oneway service.

--- a/internal/crossdock/thrift/oneway/yarpc/onewayserver/server.go
+++ b/internal/crossdock/thrift/oneway/yarpc/onewayserver/server.go
@@ -26,10 +26,10 @@ package onewayserver
 import (
 	"context"
 	"go.uber.org/thriftrw/wire"
-	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/encoding/thrift"
 	"go.uber.org/yarpc/internal/crossdock/thrift/oneway"
+	"go.uber.org/yarpc/encoding/thrift"
+	"go.uber.org/yarpc"
 )
 
 // Interface is the server-side interface for the Oneway service.
@@ -52,6 +52,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 		Name:    "Oneway",
 		Methods: map[string]thrift.UnaryHandler{},
 		OnewayMethods: map[string]thrift.OnewayHandler{
+
 			"echo": thrift.OnewayHandlerFunc(h.Echo),
 		},
 	}

--- a/internal/examples/oneway/gen.go
+++ b/internal/examples/oneway/gen.go
@@ -21,4 +21,4 @@
 package main
 
 //go:generate thriftrw --plugin=yarpc sink.thrift
-//go:generate ../../scripts/updateLicenses.sh
+//go:generate ../../../scripts/updateLicenses.sh

--- a/internal/examples/oneway/sink/yarpc/helloclient/client.go
+++ b/internal/examples/oneway/sink/yarpc/helloclient/client.go
@@ -37,7 +37,7 @@ type Interface interface {
 		ctx context.Context,
 		reqMeta yarpc.CallReqMeta,
 		Snk *sink.SinkRequest,
-	) (transport.Ack, error)
+	) (yarpc.Ack, error)
 }
 
 // New builds a new client for the Hello service.
@@ -62,7 +62,7 @@ func (c client) Sink(
 	ctx context.Context,
 	reqMeta yarpc.CallReqMeta,
 	_Snk *sink.SinkRequest,
-) (transport.Ack, error) {
+) (yarpc.Ack, error) {
 	args := sink.Hello_Sink_Helper.Args(_Snk)
 	return c.c.CallOneway(ctx, reqMeta, args)
 }

--- a/internal/examples/oneway/sink/yarpc/helloserver/server.go
+++ b/internal/examples/oneway/sink/yarpc/helloserver/server.go
@@ -52,6 +52,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 		Name:    "Hello",
 		Methods: map[string]thrift.UnaryHandler{},
 		OnewayMethods: map[string]thrift.OnewayHandler{
+
 			"sink": thrift.OnewayHandlerFunc(h.Sink),
 		},
 	}

--- a/internal/examples/thrift-hello/hello/echo/yarpc/helloserver/server.go
+++ b/internal/examples/thrift-hello/hello/echo/yarpc/helloserver/server.go
@@ -51,6 +51,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 	service := thrift.Service{
 		Name: "Hello",
 		Methods: map[string]thrift.UnaryHandler{
+
 			"echo": thrift.UnaryHandlerFunc(h.Echo),
 		},
 		OnewayMethods: map[string]thrift.OnewayHandler{},

--- a/internal/examples/thrift-hello/hello/gen.go
+++ b/internal/examples/thrift-hello/hello/gen.go
@@ -21,4 +21,4 @@
 package main
 
 //go:generate thriftrw --plugin=yarpc echo.thrift
-//go:generate ../../../scripts/updateLicenses.sh
+//go:generate ../../../../scripts/updateLicenses.sh

--- a/internal/examples/thrift-keyvalue/keyvalue/gen.go
+++ b/internal/examples/thrift-keyvalue/keyvalue/gen.go
@@ -21,4 +21,4 @@
 package keyvalue
 
 //go:generate thriftrw --plugin=yarpc kv.thrift
-//go:generate ../../../scripts/updateLicenses.sh
+//go:generate ../../../../scripts/updateLicenses.sh

--- a/internal/examples/thrift-keyvalue/keyvalue/kv/yarpc/keyvalueserver/server.go
+++ b/internal/examples/thrift-keyvalue/keyvalue/kv/yarpc/keyvalueserver/server.go
@@ -58,7 +58,9 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 	service := thrift.Service{
 		Name: "KeyValue",
 		Methods: map[string]thrift.UnaryHandler{
+
 			"getValue": thrift.UnaryHandlerFunc(h.GetValue),
+
 			"setValue": thrift.UnaryHandlerFunc(h.SetValue),
 		},
 		OnewayMethods: map[string]thrift.OnewayHandler{},


### PR DESCRIPTION
Code from `make generate` is now the same as the checked-in code, except
`mockgen` code. Pending that fix, we should be able to make codegen a CI step.

@yarpc/golang 