### PR TITLE
transport: Rename BadRequestError to InboundBadRequestError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,8 +69,8 @@ v1.0.0-dev (unreleased)
     `dontNotify` argument.
 -   Added `yarpc.IsBadRequestError`, `yarpc.IsUnexpectedError` and
     `yarpc.IsTimeoutError` functions.
--   Added a `transport.BadRequestError` function to build errors which satisfy
-    `transport.IsBadRequestError`.
+-   Added a `transport.InboundBadRequestError` function to build errors which
+    satisfy `transport.IsBadRequestError`.
 -   Added a `transport.ValidateRequest` function to validate
     `transport.Request`s.
 

--- a/api/transport/errors.go
+++ b/api/transport/errors.go
@@ -22,11 +22,11 @@ package transport
 
 import "go.uber.org/yarpc/internal/errors"
 
-// BadRequestError builds an error which indicates a bad request with the
-// given error as the reason.
+// InboundBadRequestError builds an error which indicates that an inbound
+// cannot process a request because it is a bad request.
 //
-// Transport implementations treat BadRequestErrors as user errors.
-func BadRequestError(err error) error {
+// IsBadRequestError returns true for these errors.
+func InboundBadRequestError(err error) error {
 	return errors.HandlerBadRequestError(err)
 }
 

--- a/api/transport/errors_test.go
+++ b/api/transport/errors_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestBadRequestError(t *testing.T) {
 	err := errors.New("derp")
-	err = BadRequestError(err)
+	err = InboundBadRequestError(err)
 	assert.True(t, IsBadRequestError(err))
 	assert.Equal(t, "BadRequest: derp", err.Error())
 }


### PR DESCRIPTION
This is a part of #607 which would break existing APIs if we did it post 1.0