### PR TITLE
TChannel with Peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ v1.3.0-dev (unreleased)
     ```go
     transport, err := tchannel.NewTransport(tchannel.ServiceName("keyvalue"))
     chooser := peerheap.New(transport)
-    outbound := x.NewOutbound(chooser)
+    outbound := transport.NewOutbound(chooser)
     ```
 
     The new transport hides the implementation of TChannel entirely to give us

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,20 @@ Releases
 v1.3.0-dev (unreleased)
 -----------------------
 
--   No changes yet.
+-   Added a `tchannel.NewTransport`. The new transport, a replacement for the
+    temporary `tchannel.NewChannelTransport`, supports YARPC peer choosers.
+
+    ```go
+    transport, err := tchannel.NewTransport(tchannel.ServiceName("keyvalue"))
+    chooser := peerheap.New(transport)
+    outbound := x.NewOutbound(chooser)
+    ```
+
+    The new transport hides the implementation of TChannel entirely to give us
+    flexibility going forward to relieve TChannel of all RPC-related
+    responsibilities, leaving only the wire protocol at its core.
+    As a consequence, you cannot thread an existing Channel through this
+    transport.
 
 v1.2.0 (2017-02-02)
 -----------------------

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: 41299379074d597b053894c96b24a3a512ace69e445cc4ee2fd714a990ae8e4d
-updated: 2017-01-18T14:41:33.52551281-08:00
+hash: ca5c3c79daa476f268a20dd660becd53adecf7d0cc827c55352862c845944656
+updated: 2017-02-01T17:59:45.779066488-08:00
 imports:
 - name: github.com/apache/thrift
-  version: e0ccbd6e62e14f32d7c5fe0f9cec6eff3259b863
+  version: de9c330b24c9190078eefb68c864d2a41a4dee07
   subpackages:
   - lib/go/thrift
 - name: github.com/cactus/go-statsd-client
@@ -15,7 +15,7 @@ imports:
   - assert
   - require
 - name: github.com/davecgh/go-spew
-  version: 346938d642f2ec3594ed81d874461961cd0faa76
+  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
   subpackages:
   - spew
 - name: github.com/golang/mock
@@ -23,7 +23,7 @@ imports:
   subpackages:
   - gomock
 - name: github.com/gorilla/websocket
-  version: bb547c6c5c59732c29a3266d7125a84f6c3fce32
+  version: c36f2fe5c330f0ac404b616b96c438b8616b1aaf
 - name: github.com/opentracing/opentracing-go
   version: 0c3154a3c2ce79d3271985848659870599dfb77c
   subpackages:
@@ -33,13 +33,13 @@ imports:
 - name: github.com/pborman/uuid
   version: 1b00554d822231195d1babd97ff4a781231955c9
 - name: github.com/pmezard/go-difflib
-  version: 792786c7400a136282c1664665ae0a8db921c6c2
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
 - name: github.com/Sirupsen/logrus
-  version: 61e43dc76f7ee59a82bdf3d71033dc12bea4c77d
+  version: 08a8a7c27e3d058a8989316a850daad1c10bf4ab
 - name: github.com/stretchr/objx
-  version: 1a9d0bb9f541897e62256577b352fdbc1fb4fd94
+  version: cbeaeb16a013161a98496fad62933b1d21786672
 - name: github.com/stretchr/testify
   version: 2402e8e7a02fc811447d11f881aa9746cdc57983
   subpackages:
@@ -47,11 +47,11 @@ imports:
   - mock
   - require
 - name: github.com/uber-common/bark
-  version: 8841a0f8e7ca869284ccb29c08a14cf3f4310f46
+  version: d52ffa061726911f47fcd3d9e8b9b55f22794772
 - name: github.com/uber-go/atomic
-  version: 3b8db5e93c4c02efbc313e17b2e796b0914a01fb
+  version: 0c9e689d64f004564b79d9a663634756df322902
 - name: github.com/uber/cherami-client-go
-  version: 6eaab19b8d6995792376acf65ad3ec6b5668cc86
+  version: f6da4234a00f2494cacf22e364b92c3972e2050a
   subpackages:
   - client/cherami
   - common
@@ -60,7 +60,7 @@ imports:
   - common/websocket
   - stream
 - name: github.com/uber/cherami-thrift
-  version: 158732d2fb0296d02c0b23aa343c0310b7b9a749
+  version: 0f0585c53937209f08a57c6ae51d8a7fd281e100
   subpackages:
   - .generated/go/cherami
 - name: github.com/uber/jaeger-client-go
@@ -73,10 +73,11 @@ imports:
   - transport
   - utils
 - name: github.com/uber/tchannel-go
-  version: 2caa315516e1836b7b2eff70d2fcbd23538d1b22
+  version: 79387824978f91318be3bfb43ae12e04c38cfe97
   subpackages:
   - hyperbahn
   - hyperbahn/gen-go/hyperbahn
+  - internal/argreader
   - json
   - raw
   - relay
@@ -109,20 +110,22 @@ imports:
   - version
   - wire
 - name: golang.org/x/net
-  version: f2499483f923065a842d38eb4c7f1927e6fc6e6d
+  version: 007e530097ad7f954752df63046b4036f98ba6a6
   subpackages:
   - context
   - context/ctxhttp
 - name: golang.org/x/sys
