### PR TITLE
Consolidate context accessors into CallFromContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,8 @@ v1.0.0-dev (unreleased)
     }
     ```
 
-    To access information previously available in the `yarpc.ReqMeta`, use the
-    `context.Context` accessors provided in the `yarpc` package. To write
-    response headers, use `yarpc.WriteResponseHeader`.
+    To access information previously available in the `yarpc.ReqMeta` or to
+    write response headers, use the `yarpc.CallFromContext` function.
 
 -   **Breaking**: Removed the `yarpc.CallReqMeta` and `yarpc.CallResMeta`
     types. To migrate your call sites, drop the argument and remove the return

--- a/bench_test.go
+++ b/bench_test.go
@@ -25,8 +25,11 @@ import (
 var _reqBody = []byte("hello")
 
 func yarpcEcho(ctx context.Context, body []byte) ([]byte, error) {
-	for _, k := range yarpc.HeaderNames(ctx) {
-		yarpc.WriteResponseHeader(ctx, k, yarpc.Header(ctx, k))
+	call := yarpc.CallFromContext(ctx)
+	for _, k := range call.HeaderNames() {
+		if err := call.WriteResponseHeader(k, call.Header(k)); err != nil {
+			return nil, err
+		}
 	}
 	return body, nil
 }

--- a/encoding/json/inbound_test.go
+++ b/encoding/json/inbound_test.go
@@ -27,7 +27,7 @@ type simpleResponse struct {
 
 func TestHandleStructSuccess(t *testing.T) {
 	h := func(ctx context.Context, body *simpleRequest) (*simpleResponse, error) {
-		assert.Equal(t, "simpleCall", yarpc.Procedure(ctx))
+		assert.Equal(t, "simpleCall", yarpc.CallFromContext(ctx).Procedure())
 		assert.Equal(t, "foo", body.Name)
 		assert.Equal(t, map[string]int32{"bar": 42}, body.Attributes)
 
@@ -99,7 +99,7 @@ func TestHandleInterfaceEmptySuccess(t *testing.T) {
 
 func TestHandleSuccessWithResponseHeaders(t *testing.T) {
 	h := func(ctx context.Context, _ *simpleRequest) (*simpleResponse, error) {
-		yarpc.WriteResponseHeader(ctx, "foo", "bar")
+		require.NoError(t, yarpc.CallFromContext(ctx).WriteResponseHeader("foo", "bar"))
 		return &simpleResponse{Success: true}, nil
 	}
 

--- a/encoding/raw/inbound_test.go
+++ b/encoding/raw/inbound_test.go
@@ -31,6 +31,7 @@ import (
 	"go.uber.org/yarpc/api/transport/transporttest"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go/testutils/testreader"
 )
 
@@ -59,7 +60,7 @@ func TestRawHandler(t *testing.T) {
 				{4, 5, 6},
 			},
 			handler: func(ctx context.Context, body []byte) ([]byte, error) {
-				assert.Equal(t, "foo", yarpc.Procedure(ctx))
+				assert.Equal(t, "foo", yarpc.CallFromContext(ctx).Procedure())
 				assert.Equal(t, []byte{1, 2, 3, 4, 5, 6}, body)
 				return []byte("hello"), nil
 			},
@@ -89,7 +90,7 @@ func TestRawHandler(t *testing.T) {
 			procedure:  "responseHeaders",
 			bodyChunks: [][]byte{},
 			handler: func(ctx context.Context, body []byte) ([]byte, error) {
-				yarpc.WriteResponseHeader(ctx, "hello", "world")
+				require.NoError(t, yarpc.CallFromContext(ctx).WriteResponseHeader("hello", "world"))
 				return []byte{}, nil
 			},
 			wantHeaders: transport.NewHeaders().With("hello", "world"),

--- a/internal/crossdock/server/oneway/echo.go
+++ b/internal/crossdock/server/oneway/echo.go
@@ -42,7 +42,7 @@ type onewayHandler struct {
 
 // EchoRaw implements the echo/raw procedure.
 func (o *onewayHandler) EchoRaw(ctx context.Context, body []byte) error {
-	callBackAddr := yarpc.Header(ctx, callBackAddrHeader)
+	callBackAddr := yarpc.CallFromContext(ctx).Header(callBackAddrHeader)
 	o.callHome(ctx, callBackAddr, body, raw.Encoding)
 	return nil
 }
@@ -51,14 +51,14 @@ type jsonToken struct{ Token string }
 
 // EchoJSON implements the echo/json procedure.
 func (o *onewayHandler) EchoJSON(ctx context.Context, token *jsonToken) error {
-	callBackAddr := yarpc.Header(ctx, callBackAddrHeader)
+	callBackAddr := yarpc.CallFromContext(ctx).Header(callBackAddrHeader)
 	o.callHome(ctx, callBackAddr, []byte(token.Token), json.Encoding)
 	return nil
 }
 
 // Echo implements the Oneway::Echo procedure.
 func (o *onewayHandler) Echo(ctx context.Context, Token *string) error {
-	callBackAddr := yarpc.Header(ctx, callBackAddrHeader)
+	callBackAddr := yarpc.CallFromContext(ctx).Header(callBackAddrHeader)
 	o.callHome(ctx, callBackAddr, []byte(*Token), thrift.Encoding)
 	return nil
 }

--- a/internal/crossdock/server/yarpc/echo.go
+++ b/internal/crossdock/server/yarpc/echo.go
@@ -29,16 +29,22 @@ import (
 
 // EchoRaw implements the echo/raw procedure.
 func EchoRaw(ctx context.Context, body []byte) ([]byte, error) {
-	for _, k := range yarpc.HeaderNames(ctx) {
-		yarpc.WriteResponseHeader(ctx, k, yarpc.Header(ctx, k))
+	call := yarpc.CallFromContext(ctx)
+	for _, k := range call.HeaderNames() {
+		if err := call.WriteResponseHeader(k, call.Header(k)); err != nil {
+			return nil, err
+		}
 	}
 	return body, nil
 }
 
 // EchoJSON implements the echo procedure.
 func EchoJSON(ctx context.Context, body map[string]interface{}) (map[string]interface{}, error) {
-	for _, k := range yarpc.HeaderNames(ctx) {
-		yarpc.WriteResponseHeader(ctx, k, yarpc.Header(ctx, k))
+	call := yarpc.CallFromContext(ctx)
+	for _, k := range call.HeaderNames() {
+		if err := call.WriteResponseHeader(k, call.Header(k)); err != nil {
+			return nil, err
+		}
 	}
 	return body, nil
 }
@@ -48,8 +54,11 @@ type EchoThrift struct{}
 
 // Echo endpoint for the Echo service.
 func (EchoThrift) Echo(ctx context.Context, ping *echo.Ping) (*echo.Pong, error) {
-	for _, k := range yarpc.HeaderNames(ctx) {
-		yarpc.WriteResponseHeader(ctx, k, yarpc.Header(ctx, k))
+	call := yarpc.CallFromContext(ctx)
+	for _, k := range call.HeaderNames() {
+		if err := call.WriteResponseHeader(k, call.Header(k)); err != nil {
+			return nil, err
+		}
 	}
 	return &echo.Pong{Boop: ping.Beep}, nil
 }

--- a/internal/crossdock/server/yarpc/gauntlet.go
+++ b/internal/crossdock/server/yarpc/gauntlet.go
@@ -30,8 +30,11 @@ import (
 )
 
 func copyRequestHeaders(ctx context.Context) {
-	for _, k := range yarpc.HeaderNames(ctx) {
-		yarpc.WriteResponseHeader(ctx, k, yarpc.Header(ctx, k))
+	call := yarpc.CallFromContext(ctx)
+	for _, k := range call.HeaderNames() {
+		if err := call.WriteResponseHeader(k, call.Header(k)); err != nil {
+			panic(err)
+		}
 	}
 }
 

--- a/internal/crossdock/server/yarpc/phone.go
+++ b/internal/crossdock/server/yarpc/phone.go
@@ -97,7 +97,7 @@ func Phone(ctx context.Context, body *PhoneRequest) (*PhoneResponse, error) {
 	}))
 	resBody := PhoneResponse{
 		Service:   "yarpc-test", // TODO use yarpc.Service
-		Procedure: yarpc.Procedure(ctx),
+		Procedure: yarpc.CallFromContext(ctx).Procedure(),
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)

--- a/internal/examples/thrift-hello/hello/main.go
+++ b/internal/examples/thrift-hello/hello/main.go
@@ -67,8 +67,11 @@ func main() {
 type helloHandler struct{}
 
 func (h helloHandler) Echo(ctx context.Context, e *echo.EchoRequest) (*echo.EchoResponse, error) {
-	for _, k := range yarpc.HeaderNames(ctx) {
-		yarpc.WriteResponseHeader(ctx, k, yarpc.Header(ctx, k))
+	call := yarpc.CallFromContext(ctx)
+	for _, k := range call.HeaderNames() {
+		if err := call.WriteResponseHeader(k, call.Header(k)); err != nil {
+			return nil, err
+		}
 	}
 
 	return &echo.EchoResponse{Message: e.Message, Count: e.Count + 1}, nil


### PR DESCRIPTION
This consolidates all context accessors into a single struct `*Call` which can
be obtained by using `CallFromContext`.

This should help with discoverability in godocs:

![image](https://cloud.githubusercontent.com/assets/41730/21464503/d933ca84-c933-11e6-9126-b58fbf6794c5.png)
