### PR TITLE
Add simple metric types to Pally

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,16 +1,20 @@
-hash: 2c09074fbfa6d11ed6e93843553256fcbb93e0675b2421ae0a6e3644e0b9d4d4
-updated: 2017-03-08T17:31:02.321013998-05:00
+hash: 8fe1b69230b14275368eb467d2f101cf9b5d6a50c4213b21b8a363c355bf0982
+updated: 2017-03-17T17:04:00.516469967-07:00
 imports:
 - name: github.com/apache/thrift
-  version: b79396f799fe88d2dae48573f61257aac5b2c09b
+  version: 6582757752e62efea3f9786dddf0260efaa1f450
   subpackages:
   - lib/go/thrift
+- name: github.com/beorn7/perks
+  version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
+  subpackages:
+  - quantile
 - name: github.com/cactus/go-statsd-client
   version: d8eabe07bc70ff9ba6a56836cde99d1ea3d005f7
   subpackages:
   - statsd
 - name: github.com/codahale/hdrhistogram
-  version: 3a0bb77429bd3a61596f5e8a3172445844342120
+  version: f8ad88b59a584afeee9d334eff879b104439117b
 - name: github.com/crossdock/crossdock-go
   version: 049aabb0122b03bc9bd30cab8f3f91fb60166361
   subpackages:
@@ -20,14 +24,24 @@ imports:
   version: 346938d642f2ec3594ed81d874461961cd0faa76
   subpackages:
   - spew
+- name: github.com/facebookgo/clock
+  version: 600d898af40aa09a7a93ecb9265d87b0504b6f03
 - name: github.com/golang/mock
   version: bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
   subpackages:
   - gomock
+- name: github.com/golang/protobuf
+  version: 69b215d01a5606c843240eab4937eab3acee6530
+  subpackages:
+  - proto
 - name: github.com/gorilla/websocket
-  version: 3ab3a8b8831546bd18fd182c20687ca853b2bb13
+  version: c36f2fe5c330f0ac404b616b96c438b8616b1aaf
+- name: github.com/matttproud/golang_protobuf_extensions
+  version: c12348ce28de40eed0136aa2b644d0ee0650e56c
+  subpackages:
+  - pbutil
 - name: github.com/mitchellh/mapstructure
-  version: 53818660ed4955e899c0bcafa97299a388bd7c8e
+  version: db1efb556f84b25a0a13a04aad883943538ad2e0
 - name: github.com/opentracing/opentracing-go
   version: 6edb48674bd9467b8e91fda004f2bd7202d60ce4
   subpackages:
@@ -40,8 +54,27 @@ imports:
   version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib
+- name: github.com/prometheus/client_golang
+  version: c5b7fccd204277076155f10851dad72b76a49317
+  subpackages:
+  - prometheus
+  - prometheus/promhttp
+- name: github.com/prometheus/client_model
+  version: 6f3806018612930941127f2a7c6c453ba2c527d2
+  subpackages:
+  - go
+- name: github.com/prometheus/common
+  version: dd2f054febf4a6c00f2343686efb775948a8bff4
+  subpackages:
+  - expfmt
+  - internal/bitbucket.org/ww/goautoneg
+  - model
+- name: github.com/prometheus/procfs
+  version: a1dba9ce8baed984a2495b658c82687f8157b98f
+  subpackages:
+  - xfs
 - name: github.com/Sirupsen/logrus
-  version: 1deb2db2a6fff8a35532079061b903c3a25eed52
+  version: 08a8a7c27e3d058a8989316a850daad1c10bf4ab
 - name: github.com/stretchr/objx
   version: 1a9d0bb9f541897e62256577b352fdbc1fb4fd94
 - name: github.com/stretchr/testify
@@ -51,11 +84,18 @@ imports:
   - mock
   - require
 - name: github.com/uber-common/bark
-  version: 8841a0f8e7ca869284ccb29c08a14cf3f4310f46
+  version: d52ffa061726911f47fcd3d9e8b9b55f22794772
 - name: github.com/uber-go/atomic
-  version: 3b8db5e93c4c02efbc313e17b2e796b0914a01fb
+  version: e682c1008ac17bf26d2e4b5ad6cdd08520ed0b22
+- name: github.com/uber-go/tally
+  version: 34be4a565ce6286a0ba91a54a81be3f6181ca2e2
+  subpackages:
+  - m3
+  - m3/customtransports
+  - m3/thrift
+  - m3/thriftudp
 - name: github.com/uber/cherami-client-go
-  version: 1cdcfc4a204fe42013f4cf7196fab208d3b98085
+  version: 5b008bbffe389a329274ff5ceaaa68e0b17348f9
   subpackages:
   - client/cherami
   - common
@@ -64,11 +104,11 @@ imports:
   - common/websocket
   - stream
 - name: github.com/uber/cherami-thrift
-  version: f0703bd3b598cad63ed9c7c4470f27ca1ce0edfb
+  version: 0f0585c53937209f08a57c6ae51d8a7fd281e100
   subpackages:
   - .generated/go/cherami
 - name: github.com/uber/jaeger-client-go
-  version: 2505ffc229cbe642a1af9387e8251f7e699c2f6e
+  version: 81280be4110ac49c4c2094eeffd409a0043d51c0
   subpackages:
   - internal/spanlog
   - log
@@ -100,7 +140,7 @@ imports:
   - trand
   - typed
 - name: go.uber.org/atomic
-  version: 0c9e689d64f004564b79d9a663634756df322902
+  version: 3b8db5e93c4c02efbc313e17b2e796b0914a01fb
 - name: go.uber.org/thriftrw
   version: c98a13058faa5dd41584a77221a268d2c72d832d
   subpackages:
@@ -119,7 +159,7 @@ imports:
   - version
   - wire
 - name: go.uber.org/tools
-  version: 214b415e51a0d9f12ead771d4336aafc73555bd2
+  version: fb05033aaa266ee0674167682d3da91bef95d02a
   subpackages:
   - update-license
 - name: golang.org/x/net
@@ -128,15 +168,17 @@ imports:
   - context
   - context/ctxhttp
 - name: golang.org/x/sys
-  version: 99f16d856c9836c42d24e7ab64ea72916925fa97
+  version: d4feaf1a7e61e1d9e79e6c4e76c6349e9cab0a03
   subpackages:
   - unix
 - name: golang.org/x/tools
-  version: 03d3934baf81f2387349b58864cb98b6fe7cf85e
+  version: 2946dd1f77e693e136d9ed202ba093bb4a3ea761
   subpackages:
   - go/ast/astutil
+- name: gopkg.in/bsm/ratelimit.v1
+  version: db14e161995a5177acef654cb0dd785e8ee8bc22
 - name: gopkg.in/redis.v5
-  version: a16aeec10ff407b1e7be6dd35797ccf5426ef0f0
+  version: b6bfe529a846fbb9a58c832ce71c61b6fde12c15
   subpackages:
   - internal
   - internal/consistenthash
@@ -144,5 +186,5 @@ imports:
   - internal/pool
   - internal/proto
 - name: gopkg.in/yaml.v2
-  version: a3f3340b5840cee44f372bddb5880fcbc419b46a
+  version: a83829b6f1293c91addabc89d0571c246397bbf4
 testImports: []

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 8fe1b69230b14275368eb467d2f101cf9b5d6a50c4213b21b8a363c355bf0982
-updated: 2017-03-17T17:04:00.516469967-07:00
+hash: 1ffd122bc9f21d143214077e190653c21d50d694b6dd5cbc47e3448c62127a9b
+updated: 2017-03-17T17:15:14.908793306-07:00
 imports:
 - name: github.com/apache/thrift
   version: 6582757752e62efea3f9786dddf0260efaa1f450
@@ -88,7 +88,7 @@ imports:
 - name: github.com/uber-go/atomic
   version: e682c1008ac17bf26d2e4b5ad6cdd08520ed0b22
 - name: github.com/uber-go/tally
-  version: 34be4a565ce6286a0ba91a54a81be3f6181ca2e2
+  version: 4b9d9de43ffcb0b7efe67dab2a92c2d58dbf16ab
   subpackages:
   - m3
   - m3/customtransports

--- a/glide.yaml
+++ b/glide.yaml
@@ -43,4 +43,4 @@ import:
   - prometheus
   - prometheus/promhttp
 - package: github.com/uber-go/tally
-  version: ^2.1.0
+  version: ^3

--- a/glide.yaml
+++ b/glide.yaml
@@ -27,7 +27,7 @@ import:
   - assert
   - require
 - package: github.com/uber/jaeger-client-go
-  version: ">=1, <3"
+  version: '>=1, <3'
 - package: gopkg.in/yaml.v2
 - package: gopkg.in/redis.v5
 # TODO: before cherami transport can leave the x/ package, cherami-client-go must >=1.0
@@ -36,3 +36,11 @@ import:
 - package: go.uber.org/tools
   subpackages:
   - update-license
+- package: github.com/prometheus/client_golang
+  # This isn't exposed to customers, so we can depend on a pre-1.0 release.
+  version: ~0.8.0
+  subpackages:
+  - prometheus
+  - prometheus/promhttp
+- package: github.com/uber-go/tally
+  version: ^2.1.0

