### PR TITLE
config: Add HTTP transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ v1.8.0 (unreleased)
 -   x/config: Configuration structures may now annotate primitive fields with
     `config:",interpolate"` to support reading environment variables in them.
     See the `TransportSpec` documentation for more information.
+-   http: Added support for configuring the HTTP transport using x/config.
 -   Options `thrift.Multiplexed` and `thrift.Enveloped` may now be provided for
     Thrift clients constructed by `yarpc.InjectClients` by adding a `thrift`
     tag to the corresponding struct field with the name of the option. See the

--- a/transport/http/config.go
+++ b/transport/http/config.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package http
+
+import (
+	"fmt"
+	"time"
+
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/x/config"
+)
+
+// TransportConfig configures the shared HTTP Transport. This is shared
+// between all HTTP outbounds and inbounds of a Dispatcher.
+//
+// 	transports:
+// 	  http:
+// 	    keepAlive: 30s
+//
+// All parameters of TransportConfig are optional. This section may be omitted
+// in the transports section.
+type TransportConfig struct {
+	// Specifies the keep-alive period for all HTTP clients. This field is
+	// optional.
+	KeepAlive time.Duration `config:"keepAlive"`
+}
+
+func buildTransport(tc *TransportConfig) (transport.Transport, error) {
+	var opts []TransportOption
+	if tc.KeepAlive > 0 {
+		opts = append(opts, KeepAlive(tc.KeepAlive))
+	}
+	return NewTransport(opts...), nil
+}
+
+// InboundConfig configures an HTTP inbound.
+//
+// 	inbounds:
+// 	  http:
+// 	    address: ":80"
+type InboundConfig struct {
+	// Address to listen on. This field is required.
+	Address string `config:"address"`
+}
+
+func buildInbound(ic *InboundConfig, t transport.Transport) (transport.Inbound, error) {
+	if ic.Address == "" {
+		return nil, fmt.Errorf("inbound address is required")
+	}
+	return t.(*Transport).NewInbound(ic.Address), nil
+}
+
+// OutboundConfig configures an HTTP outbound.
+//
+// 	outbounds:
+// 	  keyvalueservice:
+// 	    http:
+// 	      url: "http://127.0.0.1:80/"
+//
+// The HTTP outbound supports both, Unary and Oneway transport types. To use
+// it for only one of these, nest the section inside a "unary" or "onewy"
+// section.
+//
+// 	outbounds:
+// 	  keyvalueservice:
+// 	    unary:
+// 	      http:
+// 	        url: "http://127.0.0.1:80/"
+type OutboundConfig struct {
+	// URL to which requests will be sent for this outbound. This field is
+	// required.
+	URL string `config:"url"`
+}
+
+func buildOutbound(oc *OutboundConfig, t transport.Transport) (*Outbound, error) {
+	return t.(*Transport).NewSingleOutbound(oc.URL), nil
+}
+
+func buildUnaryOutbound(oc *OutboundConfig, t transport.Transport) (transport.UnaryOutbound, error) {
+	return buildOutbound(oc, t)
+}
+
+func buildOnewayOutbound(oc *OutboundConfig, t transport.Transport) (transport.OnewayOutbound, error) {
+	return buildOutbound(oc, t)
+}
+
+// TransportSpec returns a TransportSpec for the HTTP transport.
+//
+// See TransportConfig, InboundConfig, and OutboundConfig for details on the
+// different configuration parameters supported by this Transport.
+func TransportSpec() config.TransportSpec {
+	// TODO: Presets. Support "with:" and allow passing those in using
+	// varargs on TransportSpec().
+	return config.TransportSpec{
+		Name:                "http",
+		BuildTransport:      buildTransport,
+		BuildInbound:        buildInbound,
+		BuildUnaryOutbound:  buildUnaryOutbound,
+		BuildOnewayOutbound: buildOnewayOutbound,
+	}
+}

--- a/transport/http/config.go
+++ b/transport/http/config.go
@@ -91,7 +91,7 @@ type TransportConfig struct {
 	KeepAlive time.Duration `config:"keepAlive"`
 }
 
