### PR TITLE
redis/client: Use transport.Lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ v1.5.0 (unreleased)
 
 -   x/yarpcmeta make it easy to expose the list of procedures and other
     introspection information of a dispatcher on itself.
+-   Redis: `Client` now has an `IsRunning` function to match the `Lifecycle`
+    interface.
 
 v1.4.0 (2017-02-14)
 -----------------------

--- a/transport/x/redis/client.go
+++ b/transport/x/redis/client.go
@@ -20,14 +20,15 @@
 
 package redis
 
-import "time"
+import (
+	"time"
+
+	"go.uber.org/yarpc/api/transport"
+)
 
 // Client is a subset of redis commands used to manage a queue
 type Client interface {
-	// Start creates the connection to redis
-	Start() error
-	// Stop ends the redis connection
-	Stop() error
+	transport.Lifecycle
 
 	// LPush adds item to the queue
 	LPush(queue string, item []byte) error

--- a/transport/x/redis/redistest/client.go
+++ b/transport/x/redis/redistest/client.go
@@ -80,6 +80,16 @@ func (_mr *_MockClientRecorder) Endpoint() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Endpoint")
 }
 
+func (_m *MockClient) IsRunning() bool {
+	ret := _m.ctrl.Call(_m, "IsRunning")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+func (_mr *_MockClientRecorder) IsRunning() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsRunning")
+}
+
 func (_m *MockClient) LPush(_param0 string, _param1 []byte) error {
 	ret := _m.ctrl.Call(_m, "LPush", _param0, _param1)
 	ret0, _ := ret[0].(error)


### PR DESCRIPTION
The only `redis.Client` implementation already implements that
interface.