### PR TITLE
Fix Data Race in LightMockPeer object

### DIFF
--- a/api/peer/peertest/peers.go
+++ b/api/peer/peertest/peers.go
@@ -22,6 +22,7 @@ package peertest
 
 import (
 	"fmt"
+	"sync"
 
 	"go.uber.org/yarpc/api/peer"
 
@@ -52,6 +53,8 @@ func NewLightMockPeer(pid MockPeerIdentifier, conStatus peer.ConnectionStatus) *
 // a peer's attributes
 // MockPeer is NOT thread safe
 type LightMockPeer struct {
+	sync.Mutex
+
 	MockPeerIdentifier
 
 	PeerStatus peer.Status
@@ -64,12 +67,16 @@ func (p *LightMockPeer) Status() peer.Status {
 
 // StartRequest is run when a Request starts
 func (p *LightMockPeer) StartRequest() {
+	p.Lock()
 	p.PeerStatus.PendingRequestCount++
+	p.Unlock()
 }
 
 // EndRequest should be run after a MockPeer request has finished
 func (p *LightMockPeer) EndRequest() {
+	p.Lock()
 	p.PeerStatus.PendingRequestCount--
+	p.Unlock()
 }
 
 // PeerIdentifierMatcher is used to match a Peer/PeerIdentifier by comparing


### PR DESCRIPTION
Summary: This fixes a race in a test version of Peer Objects.  The
status objects for peers does not use an atomic for pending count,
silly in retrospect now, but still teeeeechnically part of the api.

I would count fixing the peerStatus as a bug fix, but I'm curious what
other people think.  I don't think many people are using this API yet.
(It's also not the biiiiggest deal since all peer implementations use mutexes)