### PR TITLE
Support chaining already-chained middleware

### DIFF
--- a/api/transport/handler.go
+++ b/api/transport/handler.go
@@ -28,6 +28,8 @@ import (
 	"time"
 
 	"go.uber.org/yarpc/internal/errors"
+
+	"go.uber.org/zap/zapcore"
 )
 
 // Type is an enum of RPC types
@@ -47,6 +49,12 @@ type HandlerSpec struct {
 
 	unaryHandler  UnaryHandler
 	onewayHandler OnewayHandler
+}
+
+// MarshalLogObject implements zap.ObjectMarshaler.
+func (h HandlerSpec) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddString("rpcType", h.t.String())
+	return nil
 }
 
 // Type returns the associated handler's type

--- a/api/transport/request.go
+++ b/api/transport/request.go
@@ -24,6 +24,8 @@ import (
 	"io"
 
 	"go.uber.org/yarpc/internal/errors"
+
+	"go.uber.org/zap/zapcore"
 )
 
 // Request is the low level request representation.
@@ -60,6 +62,19 @@ type Request struct {
 
 	// Request payload.
 	Body io.Reader
+}
+
+// MarshalLogObject implements zap.ObjectMarshaler.
+func (r *Request) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	// TODO (#788): Include headers once we can omit PII.
+	enc.AddString("caller", r.Caller)
+	enc.AddString("service", r.Service)
+	enc.AddString("encoding", string(r.Encoding))
+	enc.AddString("procedure", r.Procedure)
+	enc.AddString("shardKey", r.ShardKey)
+	enc.AddString("routingKey", r.RoutingKey)
+	enc.AddString("routingDelegate", r.RoutingDelegate)
+	return nil
 }
 
 // Encoding represents an encoding format for requests.

