### PR TITLE
Add OutboundKey to OutboundStatus Introspection

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -151,6 +151,7 @@ const pageHTML = `
 	<table>
 		<thead>
 		<tr>
+			<th>Outbound Key</th>
 			<th>Service</th>
 			<th>Transport</th>
 			<th>RPC Type</th>
@@ -172,6 +173,7 @@ const pageHTML = `
 		<tbody>
 		{{range .Outbounds}}
 		<tr>
+			<td>{{.OutboundKey}}</td>
 			<td>{{.Service}}</td>
 			<td>{{.Transport}}</td>
 			<td>{{.RPCType}}</td>

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -424,7 +424,7 @@ func (d *Dispatcher) introspect() dispatcherStatus {
 		inbounds = append(inbounds, status)
 	}
 	var outbounds []introspection.OutboundStatus
-	for _, o := range d.outbounds {
+	for outboundKey, o := range d.outbounds {
 		var status introspection.OutboundStatus
 		if o.Unary != nil {
 			if o, ok := o.Unary.(introspection.IntrospectableOutbound); ok {
@@ -443,6 +443,7 @@ func (d *Dispatcher) introspect() dispatcherStatus {
 			status.RPCType = "oneway"
 		}
 		status.Service = o.ServiceName
+		status.OutboundKey = outboundKey
 		outbounds = append(outbounds, status)
 	}
 	return dispatcherStatus{

--- a/internal/introspection/outbound.go
+++ b/internal/introspection/outbound.go
@@ -27,12 +27,13 @@ type IntrospectableOutbound interface {
 
 // OutboundStatus is a collection of basics info about an Outbound.
 type OutboundStatus struct {
-	Transport string
-	RPCType   string
-	Endpoint  string
-	State     string
-	Chooser   ChooserStatus
-	Service   string
+	Transport   string
+	RPCType     string
+	Endpoint    string
+	State       string
+	Chooser     ChooserStatus
+	Service     string
+	OutboundKey string
 }
 
 // OutboundStatusNotSupported is returned when not valid OutboundStatus can be


### PR DESCRIPTION
Summary: We divided the concept of "ServiceName" and
"OutboundKey" in #707.  They aren't always different, but
with the possibility that they might be we should add OutboundKey
as a separate configuration parameter on OutboundStatus

@bombela