### PR TITLE
fix changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,13 @@ Releases
 v1.2.0-dev (unreleased)
 -----------------------
 
--   No changes yet.
+-   Added experimental `transports/x/cherami` for transporting RPCs through
+    [Cherami](https://eng.uber.com/cherami/).
 
 
 v1.1.0 (2017-01-24)
 -----------------------
 
--   Added experimental `transports/x/cherami` for transporting RPCs through
-    [Cherami](https://eng.uber.com/cherami/).
 -   Thrift: Mock clients compatible with gomock are now generated for each
     service inside a test subpackage. Disable this by passing a `-no-gomock`
     flag to the plugin.


### PR DESCRIPTION
Just noticed the changelog entry @datoug created was for v1.1.0 which was already released.