### PR TITLE
config: Add TChannel transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ v1.8.0 (unreleased)
     `config:",interpolate"` to support reading environment variables in them.
     See the `TransportSpec` documentation for more information.
 -   http: Added support for configuring the HTTP transport using x/config.
+-   tchannel: Added support for configuring the TChannel transport using
+    x/config.
 -   Options `thrift.Multiplexed` and `thrift.Enveloped` may now be provided for
     Thrift clients constructed by `yarpc.InjectClients` by adding a `thrift`
     tag to the corresponding struct field with the name of the option. See the

--- a/transport/tchannel/config.go
+++ b/transport/tchannel/config.go
@@ -52,7 +52,7 @@ func TransportSpec() config.TransportSpec {
 	}
 }
 
-func buildTransport(tc *TransportConfig) (transport.Transport, error) {
+func buildTransport(tc *TransportConfig, k *config.Kit) (transport.Transport, error) {
 	var opts []TransportOption
 	if tc.Address != "" {
 		opts = append(opts, ListenAddr(tc.Address))
@@ -63,11 +63,11 @@ func buildTransport(tc *TransportConfig) (transport.Transport, error) {
 	return NewTransport(opts...)
 }
 
-func buildInbound(_ *InboundConfig, t transport.Transport) (transport.Inbound, error) {
+func buildInbound(_ *InboundConfig, t transport.Transport, k *config.Kit) (transport.Inbound, error) {
 	return t.(*Transport).NewInbound(), nil
 }
 
-func buildUnaryOutbound(oc *OutboundConfig, t transport.Transport) (transport.UnaryOutbound, error) {
+func buildUnaryOutbound(oc *OutboundConfig, t transport.Transport, k *config.Kit) (transport.UnaryOutbound, error) {
 	return t.(*Transport).NewSingleOutbound(oc.Address), nil
 }
 

--- a/transport/tchannel/config.go
+++ b/transport/tchannel/config.go
@@ -25,6 +25,8 @@ import (
 	"go.uber.org/yarpc/x/config"
 )
 
+const transportName = "tchannel"
+
 // TransportConfig configures a shared TChannel transport. This is shared
 // between all TChannel outbounds and inbounds of a Dispatcher.
 //
@@ -61,7 +63,7 @@ type OutboundConfig struct {
 // various supported configuration parameters.
 func TransportSpec() config.TransportSpec {
 	return config.TransportSpec{
-		Name:               "tchannel",
+		Name:               transportName,
 		BuildTransport:     buildTransport,
 		BuildInbound:       buildInbound,
 		BuildUnaryOutbound: buildUnaryOutbound,

--- a/transport/tchannel/config.go
+++ b/transport/tchannel/config.go
@@ -27,15 +27,31 @@ import (
 
 // TransportConfig configures a shared TChannel transport. This is shared
 // between all TChannel outbounds and inbounds of a Dispatcher.
+//
+// 	transports:
+// 	  tchannel:
+// 	    address: :4040
 type TransportConfig struct {
+	// Address to listen on. Defaults to ":0" (all network interfaces and a
+	// random OS-assigned port).
 	Address string `config:"address,interpolate"`
+
+	// Name of the service for TChannel. This may be omitted to use the
+	// Dispatcher's service name.
 	Service string `config:"service,interpolate"`
 }
 
 // InboundConfig configures a TChannel inbound.
+//
+// TChannel inbounds do not support any configuration parameters at this time.
 type InboundConfig struct{}
 
 // OutboundConfig configures a TChannel outbound.
+//
+// 	outbounds:
+// 	  myservice:
+// 	    tchannel:
+// 	      address: 127.0.0.1:4040
 type OutboundConfig struct {
 	Address string `config:"address,interpolate"`
 }

--- a/transport/tchannel/config.go
+++ b/transport/tchannel/config.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tchannel
+
+import (
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/x/config"
+)
+
+// TransportConfig configures a shared TChannel transport. This is shared
+// between all TChannel outbounds and inbounds of a Dispatcher.
+type TransportConfig struct {
+	Address string `config:"address"`
+	Service string `config:"service"`
+}
+
+// InboundConfig configures a TChannel inbound.
+type InboundConfig struct{}
+
+// OutboundConfig configures a TChannel outbound.
+type OutboundConfig struct {
+	Address string `config:"address"`
+}
+
+// TransportSpec returns a TransportSpec for the TChannel unary transport. See
+// TransportConfig, InboundConfig, and OutboundConfig for details on the
+// various supported configuration parameters.
+func TransportSpec() config.TransportSpec {
+	return config.TransportSpec{
+		Name:               "tchannel",
+		BuildTransport:     buildTransport,
+		BuildInbound:       buildInbound,
+		BuildUnaryOutbound: buildUnaryOutbound,
+	}
+}
+
+func buildTransport(tc *TransportConfig) (transport.Transport, error) {
+	var opts []TransportOption
+	if tc.Address != "" {
+		opts = append(opts, ListenAddr(tc.Address))
+	}
+	if tc.Service != "" {
+		opts = append(opts, ServiceName(tc.Service))
+	}
+	return NewTransport(opts...)
+}
+
+func buildInbound(_ *InboundConfig, t transport.Transport) (transport.Inbound, error) {
+	return t.(*Transport).NewInbound(), nil
+}
+
+func buildUnaryOutbound(oc *OutboundConfig, t transport.Transport) (transport.UnaryOutbound, error) {
+	return t.(*Transport).NewSingleOutbound(oc.Address), nil
+}
+
+// TODO: Document configuration parameters

--- a/transport/tchannel/config.go
+++ b/transport/tchannel/config.go
@@ -28,8 +28,8 @@ import (
 // TransportConfig configures a shared TChannel transport. This is shared
 // between all TChannel outbounds and inbounds of a Dispatcher.
 type TransportConfig struct {
-	Address string `config:"address"`
-	Service string `config:"service"`
+	Address string `config:"address,interpolate"`
+	Service string `config:"service,interpolate"`
 }
 
 // InboundConfig configures a TChannel inbound.
@@ -37,7 +37,7 @@ type InboundConfig struct{}
 
 // OutboundConfig configures a TChannel outbound.
 type OutboundConfig struct {
-	Address string `config:"address"`
+	Address string `config:"address,interpolate"`
 }
 
 // TransportSpec returns a TransportSpec for the TChannel unary transport. See

--- a/transport/tchannel/config.go
+++ b/transport/tchannel/config.go
@@ -37,10 +37,6 @@ type TransportConfig struct {
 	// Address to listen on. Defaults to ":0" (all network interfaces and a
 	// random OS-assigned port).
 	Address string `config:"address,interpolate"`
-
-	// Name of the service for TChannel. This may be omitted to use the
-	// Dispatcher's service name.
-	Service string `config:"service,interpolate"`
 }
 
 // InboundConfig configures a TChannel inbound.
@@ -71,12 +67,9 @@ func TransportSpec() config.TransportSpec {
 }
 
 func buildTransport(tc *TransportConfig, k *config.Kit) (transport.Transport, error) {
-	var opts []TransportOption
+	opts := []TransportOption{ServiceName(k.ServiceName())}
 	if tc.Address != "" {
 		opts = append(opts, ListenAddr(tc.Address))
-	}
-	if tc.Service != "" {
-		opts = append(opts, ServiceName(tc.Service))
 	}
 	return NewTransport(opts...)
 }

--- a/transport/tchannel/doc.go
+++ b/transport/tchannel/doc.go
@@ -54,4 +54,10 @@
 // 			{Unary: myserviceOutbound},
 // 		},
 // 	})
+//
+// Configuration
+//
+// A TChannel transport may be configured using YARPC's configuration system.
+// See TransportConfig, InboundConfig, and OutboundConfig for details on the
+// different configuration parameters supported by this transport.
 package tchannel


### PR DESCRIPTION
This adds support for the TChannel transport to the config system defined in #747.

Depends on #746, #747