### PR TITLE
raw/in: Drop *Meta from handlers

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -24,8 +24,11 @@ import (
 
 var _reqBody = []byte("hello")
 
-func yarpcEcho(ctx context.Context, reqMeta yarpc.ReqMeta, body []byte) ([]byte, yarpc.ResMeta, error) {
-	return body, yarpc.NewResMeta().Headers(reqMeta.Headers()), nil
+func yarpcEcho(ctx context.Context, body []byte) ([]byte, error) {
+	for _, k := range yarpc.HeaderNames(ctx) {
+		yarpc.WriteResponseHeader(ctx, k, yarpc.Header(ctx, k))
+	}
+	return body, nil
 }
 
 func httpEcho(t testing.TB) http.HandlerFunc {

--- a/encoding/json/doc.go
+++ b/encoding/json/doc.go
@@ -32,7 +32,7 @@
 //
 // To register a JSON procedure, define functions in the format,
 //
-// 	f(ctx context.Context, reqMeta yarpc.ReqMeta, body $reqBody) ($resBody, yarpc.ResMeta, error)
+// 	f(ctx context.Context, body $reqBody) ($resBody, error)
 //
 // Where '$reqBody' and '$resBody' are either pointers to structs representing
 // your request and response objects, or map[string]interface{}.
@@ -46,7 +46,7 @@
 // Similarly, to register a oneway JSON procedure, define functions in the
 // format,
 //
-// 	f(ctx context.Context, reqMeta yarpc.ReqMeta, body $reqBody) error
+// 	f(ctx context.Context, body $reqBody) error
 //
 // Where $reqBody is a map[string]interface{} or pointer to a struct.
 //

--- a/encoding/json/inbound.go
+++ b/encoding/json/inbound.go
@@ -28,7 +28,6 @@ import (
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/encoding"
-	"go.uber.org/yarpc/internal/meta"
 )
 
 // jsonHandler adapts a user-provided high-level handler into a transport-level
@@ -36,7 +35,7 @@ import (
 //
 // The wrapped function must already be in the correct format:
 //
-// 	f(reqMeta yarpc.ReqMeta, body $reqBody) ($resBody, yarpc.ResMeta, error)
+// 	f(ctx context.Context, body $reqBody) ($resBody, error)
 type jsonHandler struct {
 	reader  requestReader
 	handler reflect.Value
@@ -47,20 +46,24 @@ func (h jsonHandler) Handle(ctx context.Context, treq *transport.Request, rw tra
 		return err
 	}
 
+	ctx, call := yarpc.NewInboundCall(ctx)
+	if err := call.ReadFromRequest(treq); err != nil {
+		return err
+	}
+
 	reqBody, err := h.reader.Read(json.NewDecoder(treq.Body))
 	if err != nil {
 		return encoding.RequestBodyDecodeError(treq, err)
 	}
 
-	reqMeta := meta.FromTransportRequest(treq)
-	results := h.handler.Call([]reflect.Value{reflect.ValueOf(ctx), reflect.ValueOf(reqMeta), reqBody})
+	results := h.handler.Call([]reflect.Value{reflect.ValueOf(ctx), reqBody})
 
-	if err := results[2].Interface(); err != nil {
+	if err := results[1].Interface(); err != nil {
 		return err.(error)
 	}
 
-	if resMeta, ok := results[1].Interface().(yarpc.ResMeta); ok {
-		meta.ToTransportResponseWriter(resMeta, rw)
+	if err := call.WriteToResponse(rw); err != nil {
+		return err
 	}
 
 	result := results[0].Interface()
@@ -76,13 +79,17 @@ func (h jsonHandler) HandleOneway(ctx context.Context, treq *transport.Request) 
 		return err
 	}
 
+	ctx, call := yarpc.NewInboundCall(ctx)
+	if err := call.ReadFromRequest(treq); err != nil {
+		return err
+	}
+
 	reqBody, err := h.reader.Read(json.NewDecoder(treq.Body))
 	if err != nil {
 		return encoding.RequestBodyDecodeError(treq, err)
 	}
 
-	reqMeta := meta.FromTransportRequest(treq)
-	results := h.handler.Call([]reflect.Value{reflect.ValueOf(ctx), reflect.ValueOf(reqMeta), reqBody})
+	results := h.handler.Call([]reflect.Value{reflect.ValueOf(ctx), reqBody})
 
 	if err := results[0].Interface(); err != nil {
 		return err.(error)

--- a/encoding/json/register_test.go
+++ b/encoding/json/register_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"go.uber.org/yarpc"
-
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,62 +16,44 @@ func TestWrapUnaryHandlerInvalid(t *testing.T) {
 		{"not-a-function", 0},
 		{
 			"wrong-args-in",
-			func(context.Context, yarpc.ReqMeta) (*struct{}, yarpc.ResMeta, error) {
-				return nil, nil, nil
-			},
-		},
-		{
-			"wrong-ctx",
-			func(string, yarpc.ReqMeta, *struct{}) (*struct{}, yarpc.ResMeta, error) {
-				return nil, nil, nil
-			},
-		},
-		{
-			"wrong-req-meta",
-			func(context.Context, yarpc.CallReqMeta, *struct{}) (*struct{}, yarpc.ResMeta, error) {
-				return nil, nil, nil
-			},
-		},
-		{
-			"wrong-req-body",
-			func(context.Context, string, int) (*struct{}, yarpc.ResMeta, error) {
-				return nil, nil, nil
-			},
-		},
-		{
-			"wrong-response",
-			func(context.Context, yarpc.ReqMeta, map[string]interface{}) (yarpc.ResMeta, error) {
+			func(context.Context) (*struct{}, error) {
 				return nil, nil
 			},
 		},
 		{
-			"wrong-request",
-			func(context.Context, string, *struct{}) (*struct{}, yarpc.ResMeta, error) {
-				return nil, nil, nil
+			"wrong-ctx",
+			func(string, *struct{}) (*struct{}, error) {
+				return nil, nil
 			},
 		},
 		{
-			"wrong-res-meta",
-			func(context.Context, yarpc.ReqMeta, *struct{}) (*struct{}, yarpc.CallResMeta, error) {
-				return nil, nil, nil
+			"wrong-req-body",
+			func(context.Context, string, int) (*struct{}, error) {
+				return nil, nil
+			},
+		},
+		{
+			"wrong-response",
+			func(context.Context, map[string]interface{}) error {
+				return nil
 			},
 		},
 		{
 			"non-pointer-req",
-			func(context.Context, yarpc.ReqMeta, struct{}) (*struct{}, yarpc.ResMeta, error) {
-				return nil, nil, nil
+			func(context.Context, struct{}) (*struct{}, error) {
+				return nil, nil
 			},
 		},
 		{
 			"non-pointer-res",
-			func(context.Context, yarpc.ReqMeta, *struct{}) (struct{}, yarpc.ResMeta, error) {
-				return struct{}{}, nil, nil
+			func(context.Context, *struct{}) (struct{}, error) {
+				return struct{}{}, nil
 			},
 		},
 		{
 			"non-string-key",
-			func(context.Context, yarpc.ReqMeta, map[int32]interface{}) (*struct{}, yarpc.ResMeta, error) {
-				return nil, nil, nil
+			func(context.Context, map[int32]interface{}) (*struct{}, error) {
+				return nil, nil
 			},
 		},
 	}
@@ -81,7 +61,7 @@ func TestWrapUnaryHandlerInvalid(t *testing.T) {
 	for _, tt := range tests {
 		assert.Panics(t, assert.PanicTestFunc(func() {
 			wrapUnaryHandler(tt.Name, tt.Func)
-		}))
+		}), tt.Name)
 	}
 }
 
@@ -92,26 +72,26 @@ func TestWrapUnaryHandlerValid(t *testing.T) {
 	}{
 		{
 			"foo",
-			func(context.Context, yarpc.ReqMeta, *struct{}) (*struct{}, yarpc.ResMeta, error) {
-				return nil, nil, nil
+			func(context.Context, *struct{}) (*struct{}, error) {
+				return nil, nil
 			},
 		},
 		{
 			"bar",
-			func(context.Context, yarpc.ReqMeta, map[string]interface{}) (*struct{}, yarpc.ResMeta, error) {
-				return nil, nil, nil
+			func(context.Context, map[string]interface{}) (*struct{}, error) {
+				return nil, nil
 			},
 		},
 		{
 			"baz",
-			func(context.Context, yarpc.ReqMeta, map[string]interface{}) (map[string]interface{}, yarpc.ResMeta, error) {
-				return nil, nil, nil
+			func(context.Context, map[string]interface{}) (map[string]interface{}, error) {
+				return nil, nil
 			},
 		},
 		{
 			"qux",
-			func(context.Context, yarpc.ReqMeta, interface{}) (map[string]interface{}, yarpc.ResMeta, error) {
-				return nil, nil, nil
+			func(context.Context, interface{}) (map[string]interface{}, error) {
+				return nil, nil
 			},
 		},
 	}
@@ -130,19 +110,13 @@ func TestWrapOnewayHandlerInvalid(t *testing.T) {
 		{"not-a-function", 0},
 		{
 			"wrong-args-in",
-			func(context.Context, yarpc.ReqMeta) error {
+			func(context.Context) error {
 				return nil
 			},
 		},
 		{
 			"wrong-ctx",
-			func(string, yarpc.ReqMeta, *struct{}) error {
-				return nil
-			},
-		},
-		{
-			"wrong-req-meta",
-			func(context.Context, yarpc.CallReqMeta, *struct{}) error {
+			func(string, *struct{}) error {
 				return nil
 			},
 		},
@@ -154,25 +128,25 @@ func TestWrapOnewayHandlerInvalid(t *testing.T) {
 		},
 		{
 			"wrong-response",
-			func(context.Context, yarpc.ReqMeta, map[string]interface{}) (*struct{}, yarpc.ResMeta, error) {
-				return nil, nil, nil
+			func(context.Context, map[string]interface{}) (*struct{}, error) {
+				return nil, nil
 			},
 		},
 		{
 			"wrong-response-val",
-			func(context.Context, yarpc.ReqMeta, map[string]interface{}) int {
+			func(context.Context, map[string]interface{}) int {
 				return 0
 			},
 		},
 		{
 			"non-pointer-req",
-			func(context.Context, yarpc.ReqMeta, struct{}) error {
+			func(context.Context, struct{}) error {
 				return nil
 			},
 		},
 		{
 			"non-string-key",
-			func(context.Context, yarpc.ReqMeta, map[int32]interface{}) error {
+			func(context.Context, map[int32]interface{}) error {
 				return nil
 			},
 		},
@@ -191,25 +165,25 @@ func TestWrapOnewayHandlerValid(t *testing.T) {
 	}{
 		{
 			"foo",
-			func(context.Context, yarpc.ReqMeta, *struct{}) error {
+			func(context.Context, *struct{}) error {
 				return nil
 			},
 		},
 		{
 			"bar",
-			func(context.Context, yarpc.ReqMeta, map[string]interface{}) error {
+			func(context.Context, map[string]interface{}) error {
 				return nil
 			},
 		},
 		{
 			"baz",
-			func(context.Context, yarpc.ReqMeta, map[string]interface{}) error {
+			func(context.Context, map[string]interface{}) error {
 				return nil
 			},
 		},
 		{
 			"qux",
-			func(context.Context, yarpc.ReqMeta, interface{}) error {
+			func(context.Context, interface{}) error {
 				return nil
 			},
 		},

--- a/encoding/raw/doc.go
+++ b/encoding/raw/doc.go
@@ -28,7 +28,7 @@
 // Use the Procedure function to build procedures to register against a
 // Router.
 //
-// 	func Submit(reqMeta yarpc.ReqMeta, reqBody []byte) ([]byte, yarpc.ResMeta, error) {
+// 	func Submit(ctx context.Context, reqBody []byte) ([]byte, error) {
 // 		// ...
 // 	}
 //
@@ -37,7 +37,7 @@
 // Similarly, use the OnewayProcedure function to build procedures to register
 // against a Router.
 //
-// 	func RunTask(reqMeta yarpc.ReqMeta, reqBody []byte) error {
+// 	func RunTask(ctx context.Context, reqBody []byte) error {
 // 		// ...
 // 	}
 //

--- a/encoding/raw/inbound.go
+++ b/encoding/raw/inbound.go
@@ -24,9 +24,9 @@ import (
 	"context"
 	"io/ioutil"
 
+	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/encoding"
-	"go.uber.org/yarpc/internal/meta"
 )
 
 // rawUnaryHandler adapts a Handler into a transport.UnaryHandler
@@ -40,19 +40,23 @@ func (r rawUnaryHandler) Handle(ctx context.Context, treq *transport.Request, rw
 		return err
 	}
 
+	ctx, call := yarpc.NewInboundCall(ctx)
+	if err := call.ReadFromRequest(treq); err != nil {
+		return err
+	}
+
 	reqBody, err := ioutil.ReadAll(treq.Body)
 	if err != nil {
 		return err
 	}
 
-	reqMeta := meta.FromTransportRequest(treq)
-	resBody, resMeta, err := r.UnaryHandler(ctx, reqMeta, reqBody)
+	resBody, err := r.UnaryHandler(ctx, reqBody)
 	if err != nil {
 		return err
 	}
 
-	if resMeta != nil {
-		meta.ToTransportResponseWriter(resMeta, rw)
+	if err := call.WriteToResponse(rw); err != nil {
+		return err
 	}
 
 	if _, err := rw.Write(resBody); err != nil {
@@ -67,11 +71,15 @@ func (r rawOnewayHandler) HandleOneway(ctx context.Context, treq *transport.Requ
 		return err
 	}
 
+	ctx, call := yarpc.NewInboundCall(ctx)
+	if err := call.ReadFromRequest(treq); err != nil {
+		return err
+	}
+
 	reqBody, err := ioutil.ReadAll(treq.Body)
 	if err != nil {
 		return err
 	}
 
-	reqMeta := meta.FromTransportRequest(treq)
-	return r.OnewayHandler(ctx, reqMeta, reqBody)
+	return r.OnewayHandler(ctx, reqBody)
 }

--- a/encoding/raw/register.go
+++ b/encoding/raw/register.go
@@ -23,7 +23,6 @@ package raw
 import (
 	"context"
 
-	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 )
 
@@ -38,7 +37,7 @@ func Register(r transport.RouteTable, rs []transport.Procedure) {
 }
 
 // UnaryHandler implements a single, unary procedure.
-type UnaryHandler func(context.Context, yarpc.ReqMeta, []byte) ([]byte, yarpc.ResMeta, error)
+type UnaryHandler func(context.Context, []byte) ([]byte, error)
 
 // Procedure builds a Procedure from the given raw handler.
 func Procedure(name string, handler UnaryHandler) []transport.Procedure {
@@ -51,7 +50,7 @@ func Procedure(name string, handler UnaryHandler) []transport.Procedure {
 }
 
 // OnewayHandler implements a single, onweway procedure
-type OnewayHandler func(context.Context, yarpc.ReqMeta, []byte) error
+type OnewayHandler func(context.Context, []byte) error
 
 // OnewayProcedure builds a Procedure from the given raw handler
 func OnewayProcedure(name string, handler OnewayHandler) []transport.Procedure {

--- a/internal/crossdock/client/oneway/oneway.go
+++ b/internal/crossdock/client/oneway/oneway.go
@@ -23,7 +23,6 @@ package oneway
 import (
 	"context"
 
-	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/encoding/raw"
 	"go.uber.org/yarpc/internal/crossdock/client/dispatcher"
 	"go.uber.org/yarpc/internal/crossdock/client/params"
@@ -54,11 +53,10 @@ func Run(t crossdock.T) {
 // newCallBackHandler creates a oneway handler that fills a channel with the body
 func newCallBackHandler() (raw.OnewayHandler, <-chan []byte) {
 	serverCalledBack := make(chan []byte)
-	handler := func(ctx context.Context, reqMeta yarpc.ReqMeta, body []byte) error {
+	return func(ctx context.Context, body []byte) error {
 		serverCalledBack <- body
 		return nil
-	}
-	return handler, serverCalledBack
+	}, serverCalledBack
 }
 
 func getRandomID() string { return random.String(10) }

--- a/internal/crossdock/client/onewayctxpropagation/behavior.go
+++ b/internal/crossdock/client/onewayctxpropagation/behavior.go
@@ -65,11 +65,10 @@ func Run(t crossdock.T) {
 // with the received body
 func newCallBackHandler() (raw.OnewayHandler, <-chan map[string]string) {
 	serverCalledBack := make(chan map[string]string)
-	handler := func(ctx context.Context, reqMeta yarpc.ReqMeta, body []byte) error {
+	return func(ctx context.Context, body []byte) error {
 		serverCalledBack <- extractBaggage(ctx)
 		return nil
-	}
-	return handler, serverCalledBack
+	}, serverCalledBack
 }
 
 func newContextWithBaggage(baggage map[string]string) context.Context {

--- a/internal/crossdock/server/oneway/echo.go
+++ b/internal/crossdock/server/oneway/echo.go
@@ -50,8 +50,8 @@ func (o *onewayHandler) EchoRaw(ctx context.Context, body []byte) error {
 type jsonToken struct{ Token string }
 
 // EchoJSON implements the echo/json procedure.
-func (o *onewayHandler) EchoJSON(ctx context.Context, reqMeta yarpc.ReqMeta, token *jsonToken) error {
-	callBackAddr, _ := reqMeta.Headers().Get(callBackAddrHeader)
+func (o *onewayHandler) EchoJSON(ctx context.Context, token *jsonToken) error {
+	callBackAddr := yarpc.Header(ctx, callBackAddrHeader)
 	o.callHome(ctx, callBackAddr, []byte(token.Token), json.Encoding)
 	return nil
 }

--- a/internal/crossdock/server/yarpc/echo.go
+++ b/internal/crossdock/server/yarpc/echo.go
@@ -36,8 +36,11 @@ func EchoRaw(ctx context.Context, body []byte) ([]byte, error) {
 }
 
 // EchoJSON implements the echo procedure.
-func EchoJSON(ctx context.Context, reqMeta yarpc.ReqMeta, body map[string]interface{}) (map[string]interface{}, yarpc.ResMeta, error) {
-	return body, yarpc.NewResMeta().Headers(reqMeta.Headers()), nil
+func EchoJSON(ctx context.Context, body map[string]interface{}) (map[string]interface{}, error) {
+	for _, k := range yarpc.HeaderNames(ctx) {
+		yarpc.WriteResponseHeader(ctx, k, yarpc.Header(ctx, k))
+	}
+	return body, nil
 }
 
 // EchoThrift implements the Thrift Echo service.

--- a/internal/crossdock/server/yarpc/echo.go
+++ b/internal/crossdock/server/yarpc/echo.go
@@ -28,8 +28,11 @@ import (
 )
 
 // EchoRaw implements the echo/raw procedure.
-func EchoRaw(ctx context.Context, reqMeta yarpc.ReqMeta, body []byte) ([]byte, yarpc.ResMeta, error) {
-	return body, yarpc.NewResMeta().Headers(reqMeta.Headers()), nil
+func EchoRaw(ctx context.Context, body []byte) ([]byte, error) {
+	for _, k := range yarpc.HeaderNames(ctx) {
+		yarpc.WriteResponseHeader(ctx, k, yarpc.Header(ctx, k))
+	}
+	return body, nil
 }
 
 // EchoJSON implements the echo procedure.

--- a/internal/crossdock/server/yarpc/error.go
+++ b/internal/crossdock/server/yarpc/error.go
@@ -23,18 +23,16 @@ package yarpc
 import (
 	"context"
 	"fmt"
-
-	"go.uber.org/yarpc"
 )
 
 // UnexpectedError fails with an unexpected error.
-func UnexpectedError(ctx context.Context, reqMeta yarpc.ReqMeta, body interface{}) (interface{}, yarpc.ResMeta, error) {
-	return nil, nil, fmt.Errorf("error")
+func UnexpectedError(ctx context.Context, body interface{}) (interface{}, error) {
+	return nil, fmt.Errorf("error")
 }
 
 // BadResponse returns an object that's not a valid JSON response.
-func BadResponse(ctx context.Context, reqMeta yarpc.ReqMeta, body map[string]interface{}) (map[string]interface{}, yarpc.ResMeta, error) {
+func BadResponse(ctx context.Context, body map[string]interface{}) (map[string]interface{}, error) {
 	// func is not serializable
 	result := map[string]interface{}{"foo": func() {}}
-	return result, nil, nil
+	return result, nil
 }

--- a/internal/crossdock/server/yarpc/sleep.go
+++ b/internal/crossdock/server/yarpc/sleep.go
@@ -24,8 +24,6 @@ import (
 	"context"
 	"fmt"
 	"time"
-
-	"go.uber.org/yarpc"
 )
 
 // SleepRaw responds to raw requests over any transport by sleeping for one
@@ -37,9 +35,9 @@ func SleepRaw(ctx context.Context, body []byte) ([]byte, error) {
 
 // Sleep responds to json requests over any transport by sleeping for one
 // second.
-func Sleep(ctx context.Context, reqMeta yarpc.ReqMeta, body interface{}) (interface{}, yarpc.ResMeta, error) {
+func Sleep(ctx context.Context, body interface{}) (interface{}, error) {
 	time.Sleep(1 * time.Second)
-	return nil, nil, nil
+	return nil, nil
 }
 
 // WaitForTimeoutRaw waits after the context deadline then returns the context

--- a/internal/crossdock/server/yarpc/sleep.go
+++ b/internal/crossdock/server/yarpc/sleep.go
@@ -30,9 +30,9 @@ import (
 
 // SleepRaw responds to raw requests over any transport by sleeping for one
 // second.
-func SleepRaw(ctx context.Context, reqMeta yarpc.ReqMeta, body []byte) ([]byte, yarpc.ResMeta, error) {
+func SleepRaw(ctx context.Context, body []byte) ([]byte, error) {
 	time.Sleep(1 * time.Second)
-	return nil, nil, nil
+	return nil, nil
 }
 
 // Sleep responds to json requests over any transport by sleeping for one
@@ -45,12 +45,12 @@ func Sleep(ctx context.Context, reqMeta yarpc.ReqMeta, body interface{}) (interf
 // WaitForTimeoutRaw waits after the context deadline then returns the context
 // error. yarpc should interpret this as an handler timeout, which in turns
 // should be forwarded to the yarpc client as a remote handler timeout.
-func WaitForTimeoutRaw(ctx context.Context, reqMeta yarpc.ReqMeta, body []byte) ([]byte, yarpc.ResMeta, error) {
+func WaitForTimeoutRaw(ctx context.Context, body []byte) ([]byte, error) {
 	if _, ok := ctx.Deadline(); !ok {
-		return nil, nil, fmt.Errorf("no deadline set in context")
+		return nil, fmt.Errorf("no deadline set in context")
 	}
 	select {
 	case <-ctx.Done():
-		return nil, nil, ctx.Err()
+		return nil, ctx.Err()
 	}
 }

--- a/internal/examples/json-keyvalue/server/main.go
+++ b/internal/examples/json-keyvalue/server/main.go
@@ -54,18 +54,18 @@ type handler struct {
 	items map[string]string
 }
 
-func (h *handler) Get(ctx context.Context, reqMeta yarpc.ReqMeta, body *getRequest) (*getResponse, yarpc.ResMeta, error) {
+func (h *handler) Get(ctx context.Context, body *getRequest) (*getResponse, error) {
 	h.RLock()
 	result := &getResponse{Value: h.items[body.Key]}
 	h.RUnlock()
-	return result, nil, nil
+	return result, nil
 }
 
-func (h *handler) Set(ctx context.Context, reqMeta yarpc.ReqMeta, body *setRequest) (*setResponse, yarpc.ResMeta, error) {
+func (h *handler) Set(ctx context.Context, body *setRequest) (*setResponse, error) {
 	h.Lock()
 	h.items[body.Key] = body.Value
 	h.Unlock()
-	return &setResponse{}, nil, nil
+	return &setResponse{}, nil
 }
 
 func main() {

--- a/transport/tracer_test.go
+++ b/transport/tracer_test.go
@@ -49,12 +49,12 @@ func (h handler) register(dispatcher *yarpc.Dispatcher) {
 	dispatcher.Register(json.Procedure("echoecho", h.handleEchoEcho))
 }
 
-func (h handler) handleEcho(ctx context.Context, reqMeta yarpc.ReqMeta, reqBody *echoReqBody) (*echoResBody, yarpc.ResMeta, error) {
+func (h handler) handleEcho(ctx context.Context, reqBody *echoReqBody) (*echoResBody, error) {
 	h.assertBaggage(ctx)
-	return &echoResBody{}, nil, nil
+	return &echoResBody{}, nil
 }
 
-func (h handler) handleEchoEcho(ctx context.Context, reqMeta yarpc.ReqMeta, reqBody *echoReqBody) (*echoResBody, yarpc.ResMeta, error) {
+func (h handler) handleEchoEcho(ctx context.Context, reqBody *echoReqBody) (*echoResBody, error) {
 	h.assertBaggage(ctx)
 	var resBody echoResBody
 	_, err := h.client.Call(
@@ -64,9 +64,9 @@ func (h handler) handleEchoEcho(ctx context.Context, reqMeta yarpc.ReqMeta, reqB
 		&resBody,
 	)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	return &resBody, nil, nil
+	return &resBody, nil
 }
 
 func (h handler) echo(ctx context.Context) error {

--- a/yarpctest/recorder/recorder_test.go
+++ b/yarpctest/recorder/recorder_test.go
@@ -189,8 +189,8 @@ func withConnectedClient(t *testing.T, recorder *Recorder, f func(raw.Client)) {
 	})
 
 	serverDisp.Register(raw.Procedure("hello",
-		func(ctx context.Context, reqMeta yarpc.ReqMeta, body []byte) ([]byte, yarpc.ResMeta, error) {
-			return append(body, []byte(", World")...), nil, nil
+		func(ctx context.Context, body []byte) ([]byte, error) {
+			return append(body, []byte(", World")...), nil
 		}))
 
 	require.NoError(t, serverDisp.Start())


### PR DESCRIPTION
This drops Req/ResMeta from raw handlers. Request attributes are now made
available on the context and response headers are written to the context.

Issue: #617

@yarpc/golang