### PR TITLE
TChannel relay any service

### DIFF
--- a/api/transport/transporttest/echo.go
+++ b/api/transport/transporttest/echo.go
@@ -1,0 +1,35 @@
+package transporttest
+
+import (
+	"context"
+	"io"
+
+	"go.uber.org/yarpc/api/transport"
+)
+
+// EchoRouter is a router that echoes all unary inbound requests, with no
+// explicit procedures.
+type EchoRouter struct{}
+
+// Procedures returns no explicitly supported procedures.
+func (EchoRouter) Procedures() []transport.Procedure {
+	return nil
+}
+
+// Choose always returns a unary echo handler.
+func (EchoRouter) Choose(ctx context.Context, req *transport.Request) (transport.HandlerSpec, error) {
+	return echoHandlerSpec, nil
+}
+
+// EchoHandler is a unary handler that echoes the request body on the response
+// body for any inbound request.
+type EchoHandler struct{}
+
+// Handle handles an inbound request by copying the request body to the
+// response body.
+func (EchoHandler) Handle(ctx context.Context, req *transport.Request, resw transport.ResponseWriter) error {
+	_, err := io.Copy(resw, req.Body)
+	return err
+}
+
+var echoHandlerSpec = transport.NewUnaryHandlerSpec(EchoHandler{})

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: 1f78c3e930a9c9e5c2f0f80ce79c91ddb216966e60a884795555c8819c9a1a2b
-updated: 2017-02-13T15:01:10.358513497-08:00
+hash: 2f0b035a08e97be21f9703fdf0807dcad82cc6b090feabda6442201ab87ab6f2
+updated: 2017-03-02T16:10:46.861477741-08:00
 imports:
 - name: github.com/apache/thrift
-  version: 4f710aa4f47e051d41c863aa7aa9239dab5b9636
+  version: de9c330b24c9190078eefb68c864d2a41a4dee07
   subpackages:
   - lib/go/thrift
 - name: github.com/cactus/go-statsd-client
@@ -10,7 +10,7 @@ imports:
   subpackages:
   - statsd
 - name: github.com/codahale/hdrhistogram
-  version: f8ad88b59a584afeee9d334eff879b104439117b
+  version: 3a0bb77429bd3a61596f5e8a3172445844342120
 - name: github.com/crossdock/crossdock-go
   version: 049aabb0122b03bc9bd30cab8f3f91fb60166361
   subpackages:
@@ -37,21 +37,21 @@ imports:
 - name: github.com/pborman/uuid
   version: 1b00554d822231195d1babd97ff4a781231955c9
 - name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib
 - name: github.com/Sirupsen/logrus
-  version: 08a8a7c27e3d058a8989316a850daad1c10bf4ab
+  version: 881bee4e20a5d11a6a88a5667c6f292072ac1963
 - name: github.com/stretchr/objx
-  version: cbeaeb16a013161a98496fad62933b1d21786672
+  version: 1a9d0bb9f541897e62256577b352fdbc1fb4fd94
 - name: github.com/stretchr/testify
-  version: 4d4bfba8f1d1027c4fdbe371823030df51419987
+  version: 2402e8e7a02fc811447d11f881aa9746cdc57983
   subpackages:
   - assert
   - mock
   - require
 - name: github.com/uber-common/bark
-  version: d52ffa061726911f47fcd3d9e8b9b55f22794772
+  version: 8841a0f8e7ca869284ccb29c08a14cf3f4310f46
 - name: github.com/uber-go/atomic
   version: 0c9e689d64f004564b79d9a663634756df322902
 - name: github.com/uber/cherami-client-go
@@ -68,9 +68,10 @@ imports:
   subpackages:
   - .generated/go/cherami
 - name: github.com/uber/jaeger-client-go
-  version: 16278cd23777cb928243f99e29f3d097d21bc749
+  version: 2505ffc229cbe642a1af9387e8251f7e699c2f6e
   subpackages:
   - internal/spanlog
