### PR TITLE
Fix dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,8 +19,8 @@ internal/crossdock/crossdock
 internal/examples/env
 internal/examples/json-keyvalue/client/client
 internal/examples/json-keyvalue/server/server
-internal/examples/hello/hello
 internal/examples/protobuf/protobuf
+internal/examples/thrift-hello/hello/hello
 internal/examples/thrift-keyvalue/keyvalue/client/client
 internal/examples/thrift-keyvalue/keyvalue/server/server
 internal/examples/thrift-oneway/thrift-oneway


### PR DESCRIPTION
One more problem I found, docker context now down to ~12MB, and could be ~3-4MB if we ignore .git (which we can't right now, but maybe in the future).