### PR TITLE
Introspection 3/7, Add private introspection to peer chooser

### DIFF
--- a/api/peer/peer.go
+++ b/api/peer/peer.go
@@ -21,6 +21,7 @@
 package peer
 
 //go:generate mockgen -destination=peertest/peer.go -package=peertest go.uber.org/yarpc/api/peer Identifier,Peer
+//go:generate stringer -type=ConnectionStatus
 
 // ConnectionStatus maintains information about the Peer's connection state
 type ConnectionStatus int

--- a/internal/examples/thrift-keyvalue/keyvalue/gen.go
+++ b/internal/examples/thrift-keyvalue/keyvalue/gen.go
@@ -21,4 +21,4 @@
 package keyvalue
 
 //go:generate thriftrw --plugin=yarpc kv.thrift
-//go:generate ../../../scripts/updateLicenses.sh
+//go:generate ../../../../scripts/updateLicenses.sh

--- a/internal/examples/thrift-keyvalue/keyvalue/gen.go
+++ b/internal/examples/thrift-keyvalue/keyvalue/gen.go
@@ -21,4 +21,4 @@
 package keyvalue
 
 //go:generate thriftrw --plugin=yarpc kv.thrift
-//go:generate ../../../../scripts/updateLicenses.sh
+//go:generate ../../../scripts/updateLicenses.sh

--- a/internal/introspection/chooser.go
+++ b/internal/introspection/chooser.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package introspection
+
+// IntrospectableChooser extends the Chooser interfaces.
+type IntrospectableChooser interface {
+	Introspect() ChooserStatus
+}
+
+// ChooserStatus is a collection of basic chooser info.
+type ChooserStatus struct {
+	Name  string
+	State string
+	Peers []PeerStatus
+}
+
+// PeerStatus is a collection of basic peers info.
+type PeerStatus struct {
+	Identifier string
+	State      string
+}

--- a/peer/single.go
+++ b/peer/single.go
@@ -22,9 +22,11 @@ package peer
 
 import (
 	"context"
+	"fmt"
 
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/introspection"
 )
 
 // Single implements the Chooser interface for a single peer
@@ -70,4 +72,20 @@ func (s *Single) Stop() error {
 // IsRunning is a noop
 func (s *Single) IsRunning() bool {
 	return true
+}
+
+// Introspect returns a ChooserStatus with a single PeerStatus.
+func (s *Single) Introspect() introspection.ChooserStatus {
+	peerStatus := s.p.Status()
+	peer := introspection.PeerStatus{
+		Identifier: s.p.Identifier(),
+		State: fmt.Sprintf("%s, %d pending request(s)",
+			peerStatus.ConnectionStatus.String(),
+			peerStatus.PendingRequestCount),
+	}
+
+	return introspection.ChooserStatus{
+		Name:  "Single",
+		Peers: []introspection.PeerStatus{peer},
+	}
 }

--- a/peer/x/roundrobin/list.go
+++ b/peer/x/roundrobin/list.go
@@ -342,11 +342,12 @@ func (pl *List) Introspect() introspection.ChooserStatus {
 		len(availables)+len(unavailables))
 
 	buildPeerStatus := func(peer peer.Peer) introspection.PeerStatus {
+		ps := peer.Status()
 		return introspection.PeerStatus{
 			Identifier: peer.Identifier(),
 			State: fmt.Sprintf("%s, %d pending request(s)",
-				peer.Status().ConnectionStatus.String(),
-				peer.Status().PendingRequestCount),
+				ps.ConnectionStatus.String(),
+				ps.PendingRequestCount),
 		}
 	}
 

--- a/peer/x/roundrobin/peerring.go
+++ b/peer/x/roundrobin/peerring.go
@@ -101,6 +101,15 @@ func (pr *PeerRing) RemoveAll() []peer.Peer {
 	return peers
 }
 
+// All returns a snapshot of all the peers from the ring as a list.
+func (pr *PeerRing) All() []peer.Peer {
+	peers := make([]peer.Peer, 0, len(pr.peerToNode))
+	for _, node := range pr.peerToNode {
+		peers = append(peers, getPeerForRingNode(node))
+	}
+	return peers
+}
+
 func (pr *PeerRing) popNode(node *ring.Ring) peer.Peer {
 	p := getPeerForRingNode(node)
 


### PR DESCRIPTION
Because the interface for introspection is in internal/ only peer choosers
provided by yarpc can offer introspection.

This keeps the API open for experimentation and changes.