### PR TITLE
vendor-build: Don't depend on realpath

### DIFF
--- a/scripts/vendor-build.sh
+++ b/scripts/vendor-build.sh
@@ -17,8 +17,12 @@ if [[ ! -d vendor ]]; then
 fi
 
 function die() {
-	echo "$1"
+	echo "$1" >&2
 	exit 1
+}
+
+function abspath() {
+	(cd "$1" || die "Directory $1 does not exist"; pwd)
 }
 
 # findGlideLock dir looks for glide.lock in dir or any of its parent
@@ -35,7 +39,7 @@ function findGlideLock() {
 		return
 	fi
 
-	findGlideLock "$(realpath --no-symlinks "$1/..")"
+	findGlideLock "$(abspath "$1/..")"
 }
 
 outputDir="$1"

--- a/scripts/vendor-build.sh
+++ b/scripts/vendor-build.sh
@@ -22,6 +22,7 @@ function die() {
 }
 
 function abspath() {
+	# We use a subshell here so the directory change isn't persisted.
 	(cd "$1" || die "Directory $1 does not exist"; pwd)
 }
 


### PR DESCRIPTION
The realpath command isn't always available.