### PR TITLE
Wrap TChannel handlers at most once

### DIFF
--- a/dispatcher.go
+++ b/dispatcher.go
@@ -295,6 +295,11 @@ func (d *Dispatcher) Start() error {
 		return errors.ErrorGroup(errs)
 	}
 
+	// Set router for all inbounds
+	for _, i := range d.inbounds {
+		i.SetRouter(d.table)
+	}
+
 	// Start Transports
 	wait := intsync.ErrorWaiter{}
 	for _, t := range d.transports {
@@ -317,7 +322,6 @@ func (d *Dispatcher) Start() error {
 	// Start Inbounds
 	wait = intsync.ErrorWaiter{}
 	for _, i := range d.inbounds {
-		i.SetRouter(d.table)
 		wait.Submit(start(i))
 	}
 	if errs := wait.Wait(); len(errs) != 0 {

--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -209,7 +209,7 @@ func TestStartStopFailures(t *testing.T) {
 				for i := range inbounds {
 					in := transporttest.NewMockInbound(mockCtrl)
 					in.EXPECT().Transports()
-					in.EXPECT().SetRouter(gomock.Any()).Times(0)
+					in.EXPECT().SetRouter(gomock.Any())
 					in.EXPECT().Start().Times(0)
 					in.EXPECT().Stop().Times(0)
 					inbounds[i] = in


### PR DESCRIPTION
If there are multiple TChannel inbounds, the current behavior is to
unnecessarily create nested handler wrappers on the shared TChannel sub
channel. This change moves the logic for establishing a subchannel into
the transport layer to guarantee it only occurs once.