-func (ts *transportSpec) buildTransport(tc *TransportConfig) (transport.Transport, error) {
+func (ts *transportSpec) buildTransport(tc *TransportConfig, k *config.Kit) (transport.Transport, error) {
 	opts := ts.TransportOptions
 	if tc.KeepAlive > 0 {
 		opts = append(opts, KeepAlive(tc.KeepAlive))
@@ -109,7 +109,7 @@ type InboundConfig struct {
 	Address string `config:"address"`
 }
 
-func (ts *transportSpec) buildInbound(ic *InboundConfig, t transport.Transport) (transport.Inbound, error) {
+func (ts *transportSpec) buildInbound(ic *InboundConfig, t transport.Transport, k *config.Kit) (transport.Inbound, error) {
 	if ic.Address == "" {
 		return nil, fmt.Errorf("inbound address is required")
 	}
@@ -138,14 +138,14 @@ type OutboundConfig struct {
 	URL string `config:"url"`
 }
 
-func (ts *transportSpec) buildOutbound(oc *OutboundConfig, t transport.Transport) (*Outbound, error) {
+func (ts *transportSpec) buildOutbound(oc *OutboundConfig, t transport.Transport, k *config.Kit) (*Outbound, error) {
 	return t.(*Transport).NewSingleOutbound(oc.URL, ts.OutboundOptions...), nil
 }
 
-func (ts *transportSpec) buildUnaryOutbound(oc *OutboundConfig, t transport.Transport) (transport.UnaryOutbound, error) {
-	return ts.buildOutbound(oc, t)
+func (ts *transportSpec) buildUnaryOutbound(oc *OutboundConfig, t transport.Transport, k *config.Kit) (transport.UnaryOutbound, error) {
+	return ts.buildOutbound(oc, t, k)
 }
 
-func (ts *transportSpec) buildOnewayOutbound(oc *OutboundConfig, t transport.Transport) (transport.OnewayOutbound, error) {
-	return ts.buildOutbound(oc, t)
+func (ts *transportSpec) buildOnewayOutbound(oc *OutboundConfig, t transport.Transport, k *config.Kit) (transport.OnewayOutbound, error) {
+	return ts.buildOutbound(oc, t, k)
 }

--- a/transport/http/config.go
+++ b/transport/http/config.go
@@ -106,7 +106,7 @@ func (ts *transportSpec) buildTransport(tc *TransportConfig, k *config.Kit) (tra
 // 	    address: ":80"
 type InboundConfig struct {
 	// Address to listen on. This field is required.
-	Address string `config:"address"`
+	Address string `config:"address,interpolate"`
 }
 
 func (ts *transportSpec) buildInbound(ic *InboundConfig, t transport.Transport, k *config.Kit) (transport.Inbound, error) {
@@ -135,7 +135,7 @@ func (ts *transportSpec) buildInbound(ic *InboundConfig, t transport.Transport, 
 type OutboundConfig struct {
 	// URL to which requests will be sent for this outbound. This field is
 	// required.
-	URL string `config:"url"`
+	URL string `config:"url,interpolate"`
 }
 
 func (ts *transportSpec) buildOutbound(oc *OutboundConfig, t transport.Transport, k *config.Kit) (*Outbound, error) {

--- a/transport/http/config.go
+++ b/transport/http/config.go
@@ -68,7 +68,7 @@ type transportSpec struct {
 
 func (ts *transportSpec) Spec() config.TransportSpec {
 	return config.TransportSpec{
-		Name:                "http",
+		Name:                transportName,
 		BuildTransport:      ts.buildTransport,
 		BuildInbound:        ts.buildInbound,
 		BuildUnaryOutbound:  ts.buildUnaryOutbound,

--- a/transport/http/constants.go
+++ b/transport/http/constants.go
@@ -20,6 +20,8 @@
 
 package http
 
+const transportName = "http"
+
 // HTTP headers used in requests and responses to send YARPC metadata.
 const (
 	// Name of the service sending the request. This corresponds to the

--- a/transport/http/doc.go
+++ b/transport/http/doc.go
@@ -51,6 +51,12 @@
 // Note that stopping an HTTP transport does NOT immediately terminate ongoing
 // requests. Connections will remain open until all clients have disconnected.
 //
+// Configuration
+//
+// An HTTP Transport may be configured using YARPC's configuration system. See
+// TransportConfig, InboundConfig, and OutboundConfig for details on the
+// different configuration parameters supported by this transport.
+//
 // Wire Representation
 //
 // YARPC requests and responses are sent as plain HTTP requests and responses.


### PR DESCRIPTION
This adds support for the HTTP transport to the config system defined in
#747.

Depends on #746, #747, #812 