### PR TITLE
Remove examples/ and crossdock/ symlinks

### DIFF
--- a/crossdock
+++ b/crossdock
@@ -1,1 +1,0 @@
-internal/crossdock

--- a/examples
+++ b/examples
@@ -1,1 +1,0 @@
-internal/examples


### PR DESCRIPTION
Resolves #659

For discoverability, we can link from the README.