### PR TITLE
Explain why we need a mutex.Sync and atomic state in LifecycleOnce

### DIFF
--- a/internal/sync/lifecycle.go
+++ b/internal/sync/lifecycle.go
@@ -55,14 +55,15 @@ const (
 
 // LifecycleOnce is a helper for implementing transport.Lifecycles
 // with similar behavior.
+//
+// We use the sync.Mutex in order to guarantee that multiple calls
+// to Start/Stop will wait until the first call finishes and return
+// the same error (stored in startErr/stopErr).
+//
+// State is stored in an atomic so that we can read it from the `IsRunning`
+// function without having to worry about race conditions with Start/Stop.
 type LifecycleOnce struct {
-	lock sync.Mutex
-
-	// TODO(abg): We don't need a mutex if we use atomics correctly. Right
-	// now, the only reason we have an atomic is so that we can safely query
-	// the state of the lifecycle while Start() is still running. We should
-	// just switch this to an atomic instead.
-
+	lock     sync.Mutex
 	state    atomic.Int32
 	startErr error
 	stopErr  error

--- a/internal/sync/lifecycle.go
+++ b/internal/sync/lifecycle.go
@@ -58,10 +58,14 @@ const (
 type LifecycleOnce struct {
 	// We use the sync.Mutex in order to guarantee that multiple calls
 	// to Start/Stop will wait until the first call finishes and return
-	// the same error (stored in startErr/stopErr).
+	// the same error (stored in startErr/stopErr).  This is not possible
+	// with atomics because atomics will not block and we want the same error
+	// to be returned for multiple calls to Start/Stop.
 	//
 	// State is stored in an atomic so that we can read it from the `IsRunning`
 	// function without having to worry about race conditions with Start/Stop.
+	// A RWMutex is not used because we don't want IsRunning to wait until
+	// Start/Stop are finished.
 	lock     sync.Mutex
 	state    atomic.Int32
 	startErr error

--- a/internal/sync/lifecycle.go
+++ b/internal/sync/lifecycle.go
@@ -55,14 +55,13 @@ const (
 
 // LifecycleOnce is a helper for implementing transport.Lifecycles
 // with similar behavior.
-//
-// We use the sync.Mutex in order to guarantee that multiple calls
-// to Start/Stop will wait until the first call finishes and return
-// the same error (stored in startErr/stopErr).
-//
-// State is stored in an atomic so that we can read it from the `IsRunning`
-// function without having to worry about race conditions with Start/Stop.
 type LifecycleOnce struct {
+	// We use the sync.Mutex in order to guarantee that multiple calls
+	// to Start/Stop will wait until the first call finishes and return
+	// the same error (stored in startErr/stopErr).
+	//
+	// State is stored in an atomic so that we can read it from the `IsRunning`
+	// function without having to worry about race conditions with Start/Stop.
 	lock     sync.Mutex
 	state    atomic.Int32
 	startErr error


### PR DESCRIPTION
Summary: Updates the comment for LifecycleOnce to explain why we are
using a mutex.Sync and an atomic int to keep state information.