### PR TITLE
docker: comment the docker logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,7 @@ script:
       # output the logs then finally exit with the captured exit code.
       set +e
       make crossdock; code=$?
-      docker-compose logs
+      # docker-compose logs
       set -e
       exit $code
       ;;


### PR DESCRIPTION
This helps debug why docker images aren't get published.