### PR TITLE
Remove limits from thrift decoder buffer pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Releases
 v1.6.0 (unreleased)
 -----------------------
 
--   No changes yet.
+-   Remove buffer size limit from Thrift encoding/decoding buffer pool.
 
 
 

--- a/internal/buffer/pool.go
+++ b/internal/buffer/pool.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 )
 
-var _maxCapacity = 1024 * 100 // The max capacity for a buffer is 100 KiB
 var _pool = sync.Pool{
 	New: func() interface{} {
 		return &bytes.Buffer{}
@@ -22,7 +21,5 @@ func Get() *bytes.Buffer {
 
 // Put returns byte buffer to the buffer pool
 func Put(buf *bytes.Buffer) {
-	if buf.Cap() < _maxCapacity {
-		_pool.Put(buf)
-	}
+	_pool.Put(buf)
 }

--- a/internal/buffer/pool_test.go
+++ b/internal/buffer/pool_test.go
@@ -32,29 +32,3 @@ func TestBuffers(t *testing.T) {
 	}
 	wg.Wait()
 }
-
-func TestBufferWithMaxCapacity(t *testing.T) {
-	var wg sync.WaitGroup
-	for g := 0; g < 10; g++ {
-		wg.Add(1)
-		go func() {
-			for i := 0; i < 100; i++ {
-				buf := Get()
-				assert.Zero(t, buf.Len(), "Expected truncated buffer")
-				assert.True(t, buf.Cap() < _maxCapacity, "Expected buffer to not exceed the max capacity")
-
-				overCapacityByteSlice := make([]byte, _maxCapacity+10)
-				_, err := rand.Read(overCapacityByteSlice)
-				assert.NoError(t, err, "Unexpected error from rand.Read")
-				_, err = buf.Write(overCapacityByteSlice)
-				assert.NoError(t, err, "Unexpected error from buffer.Write")
-
-				assert.Equal(t, buf.Len(), len(overCapacityByteSlice), "Expected same buffer size")
-
-				Put(buf)
-			}
-			wg.Done()
-		}()
-	}
-	wg.Wait()
-}


### PR DESCRIPTION
Summary: One of the first services that uses the bufferpool for Thrift
decoding did not notice any significant change in their timings because 
their payloads were over the limit we set.

Talked it over with @prashantv  and we agreed that we can remove the
buffer size limit, trust in the golang gc, and add the limit back if it becomes 
an issue.

![](https://i.imgur.com/cJlBUVL.gif)
