### PR TITLE
Enable race detector in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ v1.6.0 (unreleased)
 -   Added MaxIdleConnsPerHost option to HTTP transports.  This option will
     configure the number of idle (keep-alive) outbound connections the transport
     will maintain per host.
+-   Fixed bug in Lifecycle Start/Stop where we would run the Stop functionality
+    even if Start hadn't been called yet.
+-   Updated RoundRobin and PeerHeap implementations to block until the list has
+    started or a timeout had been exceeded.
 
 
 v1.5.0 (2017-03-03)

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ install:
 
 .PHONY: test
 test: verify_version $(THRIFTRW)
-	PATH=$(_GENERATE_DEPS_DIR):$$PATH go test $(PACKAGES)
+	PATH=$(_GENERATE_DEPS_DIR):$$PATH go test -race $(PACKAGES)
 
 
 .PHONY: cover

--- a/api/peer/peertest/peers.go
+++ b/api/peer/peertest/peers.go
@@ -22,6 +22,7 @@ package peertest
 
 import (
 	"fmt"
+	"sync"
 
 	"go.uber.org/yarpc/api/peer"
 
@@ -52,6 +53,8 @@ func NewLightMockPeer(pid MockPeerIdentifier, conStatus peer.ConnectionStatus) *
 // a peer's attributes
 // MockPeer is NOT thread safe
 type LightMockPeer struct {
+	sync.Mutex
+
 	MockPeerIdentifier
 
 	PeerStatus peer.Status
@@ -64,12 +67,16 @@ func (p *LightMockPeer) Status() peer.Status {
 
 // StartRequest is run when a Request starts
 func (p *LightMockPeer) StartRequest() {
+	p.Lock()
 	p.PeerStatus.PendingRequestCount++
+	p.Unlock()
 }
 
 // EndRequest should be run after a MockPeer request has finished
 func (p *LightMockPeer) EndRequest() {
+	p.Lock()
 	p.PeerStatus.PendingRequestCount--
+	p.Unlock()
 }
 
 // PeerIdentifierMatcher is used to match a Peer/PeerIdentifier by comparing

--- a/internal/sync/lifecycle.go
+++ b/internal/sync/lifecycle.go
@@ -23,6 +23,7 @@ package sync
 import (
 	"context"
 	"errors"
+	syncatomic "sync/atomic"
 
 	"go.uber.org/atomic"
 )
@@ -77,7 +78,7 @@ type lifecycleOnce struct {
 	// subsequent Start() or Stop() calls will return. The right to set
 	// err is conferred to whichever goroutine is starting or stopping, until
 	// it has started or stopped, after which `err` becomes immutable.
-	err error
+	err syncatomic.Value
 	// state is an atomic LifecycleState representing the object's current
 	// state (Idle, Starting, Running, Stopping, Stopped, Errored).
 	state atomic.Int32
@@ -102,23 +103,26 @@ func Once() LifecycleOnce {
 // from the first time it was called.
 func (l *lifecycleOnce) Start(f func() error) error {
 	if l.state.CAS(int32(Idle), int32(Starting)) {
+		var err error
 		if f != nil {
-			l.err = f()
+			err = f()
 		}
 
 		// skip forward to error state
-		if l.err != nil {
+		if err != nil {
+			l.setError(err)
 			l.state.Store(int32(Errored))
 			close(l.stopCh)
 		} else {
 			l.state.Store(int32(Running))
 		}
 		close(l.startCh)
-		return l.err
+
+		return err
 	}
 
 	<-l.startCh
-	return l.err
+	return l.loadError()
 }
 
 func (l *lifecycleOnce) WhenRunning(ctx context.Context) error {
@@ -159,21 +163,41 @@ func (l *lifecycleOnce) Stop(f func() error) error {
 	<-l.startCh
 
 	if l.state.CAS(int32(Running), int32(Stopping)) {
+		var err error
 		if f != nil {
-			l.err = f()
+			err = f()
 		}
 
-		if l.err != nil {
+		if err != nil {
+			l.setError(err)
 			l.state.Store(int32(Errored))
 		} else {
 			l.state.Store(int32(Stopped))
 		}
 		close(l.stopCh)
-		return l.err
+		return err
 	}
 
 	<-l.stopCh
-	return l.err
+	return l.loadError()
+}
+
+func (l *lifecycleOnce) setError(err error) {
+	l.err.Store(err)
+}
+
+func (l *lifecycleOnce) loadError() error {
+	errVal := l.err.Load()
+	if errVal == nil {
+		return nil
+	}
+
+	if err, ok := errVal.(error); ok {
+		return err
+	}
+
+	// TODO replace with DPanic log
+	return errors.New("lifecycle err was not `error` type")
 }
 
 // LifecycleState returns the state of the object within its life cycle, from

--- a/internal/sync/lifecycle.go
+++ b/internal/sync/lifecycle.go
@@ -78,25 +78,9 @@ type lifecycleOnce struct {
 	// err is conferred to whichever goroutine is starting or stopping, until
 	// it has started or stopped, after which `err` becomes immutable.
 	err error
-	// starting indicates that the lifecycle is at least starting.
-	// Losing the race to set "starting" means that your goroutine must block
-	// on "startCh".
-	starting atomic.Bool
-	// started indicates that the lifecycle is at least running.
-	// Winning the race to set "started" means that the goroutine must close
-	// "startCh".
-	started atomic.Bool
-	// stopping indicates that the lifecycle is at least stopping.
-	// Losing the race to set "stopping" means that the goroutine must block on
-	// "stopCh".
-	stopping atomic.Bool
-	// stopped indicates that the lifecycle is at least stopped.
-	// Winning the race to set "stopped" means that the goroutine must close
-	// "stopCh".
-	stopped atomic.Bool
-	// errored indicates that the lifecycle produced an error either while
-	// starting or stopping.
-	errored atomic.Bool
+	// state is an atomic LifecycleState representing the object's current
+	// state (Idle, Starting, Running, Stopping, Stopped, Errored).
+	state atomic.Int32
 }
 
 // Once returns a lifecycle controller.
@@ -117,29 +101,33 @@ func Once() LifecycleOnce {
 // If Start is called multiple times it will return the error
 // from the first time it was called.
 func (l *lifecycleOnce) Start(f func() error) error {
-	if l.starting.Swap(true) {
-		<-l.startCh
+	if l.state.CAS(int32(Idle), int32(Starting)) {
+		if f != nil {
+			l.err = f()
+		}
+
+		// skip forward to error state
+		if l.err != nil {
+			l.state.Store(int32(Errored))
+			close(l.stopCh)
+		} else {
+			l.state.Store(int32(Running))
+		}
+		close(l.startCh)
 		return l.err
 	}
-	if f != nil {
-		l.err = f()
-	}
-	// skip forward to error state
-	if l.err != nil {
-		l.errored.Store(true)
-		l.stopped.Store(true)
-		l.stopping.Store(true)
-		close(l.stopCh)
-	}
-	l.started.Store(true)
-	close(l.startCh)
 
+	<-l.startCh
 	return l.err
 }
 
 func (l *lifecycleOnce) WhenRunning(ctx context.Context) error {
-	if !l.stopping.Load() && l.started.Load() {
+	state := LifecycleState(l.state.Load())
+	if state == Running {
 		return nil
+	}
+	if state > Running {
+		return context.DeadlineExceeded
 	}
 
 	if _, ok := ctx.Deadline(); !ok {
@@ -148,8 +136,10 @@ func (l *lifecycleOnce) WhenRunning(ctx context.Context) error {
 
 	select {
 	case <-l.startCh:
-		return nil
-	case <-l.stopCh:
+		state := LifecycleState(l.state.Load())
+		if state == Running {
+			return nil
+		}
 		return context.DeadlineExceeded
 	case <-ctx.Done():
 		return ctx.Err()
@@ -160,33 +150,29 @@ func (l *lifecycleOnce) WhenRunning(ctx context.Context) error {
 // If Stop is called multiple times it will return the error
 // from the first time it was called.
 func (l *lifecycleOnce) Stop(f func() error) error {
-	if l.stopping.Swap(true) {
-		<-l.stopCh
-		return l.err
-	}
-
-	if !l.starting.Swap(true) {
-		// Was not already starting:
-		// Pre-empt start
-		l.started.Store(true)
+	if l.state.CAS(int32(Idle), int32(Stopped)) {
 		close(l.startCh)
-	} else if !l.started.Load() {
-		// Starting, but not yet started:
-		// Wait for concurrent start to finish
-		<-l.startCh
+		close(l.stopCh)
+		return nil
 	}
 
-	if l.err != nil {
+	<-l.startCh
+
+	if l.state.CAS(int32(Running), int32(Stopping)) {
+		if f != nil {
+			l.err = f()
+		}
+
+		if l.err != nil {
+			l.state.Store(int32(Errored))
+		} else {
+			l.state.Store(int32(Stopped))
+		}
+		close(l.stopCh)
 		return l.err
 	}
 
-	if f != nil {
-		l.err = f()
-	}
-	l.errored.Store(l.err != nil)
-	l.stopped.Store(true)
-	close(l.stopCh)
-
+	<-l.stopCh
 	return l.err
 }
 
@@ -195,20 +181,7 @@ func (l *lifecycleOnce) Stop(f func() error) error {
 // The function only guarantees that the lifecycle has at least passed through
 // the returned state and may have progressed further in the intervening time.
 func (l *lifecycleOnce) LifecycleState() LifecycleState {
-	switch {
-	case l.errored.Load():
-		return Errored
-	case l.stopped.Load():
-		return Stopped
-	case l.stopping.Load():
-		return Stopping
-	case l.started.Load():
-		return Running
-	case l.starting.Load():
-		return Starting
-	default:
-		return Idle
-	}
+	return LifecycleState(l.state.Load())
 }
 
 // IsRunning will return true if current state of the Lifecycle is running

--- a/peer/x/roundrobin/list_test.go
+++ b/peer/x/roundrobin/list_test.go
@@ -18,6 +18,9 @@ func TestRoundRobinList(t *testing.T) {
 	type testStruct struct {
 		msg string
 
+		// StartWaitTimeout is how long the list will block on starteing in Update calls
+		startWaitTimeout time.Duration
+
 		// PeerIDs that will be returned from the transport's OnRetain with "Available" status
 		retainedAvailablePeerIDs []string
 
@@ -53,26 +56,30 @@ func TestRoundRobinList(t *testing.T) {
 			retainedAvailablePeerIDs: []string{"1"},
 			expectedAvailablePeers:   []string{"1"},
 			peerListActions: []PeerListAction{
+				StartAction{},
 				UpdateAction{AddedPeerIDs: []string{"1"}},
 			},
+			expectedRunning: true,
 		},
 		{
 			msg: "setup with disconnected",
 			retainedAvailablePeerIDs:   []string{"1"},
 			retainedUnavailablePeerIDs: []string{"2"},
 			peerListActions: []PeerListAction{
+				StartAction{},
 				UpdateAction{AddedPeerIDs: []string{"1", "2"}},
 			},
 			expectedAvailablePeers:   []string{"1"},
 			expectedUnavailablePeers: []string{"2"},
+			expectedRunning:          true,
 		},
 		{
 			msg: "start",
 			retainedAvailablePeerIDs: []string{"1"},
 			expectedAvailablePeers:   []string{"1"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
 				ChooseAction{
 					ExpectedPeer: "1",
 				},
@@ -85,8 +92,8 @@ func TestRoundRobinList(t *testing.T) {
 			retainedUnavailablePeerIDs: []string{"7", "8", "9"},
 			releasedPeerIDs:            []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"}},
 				StopAction{},
 				ChooseAction{
 					ExpectedErr:         context.DeadlineExceeded,
@@ -100,8 +107,8 @@ func TestRoundRobinList(t *testing.T) {
 			retainedAvailablePeerIDs: []string{"1", "2", "3", "4", "5", "6"},
 			expectedAvailablePeers:   []string{"1", "2", "3", "4", "5", "6"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1", "2", "3", "4", "5", "6"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1", "2", "3", "4", "5", "6"}},
 				ChooseAction{ExpectedPeer: "1"},
 				ChooseAction{ExpectedPeer: "2"},
 				ChooseAction{ExpectedPeer: "3"},
@@ -117,8 +124,8 @@ func TestRoundRobinList(t *testing.T) {
 			retainedAvailablePeerIDs: []string{"1"},
 			expectedAvailablePeers:   []string{"1"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
 				StartAction{},
 				StartAction{},
 				ChooseAction{
@@ -129,11 +136,11 @@ func TestRoundRobinList(t *testing.T) {
 		},
 		{
 			msg: "stop no start",
-			retainedAvailablePeerIDs: []string{"1"},
-			releasedPeerIDs:          []string{"1"},
+			retainedAvailablePeerIDs: []string{},
+			releasedPeerIDs:          []string{},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1"}},
 				StopAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}, ExpectedErr: context.DeadlineExceeded},
 			},
 			expectedRunning: false,
 		},
@@ -142,8 +149,10 @@ func TestRoundRobinList(t *testing.T) {
 			errRetainedPeerIDs: []string{"1"},
 			retainErr:          peer.ErrInvalidPeerType{},
 			peerListActions: []PeerListAction{
+				StartAction{},
 				UpdateAction{AddedPeerIDs: []string{"1"}, ExpectedErr: peer.ErrInvalidPeerType{}},
 			},
+			expectedRunning: true,
 		},
 		{
 			msg: "update retain multiple errors",
@@ -151,12 +160,14 @@ func TestRoundRobinList(t *testing.T) {
 			errRetainedPeerIDs:       []string{"1", "3"},
 			retainErr:                peer.ErrInvalidPeerType{},
 			peerListActions: []PeerListAction{
+				StartAction{},
 				UpdateAction{
 					AddedPeerIDs: []string{"1", "2", "3"},
 					ExpectedErr:  yerrors.ErrorGroup{peer.ErrInvalidPeerType{}, peer.ErrInvalidPeerType{}},
 				},
 			},
 			expectedAvailablePeers: []string{"2"},
+			expectedRunning:        true,
 		},
 		{
 			msg: "start stop release error",
@@ -164,8 +175,8 @@ func TestRoundRobinList(t *testing.T) {
 			errReleasedPeerIDs:       []string{"1"},
 			releaseErr:               peer.ErrTransportHasNoReferenceToPeer{},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
 				StopAction{
 					ExpectedErr: peer.ErrTransportHasNoReferenceToPeer{},
 				},
@@ -178,8 +189,8 @@ func TestRoundRobinList(t *testing.T) {
 			errReleasedPeerIDs:       []string{"1"},
 			releaseErr:               peer.ErrTransportHasNoReferenceToPeer{},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
 				ConcurrentAction{
 					Actions: []PeerListAction{
 						StopAction{
@@ -203,8 +214,8 @@ func TestRoundRobinList(t *testing.T) {
 			errReleasedPeerIDs:       []string{"1", "3"},
 			releaseErr:               peer.ErrTransportHasNoReferenceToPeer{},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1", "2", "3"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1", "2", "3"}},
 				StopAction{
 					ExpectedErr: yerrors.ErrorGroup{
 						peer.ErrTransportHasNoReferenceToPeer{},
@@ -216,10 +227,7 @@ func TestRoundRobinList(t *testing.T) {
 		},
 		{
 			msg: "choose before start",
-			retainedAvailablePeerIDs: []string{"1"},
-			expectedAvailablePeers:   []string{"1"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1"}},
 				ChooseAction{
 					ExpectedErr:         context.DeadlineExceeded,
 					InputContextTimeout: 10 * time.Millisecond,
@@ -230,6 +238,36 @@ func TestRoundRobinList(t *testing.T) {
 				},
 			},
 			expectedRunning: false,
+		},
+		{
+			msg:                      "update before start",
+			startWaitTimeout:         time.Second,
+			retainedAvailablePeerIDs: []string{"1"},
+			expectedAvailablePeers:   []string{"1"},
+			peerListActions: []PeerListAction{
+				ConcurrentAction{
+					Actions: []PeerListAction{
+						UpdateAction{AddedPeerIDs: []string{"1"}},
+						StartAction{},
+					},
+					Wait: 20 * time.Millisecond,
+				},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg:              "update timeout before start",
+			startWaitTimeout: 30 * time.Millisecond,
+			peerListActions: []PeerListAction{
+				ConcurrentAction{
+					Actions: []PeerListAction{
+						UpdateAction{AddedPeerIDs: []string{"1"}, ExpectedErr: context.DeadlineExceeded},
+						StartAction{},
+					},
+					Wait: 50 * time.Millisecond,
+				},
+			},
+			expectedRunning: true,
 		},
 		{
 			msg: "start choose no peers",
@@ -247,8 +285,8 @@ func TestRoundRobinList(t *testing.T) {
 			retainedAvailablePeerIDs: []string{"1", "2"},
 			expectedAvailablePeers:   []string{"1", "2"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
 				UpdateAction{AddedPeerIDs: []string{"2"}},
 				ChooseAction{ExpectedPeer: "1"},
 				ChooseAction{ExpectedPeer: "2"},
@@ -262,8 +300,8 @@ func TestRoundRobinList(t *testing.T) {
 			expectedAvailablePeers:   []string{"2"},
 			releasedPeerIDs:          []string{"1"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1", "2"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1", "2"}},
 				UpdateAction{RemovedPeerIDs: []string{"1"}},
 				ChooseAction{ExpectedPeer: "2"},
 			},
@@ -275,8 +313,8 @@ func TestRoundRobinList(t *testing.T) {
 			releasedPeerIDs:          []string{"3-r", "4-r", "5-a-r", "6-a-r"},
 			expectedAvailablePeers:   []string{"1", "2", "7-a", "8-a"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1", "2", "3-r", "4-r"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1", "2", "3-r", "4-r"}},
 				UpdateAction{
 					AddedPeerIDs: []string{"5-a-r", "6-a-r", "7-a", "8-a"},
 				},
@@ -298,8 +336,8 @@ func TestRoundRobinList(t *testing.T) {
 			errRetainedPeerIDs:       []string{"3"},
 			retainErr:                peer.ErrInvalidPeerType{},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1", "2"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1", "2"}},
 				UpdateAction{
 					AddedPeerIDs: []string{"3"},
 					ExpectedErr:  peer.ErrInvalidPeerType{},
@@ -315,8 +353,8 @@ func TestRoundRobinList(t *testing.T) {
 			retainedAvailablePeerIDs: []string{"1", "2", "2"},
 			expectedAvailablePeers:   []string{"1", "2"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1", "2"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1", "2"}},
 				UpdateAction{
 					AddedPeerIDs: []string{"2"},
 					ExpectedErr:  peer.ErrPeerAddAlreadyInList("2"),
@@ -332,8 +370,8 @@ func TestRoundRobinList(t *testing.T) {
 			retainedAvailablePeerIDs: []string{"1", "2"},
 			expectedAvailablePeers:   []string{"1", "2"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1", "2"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1", "2"}},
 				UpdateAction{
 					RemovedPeerIDs: []string{"3"},
 					ExpectedErr:    peer.ErrPeerRemoveNotInList("3"),
@@ -351,8 +389,8 @@ func TestRoundRobinList(t *testing.T) {
 			releaseErr:               peer.ErrTransportHasNoReferenceToPeer{},
 			expectedAvailablePeers:   []string{"1"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1", "2"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1", "2"}},
 				UpdateAction{
 					RemovedPeerIDs: []string{"2"},
 					ExpectedErr:    peer.ErrTransportHasNoReferenceToPeer{},
@@ -436,8 +474,8 @@ func TestRoundRobinList(t *testing.T) {
 			releasedPeerIDs:          []string{"1"},
 			expectedAvailablePeers:   []string{"2"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
 				UpdateAction{RemovedPeerIDs: []string{"1"}},
 				ConcurrentAction{
 					Actions: []PeerListAction{
@@ -471,8 +509,8 @@ func TestRoundRobinList(t *testing.T) {
 			expectedAvailablePeers:     []string{"1"},
 			expectedUnavailablePeers:   []string{"2"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
 				UpdateAction{AddedPeerIDs: []string{"2"}},
 				ChooseAction{ExpectedPeer: "1"},
 				ChooseAction{ExpectedPeer: "1"},
@@ -484,8 +522,8 @@ func TestRoundRobinList(t *testing.T) {
 			retainedUnavailablePeerIDs: []string{"1"},
 			releasedPeerIDs:            []string{"1"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
 				UpdateAction{RemovedPeerIDs: []string{"1"}},
 				ChooseAction{
 					InputContextTimeout: 10 * time.Millisecond,
@@ -499,8 +537,8 @@ func TestRoundRobinList(t *testing.T) {
 			retainedUnavailablePeerIDs: []string{"1"},
 			expectedAvailablePeers:     []string{"1"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
 				ChooseAction{
 					InputContextTimeout: 10 * time.Millisecond,
 					ExpectedErr:         context.DeadlineExceeded,
@@ -515,8 +553,8 @@ func TestRoundRobinList(t *testing.T) {
 			retainedAvailablePeerIDs: []string{"1"},
 			expectedAvailablePeers:   []string{"1"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
 				ChooseAction{ExpectedPeer: "1"},
 				NotifyStatusChangeAction{PeerID: "1", NewConnectionStatus: peer.Available},
 				ChooseAction{ExpectedPeer: "1"},
@@ -528,8 +566,8 @@ func TestRoundRobinList(t *testing.T) {
 			retainedAvailablePeerIDs: []string{"1"},
 			expectedUnavailablePeers: []string{"1"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
 				ChooseAction{ExpectedPeer: "1"},
 				NotifyStatusChangeAction{PeerID: "1", NewConnectionStatus: peer.Unavailable},
 				ChooseAction{
@@ -544,8 +582,8 @@ func TestRoundRobinList(t *testing.T) {
 			retainedUnavailablePeerIDs: []string{"1"},
 			expectedUnavailablePeers:   []string{"1"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
 				NotifyStatusChangeAction{PeerID: "1", NewConnectionStatus: peer.Unavailable},
 				ChooseAction{
 					InputContextTimeout: 10 * time.Millisecond,
@@ -559,8 +597,8 @@ func TestRoundRobinList(t *testing.T) {
 			retainedAvailablePeerIDs: []string{"1"},
 			releasedPeerIDs:          []string{"1"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
 				UpdateAction{RemovedPeerIDs: []string{"1"}},
 				NotifyStatusChangeAction{PeerID: "1", NewConnectionStatus: peer.Available},
 			},
@@ -575,8 +613,8 @@ func TestRoundRobinList(t *testing.T) {
 			expectedAvailablePeers:     []string{"1v", "2va", "8uav"},
 			expectedUnavailablePeers:   []string{"3vau", "6u", "7ua"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1v", "6u"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1v", "6u"}},
 
 				// Added Peers
 				UpdateAction{
@@ -615,8 +653,8 @@ func TestRoundRobinList(t *testing.T) {
 			retainedUnavailablePeerIDs: []string{"1"},
 			expectedAvailablePeers:     []string{"1"},
 			peerListActions: []PeerListAction{
-				UpdateAction{AddedPeerIDs: []string{"1"}},
 				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
 				ConcurrentAction{
 					Actions: []PeerListAction{
 						ChooseAction{
@@ -652,7 +690,11 @@ func TestRoundRobinList(t *testing.T) {
 			ExpectPeerRetainsWithError(transport, tt.errRetainedPeerIDs, tt.retainErr)
 			ExpectPeerReleases(transport, tt.errReleasedPeerIDs, tt.releaseErr)
 
-			pl := New(transport)
+			var opts []ListOption
+			if tt.startWaitTimeout != 0 {
+				opts = append(opts, StartupWait(tt.startWaitTimeout))
+			}
+			pl := New(transport, opts...)
 
 			deps := ListActionDeps{
 				Peers: peerMap,
@@ -678,7 +720,7 @@ func TestRoundRobinList(t *testing.T) {
 				}
 			}
 
-			assert.Equal(t, tt.expectedRunning, pl.IsRunning())
+			assert.Equal(t, tt.expectedRunning, pl.IsRunning(), "List was not in the expected state")
 		})
 	}
 }

--- a/scripts/cover.sh
+++ b/scripts/cover.sh
@@ -52,7 +52,7 @@ for pkg in "$@"; do
 		args="-coverprofile $COVER/cover.${i}.out -coverpkg $coverpkg"
 	fi
 
-	go test $args -v "$pkg"
+	go test -race $args -v "$pkg"
 done
 
 gocovmerge "$COVER"/*.out > cover.out


### PR DESCRIPTION
We're not testing with the race detector enabled, which has allowed several data races to sneak into YARPC. This PR breaks the build, but we should consider merging it and fixing the existing races in follow-on PRs.

```
$ go test -race ./internal/sync                                                                                                                                                                                                                                
==================
WARNING: DATA RACE
Write at 0x00c420074c50 by goroutine 42:
  go.uber.org/yarpc/internal/sync.(*lifecycleOnce).Stop()
      /Users/ashah/src/go.uber.org/yarpc/internal/sync/lifecycle.go:184 +0x233
  go.uber.org/yarpc/internal/sync.StopAction.Apply()
      /Users/ashah/src/go.uber.org/yarpc/internal/sync/lifecycle_action_test.go:84 +0x19a
  go.uber.org/yarpc/internal/sync.(*StopAction).Apply()
      <autogenerated>:18 +0xb2
  go.uber.org/yarpc/internal/sync.ConcurrentAction.Apply.func1()
      /Users/ashah/src/go.uber.org/yarpc/internal/sync/lifecycle_action_test.go:118 +0x92

Previous read at 0x00c420074c50 by goroutine 41:
  go.uber.org/yarpc/internal/sync.(*lifecycleOnce).Start()
      /Users/ashah/src/go.uber.org/yarpc/internal/sync/lifecycle.go:137 +0xcc
  go.uber.org/yarpc/internal/sync.StartAction.Apply()
      /Users/ashah/src/go.uber.org/yarpc/internal/sync/lifecycle_action_test.go:61 +0x1a3
  go.uber.org/yarpc/internal/sync.(*StartAction).Apply()
      <autogenerated>:17 +0xb2
  go.uber.org/yarpc/internal/sync.ConcurrentAction.Apply.func1()
      /Users/ashah/src/go.uber.org/yarpc/internal/sync/lifecycle_action_test.go:118 +0x92

Goroutine 42 (running) created at:
  go.uber.org/yarpc/internal/sync.ConcurrentAction.Apply()
      /Users/ashah/src/go.uber.org/yarpc/internal/sync/lifecycle_action_test.go:119 +0x11b
  go.uber.org/yarpc/internal/sync.(*ConcurrentAction).Apply()
      <autogenerated>:21 +0xb9
  go.uber.org/yarpc/internal/sync.ApplyLifecycleActions.func1()
      /Users/ashah/src/go.uber.org/yarpc/internal/sync/lifecycle_action_test.go:138 +0xb7
  testing.tRunner()
      /usr/local/Cellar/go/1.7.5/libexec/src/testing/testing.go:610 +0xc9

Goroutine 41 (finished) created at:
  go.uber.org/yarpc/internal/sync.ConcurrentAction.Apply()
      /Users/ashah/src/go.uber.org/yarpc/internal/sync/lifecycle_action_test.go:119 +0x11b
  go.uber.org/yarpc/internal/sync.(*ConcurrentAction).Apply()
      <autogenerated>:21 +0xb9
  go.uber.org/yarpc/internal/sync.ApplyLifecycleActions.func1()
      /Users/ashah/src/go.uber.org/yarpc/internal/sync/lifecycle_action_test.go:138 +0xb7
  testing.tRunner()
      /usr/local/Cellar/go/1.7.5/libexec/src/testing/testing.go:610 +0xc9
==================
PASS
Found 1 data race(s)
FAIL    go.uber.org/yarpc/internal/sync 1.665s
```

```
$ go test -race ./peer/x/roundrobin
==================
WARNING: DATA RACE
Read at 0x00c4201a0050 by goroutine 62:
  go.uber.org/yarpc/api/peer/peertest.(*LightMockPeer).StartRequest()
      /Users/ashah/src/go.uber.org/yarpc/api/peer/peertest/peers.go:67 +0x44
  go.uber.org/yarpc/peer/x/roundrobin.(*List).Choose()
      /Users/ashah/src/go.uber.org/yarpc/peer/x/roundrobin/list.go:220 +0x165
  go.uber.org/yarpc/api/peer/peertest.ChooseAction.Apply()
      /Users/ashah/src/go.uber.org/yarpc/api/peer/peertest/peerlistaction.go:108 +0x9a
  go.uber.org/yarpc/api/peer/peertest.(*ChooseAction).Apply()
      <autogenerated>:7 +0xb8
  go.uber.org/yarpc/api/peer/peertest.ConcurrentAction.Apply.func1()
      /Users/ashah/src/go.uber.org/yarpc/api/peer/peertest/peerlistaction.go:174 +0x92

Previous write at 0x00c4201a0050 by goroutine 60:
  go.uber.org/yarpc/api/peer/peertest.(*LightMockPeer).StartRequest()
      /Users/ashah/src/go.uber.org/yarpc/api/peer/peertest/peers.go:67 +0x60
  go.uber.org/yarpc/peer/x/roundrobin.(*List).Choose()
      /Users/ashah/src/go.uber.org/yarpc/peer/x/roundrobin/list.go:220 +0x165
  go.uber.org/yarpc/api/peer/peertest.ChooseAction.Apply()
      /Users/ashah/src/go.uber.org/yarpc/api/peer/peertest/peerlistaction.go:108 +0x9a
  go.uber.org/yarpc/api/peer/peertest.(*ChooseAction).Apply()
      <autogenerated>:7 +0xb8
  go.uber.org/yarpc/api/peer/peertest.ConcurrentAction.Apply.func1()
      /Users/ashah/src/go.uber.org/yarpc/api/peer/peertest/peerlistaction.go:174 +0x92

Goroutine 62 (running) created at:
  go.uber.org/yarpc/api/peer/peertest.ConcurrentAction.Apply()
      /Users/ashah/src/go.uber.org/yarpc/api/peer/peertest/peerlistaction.go:175 +0x11b
  go.uber.org/yarpc/api/peer/peertest.(*ConcurrentAction).Apply()
      <autogenerated>:10 +0xb9
  go.uber.org/yarpc/api/peer/peertest.ApplyPeerListActions.func1()
      /Users/ashah/src/go.uber.org/yarpc/api/peer/peertest/peerlistaction.go:208 +0xa6
  testing.tRunner()
      /usr/local/Cellar/go/1.7.5/libexec/src/testing/testing.go:610 +0xc9

Goroutine 60 (finished) created at:
  go.uber.org/yarpc/api/peer/peertest.ConcurrentAction.Apply()
      /Users/ashah/src/go.uber.org/yarpc/api/peer/peertest/peerlistaction.go:175 +0x11b
  go.uber.org/yarpc/api/peer/peertest.(*ConcurrentAction).Apply()
      <autogenerated>:10 +0xb9
  go.uber.org/yarpc/api/peer/peertest.ApplyPeerListActions.func1()
      /Users/ashah/src/go.uber.org/yarpc/api/peer/peertest/peerlistaction.go:208 +0xa6
  testing.tRunner()
      /usr/local/Cellar/go/1.7.5/libexec/src/testing/testing.go:610 +0xc9
==================
==================
WARNING: DATA RACE
Read at 0x00c4201a0050 by goroutine 76:
  go.uber.org/yarpc/api/peer/peertest.(*LightMockPeer).StartRequest()
      /Users/ashah/src/go.uber.org/yarpc/api/peer/peertest/peers.go:67 +0x44
  go.uber.org/yarpc/peer/x/roundrobin.(*List).Choose()
      /Users/ashah/src/go.uber.org/yarpc/peer/x/roundrobin/list.go:220 +0x165
  go.uber.org/yarpc/api/peer/peertest.ChooseAction.Apply()
      /Users/ashah/src/go.uber.org/yarpc/api/peer/peertest/peerlistaction.go:108 +0x9a
  go.uber.org/yarpc/api/peer/peertest.(*ChooseAction).Apply()
      <autogenerated>:7 +0xb8
  go.uber.org/yarpc/api/peer/peertest.ConcurrentAction.Apply.func1()
      /Users/ashah/src/go.uber.org/yarpc/api/peer/peertest/peerlistaction.go:174 +0x92

Previous write at 0x00c4201a0050 by goroutine 60:
  go.uber.org/yarpc/api/peer/peertest.(*LightMockPeer).StartRequest()
      /Users/ashah/src/go.uber.org/yarpc/api/peer/peertest/peers.go:67 +0x60
  go.uber.org/yarpc/peer/x/roundrobin.(*List).Choose()
      /Users/ashah/src/go.uber.org/yarpc/peer/x/roundrobin/list.go:220 +0x165
  go.uber.org/yarpc/api/peer/peertest.ChooseAction.Apply()
      /Users/ashah/src/go.uber.org/yarpc/api/peer/peertest/peerlistaction.go:108 +0x9a
  go.uber.org/yarpc/api/peer/peertest.(*ChooseAction).Apply()
      <autogenerated>:7 +0xb8
  go.uber.org/yarpc/api/peer/peertest.ConcurrentAction.Apply.func1()
      /Users/ashah/src/go.uber.org/yarpc/api/peer/peertest/peerlistaction.go:174 +0x92

Goroutine 76 (running) created at:
  go.uber.org/yarpc/api/peer/peertest.ConcurrentAction.Apply()
      /Users/ashah/src/go.uber.org/yarpc/api/peer/peertest/peerlistaction.go:175 +0x11b
  go.uber.org/yarpc/api/peer/peertest.(*ConcurrentAction).Apply()
      <autogenerated>:10 +0xb9
  go.uber.org/yarpc/api/peer/peertest.ApplyPeerListActions.func1()
      /Users/ashah/src/go.uber.org/yarpc/api/peer/peertest/peerlistaction.go:208 +0xa6
  testing.tRunner()
      /usr/local/Cellar/go/1.7.5/libexec/src/testing/testing.go:610 +0xc9

Goroutine 60 (finished) created at:
  go.uber.org/yarpc/api/peer/peertest.ConcurrentAction.Apply()
      /Users/ashah/src/go.uber.org/yarpc/api/peer/peertest/peerlistaction.go:175 +0x11b
  go.uber.org/yarpc/api/peer/peertest.(*ConcurrentAction).Apply()
      <autogenerated>:10 +0xb9
  go.uber.org/yarpc/api/peer/peertest.ApplyPeerListActions.func1()
      /Users/ashah/src/go.uber.org/yarpc/api/peer/peertest/peerlistaction.go:208 +0xa6
  testing.tRunner()
      /usr/local/Cellar/go/1.7.5/libexec/src/testing/testing.go:610 +0xc9
==================
PASS
Found 2 data race(s)
FAIL	go.uber.org/yarpc/peer/x/roundrobin	1.409s
```