### PR TITLE
thrift/out: Drop *Meta

### DIFF
--- a/encoding/thrift/outbound_test.go
+++ b/encoding/thrift/outbound_test.go
@@ -191,7 +191,7 @@ func TestClient(t *testing.T) {
 				}),
 		}, opts...)
 
-		_, _, err := c.Call(ctx, nil, tt.giveRequestBody)
+		_, err := c.Call(ctx, tt.giveRequestBody)
 		if tt.wantError != "" {
 			if assert.Error(t, err, "%v: expected failure", tt.desc) {
 				assert.Contains(t, err.Error(), tt.wantError, "%v: error mismatch", tt.desc)
@@ -310,7 +310,7 @@ func TestClientOneway(t *testing.T) {
 				}),
 		}, opts...)
 
-		ack, err := c.CallOneway(ctx, nil, tt.giveRequestBody)
+		ack, err := c.CallOneway(ctx, tt.giveRequestBody)
 		if tt.wantError != "" {
 			if assert.Error(t, err, "%v: expected failure", tt.desc) {
 				assert.Contains(t, err.Error(), tt.wantError, "%v: error mismatch", tt.desc)

--- a/internal/crossdock/client/echo/thrift.go
+++ b/internal/crossdock/client/echo/thrift.go
@@ -47,7 +47,7 @@ func Thrift(t crossdock.T) {
 
 	token := random.String(5)
 
-	pong, _, err := client.Echo(ctx, nil, &echo.Ping{Beep: token})
+	pong, err := client.Echo(ctx, &echo.Ping{Beep: token})
 
 	crossdock.Fatals(t).NoError(err, "call to Echo::echo failed: %v", err)
 	crossdock.Assert(t).Equal(token, pong.Boop, "server said: %v", pong.Boop)

--- a/internal/crossdock/client/gauntlet/behavior.go
+++ b/internal/crossdock/client/gauntlet/behavior.go
@@ -431,8 +431,8 @@ func RunGauntlet(t crossdock.T, c Config) {
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
-		args := []reflect.Value{reflect.ValueOf(ctx), reflect.ValueOf(yarpc.NewReqMeta())}
-		if give, ok := BuildArgs(t, desc, f.Type(), tt.Give, 2); ok {
+		args := []reflect.Value{reflect.ValueOf(ctx)}
+		if give, ok := BuildArgs(t, desc, f.Type(), tt.Give, len(args)); ok {
 			args = append(args, give...)
 		} else {
 			continue
@@ -489,10 +489,6 @@ func buildClient(t crossdock.T, desc string, service string, c Config) reflect.V
 // BuildArgs creates an args slice than can be used to make a f.Call(args)
 func BuildArgs(t crossdock.T, desc string, ft reflect.Type, give []interface{}, initialArgs int) (_ []reflect.Value, ok bool) {
 	check := crossdock.Checks(t)
-	wantIn := len(give) + initialArgs // +2 for ctx and reqMeta
-	if !check.Equal(wantIn, ft.NumIn(), "%v: should accept %d arguments", desc, wantIn) {
-		return nil, false
-	}
 
 	var args []reflect.Value
 	for i, v := range give {
@@ -525,15 +521,14 @@ func isUnrecognizedProcedure(err error) bool {
 
 func extractCallResponse(t crossdock.T, desc string, returns []reflect.Value) (got interface{}, err error) {
 	switch len(returns) {
-	case 2:
-		e := returns[1].Interface()
+	case 1:
+		e := returns[0].Interface()
 		if e != nil {
 			err = e.(error)
 		}
-	case 3:
+	case 2:
 		got = returns[0].Interface()
-		e := returns[2].Interface()
-		if e != nil {
+		if e := returns[1].Interface(); e != nil {
 			err = e.(error)
 		}
 	default:

--- a/internal/crossdock/client/oneway/thrift.go
+++ b/internal/crossdock/client/oneway/thrift.go
@@ -37,11 +37,7 @@ func Thrift(t crossdock.T, dispatcher *yarpc.Dispatcher, serverCalledBack <-chan
 	client := onewayclient.New(dispatcher.ClientConfig("oneway-server"))
 	token := getRandomID()
 
-	ack, err := client.Echo(
-		context.Background(),
-		yarpc.NewReqMeta().
-			Headers(yarpc.NewHeaders().With("callBackAddr", callBackAddr)),
-		&token)
+	ack, err := client.Echo(context.Background(), &token, yarpc.WithHeader("callBackAddr", callBackAddr))
 
 	// ensure channel hasn't been filled yet
 	select {

--- a/internal/crossdock/thrift/echo/yarpc/echoclient/client.go
+++ b/internal/crossdock/thrift/echo/yarpc/echoclient/client.go
@@ -36,9 +36,9 @@ import (
 type Interface interface {
 	Echo(
 		ctx context.Context,
-		reqMeta yarpc.CallReqMeta,
 		Ping *echo.Ping,
-	) (*echo.Pong, yarpc.CallResMeta, error)
+		opts ...yarpc.CallOption,
+	) (*echo.Pong, error)
 }
 
 // New builds a new client for the Echo service.
@@ -61,14 +61,14 @@ type client struct{ c thrift.Client }
 
 func (c client) Echo(
 	ctx context.Context,
-	reqMeta yarpc.CallReqMeta,
 	_Ping *echo.Ping,
-) (success *echo.Pong, resMeta yarpc.CallResMeta, err error) {
+	opts ...yarpc.CallOption,
+) (success *echo.Pong, err error) {
 
 	args := echo.Echo_Echo_Helper.Args(_Ping)
 
 	var body wire.Value
-	body, resMeta, err = c.c.Call(ctx, reqMeta, args)
+	body, err = c.c.Call(ctx, args, opts...)
 	if err != nil {
 		return
 	}

--- a/internal/crossdock/thrift/gauntlet/yarpc/secondserviceclient/client.go
+++ b/internal/crossdock/thrift/gauntlet/yarpc/secondserviceclient/client.go
@@ -36,14 +36,14 @@ import (
 type Interface interface {
 	BlahBlah(
 		ctx context.Context,
-		reqMeta yarpc.CallReqMeta,
-	) (yarpc.CallResMeta, error)
+		opts ...yarpc.CallOption,
+	) error
 
 	SecondtestString(
 		ctx context.Context,
-		reqMeta yarpc.CallReqMeta,
 		Thing *string,
-	) (string, yarpc.CallResMeta, error)
+		opts ...yarpc.CallOption,
+	) (string, error)
 }
 
 // New builds a new client for the SecondService service.
@@ -66,13 +66,13 @@ type client struct{ c thrift.Client }
 
 func (c client) BlahBlah(
 	ctx context.Context,
-	reqMeta yarpc.CallReqMeta,
-) (resMeta yarpc.CallResMeta, err error) {
+	opts ...yarpc.CallOption,
+) (err error) {
 
 	args := gauntlet.SecondService_BlahBlah_Helper.Args()
 
 	var body wire.Value
-	body, resMeta, err = c.c.Call(ctx, reqMeta, args)
+	body, err = c.c.Call(ctx, args, opts...)
 	if err != nil {
 		return
 	}
@@ -88,14 +88,14 @@ func (c client) BlahBlah(
 
 func (c client) SecondtestString(
 	ctx context.Context,
-	reqMeta yarpc.CallReqMeta,
 	_Thing *string,
-) (success string, resMeta yarpc.CallResMeta, err error) {
+	opts ...yarpc.CallOption,
+) (success string, err error) {
 
 	args := gauntlet.SecondService_SecondtestString_Helper.Args(_Thing)
 
 	var body wire.Value
-	body, resMeta, err = c.c.Call(ctx, reqMeta, args)
+	body, err = c.c.Call(ctx, args, opts...)
 	if err != nil {
 		return
 	}

--- a/internal/crossdock/thrift/gauntlet/yarpc/thrifttestclient/client.go
+++ b/internal/crossdock/thrift/gauntlet/yarpc/thrifttestclient/client.go
@@ -36,134 +36,134 @@ import (
 type Interface interface {
 	TestBinary(
 		ctx context.Context,
-		reqMeta yarpc.CallReqMeta,
 		Thing []byte,
-	) ([]byte, yarpc.CallResMeta, error)
+		opts ...yarpc.CallOption,
+	) ([]byte, error)
 
 	TestByte(
 		ctx context.Context,
-		reqMeta yarpc.CallReqMeta,
 		Thing *int8,
-	) (int8, yarpc.CallResMeta, error)
+		opts ...yarpc.CallOption,
+	) (int8, error)
 
 	TestDouble(
 		ctx context.Context,
-		reqMeta yarpc.CallReqMeta,
 		Thing *float64,
-	) (float64, yarpc.CallResMeta, error)
+		opts ...yarpc.CallOption,
+	) (float64, error)
 
 	TestEnum(
 		ctx context.Context,
-		reqMeta yarpc.CallReqMeta,
 		Thing *gauntlet.Numberz,
-	) (gauntlet.Numberz, yarpc.CallResMeta, error)
+		opts ...yarpc.CallOption,
+	) (gauntlet.Numberz, error)
 
 	TestException(
 		ctx context.Context,
-		reqMeta yarpc.CallReqMeta,
 		Arg *string,
-	) (yarpc.CallResMeta, error)
+		opts ...yarpc.CallOption,
+	) error
 
 	TestI32(
 		ctx context.Context,
-		reqMeta yarpc.CallReqMeta,
 		Thing *int32,
-	) (int32, yarpc.CallResMeta, error)
+		opts ...yarpc.CallOption,
+	) (int32, error)
 
 	TestI64(
 		ctx context.Context,
-		reqMeta yarpc.CallReqMeta,
 		Thing *int64,
-	) (int64, yarpc.CallResMeta, error)
+		opts ...yarpc.CallOption,
+	) (int64, error)
 
 	TestInsanity(
 		ctx context.Context,
-		reqMeta yarpc.CallReqMeta,
 		Argument *gauntlet.Insanity,
-	) (map[gauntlet.UserId]map[gauntlet.Numberz]*gauntlet.Insanity, yarpc.CallResMeta, error)
+		opts ...yarpc.CallOption,
+	) (map[gauntlet.UserId]map[gauntlet.Numberz]*gauntlet.Insanity, error)
 
 	TestList(
 		ctx context.Context,
-		reqMeta yarpc.CallReqMeta,
 		Thing []int32,
-	) ([]int32, yarpc.CallResMeta, error)
+		opts ...yarpc.CallOption,
+	) ([]int32, error)
 
 	TestMap(
 		ctx context.Context,
-		reqMeta yarpc.CallReqMeta,
 		Thing map[int32]int32,
-	) (map[int32]int32, yarpc.CallResMeta, error)
+		opts ...yarpc.CallOption,
+	) (map[int32]int32, error)
 
 	TestMapMap(
 		ctx context.Context,
-		reqMeta yarpc.CallReqMeta,
 		Hello *int32,
-	) (map[int32]map[int32]int32, yarpc.CallResMeta, error)
+		opts ...yarpc.CallOption,
+	) (map[int32]map[int32]int32, error)
 
 	TestMulti(
 		ctx context.Context,
-		reqMeta yarpc.CallReqMeta,
 		Arg0 *int8,
 		Arg1 *int32,
 		Arg2 *int64,
 		Arg3 map[int16]string,
 		Arg4 *gauntlet.Numberz,
 		Arg5 *gauntlet.UserId,
-	) (*gauntlet.Xtruct, yarpc.CallResMeta, error)
+		opts ...yarpc.CallOption,
+	) (*gauntlet.Xtruct, error)
 
 	TestMultiException(
 		ctx context.Context,
-		reqMeta yarpc.CallReqMeta,
 		Arg0 *string,
 		Arg1 *string,
-	) (*gauntlet.Xtruct, yarpc.CallResMeta, error)
+		opts ...yarpc.CallOption,
+	) (*gauntlet.Xtruct, error)
 
 	TestNest(
 		ctx context.Context,
-		reqMeta yarpc.CallReqMeta,
 		Thing *gauntlet.Xtruct2,
-	) (*gauntlet.Xtruct2, yarpc.CallResMeta, error)
+		opts ...yarpc.CallOption,
+	) (*gauntlet.Xtruct2, error)
 
 	TestOneway(
 		ctx context.Context,
-		reqMeta yarpc.CallReqMeta,
 		SecondsToSleep *int32,
+		opts ...yarpc.CallOption,
 	) (yarpc.Ack, error)
 
 	TestSet(
 		ctx context.Context,
-		reqMeta yarpc.CallReqMeta,
 		Thing map[int32]struct{},
-	) (map[int32]struct{}, yarpc.CallResMeta, error)
+		opts ...yarpc.CallOption,
+	) (map[int32]struct{}, error)
 
 	TestString(
 		ctx context.Context,
-		reqMeta yarpc.CallReqMeta,
 		Thing *string,
-	) (string, yarpc.CallResMeta, error)
+		opts ...yarpc.CallOption,
+	) (string, error)
 
 	TestStringMap(
 		ctx context.Context,
-		reqMeta yarpc.CallReqMeta,
 		Thing map[string]string,
-	) (map[string]string, yarpc.CallResMeta, error)
+		opts ...yarpc.CallOption,
+	) (map[string]string, error)
 
 	TestStruct(
 		ctx context.Context,
-		reqMeta yarpc.CallReqMeta,
 		Thing *gauntlet.Xtruct,
-	) (*gauntlet.Xtruct, yarpc.CallResMeta, error)
+		opts ...yarpc.CallOption,
+	) (*gauntlet.Xtruct, error)
 
 	TestTypedef(
 		ctx context.Context,
-		reqMeta yarpc.CallReqMeta,
 		Thing *gauntlet.UserId,
-	) (gauntlet.UserId, yarpc.CallResMeta, error)
+		opts ...yarpc.CallOption,
+	) (gauntlet.UserId, error)
 
 	TestVoid(
 		ctx context.Context,
-		reqMeta yarpc.CallReqMeta,
-	) (yarpc.CallResMeta, error)
+		opts ...yarpc.CallOption,
+	) error
 }
 
 // New builds a new client for the ThriftTest service.