--- a/internal/pally/README.md
+++ b/internal/pally/README.md
@@ -1,0 +1,25 @@
+# :two_women_holding_hands: pally
+
+Pally makes [Prometheus][] and [tally][] pals. Rather than choosing one or the
+other, take the best of both!
+
+Compared to Prometheus, pally is fast: modeling metrics as integers instead of
+floats allows pally to avoid expensive increment-and-compare loops.
+
+Compared to tally, pally prioritizes introspection: like expvar and Prometheus,
+all metrics can be inspected via a simple HTTP endpoint even when central
+telemetry systems are down.
+
+Pally grew out of the internal metrics libraries built by Uber's software
+networking team. Its open-source incarnation is incubating in YARPC before
+potentially migrating into an independent project.
+
+Known to-dos:
+
+- [ ] Histogram support
+- [ ] Stopwatches (for convenient timing collection)
+- [ ] Comparative benchmarks with Tally
+- [ ] Comparative benchmarks with Prometheus
+
+[Prometheus]: http://prometheus.io
+[Tally]: https://github.com/uber-go/tally

--- a/internal/pally/README.md
+++ b/internal/pally/README.md
@@ -1,12 +1,12 @@
 # :two_women_holding_hands: pally
 
-Pally makes [Prometheus][] and [tally][] pals. Rather than choosing one or the
+Pally makes [Prometheus][] and [Tally][] pals. Rather than choosing one or the
 other, take the best of both!
 
-Compared to Prometheus, pally is fast: modeling metrics as integers instead of
+Compared to Prometheus, Pally is fast: modeling metrics as integers instead of
 floats allows pally to avoid expensive increment-and-compare loops.
 
-Compared to tally, pally prioritizes introspection: like expvar and Prometheus,
+Compared to Tally, Pally prioritizes introspection: like expvar and Prometheus,
 all metrics can be inspected via a simple HTTP endpoint even when central
 telemetry systems are down.
 
@@ -18,8 +18,6 @@ Known to-dos:
 
 - [ ] Histogram support
 - [ ] Stopwatches (for convenient timing collection)
-- [ ] Comparative benchmarks with Tally
-- [ ] Comparative benchmarks with Prometheus
 
 [Prometheus]: http://prometheus.io
 [Tally]: https://github.com/uber-go/tally

