### PR TITLE
json/out: Drop *Meta, add procedure

### DIFF
--- a/encoding/json/doc.go
+++ b/encoding/json/doc.go
@@ -24,11 +24,7 @@
 //
 // 	client := json.New(clientConfig)
 // 	var resBody GetValueResponse
-// 	resMeta, err := client.Call(
-// 		yarpc.NewReqMeta(ctx).Procedure("getValue"),
-// 		&GetValueRequest{...},
-// 		&resBody,
-// 	)
+// 	err := client.Call(ctx, "getValue", &GetValueRequest{...}, &resBody)
 //
 // To register a JSON procedure, define functions in the format,
 //

--- a/encoding/json/outbound.go
+++ b/encoding/json/outbound.go
@@ -28,7 +28,6 @@ import (
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/encoding"
-	"go.uber.org/yarpc/internal/meta"
 )
 
 // Client makes JSON requests to a single service.
@@ -39,8 +38,8 @@ type Client interface {
 	// json.Unmarshal.
 	//
 	// Returns the response or an error if the request failed.
-	Call(ctx context.Context, reqMeta yarpc.CallReqMeta, reqBody interface{}, resBodyOut interface{}) (yarpc.CallResMeta, error)
-	CallOneway(ctx context.Context, reqMeta yarpc.CallReqMeta, reqBody interface{}) (transport.Ack, error)
+	Call(ctx context.Context, procedure string, reqBody interface{}, resBodyOut interface{}, opts ...yarpc.CallOption) error
+	CallOneway(ctx context.Context, procedure string, reqBody interface{}, opts ...yarpc.CallOption) (transport.Ack, error)
 }
 
 // New builds a new JSON client.
@@ -56,51 +55,62 @@ type jsonClient struct {
 	cc transport.ClientConfig
 }
 
