### PR TITLE
Dispatcher: Add Outbounds() to read outbounds

### DIFF
--- a/dispatcher.go
+++ b/dispatcher.go
@@ -207,7 +207,7 @@ func (d *Dispatcher) Inbounds() Inbounds {
 }
 
 // Outbounds returns a copy of the map of outbounds for this RPC object.
-//
+// The outbounds are already wrapped with middleware
 func (d *Dispatcher) Outbounds() Outbounds {
 	outbounds := make(Outbounds, len(d.outbounds))
 	for k, v := range d.outbounds {

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -206,6 +206,16 @@ func (d *Dispatcher) Inbounds() Inbounds {
 	return inbounds
 }
 
+// Outbounds returns a copy of the map of outbounds for this RPC object.
+//
+func (d *Dispatcher) Outbounds() Outbounds {
+	outbounds := make(Outbounds, len(d.outbounds))
+	for k,v := range d.outbounds{
+		outbounds[k] = v
+	}
+	return outbounds
+}
+
 // ClientConfig provides the configuration needed to talk to the given
 // service through an outboundKey. This configuration may be directly
 // passed into encoding-specific RPC clients.

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -210,7 +210,7 @@ func (d *Dispatcher) Inbounds() Inbounds {
 //
 func (d *Dispatcher) Outbounds() Outbounds {
 	outbounds := make(Outbounds, len(d.outbounds))
-	for k,v := range d.outbounds{
+	for k, v := range d.outbounds {
 		outbounds[k] = v
 	}
 	return outbounds

--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -50,7 +50,7 @@ func basicDispatcher(t *testing.T) *Dispatcher {
 		Outbounds: Outbounds{
 			"service": transport.Outbounds{
 				ServiceName: "service",
-				Unary: tchannelTransport.NewOutbound(),
+				Unary:       tchannelTransport.NewOutbound(),
 			},
 		},
 	})
@@ -91,7 +91,7 @@ func TestOutboundsReturnsACopy(t *testing.T) {
 
 	outbounds := dispatcher.Outbounds()
 	require.Len(t, outbounds, 1, "expected one outbound")
-	for k,v := range outbounds {
+	for k, v := range outbounds {
 		assert.NotNil(t, v, "must not be nil")
 
 		// Mutate the outbound so that we can verify that the next call still returns non-nil
@@ -101,7 +101,7 @@ func TestOutboundsReturnsACopy(t *testing.T) {
 
 	outbounds = dispatcher.Outbounds()
 	require.Len(t, outbounds, 1, "expected one outbound")
-	for _,v := range outbounds {
+	for _, v := range outbounds {
 		assert.NotNil(t, v, "must not be nil")
 	}
 }

--- a/glide.lock
+++ b/glide.lock
@@ -95,7 +95,7 @@ imports:
   - m3/thrift
   - m3/thriftudp
 - name: github.com/uber/cherami-client-go
-  version: 5b008bbffe389a329274ff5ceaaa68e0b17348f9
+  version: 1ef6560c59eeb170f2381c02287ca44a5c50a523
   subpackages:
   - client/cherami
   - common


### PR DESCRIPTION
This adds an `Outbounds()` method to `Dispatcher` that provides read
access to the collection of outbounds specified on it.

Resolves #789 