+  - log
   - thrift-gen/agent
   - thrift-gen/sampling
   - thrift-gen/zipkincore
@@ -81,7 +82,7 @@ imports:
   subpackages:
   - metrics
 - name: github.com/uber/tchannel-go
-  version: 79387824978f91318be3bfb43ae12e04c38cfe97
+  version: 2feb388c9d0c0303f98481d1621308d634093ffb
   subpackages:
   - hyperbahn
   - hyperbahn/gen-go/hyperbahn
@@ -118,16 +119,16 @@ imports:
   - version
   - wire
 - name: golang.org/x/net
-  version: 61557ac0112b576429a0df080e1c2cef5dfbb642
+  version: 007e530097ad7f954752df63046b4036f98ba6a6
   subpackages:
   - context
   - context/ctxhttp
 - name: golang.org/x/sys
-  version: d4feaf1a7e61e1d9e79e6c4e76c6349e9cab0a03
+  version: d75a52659825e75fff6158388dddc6a5b04f9ba5
   subpackages:
   - unix
 - name: golang.org/x/tools
-  version: 6e7ee5a9ec598d425ca86d6aab6e76e21baf328c
+  version: f8ed2e405fdcbb42c55233531ad98721e6d1cb3e
   subpackages:
   - go/ast/astutil
 - name: gopkg.in/bsm/ratelimit.v1
@@ -141,5 +142,5 @@ imports:
   - internal/pool
   - internal/proto
 - name: gopkg.in/yaml.v2
-  version: a83829b6f1293c91addabc89d0571c246397bbf4
+  version: a3f3340b5840cee44f372bddb5880fcbc419b46a
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -10,7 +10,7 @@ import:
 - package: github.com/opentracing/opentracing-go
   version: ^1
 - package: github.com/uber/tchannel-go
-  version: ^1.3
+  version: ^1.4
 - package: go.uber.org/atomic
   version: ^1
 - package: go.uber.org/thriftrw

--- a/transport/tchannel/inbound_test.go
+++ b/transport/tchannel/inbound_test.go
@@ -101,7 +101,7 @@ func TestInboundSubServices(t *testing.T) {
 	otransport, err := NewTransport(ServiceName("caller"))
 	require.NoError(t, err)
 	o := otransport.NewSingleOutbound(chservEndpoint)
-
+	require.NoError(t, otransport.Start())
 	require.NoError(t, o.Start())
 	defer o.Stop()
 

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -67,7 +67,7 @@ func (t *Transport) NewSingleOutbound(addr string) *Outbound {
 
 // Call sends an RPC over this TChannel outbound.
 func (o *Outbound) Call(ctx context.Context, req *transport.Request) (*transport.Response, error) {
-	if err := o.once.WhenRunning(ctx); err != nil {
+	if err := o.transport.once.WhenRunning(ctx); err != nil {
 		return nil, err
 	}
 	root := o.transport.ch.RootPeers()

--- a/transport/tchannel/outbound_test.go
+++ b/transport/tchannel/outbound_test.go
@@ -150,6 +150,8 @@ func TestCallSuccess(t *testing.T) {
 
 	x, err := NewTransport(ServiceName("caller"))
 	require.NoError(t, err)
+	require.NoError(t, x.Start(), "failed to start transport")
+
 	out := x.NewSingleOutbound(serverHostPort)
 	require.NoError(t, out.Start(), "failed to start outbound")
 	defer out.Stop()
@@ -281,6 +283,8 @@ func TestCallError(t *testing.T) {
 
 	x, err := NewTransport(ServiceName("caller"))
 	require.NoError(t, err)
+	require.NoError(t, x.Start(), "failed to start transport")
+
 	out := x.NewSingleOutbound(serverHostPort)
 	require.NoError(t, out.Start(), "failed to start outbound")
 	defer out.Stop()


### PR DESCRIPTION
This allows a TChannel relay to receive requests with any service name. Previously, the TChannel inbound could only use the subchannel for the given service name.

- [x] unpin TChannel to next release