-func (c jsonClient) Call(ctx context.Context, reqMeta yarpc.CallReqMeta, reqBody interface{}, resBodyOut interface{}) (yarpc.CallResMeta, error) {
+func (c jsonClient) Call(ctx context.Context, procedure string, reqBody interface{}, resBodyOut interface{}, opts ...yarpc.CallOption) error {
+	call := yarpc.NewOutboundCall(opts...)
 	treq := transport.Request{
-		Caller:   c.cc.Caller(),
-		Service:  c.cc.Service(),
-		Encoding: Encoding,
+		Caller:    c.cc.Caller(),
+		Service:   c.cc.Service(),
+		Procedure: procedure,
+		Encoding:  Encoding,
 	}
-	meta.ToTransportRequest(reqMeta, &treq)
+
+	ctx, err := call.WriteToRequest(ctx, &treq)
+	if err != nil {
+		return err
+	}
 
 	encoded, err := json.Marshal(reqBody)
 	if err != nil {
-		return nil, encoding.RequestBodyEncodeError(&treq, err)
+		return encoding.RequestBodyEncodeError(&treq, err)
 	}
 
 	treq.Body = bytes.NewReader(encoded)
 	tres, err := c.cc.GetUnaryOutbound().Call(ctx, &treq)
-
 	if err != nil {
-		return nil, err
+		return err
+	}
+
+	ctx, err = call.ReadFromResponse(ctx, tres)
+	if err != nil {
+		return err
 	}
 
 	dec := json.NewDecoder(tres.Body)
 	if err := dec.Decode(resBodyOut); err != nil {
-		return nil, encoding.ResponseBodyDecodeError(&treq, err)
+		return encoding.ResponseBodyDecodeError(&treq, err)
 	}
 
-	if err := tres.Body.Close(); err != nil {
-		return nil, err
-	}
-
-	return meta.FromTransportResponse(tres), nil
+	return tres.Body.Close()
 }
 
-func (c jsonClient) CallOneway(ctx context.Context, reqMeta yarpc.CallReqMeta, reqBody interface{}) (transport.Ack, error) {
+func (c jsonClient) CallOneway(ctx context.Context, procedure string, reqBody interface{}, opts ...yarpc.CallOption) (transport.Ack, error) {
+	call := yarpc.NewOutboundCall(opts...)
 	treq := transport.Request{
-		Caller:   c.cc.Caller(),
-		Service:  c.cc.Service(),
-		Encoding: Encoding,
+		Caller:    c.cc.Caller(),
+		Service:   c.cc.Service(),
+		Procedure: procedure,
+		Encoding:  Encoding,
 	}
-	meta.ToTransportRequest(reqMeta, &treq)
+
+	ctx, err := call.WriteToRequest(ctx, &treq)
+	if err != nil {
+		return nil, err
+	}
 
 	var buff bytes.Buffer
 	if err := json.NewEncoder(&buff).Encode(reqBody); err != nil {
 		return nil, encoding.RequestBodyEncodeError(&treq, err)
 	}
-
 	treq.Body = &buff
 
 	return c.cc.GetOnewayOutbound().CallOneway(ctx, &treq)

--- a/internal/crossdock/client/echo/json.go
+++ b/internal/crossdock/client/echo/json.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"time"
 
-	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/encoding/json"
 	disp "go.uber.org/yarpc/internal/crossdock/client/dispatcher"
 	"go.uber.org/yarpc/internal/crossdock/client/random"
@@ -52,12 +51,7 @@ func JSON(t crossdock.T) {
 
 	var response jsonEcho
 	token := random.String(5)
-	_, err := client.Call(
-		ctx,
-		yarpc.NewReqMeta().Procedure("echo"),
-		&jsonEcho{Token: token},
-		&response,
-	)
+	err := client.Call(ctx, "echo", &jsonEcho{Token: token}, &response)
 	crossdock.Fatals(t).NoError(err, "call to echo failed: %v", err)
 	crossdock.Assert(t).Equal(token, response.Token, "server said: %v", response.Token)
 }

--- a/internal/crossdock/client/headers/behavior.go
+++ b/internal/crossdock/client/headers/behavior.go
@@ -161,16 +161,24 @@ func (c jsonCaller) Call(h yarpc.Headers) (yarpc.Headers, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
+	var (
+		opts       []yarpc.CallOption
+		resHeaders yarpc.Headers
+	)
+	for _, k := range h.Keys() {
+		if v, ok := h.Get(k); ok {
+			opts = append(opts, yarpc.WithHeader(k, v))
+		}
+	}
+	opts = append(opts, yarpc.ResponseHeaders(&resHeaders))
+
 	var resBody interface{}
-	res, err := c.c.Call(
-		ctx,
-		yarpc.NewReqMeta().Headers(h).Procedure("echo"),
-		map[string]interface{}{}, &resBody)
+	err := c.c.Call(ctx, "echo", map[string]interface{}{}, &resBody, opts...)
 
 	if err != nil {
 		return yarpc.Headers{}, err
 	}
-	return res.Headers(), nil
+	return resHeaders, nil
 }
 
 type thriftCaller struct{ c echoclient.Interface }

--- a/internal/crossdock/client/oneway/json.go
+++ b/internal/crossdock/client/oneway/json.go
@@ -43,10 +43,9 @@ func JSON(t crossdock.T, dispatcher *yarpc.Dispatcher, serverCalledBack <-chan [
 
 	ack, err := client.CallOneway(
 		context.Background(),
-		yarpc.NewReqMeta().
-			Procedure("echo/json").
-			Headers(yarpc.NewHeaders().With("callBackAddr", callBackAddr)),
+		"echo/json",
 		&jsonToken{Token: token},
+		yarpc.WithHeader("callBackAddr", callBackAddr),
 	)
 
 	// ensure channel hasn't been filled yet

--- a/internal/crossdock/server/yarpc/phone.go
+++ b/internal/crossdock/server/yarpc/phone.go
@@ -102,12 +102,8 @@ func Phone(ctx context.Context, body *PhoneRequest) (*PhoneResponse, error) {
 
 	ctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 	defer cancel()
-	_, err := client.Call(
-		ctx,
-		yarpc.NewReqMeta().Procedure(body.Procedure),
-		body.Body,
-		&resBody.Body)
-	if err != nil {
+
+	if err := client.Call(ctx, body.Procedure, body.Body, &resBody.Body); err != nil {
 		return nil, err
 	}
 

--- a/internal/examples/json-keyvalue/client/main.go
+++ b/internal/examples/json-keyvalue/client/main.go
@@ -57,12 +57,7 @@ func get(ctx context.Context, c json.Client, k string) (string, error) {
 	var response getResponse
 	ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
 	defer cancel()
-	_, err := c.Call(
-		ctx,
-		yarpc.NewReqMeta().Procedure("get"),
-		&getRequest{Key: k},
-		&response,
-	)
+	err := c.Call(ctx, "get", &getRequest{Key: k}, &response)
 	return response.Value, err
 }
 
@@ -70,13 +65,7 @@ func set(ctx context.Context, c json.Client, k string, v string) error {
 	var response setResponse
 	ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
 	defer cancel()
-	_, err := c.Call(
-		ctx,
-		yarpc.NewReqMeta().Procedure("set"),
-		&setRequest{Key: k, Value: v},
-		&response,
-	)
-	return err
+	return c.Call(ctx, "set", &setRequest{Key: k, Value: v}, &response)
 }
 
 func main() {

--- a/transport/tracer_test.go
+++ b/transport/tracer_test.go
@@ -57,38 +57,16 @@ func (h handler) handleEcho(ctx context.Context, reqBody *echoReqBody) (*echoRes
 func (h handler) handleEchoEcho(ctx context.Context, reqBody *echoReqBody) (*echoResBody, error) {
 	h.assertBaggage(ctx)
 	var resBody echoResBody
-	_, err := h.client.Call(
-		ctx,
-		yarpc.NewReqMeta().Procedure("echo"),
-		reqBody,
-		&resBody,
-	)
-	if err != nil {
-		return nil, err
-	}
-	return &resBody, nil
+	err := h.client.Call(ctx, "echo", reqBody, &resBody)
+	return &resBody, err
 }
 
 func (h handler) echo(ctx context.Context) error {
-	var resBody echoResBody
-	_, err := h.client.Call(
-		ctx,
-		yarpc.NewReqMeta().Procedure("echo"),
-		&echoReqBody{},
-		&resBody,
-	)
-	return err
+	return h.client.Call(ctx, "echo", &echoReqBody{}, &echoResBody{})
 }
 
 func (h handler) echoEcho(ctx context.Context) error {
-	var resBody echoResBody
-	_, err := h.client.Call(
-		ctx,
-		yarpc.NewReqMeta().Procedure("echoecho"),
-		&echoReqBody{},
-		&resBody,
-	)
-	return err
+	return h.client.Call(ctx, "echoecho", &echoReqBody{}, &echoResBody{})
 }
 
 func (h handler) createContextWithBaggage(tracer opentracing.Tracer) (context.Context, func()) {


### PR DESCRIPTION
This changes JSON outbounds to drop the *Meta argument and return values.
Instead, the CallOption interface is used for call-site options and a
procedure argument for the procedure name.

CC @yarpc/golang