### PR TITLE
ctxpropagation: Control multi-hop transports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,10 @@ services:
             - AXIS_SERVER_ONEWAY=go
             - AXIS_TRANSPORT_ONEWAY=http,redis,cherami
 
+            # Transports available to the ctxpropagation behavior for multihop
+            # requests.
+            - AXIS_CTXAVAILABLETRANSPORTS=http;tchannel
+
             - BEHAVIOR_RAW=client,server,transport
             - BEHAVIOR_JSON=client,server,transport
             - BEHAVIOR_THRIFT=client,server,transport
@@ -51,7 +55,7 @@ services:
             - BEHAVIOR_THRIFTGAUNTLET=gauntlet,server,transport
             - BEHAVIOR_TIMEOUT=client,server,transport
             # BEHAVIOR_INBOUNDTTL TODO
-            - BEHAVIOR_CTXPROPAGATION=ctxclient,ctxserver,transport
+            - BEHAVIOR_CTXPROPAGATION=ctxclient,ctxserver,transport,ctxavailabletransports
             - BEHAVIOR_APACHETHRIFT=apachethriftclient,apachethriftserver
             - BEHAVIOR_ONEWAY=client_oneway,server_oneway,transport_oneway,encoding
             - BEHAVIOR_ONEWAY_CTXPROPAGATION=client_oneway,server_oneway,transport_oneway

--- a/internal/crossdock/main_test.go
+++ b/internal/crossdock/main_test.go
@@ -116,8 +116,20 @@ func TestCrossdock(t *testing.T) {
 				"transport": []string{"http", "tchannel"},
 			},
 			params: params{
-				"ctxserver": "127.0.0.1",
-				"ctxclient": "127.0.0.1",
+				"ctxserver":              "127.0.0.1",
+				"ctxclient":              "127.0.0.1",
+				"ctxavailabletransports": "http;tchannel",
+			},
+		},
+		{
+			// Try ctxpropagation with only HTTP. We never do this in YARPC Go
+			// but other languages that don't support TChannel need this.
+			name: "ctxpropagation",
+			params: params{
+				"transport":              "http",
+				"ctxserver":              "127.0.0.1",
+				"ctxclient":              "127.0.0.1",
+				"ctxavailabletransports": "http",
 			},
 		},
 		{


### PR DESCRIPTION
This changes the ctxpropagation behavior to rely ona a
`ctxavailabletransports` parameter which lists the transports available
for multi-hop requests. Without this, we have a hard dependency on
TChannel in this behavior.

This will allow YARPC Java to say that only HTTP is available as a
transport so multi-hop requests will just go over HTTP.