@@ -186,14 +186,14 @@ type client struct{ c thrift.Client }
 
 func (c client) TestBinary(
 	ctx context.Context,
-	reqMeta yarpc.CallReqMeta,
 	_Thing []byte,
-) (success []byte, resMeta yarpc.CallResMeta, err error) {
+	opts ...yarpc.CallOption,
+) (success []byte, err error) {
 
 	args := gauntlet.ThriftTest_TestBinary_Helper.Args(_Thing)
 
 	var body wire.Value
-	body, resMeta, err = c.c.Call(ctx, reqMeta, args)
+	body, err = c.c.Call(ctx, args, opts...)
 	if err != nil {
 		return
 	}
@@ -209,14 +209,14 @@ func (c client) TestBinary(
 
 func (c client) TestByte(
 	ctx context.Context,
-	reqMeta yarpc.CallReqMeta,
 	_Thing *int8,
-) (success int8, resMeta yarpc.CallResMeta, err error) {
+	opts ...yarpc.CallOption,
+) (success int8, err error) {
 
 	args := gauntlet.ThriftTest_TestByte_Helper.Args(_Thing)
 
 	var body wire.Value
-	body, resMeta, err = c.c.Call(ctx, reqMeta, args)
+	body, err = c.c.Call(ctx, args, opts...)
 	if err != nil {
 		return
 	}
@@ -232,14 +232,14 @@ func (c client) TestByte(
 
 func (c client) TestDouble(
 	ctx context.Context,
-	reqMeta yarpc.CallReqMeta,
 	_Thing *float64,
-) (success float64, resMeta yarpc.CallResMeta, err error) {
+	opts ...yarpc.CallOption,
+) (success float64, err error) {
 
 	args := gauntlet.ThriftTest_TestDouble_Helper.Args(_Thing)
 
 	var body wire.Value
-	body, resMeta, err = c.c.Call(ctx, reqMeta, args)
+	body, err = c.c.Call(ctx, args, opts...)
 	if err != nil {
 		return
 	}
@@ -255,14 +255,14 @@ func (c client) TestDouble(
 
 func (c client) TestEnum(
 	ctx context.Context,
-	reqMeta yarpc.CallReqMeta,
 	_Thing *gauntlet.Numberz,
-) (success gauntlet.Numberz, resMeta yarpc.CallResMeta, err error) {
+	opts ...yarpc.CallOption,
+) (success gauntlet.Numberz, err error) {
 
 	args := gauntlet.ThriftTest_TestEnum_Helper.Args(_Thing)
 
 	var body wire.Value
-	body, resMeta, err = c.c.Call(ctx, reqMeta, args)
+	body, err = c.c.Call(ctx, args, opts...)
 	if err != nil {
 		return
 	}
@@ -278,14 +278,14 @@ func (c client) TestEnum(
 
 func (c client) TestException(
 	ctx context.Context,
-	reqMeta yarpc.CallReqMeta,
 	_Arg *string,
-) (resMeta yarpc.CallResMeta, err error) {
+	opts ...yarpc.CallOption,
+) (err error) {
 
 	args := gauntlet.ThriftTest_TestException_Helper.Args(_Arg)
 
 	var body wire.Value
-	body, resMeta, err = c.c.Call(ctx, reqMeta, args)
+	body, err = c.c.Call(ctx, args, opts...)
 	if err != nil {
 		return
 	}
@@ -301,14 +301,14 @@ func (c client) TestException(
 
 func (c client) TestI32(
 	ctx context.Context,
-	reqMeta yarpc.CallReqMeta,
 	_Thing *int32,
-) (success int32, resMeta yarpc.CallResMeta, err error) {
+	opts ...yarpc.CallOption,
+) (success int32, err error) {
 
 	args := gauntlet.ThriftTest_TestI32_Helper.Args(_Thing)
 
 	var body wire.Value
-	body, resMeta, err = c.c.Call(ctx, reqMeta, args)
+	body, err = c.c.Call(ctx, args, opts...)
 	if err != nil {
 		return
 	}
@@ -324,14 +324,14 @@ func (c client) TestI32(
 
 func (c client) TestI64(
 	ctx context.Context,
-	reqMeta yarpc.CallReqMeta,
 	_Thing *int64,
-) (success int64, resMeta yarpc.CallResMeta, err error) {
+	opts ...yarpc.CallOption,
+) (success int64, err error) {
 
 	args := gauntlet.ThriftTest_TestI64_Helper.Args(_Thing)
 
 	var body wire.Value
-	body, resMeta, err = c.c.Call(ctx, reqMeta, args)
+	body, err = c.c.Call(ctx, args, opts...)
 	if err != nil {
 		return
 	}
@@ -347,14 +347,14 @@ func (c client) TestI64(
 
 func (c client) TestInsanity(
 	ctx context.Context,
-	reqMeta yarpc.CallReqMeta,
 	_Argument *gauntlet.Insanity,
-) (success map[gauntlet.UserId]map[gauntlet.Numberz]*gauntlet.Insanity, resMeta yarpc.CallResMeta, err error) {
+	opts ...yarpc.CallOption,
+) (success map[gauntlet.UserId]map[gauntlet.Numberz]*gauntlet.Insanity, err error) {
 
 	args := gauntlet.ThriftTest_TestInsanity_Helper.Args(_Argument)
 
 	var body wire.Value
-	body, resMeta, err = c.c.Call(ctx, reqMeta, args)
+	body, err = c.c.Call(ctx, args, opts...)
 	if err != nil {
 		return
 	}
@@ -370,14 +370,14 @@ func (c client) TestInsanity(
 
 func (c client) TestList(
 	ctx context.Context,
-	reqMeta yarpc.CallReqMeta,
 	_Thing []int32,
-) (success []int32, resMeta yarpc.CallResMeta, err error) {
+	opts ...yarpc.CallOption,
+) (success []int32, err error) {
 
 	args := gauntlet.ThriftTest_TestList_Helper.Args(_Thing)
 
 	var body wire.Value
-	body, resMeta, err = c.c.Call(ctx, reqMeta, args)
+	body, err = c.c.Call(ctx, args, opts...)
 	if err != nil {
 		return
 	}
@@ -393,14 +393,14 @@ func (c client) TestList(
 
 func (c client) TestMap(
 	ctx context.Context,
-	reqMeta yarpc.CallReqMeta,
 	_Thing map[int32]int32,
-) (success map[int32]int32, resMeta yarpc.CallResMeta, err error) {
+	opts ...yarpc.CallOption,
+) (success map[int32]int32, err error) {
 
 	args := gauntlet.ThriftTest_TestMap_Helper.Args(_Thing)
 
 	var body wire.Value
-	body, resMeta, err = c.c.Call(ctx, reqMeta, args)
+	body, err = c.c.Call(ctx, args, opts...)
 	if err != nil {
 		return
 	}
@@ -416,14 +416,14 @@ func (c client) TestMap(
 
 func (c client) TestMapMap(
 	ctx context.Context,
-	reqMeta yarpc.CallReqMeta,
 	_Hello *int32,
-) (success map[int32]map[int32]int32, resMeta yarpc.CallResMeta, err error) {
+	opts ...yarpc.CallOption,
+) (success map[int32]map[int32]int32, err error) {
 
 	args := gauntlet.ThriftTest_TestMapMap_Helper.Args(_Hello)
 
 	var body wire.Value
-	body, resMeta, err = c.c.Call(ctx, reqMeta, args)
+	body, err = c.c.Call(ctx, args, opts...)
 	if err != nil {
 		return
 	}
@@ -439,19 +439,19 @@ func (c client) TestMapMap(
 
 func (c client) TestMulti(
 	ctx context.Context,
-	reqMeta yarpc.CallReqMeta,
 	_Arg0 *int8,
 	_Arg1 *int32,
 	_Arg2 *int64,
 	_Arg3 map[int16]string,
 	_Arg4 *gauntlet.Numberz,
 	_Arg5 *gauntlet.UserId,
-) (success *gauntlet.Xtruct, resMeta yarpc.CallResMeta, err error) {
+	opts ...yarpc.CallOption,
+) (success *gauntlet.Xtruct, err error) {
 
 	args := gauntlet.ThriftTest_TestMulti_Helper.Args(_Arg0, _Arg1, _Arg2, _Arg3, _Arg4, _Arg5)
 
 	var body wire.Value
-	body, resMeta, err = c.c.Call(ctx, reqMeta, args)
+	body, err = c.c.Call(ctx, args, opts...)
 	if err != nil {
 		return
 	}
@@ -467,15 +467,15 @@ func (c client) TestMulti(
 
 func (c client) TestMultiException(
 	ctx context.Context,
-	reqMeta yarpc.CallReqMeta,
 	_Arg0 *string,
 	_Arg1 *string,
-) (success *gauntlet.Xtruct, resMeta yarpc.CallResMeta, err error) {
+	opts ...yarpc.CallOption,
+) (success *gauntlet.Xtruct, err error) {
 
 	args := gauntlet.ThriftTest_TestMultiException_Helper.Args(_Arg0, _Arg1)
 
 	var body wire.Value
-	body, resMeta, err = c.c.Call(ctx, reqMeta, args)
+	body, err = c.c.Call(ctx, args, opts...)
 	if err != nil {
 		return
 	}
@@ -491,14 +491,14 @@ func (c client) TestMultiException(
 
 func (c client) TestNest(
 	ctx context.Context,
-	reqMeta yarpc.CallReqMeta,
 	_Thing *gauntlet.Xtruct2,
-) (success *gauntlet.Xtruct2, resMeta yarpc.CallResMeta, err error) {
+	opts ...yarpc.CallOption,
+) (success *gauntlet.Xtruct2, err error) {
 
 	args := gauntlet.ThriftTest_TestNest_Helper.Args(_Thing)
 
 	var body wire.Value
-	body, resMeta, err = c.c.Call(ctx, reqMeta, args)
+	body, err = c.c.Call(ctx, args, opts...)
 	if err != nil {
 		return
 	}
@@ -514,23 +514,23 @@ func (c client) TestNest(
 
 func (c client) TestOneway(
 	ctx context.Context,
-	reqMeta yarpc.CallReqMeta,
 	_SecondsToSleep *int32,
+	opts ...yarpc.CallOption,
 ) (yarpc.Ack, error) {
 	args := gauntlet.ThriftTest_TestOneway_Helper.Args(_SecondsToSleep)
-	return c.c.CallOneway(ctx, reqMeta, args)
+	return c.c.CallOneway(ctx, args, opts...)
 }
 
 func (c client) TestSet(
 	ctx context.Context,
-	reqMeta yarpc.CallReqMeta,
 	_Thing map[int32]struct{},
-) (success map[int32]struct{}, resMeta yarpc.CallResMeta, err error) {
+	opts ...yarpc.CallOption,
+) (success map[int32]struct{}, err error) {
 
 	args := gauntlet.ThriftTest_TestSet_Helper.Args(_Thing)
 
 	var body wire.Value
-	body, resMeta, err = c.c.Call(ctx, reqMeta, args)
+	body, err = c.c.Call(ctx, args, opts...)
 	if err != nil {
 		return
 	}
@@ -546,14 +546,14 @@ func (c client) TestSet(
 
 func (c client) TestString(
 	ctx context.Context,
-	reqMeta yarpc.CallReqMeta,
 	_Thing *string,
-) (success string, resMeta yarpc.CallResMeta, err error) {
+	opts ...yarpc.CallOption,
+) (success string, err error) {
 
 	args := gauntlet.ThriftTest_TestString_Helper.Args(_Thing)
 
 	var body wire.Value
-	body, resMeta, err = c.c.Call(ctx, reqMeta, args)
+	body, err = c.c.Call(ctx, args, opts...)
 	if err != nil {
 		return
 	}
@@ -569,14 +569,14 @@ func (c client) TestString(
 
 func (c client) TestStringMap(
 	ctx context.Context,
-	reqMeta yarpc.CallReqMeta,
 	_Thing map[string]string,
-) (success map[string]string, resMeta yarpc.CallResMeta, err error) {
+	opts ...yarpc.CallOption,
+) (success map[string]string, err error) {
 
 	args := gauntlet.ThriftTest_TestStringMap_Helper.Args(_Thing)
 
 	var body wire.Value
-	body, resMeta, err = c.c.Call(ctx, reqMeta, args)
+	body, err = c.c.Call(ctx, args, opts...)
 	if err != nil {
 		return
 	}
@@ -592,14 +592,14 @@ func (c client) TestStringMap(
 
 func (c client) TestStruct(
 	ctx context.Context,
-	reqMeta yarpc.CallReqMeta,
 	_Thing *gauntlet.Xtruct,
-) (success *gauntlet.Xtruct, resMeta yarpc.CallResMeta, err error) {
+	opts ...yarpc.CallOption,
+) (success *gauntlet.Xtruct, err error) {
 
 	args := gauntlet.ThriftTest_TestStruct_Helper.Args(_Thing)
 
 	var body wire.Value
-	body, resMeta, err = c.c.Call(ctx, reqMeta, args)
+	body, err = c.c.Call(ctx, args, opts...)
 	if err != nil {
 		return
 	}
@@ -615,14 +615,14 @@ func (c client) TestStruct(
 
 func (c client) TestTypedef(
 	ctx context.Context,
-	reqMeta yarpc.CallReqMeta,
 	_Thing *gauntlet.UserId,
-) (success gauntlet.UserId, resMeta yarpc.CallResMeta, err error) {
+	opts ...yarpc.CallOption,
+) (success gauntlet.UserId, err error) {
 
 	args := gauntlet.ThriftTest_TestTypedef_Helper.Args(_Thing)
 
 	var body wire.Value
-	body, resMeta, err = c.c.Call(ctx, reqMeta, args)
+	body, err = c.c.Call(ctx, args, opts...)
 	if err != nil {
 		return
 	}
@@ -638,13 +638,13 @@ func (c client) TestTypedef(
 
 func (c client) TestVoid(
 	ctx context.Context,
-	reqMeta yarpc.CallReqMeta,
-) (resMeta yarpc.CallResMeta, err error) {
+	opts ...yarpc.CallOption,
+) (err error) {
 
 	args := gauntlet.ThriftTest_TestVoid_Helper.Args()
 
 	var body wire.Value
-	body, resMeta, err = c.c.Call(ctx, reqMeta, args)
+	body, err = c.c.Call(ctx, args, opts...)
 	if err != nil {
 		return
 	}

--- a/internal/crossdock/thrift/oneway/yarpc/onewayclient/client.go
+++ b/internal/crossdock/thrift/oneway/yarpc/onewayclient/client.go
@@ -35,8 +35,8 @@ import (
 type Interface interface {
 	Echo(
 		ctx context.Context,
-		reqMeta yarpc.CallReqMeta,
 		Token *string,
+		opts ...yarpc.CallOption,
 	) (yarpc.Ack, error)
 }
 
@@ -60,9 +60,9 @@ type client struct{ c thrift.Client }
 
 func (c client) Echo(
 	ctx context.Context,
-	reqMeta yarpc.CallReqMeta,
 	_Token *string,
+	opts ...yarpc.CallOption,
 ) (yarpc.Ack, error) {
 	args := oneway.Oneway_Echo_Helper.Args(_Token)
-	return c.c.CallOneway(ctx, reqMeta, args)
+	return c.c.CallOneway(ctx, args, opts...)
 }

--- a/internal/examples/thrift-hello/hello/echo/yarpc/helloclient/client.go
+++ b/internal/examples/thrift-hello/hello/echo/yarpc/helloclient/client.go
@@ -36,9 +36,9 @@ import (
 type Interface interface {
 	Echo(
 		ctx context.Context,
-		reqMeta yarpc.CallReqMeta,
 		Echo *echo.EchoRequest,
-	) (*echo.EchoResponse, yarpc.CallResMeta, error)
+		opts ...yarpc.CallOption,
+	) (*echo.EchoResponse, error)
 }
 
 // New builds a new client for the Hello service.
@@ -61,14 +61,14 @@ type client struct{ c thrift.Client }
 
 func (c client) Echo(
 	ctx context.Context,
-	reqMeta yarpc.CallReqMeta,
 	_Echo *echo.EchoRequest,
-) (success *echo.EchoResponse, resMeta yarpc.CallResMeta, err error) {
+	opts ...yarpc.CallOption,
+) (success *echo.EchoResponse, err error) {
 
 	args := echo.Hello_Echo_Helper.Args(_Echo)
 
 	var body wire.Value
-	body, resMeta, err = c.c.Call(ctx, reqMeta, args)
+	body, err = c.c.Call(ctx, args, opts...)
 	if err != nil {
 		return
 	}

--- a/internal/examples/thrift-hello/hello/main.go
+++ b/internal/examples/thrift-hello/hello/main.go
@@ -76,14 +76,16 @@ func call(client helloclient.Interface, message string) (*echo.EchoResponse, yar
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	resBody, resMeta, err := client.Echo(
+	var resHeaders yarpc.Headers
+	resBody, err := client.Echo(
 		ctx,
-		yarpc.NewReqMeta().Headers(yarpc.NewHeaders().With("from", "self")),
 		&echo.EchoRequest{Message: message, Count: 1},
+		yarpc.WithHeader("from", "self"),
+		yarpc.ResponseHeaders(&resHeaders),
 	)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	return resBody, resMeta.Headers()
+	return resBody, resHeaders
 }

--- a/internal/examples/thrift-keyvalue/keyvalue/client/main.go
+++ b/internal/examples/thrift-keyvalue/keyvalue/client/main.go
@@ -103,7 +103,7 @@ func main() {
 			ctx, cancel := context.WithTimeout(rootCtx, 100*time.Millisecond)
 			defer cancel()
 
-			if value, _, err := client.GetValue(ctx, nil, &key); err != nil {
+			if value, err := client.GetValue(ctx, &key); err != nil {
 				fmt.Printf("get %q failed: %s\n", key, err)
 			} else {
 				fmt.Println(key, "=", value)
@@ -121,7 +121,7 @@ func main() {
 			ctx, cancel := context.WithTimeout(rootCtx, 100*time.Millisecond)
 			defer cancel()
 
-			if _, err := client.SetValue(ctx, nil, &key, &value); err != nil {
+			if err := client.SetValue(ctx, &key, &value); err != nil {
 				fmt.Printf("set %q = %q failed: %v\n", key, value, err.Error())
 			}
 			continue

--- a/internal/examples/thrift-keyvalue/keyvalue/kv/yarpc/keyvalueclient/client.go
+++ b/internal/examples/thrift-keyvalue/keyvalue/kv/yarpc/keyvalueclient/client.go
@@ -36,16 +36,16 @@ import (
 type Interface interface {
 	GetValue(
 		ctx context.Context,
-		reqMeta yarpc.CallReqMeta,
 		Key *string,
-	) (string, yarpc.CallResMeta, error)
+		opts ...yarpc.CallOption,
+	) (string, error)
 
 	SetValue(
 		ctx context.Context,
-		reqMeta yarpc.CallReqMeta,
 		Key *string,
 		Value *string,
-	) (yarpc.CallResMeta, error)
+		opts ...yarpc.CallOption,
+	) error
 }
 
 // New builds a new client for the KeyValue service.
@@ -68,14 +68,14 @@ type client struct{ c thrift.Client }
 
 func (c client) GetValue(
 	ctx context.Context,
-	reqMeta yarpc.CallReqMeta,
 	_Key *string,
-) (success string, resMeta yarpc.CallResMeta, err error) {
+	opts ...yarpc.CallOption,
+) (success string, err error) {
 
 	args := kv.KeyValue_GetValue_Helper.Args(_Key)
 
 	var body wire.Value
-	body, resMeta, err = c.c.Call(ctx, reqMeta, args)
+	body, err = c.c.Call(ctx, args, opts...)
 	if err != nil {
 		return
 	}
@@ -91,15 +91,15 @@ func (c client) GetValue(
 
 func (c client) SetValue(
 	ctx context.Context,
-	reqMeta yarpc.CallReqMeta,
 	_Key *string,
 	_Value *string,
-) (resMeta yarpc.CallResMeta, err error) {
+	opts ...yarpc.CallOption,
+) (err error) {
 
 	args := kv.KeyValue_SetValue_Helper.Args(_Key, _Value)
 
 	var body wire.Value
-	body, resMeta, err = c.c.Call(ctx, reqMeta, args)
+	body, err = c.c.Call(ctx, args, opts...)
 	if err != nil {
 		return
 	}

--- a/internal/examples/thrift-oneway/main.go
+++ b/internal/examples/thrift-oneway/main.go
@@ -81,7 +81,7 @@ func main() {
 	// Make outbound call every 500ms
 	for {
 		time.Sleep(time.Second / 2)
-		client.Sink(context.Background(), nil, &sink.SinkRequest{Message: "hello!"})
+		client.Sink(context.Background(), &sink.SinkRequest{Message: "hello!"})
 	}
 }
 

--- a/internal/examples/thrift-oneway/sink/yarpc/helloclient/client.go
+++ b/internal/examples/thrift-oneway/sink/yarpc/helloclient/client.go
@@ -25,19 +25,18 @@ package helloclient
 
 import (
 	"context"
-
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/encoding/thrift"
 	"go.uber.org/yarpc/internal/examples/thrift-oneway/sink"
+	"go.uber.org/yarpc/encoding/thrift"
 )
 
 // Interface is a client for the Hello service.
 type Interface interface {
 	Sink(
 		ctx context.Context,
-		reqMeta yarpc.CallReqMeta,
 		Snk *sink.SinkRequest,
+		opts ...yarpc.CallOption,
 	) (yarpc.Ack, error)
 }
 
@@ -61,9 +60,9 @@ type client struct{ c thrift.Client }
 
 func (c client) Sink(
 	ctx context.Context,
-	reqMeta yarpc.CallReqMeta,
 	_Snk *sink.SinkRequest,
+	opts ...yarpc.CallOption,
 ) (yarpc.Ack, error) {
 	args := sink.Hello_Sink_Helper.Args(_Snk)
-	return c.c.CallOneway(ctx, reqMeta, args)
+	return c.c.CallOneway(ctx, args, opts...)
 }

--- a/internal/examples/thrift-oneway/sink/yarpc/helloserver/server.go
+++ b/internal/examples/thrift-oneway/sink/yarpc/helloserver/server.go
@@ -25,12 +25,11 @@ package helloserver
 
 import (
 	"context"
-
 	"go.uber.org/thriftrw/wire"
-	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/encoding/thrift"
 	"go.uber.org/yarpc/internal/examples/thrift-oneway/sink"
+	"go.uber.org/yarpc/encoding/thrift"
+	"go.uber.org/yarpc"
 )
 
 // Interface is the server-side interface for the Hello service.


### PR DESCRIPTION
This changes Thrift outbounds and code generation to never use *Meta types for
call site options.

Issue: #617