### PR TITLE
CombineErrors instead of IfAny

### DIFF
--- a/internal/errors/group.go
+++ b/internal/errors/group.go
@@ -34,18 +34,6 @@ func (e ErrorGroup) Error() string {
 	return strings.Join(messages, "\n\t")
 }
 
-// IfAny returns nil if the error group is empty, the only error if there is
-// only one, or the error group itself if there are more.
-func (e ErrorGroup) IfAny() error {
-	if len(e) == 0 {
-		return nil
-	} else if len(e) == 1 {
-		return e[0]
-	} else {
-		return e
-	}
-}
-
 // MultiError combines a list of errors into one. The list MUST NOT contain nil.
 //
 // Returns nil if the error list is empty.

--- a/peer/bind.go
+++ b/peer/bind.go
@@ -83,7 +83,7 @@ func (c *BoundChooser) start() error {
 		}
 	}
 
-	return errs.IfAny()
+	return errors.CombineErrors(errs...)
 }
 
 // Stop stops the peer list and the peer provider binding.
@@ -102,7 +102,7 @@ func (c *BoundChooser) stop() error {
 		errs = append(errs, err)
 	}
 
-	return errs.IfAny()
+	return errors.CombineErrors(errs...)
 }
 
 // IsRunning returns whether the peer list and its peer provider binding are


### PR DESCRIPTION
I previously introduced multiError.IfAny() to reduce
an error to nil, a single error, or a group of errors.
This is effectively accounted for with CombineError(errs...).