### PR TITLE
Factor NopLifecycle for reuse

### DIFF
--- a/internal/sync/nop_lifecycle.go
+++ b/internal/sync/nop_lifecycle.go
@@ -1,0 +1,26 @@
+package sync
+
+import (
+	"go.uber.org/yarpc/api/transport"
+)
+
+// NewNopLifecycle returns a new one-time no-op lifecycle
+func NewNopLifecycle() transport.Lifecycle {
+	return &nopLifecycle{once: Once()}
+}
+
+type nopLifecycle struct {
+	once LifecycleOnce
+}
+
+func (n *nopLifecycle) Start() error {
+	return n.once.Start(nil)
+}
+
+func (n *nopLifecycle) Stop() error {
+	return n.once.Stop(nil)
+}
+
+func (n *nopLifecycle) IsRunning() bool {
+	return n.once.IsRunning()
+}


### PR DESCRIPTION
This change is debatable. I needed NopLifecycle for the peer.Bind test, but I’ve since improved that test without using NopLifecycle. This copies the implementation out of the peer.Bind hard-coded case so it can be elsewhere. I have a test in my working copy that may use this dummy lifecycle again.