### PR TITLE
MapRouter: Drop ChooseProcedure

### DIFF
--- a/router.go
+++ b/router.go
@@ -83,9 +83,10 @@ func (m MapRouter) Procedures() []transport.Procedure {
 	return procs
 }
 
-// ChooseProcedure retrieves the HandlerSpec for the given Procedure or returns an
-// error.
-func (m MapRouter) ChooseProcedure(service, procedure string) (transport.HandlerSpec, error) {
+// Choose retrives the HandlerSpec for the service and procedure noted on the
+// transport request, or returns an error.
+func (m MapRouter) Choose(ctx context.Context, req *transport.Request) (transport.HandlerSpec, error) {
+	service, procedure := req.Service, req.Procedure
 	if service == "" {
 		service = m.defaultService
 	}
@@ -102,12 +103,6 @@ func (m MapRouter) ChooseProcedure(service, procedure string) (transport.Handler
 		Service:   service,
 		Procedure: procedure,
 	}
-}
-
-// Choose retrives the HandlerSpec for the service and procedure noted on the
-// transport request, or returns an error.
-func (m MapRouter) Choose(ctx context.Context, req *transport.Request) (transport.HandlerSpec, error) {
-	return m.ChooseProcedure(req.Service, req.Procedure)
 }
 
 type byServiceProcedure []transport.Procedure

--- a/router_test.go
+++ b/router_test.go
@@ -23,6 +23,8 @@ package yarpc_test
 import (
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/api/transport/transporttest"
@@ -64,12 +66,15 @@ func TestMapRouter(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got, err := m.ChooseProcedure(tt.service, tt.procedure)
+		got, err := m.Choose(context.Background(), &transport.Request{
+			Service:   tt.service,
+			Procedure: tt.procedure,
+		})
 		if tt.want != nil {
 			assert.NoError(t, err,
-				"ChooseProcedure(%q, %q) failed", tt.service, tt.procedure)
+				"Choose(%q, %q) failed", tt.service, tt.procedure)
 			assert.True(t, tt.want == got.Unary(), // want == match, not deep equals
-				"ChooseProcedure(%q, %q) did not match", tt.service, tt.procedure)
+				"Choose(%q, %q) did not match", tt.service, tt.procedure)
 		} else {
 			assert.Error(t, err)
 		}


### PR DESCRIPTION
Leftover from a refactor