### PR TITLE
raw/out: Drop *Meta, add procedure

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -24,8 +24,11 @@ import (
 
 var _reqBody = []byte("hello")
 
-func yarpcEcho(ctx context.Context, reqMeta yarpc.ReqMeta, body []byte) ([]byte, yarpc.ResMeta, error) {
-	return body, yarpc.NewResMeta().Headers(reqMeta.Headers()), nil
+func yarpcEcho(ctx context.Context, body []byte) ([]byte, error) {
+	for _, k := range yarpc.HeaderNames(ctx) {
+		yarpc.WriteResponseHeader(ctx, k, yarpc.Header(ctx, k))
+	}
+	return body, nil
 }
 
 func httpEcho(t testing.TB) http.HandlerFunc {

--- a/bench_test.go
+++ b/bench_test.go
@@ -77,7 +77,7 @@ func runYARPCClient(b *testing.B, c raw.Client) {
 	for i := 0; i < b.N; i++ {
 		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 		defer cancel()
-		_, _, err := c.Call(ctx, yarpc.NewReqMeta().Procedure("echo"), _reqBody)
+		_, err := c.Call(ctx, "echo", _reqBody)
 		require.NoError(b, err, "request %d failed", i+1)
 	}
 }

--- a/encoding/raw/doc.go
+++ b/encoding/raw/doc.go
@@ -28,7 +28,7 @@
 // Use the Procedure function to build procedures to register against a
 // Router.
 //
-// 	func Submit(reqMeta yarpc.ReqMeta, reqBody []byte) ([]byte, yarpc.ResMeta, error) {
+// 	func Submit(ctx context.Context, reqBody []byte) ([]byte, error) {
 // 		// ...
 // 	}
 //
@@ -37,7 +37,7 @@
 // Similarly, use the OnewayProcedure function to build procedures to register
 // against a Router.
 //
-// 	func RunTask(reqMeta yarpc.ReqMeta, reqBody []byte) error {
+// 	func RunTask(ctx context.Context, reqBody []byte) error {
 // 		// ...
 // 	}
 //

--- a/encoding/raw/doc.go
+++ b/encoding/raw/doc.go
@@ -23,10 +23,7 @@
 // To make outbound requests,
 //
 // 	client := raw.New(clientConfig)
-// 	resBody, resMeta, err := client.Call(
-// 		yarpc.NewReqMeta(ctx).Procedure("submit"),
-// 		[]byte{1, 2, 3},
-// 	)
+// 	resBody, err := client.Call(ctx, "submit", []byte{1, 2, 3})
 //
 // Use the Procedure function to build procedures to register against a
 // Router.

--- a/encoding/raw/inbound.go
+++ b/encoding/raw/inbound.go
@@ -24,9 +24,9 @@ import (
 	"context"
 	"io/ioutil"
 
+	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/encoding"
-	"go.uber.org/yarpc/internal/meta"
 )
 
 // rawUnaryHandler adapts a Handler into a transport.UnaryHandler
@@ -40,19 +40,23 @@ func (r rawUnaryHandler) Handle(ctx context.Context, treq *transport.Request, rw
 		return err
 	}
 
+	ctx, call := yarpc.NewInboundCall(ctx)
+	if err := call.ReadFromRequest(treq); err != nil {
+		return err
+	}
+
 	reqBody, err := ioutil.ReadAll(treq.Body)
 	if err != nil {
 		return err
 	}
 
-	reqMeta := meta.FromTransportRequest(treq)
-	resBody, resMeta, err := r.UnaryHandler(ctx, reqMeta, reqBody)
+	resBody, err := r.UnaryHandler(ctx, reqBody)
 	if err != nil {
 		return err
 	}
 
-	if resMeta != nil {
-		meta.ToTransportResponseWriter(resMeta, rw)
+	if err := call.WriteToResponse(rw); err != nil {
+		return err
 	}
 
 	if _, err := rw.Write(resBody); err != nil {
@@ -67,11 +71,15 @@ func (r rawOnewayHandler) HandleOneway(ctx context.Context, treq *transport.Requ
 		return err
 	}
 
+	ctx, call := yarpc.NewInboundCall(ctx)
+	if err := call.ReadFromRequest(treq); err != nil {
+		return err
+	}
+
 	reqBody, err := ioutil.ReadAll(treq.Body)
 	if err != nil {
 		return err
 	}
 
-	reqMeta := meta.FromTransportRequest(treq)
-	return r.OnewayHandler(ctx, reqMeta, reqBody)
+	return r.OnewayHandler(ctx, reqBody)
 }

--- a/encoding/raw/outbound.go
+++ b/encoding/raw/outbound.go
@@ -27,15 +27,15 @@ import (
 
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/internal/meta"
 )
 
 // Client makes Raw requests to a single service.
 type Client interface {
 	// Call performs a unary outbound Raw request.
-	Call(ctx context.Context, reqMeta yarpc.CallReqMeta, body []byte) ([]byte, yarpc.CallResMeta, error)
+	Call(ctx context.Context, procedure string, body []byte, opts ...yarpc.CallOption) ([]byte, error)
+
 	// CallOneway performs a oneway outbound Raw request.
-	CallOneway(ctx context.Context, reqMeta yarpc.CallReqMeta, body []byte) (transport.Ack, error)
+	CallOneway(ctx context.Context, procedure string, body []byte, opts ...yarpc.CallOption) (transport.Ack, error)
 }
 
 // New builds a new Raw client.
@@ -51,37 +51,54 @@ type rawClient struct {
 	cc transport.ClientConfig
 }
 
-func (c rawClient) Call(ctx context.Context, reqMeta yarpc.CallReqMeta, body []byte) ([]byte, yarpc.CallResMeta, error) {
+func (c rawClient) Call(ctx context.Context, procedure string, body []byte, opts ...yarpc.CallOption) ([]byte, error) {
+	call := yarpc.NewOutboundCall(opts...)
 	treq := transport.Request{
-		Caller:   c.cc.Caller(),
-		Service:  c.cc.Service(),
-		Encoding: Encoding,
-		Body:     bytes.NewReader(body),
+		Caller:    c.cc.Caller(),
+		Service:   c.cc.Service(),
+		Procedure: procedure,
+		Encoding:  Encoding,
+		Body:      bytes.NewReader(body),
 	}
-	meta.ToTransportRequest(reqMeta, &treq)
+
+	ctx, err := call.WriteToRequest(ctx, &treq)
+	if err != nil {
+		return nil, err
+	}
 
 	tres, err := c.cc.GetUnaryOutbound().Call(ctx, &treq)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	defer tres.Body.Close()
 
+	ctx, err = call.ReadFromResponse(ctx, tres)
+	if err != nil {
+		return nil, err
+	}
+
 	resBody, err := ioutil.ReadAll(tres.Body)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	return resBody, meta.FromTransportResponse(tres), nil
+	return resBody, nil
 }
 
-func (c rawClient) CallOneway(ctx context.Context, reqMeta yarpc.CallReqMeta, body []byte) (transport.Ack, error) {
+func (c rawClient) CallOneway(ctx context.Context, procedure string, body []byte, opts ...yarpc.CallOption) (transport.Ack, error) {
+	call := yarpc.NewOutboundCall(opts...)
 	treq := transport.Request{
-		Caller:   c.cc.Caller(),
-		Service:  c.cc.Service(),
-		Encoding: Encoding,
-		Body:     bytes.NewReader(body),
+		Caller:    c.cc.Caller(),
+		Service:   c.cc.Service(),
+		Procedure: procedure,
+		Encoding:  Encoding,
+		Body:      bytes.NewReader(body),
 	}
-	meta.ToTransportRequest(reqMeta, &treq)
+
+	ctx, err := call.WriteToRequest(ctx, &treq)
+	if err != nil {
+		return nil, err
+	}
 
 	return c.cc.GetOnewayOutbound().CallOneway(ctx, &treq)
 }

--- a/encoding/raw/register.go
+++ b/encoding/raw/register.go
@@ -23,7 +23,6 @@ package raw
 import (
 	"context"
 
-	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 )
 
@@ -38,7 +37,7 @@ func Register(r transport.RouteTable, rs []transport.Procedure) {
 }
 
 // UnaryHandler implements a single, unary procedure.
-type UnaryHandler func(context.Context, yarpc.ReqMeta, []byte) ([]byte, yarpc.ResMeta, error)
+type UnaryHandler func(context.Context, []byte) ([]byte, error)
 
 // Procedure builds a Procedure from the given raw handler.
 func Procedure(name string, handler UnaryHandler) []transport.Procedure {
@@ -51,7 +50,7 @@ func Procedure(name string, handler UnaryHandler) []transport.Procedure {
 }
 
 // OnewayHandler implements a single, onweway procedure
-type OnewayHandler func(context.Context, yarpc.ReqMeta, []byte) error
+type OnewayHandler func(context.Context, []byte) error
 
 // OnewayProcedure builds a Procedure from the given raw handler
 func OnewayProcedure(name string, handler OnewayHandler) []transport.Procedure {

--- a/internal/crossdock/client/echo/raw.go
+++ b/internal/crossdock/client/echo/raw.go
@@ -25,7 +25,6 @@ import (
 	"context"
 	"time"
 
-	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/encoding/raw"
 	disp "go.uber.org/yarpc/internal/crossdock/client/dispatcher"
 	"go.uber.org/yarpc/internal/crossdock/client/random"
@@ -47,7 +46,7 @@ func Raw(t crossdock.T) {
 	defer cancel()
 
 	token := random.Bytes(5)
-	resBody, _, err := client.Call(ctx, yarpc.NewReqMeta().Procedure("echo/raw"), token)
+	resBody, err := client.Call(ctx, "echo/raw", token)
 
 	crossdock.Fatals(t).NoError(err, "call to echo/raw failed: %v", err)
 	crossdock.Assert(t).True(bytes.Equal(token, resBody), "server said: %v", resBody)

--- a/internal/crossdock/client/httpserver/behavior.go
+++ b/internal/crossdock/client/httpserver/behavior.go
@@ -68,7 +68,7 @@ func runRaw(t crossdock.T, disp *yarpc.Dispatcher) {
 	defer cancel()
 
 	client := raw.New(disp.ClientConfig("yarpc-test"))
-	_, _, err := client.Call(ctx, yarpc.NewReqMeta().Procedure("handlertimeout/raw"), nil)
+	_, err := client.Call(ctx, "handlertimeout/raw", nil)
 	fatals.Error(err, "expected an error")
 
 	if transport.IsBadRequestError(err) {

--- a/internal/crossdock/client/oneway/oneway.go
+++ b/internal/crossdock/client/oneway/oneway.go
@@ -23,7 +23,6 @@ package oneway
 import (
 	"context"
 
-	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/encoding/raw"
 	"go.uber.org/yarpc/internal/crossdock/client/dispatcher"
 	"go.uber.org/yarpc/internal/crossdock/client/params"
@@ -54,11 +53,10 @@ func Run(t crossdock.T) {
 // newCallBackHandler creates a oneway handler that fills a channel with the body
 func newCallBackHandler() (raw.OnewayHandler, <-chan []byte) {
 	serverCalledBack := make(chan []byte)
-	handler := func(ctx context.Context, reqMeta yarpc.ReqMeta, body []byte) error {
+	return func(ctx context.Context, body []byte) error {
 		serverCalledBack <- body
 		return nil
-	}
-	return handler, serverCalledBack
+	}, serverCalledBack
 }
 
 func getRandomID() string { return random.String(10) }

--- a/internal/crossdock/client/oneway/raw.go
+++ b/internal/crossdock/client/oneway/raw.go
@@ -37,12 +37,9 @@ func Raw(t crossdock.T, dispatcher *yarpc.Dispatcher, serverCalledBack <-chan []
 	client := raw.New(dispatcher.ClientConfig("oneway-server"))
 	token := []byte(getRandomID())
 
+	ctx := context.Background()
 	ack, err := client.CallOneway(
-		context.Background(),
-		yarpc.NewReqMeta().
-			Procedure("echo/raw").
-			Headers(yarpc.NewHeaders().With("callBackAddr", callBackAddr)),
-		token)
+		ctx, "echo/raw", token, yarpc.WithHeader("callBackAddr", callBackAddr))
 
 	// ensure channel hasn't been filled yet
 	select {

--- a/internal/crossdock/client/onewayctxpropagation/behavior.go
+++ b/internal/crossdock/client/onewayctxpropagation/behavior.go
@@ -65,11 +65,10 @@ func Run(t crossdock.T) {
 // with the received body
 func newCallBackHandler() (raw.OnewayHandler, <-chan map[string]string) {
 	serverCalledBack := make(chan map[string]string)
-	handler := func(ctx context.Context, reqMeta yarpc.ReqMeta, body []byte) error {
+	return func(ctx context.Context, body []byte) error {
 		serverCalledBack <- extractBaggage(ctx)
 		return nil
-	}
-	return handler, serverCalledBack
+	}, serverCalledBack
 }
 
 func newContextWithBaggage(baggage map[string]string) context.Context {

--- a/internal/crossdock/client/onewayctxpropagation/behavior.go
+++ b/internal/crossdock/client/onewayctxpropagation/behavior.go
@@ -49,13 +49,9 @@ func Run(t crossdock.T) {
 	client := raw.New(dispatcher.ClientConfig("oneway-server"))
 
 	// make call
+	ctx := newContextWithBaggage(baggage)
 	ack, err := client.CallOneway(
-		newContextWithBaggage(baggage),
-		yarpc.NewReqMeta().
-			Procedure("echo/raw").
-			Headers(yarpc.NewHeaders().
-				With("callBackAddr", callBackAddr)),
-		[]byte{})
+		ctx, "echo/raw", []byte{}, yarpc.WithHeader("callBackAddr", callBackAddr))
 
 	fatals.NoError(err, "call to oneway/raw failed: %v", err)
 	fatals.NotNil(ack, "ack is nil")

--- a/internal/crossdock/client/timeout/behavior.go
+++ b/internal/crossdock/client/timeout/behavior.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 	"time"
 
-	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/raw"
 	disp "go.uber.org/yarpc/internal/crossdock/client/dispatcher"
@@ -49,7 +48,7 @@ func Run(t crossdock.T) {
 	defer dispatcher.Stop()
 
 	client := raw.New(dispatcher.ClientConfig("yarpc-test"))
-	_, _, err := client.Call(ctx, yarpc.NewReqMeta().Procedure("sleep/raw"), nil)
+	_, err := client.Call(ctx, "sleep/raw", nil)
 	fatals.Error(err, "expected a failure for timeout")
 
 	if transport.IsBadRequestError(err) {

--- a/internal/crossdock/server/yarpc/echo.go
+++ b/internal/crossdock/server/yarpc/echo.go
@@ -28,8 +28,11 @@ import (
 )
 
 // EchoRaw implements the echo/raw procedure.
-func EchoRaw(ctx context.Context, reqMeta yarpc.ReqMeta, body []byte) ([]byte, yarpc.ResMeta, error) {
-	return body, yarpc.NewResMeta().Headers(reqMeta.Headers()), nil
+func EchoRaw(ctx context.Context, body []byte) ([]byte, error) {
+	for _, k := range yarpc.HeaderNames(ctx) {
+		yarpc.WriteResponseHeader(ctx, k, yarpc.Header(ctx, k))
+	}
+	return body, nil
 }
 
 // EchoJSON implements the echo procedure.

--- a/internal/crossdock/server/yarpc/sleep.go
+++ b/internal/crossdock/server/yarpc/sleep.go
@@ -30,9 +30,9 @@ import (
 
 // SleepRaw responds to raw requests over any transport by sleeping for one
 // second.
-func SleepRaw(ctx context.Context, reqMeta yarpc.ReqMeta, body []byte) ([]byte, yarpc.ResMeta, error) {
+func SleepRaw(ctx context.Context, body []byte) ([]byte, error) {
 	time.Sleep(1 * time.Second)
-	return nil, nil, nil
+	return nil, nil
 }
 
 // Sleep responds to json requests over any transport by sleeping for one
@@ -45,12 +45,12 @@ func Sleep(ctx context.Context, reqMeta yarpc.ReqMeta, body interface{}) (interf
 // WaitForTimeoutRaw waits after the context deadline then returns the context
 // error. yarpc should interpret this as an handler timeout, which in turns
 // should be forwarded to the yarpc client as a remote handler timeout.
-func WaitForTimeoutRaw(ctx context.Context, reqMeta yarpc.ReqMeta, body []byte) ([]byte, yarpc.ResMeta, error) {
+func WaitForTimeoutRaw(ctx context.Context, body []byte) ([]byte, error) {
 	if _, ok := ctx.Deadline(); !ok {
-		return nil, nil, fmt.Errorf("no deadline set in context")
+		return nil, fmt.Errorf("no deadline set in context")
 	}
 	select {
 	case <-ctx.Done():
-		return nil, nil, ctx.Err()
+		return nil, ctx.Err()
 	}
 }

--- a/transport/http/handler_test.go
+++ b/transport/http/handler_test.go
@@ -357,7 +357,7 @@ func TestHandlerPanic(t *testing.T) {
 	client := raw.New(clientDispatcher.ClientConfig("yarpc-test"))
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	_, _, err := client.Call(ctx, yarpc.NewReqMeta().Procedure("panic"), []byte{})
+	_, err := client.Call(ctx, "panic", []byte{})
 
 	assert.True(t, transport.IsUnexpectedError(err), "Must be an UnexpectedError")
 	assert.Equal(t,

--- a/yarpctest/recorder/recorder_test.go
+++ b/yarpctest/recorder/recorder_test.go
@@ -231,7 +231,7 @@ func TestEndToEnd(t *testing.T) {
 		defer cancel()
 
 		require.Panics(t, func() {
-			client.Call(ctx, yarpc.NewReqMeta().Procedure("hello"), []byte("Hello"))
+			client.Call(ctx, "hello", []byte("Hello"))
 		})
 		assert.Equal(t, tMock.fatalCount, 1)
 	})
@@ -243,7 +243,7 @@ func TestEndToEnd(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
 
-		rbody, _, err := client.Call(ctx, yarpc.NewReqMeta().Procedure("hello"), []byte("Hello"))
+		rbody, err := client.Call(ctx, "hello", []byte("Hello"))
 		require.NoError(t, err)
 		assert.Equal(t, rbody, []byte("Hello, World"))
 	})
@@ -255,7 +255,7 @@ func TestEndToEnd(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
 
-		rbody, _, err := client.Call(ctx, yarpc.NewReqMeta().Procedure("hello"), []byte("Hello"))
+		rbody, err := client.Call(ctx, "hello", []byte("Hello"))
 		require.NoError(t, err)
 		assert.Equal(t, rbody, []byte("Hello, World"))
 	})
@@ -277,7 +277,7 @@ func TestEmptyReplay(t *testing.T) {
 		defer cancel()
 
 		require.Panics(t, func() {
-			client.Call(ctx, yarpc.NewReqMeta().Procedure("hello"), []byte("Hello"))
+			client.Call(ctx, "hello", []byte("Hello"))
 		})
 		assert.Equal(t, tMock.fatalCount, 1)
 	})
@@ -316,7 +316,7 @@ func TestRecording(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
 
-		rbody, _, err := client.Call(ctx, yarpc.NewReqMeta().Procedure("hello"), []byte("Hello"))
+		rbody, err := client.Call(ctx, "hello", []byte("Hello"))
 		require.NoError(t, err)
 		assert.Equal(t, []byte("Hello, World"), rbody)
 	})
@@ -349,7 +349,7 @@ func TestReplaying(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
 
-		rbody, _, err := client.Call(ctx, yarpc.NewReqMeta().Procedure("hello"), []byte("Hello"))
+		rbody, err := client.Call(ctx, "hello", []byte("Hello"))
 		require.NoError(t, err)
 		assert.Equal(t, rbody, []byte("Hello, World"))
 	})

--- a/yarpctest/recorder/recorder_test.go
+++ b/yarpctest/recorder/recorder_test.go
@@ -189,8 +189,8 @@ func withConnectedClient(t *testing.T, recorder *Recorder, f func(raw.Client)) {
 	})
 
 	serverDisp.Register(raw.Procedure("hello",
-		func(ctx context.Context, reqMeta yarpc.ReqMeta, body []byte) ([]byte, yarpc.ResMeta, error) {
-			return append(body, []byte(", World")...), nil, nil
+		func(ctx context.Context, body []byte) ([]byte, error) {
+			return append(body, []byte(", World")...), nil
 		}))
 
 	require.NoError(t, serverDisp.Start())


### PR DESCRIPTION
This changes raw outbounds to drop the CallReqMeta argument and the
CallResMeta return value.

The procedure name is now provided as an explicit argument and other call site
options are passed in using the `CallOption` interface.

Issue: #617 