### PR TITLE
Introspection 6/7, HTTP inbounds special case on /debug/

### DIFF
--- a/internal/examples/thrift-keyvalue/Makefile
+++ b/internal/examples/thrift-keyvalue/Makefile
@@ -1,4 +1,12 @@
-.PHONY: all
-all:
+.PHONY: all hello kvserver kvclient
+
+all: hello kvserver kvclient
+
+hello:
+	cd hello; go build -i
+
+kvclient:
 	cd keyvalue/client; go build -i
+
+kvserver:
 	cd keyvalue/server; go build -i

--- a/transport/http/handler.go
+++ b/transport/http/handler.go
@@ -25,6 +25,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"go.uber.org/yarpc/api/transport"
@@ -49,6 +50,11 @@ type handler struct {
 
 func (h handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	start := time.Now()
+
+	if req.URL != nil && strings.HasPrefix(req.URL.Path, "/debug/") {
+		http.DefaultServeMux.ServeHTTP(w, req)
+		return
+	}
 
 	defer req.Body.Close()
 	if req.Method != "POST" {


### PR DESCRIPTION
This PR is meant for discussion.

Right now, every HTTP inbounds will automatically forward URLs starting with
"/debug/" to the default HTTP server mux.

This follows the Go standard library convention for debug pages. For example
the x/net/trace library will register handlers at /debug/requests and
/debug/events.

Maybe we do not need to standardize on some globals for debug pages yet, and we
can revisit this later.

As of now, I do not expect yarpc http inbounds being exposed outside of a
private network, but this is something to not forget.