### PR TITLE
call: Hide Inbound/OutboundCall from yarpc package

### DIFF
--- a/api/encoding/call.go
+++ b/api/encoding/call.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package encoding
+
+import (
+	"context"
+	"errors"
+	"sort"
+
+	"go.uber.org/yarpc/api/transport"
+)
+
+type keyValuePair struct{ k, v string }
+
+// Call provides information about the current request inside handlers.
+type Call struct{ ic *InboundCall }
+
+// CallFromContext retrieves information about the current incoming request
+// from the given context. Returns nil if the context is not a valid request
+// context.
+//
+// The object is valid only as long as the request is ongoing.
+func CallFromContext(ctx context.Context) *Call {
+	if ic, ok := getInboundCall(ctx); ok {
+		return &Call{ic}
+	}
+	return nil
+}
+
+// WriteResponseHeader writes headers to the response of this call.
+func (c *Call) WriteResponseHeader(k, v string) error {
+	if c == nil {
+		return errors.New(
+			"failed to write response header: " +
+				"Call was nil, make sure CallFromContext was called with a request context")
+	}
+	c.ic.resHeaders = append(c.ic.resHeaders, keyValuePair{k: k, v: v})
+	return nil
+}
+
+// Caller returns the name of the service making this request.
+func (c *Call) Caller() string {
+	if c == nil {
+		return ""
+	}
+	return c.ic.req.Caller
+}
+
+// Service returns the name of the service being called.
+func (c *Call) Service() string {
+	if c == nil {
+		return ""
+	}
+	return c.ic.req.Service
+}
+
+// Procedure returns the name of the procedure being called.
+func (c *Call) Procedure() string {
+	if c == nil {
+		return ""
+	}
+	return c.ic.req.Procedure
+}
+
+// Encoding returns the encoding for this request.
+func (c *Call) Encoding() transport.Encoding {
+	if c == nil {
+		return ""
+	}
+	return c.ic.req.Encoding
+}
+
+// Header returns the value of the given request header provided with the
+// request.
+func (c *Call) Header(k string) string {
+	if c == nil {
+		return ""
+	}
+
+	if v, ok := c.ic.req.Headers.Get(k); ok {
+		return v
+	}
+
+	return ""
+}
+
+// HeaderNames returns a sorted list of the names of user defined headers
+// provided with this request.
+func (c *Call) HeaderNames() []string {
+	if c == nil {
+		return nil
+	}
+
+	var names []string
+	for k := range c.ic.req.Headers.Items() {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// ShardKey returns the shard key for this request.
+func (c *Call) ShardKey() string {
+	if c == nil {
+		return ""
+	}
+	return c.ic.req.ShardKey
+}
+
+// RoutingKey returns the routing key for this request.
+func (c *Call) RoutingKey() string {
+	if c == nil {
+		return ""
+	}
+	return c.ic.req.RoutingKey
+}
+
+// RoutingDelegate returns the routing delegate for this request.
+func (c *Call) RoutingDelegate() string {
+	if c == nil {
+		return ""
+	}
+	return c.ic.req.RoutingDelegate
+}

--- a/api/encoding/call_option.go
+++ b/api/encoding/call_option.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package encoding
+
+// CallOption defines options that may be passed in at call sites to other
+// services.
+//
+// Encoding authors should accept yarpc.CallOptions and convert them to
+// encoding.CallOptions to use with NewOutboundCall. This will keep the
+// API for service authors simple.
+type CallOption struct{ apply func(*OutboundCall) }
+
+// ResponseHeaders specifies that headers received in response to this request
+// should replace the given map.
+func ResponseHeaders(h *map[string]string) CallOption {
+	return CallOption{func(o *OutboundCall) { o.responseHeaders = h }}
+}
+
+// WithHeader adds a new header to the request.
+func WithHeader(k, v string) CallOption {
+	return CallOption{func(o *OutboundCall) {
+		o.headers = append(o.headers, keyValuePair{k: k, v: v})
+	}}
+}
+
+// WithShardKey sets the shard key for the request.
+func WithShardKey(sk string) CallOption {
+	return CallOption{func(o *OutboundCall) { o.shardKey = &sk }}
+}
+
+// WithRoutingKey sets the routing key for the request.
+func WithRoutingKey(rk string) CallOption {
+	return CallOption{func(o *OutboundCall) { o.routingKey = &rk }}
+}
+
+// WithRoutingDelegate sets the routing delegate for the request.
+func WithRoutingDelegate(rd string) CallOption {
+	return CallOption{func(o *OutboundCall) { o.routingDelegate = &rd }}
+}

--- a/api/encoding/call_test.go
+++ b/api/encoding/call_test.go
@@ -1,0 +1,26 @@
+package encoding
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNilCall(t *testing.T) {
+	call := CallFromContext(context.Background())
+	require.Nil(t, call)
+
+	assert.Equal(t, "", call.Caller())
+	assert.Equal(t, "", call.Service())
+	assert.Equal(t, "", string(call.Encoding()))
+	assert.Equal(t, "", call.Procedure())
+	assert.Equal(t, "", call.ShardKey())
+	assert.Equal(t, "", call.RoutingKey())
+	assert.Equal(t, "", call.RoutingDelegate())
+	assert.Equal(t, "", call.Header("foo"))
+	assert.Empty(t, call.HeaderNames())
+
+	assert.Error(t, call.WriteResponseHeader("foo", "bar"))
+}

--- a/api/encoding/doc.go
+++ b/api/encoding/doc.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package encoding provides APIs for encoding authors.
+package encoding

--- a/api/encoding/inbound_call.go
+++ b/api/encoding/inbound_call.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package encoding
+
+import (
+	"context"
+
+	"go.uber.org/yarpc/api/transport"
+)
+
+// InboundCall holds information about the inbound call and its response.
+//
+// Encoding authors may use InboundCall to provide information about the
+// incoming request on the Context and send response headers through
+// WriteResponseHeader.
+type InboundCall struct {
+	resHeaders []keyValuePair
+	req        *transport.Request
+}
+
+type inboundCallKey struct{} // context key for *InboundCall
+
+// NewInboundCall builds a new InboundCall with the given context.
+//
+// A request context is returned and must be used in place of the original.
+func NewInboundCall(ctx context.Context) (context.Context, *InboundCall) {
+	call := &InboundCall{}
+	return context.WithValue(ctx, inboundCallKey{}, call), call
+}
+
+// getInboundCall returns the inbound call on this context or nil.
+func getInboundCall(ctx context.Context) (*InboundCall, bool) {
+	call, ok := ctx.Value(inboundCallKey{}).(*InboundCall)
+	return call, ok
+}
+
+// ReadFromRequest reads information from the given request.
+//
+// This information may be queried on the context using functions like Caller,
+// Service, Procedure, etc.
+func (ic *InboundCall) ReadFromRequest(req *transport.Request) error {
+	// TODO(abg): Maybe we should copy attributes over so that changes to the
+	// Request don't change the output.
+	ic.req = req
+	return nil
+}
+
+// WriteToResponse writes response information from the InboundCall onto the
+// given ResponseWriter.
+//
+// If used, this must be called before writing the response body to the
+// ResponseWriter.
+func (ic *InboundCall) WriteToResponse(resw transport.ResponseWriter) error {
+	var headers transport.Headers
+	for _, h := range ic.resHeaders {
+		headers = headers.With(h.k, h.v)
+	}
+
+	if headers.Len() > 0 {
+		resw.AddHeaders(headers)
+	}
+
+	return nil
+}

--- a/api/encoding/inbound_call_test.go
+++ b/api/encoding/inbound_call_test.go
@@ -1,0 +1,76 @@
+package encoding
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/api/transport/transporttest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInboundCallReadFromRequest(t *testing.T) {
+	ctx, inboundCall := NewInboundCall(context.Background())
+	err := inboundCall.ReadFromRequest(&transport.Request{
+		Caller:    "caller",
+		Service:   "service",
+		Encoding:  transport.Encoding("raw"),
+		Procedure: "hello",
+		Headers: transport.HeadersFromMap(map[string]string{
+			"hello":   "World",
+			"Foo":     "bar",
+			"success": "true",
+		}),
+		ShardKey:        "shardKey",
+		RoutingKey:      "routingKey",
+		RoutingDelegate: "routingDelegate",
+	})
+	require.NoError(t, err)
+
+	call := CallFromContext(ctx)
+	assert.Equal(t, "caller", call.Caller())
+	assert.Equal(t, "service", call.Service())
+	assert.Equal(t, "raw", string(call.Encoding()))
+	assert.Equal(t, "hello", call.Procedure())
+	assert.Equal(t, "shardKey", call.ShardKey())
+	assert.Equal(t, "routingKey", call.RoutingKey())
+	assert.Equal(t, "routingDelegate", call.RoutingDelegate())
+
+	assert.Equal(t, "World", call.Header("Hello"))
+	assert.Equal(t, "bar", call.Header("FOO"))
+	assert.Equal(t, "true", call.Header("success"))
+	assert.Equal(t, "", call.Header("does-not-exist"))
+
+	headerNames := call.HeaderNames()
+	sort.Strings(headerNames)
+	assert.Equal(t, []string{"foo", "hello", "success"}, headerNames)
+}
+
+func TestInboundCallWriteToResponse(t *testing.T) {
+	tests := []struct {
+		desc        string
+		sendHeaders map[string]string
+		wantHeaders transport.Headers
+	}{
+		{
+			desc: "no headers",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			ctx, inboundCall := NewInboundCall(context.Background())
+			call := CallFromContext(ctx)
+			for k, v := range tt.sendHeaders {
+				call.WriteResponseHeader(k, v)
+			}
+
+			var resw transporttest.FakeResponseWriter
+			assert.NoError(t, inboundCall.WriteToResponse(&resw))
+			assert.Equal(t, tt.wantHeaders, resw.Headers)
+		})
+	}
+}

--- a/api/encoding/outbound_call.go
+++ b/api/encoding/outbound_call.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package encoding
+
+import (
+	"context"
+
+	"go.uber.org/yarpc/api/transport"
+)
+
+// OutboundCall is an outgoing call. It holds per-call options for a request.
+//
+// Encoding authors may use OutboundCall to provide a CallOption-based request
+// customization mechanism, including returning response headers through
+// ResponseHeaders.
+type OutboundCall struct {
+	// request attributes to fill if non-nil
+	headers         []keyValuePair
+	shardKey        *string
+	routingKey      *string
+	routingDelegate *string
+
+	// If non-nil, response headers should be written here.
+	responseHeaders *map[string]string
+}
+
+// NewOutboundCall constructs a new OutboundCall with the given options.
+func NewOutboundCall(options ...CallOption) *OutboundCall {
+	var call OutboundCall
+	for _, opt := range options {
+		opt.apply(&call)
+	}
+	return &call
+}
+
+// WriteToRequest fills the given request with request-specific options from
+// the call.
+//
+// The context MAY be replaced by the OutboundCall.
+func (c *OutboundCall) WriteToRequest(ctx context.Context, req *transport.Request) (context.Context, error) {
+	for _, h := range c.headers {
+		req.Headers = req.Headers.With(h.k, h.v)
+	}
+
+	if c.shardKey != nil {
+		req.ShardKey = *c.shardKey
+	}
+	if c.routingKey != nil {
+		req.RoutingKey = *c.routingKey
+	}
+	if c.routingDelegate != nil {
+		req.RoutingDelegate = *c.routingDelegate
+	}
+
+	// NB(abg): context and error are unused for now but we want to leave room
+	// for CallOptions which can fail or modify the context.
+	return ctx, nil
+}
+
+// ReadFromResponse reads information from the response for this call.
+//
+// This should be called only if the request is unary.
+func (c *OutboundCall) ReadFromResponse(ctx context.Context, res *transport.Response) (context.Context, error) {
+	// We're not using ctx right now but we may in the future.
+	if c.responseHeaders != nil && res.Headers.Len() > 0 {
+		// We make a copy of the response headers because Headers.Items() must
+		// never be mutated.
+		headers := make(map[string]string, res.Headers.Len())
+		for k, v := range res.Headers.Items() {
+			headers[k] = v
+		}
+		*c.responseHeaders = headers
+	}
+
+	// NB(abg): context and error are unused for now but we want to leave room
+	// for CallOptions which can fail or modify the context.
+	return ctx, nil
+}

--- a/api/encoding/outbound_call_test.go
+++ b/api/encoding/outbound_call_test.go
@@ -1,12 +1,10 @@
-package yarpc
+package encoding
 
 import (
 	"context"
-	"sort"
 	"testing"
 
 	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/api/transport/transporttest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -132,84 +130,4 @@ func TestOutboundCallReadFromResponse(t *testing.T) {
 		"foo":     "bar",
 		"success": "true",
 	}, headers)
-}
-
-func TestInboundCallReadFromRequest(t *testing.T) {
-	ctx, inboundCall := NewInboundCall(context.Background())
-	err := inboundCall.ReadFromRequest(&transport.Request{
-		Caller:    "caller",
-		Service:   "service",
-		Encoding:  transport.Encoding("raw"),
-		Procedure: "hello",
-		Headers: transport.HeadersFromMap(map[string]string{
-			"hello":   "World",
-			"Foo":     "bar",
-			"success": "true",
-		}),
-		ShardKey:        "shardKey",
-		RoutingKey:      "routingKey",
-		RoutingDelegate: "routingDelegate",
-	})
-	require.NoError(t, err)
-
-	call := CallFromContext(ctx)
-	assert.Equal(t, "caller", call.Caller())
-	assert.Equal(t, "service", call.Service())
-	assert.Equal(t, "raw", string(call.Encoding()))
-	assert.Equal(t, "hello", call.Procedure())
-	assert.Equal(t, "shardKey", call.ShardKey())
-	assert.Equal(t, "routingKey", call.RoutingKey())
-	assert.Equal(t, "routingDelegate", call.RoutingDelegate())
-
-	assert.Equal(t, "World", call.Header("Hello"))
-	assert.Equal(t, "bar", call.Header("FOO"))
-	assert.Equal(t, "true", call.Header("success"))
-	assert.Equal(t, "", call.Header("does-not-exist"))
-
-	headerNames := call.HeaderNames()
-	sort.Strings(headerNames)
-	assert.Equal(t, []string{"foo", "hello", "success"}, headerNames)
-}
-
-func TestInboundCallWriteToResponse(t *testing.T) {
-	tests := []struct {
-		desc        string
-		sendHeaders map[string]string
-		wantHeaders transport.Headers
-	}{
-		{
-			desc: "no headers",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.desc, func(t *testing.T) {
-			ctx, inboundCall := NewInboundCall(context.Background())
-			call := CallFromContext(ctx)
-			for k, v := range tt.sendHeaders {
-				call.WriteResponseHeader(k, v)
-			}
-
-			var resw transporttest.FakeResponseWriter
-			assert.NoError(t, inboundCall.WriteToResponse(&resw))
-			assert.Equal(t, tt.wantHeaders, resw.Headers)
-		})
-	}
-}
-
-func TestNilCall(t *testing.T) {
-	call := CallFromContext(context.Background())
-	require.Nil(t, call)
-
-	assert.Equal(t, "", call.Caller())
-	assert.Equal(t, "", call.Service())
-	assert.Equal(t, "", string(call.Encoding()))
-	assert.Equal(t, "", call.Procedure())
-	assert.Equal(t, "", call.ShardKey())
-	assert.Equal(t, "", call.RoutingKey())
-	assert.Equal(t, "", call.RoutingDelegate())
-	assert.Equal(t, "", call.Header("foo"))
-	assert.Empty(t, call.HeaderNames())
-
-	assert.Error(t, call.WriteResponseHeader("foo", "bar"))
 }

