### PR TITLE
Only do docker login and docker push on travis if all variables set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,11 +98,13 @@ after_success:
       export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
       export TAG=`if [ "$BRANCH" == "master" ]; then echo "latest"; else echo $BRANCH; fi`
 
-      docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       docker build -f Dockerfile -t $REPO:$COMMIT .
       docker tag $REPO:$COMMIT $REPO:$TAG
       docker tag $REPO:$COMMIT $REPO:travis-$TRAVIS_BUILD_NUMBER
-      docker push $REPO
+      if [ -n "$DOCKER_EMAIL" ] && [ -n "$DOCKER_USER" ] && [ -n "$DOCKER_PASS" ]; then
+        docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+        docker push $REPO
+      fi
       ;;
   esac
   set +e


### PR DESCRIPTION
Short: sub-optimal, but should fix PR builds.

Longer: I'm not sure if this is how you want to solve this, but all PR builds are failing because DOCKER_PASS is not set. This checks to see if all variables for docker login are set before executing the commands. This is assumedly sub-optimal, I'm guessing one of the secure variables is DOCKER_PASS, but you don't want to be running docker push except on master anyways.