### PR TITLE
json/in: Drop *Meta from handlers

### DIFF
--- a/encoding/json/doc.go
+++ b/encoding/json/doc.go
@@ -24,11 +24,7 @@
 //
 // 	client := json.New(clientConfig)
 // 	var resBody GetValueResponse
-// 	resMeta, err := client.Call(
-// 		yarpc.NewReqMeta(ctx).Procedure("getValue"),
-// 		&GetValueRequest{...},
-// 		&resBody,
-// 	)
+// 	err := client.Call(ctx, "getValue", &GetValueRequest{...}, &resBody)
 //
 // To register a JSON procedure, define functions in the format,
 //

--- a/encoding/json/doc.go
+++ b/encoding/json/doc.go
@@ -32,7 +32,7 @@
 //
 // To register a JSON procedure, define functions in the format,
 //
-// 	f(ctx context.Context, reqMeta yarpc.ReqMeta, body $reqBody) ($resBody, yarpc.ResMeta, error)
+// 	f(ctx context.Context, body $reqBody) ($resBody, error)
 //
 // Where '$reqBody' and '$resBody' are either pointers to structs representing
 // your request and response objects, or map[string]interface{}.
@@ -46,7 +46,7 @@
 // Similarly, to register a oneway JSON procedure, define functions in the
 // format,
 //
-// 	f(ctx context.Context, reqMeta yarpc.ReqMeta, body $reqBody) error
+// 	f(ctx context.Context, body $reqBody) error
 //
 // Where $reqBody is a map[string]interface{} or pointer to a struct.
 //

--- a/encoding/json/inbound.go
+++ b/encoding/json/inbound.go
@@ -28,7 +28,6 @@ import (
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/encoding"
-	"go.uber.org/yarpc/internal/meta"
 )
 
 // jsonHandler adapts a user-provided high-level handler into a transport-level
