### PR TITLE
generate.sh: Make updateLicenses.sh separate

### DIFF
--- a/internal/introspection/dispatcher.go
+++ b/internal/introspection/dispatcher.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/internal/introspection/router.go
+++ b/internal/introspection/router.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -2,13 +2,6 @@
 
 set -euo pipefail
 
-# Regular expression for file paths that don't need licenses.
-#
-# We need to ignore internal/tests for licenses so that the golden test for
-# thriftrw-plugin-yarpc can verify the contents of the generated code without
-# running updateLicenses on it.
-LICENSE_FILTER="/internal/tests/"
-
 DIR="$(cd "$(dirname "${0}")/.." && pwd)"
 cd "${DIR}"
 
@@ -61,8 +54,4 @@ touch internal/crossdock/thrift/gen-go/echo/.nocover
 touch internal/crossdock/thrift/gen-go/gauntlet_apache/.nocover
 touch internal/crossdock/thrift/gen-go/gauntlet_tchannel/.nocover
 
-# this must come at the end
-python scripts/updateLicense.py $(go list -json $(glide nv) | \
-	jq -r '.Dir + "/" + (.GoFiles | .[]) | select(test("'"$LICENSE_FILTER"'") | not)')
-rm -rf internal/crossdock/thrift/gen-go/gauntlet_apache/second_service-remote # generated and not needed
-rm -rf internal/crossdock/thrift/gen-go/gauntlet_apache/thrift_test-remote # generated and not needed
+scripts/updateLicenses.sh

--- a/scripts/updateLicenses.sh
+++ b/scripts/updateLicenses.sh
@@ -2,4 +2,17 @@
 
 set -e
 
-python "$(dirname $0)"/updateLicense.py $(go list -json $(glide nv) | jq -r '.Dir + "/" + (.GoFiles | .[])')
+# Regular expression for file paths that don't need licenses.
+#
+# We need to ignore internal/tests for licenses so that the golden test for
+# thriftrw-plugin-yarpc can verify the contents of the generated code without
+# running updateLicenses on it.
+LICENSE_FILTER="/internal/tests/"
+
+DIR="$(cd "$(dirname "${0}")/.." && pwd)"
+cd "${DIR}"
+
+python scripts/updateLicense.py $(go list -json $(glide nv) | \
+	jq -r '.Dir + "/" + (.GoFiles | .[]) | select(test("'"$LICENSE_FILTER"'") | not)')
+rm -rf internal/crossdock/thrift/gen-go/gauntlet_apache/second_service-remote # generated and not needed
+rm -rf internal/crossdock/thrift/gen-go/gauntlet_apache/thrift_test-remote # generated and not needed


### PR DESCRIPTION
For cases where you want to update the license headers but don't want to
wait for `make generate`.