--- a/internal/pally/counter.go
+++ b/internal/pally/counter.go
@@ -25,6 +25,8 @@ func (c *counter) diff() int64 {
 }
 
 func (c *counter) Collect(ch chan<- prometheus.Metric) {
+	// TODO: Implement prometheus.Metric directly, which allows us to avoid
+	// this allocation.
 	m, err := prometheus.NewConstMetric(
 		c.desc,
 		prometheus.CounterValue,

--- a/internal/pally/counter.go
+++ b/internal/pally/counter.go
@@ -1,0 +1,91 @@
+package pally
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/uber-go/tally"
+)
+
+type counter struct {
+	value
+	last  int64
+	tally tally.Counter
+}
+
+func newCounter(opts Opts) *counter {
+	return &counter{value: newValue(opts)}
+}
+
+func (c *counter) diff() int64 {
+	cur := c.Load()
+	diff := cur - c.last
+	c.last = cur
+	return diff
+}
+
+func (c *counter) Collect(ch chan<- prometheus.Metric) {
+	m, err := prometheus.NewConstMetric(
+		c.desc,
+		prometheus.CounterValue,
+		float64(c.Load()),
+		c.variableLabelVals...,
+	)
+	if err == nil {
+		ch <- m
+	}
+}
+
+func (c *counter) push(scope tally.Scope) {
+	if c.opts.DisableTally {
+		return
+	}
+	if c.tally == nil {
+		labels := c.opts.copyLabels()
+		for i, key := range c.opts.VariableLabels {
+			labels[key] = c.variableLabelVals[i]
+		}
+		c.tally = scope.Tagged(labels).Counter(c.opts.Name)
+	}
+	c.tally.Inc(c.diff())
+}
+
+type counterVector vector
+
+func newCounterVector(opts Opts) *counterVector {
+	vec := counterVector(vector{
+		opts:    opts,
+		desc:    opts.describe(),
+		factory: newDynamicCounter,
+		metrics: make(map[string]metric, _defaultVectorSize),
+	})
+	return &vec
+}
+
+func (cv *counterVector) Get(variableLabelVals ...string) (Counter, error) {
+	m, err := (*vector)(cv).getOrCreate(variableLabelVals...)
+	if err != nil {
+		return nil, err
+	}
+	return m.(Counter), nil
+}
+
+func (cv *counterVector) MustGet(variableLabelVals ...string) Counter {
+	c, err := cv.Get(variableLabelVals...)
+	if err != nil {
+		panic(fmt.Sprintf("failed to get Counter with labels %v: %v", variableLabelVals, err))
+	}
+	return c
+}
+
+func (cv *counterVector) Describe(ch chan<- *prometheus.Desc) { (*vector)(cv).Describe(ch) }
+func (cv *counterVector) Collect(ch chan<- prometheus.Metric) { (*vector)(cv).Collect(ch) }
+func (cv *counterVector) push(scope tally.Scope)              { (*vector)(cv).push(scope) }
+
+func newDynamicCounter(opts Opts, desc *prometheus.Desc, variableLabelVals []string) metric {
+	return &counter{value: value{
+		opts:              &opts,
+		desc:              desc,
+		variableLabelVals: variableLabelVals,
+	}}
+}

--- a/internal/pally/counter.go
+++ b/internal/pally/counter.go
@@ -84,7 +84,7 @@ func (cv *counterVector) push(scope tally.Scope)              { (*vector)(cv).pu
 
 func newDynamicCounter(opts Opts, desc *prometheus.Desc, variableLabelVals []string) metric {
 	return &counter{value: value{
-		opts:              &opts,
+		opts:              opts,
 		desc:              desc,
 		variableLabelVals: variableLabelVals,
 	}}

--- a/internal/pally/counter_test.go
+++ b/internal/pally/counter_test.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package pally
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCounter(t *testing.T) {
+	r := NewRegistry(Labeled(Labels{"service": "users"}))
+	counter, err := r.NewCounter(Opts{
+		Name:        "test_counter",
+		Help:        "Some help.",
+		ConstLabels: Labels{"foo": "bar"},
+	})
+	require.NoError(t, err, "Unexpected error constructing counter.")
+
+	scope := newTestScope()
+	stop, err := r.Push(scope, _tick)
+	require.NoError(t, err, "Unexpected error starting Tally push.")
+
+	counter.Inc()
+	counter.Add(2)
+	assert.Equal(t, int64(3), counter.Load(), "Unexpected in-memory counter value.")
+
+	time.Sleep(5 * _tick)
+	counter.Inc()
+	assert.Equal(t, int64(4), counter.Load(), "Unexpected in-memory counter value after sleep.")
+
+	stop()
+
+	export := TallyExpectation{
+		Type:   "counter",
+		Name:   "test_counter",
+		Labels: Labels{"foo": "bar", "service": "users"},
+		Value:  4,
+	}
+	export.Test(t, scope)
+
+	assertPrometheusText(t, r, "# HELP test_counter Some help.\n"+
+		"# TYPE test_counter counter\n"+
+		`test_counter{foo="bar",service="users"} 4`)
+}
+
+func TestCounterVec(t *testing.T) {
+	r := NewRegistry(Labeled(Labels{"service": "users"}))
+	vec, err := r.NewCounterVector(Opts{
+		Name:           "test_counter",
+		Help:           "Some help.",
+		ConstLabels:    Labels{"foo": "bar"},
+		VariableLabels: []string{"baz"},
+	})
+	require.NoError(t, err, "Unexpected error constructing vector.")
+
+	scope := newTestScope()
+	stop, err := r.Push(scope, _tick)
+	require.NoError(t, err, "Unexpected error starting Tally push.")
+
+	counter, err := vec.Get("a")
+	require.NoError(t, err, "Unexpected error getting a counter with correct number of labels.")
+	counter.Inc()
+	vec.MustGet("a").Add(2)
+	vec.MustGet("a").Inc()
+
+	assert.Equal(t, int64(4), counter.Load(), "Unexpected in-memory counter value.")
+
+	time.Sleep(5 * _tick)
+	counter.Inc()
+	assert.Equal(t, int64(5), counter.Load(), "Unexpected in-memory counter value after sleep.")
+
+	stop()
+
+	export := TallyExpectation{
+		Type:   "counter",
+		Name:   "test_counter",
+		Labels: Labels{"foo": "bar", "service": "users", "baz": "a"},
+		Value:  5,
+	}
+	export.Test(t, scope)
+
+	assertPrometheusText(t, r, "# HELP test_counter Some help.\n"+
+		"# TYPE test_counter counter\n"+
+		`test_counter{baz="a",foo="bar",service="users"} 5`)
+}
+
+func TestCounterVecInvalidLabelValues(t *testing.T) {
+	r := NewRegistry()
+	vec, err := r.NewCounterVector(Opts{
+		Name:           "test_counter",
+		Help:           "Some help.",
+		VariableLabels: []string{"foo"},
+	})
+	require.NoError(t, err, "Unexpected error constructing vector.")
+
+	_, err = vec.Get("foo:")
+	assert.Error(t, err, "Expected an error using invalid label values.")
+	assert.Panics(t, func() { vec.MustGet("foo:") }, "Expected a panic using invalid label values.")
+
+	_, err = vec.Get("bar", "baz")
+	assert.Error(t, err, "Expected an error using too many label values.")
+	assert.Panics(t, func() { vec.MustGet("bar", "baz") }, "Expected a panic using too many label values.")
+}

--- a/internal/pally/doc.go
+++ b/internal/pally/doc.go
@@ -22,4 +22,44 @@
 // seamlessly with both Prometheus and Tally, providing ready-to-use Prometheus
 // text and protocol buffer endpoints, differential updates to StatsD- or
 // M3-based systems, and excellent performance along the hot path.
+//
+// Counters And Gauges
+//
+// Pally offers two simple metric types: counters and gauges. Counters
+// represent an ever-accumulating total, like a car's odometer. Gauges
+// represent a point-in-time measurement, like a car's speedometer. In Pally,
+// both counters and gauges must have all their labels specified ahead of time.
+//
+// Vectors
+//
+// In many real-world situations, it's impossible to know all the labels for a
+// metric ahead of time. For example, you may want to track the number of
+// requests your server receives by caller; in most cases, you can't list all
+// the possible callers ahead of time. To accomodate these situations, Pally
+// offers vectors.
+//
+// Vectors represent a collection of metrics that have some constant labels,
+// but some labels assigned at runtime. At vector construction time, you must
+// specify the variable label keys; in our example, we'd supply "caller_name"
+// as the only variable label. At runtime, pass the values for the variable
+// labels to the Get (or MustGet) method on the vector. The number of label
+// values must match the configured number of label keys, and they must be
+// supplied in the same order. Vectors create metrics on demand, caching them
+// for efficient repeated access.
+//
+//   registry := NewRegistry()
+//   requestsByCaller := registry.NewCounterVector(Opts{
+//     Name: "requests",
+//     Help: "Total requests by caller name.",
+//     ConstLabels: Labels{
+//       "zone": "us-west-1",
+//       "service": "my_service_name",
+//     },
+//     // At runtime, we'll supply the caller name.
+//     VariableLabels: []string{"caller_name"},
+//   })
+//   // In real-world use, we'd do this in a handler function (and we'd
+//   probably use the safer Get variant).
+//   vec.MustGet("some_calling_service").Inc()
+//
 package pally

--- a/internal/pally/doc.go
+++ b/internal/pally/doc.go
@@ -20,8 +20,14 @@
 
 // Package pally is a simple, atomic-based metrics library. It interoperates
 // seamlessly with both Prometheus and Tally, providing ready-to-use Prometheus
-// text and protocol buffer endpoints, differential updates to StatsD- or
+// text and Protocol Buffer endpoints, differential updates to StatsD- or
 // M3-based systems, and excellent performance along the hot path.
+//
+// Metric Names
+//
+// Pally requires that all metric names and labels be valid both in Tally and
+// in Prometheus. Concretely, this means that metric names, label keys, and
+// label values should match the regular expression `^[a-zA-Z_][a-zA-Z0-9_]*$`.
 //
 // Counters And Gauges
 //
@@ -59,7 +65,7 @@
 //     VariableLabels: []string{"caller_name"},
 //   })
 //   // In real-world use, we'd do this in a handler function (and we'd
-//   probably use the safer Get variant).
+//   // probably use the safer Get variant).
 //   vec.MustGet("some_calling_service").Inc()
 //
 package pally

--- a/internal/pally/doc.go
+++ b/internal/pally/doc.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package pally is a simple, atomic-based metrics library. It interoperates
+// seamlessly with both Prometheus and Tally, providing ready-to-use Prometheus
+// text and protocol buffer endpoints, differential updates to StatsD- or
+// M3-based systems, and excellent performance along the hot path.
+package pally

--- a/internal/pally/gauge.go
+++ b/internal/pally/gauge.go
@@ -1,0 +1,83 @@
+package pally
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/uber-go/tally"
+)
+
+type gauge struct {
+	value
+	tally tally.Gauge
+}
+
+func newGauge(opts Opts) *gauge {
+	return &gauge{value: newValue(opts)}
+}
+
+func (g *gauge) Collect(ch chan<- prometheus.Metric) {
+	m, err := prometheus.NewConstMetric(
+		g.desc,
+		prometheus.GaugeValue,
+		float64(g.Load()),
+		g.variableLabelVals...,
+	)
+	if err == nil {
+		ch <- m
+	}
+}
+
+func (g *gauge) push(scope tally.Scope) {
+	if g.opts.DisableTally {
+		return
+	}
+	if g.tally == nil {
+		labels := g.opts.copyLabels()
+		for i, key := range g.opts.VariableLabels {
+			labels[key] = g.variableLabelVals[i]
+		}
+		g.tally = scope.Tagged(labels).Gauge(g.opts.Name)
+	}
+	g.tally.Update(float64(g.Load()))
+}
+
+type gaugeVector vector
+
+func newGaugeVector(opts Opts) *gaugeVector {
+	vec := gaugeVector(vector{
+		opts:    opts,
+		desc:    opts.describe(),
+		factory: newDynamicGauge,
+		metrics: make(map[string]metric, _defaultVectorSize),
+	})
+	return &vec
+}
+
+func (gv *gaugeVector) Get(variableLabelVals ...string) (Gauge, error) {
+	m, err := (*vector)(gv).getOrCreate(variableLabelVals...)
+	if err != nil {
+		return nil, err
+	}
+	return m.(Gauge), nil
+}
+
+func (gv *gaugeVector) MustGet(variableLabelVals ...string) Gauge {
+	g, err := gv.Get(variableLabelVals...)
+	if err != nil {
+		panic(fmt.Sprintf("failed to get Gauge with labels %v: %v", variableLabelVals, err))
+	}
+	return g
+}
+
+func (gv *gaugeVector) Describe(ch chan<- *prometheus.Desc) { (*vector)(gv).Describe(ch) }
+func (gv *gaugeVector) Collect(ch chan<- prometheus.Metric) { (*vector)(gv).Collect(ch) }
+func (gv *gaugeVector) push(scope tally.Scope)              { (*vector)(gv).push(scope) }
+
+func newDynamicGauge(opts Opts, desc *prometheus.Desc, variableLabelVals []string) metric {
+	return &gauge{value: value{
+		opts:              &opts,
+		desc:              desc,
+		variableLabelVals: variableLabelVals,
+	}}
+}

--- a/internal/pally/gauge.go
+++ b/internal/pally/gauge.go
@@ -76,7 +76,7 @@ func (gv *gaugeVector) push(scope tally.Scope)              { (*vector)(gv).push
 
 func newDynamicGauge(opts Opts, desc *prometheus.Desc, variableLabelVals []string) metric {
 	return &gauge{value: value{
-		opts:              &opts,
+		opts:              opts,
 		desc:              desc,
 		variableLabelVals: variableLabelVals,
 	}}

--- a/internal/pally/gauge.go
+++ b/internal/pally/gauge.go
@@ -17,6 +17,8 @@ func newGauge(opts Opts) *gauge {
 }
 
 func (g *gauge) Collect(ch chan<- prometheus.Metric) {
+	// TODO: Implement prometheus.Metric directly, which allows us to avoid
+	// this allocation.
 	m, err := prometheus.NewConstMetric(
 		g.desc,
 		prometheus.GaugeValue,

--- a/internal/pally/gauge_test.go
+++ b/internal/pally/gauge_test.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package pally
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGauge(t *testing.T) {
+	r := NewRegistry(Labeled(Labels{"service": "users"}))
+	gauge, err := r.NewGauge(Opts{
+		Name:        "test_gauge",
+		Help:        "Some help.",
+		ConstLabels: Labels{"foo": "bar"},
+	})
+	require.NoError(t, err, "Unexpected error constructing gauge.")
+
+	scope := newTestScope()
+	stop, err := r.Push(scope, _tick)
+	require.NoError(t, err, "Unexpected error starting Tally push.")
+
+	gauge.Inc()
+	gauge.Store(42)
+	assert.Equal(t, int64(42), gauge.Load(), "Unexpected in-memory gauge value.")
+
+	time.Sleep(5 * _tick)
+	gauge.Store(4)
+	assert.Equal(t, int64(4), gauge.Load(), "Unexpected in-memory gauge value after sleep.")
+
+	stop()
+
+	export := TallyExpectation{
+		Type:   "gauge",
+		Name:   "test_gauge",
+		Labels: Labels{"foo": "bar", "service": "users"},
+		Value:  4,
+	}
+	export.Test(t, scope)
+
+	assertPrometheusText(t, r, "# HELP test_gauge Some help.\n"+
+		"# TYPE test_gauge gauge\n"+
+		`test_gauge{foo="bar",service="users"} 4`)
+}
+
+func TestGaugeVec(t *testing.T) {
+	r := NewRegistry(Labeled(Labels{"service": "users"}))
+	vec, err := r.NewGaugeVector(Opts{
+		Name:           "test_gauge",
+		Help:           "Some help.",
+		ConstLabels:    Labels{"foo": "bar"},
+		VariableLabels: []string{"baz"},
+	})
+	require.NoError(t, err, "Unexpected error constructing vector.")
+
+	scope := newTestScope()
+	stop, err := r.Push(scope, _tick)
+	require.NoError(t, err, "Unexpected error starting Tally push.")
+
+	gauge, err := vec.Get("a")
+	require.NoError(t, err, "Unexpected error getting a gauge with correct number of labels.")
+
+	gauge.Store(11)
+	assert.Equal(t, int64(11), gauge.Load(), "Unexpected in-memory gauge value.")
+
+	vec.MustGet("a").Add(2)
+	vec.MustGet("a").Inc()
+	assert.Equal(t, int64(14), gauge.Load(), "Unexpected in-memory gauge value.")
+
+	time.Sleep(5 * _tick)
+	gauge.Store(5)
+	assert.Equal(t, int64(5), gauge.Load(), "Unexpected in-memory gauge value after sleep.")
+
+	stop()
+
+	export := TallyExpectation{
+		Type:   "gauge",
+		Name:   "test_gauge",
+		Labels: Labels{"foo": "bar", "service": "users", "baz": "a"},
+		Value:  5,
+	}
+	export.Test(t, scope)
+
+	assertPrometheusText(t, r, "# HELP test_gauge Some help.\n"+
+		"# TYPE test_gauge gauge\n"+
+		`test_gauge{baz="a",foo="bar",service="users"} 5`)
+}
+
+func TestGaugeVecInvalidLabelValues(t *testing.T) {
+	r := NewRegistry()
+	vec, err := r.NewGaugeVector(Opts{
+		Name:           "test_counter",
+		Help:           "Some help.",
+		VariableLabels: []string{"foo"},
+	})
+	require.NoError(t, err, "Unexpected error constructing vector.")
+
+	_, err = vec.Get("foo:")
+	assert.Error(t, err, "Expected an error using invalid label values.")
+	assert.Panics(t, func() { vec.MustGet("foo:") }, "Expected an error using invalid label values.")
+
+	_, err = vec.Get("bar", "baz")
+	assert.Error(t, err, "Expected a panic using too many label values.")
+	assert.Panics(t, func() { vec.MustGet("bar", "baz") }, "Expected a panic using too many label values.")
+}

--- a/internal/pally/global_test.go
+++ b/internal/pally/global_test.go
@@ -1,0 +1,38 @@
+package pally_test
+
+import (
+	"go.uber.org/yarpc/internal/pally"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// For expvar-style usage (where all metrics are package-global), create a
+// package-global pally.Registry and use the Must* constructors. This
+// guarantees that all your metrics are unique.
+var (
+	_reg = pally.NewRegistry(
+		// Also register all metrics with the package-global Prometheus
+		// registry.
+		pally.Federated(prometheus.DefaultRegisterer),
+	)
+	_watches = _reg.MustGauge(pally.Opts{
+		Name: "watch_count",
+		Help: "Current number of active service name watches.",
+		ConstLabels: pally.Labels{
+			"foo": "bar",
+		},
+	})
+	_resolvesPerName = _reg.MustCounterVector(pally.Opts{
+		Name: "resolve_count",
+		Help: "Total name resolves by service.",
+		ConstLabels: pally.Labels{
+			"foo": "bar",
+		},
+		VariableLabels: []string{"service"},
+	})
+)
+
+func Example_globalMetrics() {
+	_watches.Store(42)
+	_resolvesPerName.MustGet("some_service").Inc()
+}

--- a/internal/pally/labels.go
+++ b/internal/pally/labels.go
@@ -35,11 +35,13 @@ var (
 )
 
 // A digester creates a null-delimited byte slice from a series of variable
-// label values.
+// label values. It's an efficient way to create map keys from metric names and
+// labels.
 type digester struct {
 	bs []byte
 }
 
+// For optimal performance, be sure to free each digester.
 func newDigester() *digester {
 	d := _digesterPool.Get().(*digester)
 	d.bs = d.bs[:0]
@@ -49,7 +51,7 @@ func newDigester() *digester {
 func (d *digester) add(s string) {
 	if len(d.bs) > 0 {
 		// separate labels with a null byte
-		d.bs = append(d.bs, 0)
+		d.bs = append(d.bs, '\x00')
 	}
 	d.bs = append(d.bs, s...)
 }

--- a/internal/pally/labels.go
+++ b/internal/pally/labels.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package pally
+
+import (
+	"errors"
+	"sync"
+)
+
+var (
+	// Match the Prometheus error message.
+	errInconsistentCardinality = errors.New("inconsistent label cardinality")
+
+	_digesterPool = sync.Pool{New: func() interface{} {
+		return &digester{make([]byte, 0, 128)}
+	}}
+)
+
+// A digester creates a null-delimited byte slice from a series of variable
+// label values.
+type digester struct {
+	bs []byte
+}
+
+func newDigester() *digester {
+	return _digesterPool.Get().(*digester)
+}
+
+func (d *digester) add(s string) {
+	if len(d.bs) > 0 {
+		// separate labels with a null byte
+		d.bs = append(d.bs, 0)
+	}
+	d.bs = append(d.bs, s...)
+}
+
+func (d *digester) digest() []byte {
+	return d.bs
+}
+
+func (d *digester) free() {
+	d.bs = d.bs[:0]
+	_digesterPool.Put(d)
+}
+
+// Labels describe the dimensions of a metric.
+type Labels map[string]string

--- a/internal/pally/labels.go
+++ b/internal/pally/labels.go
@@ -41,7 +41,9 @@ type digester struct {
 }
 
 func newDigester() *digester {
-	return _digesterPool.Get().(*digester)
+	d := _digesterPool.Get().(*digester)
+	d.bs = d.bs[:0]
+	return d
 }
 
 func (d *digester) add(s string) {
@@ -57,7 +59,6 @@ func (d *digester) digest() []byte {
 }
 
 func (d *digester) free() {
-	d.bs = d.bs[:0]
 	_digesterPool.Put(d)
 }
 

--- a/internal/pally/labels_test.go
+++ b/internal/pally/labels_test.go
@@ -42,6 +42,8 @@ func TestDigester(t *testing.T) {
 			defer wg.Done()
 			for i := 0; i < iterations; i++ {
 				d := newDigester()
+				defer d.free()
+
 				assert.Equal(t, 0, len(d.digest()), "Expected fresh digester to have no internal state.")
 				assert.True(t, cap(d.digest()) > 0, "Expected fresh digester to have available capacity.")
 

--- a/internal/pally/labels_test.go
+++ b/internal/pally/labels_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package pally
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDigester(t *testing.T) {
+	const (
+		goroutines = 10
+		iterations = 100
+	)
+
+	expected := []byte{'f', 'o', 'o', 0, 'b', 'a', 'r'}
+
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				d := newDigester()
+				assert.Equal(t, 0, len(d.digest()), "Expected fresh digester to have no internal state.")
+				assert.True(t, cap(d.digest()) > 0, "Expected fresh digester to have available capacity.")
+
+				d.add("foo")
+				d.add("bar")
+				assert.Equal(
+					t,
+					string(expected),
+					string(d.digest()),
+					"Expected digest to be null-separated concatenation of inputs.",
+				)
+			}
+		}()
+	}
+
+	wg.Wait()
+}

--- a/internal/pally/metric.go
+++ b/internal/pally/metric.go
@@ -1,0 +1,64 @@
+package pally
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/uber-go/tally"
+)
+
+// A Counter is a monotonically increasing value, like a car's odometer.
+//
+// Counters are exported to Prometheus as a snapshot of the current total, and
+// to Tally as a diff since the last export. They implement
+// prometheus.Collector, so they can also be registered directly with
+// Prometheus Registries.
+type Counter interface {
+	prometheus.Collector
+
+	Inc() int64
+	Add(int64) int64
+	Load() int64
+}
+
+// A CounterVector is a collection of Counters that share a name and some
+// constant labels, but also have an enumerated set of variable labels. It
+// implements prometheus.Collector, so it can also be registered directly with
+// Prometheus Registries.
+type CounterVector interface {
+	prometheus.Collector
+
+	Get(...string) (Counter, error)
+	MustGet(...string) Counter
+}
+
+// A Gauge is a point-in-time measurement, like a car's speedometer.
+//
+// Gauges are exported to both Prometheus and Tally by simply reporting the
+// current value. They implement prometheus.Collector, so they can also be
+// registered directly with Prometheus registries.
+type Gauge interface {
+	prometheus.Collector
+
+	Inc() int64
+	Dec() int64
+	Add(int64) int64
+	Sub(int64) int64
+	Store(int64)
+	Load() int64
+}
+
+// A GaugeVector is a collection of Gauges that share a name and some constant
+// labels, but also have an enumerated set of variable labels. It implements
+// prometheus.Collector, so it can also be registered directly with Prometheus
+// registries.
+type GaugeVector interface {
+	prometheus.Collector
+
+	Get(...string) (Gauge, error)
+	MustGet(...string) Gauge
+}
+
+type metric interface {
+	prometheus.Collector
+
+	push(tally.Scope)
+}

--- a/internal/pally/metric.go
+++ b/internal/pally/metric.go
@@ -8,24 +8,18 @@ import (
 // A Counter is a monotonically increasing value, like a car's odometer.
 //
 // Counters are exported to Prometheus as a snapshot of the current total, and
-// to Tally as a diff since the last export. They implement
-// prometheus.Collector, so they can also be registered directly with
-// Prometheus Registries.
+// to Tally as a diff since the last export.
 type Counter interface {
-	prometheus.Collector
-
 	Inc() int64
 	Add(int64) int64
 	Load() int64
 }
 
 // A CounterVector is a collection of Counters that share a name and some
-// constant labels, but also have an enumerated set of variable labels. It
-// implements prometheus.Collector, so it can also be registered directly with
-// Prometheus Registries.
+// constant labels, but also have an enumerated set of variable labels.
 type CounterVector interface {
-	prometheus.Collector
-
+	// For a description of Get, MustGet, and vector types in general, see the
+	// package-level documentation on vectors.
 	Get(...string) (Counter, error)
 	MustGet(...string) Counter
 }
@@ -33,11 +27,8 @@ type CounterVector interface {
 // A Gauge is a point-in-time measurement, like a car's speedometer.
 //
 // Gauges are exported to both Prometheus and Tally by simply reporting the
-// current value. They implement prometheus.Collector, so they can also be
-// registered directly with Prometheus registries.
+// current value.
 type Gauge interface {
-	prometheus.Collector
-
 	Inc() int64
 	Dec() int64
 	Add(int64) int64
@@ -47,12 +38,10 @@ type Gauge interface {
 }
 
 // A GaugeVector is a collection of Gauges that share a name and some constant
-// labels, but also have an enumerated set of variable labels. It implements
-// prometheus.Collector, so it can also be registered directly with Prometheus
-// registries.
+// labels, but also have an enumerated set of variable labels.
 type GaugeVector interface {
-	prometheus.Collector
-
+	// For a description of Get, MustGet, and vector types in general, see the
+	// package-level documentation on vectors.
 	Get(...string) (Gauge, error)
 	MustGet(...string) Gauge
 }

--- a/internal/pally/opts.go
+++ b/internal/pally/opts.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package pally
+
+import (
+	"errors"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Opts configure an individual metric or vector.
+type Opts struct {
+	Name           string
+	Help           string
+	ConstLabels    Labels
+	VariableLabels []string // only meaningful for vectors
+	DisableTally   bool
+}
+
+func (o Opts) describe() *prometheus.Desc {
+	return prometheus.NewDesc(
+		o.Name,
+		o.Help,
+		o.VariableLabels,
+		prometheus.Labels(o.ConstLabels),
+	)
+}
+
+func (o Opts) validate() error {
+	if o.Name == "" {
+		return errors.New("metric name must not be empty")
+	}
+	if !isValidTallyString(o.Name) {
+		// Prometheus handles its own name validation, so we only need to check
+		// Tally.
+		return errors.New("names must also be Tally-compatible")
+	}
+	if o.Help == "" {
+		return errors.New("metric help must not be empty")
+	}
+	for k, v := range o.ConstLabels {
+		if !isValidTallyString(k) || !isValidTallyString(v) {
+			return errors.New("tag names and values must also be Tally-compatible")
+		}
+	}
+	return nil
+}
+
+func (o Opts) validateVector() error {
+	if err := o.validate(); err != nil {
+		return err
+	}
+	if len(o.VariableLabels) == 0 {
+		return errors.New("vectors must have variable labels")
+	}
+	for _, l := range o.VariableLabels {
+		if !isValidTallyString(l) {
+			return errors.New("variable tag names must be Tally-compatible")
+		}
+	}
+	return nil
+}
+
+func (o Opts) copyLabels() map[string]string {
+	l := make(map[string]string, len(o.ConstLabels)+len(o.VariableLabels))
+	for k, v := range o.ConstLabels {
+		l[k] = v
+	}
+	return l
+}
+
+func isValidTallyString(s string) bool {
+	// Tally allows only a subset of the characters that Prometheus does.
+	if len(s) == 0 {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case 48 <= c && c <= 57: // 0-9
+			continue
+		case 65 <= c && c <= 90: // A-Z
+			continue
+		case 97 <= c && c <= 122: // a-z
+			continue
+		case c == '_' || c == '-':
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/pally/opts.go
+++ b/internal/pally/opts.go
@@ -95,11 +95,11 @@ func isValidTallyString(s string) bool {
 	for i := 0; i < len(s); i++ {
 		c := s[i]
 		switch {
-		case 48 <= c && c <= 57: // 0-9
+		case '0' <= c && c <= '9':
 			continue
-		case 65 <= c && c <= 90: // A-Z
+		case 'A' <= c && c <= 'Z':
 			continue
-		case 97 <= c && c <= 122: // a-z
+		case 'a' <= c && c <= 'z':
 			continue
 		case c == '_' || c == '-':
 			continue

--- a/internal/pally/opts.go
+++ b/internal/pally/opts.go
@@ -22,6 +22,7 @@ package pally
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -51,14 +52,14 @@ func (o Opts) validate() error {
 	if !isValidTallyString(o.Name) {
 		// Prometheus handles its own name validation, so we only need to check
 		// Tally.
-		return errors.New("names must also be Tally-compatible")
+		return fmt.Errorf("metric name %q is not Tally-compatible", o.Name)
 	}
 	if o.Help == "" {
 		return errors.New("metric help must not be empty")
 	}
 	for k, v := range o.ConstLabels {
 		if !isValidTallyString(k) || !isValidTallyString(v) {
-			return errors.New("tag names and values must also be Tally-compatible")
+			return fmt.Errorf("label %q=%q contains Tally-incompatible characters", k, v)
 		}
 	}
 	return nil

--- a/internal/pally/opts_test.go
+++ b/internal/pally/opts_test.go
@@ -1,0 +1,201 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package pally
+
+import (
+	"regexp"
+	"testing"
+	"testing/quick"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateTallyTags(t *testing.T) {
+	// Regexp is a slower, but more easily verifiable, description of the Tally
+	// name specification.
+	tallyRe := regexp.MustCompile(`^[0-9A-z_\-]+$`)
+	assert.NoError(t, quick.CheckEqual(
+		isValidTallyString,
+		func(s string) bool { return tallyRe.MatchString(s) },
+		nil, /* config */
+	), "Tally validation doesn't match regexp implementation.")
+}
+
+func TestOptsValidation(t *testing.T) {
+	tests := []struct {
+		desc  string
+		opts  Opts
+		ok    bool
+		vecOK bool
+	}{
+		{
+			desc: "valid names",
+			opts: Opts{
+				Name: "fOo123",
+				Help: "Some help.",
+			},
+			ok:    true,
+			vecOK: false,
+		},
+		{
+			desc: "valid names & constant labels",
+			opts: Opts{
+				Name:        "foo",
+				Help:        "Some help.",
+				ConstLabels: Labels{"foo": "bar"},
+			},
+			ok:    true,
+			vecOK: false,
+		},
+		{
+			desc: "name with Tally-forbidden characters",
+			opts: Opts{
+				Name: "foo:bar",
+				Help: "Some help.",
+			},
+			ok:    false,
+			vecOK: false,
+		},
+		{
+			desc: "no name",
+			opts: Opts{
+				Help: "Some help.",
+			},
+			ok:    false,
+			vecOK: false,
+		},
+		{
+			desc: "no help",
+			opts: Opts{
+				Name: "foo",
+			},
+			ok:    false,
+			vecOK: false,
+		},
+		{
+			desc: "valid names but invalid label key",
+			opts: Opts{
+				Name:        "foo",
+				Help:        "Some help.",
+				ConstLabels: Labels{"foo:foo": "bar"},
+			},
+			ok:    false,
+			vecOK: false,
+		},
+		{
+			desc: "valid names but invalid label value",
+			opts: Opts{
+				Name:        "foo",
+				Help:        "Some help.",
+				ConstLabels: Labels{"foo": "bar:bar"},
+			},
+			ok:    false,
+			vecOK: false,
+		},
+		{
+			desc: "valid names & variable labels",
+			opts: Opts{
+				Name:           "foo",
+				Help:           "Some help.",
+				VariableLabels: []string{"baz"},
+			},
+			ok:    true,
+			vecOK: true,
+		},
+		{
+			desc: "valid names, constant labels, & variable labels",
+			opts: Opts{
+				Name:           "foo",
+				Help:           "Some help.",
+				ConstLabels:    Labels{"foo": "bar"},
+				VariableLabels: []string{"baz"},
+			},
+			ok:    true,
+			vecOK: true,
+		},
+		{
+			desc: "valid names & constant labels, but invalid variable labels",
+			opts: Opts{
+				Name:           "foo",
+				Help:           "Some help.",
+				ConstLabels:    Labels{"foo": "bar"},
+				VariableLabels: []string{"baz:baz"},
+			},
+			ok:    false, // Prometheus always validates the VariableLabels.
+			vecOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			if tt.ok {
+				assertSimpleOptsOK(t, tt.opts)
+			} else {
+				assertSimpleOptsFail(t, tt.opts)
+			}
+			if tt.vecOK {
+				assertVectorOptsOK(t, tt.opts)
+			} else {
+				assertVectorOptsFail(t, tt.opts)
+			}
+		})
+	}
+}
+
+func assertSimpleOptsOK(t testing.TB, opts Opts) {
+	_, err := NewRegistry().NewCounter(opts)
+	assert.NoError(t, err, "Expected success from NewCounter.")
+	assert.NotPanics(t, func() { NewRegistry().MustCounter(opts) }, "Expected MustCounter to succeed.")
+
+	_, err = NewRegistry().NewGauge(opts)
+	assert.NoError(t, err, "Expected success from NewGauge.")
+	assert.NotPanics(t, func() { NewRegistry().MustGauge(opts) }, "Expected a panic from MustGauge.")
+}
+
+func assertSimpleOptsFail(t testing.TB, opts Opts) {
+	_, err := NewRegistry().NewCounter(opts)
+	assert.Error(t, err, "Expected an error from NewCounter.")
+	assert.Panics(t, func() { NewRegistry().MustCounter(opts) }, "Expected a panic from MustCounter.")
+
+	_, err = NewRegistry().NewGauge(opts)
+	assert.Error(t, err, "Expected an error from NewGauge.")
+	assert.Panics(t, func() { NewRegistry().MustGauge(opts) }, "Expected a panic from MustGauge.")
+}
+
+func assertVectorOptsOK(t testing.TB, opts Opts) {
+	_, err := NewRegistry().NewCounterVector(opts)
+	assert.NoError(t, err, "Expected success from NewCounterVector.")
+	assert.NotPanics(t, func() { NewRegistry().MustCounterVector(opts) }, "Expected MustCounterVector to succeed.")
+
+	_, err = NewRegistry().NewGaugeVector(opts)
+	assert.NoError(t, err, "Expected success from NewGaugeVector.")
+	assert.NotPanics(t, func() { NewRegistry().MustGaugeVector(opts) }, "Expected a panic from MustGaugeVector.")
+}
+
+func assertVectorOptsFail(t testing.TB, opts Opts) {
+	_, err := NewRegistry().NewCounterVector(opts)
+	assert.Error(t, err, "Expected an error from NewCounterVector.")
+	assert.Panics(t, func() { NewRegistry().MustCounterVector(opts) }, "Expected a panic from MustCounterVector.")
+
+	_, err = NewRegistry().NewGaugeVector(opts)
+	assert.Error(t, err, "Expected an error from NewGaugeVector.")
+	assert.Panics(t, func() { NewRegistry().MustGaugeVector(opts) }, "Expected a panic from MustGaugeVector.")
+}

--- a/internal/pally/opts_test.go
+++ b/internal/pally/opts_test.go
@@ -34,7 +34,7 @@ func TestValidateTallyTags(t *testing.T) {
 	tallyRe := regexp.MustCompile(`^[0-9A-z_\-]+$`)
 	assert.NoError(t, quick.CheckEqual(
 		isValidTallyString,
-		func(s string) bool { return tallyRe.MatchString(s) },
+		tallyRe.MatchString,
 		nil, /* config */
 	), "Tally validation doesn't match regexp implementation.")
 }

--- a/internal/pally/registry.go
+++ b/internal/pally/registry.go
@@ -1,0 +1,250 @@
+package pally
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/common/model"
+	"github.com/uber-go/tally"
+	"go.uber.org/atomic"
+)
+
+// A Registry is a collection of metrics, usually scoped to a single package or
+// object. Each Registry is also its own http.Handler, and can serve
+// Prometheus-flavored text and protocol buffer pages for metrics introspection
+// or scraping.
+type Registry struct {
+	http.Handler
+
+	metricsMu   sync.RWMutex
+	metrics     []metric
+	constLabels Labels
+
+	// TODO: To serve our own Prometheus endpoints, we only need to implement
+	// prometheus.Gatherer. The vanilla Prometheus registry is a convenient
+	// implementation, but it enforces metric uniqueness via FNV64a; if we run
+	// into hash collisions in our more-demanding applications, we should use a
+	// simple map[string]struct{} instead.
+	prom      *prometheus.Registry
+	federated []prometheus.Registerer
+
+	pushing atomic.Bool
+	scope   tally.Scope
+	ticker  *time.Ticker
+	stop    chan struct{}
+	stopped chan struct{}
+}
+
+// A RegistryOption configures a Registry.
+type RegistryOption func(*Registry)
+
+// Federated links a pally.Registry with a prometheus.Registerer, so that all
+// metrics created in one also appear in the other.
+func Federated(prom prometheus.Registerer) RegistryOption {
+	return func(r *Registry) {
+		r.federated = append(r.federated, prom)
+	}
+}
+
+// Labeled adds constant labels to a Registry. All metrics created by a
+// Registry inherit its constant labels.
+func Labeled(ls Labels) RegistryOption {
+	return func(r *Registry) {
+		for k, v := range ls {
+			if !model.LabelName(k).IsValid() || !model.LabelValue(v).IsValid() {
+				continue
+			}
+			if !isValidTallyString(k) || !isValidTallyString(v) {
+				continue
+			}
+			r.constLabels[k] = v
+		}
+	}
+}
+
+// NewRegistry constructs a new Registry.
+func NewRegistry(opts ...RegistryOption) *Registry {
+	prom := prometheus.NewRegistry()
+	handler := promhttp.HandlerFor(prom, promhttp.HandlerOpts{
+		ErrorHandling: promhttp.HTTPErrorOnError, // 500 on errors
+	})
+
+	r := &Registry{
+		Handler:     handler,
+		metrics:     make([]metric, 0, _defaultVectorSize),
+		constLabels: make(Labels),
+		prom:        prom,
+		// Assume that we'll be federated with the global prometheus Registry.
+		federated: make([]prometheus.Registerer, 0, 1),
+		stop:      make(chan struct{}),
+		stopped:   make(chan struct{}),
+	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
+}
+
+// Push starts a goroutine that periodically exports all registered metrics to
+// a Tally scope. Each Registry can only push to a single Scope; calling Push a
+// second time returns an error.
+func (r *Registry) Push(scope tally.Scope, tick time.Duration) (context.CancelFunc, error) {
+	if r.pushing.Swap(true) {
+		return nil, errors.New("already pushing to Tally")
+	}
+	r.scope = scope
+	r.ticker = time.NewTicker(tick)
+	go r.exportToTally()
+	return func() {
+		r.ticker.Stop()
+		close(r.stop)
+		<-r.stopped
+	}, nil
+}
+
+// NewCounter constructs a new Counter.
+func (r *Registry) NewCounter(opts Opts) (Counter, error) {
+	opts = r.addConstLabels(opts)
+	if err := opts.validate(); err != nil {
+		return nil, err
+	}
+	c := newCounter(opts)
+	if err := r.register(c); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+// MustCounter constructs a new Counter. It panics if it encounters an error.
+func (r *Registry) MustCounter(opts Opts) Counter {
+	c, err := r.NewCounter(opts)
+	if err != nil {
+		panic(fmt.Sprintf("failed to create Counter with options %+v: %v", opts, err))
+	}
+	return c
+}
+
+// NewGauge constructs a new Gauge.
+func (r *Registry) NewGauge(opts Opts) (Gauge, error) {
+	opts = r.addConstLabels(opts)
+	if err := opts.validate(); err != nil {
+		return nil, err
+	}
+	g := newGauge(opts)
+	if err := r.register(g); err != nil {
+		return nil, err
+	}
+	return g, nil
+}
+
+// MustGauge constructs a new Gauge. It panics if it encounters an error.
+func (r *Registry) MustGauge(opts Opts) Gauge {
+	g, err := r.NewGauge(opts)
+	if err != nil {
+		panic(fmt.Sprintf("failed to create Gauge with options %+v: %v", opts, err))
+	}
+	return g
+}
+
+// NewCounterVector constructs a new CounterVector.
+func (r *Registry) NewCounterVector(opts Opts) (CounterVector, error) {
+	opts = r.addConstLabels(opts)
+	if err := opts.validateVector(); err != nil {
+		return nil, err
+	}
+	v := newCounterVector(opts)
+	if err := r.register(v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+// MustCounterVector constructs a new CounterVector. It panics if it encounters
+// an error.
+func (r *Registry) MustCounterVector(opts Opts) CounterVector {
+	v, err := r.NewCounterVector(opts)
+	if err != nil {
+		panic(fmt.Sprintf("failed to create CounterVector with options %+v: %v", opts, err))
+	}
+	return v
+}
+
+// NewGaugeVector constructs a new CounterVector.
+func (r *Registry) NewGaugeVector(opts Opts) (GaugeVector, error) {
+	opts = r.addConstLabels(opts)
+	if err := opts.validateVector(); err != nil {
+		return nil, err
+	}
+	v := newGaugeVector(opts)
+	if err := r.register(v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+// MustGaugeVector constructs a new GaugeVector. It panics if it encounters an
+// error.
+func (r *Registry) MustGaugeVector(opts Opts) GaugeVector {
+	v, err := r.NewGaugeVector(opts)
+	if err != nil {
+		panic(fmt.Sprintf("failed to create GaugeVector with options %+v: %v", opts, err))
+	}
+	return v
+}
+
+func (r *Registry) exportToTally() {
+	defer close(r.stopped)
+	// When stopping, do one last export to catch any stragglers.
+	defer r.push()
+
+	for {
+		select {
+		case <-r.stop:
+			return
+		case <-r.ticker.C:
+			r.push()
+		}
+	}
+}
+
+func (r *Registry) push() {
+	r.metricsMu.RLock()
+	for _, m := range r.metrics {
+		m.push(r.scope)
+	}
+	r.metricsMu.RUnlock()
+}
+
+func (r *Registry) register(m metric) error {
+	r.metricsMu.Lock()
+	r.metrics = append(r.metrics, m)
+	r.metricsMu.Unlock()
+
+	if err := r.prom.Register(m); err != nil {
+		return err
+	}
+	for _, fed := range r.federated {
+		if err := fed.Register(m); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *Registry) addConstLabels(opts Opts) Opts {
+	if len(r.constLabels) == 0 {
+		return opts
+	}
+	labels := opts.copyLabels()
+	for k, v := range r.constLabels {
+		labels[k] = v
+	}
+	opts.ConstLabels = labels
+	return opts
+}

--- a/internal/pally/registry_test.go
+++ b/internal/pally/registry_test.go
@@ -26,14 +26,13 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/atomic"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally"
 	"github.com/uber-go/tally/m3"
+	"go.uber.org/atomic"
 )
 
 func TestSimpleMetricDuplicates(t *testing.T) {

--- a/internal/pally/registry_test.go
+++ b/internal/pally/registry_test.go
@@ -1,0 +1,232 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package pally
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"go.uber.org/atomic"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
+	"github.com/uber-go/tally/m3"
+)
+
+func TestSimpleMetricDuplicates(t *testing.T) {
+	r := NewRegistry()
+	opts := Opts{
+		Name: "foo",
+		Help: "help",
+	}
+	_, err := r.NewCounter(opts)
+	assert.NoError(t, err, "Unexpected error registering metadata for the first time.")
+
+	t.Run("same type", func(t *testing.T) {
+		// You can't reuse options with the same metric type.
+		_, err := r.NewCounter(opts)
+		assert.Error(t, err, "Unexpected success re-using metrics metadata.")
+		assert.Panics(t, func() { r.MustCounter(opts) }, "Unexpected success re-using metrics metadata.")
+	})
+
+	t.Run("different type", func(t *testing.T) {
+		// Even if you change the metric type, you still can't re-use metadata.
+		_, err := r.NewGauge(opts)
+		assert.Error(t, err, "Unexpected success re-using metrics metadata.")
+		assert.Panics(t, func() { r.MustGauge(opts) }, "Unexpected success re-using metrics metadata.")
+	})
+}
+
+func TestVectorMetricDuplicates(t *testing.T) {
+	r := NewRegistry()
+	opts := Opts{
+		Name:           "foo",
+		Help:           "help",
+		VariableLabels: []string{"foo"},
+	}
+	_, err := r.NewCounterVector(opts)
+	assert.NoError(t, err, "Unexpected error registering vector metadata for the first time.")
+
+	t.Run("same type", func(t *testing.T) {
+		// You can't reuse options with the same metric type.
+		_, err := r.NewCounterVector(opts)
+		assert.Error(t, err, "Unexpected success re-using vector metrics metadata.")
+		assert.Panics(t, func() { r.MustCounterVector(opts) }, "Unexpected success re-using vector metrics metadata.")
+	})
+
+	t.Run("different type", func(t *testing.T) {
+		// Even if you change the metric type, you still can't re-use metadata.
+		_, err := r.NewGaugeVector(opts)
+		assert.Error(t, err, "Unexpected success re-using vector metrics metadata.")
+		assert.Panics(t, func() { r.MustGaugeVector(opts) }, "Unexpected success re-using vector metrics metadata.")
+	})
+}
+
+func TestFederatedMetrics(t *testing.T) {
+	prom := prometheus.NewRegistry()
+	r := NewRegistry(Federated(prom))
+	opts := Opts{
+		Name: "foo",
+		Help: "Some help.",
+	}
+	c, err := r.NewCounter(opts)
+	assert.NoError(t, err, "Unexpected error registering vector metadata for the first time.")
+
+	c.Inc()
+	expected := "# HELP foo Some help.\n" +
+		"# TYPE foo counter\n" +
+		"foo 1"
+
+	assertPrometheusText(t, promhttp.HandlerFor(prom, promhttp.HandlerOpts{}), expected)
+}
+
+func TestConstLabelValidation(t *testing.T) {
+	r := NewRegistry(Labeled(Labels{
+		"invalid-prometheus-name": "foo",
+		"tally":                   "invalid.value",
+		"ok":                      "yes",
+	}))
+	_, err := r.NewCounter(Opts{
+		Name: "test",
+		Help: "help",
+	})
+	require.NoError(t, err, "Unexpected error creating a counter.")
+	assertPrometheusText(t, r, "# HELP test help\n"+
+		"# TYPE test counter\n"+
+		`test{ok="yes"} 0`)
+}
+
+func BenchmarkCreateNewMetrics(b *testing.B) {
+	b.Run("create pally counter", func(b *testing.B) {
+		r := NewRegistry()
+		var count atomic.Int64
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				opts := Opts{
+					Name:        "foo",
+					Help:        "Some help.",
+					ConstLabels: Labels{"iteration": strconv.FormatInt(count.Inc(), 10)},
+				}
+				r.NewCounter(opts)
+			}
+		})
+	})
+	b.Run("create tally counter", func(b *testing.B) {
+		scope, close := newTallyScope(b)
+		defer close()
+		var count atomic.Int64
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				tags := map[string]string{"iteration": strconv.FormatInt(count.Inc(), 10)}
+				scope.Tagged(tags).Counter("foo")
+			}
+		})
+	})
+	b.Run("create dynamic pally counter", func(b *testing.B) {
+		vec := NewRegistry().MustCounterVector(Opts{
+			Name:           "foo",
+			Help:           "Some help.",
+			VariableLabels: []string{"foo", "bar"},
+		})
+		var count atomic.Int64
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				foo := strconv.FormatInt(count.Inc(), 10)
+				bar := strconv.FormatInt(count.Inc(), 10)
+				vec.MustGet(foo, bar)
+			}
+		})
+	})
+	b.Run("create dynamic tally counter", func(b *testing.B) {
+		scope, close := newTallyScope(b)
+		defer close()
+		var count atomic.Int64
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				foo := strconv.FormatInt(count.Inc(), 10)
+				bar := strconv.FormatInt(count.Inc(), 10)
+				scope.Tagged(map[string]string{"foo": foo, "bar": bar}).Counter("foo")
+			}
+		})
+	})
+	b.Run("increment pally counter", func(b *testing.B) {
+		c := NewRegistry().MustCounter(Opts{
+			Name: "foo",
+			Help: "Some help.",
+		})
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				c.Inc()
+			}
+		})
+	})
+	b.Run("increment tally counter", func(b *testing.B) {
+		scope, close := newTallyScope(b)
+		defer close()
+		c := scope.Counter("foo")
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				c.Inc(1)
+			}
+		})
+	})
+	b.Run("increment dynamic pally counter", func(b *testing.B) {
+		vec := NewRegistry().MustCounterVector(Opts{
+			Name:           "foo",
+			Help:           "Some help.",
+			VariableLabels: []string{"foo", "bar"},
+		})
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				vec.MustGet("one", "two").Inc()
+			}
+		})
+	})
+	b.Run("increment dynamic tally counter", func(b *testing.B) {
+		scope, close := newTallyScope(b)
+		defer close()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				scope.Tagged(map[string]string{"foo": "one", "bar": "two"}).Counter("foo").Inc(1)
+			}
+		})
+	})
+}
+
+// Create a real, M3-backed Tally scope.
+func newTallyScope(t testing.TB) (tally.Scope, context.CancelFunc) {
+	reporter, err := m3.NewReporter(m3.Options{
+		HostPorts: []string{"localhost:1234"},
+		Service:   "benchmark",
+		Env:       "production",
+	})
+	require.NoError(t, err, "Failed to construct an M3 reporter.")
+	scope, close := tally.NewRootScope(
+		tally.ScopeOptions{CachedReporter: reporter},
+		time.Second,
+	)
+	return scope, func() { close.Close() }
+}

