### PR TITLE
Add peer.ChooserList interface for convenience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ v1.6.0 (2017-03-08)
     even if Start hadn't been called yet.
 -   Updated RoundRobin and PeerHeap implementations to block until the list has
     started or a timeout had been exceeded.
+-   Adds a peer.ChooserList interface to the API, for convenience when passing
+    instances with both capabilities (suitable for outbounds, suitable for peer
+    providers).
 
 
 v1.5.0 (2017-03-03)

--- a/api/peer/list.go
+++ b/api/peer/list.go
@@ -26,7 +26,8 @@ import (
 	"go.uber.org/yarpc/api/transport"
 )
 
-// Chooser is a collection of Peers.  Outbounds request peers from the peer.Chooser to determine where to send requests
+// Chooser is a collection of Peers. Outbounds request peers from the
+// peer.Chooser to determine where to send requests.
 type Chooser interface {
 	transport.Lifecycle
 
@@ -40,6 +41,13 @@ type Chooser interface {
 type List interface {
 	// Update performs the additions and removals to the Peer List
 	Update(updates ListUpdates) error
+}
+
+// ChooserList is both a Chooser and a List, useful for expressing both
+// capabilities of a single instance.
+type ChooserList interface {
+	Chooser
+	List
 }
 
 // ListUpdates specifies the updates to be made to a List


### PR DESCRIPTION
Allows us to pass objects with both capabilities, for example to utilities that
bind a peer provider to a peer list and return just the composite peer chooser
API.