### PR TITLE
docker: Better caching and add `make docker-{build,test}`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+vendor
+node_modules
+*.o
+*.a
+*.so
+*.exe
+*.prof
+/cover
+/cover.html
+/cover.out
+/TAGS
+/.tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
-FROM golang:1.7
-ADD . /go/src/go.uber.org/yarpc
-RUN go install go.uber.org/yarpc/internal/crossdock
-ENTRYPOINT /go/bin/crossdock
+FROM golang:1.7.4
+
 EXPOSE 8080-8087
+RUN mkdir -p /go/src/go.uber.org/yarpc
+WORKDIR /go/src/go.uber.org/yarpc
+ADD glide.yaml /go/src/go.uber.org/yarpc/
+ADD glide.lock /go/src/go.uber.org/yarpc/
+RUN go get github.com/Masterminds/glide
+RUN glide install
+ADD . /go/src/go.uber.org/yarpc/
+RUN go install go.uber.org/yarpc/internal/crossdock
+CMD ["/go/bin/crossdock"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,8 @@ FROM golang:1.7.4
 EXPOSE 8080-8087
 RUN mkdir -p /go/src/go.uber.org/yarpc
 WORKDIR /go/src/go.uber.org/yarpc
-ADD glide.yaml /go/src/go.uber.org/yarpc/
-ADD glide.lock /go/src/go.uber.org/yarpc/
-RUN go get github.com/Masterminds/glide
-RUN glide install
+ADD glide.yaml glide.lock /go/src/go.uber.org/yarpc/
+RUN go get github.com/Masterminds/glide && glide install
 ADD . /go/src/go.uber.org/yarpc/
 RUN go install go.uber.org/yarpc/internal/crossdock
 CMD ["/go/bin/crossdock"]

--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,14 @@ crossdock-fresh: install
 	docker-compose build
 	docker-compose run crossdock
 
+.PHONY: docker-build
+docker-build:
+	docker build -t yarpc_go .
+
+.PHONY: docker-test
+docker-test: docker-build
+	docker run yarpc_go make test
+
 .PHONY: test_ci
 test_ci: verify_version
 	./scripts/cover.sh $(shell go list $(PACKAGES))


### PR DESCRIPTION
This does a few things:

-   Adds a .dockerignore that matches .gitignore, specifically so that vendor
    is ignored.
-   Updates the Dockerfile with a few minor cleanups (1.7 -> 1.74, etc).
-   Updates the Dockerfile to do `glide install` in a cache-friendly way, and
    set WORKDIR.
-   Changes ENTRYPOINT to CMD to make it simpler to override the default
    command.
-   Adds `make docker-build` and `make docker-test`, which use Docker
    directly, but match the current name of the image outputted by docker-
    compose (because of port bindings, doing `docker-compose run go make test`
    will fail).

I like having a Dockerfile that allows me to run make test in a fresh
environment, to confirm that make test works out of the box for new
developers. With that said, it still doesn't, because vendor isn't checked in,
and glide install is not a dependency of make test, but at least the
Dockerfile somewhat documents that (and it is annoying to have glide install
run every time).