### PR TITLE
travis: Push crossdock Docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ script:
       ;;
     crossdock)
       # We run this inside a subshell so that we can always emit
-      # `docker-compose logs` regarldess of success or failure.
+      # `docker-compose logs` regardless of success or failure.
       ( trap "docker-compose logs" EXIT; \
         make crossdock )
       ;;

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
       sudo: required
       env:
         - TYPE=crossdock
+        - CROSSDOCK_PUSH=0
         - DOCKER_COMPOSE_VERSION=1.10.0
         - COMMIT=${TRAVIS_COMMIT::8}
         - secure: rZOVU0zQTkPvaG43IIt/guPoq3EAE6/So/+elGcmHF14PsfPcPQ6MyexqdwRkVPd/fAuNwiXXwTXHkjI8ECYz5LF+m+g2VwvrhE9H1wfLuGbtgXSSXqB+dqylHGUz4ksm4q1gwiet8fpVHlNfbSfu+lhTpbl4+SUfFK+s9LqnAKbm+Hi8vKzyhGhvlTngi0Y2O4Z2FLUgU2fkUm5fesdUyW0H2/Bn5KRqJRtcyTmmj4eD/qMq5WDe8n5Sy9J+kuCpweC8vBZQzAGuPpGdj8jvbPCO+N2xM26Y7DNKMsgj6IU49D6sbmLvyVMbI1pBeAQ54TCJx5LySuZpLAzyaaqHEDwOs4+cRolZSQwpd7Q8/wOxZ13KqMhYOokBIcDlLs0yB9J3KOTS1lxU8YC6A3j+Wenw9/JjL0sXSSeOAvNkAeVtEu3dqXg326HJjzXgIQbci83TTtWv4MsQKIXMADOgMnQdgd4JRaGyfxM2hswsE2/Y5OlyXqrqtFHvgKy6MpLTB26r3aRA22VY6p5hFhuEGLClbHidyeHgkNI2iHOXZqoEdmno33Eq7WicH64bezmq+Z4nwyjBOLTblcG7V79s9hI296zGdAN+KLXezlS00qhWH3UVmsi/hYTyXbWXay3S0Hc5jB+YUrHZ1y+OM6fm442qzz+M5q+MdtCfRad7ZM=
@@ -27,6 +28,7 @@ matrix:
       sudo: required
       env:
         - TYPE=crossdock
+        - CROSSDOCK_PUSH=1
         - DOCKER_COMPOSE_VERSION=1.10.0
         - COMMIT=${TRAVIS_COMMIT::8}
         - secure: rZOVU0zQTkPvaG43IIt/guPoq3EAE6/So/+elGcmHF14PsfPcPQ6MyexqdwRkVPd/fAuNwiXXwTXHkjI8ECYz5LF+m+g2VwvrhE9H1wfLuGbtgXSSXqB+dqylHGUz4ksm4q1gwiet8fpVHlNfbSfu+lhTpbl4+SUfFK+s9LqnAKbm+Hi8vKzyhGhvlTngi0Y2O4Z2FLUgU2fkUm5fesdUyW0H2/Bn5KRqJRtcyTmmj4eD/qMq5WDe8n5Sy9J+kuCpweC8vBZQzAGuPpGdj8jvbPCO+N2xM26Y7DNKMsgj6IU49D6sbmLvyVMbI1pBeAQ54TCJx5LySuZpLAzyaaqHEDwOs4+cRolZSQwpd7Q8/wOxZ13KqMhYOokBIcDlLs0yB9J3KOTS1lxU8YC6A3j+Wenw9/JjL0sXSSeOAvNkAeVtEu3dqXg326HJjzXgIQbci83TTtWv4MsQKIXMADOgMnQdgd4JRaGyfxM2hswsE2/Y5OlyXqrqtFHvgKy6MpLTB26r3aRA22VY6p5hFhuEGLClbHidyeHgkNI2iHOXZqoEdmno33Eq7WicH64bezmq+Z4nwyjBOLTblcG7V79s9hI296zGdAN+KLXezlS00qhWH3UVmsi/hYTyXbWXay3S0Hc5jB+YUrHZ1y+OM6fm442qzz+M5q+MdtCfRad7ZM=
@@ -116,9 +118,11 @@ after_success:
       docker build -f Dockerfile -t $REPO:$COMMIT .
       docker tag $REPO:$COMMIT $REPO:$TAG
       docker tag $REPO:$COMMIT $REPO:travis-$TRAVIS_BUILD_NUMBER
-      if [ -n "$DOCKER_EMAIL" ] && [ -n "$DOCKER_USER" ] && [ -n "$DOCKER_PASS" ]; then
-        docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
-        docker push $REPO
+      if [ "$CROSSDOCK_PUSH" == 1 ]; then
+        if [ -n "$DOCKER_EMAIL" ] && [ -n "$DOCKER_USER" ] && [ -n "$DOCKER_PASS" ]; then
+          docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+          docker push $REPO
+        fi
       fi
       ;;
   esac

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,14 +96,10 @@ script:
       travis_retry goveralls -coverprofile=cover.out -service=travis-ci || true
       ;;
     crossdock)
-      # break out of "set -e" to manage exiting explicitly.
-      # run crossdock then capture the exit code,
-      # output the logs then finally exit with the captured exit code.
-      set +e
-      make crossdock; code=$?
-      docker-compose logs
-      set -e
-      exit $code
+      # We run this inside a subshell so that we can always emit
+      # `docker-compose logs` regarldess of success or failure.
+      ( trap "docker-compose logs" EXIT; \
+        make crossdock )
       ;;
   esac
   set +e


### PR DESCRIPTION
A bug was introduced previously where we stopped pushing Docker images
on success because `script` was always exiting.

This additionally makes the system push only on Go 1.8 so that we're not
stomping on the image on Docker Hub.

Resolves #777

CC @yarpc/golang 