-  version: d75a52659825e75fff6158388dddc6a5b04f9ba5
+  version: d4feaf1a7e61e1d9e79e6c4e76c6349e9cab0a03
   subpackages:
   - unix
 - name: golang.org/x/tools
-  version: add1aac04e65808e1f3ea9969c10e4494fd39d93
+  version: f8ed2e405fdcbb42c55233531ad98721e6d1cb3e
   subpackages:
   - go/ast/astutil
+- name: gopkg.in/bsm/ratelimit.v1
+  version: db14e161995a5177acef654cb0dd785e8ee8bc22
 - name: gopkg.in/redis.v5
-  version: 8829ddcd8bdb333e477cc845946c4b9b2ef66280
+  version: b6bfe529a846fbb9a58c832ce71c61b6fde12c15
   subpackages:
   - internal
   - internal/consistenthash
@@ -130,5 +133,5 @@ imports:
   - internal/pool
   - internal/proto
 - name: gopkg.in/yaml.v2
-  version: a5b47d31c556af34a302ce5d659e6fea44d90de0
+  version: a83829b6f1293c91addabc89d0571c246397bbf4
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -10,12 +10,11 @@ import:
 - package: github.com/opentracing/opentracing-go
   version: ^1
 - package: github.com/uber/tchannel-go
-  version: ^1.2
+  version: ^1.3
 - package: go.uber.org/atomic
   version: ^1
 - package: go.uber.org/thriftrw
   version: ^1
-
 - package: github.com/crossdock/crossdock-go
   version: master
 - package: github.com/golang/mock

--- a/transport/tchannel/channel.go
+++ b/transport/tchannel/channel.go
@@ -40,6 +40,7 @@ type Channel interface {
 	GetSubChannel(serviceName string, opts ...tchannel.SubChannelOption) *tchannel.SubChannel
 	ListenAndServe(hostPort string) error
 	PeerInfo() tchannel.LocalPeerInfo
+	RootPeers() *tchannel.RootPeerList
 	ServiceName() string
 	State() tchannel.ChannelState
 }

--- a/transport/tchannel/channel_inbound.go
+++ b/transport/tchannel/channel_inbound.go
@@ -26,8 +26,10 @@ import (
 	"go.uber.org/yarpc/internal/sync"
 )
 
