### PR TITLE
http: Update godocs

### DIFF
--- a/internal/crossdock/client/apachethrift/behavior.go
+++ b/internal/crossdock/client/apachethrift/behavior.go
@@ -44,20 +44,11 @@ func Run(t crossdock.T) {
 	fatals.NotEmpty(server, "apachethriftserver is required")
 
 	httpTransport := http.NewTransport()
-	url := fmt.Sprintf("http://%v:%v/", server, serverPort)
+	url := fmt.Sprintf("http://%v:%v", server, serverPort)
 
-	thriftOutbound := httpTransport.NewSingleOutbound(
-		url,
-		http.URLTemplate("http://host:port/thrift/ThriftTest"),
-	)
-	secondOutbound := httpTransport.NewSingleOutbound(
-		url,
-		http.URLTemplate("http://host:port/thrift/SecondService"),
-	)
-	multiplexOutbound := httpTransport.NewSingleOutbound(
-		url,
-		http.URLTemplate("http://host:port/thrift/multiplexed"),
-	)
+	thriftOutbound := httpTransport.NewSingleOutbound(url + "/thrift/ThriftTest")
+	secondOutbound := httpTransport.NewSingleOutbound(url + "/thrift/SecondService")
+	multiplexOutbound := httpTransport.NewSingleOutbound(url + "/thrift/multiplexed")
 
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name: "apache-thrift-client",

--- a/transport/http/constants.go
+++ b/transport/http/constants.go
@@ -20,52 +20,53 @@
 
 package http
 
+// HTTP headers used in requests and responses to send YARPC metadata.
 const (
-	// ApplicationHeaderPrefix is the prefix added to application headers over
-	// the wire.
-	ApplicationHeaderPrefix = "Rpc-Header-"
-
-	// TODO(abg): Allow customizing header prefixes
-
-	// CallerHeader is the HTTP header used to indiate the service doing the calling
+	// Name of the service sending the request. This corresponds to the
+	// Request.Caller attribute.
 	CallerHeader = "Rpc-Caller"
 
-	// EncodingHeader is the HTTP header used to specify the name of the
-	// encoding.
+	// Name of the encoding used for the request body. This corresponds to the
+	// Request.Encoding attribute.
 	EncodingHeader = "Rpc-Encoding"
 
-	// TTLMSHeader is the HTTP header used to indicate the ttl in ms
+	// Amount of time (in milliseconds) within which the request is expected
+	// to finish.
 	TTLMSHeader = "Context-TTL-MS"
 
-	// ProcedureHeader is the HTTP header used to indicate the procedure
+	// Name of the procedure being called. This corresponds to the
+	// Request.Procedure attribute.
 	ProcedureHeader = "Rpc-Procedure"
 
-	// ServiceHeader is the HTTP header used to indicate the service
+	// Name of the service to which the request is being sent. This
+	// corresponds to the Request.Service attribute.
 	ServiceHeader = "Rpc-Service"
 
-	// ShardKeyHeader is the HTTP header used by a clustered service to
-	// identify the node responsible for handling the request.
+	// Shard key used by the destined service to shard the request. This
+	// corresponds to the Request.ShardKey attribute.
 	ShardKeyHeader = "Rpc-Shard-Key"
 
-	// RoutingKeyHeader is the HTTP header used by a relay to identify
-	// the traffic group responsible for handling the request, overriding the
-	// service name when available.
+	// The traffic group responsible for handling the request. This
+	// corresponds to the Request.RoutingKey attribute.
 	RoutingKeyHeader = "Rpc-Routing-Key"
 
-	// RoutingDelegateHeader is the HTTP header used by a relay to identify a
-	// service that can proxy for the destined service and perform
-	// application-specific routing.
+	// A service that can proxy the destined service. This corresponds to the
+	// Request.RoutingDelegate attribute.
 	RoutingDelegateHeader = "Rpc-Routing-Delegate"
 
-	// ApplicationStatusHeader is the HTTP response header used to express
-	// whether the response body represents an application error.
+	// Whether the response body contains an application error.
 	ApplicationStatusHeader = "Rpc-Status"
+)
 
-	// ApplicationSuccessStatus is the value for ApplicationStatusHeader for
-	// successful requests.
+// Valid values for the Rpc-Status header.
+const (
+	// The request was successful.
 	ApplicationSuccessStatus = "success"
 
-	// ApplicationErrorStatus is the value for ApplicationStatusHeader for
-	// errant requests.
+	// An error occurred. The response body contains an application header.
 	ApplicationErrorStatus = "error"
 )
+
+// ApplicationHeaderPrefix is the prefix added to application header keys to
+// send them in requests or responses.
+const ApplicationHeaderPrefix = "Rpc-Header-"

--- a/transport/http/doc.go
+++ b/transport/http/doc.go
@@ -18,9 +18,45 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Package http implements the HTTP inbound and outbound transports for YARPC.
+// Package http implements a YARPC transport based on the HTTP/1.1 protocol.
+// The HTTP transport provides first class support for Unary RPCs and
+// experimental support for Oneway RPCs.
 //
-// Note that the Close method for the HTTP Inbound does NOT immediately close
-// the ongoing connections. The connection will remain open until all clients
-// have disconnected.
+// Usage
+//
+// An HTTP Transport must be constructed to use this transport.
+//
+// 	httpTransport := http.NewTransport()
+//
+// To serve your YARPC application over HTTP, pass the HTTP inbound in your
+// yarpc.Config.
+//
+// 	myInbound := httpTransport.NewInbound(":8080")
+// 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
+// 		Name: "myservice",
+// 		Inbounds: yarpc.Inbounds{myInbound},
+// 	})
+//
+// To make requests to a YARPC application that supports HTTP, pass the HTTP
+// outbound in your yarpc.Config.
+//
+// 	myserviceOutbound := httpTransport.NewSingleOutbound("http://127.0.0.1:8080")
+// 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
+// 		Name: "myclient",
+// 		Outbounds: yarpc.Outbounds{
+// 			"myservice": {Unary: myserviceOutbound},
+// 		},
+// 	})
+//
+// Note that stopping an HTTP transport does NOT immediately terminate ongoing
+// requests. Connections will remain open until all clients have disconnected.
+//
+// Wire Representation
+//
+// YARPC requests and responses are sent as plain HTTP requests and responses.
+// YARPC metadata is sent inside reserved HTTP headers. Application headers
+// for requests and responses are sent as HTTP headers with the header names
+// prefixed with a pre-defined string. See Constants for more information on
+// the names of these headers. The request and response bodies are sent as-is
+// in the HTTP request or response body.
 package http

--- a/transport/http/doc.go
+++ b/transport/http/doc.go
@@ -59,4 +59,8 @@
 // prefixed with a pre-defined string. See Constants for more information on
 // the names of these headers. The request and response bodies are sent as-is
 // in the HTTP request or response body.
+//
+// See Also
+//
+// YARPC Properties: https://github.com/yarpc/yarpc/blob/master/properties.md
 package http

--- a/transport/http/inbound.go
+++ b/transport/http/inbound.go
@@ -33,12 +33,15 @@ import (
 	"github.com/opentracing/opentracing-go"
 )
 
-// InboundOption can be added as a variadic argument to the NewInbound
-// constructor.
+// InboundOption customizes the behavior of an HTTP Inbound constructed with
+// NewInbound.
 type InboundOption func(*Inbound)
 
-// Mux specifies the ServeMux that the HTTP server should use and the pattern
-// under which the YARPC endpoint should be registered.
+// Mux specifies that the HTTP server should make the YARPC endpoint available
+// under the given pattern on the given ServeMux. By default, the YARPC
+// service is made available on all paths of the HTTP server. By specifying a
+// ServeMux, users can narrow the endpoints under which the YARPC service is
+// available and offer their own non-YARPC endpoints.
 func Mux(pattern string, mux *http.ServeMux) InboundOption {
 	return func(i *Inbound) {
 		i.mux = mux
@@ -59,9 +62,8 @@ func (t *Transport) NewInbound(addr string, opts ...InboundOption) *Inbound {
 	return i
 }
 
-// Inbound represents an HTTP Inbound. It is the same as the transport Inbound
-// except it exposes the address on which the system is listening for
-// connections.
+// Inbound receives YARPC requests using an HTTP server. It may be constructed
+// using the NewInbound method on the Transport.
 type Inbound struct {
 	addr       string
 	mux        *http.ServeMux

--- a/transport/http/inbound_example_test.go
+++ b/transport/http/inbound_example_test.go
@@ -1,0 +1,61 @@
+package http_test
+
+import (
+	"fmt"
+	"io"
+	"log"
+	nethttp "net/http"
+	"os"
+
+	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/transport/http"
+)
+
+func ExampleInbound() {
+	transport := http.NewTransport()
+	inbound := transport.NewInbound(":8888")
+
+	yarpc.NewDispatcher(yarpc.Config{
+		Name:     "myservice",
+		Inbounds: yarpc.Inbounds{inbound},
+	})
+}
+
+func ExampleMux() {
+	// import nethttp "net/http"
+
+	// We set up a ServeMux which provides a /health endpoint.
+	mux := nethttp.NewServeMux()
+	mux.HandleFunc("/health", func(w nethttp.ResponseWriter, _ *nethttp.Request) {
+		if _, err := fmt.Fprintln(w, "hello from /health"); err != nil {
+			panic(err)
+		}
+	})
+
+	// This inbound will serve the YARPC service on the path /yarpc.  The
+	// /health endpoint on the Mux will be left alone.
+	transport := http.NewTransport()
+	inbound := transport.NewInbound(":8888", http.Mux("/yarpc", mux))
+
+	// Fire up a dispatcher with the new inbound.
+	dispatcher := yarpc.NewDispatcher(yarpc.Config{
+		Name:     "server",
+		Inbounds: yarpc.Inbounds{inbound},
+	})
+	if err := dispatcher.Start(); err != nil {
+		log.Fatal(err)
+	}
+	defer dispatcher.Stop()
+
+	// Make a request to the /health endpoint.
+	res, err := nethttp.Get("http://127.0.0.1:8888/health")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer res.Body.Close()
+
+	if _, err := io.Copy(os.Stdout, res.Body); err != nil {
+		log.Fatal(err)
+	}
+	// Output: hello from /health
+}

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -119,7 +119,6 @@ func (t *Transport) NewSingleOutbound(uri string, opts ...OutboundOption) *Outbo
 	for _, opt := range opts {
 		opt(o)
 	}
-
 	o.setURLTemplate(uri)
 	return o
 }

--- a/transport/http/outbound_example_test.go
+++ b/transport/http/outbound_example_test.go
@@ -1,0 +1,22 @@
+package http_test
+
+import (
+	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/transport/http"
+)
+
+func ExampleOutbound() {
+	transport := http.NewTransport()
+
+	yarpc.NewDispatcher(yarpc.Config{
+		Name: "myservice",
+		Outbounds: yarpc.Outbounds{
+			"myservice": {
+				Unary: transport.NewSingleOutbound("http://127.0.0.1:8888"),
+			},
+			"anotherservice": {
+				Unary: transport.NewSingleOutbound("http://127.0.0.1:9999"),
+			},
+		},
+	})
+}

--- a/transport/http/transport.go
+++ b/transport/http/transport.go
@@ -60,7 +60,7 @@ func Tracer(tracer opentracing.Tracer) TransportOption {
 	}
 }
 
-// NewTransport creates a new http transport for managing peers and sending requests
+// NewTransport creates a new HTTP transport for managing peers and sending requests
 func NewTransport(opts ...TransportOption) *Transport {
 	cfg := defaultTransportConfig
 	cfg.tracer = opentracing.GlobalTracer()
@@ -90,7 +90,9 @@ func buildClient(cfg *transportConfig) *http.Client {
 	}
 }
 
-// Transport keeps track of http peers and the associated client with which the peer will call into.
+// Transport keeps track of HTTP peers and the associated HTTP client. It
+// allows using a single HTTP client to make requests to multiple YARPC
+// services and pooling the resources needed therein.
 type Transport struct {
 	lock sync.Mutex
 


### PR DESCRIPTION
I took a pass over the transport/http godocs to make them a bit more readable.
Added examples in some places and documented the wire format.

@yarpc/golang