### PR TITLE
Update HTTP transport to allow customizing MaxIdleConnsPerHost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ v1.6.0 (unreleased)
 
 -   Remove buffer size limit from Thrift encoding/decoding buffer pool.
 -   Increased efficiency of inbound/outbound requests by pooling buffers.
+-   Added MaxIdleConnsPerHost option to HTTP transports.  This option will
+    configure the number of idle outbound connections the transport will
+    maintain per host.
 
 
 v1.5.0 (2017-03-03)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ v1.6.0 (unreleased)
 -   Remove buffer size limit from Thrift encoding/decoding buffer pool.
 -   Increased efficiency of inbound/outbound requests by pooling buffers.
 -   Added MaxIdleConnsPerHost option to HTTP transports.  This option will
-    configure the number of idle outbound connections the transport will
-    maintain per host.
+    configure the number of idle (keep-alive) outbound connections the transport
+    will maintain per host.
 
 
 v1.5.0 (2017-03-03)

--- a/transport/http/transport.go
+++ b/transport/http/transport.go
@@ -58,8 +58,10 @@ func KeepAlive(t time.Duration) TransportOption {
 	}
 }
 
-// MaxIdleConnsPerHost specifies the number of idle http connections
-// that will be maintained per host.
+// MaxIdleConnsPerHost specifies the number of idle (keep-alive) HTTP
+// connections that will be maintained per host.
+// Existing idle connections will be used instead of creating new HTTP
+// connections.
 //
 // Defaults to 2 connections.
 func MaxIdleConnsPerHost(i int) TransportOption {

--- a/transport/http/transport_test.go
+++ b/transport/http/transport_test.go
@@ -264,7 +264,7 @@ func TestTransportClient(t *testing.T) {
 
 func TestTransportClientWithKeepAlive(t *testing.T) {
 	// Unfortunately the KeepAlive is obfuscated in the client, so we can't really
-	// assert this worked
+	// assert this worked.
 	transport := NewTransport(KeepAlive(time.Second))
 
 	assert.NotNil(t, transport.client)
@@ -272,7 +272,7 @@ func TestTransportClientWithKeepAlive(t *testing.T) {
 
 func TestTransportClientWithMaxIdleConnections(t *testing.T) {
 	// Unfortunately the MaxIdleConnsPerHost is obfuscated in the client, so we can't really
-	// assert this worked
+	// assert this worked.
 	transport := NewTransport(MaxIdleConnsPerHost(100))
 
 	assert.NotNil(t, transport.client)

--- a/transport/http/transport_test.go
+++ b/transport/http/transport_test.go
@@ -269,3 +269,11 @@ func TestTransportClientWithKeepAlive(t *testing.T) {
 
 	assert.NotNil(t, transport.client)
 }
+
+func TestTransportClientWithMaxIdleConnections(t *testing.T) {
+	// Unfortunately the MaxIdleConnsPerHost is obfuscated in the client, so we can't really
+	// assert this worked
+	transport := NewTransport(MaxIdleConnsPerHost(100))
+
+	assert.NotNil(t, transport.client)
+}


### PR DESCRIPTION
Summary: I've been running into a large issue with the http transport
during benchmarks where we see transient errors like: "Can't assign
requested address" which means that we've exausted the ephemeral port
range.  After some investigation I found out it was because the go http
library sets a limit on the number of idle connections it keeps.

The parameter is MaxIdleConnsPerHost and The default is 2, which means
if we have more than 2 idle requests at any point we'll start churning
through ephemeral ports until we run out.