--- a/encoding/json/inbound.go
+++ b/encoding/json/inbound.go
@@ -25,7 +25,7 @@ import (
 	"encoding/json"
 	"reflect"
 
-	"go.uber.org/yarpc"
+	encodingapi "go.uber.org/yarpc/api/encoding"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/encoding"
 )
@@ -46,7 +46,7 @@ func (h jsonHandler) Handle(ctx context.Context, treq *transport.Request, rw tra
 		return err
 	}
 
-	ctx, call := yarpc.NewInboundCall(ctx)
+	ctx, call := encodingapi.NewInboundCall(ctx)
 	if err := call.ReadFromRequest(treq); err != nil {
 		return err
 	}
@@ -79,7 +79,7 @@ func (h jsonHandler) HandleOneway(ctx context.Context, treq *transport.Request) 
 		return err
 	}
 
-	ctx, call := yarpc.NewInboundCall(ctx)
+	ctx, call := encodingapi.NewInboundCall(ctx)
 	if err := call.ReadFromRequest(treq); err != nil {
 		return err
 	}

--- a/encoding/json/outbound.go
+++ b/encoding/json/outbound.go
@@ -26,6 +26,7 @@ import (
 	"encoding/json"
 
 	"go.uber.org/yarpc"
+	encodingapi "go.uber.org/yarpc/api/encoding"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/encoding"
 )
