### PR TITLE
Disable golang tip testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,9 +48,9 @@ matrix:
     - go: 1.8
       env: type=test
       addons: {apt: {packages: [python-virtualenv]}}
-    - go: tip
-      env: TYPE=test
-      addons: {apt: {packages: [python-virtualenv]}}
+    #- go: tip
+      #env: TYPE=test
+      #addons: {apt: {packages: [python-virtualenv]}}
 
 before_install:
 - go version


### PR DESCRIPTION
https://travis-ci.org/yarpc/yarpc-go/builds

The builds on tip are taking forever and sometimes failing, I get that it would be nice to test against tip, but 10 minutes vs 30 minutes doesn't seem to be worth it right now. If we want to test against tip, we should make this quicker somehow.