### PR TITLE
tchannel: NewChannelTransport can return errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ Releases
 v1.0.0-dev (unreleased)
 -----------------------
 
--   No changes yet.
+-   **Breaking**: `NewChannelTransport` can now return an error upon
+    construction.
+
 
 v1.0.0-rc4 (2016-12-28)
 -----------------------

--- a/bench_test.go
+++ b/bench_test.go
@@ -193,17 +193,16 @@ func Benchmark_HTTP_NetHTTPToNetHTTP(b *testing.B) {
 }
 
 func Benchmark_TChannel_YARPCToYARPC(b *testing.B) {
-	serverTChannel := ytchannel.NewChannelTransport(
-		ytchannel.ServiceName("server"),
-	)
+	serverTChannel, err := ytchannel.NewChannelTransport(ytchannel.ServiceName("server"))
+	require.NoError(b, err)
+
 	serverCfg := yarpc.Config{
 		Name:     "server",
 		Inbounds: yarpc.Inbounds{serverTChannel.NewInbound()},
 	}
 
-	clientTChannel := ytchannel.NewChannelTransport(
-		ytchannel.ServiceName("client"),
-	)
+	clientTChannel, err := ytchannel.NewChannelTransport(ytchannel.ServiceName("client"))
+	require.NoError(b, err)
 
 	// no defer close on channels because YARPC will take care of that
 
@@ -234,7 +233,9 @@ func Benchmark_TChannel_YARPCToTChannel(b *testing.B) {
 	serverCh.Register(traw.Wrap(tchannelEcho{t: b}), "echo")
 	require.NoError(b, serverCh.ListenAndServe(":0"), "failed to start up TChannel")
 
-	clientTChannel := ytchannel.NewChannelTransport(ytchannel.ServiceName("client"))
+	clientTChannel, err := ytchannel.NewChannelTransport(ytchannel.ServiceName("client"))
+	require.NoError(b, err)
+
 	clientCfg := yarpc.Config{
 		Name: "client",
 		Outbounds: yarpc.Outbounds{
@@ -251,9 +252,8 @@ func Benchmark_TChannel_YARPCToTChannel(b *testing.B) {
 }
 
 func Benchmark_TChannel_TChannelToYARPC(b *testing.B) {
-	tchannelTransport := ytchannel.NewChannelTransport(
-		ytchannel.ServiceName("server"),
-	)
+	tchannelTransport, err := ytchannel.NewChannelTransport(ytchannel.ServiceName("server"))
+	require.NoError(b, err)
 
 	serverCfg := yarpc.Config{
 		Name:     "server",

--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -38,7 +38,9 @@ import (
 
 func basicDispatcher(t *testing.T) *Dispatcher {
 	httpTransport := http.NewTransport()
-	tchannelTransport := tchannel.NewChannelTransport(tchannel.ServiceName("test"))
+	tchannelTransport, err := tchannel.NewChannelTransport(tchannel.ServiceName("test"))
+	require.NoError(t, err)
+
 	return NewDispatcher(Config{
 		Name: "test",
 		Inbounds: Inbounds{

--- a/internal/crossdock/client/ctxpropagation/behavior.go
+++ b/internal/crossdock/client/ctxpropagation/behavior.go
@@ -341,7 +341,8 @@ func buildDispatcher(t crossdock.T) (dispatcher *yarpc.Dispatcher, tconfig serve
 	fatals.NotEmpty(subject, "ctxserver is required")
 
 	httpTransport := http.NewTransport()
-	tchannelTransport := tch.NewChannelTransport(tch.ListenAddr(":8087"), tch.ServiceName("ctxclient"))
+	tchannelTransport, err := tch.NewChannelTransport(tch.ListenAddr(":8087"), tch.ServiceName("ctxclient"))
+	fatals.NoError(err, "Failed to build ChannelTransport")
 
 	var outbound transport.UnaryOutbound
 	switch trans := t.Param(params.Transport); trans {

--- a/internal/crossdock/client/dispatcher/dispatcher.go
+++ b/internal/crossdock/client/dispatcher/dispatcher.go
@@ -48,7 +48,9 @@ func Create(t crossdock.T) *yarpc.Dispatcher {
 		httpTransport := http.NewTransport()
 		unaryOutbound = httpTransport.NewSingleOutbound(fmt.Sprintf("http://%s:8081", server))
 	case "tchannel":
-		tchannelTransport := tchannel.NewChannelTransport(tchannel.ServiceName("client"))
+		tchannelTransport, err := tchannel.NewChannelTransport(tchannel.ServiceName("client"))
+		fatals.NoError(err, "Failed to build ChannelTransport")
+
 		unaryOutbound = tchannelTransport.NewSingleOutbound(server + ":8082")
 	default:
 		fatals.Fail("", "unknown transport %q", trans)

--- a/internal/crossdock/client/tchserver/behavior.go
+++ b/internal/crossdock/client/tchserver/behavior.go
@@ -43,7 +43,9 @@ func Run(t crossdock.T) {
 	server := t.Param(params.Server)
 	serverHostPort := fmt.Sprintf("%v:%v", server, serverPort)
 
-	tchannelTransport := tchannel.NewChannelTransport(tchannel.ServiceName("yarpc-client"))
+	tchannelTransport, err := tchannel.NewChannelTransport(tchannel.ServiceName("yarpc-client"))
+	fatals.NoError(err, "Failed to build ChannelTransport")
+
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name: "yarpc-client",
 		Outbounds: yarpc.Outbounds{

--- a/internal/crossdock/server/yarpc/phone.go
+++ b/internal/crossdock/server/yarpc/phone.go
@@ -72,7 +72,10 @@ func Phone(ctx context.Context, body *PhoneRequest) (*PhoneResponse, error) {
 	var outbound transport.UnaryOutbound
 
 	httpTransport := http.NewTransport()
-	tchannelTransport := tchannel.NewChannelTransport(tchannel.ServiceName("yarpc-test-client"))
+	tchannelTransport, err := tchannel.NewChannelTransport(tchannel.ServiceName("yarpc-test-client"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to build ChannelTransport: %v", err)
+	}
 
 	switch {
 	case body.Transport.HTTP != nil:

--- a/internal/crossdock/server/yarpc/server.go
+++ b/internal/crossdock/server/yarpc/server.go
@@ -22,6 +22,7 @@ package yarpc
 
 import (
 	"fmt"
+	"log"
 
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/encoding/json"
@@ -37,10 +38,14 @@ var dispatcher *yarpc.Dispatcher
 
 // Start starts the test server that clients will make requests to
 func Start() {
-	tchannelTransport := tchannel.NewChannelTransport(
+	tchannelTransport, err := tchannel.NewChannelTransport(
 		tchannel.ListenAddr(":8082"),
 		tchannel.ServiceName("yarpc-test"),
 	)
+	if err != nil {
+		log.Panicf("failed to build ChannelTransport: %v", err)
+	}
+
 	httpTransport := http.NewTransport()
 	dispatcher = yarpc.NewDispatcher(yarpc.Config{
 		Name: "yarpc-test",

--- a/internal/examples/json-keyvalue/client/main.go
+++ b/internal/examples/json-keyvalue/client/main.go
@@ -78,7 +78,10 @@ func main() {
 	flag.Parse()
 
 	httpTransport := http.NewTransport()
-	tchannelTransport := tchannel.NewChannelTransport(tchannel.ServiceName("keyvalue-client"))
+	tchannelTransport, err := tchannel.NewChannelTransport(tchannel.ServiceName("keyvalue-client"))
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	var outbound transport.UnaryOutbound
 	switch strings.ToLower(outboundName) {

--- a/internal/examples/json-keyvalue/server/main.go
+++ b/internal/examples/json-keyvalue/server/main.go
@@ -23,6 +23,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"sync"
 
@@ -69,10 +70,14 @@ func (h *handler) Set(ctx context.Context, body *setRequest) (*setResponse, erro
 }
 
 func main() {
-	tchannelTransport := tchannel.NewChannelTransport(
+	tchannelTransport, err := tchannel.NewChannelTransport(
 		tchannel.ServiceName("keyvalue"),
 		tchannel.ListenAddr(":28941"),
 	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	httpTransport := http.NewTransport()
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name: "keyvalue",

--- a/internal/examples/thrift-keyvalue/keyvalue/client/main.go
+++ b/internal/examples/thrift-keyvalue/keyvalue/client/main.go
@@ -48,7 +48,10 @@ func main() {
 	flag.Parse()
 
 	httpTransport := http.NewTransport()
-	tchannelTransport := tchannel.NewChannelTransport(tchannel.ServiceName("keyvalue-client"))
+	tchannelTransport, err := tchannel.NewChannelTransport(tchannel.ServiceName("keyvalue-client"))
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	var outbound transport.UnaryOutbound
 	switch strings.ToLower(outboundName) {

--- a/internal/examples/thrift-keyvalue/keyvalue/server/main.go
+++ b/internal/examples/thrift-keyvalue/keyvalue/server/main.go
@@ -23,6 +23,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"log"
 	"sync"
 
 	"go.uber.org/yarpc/internal/examples/thrift-keyvalue/keyvalue/kv"
@@ -58,10 +59,14 @@ func (h *handler) SetValue(ctx context.Context, key *string, value *string) erro
 }
 
 func main() {
-	tchannelTransport := tchannel.NewChannelTransport(
+	tchannelTransport, err := tchannel.NewChannelTransport(
 		tchannel.ServiceName("keyvalue"),
 		tchannel.ListenAddr(":28941"),
 	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	httpTransport := http.NewTransport()
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name: "keyvalue",

--- a/transport/roundtrip_test.go
+++ b/transport/roundtrip_test.go
@@ -132,7 +132,9 @@ func (tt tchannelTransport) WithRouter(r transport.Router, f func(transport.Unar
 	serverOpts := testutils.NewOpts().SetServiceName(testService)
 	clientOpts := testutils.NewOpts().SetServiceName(testCaller)
 	testutils.WithServer(tt.t, serverOpts, func(ch *tchannel.Channel, hostPort string) {
-		ix := tch.NewChannelTransport(tch.WithChannel(ch))
+		ix, err := tch.NewChannelTransport(tch.WithChannel(ch))
+		require.NoError(tt.t, err)
+
 		i := ix.NewInbound()
 		i.SetRouter(r)
 		require.NoError(tt.t, ix.Start(), "failed to start inbound transport")
@@ -143,7 +145,9 @@ func (tt tchannelTransport) WithRouter(r transport.Router, f func(transport.Unar
 		// handler.
 
 		client := testutils.NewClient(tt.t, clientOpts)
-		ox := tch.NewChannelTransport(tch.WithChannel(client))
+		ox, err := tch.NewChannelTransport(tch.WithChannel(client))
+		require.NoError(tt.t, err)
+
 		o := ox.NewSingleOutbound(hostPort)
 		require.NoError(tt.t, ox.Start(), "failed to start outbound transport")
 		require.NoError(tt.t, o.Start(), "failed to start outbound")

--- a/transport/tchannel/channel_example_test.go
+++ b/transport/tchannel/channel_example_test.go
@@ -8,7 +8,11 @@ import (
 )
 
 func ExampleChannelInbound() {
-	transport := tchannel.NewChannelTransport(tchannel.ServiceName("myservice"))
+	transport, err := tchannel.NewChannelTransport(tchannel.ServiceName("myservice"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name:     "myservice",
 		Inbounds: yarpc.Inbounds{transport.NewInbound()},
@@ -21,7 +25,11 @@ func ExampleChannelInbound() {
 }
 
 func ExampleChannelOutbound() {
-	transport := tchannel.NewChannelTransport(tchannel.ServiceName("myclient"))
+	transport, err := tchannel.NewChannelTransport(tchannel.ServiceName("myclient"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name: "myclient",
 		Outbounds: yarpc.Outbounds{
@@ -36,7 +44,11 @@ func ExampleChannelOutbound() {
 }
 
 func ExampleChannelOutbound_single() {
-	transport := tchannel.NewChannelTransport(tchannel.ServiceName("myclient"))
+	transport, err := tchannel.NewChannelTransport(tchannel.ServiceName("myclient"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name: "myclient",
 		Outbounds: yarpc.Outbounds{

--- a/transport/tchannel/doc.go
+++ b/transport/tchannel/doc.go
@@ -27,13 +27,13 @@
 // provide an existing TChannel Channel to construct the Channel transport.
 //
 // 	ch := getTChannelChannel()
-// 	tchannelTransport := tchannel.NewChannelTransport(tchannel.WithChannel(ch))
+// 	tchannelTransport, err := tchannel.NewChannelTransport(tchannel.WithChannel(ch))
 //
 // Alternatively, you can let YARPC own and manage the TChannel Channel for
 // you by providing the service name. Note that this is the name of the local
 // service, not the name of the service you will be sending requests to.
 //
-// 	tchannelTransport := tchannel.NewChannelTransport(tchannel.ServiceName("myservice"))
+// 	tchannelTransport, err := tchannel.NewChannelTransport(tchannel.ServiceName("myservice"))
 //
 // To serve a YARPC application over TChannel, pass a TChannel inbound in your
 // yarpc.Config.

--- a/transport/tchannel/inbound_test.go
+++ b/transport/tchannel/inbound_test.go
@@ -38,7 +38,9 @@ func TestInboundStartNew(t *testing.T) {
 	}{
 		{
 			func(ch *tchannel.Channel, f func(*ChannelInbound)) {
-				x := NewChannelTransport(WithChannel(ch))
+				x, err := NewChannelTransport(WithChannel(ch))
+				require.NoError(t, err)
+
 				i := x.NewInbound()
 				i.SetRouter(new(transporttest.MockRouter))
 				// Can't do Equal because we want to match the pointer, not a
@@ -54,7 +56,9 @@ func TestInboundStartNew(t *testing.T) {
 		},
 		{
 			func(ch *tchannel.Channel, f func(*ChannelInbound)) {
-				x := NewChannelTransport(WithChannel(ch))
+				x, err := NewChannelTransport(WithChannel(ch))
+				require.NoError(t, err)
+
 				i := x.NewInbound()
 				i.SetRouter(new(transporttest.MockRouter))
 				assert.True(t, ch == i.Channel(), "channel does not match")
@@ -88,7 +92,9 @@ func TestInboundStartAlreadyListening(t *testing.T) {
 	require.NoError(t, ch.ListenAndServe(":0"))
 	assert.Equal(t, tchannel.ChannelListening, ch.State())
 
-	x := NewChannelTransport(WithChannel(ch))
+	x, err := NewChannelTransport(WithChannel(ch))
+	require.NoError(t, err)
+
 	i := x.NewInbound()
 
 	i.SetRouter(new(transporttest.MockRouter))
@@ -104,13 +110,17 @@ func TestInboundStopWithoutStarting(t *testing.T) {
 	ch, err := tchannel.NewChannel("foo", nil)
 	require.NoError(t, err)
 
-	x := NewChannelTransport(WithChannel(ch))
+	x, err := NewChannelTransport(WithChannel(ch))
+	require.NoError(t, err)
+
 	i := x.NewInbound()
 	assert.NoError(t, i.Stop())
 }
 
 func TestInboundInvalidAddress(t *testing.T) {
-	x := NewChannelTransport(ServiceName("foo"), ListenAddr("not valid"))
+	x, err := NewChannelTransport(ServiceName("foo"), ListenAddr("not valid"))
+	require.NoError(t, err)
+
 	i := x.NewInbound()
 	i.SetRouter(new(transporttest.MockRouter))
 	assert.Nil(t, i.Start())
@@ -129,7 +139,9 @@ func TestInboundExistingMethods(t *testing.T) {
 		},
 	}, nil)
 
-	x := NewChannelTransport(WithChannel(ch))
+	x, err := NewChannelTransport(WithChannel(ch))
+	require.NoError(t, err)
+
 	i := x.NewInbound()
 	i.SetRouter(new(transporttest.MockRouter))
 	require.NoError(t, i.Start())

--- a/transport/tracer_test.go
+++ b/transport/tracer_test.go
@@ -111,11 +111,12 @@ func createHTTPDispatcher(tracer opentracing.Tracer) *yarpc.Dispatcher {
 func createTChannelDispatcher(tracer opentracing.Tracer, t *testing.T) *yarpc.Dispatcher {
 	hp := "127.0.0.1:4040"
 
-	tchannelTransport := ytchannel.NewChannelTransport(
+	tchannelTransport, err := ytchannel.NewChannelTransport(
 		ytchannel.ListenAddr(hp),
 		ytchannel.Tracer(tracer),
 		ytchannel.ServiceName("yarpc-test"),
 	)
+	require.NoError(t, err)
 
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name: "yarpc-test",


### PR DESCRIPTION
It's not clear why NewChannelTransport deferred the error until
`ChannelTransport.Start`. This leads to unpredictable and harder to track down
errors so we're switching NewChannelTransport to returning an error at
instantiation.