### PR TITLE
Wait for start, not assert, in outbound calls

### DIFF
--- a/peer/x/roundrobin/list.go
+++ b/peer/x/roundrobin/list.go
@@ -210,7 +210,7 @@ func (pl *List) removeFromUnavailablePeers(p peer.Peer) {
 
 // Choose selects the next available peer in the round robin
 func (pl *List) Choose(ctx context.Context, req *transport.Request) (peer.Peer, func(error), error) {
-	if !pl.IsRunning() {
+	if err := pl.once.WaitForStart(ctx); err != nil {
 		return nil, nil, peer.ErrPeerListNotStarted("RoundRobinList")
 	}
 

--- a/peer/x/roundrobin/list_test.go
+++ b/peer/x/roundrobin/list_test.go
@@ -220,10 +220,12 @@ func TestRoundRobinList(t *testing.T) {
 			peerListActions: []PeerListAction{
 				UpdateAction{AddedPeerIDs: []string{"1"}},
 				ChooseAction{
-					ExpectedErr: peer.ErrPeerListNotStarted("RoundRobinList"),
+					ExpectedErr:         peer.ErrPeerListNotStarted("RoundRobinList"),
+					InputContextTimeout: 10 * time.Millisecond,
 				},
 				ChooseAction{
-					ExpectedErr: peer.ErrPeerListNotStarted("RoundRobinList"),
+					ExpectedErr:         peer.ErrPeerListNotStarted("RoundRobinList"),
+					InputContextTimeout: 10 * time.Millisecond,
 				},
 			},
 			expectedRunning: false,

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -170,10 +170,10 @@ func (o *Outbound) IsRunning() bool {
 
 // Call makes a HTTP request
 func (o *Outbound) Call(ctx context.Context, treq *transport.Request) (*transport.Response, error) {
-	if !o.IsRunning() {
-		// TODO replace with "panicInDebug"
-		return nil, errOutboundNotStarted
+	if err := o.once.WaitForStart(ctx); err != nil {
+		return nil, err
 	}
+
 	start := time.Now()
 	deadline, _ := ctx.Deadline()
 	ttl := deadline.Sub(start)
@@ -183,10 +183,10 @@ func (o *Outbound) Call(ctx context.Context, treq *transport.Request) (*transpor
 
 // CallOneway makes a oneway request
 func (o *Outbound) CallOneway(ctx context.Context, treq *transport.Request) (transport.Ack, error) {
-	if !o.IsRunning() {
-		// TODO replace with "panicInDebug"
-		return nil, errOutboundNotStarted
+	if err := o.once.WaitForStart(ctx); err != nil {
+		return nil, err
 	}
+
 	start := time.Now()
 	var ttl time.Duration
 

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -322,5 +322,5 @@ func TestCallWithoutStarting(t *testing.T) {
 		},
 	)
 
-	assert.Equal(t, errOutboundNotStarted, err)
+	assert.Equal(t, context.DeadlineExceeded, err)
 }

--- a/transport/tchannel/channel_outbound.go
+++ b/transport/tchannel/channel_outbound.go
@@ -102,7 +102,7 @@ func (o *ChannelOutbound) IsRunning() bool {
 
 // Call sends an RPC over this TChannel outbound.
 func (o *ChannelOutbound) Call(ctx context.Context, req *transport.Request) (*transport.Response, error) {
-	if !o.IsRunning() {
+	if err := o.once.WaitForStart(ctx); err != nil {
 		// TODO replace with "panicInDebug"
 		return nil, errOutboundNotStarted
 	}

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -46,7 +46,7 @@ func (t *Transport) NewSingleOutbound(addr string) *Outbound {
 
 // Call sends an RPC over this TChannel outbound.
 func (o *Outbound) Call(ctx context.Context, req *transport.Request) (*transport.Response, error) {
-	if !o.IsRunning() {
+	if err := o.once.WaitForStart(ctx); err != nil {
 		// TODO replace with "panicInDebug"
 		return nil, errOutboundNotStarted
 	}


### PR DESCRIPTION
This change introduces WaitForStart(ctx)error as a method of the lifecycle utility, and introduces its usage in methods that cannot run until a component has started, like peer.Choose or outbound.Call. The method takes a context to bound its wait time.

This adds the use of a channel to coordinate one or more goroutines awaiting a lifecycle to begin. The channel is only constructed if WaitForStart is called before the component starts.