@@ -36,7 +35,7 @@ import (
 //
 // The wrapped function must already be in the correct format:
 //
-// 	f(reqMeta yarpc.ReqMeta, body $reqBody) ($resBody, yarpc.ResMeta, error)
+// 	f(ctx context.Context, body $reqBody) ($resBody, error)
 type jsonHandler struct {
 	reader  requestReader
 	handler reflect.Value
@@ -47,20 +46,24 @@ func (h jsonHandler) Handle(ctx context.Context, treq *transport.Request, rw tra
 		return err
 	}
 
+	ctx, call := yarpc.NewInboundCall(ctx)
+	if err := call.ReadFromRequest(treq); err != nil {
+		return err
+	}
+
 	reqBody, err := h.reader.Read(json.NewDecoder(treq.Body))
 	if err != nil {
 		return encoding.RequestBodyDecodeError(treq, err)
 	}
 
-	reqMeta := meta.FromTransportRequest(treq)
-	results := h.handler.Call([]reflect.Value{reflect.ValueOf(ctx), reflect.ValueOf(reqMeta), reqBody})
+	results := h.handler.Call([]reflect.Value{reflect.ValueOf(ctx), reqBody})
 
-	if err := results[2].Interface(); err != nil {
+	if err := results[1].Interface(); err != nil {
 		return err.(error)
 	}
 
-	if resMeta, ok := results[1].Interface().(yarpc.ResMeta); ok {
-		meta.ToTransportResponseWriter(resMeta, rw)
+	if err := call.WriteToResponse(rw); err != nil {
+		return err
 	}
 
 	result := results[0].Interface()
@@ -76,13 +79,17 @@ func (h jsonHandler) HandleOneway(ctx context.Context, treq *transport.Request) 
 		return err
 	}
 
+	ctx, call := yarpc.NewInboundCall(ctx)
+	if err := call.ReadFromRequest(treq); err != nil {
+		return err
+	}
+
 	reqBody, err := h.reader.Read(json.NewDecoder(treq.Body))
 	if err != nil {
 		return encoding.RequestBodyDecodeError(treq, err)
 	}
 
-	reqMeta := meta.FromTransportRequest(treq)
-	results := h.handler.Call([]reflect.Value{reflect.ValueOf(ctx), reflect.ValueOf(reqMeta), reqBody})
+	results := h.handler.Call([]reflect.Value{reflect.ValueOf(ctx), reqBody})
 
 	if err := results[0].Interface(); err != nil {
 		return err.(error)

--- a/encoding/json/outbound.go
+++ b/encoding/json/outbound.go
@@ -28,7 +28,6 @@ import (
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/encoding"
-	"go.uber.org/yarpc/internal/meta"
 )
 
 // Client makes JSON requests to a single service.
@@ -39,8 +38,8 @@ type Client interface {
 	// json.Unmarshal.
 	//
 	// Returns the response or an error if the request failed.
-	Call(ctx context.Context, reqMeta yarpc.CallReqMeta, reqBody interface{}, resBodyOut interface{}) (yarpc.CallResMeta, error)
-	CallOneway(ctx context.Context, reqMeta yarpc.CallReqMeta, reqBody interface{}) (transport.Ack, error)
+	Call(ctx context.Context, procedure string, reqBody interface{}, resBodyOut interface{}, opts ...yarpc.CallOption) error
+	CallOneway(ctx context.Context, procedure string, reqBody interface{}, opts ...yarpc.CallOption) (transport.Ack, error)
 }
 
 // New builds a new JSON client.
@@ -56,51 +55,62 @@ type jsonClient struct {
 	cc transport.ClientConfig
 }
 
-func (c jsonClient) Call(ctx context.Context, reqMeta yarpc.CallReqMeta, reqBody interface{}, resBodyOut interface{}) (yarpc.CallResMeta, error) {
+func (c jsonClient) Call(ctx context.Context, procedure string, reqBody interface{}, resBodyOut interface{}, opts ...yarpc.CallOption) error {
+	call := yarpc.NewOutboundCall(opts...)
 	treq := transport.Request{
-		Caller:   c.cc.Caller(),
-		Service:  c.cc.Service(),
-		Encoding: Encoding,
+		Caller:    c.cc.Caller(),
+		Service:   c.cc.Service(),
+		Procedure: procedure,
+		Encoding:  Encoding,
 	}
-	meta.ToTransportRequest(reqMeta, &treq)
+
+	ctx, err := call.WriteToRequest(ctx, &treq)
+	if err != nil {
+		return err
+	}
 
 	encoded, err := json.Marshal(reqBody)
 	if err != nil {
-		return nil, encoding.RequestBodyEncodeError(&treq, err)
+		return encoding.RequestBodyEncodeError(&treq, err)
 	}
 
 	treq.Body = bytes.NewReader(encoded)
 	tres, err := c.cc.GetUnaryOutbound().Call(ctx, &treq)
-
 	if err != nil {
-		return nil, err
+		return err
+	}
+
+	ctx, err = call.ReadFromResponse(ctx, tres)
+	if err != nil {
+		return err
 	}
 
 	dec := json.NewDecoder(tres.Body)
 	if err := dec.Decode(resBodyOut); err != nil {
-		return nil, encoding.ResponseBodyDecodeError(&treq, err)
+		return encoding.ResponseBodyDecodeError(&treq, err)
 	}
 
-	if err := tres.Body.Close(); err != nil {
-		return nil, err
-	}
-
-	return meta.FromTransportResponse(tres), nil
+	return tres.Body.Close()
 }
 
-func (c jsonClient) CallOneway(ctx context.Context, reqMeta yarpc.CallReqMeta, reqBody interface{}) (transport.Ack, error) {
+func (c jsonClient) CallOneway(ctx context.Context, procedure string, reqBody interface{}, opts ...yarpc.CallOption) (transport.Ack, error) {
+	call := yarpc.NewOutboundCall(opts...)
 	treq := transport.Request{
-		Caller:   c.cc.Caller(),
-		Service:  c.cc.Service(),
-		Encoding: Encoding,
+		Caller:    c.cc.Caller(),
+		Service:   c.cc.Service(),
+		Procedure: procedure,
+		Encoding:  Encoding,
 	}
-	meta.ToTransportRequest(reqMeta, &treq)
+
+	ctx, err := call.WriteToRequest(ctx, &treq)
+	if err != nil {
+		return nil, err
+	}
 
 	var buff bytes.Buffer
 	if err := json.NewEncoder(&buff).Encode(reqBody); err != nil {
 		return nil, encoding.RequestBodyEncodeError(&treq, err)
 	}
-
 	treq.Body = &buff
 
 	return c.cc.GetOnewayOutbound().CallOneway(ctx, &treq)

--- a/encoding/json/register_test.go
+++ b/encoding/json/register_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"go.uber.org/yarpc"
-
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,62 +16,44 @@ func TestWrapUnaryHandlerInvalid(t *testing.T) {
 		{"not-a-function", 0},
 		{
 			"wrong-args-in",
-			func(context.Context, yarpc.ReqMeta) (*struct{}, yarpc.ResMeta, error) {
-				return nil, nil, nil
-			},
-		},
-		{
-			"wrong-ctx",
-			func(string, yarpc.ReqMeta, *struct{}) (*struct{}, yarpc.ResMeta, error) {
-				return nil, nil, nil
-			},
-		},
-		{
-			"wrong-req-meta",
-			func(context.Context, yarpc.CallReqMeta, *struct{}) (*struct{}, yarpc.ResMeta, error) {
-				return nil, nil, nil
-			},
-		},
-		{
-			"wrong-req-body",
-			func(context.Context, string, int) (*struct{}, yarpc.ResMeta, error) {
-				return nil, nil, nil
-			},
-		},
-		{
-			"wrong-response",
-			func(context.Context, yarpc.ReqMeta, map[string]interface{}) (yarpc.ResMeta, error) {
+			func(context.Context) (*struct{}, error) {
 				return nil, nil
 			},
 		},
 		{
-			"wrong-request",
-			func(context.Context, string, *struct{}) (*struct{}, yarpc.ResMeta, error) {
-				return nil, nil, nil
+			"wrong-ctx",
+			func(string, *struct{}) (*struct{}, error) {
+				return nil, nil
 			},
 		},
 		{
-			"wrong-res-meta",
-			func(context.Context, yarpc.ReqMeta, *struct{}) (*struct{}, yarpc.CallResMeta, error) {
-				return nil, nil, nil
+			"wrong-req-body",
+			func(context.Context, string, int) (*struct{}, error) {
+				return nil, nil
+			},
+		},
+		{
+			"wrong-response",
+			func(context.Context, map[string]interface{}) error {
+				return nil
 			},
 		},
 		{
 			"non-pointer-req",
-			func(context.Context, yarpc.ReqMeta, struct{}) (*struct{}, yarpc.ResMeta, error) {
-				return nil, nil, nil
+			func(context.Context, struct{}) (*struct{}, error) {
+				return nil, nil
 			},
 		},
 		{
 			"non-pointer-res",
-			func(context.Context, yarpc.ReqMeta, *struct{}) (struct{}, yarpc.ResMeta, error) {
-				return struct{}{}, nil, nil
+			func(context.Context, *struct{}) (struct{}, error) {
+				return struct{}{}, nil
 			},
 		},
 		{
 			"non-string-key",
-			func(context.Context, yarpc.ReqMeta, map[int32]interface{}) (*struct{}, yarpc.ResMeta, error) {
-				return nil, nil, nil
+			func(context.Context, map[int32]interface{}) (*struct{}, error) {
+				return nil, nil
 			},
 		},
 	}
@@ -81,7 +61,7 @@ func TestWrapUnaryHandlerInvalid(t *testing.T) {
 	for _, tt := range tests {
 		assert.Panics(t, assert.PanicTestFunc(func() {
 			wrapUnaryHandler(tt.Name, tt.Func)
-		}))
+		}), tt.Name)
 	}
 }
 
@@ -92,26 +72,26 @@ func TestWrapUnaryHandlerValid(t *testing.T) {
 	}{
 		{
 			"foo",
-			func(context.Context, yarpc.ReqMeta, *struct{}) (*struct{}, yarpc.ResMeta, error) {
-				return nil, nil, nil
+			func(context.Context, *struct{}) (*struct{}, error) {
+				return nil, nil
 			},
 		},
 		{
 			"bar",
-			func(context.Context, yarpc.ReqMeta, map[string]interface{}) (*struct{}, yarpc.ResMeta, error) {
-				return nil, nil, nil
+			func(context.Context, map[string]interface{}) (*struct{}, error) {
+				return nil, nil
 			},
 		},
 		{
 			"baz",
-			func(context.Context, yarpc.ReqMeta, map[string]interface{}) (map[string]interface{}, yarpc.ResMeta, error) {
-				return nil, nil, nil
+			func(context.Context, map[string]interface{}) (map[string]interface{}, error) {
+				return nil, nil
 			},
 		},
 		{
 			"qux",
-			func(context.Context, yarpc.ReqMeta, interface{}) (map[string]interface{}, yarpc.ResMeta, error) {
-				return nil, nil, nil
+			func(context.Context, interface{}) (map[string]interface{}, error) {
+				return nil, nil
 			},
 		},
 	}
@@ -130,19 +110,13 @@ func TestWrapOnewayHandlerInvalid(t *testing.T) {
 		{"not-a-function", 0},
 		{
 			"wrong-args-in",
-			func(context.Context, yarpc.ReqMeta) error {
+			func(context.Context) error {
 				return nil
 			},
 		},
 		{
 			"wrong-ctx",
-			func(string, yarpc.ReqMeta, *struct{}) error {
-				return nil
-			},
-		},
-		{
-			"wrong-req-meta",
-			func(context.Context, yarpc.CallReqMeta, *struct{}) error {
+			func(string, *struct{}) error {
 				return nil
 			},
 		},
@@ -154,25 +128,25 @@ func TestWrapOnewayHandlerInvalid(t *testing.T) {
 		},
 		{
 			"wrong-response",
-			func(context.Context, yarpc.ReqMeta, map[string]interface{}) (*struct{}, yarpc.ResMeta, error) {
-				return nil, nil, nil
+			func(context.Context, map[string]interface{}) (*struct{}, error) {
+				return nil, nil
 			},
 		},
 		{
 			"wrong-response-val",
-			func(context.Context, yarpc.ReqMeta, map[string]interface{}) int {
+			func(context.Context, map[string]interface{}) int {
 				return 0
 			},
 		},
 		{
 			"non-pointer-req",
-			func(context.Context, yarpc.ReqMeta, struct{}) error {
+			func(context.Context, struct{}) error {
 				return nil
 			},
 		},
 		{
 			"non-string-key",
-			func(context.Context, yarpc.ReqMeta, map[int32]interface{}) error {
+			func(context.Context, map[int32]interface{}) error {
 				return nil
 			},
 		},
@@ -191,25 +165,25 @@ func TestWrapOnewayHandlerValid(t *testing.T) {
 	}{
 		{
 			"foo",
-			func(context.Context, yarpc.ReqMeta, *struct{}) error {
+			func(context.Context, *struct{}) error {
 				return nil
 			},
 		},
 		{
 			"bar",
-			func(context.Context, yarpc.ReqMeta, map[string]interface{}) error {
+			func(context.Context, map[string]interface{}) error {
 				return nil
 			},
 		},
 		{
 			"baz",
-			func(context.Context, yarpc.ReqMeta, map[string]interface{}) error {
+			func(context.Context, map[string]interface{}) error {
 				return nil
 			},
 		},
 		{
 			"qux",
-			func(context.Context, yarpc.ReqMeta, interface{}) error {
+			func(context.Context, interface{}) error {
 				return nil
 			},
 		},

--- a/internal/crossdock/client/echo/json.go
+++ b/internal/crossdock/client/echo/json.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"time"
 
-	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/encoding/json"
 	disp "go.uber.org/yarpc/internal/crossdock/client/dispatcher"
 	"go.uber.org/yarpc/internal/crossdock/client/random"
@@ -52,12 +51,7 @@ func JSON(t crossdock.T) {
 
 	var response jsonEcho
 	token := random.String(5)
-	_, err := client.Call(
-		ctx,
-		yarpc.NewReqMeta().Procedure("echo"),
-		&jsonEcho{Token: token},
-		&response,
-	)
+	err := client.Call(ctx, "echo", &jsonEcho{Token: token}, &response)
 	crossdock.Fatals(t).NoError(err, "call to echo failed: %v", err)
 	crossdock.Assert(t).Equal(token, response.Token, "server said: %v", response.Token)
 }

--- a/internal/crossdock/client/headers/behavior.go
+++ b/internal/crossdock/client/headers/behavior.go
@@ -161,16 +161,24 @@ func (c jsonCaller) Call(h yarpc.Headers) (yarpc.Headers, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
+	var (
+		opts       []yarpc.CallOption
+		resHeaders yarpc.Headers
+	)
+	for _, k := range h.Keys() {
+		if v, ok := h.Get(k); ok {
+			opts = append(opts, yarpc.WithHeader(k, v))
+		}
+	}
+	opts = append(opts, yarpc.ResponseHeaders(&resHeaders))
+
 	var resBody interface{}
-	res, err := c.c.Call(
-		ctx,
-		yarpc.NewReqMeta().Headers(h).Procedure("echo"),
-		map[string]interface{}{}, &resBody)
+	err := c.c.Call(ctx, "echo", map[string]interface{}{}, &resBody, opts...)
 
 	if err != nil {
 		return yarpc.Headers{}, err
 	}
-	return res.Headers(), nil
+	return resHeaders, nil
 }
 
 type thriftCaller struct{ c echoclient.Interface }

--- a/internal/crossdock/client/oneway/json.go
+++ b/internal/crossdock/client/oneway/json.go
@@ -43,10 +43,9 @@ func JSON(t crossdock.T, dispatcher *yarpc.Dispatcher, serverCalledBack <-chan [
 
 	ack, err := client.CallOneway(
 		context.Background(),
-		yarpc.NewReqMeta().
-			Procedure("echo/json").
-			Headers(yarpc.NewHeaders().With("callBackAddr", callBackAddr)),
+		"echo/json",
 		&jsonToken{Token: token},
+		yarpc.WithHeader("callBackAddr", callBackAddr),
 	)
 
 	// ensure channel hasn't been filled yet

--- a/internal/crossdock/server/oneway/echo.go
+++ b/internal/crossdock/server/oneway/echo.go
@@ -50,8 +50,8 @@ func (o *onewayHandler) EchoRaw(ctx context.Context, body []byte) error {
 type jsonToken struct{ Token string }
 
 // EchoJSON implements the echo/json procedure.
-func (o *onewayHandler) EchoJSON(ctx context.Context, reqMeta yarpc.ReqMeta, token *jsonToken) error {
-	callBackAddr, _ := reqMeta.Headers().Get(callBackAddrHeader)
+func (o *onewayHandler) EchoJSON(ctx context.Context, token *jsonToken) error {
+	callBackAddr := yarpc.Header(ctx, callBackAddrHeader)
 	o.callHome(ctx, callBackAddr, []byte(token.Token), json.Encoding)
 	return nil
 }

--- a/internal/crossdock/server/yarpc/echo.go
+++ b/internal/crossdock/server/yarpc/echo.go
@@ -36,8 +36,11 @@ func EchoRaw(ctx context.Context, body []byte) ([]byte, error) {
 }
 
 // EchoJSON implements the echo procedure.
-func EchoJSON(ctx context.Context, reqMeta yarpc.ReqMeta, body map[string]interface{}) (map[string]interface{}, yarpc.ResMeta, error) {
-	return body, yarpc.NewResMeta().Headers(reqMeta.Headers()), nil
+func EchoJSON(ctx context.Context, body map[string]interface{}) (map[string]interface{}, error) {
+	for _, k := range yarpc.HeaderNames(ctx) {
+		yarpc.WriteResponseHeader(ctx, k, yarpc.Header(ctx, k))
+	}
+	return body, nil
 }
 
 // EchoThrift implements the Thrift Echo service.

--- a/internal/crossdock/server/yarpc/error.go
+++ b/internal/crossdock/server/yarpc/error.go
@@ -23,18 +23,16 @@ package yarpc
 import (
 	"context"
 	"fmt"
-
-	"go.uber.org/yarpc"
 )
 
 // UnexpectedError fails with an unexpected error.
-func UnexpectedError(ctx context.Context, reqMeta yarpc.ReqMeta, body interface{}) (interface{}, yarpc.ResMeta, error) {
-	return nil, nil, fmt.Errorf("error")
+func UnexpectedError(ctx context.Context, body interface{}) (interface{}, error) {
+	return nil, fmt.Errorf("error")
 }
 
 // BadResponse returns an object that's not a valid JSON response.
-func BadResponse(ctx context.Context, reqMeta yarpc.ReqMeta, body map[string]interface{}) (map[string]interface{}, yarpc.ResMeta, error) {
+func BadResponse(ctx context.Context, body map[string]interface{}) (map[string]interface{}, error) {
 	// func is not serializable
 	result := map[string]interface{}{"foo": func() {}}
-	return result, nil, nil
+	return result, nil
 }

--- a/internal/crossdock/server/yarpc/phone.go
+++ b/internal/crossdock/server/yarpc/phone.go
@@ -102,12 +102,8 @@ func Phone(ctx context.Context, body *PhoneRequest) (*PhoneResponse, error) {
 
 	ctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
-	_, err := client.Call(
-		ctx,
-		yarpc.NewReqMeta().Procedure(body.Procedure),
-		body.Body,
-		&resBody.Body)
-	if err != nil {
+
+	if err := client.Call(ctx, body.Procedure, body.Body, &resBody.Body); err != nil {
 		return nil, err
 	}
 

--- a/internal/crossdock/server/yarpc/sleep.go
+++ b/internal/crossdock/server/yarpc/sleep.go
@@ -24,8 +24,6 @@ import (
 	"context"
 	"fmt"
 	"time"
-
-	"go.uber.org/yarpc"
 )
 
 // SleepRaw responds to raw requests over any transport by sleeping for one
@@ -37,9 +35,9 @@ func SleepRaw(ctx context.Context, body []byte) ([]byte, error) {
 
 // Sleep responds to json requests over any transport by sleeping for one
 // second.
-func Sleep(ctx context.Context, reqMeta yarpc.ReqMeta, body interface{}) (interface{}, yarpc.ResMeta, error) {
+func Sleep(ctx context.Context, body interface{}) (interface{}, error) {
 	time.Sleep(1 * time.Second)
-	return nil, nil, nil
+	return nil, nil
 }
 
 // WaitForTimeoutRaw waits after the context deadline then returns the context

--- a/internal/examples/json-keyvalue/client/main.go
+++ b/internal/examples/json-keyvalue/client/main.go
@@ -57,12 +57,7 @@ func get(ctx context.Context, c json.Client, k string) (string, error) {
 	var response getResponse
 	ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
 	defer cancel()
-	_, err := c.Call(
-		ctx,
-		yarpc.NewReqMeta().Procedure("get"),
-		&getRequest{Key: k},
-		&response,
-	)
+	err := c.Call(ctx, "get", &getRequest{Key: k}, &response)
 	return response.Value, err
 }
 
@@ -70,13 +65,7 @@ func set(ctx context.Context, c json.Client, k string, v string) error {
 	var response setResponse
 	ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
 	defer cancel()
-	_, err := c.Call(
-		ctx,
-		yarpc.NewReqMeta().Procedure("set"),
-		&setRequest{Key: k, Value: v},
-		&response,
-	)
-	return err
+	return c.Call(ctx, "set", &setRequest{Key: k, Value: v}, &response)
 }
 
 func main() {

--- a/internal/examples/json-keyvalue/server/main.go
+++ b/internal/examples/json-keyvalue/server/main.go
@@ -54,18 +54,18 @@ type handler struct {
 	items map[string]string
 }
 
-func (h *handler) Get(ctx context.Context, reqMeta yarpc.ReqMeta, body *getRequest) (*getResponse, yarpc.ResMeta, error) {
+func (h *handler) Get(ctx context.Context, body *getRequest) (*getResponse, error) {
 	h.RLock()
 	result := &getResponse{Value: h.items[body.Key]}
 	h.RUnlock()
-	return result, nil, nil
+	return result, nil
 }
 
-func (h *handler) Set(ctx context.Context, reqMeta yarpc.ReqMeta, body *setRequest) (*setResponse, yarpc.ResMeta, error) {
+func (h *handler) Set(ctx context.Context, body *setRequest) (*setResponse, error) {
 	h.Lock()
 	h.items[body.Key] = body.Value
 	h.Unlock()
-	return &setResponse{}, nil, nil
+	return &setResponse{}, nil
 }
 
 func main() {

--- a/transport/tracer_test.go
+++ b/transport/tracer_test.go
@@ -49,12 +49,12 @@ func (h handler) register(dispatcher *yarpc.Dispatcher) {
 	dispatcher.Register(json.Procedure("echoecho", h.handleEchoEcho))
 }
 
-func (h handler) handleEcho(ctx context.Context, reqMeta yarpc.ReqMeta, reqBody *echoReqBody) (*echoResBody, yarpc.ResMeta, error) {
+func (h handler) handleEcho(ctx context.Context, reqBody *echoReqBody) (*echoResBody, error) {
 	h.assertBaggage(ctx)
-	return &echoResBody{}, nil, nil
+	return &echoResBody{}, nil
 }
 
-func (h handler) handleEchoEcho(ctx context.Context, reqMeta yarpc.ReqMeta, reqBody *echoReqBody) (*echoResBody, yarpc.ResMeta, error) {
+func (h handler) handleEchoEcho(ctx context.Context, reqBody *echoReqBody) (*echoResBody, error) {
 	h.assertBaggage(ctx)
 	var resBody echoResBody
 	_, err := h.client.Call(
@@ -64,9 +64,9 @@ func (h handler) handleEchoEcho(ctx context.Context, reqMeta yarpc.ReqMeta, reqB
 		&resBody,
 	)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	return &resBody, nil, nil
+	return &resBody, nil
 }
 
 func (h handler) echo(ctx context.Context) error {

--- a/transport/tracer_test.go
+++ b/transport/tracer_test.go
@@ -57,38 +57,16 @@ func (h handler) handleEcho(ctx context.Context, reqBody *echoReqBody) (*echoRes
 func (h handler) handleEchoEcho(ctx context.Context, reqBody *echoReqBody) (*echoResBody, error) {
 	h.assertBaggage(ctx)
 	var resBody echoResBody
-	_, err := h.client.Call(
-		ctx,
-		yarpc.NewReqMeta().Procedure("echo"),
-		reqBody,
-		&resBody,
-	)
-	if err != nil {
-		return nil, err
-	}
-	return &resBody, nil
+	err := h.client.Call(ctx, "echo", reqBody, &resBody)
+	return &resBody, err
 }
 
 func (h handler) echo(ctx context.Context) error {
-	var resBody echoResBody
-	_, err := h.client.Call(
-		ctx,
-		yarpc.NewReqMeta().Procedure("echo"),
-		&echoReqBody{},
-		&resBody,
-	)
-	return err
+	return h.client.Call(ctx, "echo", &echoReqBody{}, &echoResBody{})
 }
 
 func (h handler) echoEcho(ctx context.Context) error {
-	var resBody echoResBody
-	_, err := h.client.Call(
-		ctx,
-		yarpc.NewReqMeta().Procedure("echoecho"),
-		&echoReqBody{},
-		&resBody,
-	)
-	return err
+	return h.client.Call(ctx, "echoecho", &echoReqBody{}, &echoResBody{})
 }
 
 func (h handler) createContextWithBaggage(tracer opentracing.Tracer) (context.Context, func()) {


### PR DESCRIPTION
This drops Req/ResMeta from JSON handlers.

Issue: #617 

CC @yarpc/golang