### PR TITLE
Update lifecycle state management internals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ v1.6.0 (unreleased)
 -   Added MaxIdleConnsPerHost option to HTTP transports.  This option will
     configure the number of idle (keep-alive) outbound connections the transport
     will maintain per host.
+-   Fixed bug in Lifecycle Start/Stop where we would run the Stop functionality
+    even if Start hadn't been called yet.
+-   Updated RoundRobin and PeerHeap implementations to block until the list has
+    started or a timeout had been exceeded.
 
 
 v1.5.0 (2017-03-03)

--- a/internal/sync/lifecycle.go
+++ b/internal/sync/lifecycle.go
@@ -153,7 +153,7 @@ func (l *lifecycleOnce) Stop(f func() error) error {
 	if l.state.CAS(int32(Idle), int32(Stopped)) {
 		close(l.startCh)
 		close(l.stopCh)
-		return l.err
+		return nil
 	}
 
 	<-l.startCh

--- a/peer/x/roundrobin/list_test.go
+++ b/peer/x/roundrobin/list_test.go
@@ -18,6 +18,9 @@ func TestRoundRobinList(t *testing.T) {
 	type testStruct struct {
 		msg string
 
+		// StartWaitTimeout is how long the list will block on starteing in Update calls
+		startWaitTimeout time.Duration
+
 		// PeerIDs that will be returned from the transport's OnRetain with "Available" status
 		retainedAvailablePeerIDs []string
 
@@ -53,26 +56,30 @@ func TestRoundRobinList(t *testing.T) {
 			retainedAvailablePeerIDs: []string{"1"},
 			expectedAvailablePeers:   []string{"1"},
 			peerListActions: []PeerListAction{
+				StartAction{},
 				UpdateAction{AddedPeerIDs: []string{"1"}},
 			},
+			expectedRunning: true,
 		},
 		{
 			msg: "setup with disconnected",
 			retainedAvailablePeerIDs:   []string{"1"},
 			retainedUnavailablePeerIDs: []string{"2"},
 			peerListActions: []PeerListAction{
+				StartAction{},
 				UpdateAction{AddedPeerIDs: []string{"1", "2"}},
 			},
 			expectedAvailablePeers:   []string{"1"},
 			expectedUnavailablePeers: []string{"2"},
+			expectedRunning:          true,
 		},
 		{
 			msg: "start",
 			retainedAvailablePeerIDs: []string{"1"},
 			expectedAvailablePeers:   []string{"1"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
 				ChooseAction{
 					ExpectedPeer: "1",
 				},
@@ -85,8 +92,8 @@ func TestRoundRobinList(t *testing.T) {
 			retainedUnavailablePeerIDs: []string{"7", "8", "9"},
 			releasedPeerIDs:            []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"}},
 				StopAction{},
 				ChooseAction{
 					ExpectedErr:         context.DeadlineExceeded,
@@ -100,8 +107,8 @@ func TestRoundRobinList(t *testing.T) {
 			retainedAvailablePeerIDs: []string{"1", "2", "3", "4", "5", "6"},
 			expectedAvailablePeers:   []string{"1", "2", "3", "4", "5", "6"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1", "2", "3", "4", "5", "6"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1", "2", "3", "4", "5", "6"}},
 				ChooseAction{ExpectedPeer: "1"},
 				ChooseAction{ExpectedPeer: "2"},
 				ChooseAction{ExpectedPeer: "3"},
@@ -117,8 +124,8 @@ func TestRoundRobinList(t *testing.T) {
 			retainedAvailablePeerIDs: []string{"1"},
 			expectedAvailablePeers:   []string{"1"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
 				StartAction{},
 				StartAction{},
 				ChooseAction{
@@ -129,11 +136,11 @@ func TestRoundRobinList(t *testing.T) {
 		},
 		{
 			msg: "stop no start",
-			retainedAvailablePeerIDs: []string{"1"},
-			releasedPeerIDs:          []string{"1"},
+			retainedAvailablePeerIDs: []string{},
+			releasedPeerIDs:          []string{},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1"}},
 				StopAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}, ExpectedErr: context.DeadlineExceeded},
 			},
 			expectedRunning: false,
 		},
@@ -142,8 +149,10 @@ func TestRoundRobinList(t *testing.T) {
 			errRetainedPeerIDs: []string{"1"},
 			retainErr:          peer.ErrInvalidPeerType{},
 			peerListActions: []PeerListAction{
+				StartAction{},
 				UpdateAction{AddedPeerIDs: []string{"1"}, ExpectedErr: peer.ErrInvalidPeerType{}},
 			},
+			expectedRunning: true,
 		},
 		{
 			msg: "update retain multiple errors",
@@ -151,12 +160,14 @@ func TestRoundRobinList(t *testing.T) {
 			errRetainedPeerIDs:       []string{"1", "3"},
 			retainErr:                peer.ErrInvalidPeerType{},
 			peerListActions: []PeerListAction{
+				StartAction{},
 				UpdateAction{
 					AddedPeerIDs: []string{"1", "2", "3"},
 					ExpectedErr:  yerrors.ErrorGroup{peer.ErrInvalidPeerType{}, peer.ErrInvalidPeerType{}},
 				},
 			},
 			expectedAvailablePeers: []string{"2"},
+			expectedRunning:        true,
 		},
 		{
 			msg: "start stop release error",
@@ -164,8 +175,8 @@ func TestRoundRobinList(t *testing.T) {
 			errReleasedPeerIDs:       []string{"1"},
 			releaseErr:               peer.ErrTransportHasNoReferenceToPeer{},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
 				StopAction{
 					ExpectedErr: peer.ErrTransportHasNoReferenceToPeer{},
 				},
@@ -178,8 +189,8 @@ func TestRoundRobinList(t *testing.T) {
 			errReleasedPeerIDs:       []string{"1"},
 			releaseErr:               peer.ErrTransportHasNoReferenceToPeer{},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
 				ConcurrentAction{
 					Actions: []PeerListAction{
 						StopAction{
@@ -203,8 +214,8 @@ func TestRoundRobinList(t *testing.T) {
 			errReleasedPeerIDs:       []string{"1", "3"},
 			releaseErr:               peer.ErrTransportHasNoReferenceToPeer{},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1", "2", "3"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1", "2", "3"}},
 				StopAction{
 					ExpectedErr: yerrors.ErrorGroup{
 						peer.ErrTransportHasNoReferenceToPeer{},
@@ -216,10 +227,7 @@ func TestRoundRobinList(t *testing.T) {
 		},
 		{
 			msg: "choose before start",
-			retainedAvailablePeerIDs: []string{"1"},
-			expectedAvailablePeers:   []string{"1"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1"}},
 				ChooseAction{
 					ExpectedErr:         context.DeadlineExceeded,
 					InputContextTimeout: 10 * time.Millisecond,
@@ -230,6 +238,36 @@ func TestRoundRobinList(t *testing.T) {
 				},
 			},
 			expectedRunning: false,
+		},
+		{
+			msg:                      "update before start",
+			startWaitTimeout:         time.Second,
+			retainedAvailablePeerIDs: []string{"1"},
+			expectedAvailablePeers:   []string{"1"},
+			peerListActions: []PeerListAction{
+				ConcurrentAction{
+					Actions: []PeerListAction{
+						UpdateAction{AddedPeerIDs: []string{"1"}},
+						StartAction{},
+					},
+					Wait: 20 * time.Millisecond,
+				},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg:              "update timeout before start",
+			startWaitTimeout: 30 * time.Millisecond,
+			peerListActions: []PeerListAction{
+				ConcurrentAction{
+					Actions: []PeerListAction{
+						UpdateAction{AddedPeerIDs: []string{"1"}, ExpectedErr: context.DeadlineExceeded},
+						StartAction{},
+					},
+					Wait: 50 * time.Millisecond,
+				},
+			},
+			expectedRunning: true,
 		},
 		{
 			msg: "start choose no peers",
@@ -247,8 +285,8 @@ func TestRoundRobinList(t *testing.T) {
 			retainedAvailablePeerIDs: []string{"1", "2"},
 			expectedAvailablePeers:   []string{"1", "2"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
 				UpdateAction{AddedPeerIDs: []string{"2"}},
 				ChooseAction{ExpectedPeer: "1"},
 				ChooseAction{ExpectedPeer: "2"},
@@ -262,8 +300,8 @@ func TestRoundRobinList(t *testing.T) {
 			expectedAvailablePeers:   []string{"2"},
 			releasedPeerIDs:          []string{"1"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1", "2"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1", "2"}},
 				UpdateAction{RemovedPeerIDs: []string{"1"}},
 				ChooseAction{ExpectedPeer: "2"},
 			},
@@ -275,8 +313,8 @@ func TestRoundRobinList(t *testing.T) {
 			releasedPeerIDs:          []string{"3-r", "4-r", "5-a-r", "6-a-r"},
 			expectedAvailablePeers:   []string{"1", "2", "7-a", "8-a"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1", "2", "3-r", "4-r"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1", "2", "3-r", "4-r"}},
 				UpdateAction{
 					AddedPeerIDs: []string{"5-a-r", "6-a-r", "7-a", "8-a"},
 				},
@@ -298,8 +336,8 @@ func TestRoundRobinList(t *testing.T) {
 			errRetainedPeerIDs:       []string{"3"},
 			retainErr:                peer.ErrInvalidPeerType{},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1", "2"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1", "2"}},
 				UpdateAction{
 					AddedPeerIDs: []string{"3"},
 					ExpectedErr:  peer.ErrInvalidPeerType{},
@@ -315,8 +353,8 @@ func TestRoundRobinList(t *testing.T) {
 			retainedAvailablePeerIDs: []string{"1", "2", "2"},
 			expectedAvailablePeers:   []string{"1", "2"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1", "2"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1", "2"}},
 				UpdateAction{
 					AddedPeerIDs: []string{"2"},
 					ExpectedErr:  peer.ErrPeerAddAlreadyInList("2"),
@@ -332,8 +370,8 @@ func TestRoundRobinList(t *testing.T) {
 			retainedAvailablePeerIDs: []string{"1", "2"},
 			expectedAvailablePeers:   []string{"1", "2"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1", "2"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1", "2"}},
 				UpdateAction{
 					RemovedPeerIDs: []string{"3"},
 					ExpectedErr:    peer.ErrPeerRemoveNotInList("3"),
@@ -351,8 +389,8 @@ func TestRoundRobinList(t *testing.T) {
 			releaseErr:               peer.ErrTransportHasNoReferenceToPeer{},
 			expectedAvailablePeers:   []string{"1"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1", "2"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1", "2"}},
 				UpdateAction{
 					RemovedPeerIDs: []string{"2"},
 					ExpectedErr:    peer.ErrTransportHasNoReferenceToPeer{},
@@ -436,8 +474,8 @@ func TestRoundRobinList(t *testing.T) {
 			releasedPeerIDs:          []string{"1"},
 			expectedAvailablePeers:   []string{"2"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
 				UpdateAction{RemovedPeerIDs: []string{"1"}},
 				ConcurrentAction{
 					Actions: []PeerListAction{
@@ -471,8 +509,8 @@ func TestRoundRobinList(t *testing.T) {
 			expectedAvailablePeers:     []string{"1"},
 			expectedUnavailablePeers:   []string{"2"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
 				UpdateAction{AddedPeerIDs: []string{"2"}},
 				ChooseAction{ExpectedPeer: "1"},
 				ChooseAction{ExpectedPeer: "1"},
@@ -484,8 +522,8 @@ func TestRoundRobinList(t *testing.T) {
 			retainedUnavailablePeerIDs: []string{"1"},
 			releasedPeerIDs:            []string{"1"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
 				UpdateAction{RemovedPeerIDs: []string{"1"}},
 				ChooseAction{
 					InputContextTimeout: 10 * time.Millisecond,
@@ -499,8 +537,8 @@ func TestRoundRobinList(t *testing.T) {
 			retainedUnavailablePeerIDs: []string{"1"},
 			expectedAvailablePeers:     []string{"1"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
 				ChooseAction{
 					InputContextTimeout: 10 * time.Millisecond,
 					ExpectedErr:         context.DeadlineExceeded,
@@ -515,8 +553,8 @@ func TestRoundRobinList(t *testing.T) {
 			retainedAvailablePeerIDs: []string{"1"},
 			expectedAvailablePeers:   []string{"1"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
 				ChooseAction{ExpectedPeer: "1"},
 				NotifyStatusChangeAction{PeerID: "1", NewConnectionStatus: peer.Available},
 				ChooseAction{ExpectedPeer: "1"},
@@ -528,8 +566,8 @@ func TestRoundRobinList(t *testing.T) {
 			retainedAvailablePeerIDs: []string{"1"},
 			expectedUnavailablePeers: []string{"1"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
 				ChooseAction{ExpectedPeer: "1"},
 				NotifyStatusChangeAction{PeerID: "1", NewConnectionStatus: peer.Unavailable},
 				ChooseAction{
@@ -544,8 +582,8 @@ func TestRoundRobinList(t *testing.T) {
 			retainedUnavailablePeerIDs: []string{"1"},
 			expectedUnavailablePeers:   []string{"1"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
 				NotifyStatusChangeAction{PeerID: "1", NewConnectionStatus: peer.Unavailable},
 				ChooseAction{
 					InputContextTimeout: 10 * time.Millisecond,
@@ -559,8 +597,8 @@ func TestRoundRobinList(t *testing.T) {
 			retainedAvailablePeerIDs: []string{"1"},
 			releasedPeerIDs:          []string{"1"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
 				UpdateAction{RemovedPeerIDs: []string{"1"}},
 				NotifyStatusChangeAction{PeerID: "1", NewConnectionStatus: peer.Available},
 			},
@@ -575,8 +613,8 @@ func TestRoundRobinList(t *testing.T) {
 			expectedAvailablePeers:     []string{"1v", "2va", "8uav"},
 			expectedUnavailablePeers:   []string{"3vau", "6u", "7ua"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1v", "6u"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1v", "6u"}},
 
 				// Added Peers
 				UpdateAction{
@@ -615,8 +653,8 @@ func TestRoundRobinList(t *testing.T) {
 			retainedUnavailablePeerIDs: []string{"1"},
 			expectedAvailablePeers:     []string{"1"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
 				ConcurrentAction{
 					Actions: []PeerListAction{
 						ChooseAction{
@@ -652,7 +690,11 @@ func TestRoundRobinList(t *testing.T) {
 			ExpectPeerRetainsWithError(transport, tt.errRetainedPeerIDs, tt.retainErr)
 			ExpectPeerReleases(transport, tt.errReleasedPeerIDs, tt.releaseErr)
 
-			pl := New(transport)
+			var opts []ListOption
+			if tt.startWaitTimeout != 0 {
+				opts = append(opts, StartupWait(tt.startWaitTimeout))
+			}
+			pl := New(transport, opts...)
 
 			deps := ListActionDeps{
 				Peers: peerMap,
@@ -678,7 +720,7 @@ func TestRoundRobinList(t *testing.T) {
 				}
 			}
 
-			assert.Equal(t, tt.expectedRunning, pl.IsRunning())
+			assert.Equal(t, tt.expectedRunning, pl.IsRunning(), "List was not in the expected state")
 		})
 	}
 }


### PR DESCRIPTION
Summary: During an intellectual excercise between @bombela and I
went through the LifecycleOnce API to change it to use a single atomic
for state.  At the same time we noticed a bug in the functionality where
"Stop" would be called even if "Start" had never been called.

This diff changes the LifecycleOnce to use a singel atomic for state,
and updates the peer list implementations (which had bad assumptions
about what to do if the list hadn't been started yet) to block updates
to the list until the peer list had been started.  The blocks in the
update should block any watchers that attempt to write to the peerlist
so we should retain the order of updates.