### PR TITLE
Use sync.Pool for thrift byte reads

### DIFF
--- a/encoding/thrift/inbound.go
+++ b/encoding/thrift/inbound.go
@@ -23,7 +23,6 @@ package thrift
 import (
 	"bytes"
 	"context"
-	"io"
 
 	encodingapi "go.uber.org/yarpc/api/encoding"
 	"go.uber.org/yarpc/api/transport"
@@ -60,7 +59,7 @@ func (t thriftUnaryHandler) Handle(ctx context.Context, treq *transport.Request,
 
 	buf := buffer.Get()
 	defer buffer.Put(buf)
-	if _, err := io.Copy(buf, treq.Body); err != nil {
+	if _, err := buf.ReadFrom(treq.Body); err != nil {
 		return err
 	}
 
@@ -133,7 +132,7 @@ func (t thriftOnewayHandler) HandleOneway(ctx context.Context, treq *transport.R
 
 	buf := buffer.Get()
 	defer buffer.Put(buf)
-	if _, err := io.Copy(buf, treq.Body); err != nil {
+	if _, err := buf.ReadFrom(treq.Body); err != nil {
 		return err
 	}
 

--- a/encoding/thrift/inbound.go
+++ b/encoding/thrift/inbound.go
@@ -59,9 +59,8 @@ func (t thriftUnaryHandler) Handle(ctx context.Context, treq *transport.Request,
 	}
 
 	buf := buffer.Get()
-	_, err := io.Copy(buf, treq.Body)
 	defer buffer.Put(buf)
-	if err != nil {
+	if _, err := io.Copy(buf, treq.Body); err != nil {
 		return err
 	}
 
@@ -133,9 +132,8 @@ func (t thriftOnewayHandler) HandleOneway(ctx context.Context, treq *transport.R
 	}
 
 	buf := buffer.Get()
-	_, err := io.Copy(buf, treq.Body)
 	defer buffer.Put(buf)
-	if err != nil {
+	if _, err := io.Copy(buf, treq.Body); err != nil {
 		return err
 	}
 

--- a/encoding/thrift/outbound.go
+++ b/encoding/thrift/outbound.go
@@ -24,12 +24,13 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"go.uber.org/yarpc"
 	encodingapi "go.uber.org/yarpc/api/encoding"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/thrift/internal"
+	"go.uber.org/yarpc/internal/buffer"
 	"go.uber.org/yarpc/internal/encoding"
 
 	"go.uber.org/thriftrw/envelope"
@@ -146,12 +147,13 @@ func (c thriftClient) Call(ctx context.Context, reqBody envelope.Enveloper, opts
 		return wire.Value{}, err
 	}
 
-	payload, err := ioutil.ReadAll(tres.Body)
-	if err != nil {
+	buf := buffer.Get()
+	defer buffer.Put(buf)
+	if _, err = io.Copy(buf, tres.Body); err != nil {
 		return wire.Value{}, err
 	}
 
-	envelope, err := proto.DecodeEnveloped(bytes.NewReader(payload))
+	envelope, err := proto.DecodeEnveloped(bytes.NewReader(buf.Bytes()))
 	if err != nil {
 		return wire.Value{}, encoding.ResponseBodyDecodeError(treq, err)
 	}

--- a/encoding/thrift/outbound.go
+++ b/encoding/thrift/outbound.go
@@ -24,7 +24,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 
 	"go.uber.org/yarpc"
 	encodingapi "go.uber.org/yarpc/api/encoding"
@@ -149,7 +148,7 @@ func (c thriftClient) Call(ctx context.Context, reqBody envelope.Enveloper, opts
 
 	buf := buffer.Get()
 	defer buffer.Put(buf)
-	if _, err = io.Copy(buf, tres.Body); err != nil {
+	if _, err = buf.ReadFrom(tres.Body); err != nil {
 		return wire.Value{}, err
 	}
 

--- a/internal/buffer/pool.go
+++ b/internal/buffer/pool.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 )
 
-var _max_capacity = 1024 * 100 // The max capacity for a buffer is 100 KiB
+var _maxCapacity = 1024 * 100 // The max capacity for a buffer is 100 KiB
 var _pool = sync.Pool{
 	New: func() interface{} {
 		return &bytes.Buffer{}
@@ -22,7 +22,7 @@ func Get() *bytes.Buffer {
 
 // Put returns byte buffer to the buffer pool
 func Put(buf *bytes.Buffer) {
-	if buf.Cap() < _max_capacity {
+	if buf.Cap() < _maxCapacity {
 		_pool.Put(buf)
 	}
 }

--- a/internal/buffer/pool.go
+++ b/internal/buffer/pool.go
@@ -1,0 +1,25 @@
+package buffer
+
+import (
+	"bytes"
+	"sync"
+)
+
+var _pool = sync.Pool{
+	New: func() interface{} {
+		return &bytes.Buffer{}
+	},
+}
+
+// Get returns a new Byte Buffer from the buffer pool
+// that has been reset
+func Get() *bytes.Buffer {
+	buf := _pool.Get().(*bytes.Buffer)
+	buf.Reset()
+	return buf
+}
+
+// Put returns byte buffer to the buffer pool
+func Put(buf *bytes.Buffer) {
+	_pool.Put(buf)
+}

--- a/internal/buffer/pool.go
+++ b/internal/buffer/pool.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 )
 
+var _max_capacity = 1024 * 100 // The max capacity for a buffer is 100 KiB
 var _pool = sync.Pool{
 	New: func() interface{} {
 		return &bytes.Buffer{}
@@ -21,5 +22,7 @@ func Get() *bytes.Buffer {
 
 // Put returns byte buffer to the buffer pool
 func Put(buf *bytes.Buffer) {
-	_pool.Put(buf)
+	if buf.Cap() < _max_capacity {
+		_pool.Put(buf)
+	}
 }

--- a/internal/buffer/pool_test.go
+++ b/internal/buffer/pool_test.go
@@ -1,0 +1,37 @@
+package buffer
+
+import (
+	"math/rand"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuffers(t *testing.T) {
+	var wg sync.WaitGroup
+	for g := 0; g < 10; g++ {
+		wg.Add(1)
+		go func() {
+			for i := 0; i < 100; i++ {
+				buf := Get()
+				assert.Zero(t, buf.Len(), "Expected truncated buffer")
+
+				b := getRandBytes()
+				buf.Write(b)
+
+				assert.Equal(t, buf.Len(), len(b), "Expected same buffer size")
+
+				Put(buf)
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+}
+
+func getRandBytes() []byte {
+	b := make([]byte, rand.Intn(5000))
+	rand.Read(b)
+	return b
+}

--- a/internal/buffer/pool_test.go
+++ b/internal/buffer/pool_test.go
@@ -41,9 +41,9 @@ func TestBufferWithMaxCapacity(t *testing.T) {
 			for i := 0; i < 100; i++ {
 				buf := Get()
 				assert.Zero(t, buf.Len(), "Expected truncated buffer")
-				assert.True(t, buf.Cap() < _max_capacity, "Expected buffer to not exceed the max capacity")
+				assert.True(t, buf.Cap() < _maxCapacity, "Expected buffer to not exceed the max capacity")
 
-				overCapacityByteSlice := make([]byte, _max_capacity+10)
+				overCapacityByteSlice := make([]byte, _maxCapacity+10)
 				_, err := rand.Read(overCapacityByteSlice)
 				assert.NoError(t, err, "Unexpected error from rand.Read")
 				_, err = buf.Write(overCapacityByteSlice)

--- a/internal/buffer/pool_test.go
+++ b/internal/buffer/pool_test.go
@@ -18,7 +18,8 @@ func TestBuffers(t *testing.T) {
 				assert.Zero(t, buf.Len(), "Expected truncated buffer")
 
 				b := getRandBytes()
-				buf.Write(b)
+				_, err := buf.Write(b)
+				assert.NoError(t, err, "Unexpected error from buffer.Write")
 
 				assert.Equal(t, buf.Len(), len(b), "Expected same buffer size")
 


### PR DESCRIPTION
Summary: While investigating one of our services we noticed that there
was inefficiency coming from allocations on ioutil.ReadAll.  This PR
changes the thrift inbounds and outbounds to use a sync.pool of buffers to ensure we
aren't allocating on every request.