### PR TITLE
travis: Update staticcheck path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ golint:
 
 .PHONY: staticcheck
 staticcheck:
-	@go get honnef.co/go/staticcheck/cmd/staticcheck
+	@go get honnef.co/go/tools/cmd/staticcheck
 	$(eval STATICCHECK_LOG := $(shell mktemp -t staticcheck.XXXXX))
 	@staticcheck $(PACKAGES) 2>&1 | $(FILTER_LINT) > $(STATICCHECK_LOG) || true
 	@[ ! -s "$(STATICCHECK_LOG)" ] || (echo "staticcheck failed:" | cat - $(STATICCHECK_LOG) && false)


### PR DESCRIPTION
Builds have been failing because staticcheck has moved to
https://github.com/dominikh/go-tools