-// ChannelInbound receives YARPC requests over TChannel. It may be constructed
-// using the NewInbound method on ChannelTransport.
+// ChannelInbound receives YARPC requests over TChannel.
+// It may be constructed using the NewInbound method on ChannelTransport.
+// If you have a YARPC peer.Chooser, use the unqualified tchannel.Transport
+// instead (instead of the tchannel.ChannelTransport).
 type ChannelInbound struct {
 	transport *ChannelTransport
 
@@ -37,6 +39,11 @@ type ChannelInbound struct {
 // NewInbound returns a new TChannel inbound backed by a shared TChannel
 // transport.  The returned ChannelInbound does not support peer.Chooser
 // and uses TChannel's own internal load balancing peer selection.
+// If you have a YARPC peer.Chooser, use the unqualified tchannel.NewInbound
+// instead.
+// There should only be one inbound for TChannel since all outbounds send the
+// listening port over non-ephemeral connections so a service can deduplicate
+// locally- and remotely-initiated persistent connections.
 func (t *ChannelTransport) NewInbound() *ChannelInbound {
 	return &ChannelInbound{
 		transport: t,

--- a/transport/tchannel/channel_inbound_test.go
+++ b/transport/tchannel/channel_inbound_test.go
@@ -32,13 +32,13 @@ import (
 	"github.com/uber/tchannel-go/json"
 )
 
-func TestInboundStartNew(t *testing.T) {
+func TestChannelInboundStartNew(t *testing.T) {
 	tests := []struct {
-		withInbound func(*tchannel.Channel, func(*Inbound))
+		withInbound func(*tchannel.Channel, func(*ChannelInbound))
 	}{
 		{
-			func(ch *tchannel.Channel, f func(*Inbound)) {
-				x, err := NewTransport(WithChannel(ch))
+			func(ch *tchannel.Channel, f func(*ChannelInbound)) {
+				x, err := NewChannelTransport(WithChannel(ch))
 				require.NoError(t, err)
 
 				i := x.NewInbound()
@@ -55,8 +55,8 @@ func TestInboundStartNew(t *testing.T) {
 			},
 		},
 		{
-			func(ch *tchannel.Channel, f func(*Inbound)) {
-				x, err := NewTransport(WithChannel(ch))
+			func(ch *tchannel.Channel, f func(*ChannelInbound)) {
+				x, err := NewChannelTransport(WithChannel(ch))
 				require.NoError(t, err)
 
 				i := x.NewInbound()
@@ -75,7 +75,7 @@ func TestInboundStartNew(t *testing.T) {
 	for _, tt := range tests {
 		ch, err := tchannel.NewChannel("foo", nil)
 		require.NoError(t, err)
-		tt.withInbound(ch, func(i *Inbound) {
+		tt.withInbound(ch, func(i *ChannelInbound) {
 			assert.Equal(t, tchannel.ChannelListening, ch.State())
 			assert.NoError(t, i.Stop())
 			x := i.Transports()[0]
@@ -85,14 +85,14 @@ func TestInboundStartNew(t *testing.T) {
 	}
 }
 
-func TestInboundStartAlreadyListening(t *testing.T) {
+func TestChannelInboundStartAlreadyListening(t *testing.T) {
 	ch, err := tchannel.NewChannel("foo", nil)
 	require.NoError(t, err)
 
 	require.NoError(t, ch.ListenAndServe(":0"))
 	assert.Equal(t, tchannel.ChannelListening, ch.State())
 
-	x, err := NewTransport(WithChannel(ch))
+	x, err := NewChannelTransport(WithChannel(ch))
 	require.NoError(t, err)
 
 	i := x.NewInbound()
@@ -106,19 +106,19 @@ func TestInboundStartAlreadyListening(t *testing.T) {
 	assert.Equal(t, tchannel.ChannelClosed, ch.State())
 }
 
-func TestInboundStopWithoutStarting(t *testing.T) {
+func TestChannelInboundStopWithoutStarting(t *testing.T) {
 	ch, err := tchannel.NewChannel("foo", nil)
 	require.NoError(t, err)
 
-	x, err := NewTransport(WithChannel(ch))
+	x, err := NewChannelTransport(WithChannel(ch))
 	require.NoError(t, err)
 
 	i := x.NewInbound()
 	assert.NoError(t, i.Stop())
 }
 
-func TestInboundInvalidAddress(t *testing.T) {
-	x, err := NewTransport(ServiceName("foo"), ListenAddr("not valid"))
+func TestChannelInboundInvalidAddress(t *testing.T) {
+	x, err := NewChannelTransport(ServiceName("foo"), ListenAddr("not valid"))
 	require.NoError(t, err)
 
 	i := x.NewInbound()
@@ -129,7 +129,7 @@ func TestInboundInvalidAddress(t *testing.T) {
 	defer x.Stop()
 }
 
-func TestInboundExistingMethods(t *testing.T) {
+func TestChannelInboundExistingMethods(t *testing.T) {
 	// Create a channel with an existing "echo" method.
 	ch, err := tchannel.NewChannel("foo", nil)
 	require.NoError(t, err)
@@ -139,7 +139,7 @@ func TestInboundExistingMethods(t *testing.T) {
 		},
 	}, nil)
 
-	x, err := NewTransport(WithChannel(ch))
+	x, err := NewChannelTransport(WithChannel(ch))
 	require.NoError(t, err)
 
 	i := x.NewInbound()

--- a/transport/tchannel/channel_outbound.go
+++ b/transport/tchannel/channel_outbound.go
@@ -58,8 +58,10 @@ func (t *ChannelTransport) NewSingleOutbound(addr string) *ChannelOutbound {
 }
 
 // ChannelOutbound sends YARPC requests over TChannel. It may be constructed
-// using the NewOutbound or NewSingleOutbound methods on the TChannel
-// Transport.
+// using the NewOutbound or NewSingleOutbound methods on the
+// tchannel.ChannelTransport.
+// If you have a YARPC peer.Chooser, use the unqualified tchannel.Transport
+// instead (instead of the tchannel.ChannelTransport).
 type ChannelOutbound struct {
 	channel   Channel
 	transport *ChannelTransport

--- a/transport/tchannel/channel_outbound_test.go
+++ b/transport/tchannel/channel_outbound_test.go
@@ -110,7 +110,8 @@ func TestChannelOutboundHeaders(t *testing.T) {
 
 							err = writeArgs(call.Response(), []byte{0x00, 0x00}, []byte("bye!"))
 							assert.NoError(t, err, "failed to write response")
-						}))
+						},
+					))
 
 					out, err := constructor.new(testutils.NewClient(t, &testutils.ChannelOpts{
 						ServiceName: "caller",

--- a/transport/tchannel/channel_transport.go
+++ b/transport/tchannel/channel_transport.go
@@ -44,8 +44,8 @@ var errChannelOrServiceNameIsRequired = errors.New(
 // TChannel (with the WithChannel option) MUST be specified.
 //
 // ChannelTransport uses the underlying TChannel Channel for load balancing
-// and peer managament. A future version of YARPC will include support for
-// peer.Chooser-based TChannel transports.
+// and peer managament.
+// Use NewTransport and its NewOutbound to support YARPC peer.Choosers.
 func NewChannelTransport(opts ...TransportOption) (*ChannelTransport, error) {
 	var config transportConfig
 	config.tracer = opentracing.GlobalTracer()
@@ -77,6 +77,8 @@ func NewChannelTransport(opts ...TransportOption) (*ChannelTransport, error) {
 
 // ChannelTransport maintains TChannel peers and creates inbounds and outbounds for
 // TChannel.
+// If you have a YARPC peer.Chooser, use the unqualified tchannel.Transport
+// instead.
 type ChannelTransport struct {
 	ch     Channel
 	name   string
@@ -147,8 +149,9 @@ func (t *ChannelTransport) start() error {
 }
 
 // Stop stops the TChannel transport. It starts rejecting incoming requests
-// and draining connections before closing them. Stop blocks until the
-// underlying channel has closed completely.
+// and draining connections before closing them.
+// In a future version of YARPC, Stop will block until the underlying channel
+// has closed completely.
 func (t *ChannelTransport) Stop() error {
 	return t.once.Stop(t.stop)
 }

--- a/transport/tchannel/example_test.go
+++ b/transport/tchannel/example_test.go
@@ -1,0 +1,44 @@
+package tchannel_test
+
+import (
+	"log"
+
+	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/transport/tchannel"
+)
+
+func ExampleInbound() {
+	transport, err := tchannel.NewTransport(tchannel.ServiceName("myservice"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	dispatcher := yarpc.NewDispatcher(yarpc.Config{
+		Name:     "myservice",
+		Inbounds: yarpc.Inbounds{transport.NewInbound()},
+	})
+
+	if err := dispatcher.Start(); err != nil {
+		log.Fatal(err)
+	}
+	defer dispatcher.Stop()
+}
+
+func ExampleOutbound() {
+	transport, err := tchannel.NewTransport(tchannel.ServiceName("myclient"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	dispatcher := yarpc.NewDispatcher(yarpc.Config{
+		Name: "myclient",
+		Outbounds: yarpc.Outbounds{
+			"myservice": {Unary: transport.NewSingleOutbound("127.0.0.0:4040")},
+		},
+	})
+
+	if err := dispatcher.Start(); err != nil {
+		log.Fatal(err)
+	}
+	defer dispatcher.Stop()
+}

--- a/transport/tchannel/inbound.go
+++ b/transport/tchannel/inbound.go
@@ -1,0 +1,73 @@
+package tchannel
+
+import (
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/introspection"
+	"go.uber.org/yarpc/internal/sync"
+)
+
+// Inbound receives YARPC requests over TChannel. It may be constructed using
+// the NewInbound method on a tchannel.Transport.
+type Inbound struct {
+	once      sync.LifecycleOnce
+	transport *Transport
+}
+
+// NewInbound returns a new TChannel inbound backed by a shared TChannel
+// transport.
+// There should only be one inbound for TChannel since all outbounds send the
+// listening port over non-ephemeral connections so a service can deduplicate
+// locally- and remotely-initiated persistent connections.
+func (t *Transport) NewInbound() *Inbound {
+	return &Inbound{
+		transport: t,
+	}
+}
+
+// SetRouter configures a router to handle incoming requests.
+// This satisfies the transport.Inbound interface, and would be called
+// by a dispatcher when it starts.
+func (i *Inbound) SetRouter(router transport.Router) {
+	i.transport.router = router
+}
+
+// Transports returns a slice containing the Inbound's underlying
+// Transport.
+func (i *Inbound) Transports() []transport.Transport {
+	return []transport.Transport{i.transport}
+}
+
+// Channel returns the underlying Channel for this Inbound.
+func (i *Inbound) Channel() Channel {
+	return i.transport.ch
+}
+
+// Start starts this Inbound. Note that this does not start listening for
+// connections; that occurs when you start the underlying ChannelTransport is
+// started.
+func (i *Inbound) Start() error {
+	return i.once.Start(func() error {
+		return nil // Nothing to do
+	})
+}
+
+// Stop stops the TChannel outbound. This currently does nothing.
+func (i *Inbound) Stop() error {
+	return i.once.Stop(func() error {
+		return nil // Nothing to do
+	})
+}
+
+// IsRunning returns whether the Inbound is running.
+func (i *Inbound) IsRunning() bool {
+	return i.once.IsRunning()
+}
+
+// Introspect returns the state of the inbound for introspection purposes.
+func (i *Inbound) Introspect() introspection.InboundStatus {
+	return introspection.InboundStatus{
+		Transport: "tchannel",
+		Endpoint:  i.transport.addr,
+		State:     i.transport.ch.State().String(),
+	}
+}

--- a/transport/tchannel/inbound.go
+++ b/transport/tchannel/inbound.go
@@ -37,25 +37,16 @@ func (i *Inbound) Transports() []transport.Transport {
 	return []transport.Transport{i.transport}
 }
 
-// Channel returns the underlying Channel for this Inbound.
-func (i *Inbound) Channel() Channel {
-	return i.transport.ch
-}
-
 // Start starts this Inbound. Note that this does not start listening for
 // connections; that occurs when you start the underlying ChannelTransport is
 // started.
 func (i *Inbound) Start() error {
-	return i.once.Start(func() error {
-		return nil // Nothing to do
-	})
+	return i.once.Start(nil)
 }
 
 // Stop stops the TChannel outbound. This currently does nothing.
 func (i *Inbound) Stop() error {
-	return i.once.Stop(func() error {
-		return nil // Nothing to do
-	})
+	return i.once.Stop(nil)
 }
 
 // IsRunning returns whether the Inbound is running.

--- a/transport/tchannel/inbound_test.go
+++ b/transport/tchannel/inbound_test.go
@@ -22,97 +22,28 @@ package tchannel
 
 import (
 	"testing"
-	"time"
 
 	"go.uber.org/yarpc/api/transport/transporttest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/uber/tchannel-go"
-	"github.com/uber/tchannel-go/json"
 )
 
 func TestInboundStartNew(t *testing.T) {
-	tests := []struct {
-		withInbound func(*tchannel.Channel, func(*Inbound))
-	}{
-		{
-			func(ch *tchannel.Channel, f func(*Inbound)) {
-				x, err := NewTransport(WithChannel(ch))
-				require.NoError(t, err)
-
-				i := x.NewInbound()
-				i.SetRouter(new(transporttest.MockRouter))
-				// Can't do Equal because we want to match the pointer, not a
-				// DeepEqual.
-				assert.True(t, ch == i.Channel(), "channel does not match")
-				require.NoError(t, i.Start())
-				defer i.Stop()
-				require.NoError(t, x.Start())
-				defer x.Stop()
-
-				f(i)
-			},
-		},
-		{
-			func(ch *tchannel.Channel, f func(*Inbound)) {
-				x, err := NewTransport(WithChannel(ch))
-				require.NoError(t, err)
-
-				i := x.NewInbound()
-				i.SetRouter(new(transporttest.MockRouter))
-				assert.True(t, ch == i.Channel(), "channel does not match")
-				require.NoError(t, i.Start())
-				defer i.Stop()
-				require.NoError(t, x.Start())
-				defer x.Stop()
-
-				f(i)
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		ch, err := tchannel.NewChannel("foo", nil)
-		require.NoError(t, err)
-		tt.withInbound(ch, func(i *Inbound) {
-			assert.Equal(t, tchannel.ChannelListening, ch.State())
-			assert.NoError(t, i.Stop())
-			x := i.Transports()[0]
-			assert.NoError(t, x.Stop())
-			assert.Equal(t, tchannel.ChannelClosed, ch.State())
-		})
-	}
-}
-
-func TestInboundStartAlreadyListening(t *testing.T) {
-	ch, err := tchannel.NewChannel("foo", nil)
-	require.NoError(t, err)
-
-	require.NoError(t, ch.ListenAndServe(":0"))
-	assert.Equal(t, tchannel.ChannelListening, ch.State())
-
-	x, err := NewTransport(WithChannel(ch))
+	x, err := NewTransport(ServiceName("foo"))
 	require.NoError(t, err)
 
 	i := x.NewInbound()
-
 	i.SetRouter(new(transporttest.MockRouter))
 	require.NoError(t, i.Start())
 	require.NoError(t, x.Start())
-
-	assert.NoError(t, i.Stop())
-	assert.NoError(t, x.Stop())
-	assert.Equal(t, tchannel.ChannelClosed, ch.State())
+	require.NoError(t, i.Stop())
+	require.NoError(t, x.Stop())
 }
 
 func TestInboundStopWithoutStarting(t *testing.T) {
-	ch, err := tchannel.NewChannel("foo", nil)
+	x, err := NewTransport(ServiceName("foo"))
 	require.NoError(t, err)
-
-	x, err := NewTransport(WithChannel(ch))
-	require.NoError(t, err)
-
 	i := x.NewInbound()
 	assert.NoError(t, i.Stop())
 }
@@ -127,38 +58,4 @@ func TestInboundInvalidAddress(t *testing.T) {
 	defer i.Stop()
 	assert.Error(t, x.Start())
 	defer x.Stop()
-}
-
-func TestInboundExistingMethods(t *testing.T) {
-	// Create a channel with an existing "echo" method.
-	ch, err := tchannel.NewChannel("foo", nil)
-	require.NoError(t, err)
-	json.Register(ch, json.Handlers{
-		"echo": func(ctx json.Context, req map[string]string) (map[string]string, error) {
-			return req, nil
-		},
-	}, nil)
-
-	x, err := NewTransport(WithChannel(ch))
-	require.NoError(t, err)
-
-	i := x.NewInbound()
-	i.SetRouter(new(transporttest.MockRouter))
-	require.NoError(t, i.Start())
-	defer i.Stop()
-	require.NoError(t, x.Start())
-	defer x.Stop()
-
-	// Make a call to the "echo" method which should call our pre-registered method.
-	ctx, cancel := json.NewContext(time.Second)
-	defer cancel()
-
-	var resp map[string]string
-	arg := map[string]string{"k": "v"}
-
-	svc := ch.ServiceName()
-	peer := ch.Peers().GetOrAdd(ch.PeerInfo().HostPort)
-	err = json.CallPeer(ctx, peer, svc, "echo", arg, &resp)
-	require.NoError(t, err, "Call failed")
-	assert.Equal(t, arg, resp, "Response mismatch")
 }

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -1,0 +1,175 @@
+package tchannel
+
+import (
+	"context"
+
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/encoding"
+	"go.uber.org/yarpc/internal/introspection"
+	intsync "go.uber.org/yarpc/internal/sync"
+	peerchooser "go.uber.org/yarpc/peer"
+	"go.uber.org/yarpc/peer/hostport"
+
+	"github.com/uber/tchannel-go"
+)
+
+var (
+	_ transport.UnaryOutbound              = (*Outbound)(nil)
+	_ introspection.IntrospectableOutbound = (*Outbound)(nil)
+)
+
+// Outbound sends YARPC requests over TChannel.
+// It may be constructed using the NewOutbound or NewSingleOutbound methods on
+// the TChannel Transport.
+type Outbound struct {
+	transport *Transport
+	chooser   peer.Chooser
+	once      intsync.LifecycleOnce
+}
+
+// NewOutbound builds a new TChannel outbound that selects a peer for each
+// request using the given peer chooser.
+func (t *Transport) NewOutbound(chooser peer.Chooser) *Outbound {
+	return &Outbound{
+		transport: t,
+		chooser:   chooser,
+	}
+}
+
+// NewSingleOutbound builds a new TChannel outbound always using the peer with
+// the given address.
+func (t *Transport) NewSingleOutbound(addr string) *Outbound {
+	chooser := peerchooser.NewSingle(hostport.PeerIdentifier(addr), t)
+	return t.NewOutbound(chooser)
+}
+
+// Call sends an RPC over this TChannel outbound.
+func (o *Outbound) Call(ctx context.Context, req *transport.Request) (*transport.Response, error) {
+	if !o.IsRunning() {
+		// TODO replace with "panicInDebug"
+		return nil, errOutboundNotStarted
+	}
+	root := o.transport.ch.RootPeers()
+	p, onFinish, err := o.getPeerForRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	tp := root.GetOrAdd(p.HostPort())
+	res, err := o.callWithPeer(ctx, req, tp)
+	onFinish(err)
+	return res, err
+}
+
+// callWithPeer sends a request with the chosen peer.
+func (o *Outbound) callWithPeer(ctx context.Context, req *transport.Request, peer *tchannel.Peer) (*transport.Response, error) {
+	// NB(abg): Under the current API, the local service's name is required
+	// twice: once when constructing the TChannel and then again when
+	// constructing the RPC.
+	var call *tchannel.OutboundCall
+	var err error
+
+	format := tchannel.Format(req.Encoding)
+	callOptions := tchannel.CallOptions{
+		Format:          format,
+		ShardKey:        req.ShardKey,
+		RoutingKey:      req.RoutingKey,
+		RoutingDelegate: req.RoutingDelegate,
+	}
+
+	// If the hostport is given, we use the BeginCall on the channel
+	// instead of the subchannel.
+	call, err = peer.BeginCall(
+		// TODO(abg): Set TimeoutPerAttempt in the context's retry options if
+		// TTL is set.
+		// (kris): Consider instead moving TimeoutPerAttempt to an outer
+		// layer, just clamp the context on outbound call.
+		ctx,
+		req.Service,
+		req.Procedure,
+		&callOptions,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Inject tracing system baggage
+	reqHeaders := tchannel.InjectOutboundSpan(call.Response(), req.Headers.Items())
+
+	if err := writeRequestHeaders(ctx, format, reqHeaders, call.Arg2Writer); err != nil {
+		// TODO(abg): This will wrap IO errors while writing headers as encode
+		// errors. We should fix that.
+		return nil, encoding.RequestHeadersEncodeError(req, err)
+	}
+
+	if err := writeBody(req.Body, call); err != nil {
+		return nil, err
+	}
+
+	res := call.Response()
+	headers, err := readHeaders(format, res.Arg2Reader)
+	if err != nil {
+		if err, ok := err.(tchannel.SystemError); ok {
+			return nil, fromSystemError(err)
+		}
+		// TODO(abg): This will wrap IO errors while reading headers as decode
+		// errors. We should fix that.
+		return nil, encoding.ResponseHeadersDecodeError(req, err)
+	}
+
+	resBody, err := res.Arg3Reader()
+	if err != nil {
+		if err, ok := err.(tchannel.SystemError); ok {
+			return nil, fromSystemError(err)
+		}
+		return nil, err
+	}
+
+	return &transport.Response{
+		Headers:          headers,
+		Body:             resBody,
+		ApplicationError: res.ApplicationError(),
+	}, nil
+}
+
+func (o *Outbound) getPeerForRequest(ctx context.Context, treq *transport.Request) (*hostport.Peer, func(error), error) {
+	p, onFinish, err := o.chooser.Choose(ctx, treq)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	hpPeer, ok := p.(*hostport.Peer)
+	if !ok {
+		return nil, nil, peer.ErrInvalidPeerConversion{
+			Peer:         p,
+			ExpectedType: "*hostport.Peer",
+		}
+	}
+
+	return hpPeer, onFinish, nil
+}
+
+// Transports returns the underlying TChannel Transport for this outbound.
+func (o *Outbound) Transports() []transport.Transport {
+	return []transport.Transport{o.transport}
+}
+
+// Start starts the TChannel outbound.
+func (o *Outbound) Start() error {
+	return o.once.Start(func() error {
+		return nil // Nothing to do
+	})
+}
+
+// Stop stops the TChannel outbound.
+func (o *Outbound) Stop() error {
+	return o.once.Stop(func() error {
+		return nil // Nothing to do
+	})
+}
+
+// IsRunning returns whether the ChannelOutbound is running.
+func (o *Outbound) IsRunning() bool {
+	return o.once.IsRunning()
+}

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -158,14 +158,14 @@ func (o *Outbound) Transports() []transport.Transport {
 // Start starts the TChannel outbound.
 func (o *Outbound) Start() error {
 	return o.once.Start(func() error {
-		return nil // Nothing to do
+		return o.chooser.Start()
 	})
 }
 
 // Stop stops the TChannel outbound.
 func (o *Outbound) Stop() error {
 	return o.once.Stop(func() error {
-		return nil // Nothing to do
+		return o.chooser.Stop()
 	})
 }
 

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -173,3 +173,24 @@ func (o *Outbound) Stop() error {
 func (o *Outbound) IsRunning() bool {
 	return o.once.IsRunning()
 }
+
+// Introspect returns basic status about this outbound.
+func (o *Outbound) Introspect() introspection.OutboundStatus {
+	state := "Stopped"
+	if o.IsRunning() {
+		state = "Running"
+	}
+	var chooser introspection.ChooserStatus
+	if i, ok := o.chooser.(introspection.IntrospectableChooser); ok {
+		chooser = i.Introspect()
+	} else {
+		chooser = introspection.ChooserStatus{
+			Name: "Introspection not available",
+		}
+	}
+	return introspection.OutboundStatus{
+		Transport: "tchannel",
+		State:     state,
+		Chooser:   chooser,
+	}
+}

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -157,16 +157,12 @@ func (o *Outbound) Transports() []transport.Transport {
 
 // Start starts the TChannel outbound.
 func (o *Outbound) Start() error {
-	return o.once.Start(func() error {
-		return o.chooser.Start()
-	})
+	return o.once.Start(o.chooser.Start)
 }
 
 // Stop stops the TChannel outbound.
 func (o *Outbound) Stop() error {
-	return o.once.Stop(func() error {
-		return o.chooser.Stop()
-	})
+	return o.once.Stop(o.chooser.Stop)
 }
 
 // IsRunning returns whether the ChannelOutbound is running.

--- a/transport/tchannel/transport.go
+++ b/transport/tchannel/transport.go
@@ -1,6 +1,7 @@
 package tchannel
 
 import (
+	"fmt"
 	"sync"
 
 	"go.uber.org/yarpc/api/peer"
@@ -49,15 +50,18 @@ func NewTransport(opts ...TransportOption) (*Transport, error) {
 	// Defer the error until Start since NewChannelTransport does not have
 	// an error return.
 	var err error
-	ch := config.ch
 
-	if ch == nil {
-		if config.name == "" {
-			err = errChannelOrServiceNameIsRequired
-		} else {
-			opts := tchannel.ChannelOptions{Tracer: config.tracer}
-			ch, err = tchannel.NewChannel(config.name, &opts)
-		}
+	if config.ch != nil {
+		return nil, fmt.Errorf("NewTransport does not accept WithChannel, use NewChannelTransport")
+	}
+	// if config.name == "" {
+	// 	return nil, errChannelOrServiceNameIsRequired
+	// }
+
+	chopts := tchannel.ChannelOptions{Tracer: config.tracer}
+	ch, err := tchannel.NewChannel(config.name, &chopts)
+	if err != nil {
+		return nil, err
 	}
 
 	return &Transport{

--- a/transport/tchannel/transport.go
+++ b/transport/tchannel/transport.go
@@ -68,7 +68,7 @@ func NewTransport(opts ...TransportOption) (*Transport, error) {
 		addr:   config.addr,
 		tracer: config.tracer,
 		peers:  make(map[string]*hostport.Peer),
-	}, err
+	}, nil
 }
 
 // ListenAddr exposes the listen address of the transport.

--- a/transport/tchannel/transport.go
+++ b/transport/tchannel/transport.go
@@ -6,7 +6,6 @@ import (
 
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/internal/introspection"
 	intsync "go.uber.org/yarpc/internal/sync"
 	"go.uber.org/yarpc/peer/hostport"
 
@@ -200,16 +199,4 @@ func (t *Transport) stop() error {
 // IsRunning returns whether the TChannel transport is running.
 func (t *Transport) IsRunning() bool {
 	return t.once.IsRunning()
-}
-
-// Introspect returns basic status about this outbound.
-func (o *Outbound) Introspect() introspection.OutboundStatus {
-	state := "Stopped"
-	if o.IsRunning() {
-		state = "Running"
-	}
-	return introspection.OutboundStatus{
-		Transport: "tchannel",
-		State:     state,
-	}
 }

--- a/transport/tchannel/transport.go
+++ b/transport/tchannel/transport.go
@@ -1,0 +1,211 @@
+package tchannel
+
+import (
+	"sync"
+
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/introspection"
+	intsync "go.uber.org/yarpc/internal/sync"
+	"go.uber.org/yarpc/peer/hostport"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/uber/tchannel-go"
+)
+
+// Transport is a TChannel transport suitable for use with YARPC's peer
+// selection system.
+// The transport implements peer.Transport so multiple peer.List
+// implementations can retain and release shared peers.
+// The transport implements transport.Transport so it is suitable for lifecycle
+// management.
+type Transport struct {
+	lock sync.Mutex
+	once intsync.LifecycleOnce
+
+	ch     Channel
+	router transport.Router
+	tracer opentracing.Tracer
+	addr   string
+
+	peers map[string]*hostport.Peer
+}
+
+// NewTransport is a YARPC transport that facilitates sending and receiving
+// YARPC requests through TChannel.
+// It uses a shared TChannel Channel for both, incoming and outgoing requests,
+// ensuring reuse of connections and other resources.
+//
+// Either the local service name (with the ServiceName option) or a user-owned
+// TChannel (with the WithChannel option) MUST be specified.
+func NewTransport(opts ...TransportOption) (*Transport, error) {
+	var config transportConfig
+	config.tracer = opentracing.GlobalTracer()
+	for _, opt := range opts {
+		opt(&config)
+	}
+
+	// Attempt to construct a channel on behalf of the caller if none given.
+	// Defer the error until Start since NewChannelTransport does not have
+	// an error return.
+	var err error
+	ch := config.ch
+
+	if ch == nil {
+		if config.name == "" {
+			err = errChannelOrServiceNameIsRequired
+		} else {
+			opts := tchannel.ChannelOptions{Tracer: config.tracer}
+			ch, err = tchannel.NewChannel(config.name, &opts)
+		}
+	}
+
+	return &Transport{
+		ch:     ch,
+		addr:   config.addr,
+		tracer: config.tracer,
+		peers:  make(map[string]*hostport.Peer),
+	}, err
+}
+
+// ListenAddr exposes the listen address of the transport.
+func (t *Transport) ListenAddr() string {
+	return t.addr
+}
+
+// RetainPeer adds a peer subscriber (typically a peer chooser) and causes the
+// transport to maintain persistent connections with that peer.
+func (t *Transport) RetainPeer(pid peer.Identifier, sub peer.Subscriber) (peer.Peer, error) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	hppid, ok := pid.(hostport.PeerIdentifier)
+	if !ok {
+		return nil, peer.ErrInvalidPeerType{
+			ExpectedType:   "hostport.PeerIdentifier",
+			PeerIdentifier: pid,
+		}
+	}
+
+	p := t.getOrCreatePeer(hppid)
+	p.Subscribe(sub)
+	return p, nil
+}
+
+// **NOTE** should only be called while the lock write mutex is acquired
+func (t *Transport) getOrCreatePeer(pid hostport.PeerIdentifier) *hostport.Peer {
+	if p, ok := t.peers[pid.Identifier()]; ok {
+		return p
+	}
+
+	p := hostport.NewPeer(pid, t)
+	p.SetStatus(peer.Available)
+
+	t.peers[p.Identifier()] = p
+
+	return p
+}
+
+// ReleasePeer releases a peer from the peer.Subscriber and removes that peer
+// from the Transport if nothing is listening to it.
+func (t *Transport) ReleasePeer(pid peer.Identifier, sub peer.Subscriber) error {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	p, ok := t.peers[pid.Identifier()]
+	if !ok {
+		return peer.ErrTransportHasNoReferenceToPeer{
+			TransportName:  "tchannel.Transport",
+			PeerIdentifier: pid.Identifier(),
+		}
+	}
+
+	if err := p.Unsubscribe(sub); err != nil {
+		return err
+	}
+
+	if p.NumSubscribers() == 0 {
+		delete(t.peers, pid.Identifier())
+	}
+
+	return nil
+}
+
+// Start starts the TChannel transport. This starts making connections and
+// accepting inbound requests. All inbounds must have been assigned a router
+// to accept inbound requests before this is called.
+func (t *Transport) Start() error {
+	return t.once.Start(t.start)
+}
+
+func (t *Transport) start() error {
+
+	if t.router != nil {
+		// Set up handlers. This must occur after construction because the
+		// dispatcher, or its equivalent, calls SetRouter before Start.
+		// This also means that SetRouter should be called on every inbound
+		// before calling Start on any transport or inbound.
+		sc := t.ch.GetSubChannel(t.ch.ServiceName())
+		existing := sc.GetHandlers()
+		sc.SetHandler(handler{existing: existing, router: t.router, tracer: t.tracer})
+	}
+
+	if t.ch.State() == tchannel.ChannelListening {
+		// Channel.Start() was called before RPC.Start(). We still want to
+		// update the Handler and what t.addr means, but nothing else.
+		t.addr = t.ch.PeerInfo().HostPort
+		return nil
+	}
+
+	// Default to ListenIP if addr wasn't given.
+	addr := t.addr
+	if addr == "" {
+		listenIP, err := tchannel.ListenIP()
+		if err != nil {
+			return err
+		}
+
+		addr = listenIP.String() + ":0"
+		// TODO(abg): Find a way to export this to users
+	}
+
+	// TODO(abg): If addr was just the port (":4040"), we want to use
+	// ListenIP() + ":4040" rather than just ":4040".
+
+	if err := t.ch.ListenAndServe(addr); err != nil {
+		return err
+	}
+
+	t.addr = t.ch.PeerInfo().HostPort
+	return nil
+}
+
+// Stop stops the TChannel transport. It starts rejecting incoming requests
+// and draining connections before closing them.
+// In a future version of YARPC, Stop will block until the underlying channel
+// has closed completely.
+func (t *Transport) Stop() error {
+	return t.once.Stop(t.stop)
+}
+
+func (t *Transport) stop() error {
+	t.ch.Close()
+	return nil
+}
+
+// IsRunning returns whether the TChannel transport is running.
+func (t *Transport) IsRunning() bool {
+	return t.once.IsRunning()
+}
+
+// Introspect returns basic status about this outbound.
+func (o *Outbound) Introspect() introspection.OutboundStatus {
+	state := "Stopped"
+	if o.IsRunning() {
+		state = "Running"
+	}
+	return introspection.OutboundStatus{
+		Transport: "tchannel",
+		State:     state,
+	}
+}


### PR DESCRIPTION
This adds the long-prepared TChannel transport with peer selection.

- [x] Remove the pin to the tchannel-go branch that exposes the root peer list and peer connectivity notifications. Uprev to a released version of tchannel-go.

Can punt:
- [x] Thread peer availability notification changes (not yet used) https://github.com/yarpc/yarpc-go/issues/718
- [x] Use peer availability notification changes in peer lists (e.g., connect to up to *n* peers in each peer list, rotate from among provided peers favoring peers that have made fewer connection attempts) Current implementation of peer chooser fully connects to all provided peers and reconnects on send if a peer has disconnected. There are no client-initiated disconnects. https://github.com/yarpc/yarpc-go/issues/719
- [x] Land https://github.com/uber/tchannel-go/pull/572 in the short term, since this feature is not necessary to ship the minimum viable feature. To support persistent connections with a subset of a peer provider and rotate through peers if they disconnect, we’ll need peer disconnect notifications, but our current peer choosers don't do anything with that information. 
- [x] We should also investigate whether we’re using ephemeral or persistent connections and expose configuration to choose between them. Behavior in production will vary considerably! https://github.com/yarpc/yarpc-go/issues/720