### PR TITLE
Implement arbitrary interface{} decoder

### DIFF
--- a/encoding/json/outbound.go
+++ b/encoding/json/outbound.go
@@ -85,8 +85,7 @@ func (c jsonClient) Call(ctx context.Context, procedure string, reqBody interfac
 		return err
 	}
 
-	dec := json.NewDecoder(tres.Body)
-	if err := dec.Decode(resBodyOut); err != nil {
+	if err := json.NewDecoder(tres.Body).Decode(resBodyOut); err != nil {
 		return encoding.ResponseBodyDecodeError(&treq, err)
 	}
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: 0907b00470931cc8d88368dd3a88b9396e1f46ff18cd22920703d342d5963280
-updated: 2017-02-13T16:25:47.699945516-05:00
+hash: 1f78c3e930a9c9e5c2f0f80ce79c91ddb216966e60a884795555c8819c9a1a2b
+updated: 2017-02-13T15:01:10.358513497-08:00
 imports:
 - name: github.com/apache/thrift
-  version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
+  version: 4f710aa4f47e051d41c863aa7aa9239dab5b9636
   subpackages:
   - lib/go/thrift
 - name: github.com/cactus/go-statsd-client
@@ -17,7 +17,7 @@ imports:
   - assert
   - require
 - name: github.com/davecgh/go-spew
-  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
+  version: 346938d642f2ec3594ed81d874461961cd0faa76
   subpackages:
   - spew
 - name: github.com/golang/mock
@@ -26,6 +26,8 @@ imports:
   - gomock
 - name: github.com/gorilla/websocket
   version: c36f2fe5c330f0ac404b616b96c438b8616b1aaf
+- name: github.com/mitchellh/mapstructure
+  version: db1efb556f84b25a0a13a04aad883943538ad2e0
 - name: github.com/opentracing/opentracing-go
   version: 6edb48674bd9467b8e91fda004f2bd7202d60ce4
   subpackages:
@@ -125,7 +127,7 @@ imports:
   subpackages:
   - unix
 - name: golang.org/x/tools
-  version: 8524ce5143c569852232960af38dc05cad8c6189
+  version: 6e7ee5a9ec598d425ca86d6aab6e76e21baf328c
   subpackages:
   - go/ast/astutil
 - name: gopkg.in/bsm/ratelimit.v1

--- a/glide.yaml
+++ b/glide.yaml
@@ -32,3 +32,4 @@ import:
 - package: gopkg.in/redis.v5
 # TODO: before cherami transport can leave the x/ package, cherami-client-go must >=1.0
 - package: github.com/uber/cherami-client-go
+- package: github.com/mitchellh/mapstructure

--- a/internal/decode/decode.go
+++ b/internal/decode/decode.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 // Package decode implements a generic interface{} decoder. The intention is
 // to use it to decode arbitrary map[interface{}]interface{} objects into
 // structs or other complex objects.

--- a/internal/decode/decode.go
+++ b/internal/decode/decode.go
@@ -1,0 +1,121 @@
+// Package decode implements a generic interface{} decoder. The intention is
+// to use it to decode arbitrary map[interface{}]interface{} objects into
+// structs or other complex objects.
+package decode
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+const _tagName = "config"
+
+var _typeOfDecoder = reflect.TypeOf((*Decoder)(nil)).Elem()
+
+// Into is a function that attempts to decode the source data into the given
+// destination. dst MUST be a pointer to a value.
+//
+// 	var (
+// 		decode decode.Into = ...
+// 		value map[string]MyStruct
+// 	)
+// 	err := decode(&value)
+type Into func(dst interface{}) error
+
+// Decoder is any type which has custom decoding logic. Types may implement
+// Decode and rely on the given Decode function to read values.
+//
+// For example,
+//
+// 	type StringSet map[string]struct{}
+//
+// 	func (ss *StringSet) Decode(dec decode.Into) error {
+// 		var items []string
+// 		if err := dec(&items); err != nil {
+// 			return err
+// 		}
+//
+// 		*ss = make(map[string]struct{})
+// 		for _, item := range items {
+// 			(*ss)[item] = struct{}{}
+// 		}
+// 		return nil
+// 	}
+type Decoder interface {
+	// Decode receives a function that will attempt to decode the source data
+	// into the given target. The argument MUST be a pointer to the target
+	// object.
+	Decode(Into) error
+}
+
+// Decode from src into dst. dst may implement Decoder to customize how src is
+// read into it.
+func Decode(dst, src interface{}) error {
+	return decodeFrom(src)(dst)
+}
+
+// decodeFrom builds a decode Into function that reads the given value into
+// the destination.
+func decodeFrom(src interface{}) Into {
+	return func(dst interface{}) error {
+		cfg := mapstructure.DecoderConfig{
+			ErrorUnused: true,
+			Result:      dst,
+			DecodeHook: mapstructure.ComposeDecodeHookFunc(
+				mapstructure.StringToTimeDurationHookFunc(),
+				decoderDecodeHook,
+			),
+			TagName: _tagName,
+		}
+
+		dec, err := mapstructure.NewDecoder(&cfg)
+		if err != nil {
+			return fmt.Errorf("failed to set up decoder: %v", err)
+		}
+
+		return dec.Decode(src)
+	}
+}
+
+// decoderDecodeHook is a DecodeHook for mapstructure which recognizes types
+// that implement the Decoder interface.
+func decoderDecodeHook(from, to reflect.Type, data interface{}) (interface{}, error) {
+	switch {
+	case from == to:
+		// Decoding from the same type
+		return data, nil
+	case from == reflect.PtrTo(to):
+		// Decoding from a pointer to the target type
+		value := reflect.New(to).Elem()
+		value.Set(reflect.ValueOf(data).Elem())
+		return value.Interface(), nil
+	case reflect.PtrTo(from) == to:
+		// Decoding from a value to a pointer of the target type
+		value := reflect.New(to.Elem())
+		value.Elem().Set(reflect.ValueOf(data))
+		return value.Interface(), nil
+	}
+
+	var (
+		value reflect.Value
+		dec   Decoder
+	)
+
+	if to.Kind() == reflect.Ptr && to.Implements(_typeOfDecoder) {
+		value = reflect.New(to.Elem())
+		dec = value.Interface().(Decoder)
+	} else if reflect.PtrTo(to).Implements(_typeOfDecoder) {
+		value = reflect.New(to).Elem()
+		dec = value.Addr().Interface().(Decoder)
+	} else {
+		return data, nil
+	}
+
+	err := dec.Decode(decodeFrom(data))
+	if err != nil {
+		err = fmt.Errorf("could not decode %v: %v", to, err)
+	}
+	return value.Interface(), err
+}

--- a/internal/decode/decode.go
+++ b/internal/decode/decode.go
@@ -47,9 +47,9 @@ func Decode(dest, src interface{}) error {
 //
 // 	type StringSet map[string]struct{}
 //
-// 	func (ss *StringSet) Decode(dec decode.Into) error {
+// 	func (ss *StringSet) Decode(into decode.Into) error {
 // 		var items []string
-// 		if err := dec(&items); err != nil {
+// 		if err := into(&items); err != nil {
 // 			return err
 // 		}
 //
@@ -90,12 +90,12 @@ func decodeFrom(src interface{}) Into {
 			TagName: _tagName,
 		}
 
-		dec, err := mapstructure.NewDecoder(&cfg)
+		decoder, err := mapstructure.NewDecoder(&cfg)
 		if err != nil {
 			return fmt.Errorf("failed to set up decoder: %v", err)
 		}
 
-		return dec.Decode(src)
+		return decoder.Decode(src)
 	}
 }
 