--- a/api/transport/router_test.go
+++ b/api/transport/router_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package transport
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestProcedureLogMarshaling(t *testing.T) {
+	p := Procedure{
+		Name:    "name",
+		Service: "service",
+		HandlerSpec: NewUnaryHandlerSpec(unaryHandlerFunc(func(_ context.Context, _ *Request, _ ResponseWriter) error {
+			return nil
+		})),
+		Encoding:  "raw",
+		Signature: "signature",
+	}
+	enc := zapcore.NewMapObjectEncoder()
+	assert.NoError(t, p.MarshalLogObject(enc), "Unexpected error marshaling procedure.")
+	assert.Equal(t, map[string]interface{}{
+		"name":      "name",
+		"service":   "service",
+		"handler":   map[string]interface{}{"rpcType": "Unary"},
+		"encoding":  "raw",
+		"signature": "signature",
+	}, enc.Fields, "Unexpected output from marshaling procedure.")
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: a20d870d4ec92870b40e039273bc630f16172331e11b0ba1237c53fc6e3975be
-updated: 2017-03-29T14:08:15.515192528+02:00
+hash: 7b4a853fba266dd0e48df4c4fde8709ca2f279f5838de838c0c50f8ec03a4fbc
+updated: 2017-03-29T08:35:29.463444274-07:00
 imports:
 - name: github.com/apache/thrift
   version: b2a4d4ae21c789b689dd162deb819665567f481c
@@ -167,8 +167,18 @@ imports:
   - ptr
   - version
   - wire
+- name: go.uber.org/zap
+  version: 4257c7cf05477d92ec25c31cfd3d60e89575f18a
+  subpackages:
+  - buffer
+  - internal/bufferpool
+  - internal/color
+  - internal/exit
+  - internal/multierror
+  - zapcore
+  - zaptest/observer
 - name: golang.org/x/net
-  version: 05d3205156cb1bdc096578d6457fa161cd950aa2
+  version: 3e967e1d28d2c9c06e749dc2bdc14b04df89e689
   subpackages:
   - context
   - context/ctxhttp

--- a/glide.yaml
+++ b/glide.yaml
@@ -18,6 +18,9 @@ import:
   version: ~0.8.0
   subpackages:
   - prometheus
+  - prometheus/promhttp
+- package: go.uber.org/zap
+  version: ^1
 - package: github.com/stretchr/testify
   version: master
   # TODO: before cherami transport can leave the x/ package, cherami-client-go must >=1.0

--- a/internal/inboundmiddleware/chain.go
+++ b/internal/inboundmiddleware/chain.go
@@ -29,13 +29,22 @@ import (
 
 // UnaryChain combines a series of `UnaryInbound`s into a single `InboundMiddleware`.
 func UnaryChain(mw ...middleware.UnaryInbound) middleware.UnaryInbound {
-	switch len(mw) {
+	unchained := make([]middleware.UnaryInbound, 0, len(mw))
+	for _, m := range mw {
+		if c, ok := m.(unaryChain); ok {
+			unchained = append(unchained, c...)
+			continue
+		}
+		unchained = append(unchained, m)
+	}
+
+	switch len(unchained) {
 	case 0:
 		return middleware.NopUnaryInbound
 	case 1:
-		return mw[0]
+		return unchained[0]
 	default:
-		return unaryChain(mw)
+		return unaryChain(unchained)
 	}
 }
 
@@ -66,11 +75,20 @@ func (x unaryChainExec) Handle(ctx context.Context, req *transport.Request, resw
 
 // OnewayChain combines a series of `OnewayInbound`s into a single `InboundMiddleware`.
 func OnewayChain(mw ...middleware.OnewayInbound) middleware.OnewayInbound {
-	switch len(mw) {
+	unchained := make([]middleware.OnewayInbound, 0, len(mw))
+	for _, m := range mw {
+		if c, ok := m.(onewayChain); ok {
+			unchained = append(unchained, c...)
+			continue
+		}
+		unchained = append(unchained, m)
+	}
+
+	switch len(unchained) {
 	case 0:
 		return middleware.NopOnewayInbound
 	case 1:
-		return mw[0]
+		return unchained[0]
 	default:
 		return onewayChain(mw)
 	}

--- a/internal/observerware/common_test.go
+++ b/internal/observerware/common_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package observerware
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/yarpc/api/transport"
+)
+
+type fakeInboundMiddleware struct {
+	err error
+}
+
+func (m fakeInboundMiddleware) Handle(_ context.Context, _ *transport.Request, _ transport.ResponseWriter, _ transport.UnaryHandler) error {
+	return m.err
+}
+
+func (m fakeInboundMiddleware) HandleOneway(_ context.Context, _ *transport.Request, _ transport.OnewayHandler) error {
+	return m.err
+}
+
+type fakeHandler struct {
+	err error
+}
+
+func (h fakeHandler) Handle(_ context.Context, _ *transport.Request, _ transport.ResponseWriter) error {
+	return h.err
+}
+
+func (h fakeHandler) HandleOneway(_ context.Context, _ *transport.Request, _ transport.ResponseWriter) error {
+	return h.err
+}
+
+func stubTime() func() {
+	prev := _timeNow
+	_timeNow = func() time.Time { return time.Time{} }
+	return func() { _timeNow = prev }
+}

--- a/internal/observerware/doc.go
+++ b/internal/observerware/doc.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package observerware provides logging and metrics collection middleware for
+// YARPC.
+package observerware

--- a/internal/observerware/extractor.go
+++ b/internal/observerware/extractor.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package observerware
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// A ContextExtractor pulls any relevant request-scoped data (e.g., tracing
+// spans) from the request's Context.
+type ContextExtractor func(context.Context) zapcore.Field
+
+// NewNopContextExtractor returns a no-op ContextExtractor.
+func NewNopContextExtractor() ContextExtractor {
+	return ContextExtractor(func(_ context.Context) zapcore.Field { return zap.Skip() })
+}

--- a/internal/observerware/middleware.go
+++ b/internal/observerware/middleware.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package observerware
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/yarpc/api/transport"
+
+	"go.uber.org/zap"
+)
+
+// For tests.
+var _timeNow = time.Now
+
+// UnaryInbound is middleware for unary inbound handlers.
+type UnaryInbound struct {
+	logger  *zap.Logger
+	extract ContextExtractor
+}
+
+// NewUnaryInbound constructs a UnaryInbound.
+func NewUnaryInbound(logger *zap.Logger, extract ContextExtractor) *UnaryInbound {
+	return &UnaryInbound{
+		logger:  logger.With(zap.String("rpcType", "unary inbound")),
+		extract: extract,
+	}
+}
+
+// Handle implements middleware.UnaryInbound.
+func (m *UnaryInbound) Handle(ctx context.Context, req *transport.Request, w transport.ResponseWriter, h transport.UnaryHandler) error {
+	// TODO (shah): Add timing info to the request struct so that we don't lose
+	// time spent in the transport.
+	start := _timeNow()
+	err := h.Handle(ctx, req, w)
+	elapsed := _timeNow().Sub(start)
+
+	if ce := m.logger.Check(zap.DebugLevel, "Handled request."); ce != nil {
+		ce.Write(
+			m.extract(ctx),
+			zap.Object("request", req),
+			zap.Duration("latency", elapsed),
+			zap.Bool("successful", err == nil),
+			zap.Error(err),
+		)
+	}
+	return err
+}

--- a/internal/observerware/middleware_test.go
+++ b/internal/observerware/middleware_test.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package observerware
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"go.uber.org/yarpc/api/transport"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestUnaryInboundMiddleware(t *testing.T) {
+	defer stubTime()()
+	req := &transport.Request{
+		Caller:          "caller",
+		Service:         "service",
+		Encoding:        "raw",
+		Procedure:       "procedure",
+		Headers:         transport.NewHeaders().With("password", "super-secret"),
+		ShardKey:        "shard01",
+		RoutingKey:      "routing-key",
+		RoutingDelegate: "routing-delegate",
+		Body:            strings.NewReader("body"),
+	}
+	failed := errors.New("fail")
+
+	tests := []struct {
+		desc    string
+		handler transport.UnaryHandler
+		extract ContextExtractor
+
+		wantErr    bool
+		wantFields []zapcore.Field
+	}{
+		{
+			desc:    "downstream errors",
+			handler: fakeHandler{},
+			extract: NewNopContextExtractor(),
+			wantFields: []zapcore.Field{
+				zap.String("rpcType", "unary inbound"),
+				zap.Skip(),
+				zap.Object("request", req),
+				zap.Duration("latency", 0),
+				zap.Bool("successful", true),
+				zap.Skip(),
+			},
+		},
+		{
+			desc:    "no downstream errors",
+			extract: NewNopContextExtractor(),
+			handler: fakeHandler{failed},
+			wantErr: true,
+			wantFields: []zapcore.Field{
+				zap.String("rpcType", "unary inbound"),
+				zap.Skip(),
+				zap.Object("request", req),
+				zap.Duration("latency", 0),
+				zap.Bool("successful", false),
+				zap.Error(failed),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			core, logs := observer.New(zapcore.DebugLevel)
+			mw := NewUnaryInbound(zap.New(core), tt.extract)
+			err := mw.Handle(context.Background(), req, nil /* response writer */, tt.handler)
+			if tt.wantErr {
+				assert.Error(t, err, "Expected an error from middleware.")
+			} else {
+				assert.NoError(t, err, "Unexpected error from middleware.")
+			}
+			require.Equal(t, 1, logs.Len(), "Unexpected number of logs written.")
+			expected := observer.LoggedEntry{
+				Entry: zapcore.Entry{
+					Level:   zapcore.DebugLevel,
+					Message: "Handled request.",
+				},
+				Context: tt.wantFields,
+			}
+			assert.Equal(t, expected, logs.AllUntimed()[0], "Unexpected log entry written.")
+		})
+	}
+}

--- a/internal/outboundmiddleware/chain.go
+++ b/internal/outboundmiddleware/chain.go
@@ -30,13 +30,22 @@ import (
 
 // UnaryChain combines a series of `UnaryOutbound`s into a single `UnaryOutbound`.
 func UnaryChain(mw ...middleware.UnaryOutbound) middleware.UnaryOutbound {
-	switch len(mw) {
+	unchained := make([]middleware.UnaryOutbound, 0, len(mw))
+	for _, m := range mw {
+		if c, ok := m.(unaryChain); ok {
+			unchained = append(unchained, c...)
+			continue
+		}
+		unchained = append(unchained, m)
+	}
+
+	switch len(unchained) {
 	case 0:
 		return middleware.NopUnaryOutbound
 	case 1:
-		return mw[0]
+		return unchained[0]
 	default:
-		return unaryChain(mw)
+		return unaryChain(unchained)
 	}
 }
 
@@ -90,13 +99,22 @@ func (x unaryChainExec) Introspect() introspection.OutboundStatus {
 
 // OnewayChain combines a series of `OnewayOutbound`s into a single `OnewayOutbound`.
 func OnewayChain(mw ...middleware.OnewayOutbound) middleware.OnewayOutbound {
-	switch len(mw) {
+	unchained := make([]middleware.OnewayOutbound, 0, len(mw))
+	for _, m := range mw {
+		if c, ok := m.(onewayChain); ok {
+			unchained = append(unchained, c...)
+			continue
+		}
+		unchained = append(unchained, m)
+	}
+
+	switch len(unchained) {
 	case 0:
 		return middleware.NopOnewayOutbound
 	case 1:
-		return mw[0]
+		return unchained[0]
 	default:
-		return onewayChain(mw)
+		return onewayChain(unchained)
 	}
 }
 


### PR DESCRIPTION
In order to better support internal middleware, chaining middleware should
implicitly unroll any already-chained middlewares.