### PR TITLE
vendor-build: Fix bug in glide.yaml search

### DIFF
--- a/scripts/vendor-build.sh
+++ b/scripts/vendor-build.sh
@@ -31,7 +31,7 @@ function findGlideLock() {
 		return
 	fi
 
-	if [[ src == "$(basename "$1")" ]]; then
+	if [[ "$GOPATH/src" == "$1" ]]; then
 		return
 	fi
 


### PR DESCRIPTION
This fixes a bug where glide.yaml search would stop at any directory named
"src" rather than the top level `$GOPATH/src` directory.

@prashantv