### PR TITLE
config: Register custom peer choosers/binders

### DIFF
--- a/api/peer/list.go
+++ b/api/peer/list.go
@@ -58,3 +58,12 @@ type ListUpdates struct {
 	// Removals are the identifiers that should be removed to the list
 	Removals []Identifier
 }
+
+// Binder is a callback for peer.Bind that accepts a peer list and binds it to
+// a peer provider for the duration of the returned lifecycle.
+// The lifecycle that the binder returns should start and stop binding peers to
+// the list.
+// The binder must not block on updating the list, because that will typically
+// block until the peer list has started. The binder must arrange for
+// the first list update to occur when the returned lifecycle starts.
+type Binder func(List) transport.Lifecycle

--- a/x/config/configurator.go
+++ b/x/config/configurator.go
@@ -40,13 +40,21 @@ import (
 // RegisterTransport function.
 type Configurator struct {
 	knownTransports map[string]*compiledTransportSpec
+	knownChoosers   map[string]*compiledChooserSpec
+	knownBinders    map[string]*compiledBinderSpec
 }
 
 // New sets up a new empty Configurator. The returned Configurator does not
-// know about any transports. Individual TransportSpecs must be registered
-// against it using the RegisterTransport function.
+// know about any Transports, peer Chooser lists, or peer list Binders.
+// Individual TransportSpecs, ChooserSpecs, and BinderSpecs must be registered
+// against it using the RegisterTransport, RegisterChooser, and RegisterBinder
+// functions.
 func New() *Configurator {
-	return &Configurator{knownTransports: make(map[string]*compiledTransportSpec)}
+	return &Configurator{
+		knownTransports: make(map[string]*compiledTransportSpec),
+		knownChoosers:   make(map[string]*compiledChooserSpec),
+		knownBinders:    make(map[string]*compiledBinderSpec),
+	}
 }
 
 // RegisterTransport registers a TransportSpec with the given Configurator. An
@@ -76,6 +84,65 @@ func (c *Configurator) RegisterTransport(t TransportSpec) error {
 // Configurator. This function panics if the TransportSpec was invalid.
 func (c *Configurator) MustRegisterTransport(t TransportSpec) {
 	if err := c.RegisterTransport(t); err != nil {
+		panic(err)
+	}
+}
+
+// RegisterChooser registers a ChooserSpec with the given Configurator. Returns
+// an error if the ChooserSpec is invalid.
+//
+// If a chooser with the same name already exists, it will be replaced.
+//
+// Use MustRegisterChooser to panic in the case of registration failure.
+func (c *Configurator) RegisterChooser(s ChooserSpec) error {
+	if s.Name == "" {
+		return errors.New("name is required")
+	}
+
+	spec, err := compileChooserSpec(&s)
+	if err != nil {
+		return fmt.Errorf("invalid ChooserSpec for %q: %v", s.Name, err)
+	}
+
+	c.knownChoosers[s.Name] = spec
+	return nil
+}
+
+// MustRegisterChooser registers the given ChooserSpec with the Configurator.
+// This function panics if the ChooserSpec is invalid.
+func (c *Configurator) MustRegisterChooser(s ChooserSpec) {
+	if err := c.RegisterChooser(s); err != nil {
+		panic(err)
+	}
+}
+
+// RegisterBinder registers a BinderSpec with the given Configurator. Returns
+// an error if the BinderSpec is invalid.
+//
+// A binder enables custom peer list bindings, like DNS with SRV + A records or
+// a task list file watcher.
+//
+// If a binder with the same name already exists, it will be replaced.
+//
+// Use MustRegisterBinder to panic if the registration fails.
+func (c *Configurator) RegisterBinder(s BinderSpec) error {
+	if s.Name == "" {
+		return errors.New("name is required")
+	}
+
+	spec, err := compileBinderSpec(&s)
+	if err != nil {
+		return fmt.Errorf("invalid BinderSpec for %q: %v", s.Name, err)
+	}
+
+	c.knownBinders[s.Name] = spec
+	return nil
+}
+
+// MustRegisterBinder registers the given BinderSpec with the Configurator.
+// This function panics if the BinderSpec is invalid.
+func (c *Configurator) MustRegisterBinder(s BinderSpec) {
+	if err := c.RegisterBinder(s); err != nil {
 		panic(err)
 	}
 }

--- a/x/config/kit.go
+++ b/x/config/kit.go
@@ -22,10 +22,20 @@ package config
 
 import "reflect"
 
-// Kit carries tools for building transports, inbounds, and outbounds using
-// plugins.
+// Kit carries internal dependencies for building peer choosers.
+// The kit gets threaded through transport, outbound, and inbound builders
+// so they can thread the kit through functions like BuildChooser on a
+// ChooserConfig.
 type Kit struct {
 	c *Configurator
 }
 
 var _typeOfKit = reflect.TypeOf((*Kit)(nil))
+
+func (k *Kit) binder(name string) *compiledBinderSpec {
+	return k.c.knownBinders[name]
+}
+
+func (k *Kit) chooser(name string) *compiledChooserSpec {
+	return k.c.knownChoosers[name]
+}

--- a/x/config/spec_test.go
+++ b/x/config/spec_test.go
@@ -26,6 +26,7 @@ import (
 	"reflect"
 	"testing"
 
+	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
 
 	"github.com/golang/mock/gomock"
@@ -535,6 +536,209 @@ func TestCompileOnewayOutboundConfig(t *testing.T) {
 	}
 }
 
+func TestCompileChooserSpec(t *testing.T) {
+	tests := []struct {
+		desc     string
+		spec     ChooserSpec
+		wantName string
+		wantErr  string
+	}{
+		{
+			desc:    "missing name",
+			wantErr: "Name is required",
+		},
+		{
+			desc: "missing BuildChooser",
+			spec: ChooserSpec{
+				Name: "random",
+			},
+			wantErr: "BuildChooser is required",
+		},
+		{
+			desc: "not a function",
+			spec: ChooserSpec{
+				Name:         "much sadness",
+				BuildChooser: 10,
+			},
+			wantErr: "invalid BuildChooser int: must be a function",
+		},
+		{
+			desc: "too many arguments",
+			spec: ChooserSpec{
+				Name:         "much sadness",
+				BuildChooser: func(a, b, c int) {},
+			},
+			wantErr: "invalid BuildChooser func(int, int, int): must accept exactly two arguments, found 3",
+		},
+		{
+			desc: "wrong kind of first argument",
+			spec: ChooserSpec{
+				Name:         "much sadness",
+				BuildChooser: func(a, b int) {},
+			},
+			wantErr: "invalid BuildChooser func(int, int): must accept a struct or struct pointer as its first argument, found int",
+		},
+		{
+			desc: "wrong kind of second argument",
+			spec: ChooserSpec{
+				Name:         "much sadness",
+				BuildChooser: func(a struct{}, b int) {},
+			},
+			wantErr: "invalid BuildChooser func(struct {}, int): must accept a *config.Kit as its second argument, found int",
+		},
+		{
+			desc: "wrong number of returns",
+			spec: ChooserSpec{
+				Name:         "much sadness",
+				BuildChooser: func(a struct{}, b *Kit) {},
+			},
+			wantErr: "invalid BuildChooser func(struct {}, *config.Kit): must return exactly two results, found 0",
+		},
+		{
+			desc: "wrong type of first return",
+			spec: ChooserSpec{
+				Name: "much sadness",
+				BuildChooser: func(a struct{}, b *Kit) (int, error) {
+					return 0, nil
+				},
+			},
+			wantErr: "invalid BuildChooser func(struct {}, *config.Kit) (int, error): must return a peer.ChooserList as its first result, found int",
+		},
+		{
+			desc: "wrong type of second return",
+			spec: ChooserSpec{
+				Name: "much sadness",
+				BuildChooser: func(a struct{}, b *Kit) (peer.ChooserList, int) {
+					return nil, 0
+				},
+			},
+			wantErr: "invalid BuildChooser func(struct {}, *config.Kit) (peer.ChooserList, int): must return an error as its second result, found int",
+		},
+		{
+			desc: "such gladness",
+			spec: ChooserSpec{
+				Name: "such gladness",
+				BuildChooser: func(a struct{}, b *Kit) (peer.ChooserList, error) {
+					return nil, nil
+				},
+			},
+			wantName: "such gladness",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			s, err := compileChooserSpec(&tt.spec)
+			if err != nil {
+				assert.Equal(t, tt.wantErr, err.Error(), "expected error")
+			} else {
+				assert.Equal(t, tt.wantName, s.Name, "expected name")
+			}
+		})
+	}
+}
+
+func TestCompileBinderSpec(t *testing.T) {
+	tests := []struct {
+		desc     string
+		spec     BinderSpec
+		wantName string
+		wantErr  string
+	}{
+		{
+			desc:    "missing name",
+			wantErr: "Name is required",
+		},
+		{
+			desc: "missing BuildBinder",
+			spec: BinderSpec{
+				Name: "random",
+			},
+			wantErr: "BuildBinder is required",
+		},
+		{
+			desc: "not a function",
+			spec: BinderSpec{
+				Name:        "much sadness",
+				BuildBinder: 10,
+			},
+			wantErr: "invalid BuildBinder int: must be a function",
+		},
+		{
+			desc: "too many arguments",
+			spec: BinderSpec{
+				Name:        "much sadness",
+				BuildBinder: func(a, b, c int) {},
+			},
+			wantErr: "invalid BuildBinder func(int, int, int): must accept exactly two arguments, found 3",
+		},
+		{
+			desc: "wrong kind of first argument",
+			spec: BinderSpec{
+				Name:        "much sadness",
+				BuildBinder: func(a, b int) {},
+			},
+			wantErr: "invalid BuildBinder func(int, int): must accept a struct or struct pointer as its first argument, found int",
+		},
+		{
+			desc: "wrong kind of second argument",
+			spec: BinderSpec{
+				Name:        "much sadness",
+				BuildBinder: func(a struct{}, b int) {},
+			},
+			wantErr: "invalid BuildBinder func(struct {}, int): must accept a *config.Kit as its second argument, found int",
+		},
+		{
+			desc: "wrong number of returns",
+			spec: BinderSpec{
+				Name:        "much sadness",
+				BuildBinder: func(a struct{}, b *Kit) {},
+			},
+			wantErr: "invalid BuildBinder func(struct {}, *config.Kit): must return exactly two results, found 0",
+		},
+		{
+			desc: "wrong type of first return",
+			spec: BinderSpec{
+				Name: "much sadness",
+				BuildBinder: func(a struct{}, b *Kit) (int, error) {
+					return 0, nil
+				},
+			},
+			wantErr: "invalid BuildBinder func(struct {}, *config.Kit) (int, error): must return a peer.Binder as its first result, found int",
+		},
+		{
+			desc: "wrong type of second return",
+			spec: BinderSpec{
+				Name: "much sadness",
+				BuildBinder: func(a struct{}, b *Kit) (peer.Binder, int) {
+					return nil, 0
+				},
+			},
+			wantErr: "invalid BuildBinder func(struct {}, *config.Kit) (peer.Binder, int): must return an error as its second result, found int",
+		},
+		{
+			desc: "such gladness",
+			spec: BinderSpec{
+				Name: "such gladness",
+				BuildBinder: func(a struct{}, b *Kit) (peer.Binder, error) {
+					return nil, nil
+				},
+			},
+			wantName: "such gladness",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			s, err := compileBinderSpec(&tt.spec)
+			if err != nil {
+				assert.Equal(t, tt.wantErr, err.Error(), "expected error")
+			} else {
+				assert.Equal(t, tt.wantName, s.Name, "expected name")
+			}
+		})
+	}
+}
 func TestValidateConfigFunc(t *testing.T) {
 	tests := []struct {
 		desc string


### PR DESCRIPTION
This change adds supports for adding custom Choosers and Binders to the Configurator, so they can be applied in outbound builders.

- [x] This entrains two commits that are out-of-band and need to be rebased out. #840 and the already-landed peer.BindPeers change.