@@ -56,7 +57,7 @@ type jsonClient struct {
 }
 
 func (c jsonClient) Call(ctx context.Context, procedure string, reqBody interface{}, resBodyOut interface{}, opts ...yarpc.CallOption) error {
-	call := yarpc.NewOutboundCall(opts...)
+	call := encodingapi.NewOutboundCall(encoding.FromOptions(opts)...)
 	treq := transport.Request{
 		Caller:    c.cc.Caller(),
 		Service:   c.cc.Service(),
@@ -94,7 +95,7 @@ func (c jsonClient) Call(ctx context.Context, procedure string, reqBody interfac
 }
 
 func (c jsonClient) CallOneway(ctx context.Context, procedure string, reqBody interface{}, opts ...yarpc.CallOption) (transport.Ack, error) {
-	call := yarpc.NewOutboundCall(opts...)
+	call := encodingapi.NewOutboundCall(encoding.FromOptions(opts)...)
 	treq := transport.Request{
 		Caller:    c.cc.Caller(),
 		Service:   c.cc.Service(),

--- a/encoding/raw/inbound.go
+++ b/encoding/raw/inbound.go
@@ -24,7 +24,7 @@ import (
 	"context"
 	"io/ioutil"
 
-	"go.uber.org/yarpc"
+	encodingapi "go.uber.org/yarpc/api/encoding"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/encoding"
 )
@@ -40,7 +40,7 @@ func (r rawUnaryHandler) Handle(ctx context.Context, treq *transport.Request, rw
 		return err
 	}
 
-	ctx, call := yarpc.NewInboundCall(ctx)
+	ctx, call := encodingapi.NewInboundCall(ctx)
 	if err := call.ReadFromRequest(treq); err != nil {
 		return err
 	}
@@ -71,7 +71,7 @@ func (r rawOnewayHandler) HandleOneway(ctx context.Context, treq *transport.Requ
 		return err
 	}
 
-	ctx, call := yarpc.NewInboundCall(ctx)
+	ctx, call := encodingapi.NewInboundCall(ctx)
 	if err := call.ReadFromRequest(treq); err != nil {
 		return err
 	}

--- a/encoding/raw/outbound.go
+++ b/encoding/raw/outbound.go
@@ -26,7 +26,9 @@ import (
 	"io/ioutil"
 
 	"go.uber.org/yarpc"
+	encodingapi "go.uber.org/yarpc/api/encoding"
 	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/encoding"
 )
 
 // Client makes Raw requests to a single service.
@@ -52,7 +54,7 @@ type rawClient struct {
 }
 
 func (c rawClient) Call(ctx context.Context, procedure string, body []byte, opts ...yarpc.CallOption) ([]byte, error) {
-	call := yarpc.NewOutboundCall(opts...)
+	call := encodingapi.NewOutboundCall(encoding.FromOptions(opts)...)
 	treq := transport.Request{
 		Caller:    c.cc.Caller(),
 		Service:   c.cc.Service(),
@@ -86,7 +88,7 @@ func (c rawClient) Call(ctx context.Context, procedure string, body []byte, opts
 }
 
 func (c rawClient) CallOneway(ctx context.Context, procedure string, body []byte, opts ...yarpc.CallOption) (transport.Ack, error) {
-	call := yarpc.NewOutboundCall(opts...)
+	call := encodingapi.NewOutboundCall(encoding.FromOptions(opts)...)
 	treq := transport.Request{
 		Caller:    c.cc.Caller(),
 		Service:   c.cc.Service(),

--- a/encoding/thrift/inbound.go
+++ b/encoding/thrift/inbound.go
@@ -25,7 +25,7 @@ import (
 	"context"
 	"io/ioutil"
 
-	"go.uber.org/yarpc"
+	encodingapi "go.uber.org/yarpc/api/encoding"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/encoding"
 
@@ -52,7 +52,7 @@ func (t thriftUnaryHandler) Handle(ctx context.Context, treq *transport.Request,
 		return err
 	}
 
-	ctx, call := yarpc.NewInboundCall(ctx)
+	ctx, call := encodingapi.NewInboundCall(ctx)
 	if err := call.ReadFromRequest(treq); err != nil {
 		return err
 	}
@@ -124,7 +124,7 @@ func (t thriftOnewayHandler) HandleOneway(ctx context.Context, treq *transport.R
 		return err
 	}
 
-	ctx, call := yarpc.NewInboundCall(ctx)
+	ctx, call := encodingapi.NewInboundCall(ctx)
 	if err := call.ReadFromRequest(treq); err != nil {
 		return err
 	}

--- a/encoding/thrift/outbound.go
+++ b/encoding/thrift/outbound.go
@@ -27,6 +27,7 @@ import (
 	"io/ioutil"
 
 	"go.uber.org/yarpc"
+	encodingapi "go.uber.org/yarpc/api/encoding"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/thrift/internal"
 	"go.uber.org/yarpc/internal/encoding"
@@ -129,7 +130,7 @@ func (c thriftClient) Call(ctx context.Context, reqBody envelope.Enveloper, opts
 		return wire.Value{}, err
 	}
 
-	call := yarpc.NewOutboundCall(opts...)
+	call := encodingapi.NewOutboundCall(encoding.FromOptions(opts)...)
 	ctx, err = call.WriteToRequest(ctx, treq)
 	if err != nil {
 		return wire.Value{}, err
@@ -183,7 +184,7 @@ func (c thriftClient) CallOneway(ctx context.Context, reqBody envelope.Enveloper
 		return nil, err
 	}
 
-	call := yarpc.NewOutboundCall(opts...)
+	call := encodingapi.NewOutboundCall(encoding.FromOptions(opts)...)
 	ctx, err = call.WriteToRequest(ctx, treq)
 	if err != nil {
 		return nil, err

--- a/internal/encoding/options.go
+++ b/internal/encoding/options.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package encoding
+
+import (
+	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/api/encoding"
+)
+
+// FromOptions converts a collection of yarpc.CallOptionso to
+// encoding.CallOptions.
+func FromOptions(opts []yarpc.CallOption) []encoding.CallOption {
+	newOpts := make([]encoding.CallOption, len(opts))
+	for i, o := range opts {
+		newOpts[i] = encoding.CallOption(o)
+	}
+	return newOpts
+}


### PR DESCRIPTION
InboundCall and OutboundCall are APIs for encoding authors. Instead of
exposing them at the top level, this exposes them on /api/encoding.

CallOption and Call, which are service-author-facing APIs still need to be
defined in the same package as Inbound/OutboundCall because they rely on
internal details, so copies of them are exposed at the top-level instead.