--- a/internal/decode/decode.go
+++ b/internal/decode/decode.go
@@ -216,9 +216,10 @@ func _decoderDecodeHook(from, to reflect.Type, data reflect.Value) (reflect.Valu
 		return data, nil
 	}
 
-	// value := new(foo)
-	// err := value.Decode(...)
-	// return *value, err
+	// The following lines are roughly equivalent to,
+	// 	value := new(foo)
+	// 	err := value.Decode(...)
+	// 	return *value, err
 	value := reflect.New(to)
 	err := value.Interface().(Decoder).Decode(decodeFrom(data.Interface()))
 	if err != nil {

--- a/internal/decode/decode_example_test.go
+++ b/internal/decode/decode_example_test.go
@@ -1,0 +1,60 @@
+package decode
+
+import (
+	"fmt"
+	"log"
+	"sort"
+)
+
+func ExampleDecode() {
+	type Item struct {
+		Key   string `config:"name"`
+		Value string
+	}
+
+	var item Item
+	err := Decode(&item, map[string]interface{}{
+		"name":  "foo",
+		"value": "bar",
+	})
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(item.Key, item.Value)
+	// Output: foo bar
+}
+
+type StringSet map[string]struct{}
+
+func (ss *StringSet) Decode(decode Into) error {
+	var items []string
+	if err := decode(&items); err != nil {
+		return err
+	}
+
+	*ss = make(map[string]struct{})
+	for _, item := range items {
+		(*ss)[item] = struct{}{}
+	}
+	return nil
+}
+
+func ExampleDecode_decoder() {
+	var ss StringSet
+
+	err := Decode(&ss, []interface{}{"foo", "bar", "foo", "baz"})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var items []string
+	for item := range ss {
+		items = append(items, item)
+	}
+	sort.Strings(items)
+
+	fmt.Println(items)
+	// Output: [bar baz foo]
+}

--- a/internal/decode/decode_test.go
+++ b/internal/decode/decode_test.go
@@ -10,9 +10,9 @@ import (
 
 type stringSet map[string]struct{}
 
-func (ss *stringSet) Decode(dec Into) error {
+func (ss *stringSet) Decode(into Into) error {
 	var items []string
-	if err := dec(&items); err != nil {
+	if err := into(&items); err != nil {
 		return err
 	}
 

--- a/internal/decode/decode_test.go
+++ b/internal/decode/decode_test.go
@@ -1,0 +1,168 @@
+package decode
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type stringSet map[string]struct{}
+
+func (ss *stringSet) Decode(dec Into) error {
+	var items []string
+	if err := dec(&items); err != nil {
+		return err
+	}
+
+	result := make(stringSet)
+	for _, item := range items {
+		result[item] = struct{}{}
+	}
+	*ss = result
+
+	return nil
+}
+
+type sadDecoder struct{}
+
+func (*sadDecoder) Decode(Into) error {
+	return errors.New("great sadness")
+}
+
+func TestDecode(t *testing.T) {
+	someInt := 42
+	ptrToInt := &someInt
+
+	someString := "hello world"
+	ptrToString := &someString
+
+	someStringSet := stringSet{"hello": {}, "world": {}}
+	ptrToStringSet := &someStringSet
+
+	someTimeout := 4*time.Second + 2*time.Millisecond
+
+	type someStruct struct {
+		Int              int
+		PtrToString      *string
+		PtrToPtrToString **string
+		SomeValue        float64 `config:"some_value"`
+		Timeout          time.Duration
+		PtrToTimeout     *time.Duration
+
+		StringSet           stringSet
+		PtrToStringSet      *stringSet
+		PtrToPtrToStringSet **stringSet
+
+		AlwaysFails *sadDecoder
+	}
+
+	tests := []struct {
+		desc string
+		give interface{}
+
+		want       someStruct
+		wantErrors []string
+	}{
+		{
+			desc: "nil",
+			give: nil,
+		},
+		{
+			desc: "nil value",
+			give: map[interface{}]interface{}{"int": nil},
+		},
+		{
+			desc: "int to int",
+			give: map[string]int{"int": someInt},
+			want: someStruct{Int: someInt},
+		},
+		{
+			desc: "*int to int",
+			give: map[interface{}]interface{}{
+				"int": ptrToInt,
+			},
+			want: someStruct{Int: someInt},
+		},
+		{
+			desc: "string to *string",
+			give: map[interface{}]interface{}{
+				"ptrToString": someString,
+			},
+			want: someStruct{PtrToString: ptrToString},
+		},
+		{
+			desc: "int to string",
+			give: map[string]string{"int": "42"},
+			wantErrors: []string{
+				"'Int' expected type 'int', got unconvertible type 'string'",
+			},
+		},
+		{
+			desc: "**int to int",
+			give: map[interface{}]interface{}{"int": &ptrToInt},
+			want: someStruct{Int: someInt},
+		},
+		{
+			desc: "string to **string",
+			give: map[interface{}]interface{}{"ptrToPtrToString": someString},
+			want: someStruct{PtrToPtrToString: &ptrToString},
+		},
+		{
+			desc: "config tag",
+			give: map[string]interface{}{"some_value": 42.0},
+			want: someStruct{SomeValue: 42.0},
+		},
+		{
+			desc: "stringSet",
+			give: map[string]interface{}{"stringSet": []string{"hello", "world"}},
+			want: someStruct{StringSet: someStringSet},
+		},
+		{
+			desc: "*stringSet",
+			give: map[string]interface{}{"ptrToStringSet": []string{"hello", "world"}},
+			want: someStruct{PtrToStringSet: ptrToStringSet},
+		},
+		{
+			desc: "**stringSet",
+			give: map[interface{}]interface{}{"ptrToPtrToStringSet": []string{"hello", "world"}},
+			want: someStruct{PtrToPtrToStringSet: &ptrToStringSet},
+		},
+		{
+			desc: "decode failure",
+			give: map[interface{}]interface{}{"alwaysFails": struct{}{}},
+			wantErrors: []string{
+				"error decoding 'AlwaysFails': could not decode decode.sadDecoder from struct {}: great sadness",
+			},
+		},
+		{
+			desc: "time.Duration",
+			give: map[interface{}]interface{}{"timeout": "4s2ms"},
+			want: someStruct{Timeout: someTimeout},
+		},
+		{
+			desc: "*time.Duration",
+			give: map[interface{}]interface{}{"ptrToTimeout": "4s2ms"},
+			want: someStruct{PtrToTimeout: &someTimeout},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var dest someStruct
+			err := Decode(&dest, tt.give)
+
+			if len(tt.wantErrors) == 0 {
+				assert.NoError(t, err, "expected success")
+				assert.Equal(t, tt.want, dest, "result mismatch")
+				return
+			}
+
+			assert.Error(t, err, "expected error")
+			for _, msg := range tt.wantErrors {
+				assert.Contains(t, err.Error(), msg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This implements an internal `decode` package that allows us to decode
any `interface{}` (more specifically, `map[interface{}]interface{}`)
into a more complex object.

This mostly relies on the `mapstructure` library for most of its
functionality with the exception of a custom `Decoder` interface which
types may implement for more complex decoding logic. This is very
similar to the `yaml.Unmarshaler` interface and how that behaves.

We will use this package for the config system to allow decoding
user-provided configurations (in `map[string]interface{}` form) into
something more complex which we need to build a `yarpc.Config`.