### PR TITLE
Add support for services to tchannel.

### DIFF
--- a/internal/crossdock/client/ctxpropagation/behavior.go
+++ b/internal/crossdock/client/ctxpropagation/behavior.go
@@ -172,8 +172,6 @@ func Run(t crossdock.T) {
 			}
 
 			dispatcher, tconfig := buildDispatcher(t)
-			fatals.NoError(dispatcher.Start(), "%v: Dispatcher failed to start", tt.desc)
-			defer dispatcher.Stop()
 
 			jsonClient := json.New(dispatcher.ClientConfig("yarpc-test"))
 			for name, handler := range tt.handlers {
@@ -181,6 +179,9 @@ func Run(t crossdock.T) {
 				handler.SetTransport(tconfig)
 				dispatcher.Register(json.Procedure(name, handler.Handle))
 			}
+
+			fatals.NoError(dispatcher.Start(), "%v: Dispatcher failed to start", tt.desc)
+			defer dispatcher.Stop()
 
 			ctx := context.Background()
 			if tt.initCtx != nil {

--- a/transport/tchannel/channel_inbound_test.go
+++ b/transport/tchannel/channel_inbound_test.go
@@ -29,10 +29,8 @@ import (
 
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/api/transport/transporttest"
 	"go.uber.org/yarpc/encoding/raw"
 
-	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go"
@@ -48,10 +46,7 @@ func TestChannelInboundStartNew(t *testing.T) {
 	require.NoError(t, err)
 
 	i := x.NewInbound()
-	mctrl := gomock.NewController(t)
-	router := transporttest.NewMockRouter(mctrl)
-	router.EXPECT().Procedures().Return(nil)
-	i.SetRouter(router)
+	i.SetRouter(yarpc.NewMapRouter("foo"))
 	// Can't do Equal because we want to match the pointer, not a
 	// DeepEqual.
 	assert.True(t, ch == i.Channel(), "channel does not match")
@@ -76,10 +71,7 @@ func TestChannelInboundStartAlreadyListening(t *testing.T) {
 
 	i := x.NewInbound()
 
-	mctrl := gomock.NewController(t)
-	router := transporttest.NewMockRouter(mctrl)
-	router.EXPECT().Procedures().Return(nil)
-	i.SetRouter(router)
+	i.SetRouter(yarpc.NewMapRouter("foo"))
 	require.NoError(t, i.Start())
 	require.NoError(t, x.Start())
 	assert.Equal(t, tchannel.ChannelListening, ch.State())
@@ -105,10 +97,7 @@ func TestChannelInboundInvalidAddress(t *testing.T) {
 	require.NoError(t, err)
 
 	i := x.NewInbound()
-	mctrl := gomock.NewController(t)
-	router := transporttest.NewMockRouter(mctrl)
-	router.EXPECT().Procedures().Return(nil)
-	i.SetRouter(router)
+	i.SetRouter(yarpc.NewMapRouter("foo"))
 	assert.Nil(t, i.Start())
 	defer i.Stop()
 	assert.Error(t, x.Start())
@@ -129,10 +118,7 @@ func TestChannelInboundExistingMethods(t *testing.T) {
 	require.NoError(t, err)
 
 	i := x.NewInbound()
-	mctrl := gomock.NewController(t)
-	router := transporttest.NewMockRouter(mctrl)
-	router.EXPECT().Procedures().Return(nil)
-	i.SetRouter(router)
+	i.SetRouter(yarpc.NewMapRouter("foo"))
 	require.NoError(t, i.Start())
 	defer i.Stop()
 	require.NoError(t, x.Start())

--- a/transport/tchannel/channel_inbound_test.go
+++ b/transport/tchannel/channel_inbound_test.go
@@ -21,15 +21,23 @@
 package tchannel
 
 import (
+	"bytes"
+	"context"
+	"io/ioutil"
 	"testing"
 	"time"
 
+	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/api/transport/transporttest"
+	"go.uber.org/yarpc/encoding/raw"
 
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/json"
+	"github.com/uber/tchannel-go/testutils"
 )
 
 func TestChannelInboundStartNew(t *testing.T) {
@@ -40,7 +48,10 @@ func TestChannelInboundStartNew(t *testing.T) {
 	require.NoError(t, err)
 
 	i := x.NewInbound()
-	i.SetRouter(new(transporttest.MockRouter))
+	mctrl := gomock.NewController(t)
+	router := transporttest.NewMockRouter(mctrl)
+	router.EXPECT().Procedures().Return(nil)
+	i.SetRouter(router)
 	// Can't do Equal because we want to match the pointer, not a
 	// DeepEqual.
 	assert.True(t, ch == i.Channel(), "channel does not match")
@@ -65,7 +76,10 @@ func TestChannelInboundStartAlreadyListening(t *testing.T) {
 
 	i := x.NewInbound()
 
-	i.SetRouter(new(transporttest.MockRouter))
+	mctrl := gomock.NewController(t)
+	router := transporttest.NewMockRouter(mctrl)
+	router.EXPECT().Procedures().Return(nil)
+	i.SetRouter(router)
 	require.NoError(t, i.Start())
 	require.NoError(t, x.Start())
 	assert.Equal(t, tchannel.ChannelListening, ch.State())
@@ -91,7 +105,10 @@ func TestChannelInboundInvalidAddress(t *testing.T) {
 	require.NoError(t, err)
 
 	i := x.NewInbound()
-	i.SetRouter(new(transporttest.MockRouter))
+	mctrl := gomock.NewController(t)
+	router := transporttest.NewMockRouter(mctrl)
+	router.EXPECT().Procedures().Return(nil)
+	i.SetRouter(router)
 	assert.Nil(t, i.Start())
 	defer i.Stop()
 	assert.Error(t, x.Start())
@@ -112,7 +129,10 @@ func TestChannelInboundExistingMethods(t *testing.T) {
 	require.NoError(t, err)
 
 	i := x.NewInbound()
-	i.SetRouter(new(transporttest.MockRouter))
+	mctrl := gomock.NewController(t)
+	router := transporttest.NewMockRouter(mctrl)
+	router.EXPECT().Procedures().Return(nil)
+	i.SetRouter(router)
 	require.NoError(t, i.Start())
 	defer i.Stop()
 	require.NoError(t, x.Start())
@@ -130,4 +150,76 @@ func TestChannelInboundExistingMethods(t *testing.T) {
 	err = json.CallPeer(ctx, peer, svc, "echo", arg, &resp)
 	require.NoError(t, err, "Call failed")
 	assert.Equal(t, arg, resp, "Response mismatch")
+}
+
+func TestChannelInboundSubServices(t *testing.T) {
+	chserv := testutils.NewServer(t, nil)
+	defer chserv.Close()
+	chservEndpoint := chserv.PeerInfo().HostPort
+
+	itransport, err := NewChannelTransport(ServiceName("myservice"), WithChannel(chserv))
+	require.NoError(t, err)
+
+	router := yarpc.NewMapRouter("myservice")
+
+	i := itransport.NewInbound()
+	i.SetRouter(router)
+
+	nophandlerspec := transport.NewUnaryHandlerSpec(nophandler{})
+
+	router.Register([]transport.Procedure{
+		{Name: "hello", HandlerSpec: nophandlerspec},
+		{Service: "subservice", Name: "hello", HandlerSpec: nophandlerspec},
+		{Service: "subservice", Name: "world", HandlerSpec: nophandlerspec},
+		{Service: "subservice2", Name: "hello", HandlerSpec: nophandlerspec},
+		{Service: "subservice2", Name: "monde", HandlerSpec: nophandlerspec},
+	})
+
+	require.NoError(t, i.Start())
+	require.NoError(t, itransport.Start())
+
+	otransport, err := NewChannelTransport(ServiceName("caller"))
+	require.NoError(t, err)
+	o := otransport.NewSingleOutbound(chservEndpoint)
+
+	require.NoError(t, o.Start())
+	defer o.Stop()
+
+	for _, tt := range []struct {
+		service   string
+		procedure string
+	}{
+		{"myservice", "hello"},
+		{"subservice", "hello"},
+		{"subservice", "world"},
+		{"subservice2", "hello"},
+		{"subservice2", "monde"},
+	} {
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+		res, err := o.Call(
+			ctx,
+			&transport.Request{
+				Caller:    "caller",
+				Service:   tt.service,
+				Procedure: tt.procedure,
+				Encoding:  raw.Encoding,
+				Body:      bytes.NewReader([]byte{}),
+			},
+		)
+		if !assert.NoError(t, err, "failed to make call") {
+			continue
+		}
+		if !assert.Equal(t, false, res.ApplicationError, "not application error") {
+			continue
+		}
+		body, err := ioutil.ReadAll(res.Body)
+		if !assert.NoError(t, err) {
+			continue
+		}
+		assert.Equal(t, string(body), tt.service)
+	}
+
+	require.NoError(t, i.Stop())
+	require.NoError(t, itransport.Stop())
 }

--- a/transport/tchannel/channel_transport.go
+++ b/transport/tchannel/channel_transport.go
@@ -114,9 +114,16 @@ func (t *ChannelTransport) start() error {
 		// dispatcher, or its equivalent, calls SetRouter before Start.
 		// This also means that SetRouter should be called on every inbound
 		// before calling Start on any transport or inbound.
-		sc := t.ch.GetSubChannel(t.ch.ServiceName())
-		existing := sc.GetHandlers()
-		sc.SetHandler(handler{existing: existing, router: t.router, tracer: t.tracer})
+		services := make(map[string]struct{})
+		for _, p := range t.router.Procedures() {
+			services[p.Service] = struct{}{}
+		}
+
+		for s := range services {
+			sc := t.ch.GetSubChannel(s)
+			existing := sc.GetHandlers()
+			sc.SetHandler(handler{existing: existing, router: t.router, tracer: t.tracer})
+		}
 	}
 
 	if t.ch.State() == tchannel.ChannelListening {

--- a/transport/tchannel/inbound_test.go
+++ b/transport/tchannel/inbound_test.go
@@ -21,10 +21,18 @@
 package tchannel
 
 import (
+	"bytes"
+	"context"
+	"io/ioutil"
 	"testing"
+	"time"
 
+	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/api/transport/transporttest"
+	"go.uber.org/yarpc/encoding/raw"
 
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -34,7 +42,10 @@ func TestInboundStartNew(t *testing.T) {
 	require.NoError(t, err)
 
 	i := x.NewInbound()
-	i.SetRouter(new(transporttest.MockRouter))
+	mctrl := gomock.NewController(t)
+	router := transporttest.NewMockRouter(mctrl)
+	router.EXPECT().Procedures().Return(nil)
+	i.SetRouter(router)
 	require.NoError(t, i.Start())
 	require.NoError(t, x.Start())
 	require.NoError(t, i.Stop())
@@ -53,9 +64,90 @@ func TestInboundInvalidAddress(t *testing.T) {
 	require.NoError(t, err)
 
 	i := x.NewInbound()
-	i.SetRouter(new(transporttest.MockRouter))
+	mctrl := gomock.NewController(t)
+	router := transporttest.NewMockRouter(mctrl)
+	router.EXPECT().Procedures().Return(nil)
+	i.SetRouter(router)
 	assert.Nil(t, i.Start())
 	defer i.Stop()
 	assert.Error(t, x.Start())
 	defer x.Stop()
+}
+
+type nophandler struct{}
+
+func (nophandler) Handle(ctx context.Context, req *transport.Request,
+	resw transport.ResponseWriter) error {
+	resw.Write([]byte(req.Service))
+	return nil
+}
+
+func TestInboundSubServices(t *testing.T) {
+	itransport, err := NewTransport(ServiceName("myservice"), ListenAddr("localhost:0"))
+	require.NoError(t, err)
+
+	router := yarpc.NewMapRouter("myservice")
+
+	i := itransport.NewInbound()
+	i.SetRouter(router)
+
+	nophandlerspec := transport.NewUnaryHandlerSpec(nophandler{})
+
+	router.Register([]transport.Procedure{
+		{Name: "hello", HandlerSpec: nophandlerspec},
+		{Service: "subservice", Name: "hello", HandlerSpec: nophandlerspec},
+		{Service: "subservice", Name: "world", HandlerSpec: nophandlerspec},
+		{Service: "subservice2", Name: "hello", HandlerSpec: nophandlerspec},
+		{Service: "subservice2", Name: "monde", HandlerSpec: nophandlerspec},
+	})
+
+	require.NoError(t, i.Start())
+	require.NoError(t, itransport.Start())
+
+	chservEndpoint := itransport.ch.PeerInfo().HostPort
+
+	otransport, err := NewTransport(ServiceName("caller"))
+	require.NoError(t, err)
+	o := otransport.NewSingleOutbound(chservEndpoint)
+
+	require.NoError(t, o.Start())
+	defer o.Stop()
+
+	for _, tt := range []struct {
+		service   string
+		procedure string
+	}{
+		{"myservice", "hello"},
+		{"subservice", "hello"},
+		{"subservice", "world"},
+		{"subservice2", "hello"},
+		{"subservice2", "monde"},
+	} {
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+		res, err := o.Call(
+			ctx,
+			&transport.Request{
+				Caller:    "caller",
+				Service:   tt.service,
+				Procedure: tt.procedure,
+				Encoding:  raw.Encoding,
+				Body:      bytes.NewReader([]byte{}),
+			},
+		)
+		if !assert.NoError(t, err, "failed to make call") {
+			continue
+		}
+		if !assert.Equal(t, false, res.ApplicationError, "not application error") {
+			continue
+		}
+		body, err := ioutil.ReadAll(res.Body)
+		if !assert.NoError(t, err) {
+			continue
+		}
+		assert.Equal(t, string(body), tt.service)
+	}
+
+	require.NoError(t, i.Stop())
+	require.NoError(t, itransport.Stop())
 }

--- a/transport/tchannel/inbound_test.go
+++ b/transport/tchannel/inbound_test.go
@@ -29,10 +29,8 @@ import (
 
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/api/transport/transporttest"
 	"go.uber.org/yarpc/encoding/raw"
 
-	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -42,10 +40,7 @@ func TestInboundStartNew(t *testing.T) {
 	require.NoError(t, err)
 
 	i := x.NewInbound()
-	mctrl := gomock.NewController(t)
-	router := transporttest.NewMockRouter(mctrl)
-	router.EXPECT().Procedures().Return(nil)
-	i.SetRouter(router)
+	i.SetRouter(yarpc.NewMapRouter("foo"))
 	require.NoError(t, i.Start())
 	require.NoError(t, x.Start())
 	require.NoError(t, i.Stop())
@@ -64,10 +59,7 @@ func TestInboundInvalidAddress(t *testing.T) {
 	require.NoError(t, err)
 
 	i := x.NewInbound()
-	mctrl := gomock.NewController(t)
-	router := transporttest.NewMockRouter(mctrl)
-	router.EXPECT().Procedures().Return(nil)
-	i.SetRouter(router)
+	i.SetRouter(yarpc.NewMapRouter("foo"))
 	assert.Nil(t, i.Start())
 	defer i.Stop()
 	assert.Error(t, x.Start())

--- a/transport/tchannel/outbound_test.go
+++ b/transport/tchannel/outbound_test.go
@@ -151,7 +151,6 @@ func TestCallSuccess(t *testing.T) {
 	x, err := NewTransport(ServiceName("caller"))
 	require.NoError(t, err)
 	out := x.NewSingleOutbound(serverHostPort)
-	require.NoError(t, err)
 	require.NoError(t, out.Start(), "failed to start outbound")
 	defer out.Stop()
 

--- a/transport/tchannel/transport.go
+++ b/transport/tchannel/transport.go
@@ -169,9 +169,16 @@ func (t *Transport) start() error {
 		// dispatcher, or its equivalent, calls SetRouter before Start.
 		// This also means that SetRouter should be called on every inbound
 		// before calling Start on any transport or inbound.
-		sc := t.ch.GetSubChannel(t.ch.ServiceName())
-		existing := sc.GetHandlers()
-		sc.SetHandler(handler{existing: existing, router: t.router, tracer: t.tracer})
+		services := make(map[string]struct{})
+		for _, p := range t.router.Procedures() {
+			services[p.Service] = struct{}{}
+		}
+
+		for s := range services {
+			sc := t.ch.GetSubChannel(s)
+			existing := sc.GetHandlers()
+			sc.SetHandler(handler{existing: existing, router: t.router, tracer: t.tracer})
+		}
 	}
 
 	if t.ch.State() == tchannel.ChannelListening {


### PR DESCRIPTION
To be clear:
 - the dispatcher has a Name. This is also the routing key to the process.
 - a disptacher exposes many procedures each namespaced behind a service name.
 - when a procedure doesn't set a service name explicitly, it is set to the
dispatcher name. Effectively we can think of the dispatcher name as the default
service name.

TChannel represents different services via sub-channels. Before we instantiated
only one from the dispatcher name. This patch instantiates one sub-channel for
every services.