--- a/internal/pally/scoped_test.go
+++ b/internal/pally/scoped_test.go
@@ -1,0 +1,90 @@
+package pally_test
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"go.uber.org/yarpc/internal/pally"
+
+	"github.com/uber-go/tally"
+)
+
+// If you'd prefer to use pure dependency injection and scope your metrics
+// to a single struct, create a new pally.Registry in your struct's
+// constructor. In this case, we're also exporting our metrics to a Tally
+// scope, which can report to StatsD- or M3-aware systems.
+type Resolver struct {
+	registry        *pally.Registry
+	watches         pally.Gauge
+	resolves        pally.CounterVector
+	stopTallyExport context.CancelFunc
+}
+
+func NewResolver(scope tally.Scope) (*Resolver, error) {
+	reg := pally.NewRegistry()
+	stop, err := reg.Push(scope, time.Second)
+	if err != nil {
+		return nil, err
+	}
+
+	watches, err := _reg.NewGauge(pally.Opts{
+		Name: "watch_count",
+		Help: "Current number of active service name watches.",
+		ConstLabels: pally.Labels{
+			"foo": "bar",
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	resolves, err := _reg.NewCounterVector(pally.Opts{
+		Name: "resolve_count",
+		Help: "Total name resolves by path.",
+		ConstLabels: pally.Labels{
+			"foo": "bar",
+		},
+		VariableLabels: []string{"service"},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &Resolver{
+		registry:        reg,
+		watches:         watches,
+		resolves:        resolves,
+		stopTallyExport: stop,
+	}, nil
+}
+
+func (r *Resolver) Watch() {
+	r.watches.Inc()
+}
+
+func (r *Resolver) Resolve(name string) {
+	if c, err := r.resolves.Get(name); err == nil {
+		c.Inc()
+	}
+}
+
+func (r *Resolver) Close() {
+	r.stopTallyExport()
+}
+
+func (r *Resolver) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	// Our registry can report its own metrics via a Prometheus-compatible HTTP
+	// handler.
+	r.registry.ServeHTTP(w, req)
+}
+
+func Example_dependencyInjection() {
+	scope := tally.NewTestScope("testing", nil /* labels */)
+	reg, err := NewResolver(scope)
+	if err != nil {
+		panic(err.Error())
+	}
+	reg.Watch()
+	reg.Resolve("some_service")
+}

--- a/internal/pally/utils_test.go
+++ b/internal/pally/utils_test.go
@@ -84,8 +84,9 @@ func (exp TallyExpectation) assertOnlyCounter(t testing.TB, snap tally.Snapshot)
 
 	counters := snap.Counters()
 	require.Equal(t, 1, len(counters), "Expected exactly one counter in Tally snapshot.")
-	c, ok := counters[exp.Name]
-	require.True(t, ok, "Didn't find Tally counter with name %q.", exp.Name)
+	key := tally.KeyForPrefixedStringMap(exp.Name, exp.Labels)
+	c, ok := counters[key]
+	require.True(t, ok, "Didn't find Tally counter with key %q.", key)
 	assert.Equal(t, exp.Name, c.Name(), "Tally counter has an unexpected name.")
 	assert.Equal(t, map[string]string(exp.Labels), c.Tags(), "Tally counter has unexpected tags.")
 	assert.Equal(t, exp.Value, c.Value(), "Tally counter has unexpected value.")
@@ -97,8 +98,9 @@ func (exp TallyExpectation) assertOnlyGauge(t testing.TB, snap tally.Snapshot) {
 
 	gauges := snap.Gauges()
 	require.Equal(t, 1, len(gauges), "Expected exactly one gauge in Tally snapshot.")
-	g, ok := gauges[exp.Name]
-	require.True(t, ok, "Didn't find Tally gauge with name %q.", exp.Name)
+	key := tally.KeyForPrefixedStringMap(exp.Name, exp.Labels)
+	g, ok := gauges[key]
+	require.True(t, ok, "Didn't find Tally gauge with key %q.", key)
 	assert.Equal(t, exp.Name, g.Name(), "Tally counter has an unexpected name.")
 	assert.Equal(t, map[string]string(exp.Labels), g.Tags(), "Tally counter has unexpected tags.")
 	assert.Equal(t, exp.Value, int64(g.Value()), "Tally counter has unexpected value.")

--- a/internal/pally/utils_test.go
+++ b/internal/pally/utils_test.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package pally
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
+)
+
+const _tick = 10 * time.Millisecond
+
+func newTestScope() tally.TestScope {
+	return tally.NewTestScope("" /* prefix */, nil /* tags */)
+}
+
+func scrape(t testing.TB, registry http.Handler) (int, string) {
+	server := httptest.NewServer(registry)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL)
+	require.NoError(t, err, "Unexpected error scraping Prometheus endpoint.")
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err, "Unexpected error reading response body.")
+	return resp.StatusCode, string(body)
+}
+
+func assertPrometheusText(t testing.TB, registry http.Handler, expected string) {
+	code, body := scrape(t, registry)
+	assert.Equal(t, http.StatusOK, code, "Unexpected HTTP response code from Prometheus scrape.")
+	assert.Equal(t, expected, strings.TrimSpace(body), "Unexpected plain-text Prometheus scrape.")
+}
+
+type TallyExpectation struct {
+	Type   string
+	Value  int64
+	Name   string
+	Labels Labels
+}
+
+// Test checks that the specified metric is the only metric exported to
+// Tally.
+func (exp TallyExpectation) Test(t testing.TB, scope tally.TestScope) {
+	snap := scope.Snapshot()
+	if exp.Name == "" {
+		exp.assertEmpty(t, snap)
+	} else if exp.Type == "counter" {
+		exp.assertOnlyCounter(t, snap)
+	} else if exp.Type == "gauge" {
+		exp.assertOnlyGauge(t, snap)
+	} else {
+		t.Fatalf("Can't make Tally assertions about type %q.", exp.Type)
+	}
+}
+
+func (exp TallyExpectation) assertOnlyCounter(t testing.TB, snap tally.Snapshot) {
+	exp.assertNoGauges(t, snap)
+	exp.assertNoTimers(t, snap)
+
+	counters := snap.Counters()
+	require.Equal(t, 1, len(counters), "Expected exactly one counter in Tally snapshot.")
+	c, ok := counters[exp.Name]
+	require.True(t, ok, "Didn't find Tally counter with name %q.", exp.Name)
+	assert.Equal(t, exp.Name, c.Name(), "Tally counter has an unexpected name.")
+	assert.Equal(t, map[string]string(exp.Labels), c.Tags(), "Tally counter has unexpected tags.")
+	assert.Equal(t, exp.Value, c.Value(), "Tally counter has unexpected value.")
+}
+
+func (exp TallyExpectation) assertOnlyGauge(t testing.TB, snap tally.Snapshot) {
+	exp.assertNoCounters(t, snap)
+	exp.assertNoTimers(t, snap)
+
+	gauges := snap.Gauges()
+	require.Equal(t, 1, len(gauges), "Expected exactly one gauge in Tally snapshot.")
+	g, ok := gauges[exp.Name]
+	require.True(t, ok, "Didn't find Tally gauge with name %q.", exp.Name)
+	assert.Equal(t, exp.Name, g.Name(), "Tally counter has an unexpected name.")
+	assert.Equal(t, map[string]string(exp.Labels), g.Tags(), "Tally counter has unexpected tags.")
+	assert.Equal(t, exp.Value, int64(g.Value()), "Tally counter has unexpected value.")
+}
+
+func (exp TallyExpectation) assertEmpty(t testing.TB, snap tally.Snapshot) {
+	exp.assertNoGauges(t, snap)
+	exp.assertNoCounters(t, snap)
+	exp.assertNoTimers(t, snap)
+}
+
+func (exp TallyExpectation) assertNoGauges(t testing.TB, snap tally.Snapshot) {
+	assert.Equal(t, 0, len(snap.Gauges()), "Unexpected gauges in exported Tally data.")
+}
+
+func (exp TallyExpectation) assertNoCounters(t testing.TB, snap tally.Snapshot) {
+	assert.Equal(t, 0, len(snap.Counters()), "Unexpected counters in exported Tally data.")
+}
+
+func (exp TallyExpectation) assertNoTimers(t testing.TB, snap tally.Snapshot) {
+	assert.Equal(t, 0, len(snap.Timers()), "Unexpected timers in exported Tally data.")
+}

--- a/internal/pally/value.go
+++ b/internal/pally/value.go
@@ -1,0 +1,105 @@
+package pally
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/uber-go/tally"
+	"go.uber.org/atomic"
+)
+
+const _defaultVectorSize = 100
+
+// Value is an atomic with some associated metadata. It's a building block
+// for higher-level metric types.
+type value struct {
+	atomic.Int64
+
+	opts              *Opts
+	desc              *prometheus.Desc
+	variableLabelVals []string
+}
+
+func newValue(opts Opts) value {
+	return value{opts: &opts, desc: opts.describe()}
+}
+
+// Describe implements half of prometheus.Collector.
+func (v value) Describe(ch chan<- *prometheus.Desc) {
+	ch <- v.desc
+}
+
+// A vector is a collection of values that share the same metadata.
+type vector struct {
+	opts Opts
+	desc *prometheus.Desc
+
+	// The factory function creates a new metric given the vector's metadata
+	// and values for the variable labels.
+	factory func(Opts, *prometheus.Desc, []string) metric
+
+	metricsMu sync.RWMutex
+	metrics   map[string]metric
+}
+
+func (vec *vector) getOrCreate(labels ...string) (metric, error) {
+	for _, l := range labels {
+		if !isValidTallyString(l) {
+			return nil, errors.New("variable label values must also be Tally-compatible")
+		}
+	}
+
+	digester := newDigester()
+	for _, s := range labels {
+		digester.add(s)
+	}
+
+	vec.metricsMu.RLock()
+	m, ok := vec.metrics[string(digester.digest())]
+	vec.metricsMu.RUnlock()
+	if ok {
+		digester.free()
+		return m, nil
+	}
+
+	vec.metricsMu.Lock()
+	m, err := vec.newValue(digester.digest(), labels)
+	vec.metricsMu.Unlock()
+	digester.free()
+
+	return m, err
+}
+
+func (vec *vector) newValue(key []byte, variableLabelVals []string) (metric, error) {
+	m, ok := vec.metrics[string(key)]
+	if ok {
+		return m, nil
+	}
+	if len(vec.opts.VariableLabels) != len(variableLabelVals) {
+		return nil, errInconsistentCardinality
+	}
+	m = vec.factory(vec.opts, vec.desc, variableLabelVals)
+	vec.metrics[string(key)] = m
+	return m, nil
+}
+
+func (vec *vector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- vec.desc
+}
+
+func (vec *vector) Collect(ch chan<- prometheus.Metric) {
+	vec.metricsMu.RLock()
+	for _, m := range vec.metrics {
+		m.Collect(ch)
+	}
+	vec.metricsMu.RUnlock()
+}
+
+func (vec *vector) push(scope tally.Scope) {
+	vec.metricsMu.RLock()
+	for _, m := range vec.metrics {
+		m.push(scope)
+	}
+	vec.metricsMu.RUnlock()
+}

--- a/internal/pally/value.go
+++ b/internal/pally/value.go
@@ -16,13 +16,13 @@ const _defaultVectorSize = 100
 type value struct {
 	atomic.Int64
 
-	opts              *Opts
+	opts              Opts
 	desc              *prometheus.Desc
 	variableLabelVals []string
 }
 
 func newValue(opts Opts) value {
-	return value{opts: &opts, desc: opts.describe()}
+	return value{opts: opts, desc: opts.describe()}
 }
 
 // Describe implements half of prometheus.Collector.


### PR DESCRIPTION
Incubate pally as an internal YARPC package, and add simple types (counters, gauges, and vectors). The two included examples (`global_example.go` and `scoped_example.go`) should give you a flavor of what using this package looks like.

This is already quite a bit faster than Tally, especially for our use cases:

```
# Create counters with a static set of tags
BenchmarkCreateNewMetrics/create_pally_counter-4                  300000              5907 ns/op            1678 B/op         24 allocs/op
BenchmarkCreateNewMetrics/create_tally_counter-4                  200000              7314 ns/op            1928 B/op         39 allocs/op

# Create counters with some dynamic tags (e.g., caller name)
BenchmarkCreateNewMetrics/create_dynamic_pally_counter-4         1000000              1683 ns/op             383 B/op          6 allocs/op
BenchmarkCreateNewMetrics/create_dynamic_tally_counter-4          200000              8921 ns/op            2027 B/op         47 allocs/op

# Increment a static counter
BenchmarkCreateNewMetrics/increment_pally_counter-4             50000000                29.6 ns/op             0 B/op          0 allocs/op
BenchmarkCreateNewMetrics/increment_tally_counter-4             100000000               24.0 ns/op             0 B/op          0 allocs/op

# Fetch an dynamically-tagged counter that's already created,
# then increment it.
BenchmarkCreateNewMetrics/increment_dynamic_pally_counter-4             10000000               174 ns/op              32 B/op          1 allocs/op
BenchmarkCreateNewMetrics/increment_dynamic_tally_counter-4              1000000              1064 ns/op             417 B/op          5 allocs/op
```