### PR TITLE
Add Yarpc to public types generated by protoc-gen-yarpc-go

### DIFF
--- a/encoding/x/protobuf/protoc-gen-yarpc-go/main.go
+++ b/encoding/x/protobuf/protoc-gen-yarpc-go/main.go
@@ -69,78 +69,78 @@ import (
 )
 
 {{range $service := .Services }}
-// {{$service.GetName}}Client is the client-side interface for the {{$service.GetName}} service.
-type {{$service.GetName}}Client interface {
+// {{$service.GetName}}YarpcClient is the yarpc client-side interface for the {{$service.GetName}} service.
+type {{$service.GetName}}YarpcClient interface {
 	{{range $method := unaryMethods $service}}{{$method.GetName}}(context.Context, *{{$method.RequestType.GoType $packagePath}}, ...yarpc.CallOption) (*{{$method.ResponseType.GoType $packagePath}}, error)
 	{{end}}
 	{{range $method := onewayMethods $service}}{{$method.GetName}}(context.Context, *{{$method.RequestType.GoType $packagePath}}, ...yarpc.CallOption) (yarpc.Ack, error)
 	{{end}}
 }
 
-// New{{$service.GetName}}Client builds a new client for the {{$service.GetName}} service.
-func New{{$service.GetName}}Client(clientConfig transport.ClientConfig) {{$service.GetName}}Client {
-	return &_{{$service.GetName}}Caller{protobuf.NewClient("{{$service.GetName}}", clientConfig)}
+// New{{$service.GetName}}YarpcClient builds a new yarpc client for the {{$service.GetName}} service.
+func New{{$service.GetName}}YarpcClient(clientConfig transport.ClientConfig) {{$service.GetName}}YarpcClient {
+	return &_{{$service.GetName}}YarpcCaller{protobuf.NewClient("{{$service.GetName}}", clientConfig)}
 }
 
-// {{$service.GetName}}Server is the server-side interface for the {{$service.GetName}} service.
-type {{$service.GetName}}Server interface {
+// {{$service.GetName}}YarpcServer is the yarpc server-side interface for the {{$service.GetName}} service.
+type {{$service.GetName}}YarpcServer interface {
 	{{range $method := unaryMethods $service}}{{$method.GetName}}(context.Context, *{{$method.RequestType.GoType $packagePath}}) (*{{$method.ResponseType.GoType $packagePath}}, error)
 	{{end}}
 	{{range $method := onewayMethods $service}}{{$method.GetName}}(context.Context, *{{$method.RequestType.GoType $packagePath}}) error
 	{{end}}
 }
 
-// Build{{$service.GetName}}Procedures prepares an implementation of the {{$service.GetName}} service for registration.
-func Build{{$service.GetName}}Procedures(server {{$service.GetName}}Server) []transport.Procedure {
-	handler := &_{{$service.GetName}}Handler{server}
+// Build{{$service.GetName}}YarpcProcedures prepares an implementation of the {{$service.GetName}} service for yarpc registration.
+func Build{{$service.GetName}}YarpcProcedures(server {{$service.GetName}}YarpcServer) []transport.Procedure {
+	handler := &_{{$service.GetName}}YarpcHandler{server}
 	return protobuf.BuildProcedures(
 		"{{$service.GetName}}",
 		map[string]transport.UnaryHandler{
-		{{range $method := unaryMethods $service}}"{{$method.GetName}}": protobuf.NewUnaryHandler(handler.{{$method.GetName}}, new{{$service.GetName}}_{{$method.GetName}}Request),
+		{{range $method := unaryMethods $service}}"{{$method.GetName}}": protobuf.NewUnaryHandler(handler.{{$method.GetName}}, new{{$service.GetName}}_{{$method.GetName}}YarpcRequest),
 		{{end}}
 		},
 		map[string]transport.OnewayHandler{
-		{{range $method := onewayMethods $service}}"{{$method.GetName}}": protobuf.NewOnewayHandler(handler.{{$method.GetName}}, new{{$service.GetName}}_{{$method.GetName}}Request),
+		{{range $method := onewayMethods $service}}"{{$method.GetName}}": protobuf.NewOnewayHandler(handler.{{$method.GetName}}, new{{$service.GetName}}_{{$method.GetName}}YarpcRequest),
 		{{end}}
 		},
 	)
 }
 
-type _{{$service.GetName}}Caller struct {
+type _{{$service.GetName}}YarpcCaller struct {
 	client protobuf.Client
 }
 
 {{range $method := unaryMethods $service}}
-func (c *_{{$service.GetName}}Caller) {{$method.GetName}}(ctx context.Context, request *{{$method.RequestType.GoType $packagePath}}, options ...yarpc.CallOption) (*{{$method.ResponseType.GoType $packagePath}}, error) {
-	responseMessage, err := c.client.Call(ctx, "{{$method.GetName}}", request, new{{$service.GetName}}_{{$method.GetName}}Response, options...)
+func (c *_{{$service.GetName}}YarpcCaller) {{$method.GetName}}(ctx context.Context, request *{{$method.RequestType.GoType $packagePath}}, options ...yarpc.CallOption) (*{{$method.ResponseType.GoType $packagePath}}, error) {
+	responseMessage, err := c.client.Call(ctx, "{{$method.GetName}}", request, new{{$service.GetName}}_{{$method.GetName}}YarpcResponse, options...)
 	if responseMessage == nil {
 		return nil, err
 	}
 	response, ok := responseMessage.(*{{$method.ResponseType.GoType $packagePath}})
 	if !ok {
-		return nil, protobuf.CastError(empty{{$service.GetName}}_{{$method.GetName}}Response, responseMessage)
+		return nil, protobuf.CastError(empty{{$service.GetName}}_{{$method.GetName}}YarpcResponse, responseMessage)
 	}
 	return response, err
 }
 {{end}}
 {{range $method := onewayMethods $service}}
-func (c *_{{$service.GetName}}Caller) {{$method.GetName}}(ctx context.Context, request *{{$method.RequestType.GoType $packagePath}}, options ...yarpc.CallOption) (yarpc.Ack, error) {
+func (c *_{{$service.GetName}}YarpcCaller) {{$method.GetName}}(ctx context.Context, request *{{$method.RequestType.GoType $packagePath}}, options ...yarpc.CallOption) (yarpc.Ack, error) {
 	return c.client.CallOneway(ctx, "{{$method.GetName}}", request, options...)
 }
 {{end}}
 
-type _{{$service.GetName}}Handler struct {
-	server {{$service.GetName}}Server
+type _{{$service.GetName}}YarpcHandler struct {
+	server {{$service.GetName}}YarpcServer
 }
 
 {{range $method := unaryMethods $service}}
-func (h *_{{$service.GetName}}Handler) {{$method.GetName}}(ctx context.Context, requestMessage proto.Message) (proto.Message, error) {
+func (h *_{{$service.GetName}}YarpcHandler) {{$method.GetName}}(ctx context.Context, requestMessage proto.Message) (proto.Message, error) {
 	var request *{{$method.RequestType.GoType $packagePath}}
 	var ok bool
 	if requestMessage != nil {
 		request, ok = requestMessage.(*{{$method.RequestType.GoType $packagePath}})
 		if !ok {
-			return nil, protobuf.CastError(empty{{$service.GetName}}_{{$method.GetName}}Request, requestMessage)
+			return nil, protobuf.CastError(empty{{$service.GetName}}_{{$method.GetName}}YarpcRequest, requestMessage)
 		}
 	}
 	response, err := h.server.{{$method.GetName}}(ctx, request)
@@ -151,13 +151,13 @@ func (h *_{{$service.GetName}}Handler) {{$method.GetName}}(ctx context.Context, 
 }
 {{end}}
 {{range $method := onewayMethods $service}}
-func (h *_{{$service.GetName}}Handler) {{$method.GetName}}(ctx context.Context, requestMessage proto.Message) error {
+func (h *_{{$service.GetName}}YarpcHandler) {{$method.GetName}}(ctx context.Context, requestMessage proto.Message) error {
 	var request *{{$method.RequestType.GoType $packagePath}}
 	var ok bool
 	if requestMessage != nil {
 		request, ok = requestMessage.(*{{$method.RequestType.GoType $packagePath}})
 		if !ok {
-			return protobuf.CastError(empty{{$service.GetName}}_{{$method.GetName}}Request, requestMessage)
+			return protobuf.CastError(empty{{$service.GetName}}_{{$method.GetName}}YarpcRequest, requestMessage)
 		}
 	}
 	return h.server.{{$method.GetName}}(ctx, request)
@@ -165,18 +165,18 @@ func (h *_{{$service.GetName}}Handler) {{$method.GetName}}(ctx context.Context, 
 {{end}}
 
 {{range $method := $service.Methods}}
-func new{{$service.GetName}}_{{$method.GetName}}Request() proto.Message {
+func new{{$service.GetName}}_{{$method.GetName}}YarpcRequest() proto.Message {
 	return &{{$method.RequestType.GoType $packagePath}}{}
 }
 
-func new{{$service.GetName}}_{{$method.GetName}}Response() proto.Message {
+func new{{$service.GetName}}_{{$method.GetName}}YarpcResponse() proto.Message {
 	return &{{$method.ResponseType.GoType $packagePath}}{}
 }
 {{end}}
 var (
 {{range $method := $service.Methods}}
-	empty{{$service.GetName}}_{{$method.GetName}}Request = &{{$method.RequestType.GoType $packagePath}}{}
-	empty{{$service.GetName}}_{{$method.GetName}}Response = &{{$method.ResponseType.GoType $packagePath}}{}{{end}}
+	empty{{$service.GetName}}_{{$method.GetName}}YarpcRequest = &{{$method.RequestType.GoType $packagePath}}{}
+	empty{{$service.GetName}}_{{$method.GetName}}YarpcResponse = &{{$method.ResponseType.GoType $packagePath}}{}{{end}}
 )
 {{end}}
 `

--- a/encoding/x/protobuf/testing/benchmark_test.go
+++ b/encoding/x/protobuf/testing/benchmark_test.go
@@ -35,14 +35,14 @@ func BenchmarkIntegration(b *testing.B) {
 }
 
 func benchmarkIntegrationForTransportType(b *testing.B, transportType testutils.TransportType) {
-	keyValueServer := example.NewKeyValueServer()
-	sinkServer := example.NewSinkServer()
+	keyValueYarpcServer := example.NewKeyValueYarpcServer()
+	sinkYarpcServer := example.NewSinkYarpcServer()
 	example.WithClients(
 		transportType,
-		keyValueServer,
-		sinkServer,
-		func(keyValueClient examplepb.KeyValueClient, sinkClient examplepb.SinkClient) error {
-			benchmarkIntegration(b, keyValueClient, sinkClient, keyValueServer, sinkServer)
+		keyValueYarpcServer,
+		sinkYarpcServer,
+		func(keyValueYarpcClient examplepb.KeyValueYarpcClient, sinkYarpcClient examplepb.SinkYarpcClient) error {
+			benchmarkIntegration(b, keyValueYarpcClient, sinkYarpcClient, keyValueYarpcServer, sinkYarpcServer)
 			return nil
 		},
 	)
@@ -50,16 +50,16 @@ func benchmarkIntegrationForTransportType(b *testing.B, transportType testutils.
 
 func benchmarkIntegration(
 	b *testing.B,
-	keyValueClient examplepb.KeyValueClient,
-	sinkClient examplepb.SinkClient,
-	keyValueServer *example.KeyValueServer,
-	sinkServer *example.SinkServer,
+	keyValueYarpcClient examplepb.KeyValueYarpcClient,
+	sinkYarpcClient examplepb.SinkYarpcClient,
+	keyValueYarpcServer *example.KeyValueYarpcServer,
+	sinkYarpcServer *example.SinkYarpcServer,
 ) {
 	b.Run("Get", func(b *testing.B) {
-		setValue(keyValueClient, "foo", "bar")
+		setValue(keyValueYarpcClient, "foo", "bar")
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			getValue(keyValueClient, "foo")
+			getValue(keyValueYarpcClient, "foo")
 		}
 	})
 }

--- a/encoding/x/protobuf/testing/testing_test.go
+++ b/encoding/x/protobuf/testing/testing_test.go
@@ -42,16 +42,16 @@ func TestIntegration(t *testing.T) {
 }
 
 func testIntegrationForTransportType(t *testing.T, transportType testutils.TransportType) {
-	keyValueServer := example.NewKeyValueServer()
-	sinkServer := example.NewSinkServer()
+	keyValueYarpcServer := example.NewKeyValueYarpcServer()
+	sinkYarpcServer := example.NewSinkYarpcServer()
 	assert.NoError(
 		t,
 		example.WithClients(
 			transportType,
-			keyValueServer,
-			sinkServer,
-			func(keyValueClient examplepb.KeyValueClient, sinkClient examplepb.SinkClient) error {
-				testIntegration(t, keyValueClient, sinkClient, keyValueServer, sinkServer)
+			keyValueYarpcServer,
+			sinkYarpcServer,
+			func(keyValueYarpcClient examplepb.KeyValueYarpcClient, sinkYarpcClient examplepb.SinkYarpcClient) error {
+				testIntegration(t, keyValueYarpcClient, sinkYarpcClient, keyValueYarpcServer, sinkYarpcServer)
 				return nil
 			},
 		),
@@ -60,59 +60,59 @@ func testIntegrationForTransportType(t *testing.T, transportType testutils.Trans
 
 func testIntegration(
 	t *testing.T,
-	keyValueClient examplepb.KeyValueClient,
-	sinkClient examplepb.SinkClient,
-	keyValueServer *example.KeyValueServer,
-	sinkServer *example.SinkServer,
+	keyValueYarpcClient examplepb.KeyValueYarpcClient,
+	sinkYarpcClient examplepb.SinkYarpcClient,
+	keyValueYarpcServer *example.KeyValueYarpcServer,
+	sinkYarpcServer *example.SinkYarpcServer,
 ) {
-	_, err := getValue(keyValueClient, "foo")
+	_, err := getValue(keyValueYarpcClient, "foo")
 	assert.Error(t, err)
 	assert.NotNil(t, protobuf.GetApplicationError(err))
 
-	assert.NoError(t, setValue(keyValueClient, "foo", "bar"))
-	value, err := getValue(keyValueClient, "foo")
+	assert.NoError(t, setValue(keyValueYarpcClient, "foo", "bar"))
+	value, err := getValue(keyValueYarpcClient, "foo")
 	assert.NoError(t, err)
 	assert.Equal(t, "bar", value)
 
-	assert.NoError(t, setValue(keyValueClient, "foo", ""))
-	_, err = getValue(keyValueClient, "foo")
+	assert.NoError(t, setValue(keyValueYarpcClient, "foo", ""))
+	_, err = getValue(keyValueYarpcClient, "foo")
 	assert.Error(t, err)
 	assert.NotNil(t, protobuf.GetApplicationError(err))
 
-	assert.NoError(t, setValue(keyValueClient, "foo", "baz"))
-	assert.NoError(t, setValue(keyValueClient, "baz", "bat"))
-	value, err = getValue(keyValueClient, "foo")
+	assert.NoError(t, setValue(keyValueYarpcClient, "foo", "baz"))
+	assert.NoError(t, setValue(keyValueYarpcClient, "baz", "bat"))
+	value, err = getValue(keyValueYarpcClient, "foo")
 	assert.NoError(t, err)
 	assert.Equal(t, "baz", value)
-	value, err = getValue(keyValueClient, "baz")
+	value, err = getValue(keyValueYarpcClient, "baz")
 	assert.NoError(t, err)
 	assert.Equal(t, "bat", value)
 
-	assert.NoError(t, fire(sinkClient, "foo"))
-	assert.NoError(t, fire(sinkClient, "bar"))
-	assert.Equal(t, []string{"foo", "bar"}, sinkServer.Values())
+	assert.NoError(t, fire(sinkYarpcClient, "foo"))
+	assert.NoError(t, fire(sinkYarpcClient, "bar"))
+	assert.Equal(t, []string{"foo", "bar"}, sinkYarpcServer.Values())
 }
 
-func getValue(keyValueClient examplepb.KeyValueClient, key string) (string, error) {
+func getValue(keyValueYarpcClient examplepb.KeyValueYarpcClient, key string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
-	response, err := keyValueClient.GetValue(ctx, &examplepb.GetValueRequest{key})
+	response, err := keyValueYarpcClient.GetValue(ctx, &examplepb.GetValueRequest{key})
 	if err != nil {
 		return "", err
 	}
 	return response.Value, nil
 }
 
-func setValue(keyValueClient examplepb.KeyValueClient, key string, value string) error {
+func setValue(keyValueYarpcClient examplepb.KeyValueYarpcClient, key string, value string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
-	_, err := keyValueClient.SetValue(ctx, &examplepb.SetValueRequest{key, value})
+	_, err := keyValueYarpcClient.SetValue(ctx, &examplepb.SetValueRequest{key, value})
 	return err
 }
 
-func fire(sinkClient examplepb.SinkClient, value string) error {
+func fire(sinkYarpcClient examplepb.SinkYarpcClient, value string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
-	_, err := sinkClient.Fire(ctx, &examplepb.FireRequest{value})
+	_, err := sinkYarpcClient.Fire(ctx, &examplepb.FireRequest{value})
 	return err
 }

--- a/internal/examples/protobuf/example/example.go
+++ b/internal/examples/protobuf/example/example.go
@@ -40,16 +40,16 @@ var (
 // WithClients calls f on the Clients.
 func WithClients(
 	transportType testutils.TransportType,
-	keyValueServer examplepb.KeyValueServer,
-	sinkServer examplepb.SinkServer,
-	f func(examplepb.KeyValueClient, examplepb.SinkClient) error,
+	keyValueYarpcServer examplepb.KeyValueYarpcServer,
+	sinkYarpcServer examplepb.SinkYarpcServer,
+	f func(examplepb.KeyValueYarpcClient, examplepb.SinkYarpcClient) error,
 ) error {
 	var procedures []transport.Procedure
-	if keyValueServer != nil {
-		procedures = append(procedures, examplepb.BuildKeyValueProcedures(keyValueServer)...)
+	if keyValueYarpcServer != nil {
+		procedures = append(procedures, examplepb.BuildKeyValueYarpcProcedures(keyValueYarpcServer)...)
 	}
-	if sinkServer != nil {
-		procedures = append(procedures, examplepb.BuildSinkProcedures(sinkServer)...)
+	if sinkYarpcServer != nil {
+		procedures = append(procedures, examplepb.BuildSinkYarpcProcedures(sinkYarpcServer)...)
 	}
 	return testutils.WithClientConfig(
 		"example",
@@ -57,26 +57,26 @@ func WithClients(
 		transportType,
 		func(clientConfig transport.ClientConfig) error {
 			return f(
-				examplepb.NewKeyValueClient(clientConfig),
-				examplepb.NewSinkClient(clientConfig),
+				examplepb.NewKeyValueYarpcClient(clientConfig),
+				examplepb.NewSinkYarpcClient(clientConfig),
 			)
 		},
 	)
 }
 
-// KeyValueServer implements examplepb.KeyValueServer.
-type KeyValueServer struct {
+// KeyValueYarpcServer implements examplepb.KeyValueYarpcServer.
+type KeyValueYarpcServer struct {
 	sync.RWMutex
 	items map[string]string
 }
 
-// NewKeyValueServer returns a new KeyValueServer.
-func NewKeyValueServer() *KeyValueServer {
-	return &KeyValueServer{sync.RWMutex{}, make(map[string]string)}
+// NewKeyValueYarpcServer returns a new KeyValueYarpcServer.
+func NewKeyValueYarpcServer() *KeyValueYarpcServer {
+	return &KeyValueYarpcServer{sync.RWMutex{}, make(map[string]string)}
 }
 
 // GetValue implements GetValue.
-func (k *KeyValueServer) GetValue(ctx context.Context, request *examplepb.GetValueRequest) (*examplepb.GetValueResponse, error) {
+func (k *KeyValueYarpcServer) GetValue(ctx context.Context, request *examplepb.GetValueRequest) (*examplepb.GetValueResponse, error) {
 	if request == nil {
 		return nil, errRequestNil
 	}
@@ -93,7 +93,7 @@ func (k *KeyValueServer) GetValue(ctx context.Context, request *examplepb.GetVal
 }
 
 // SetValue implements SetValue.
-func (k *KeyValueServer) SetValue(ctx context.Context, request *examplepb.SetValueRequest) (*examplepb.SetValueResponse, error) {
+func (k *KeyValueYarpcServer) SetValue(ctx context.Context, request *examplepb.SetValueRequest) (*examplepb.SetValueResponse, error) {
 	if request == nil {
 		return nil, errRequestNil
 	}
@@ -110,19 +110,19 @@ func (k *KeyValueServer) SetValue(ctx context.Context, request *examplepb.SetVal
 	return nil, nil
 }
 
-// SinkServer implements examplepb.SinkServer.
-type SinkServer struct {
+// SinkYarpcServer implements examplepb.SinkYarpcServer.
+type SinkYarpcServer struct {
 	sync.RWMutex
 	values []string
 }
 
-// NewSinkServer returns a new SinkServer.
-func NewSinkServer() *SinkServer {
-	return &SinkServer{sync.RWMutex{}, make([]string, 0)}
+// NewSinkYarpcServer returns a new SinkYarpcServer.
+func NewSinkYarpcServer() *SinkYarpcServer {
+	return &SinkYarpcServer{sync.RWMutex{}, make([]string, 0)}
 }
 
 // Fire implements Fire.
-func (s *SinkServer) Fire(ctx context.Context, request *examplepb.FireRequest) error {
+func (s *SinkYarpcServer) Fire(ctx context.Context, request *examplepb.FireRequest) error {
 	if request == nil {
 		return errRequestNil
 	}
@@ -136,7 +136,7 @@ func (s *SinkServer) Fire(ctx context.Context, request *examplepb.FireRequest) e
 }
 
 // Values returns a copy of the values that have been fired.
-func (s *SinkServer) Values() []string {
+func (s *SinkYarpcServer) Values() []string {
 	s.RLock()
 	values := make([]string, len(s.values))
 	copy(values, s.values)

--- a/internal/examples/protobuf/example/example.go
+++ b/internal/examples/protobuf/example/example.go
@@ -129,7 +129,7 @@ func NewSinkYarpcServer(withFireDone bool) *SinkYarpcServer {
 	if withFireDone {
 		fireDone = make(chan struct{})
 	}
-	return &SinkServer{sync.RWMutex{}, make([]string, 0), fireDone}
+	return &SinkYarpcServer{sync.RWMutex{}, make([]string, 0), fireDone}
 }
 
 // Fire implements Fire.

--- a/internal/examples/protobuf/examplepb/example.pb.yarpc.go
+++ b/internal/examples/protobuf/examplepb/example.pb.yarpc.go
@@ -34,75 +34,75 @@ import (
 	"go.uber.org/yarpc/yarpcproto"
 )
 
-// KeyValueClient is the client-side interface for the KeyValue service.
-type KeyValueClient interface {
+// KeyValueYarpcClient is the yarpc client-side interface for the KeyValue service.
+type KeyValueYarpcClient interface {
 	GetValue(context.Context, *GetValueRequest, ...yarpc.CallOption) (*GetValueResponse, error)
 	SetValue(context.Context, *SetValueRequest, ...yarpc.CallOption) (*SetValueResponse, error)
 }
 
-// NewKeyValueClient builds a new client for the KeyValue service.
-func NewKeyValueClient(clientConfig transport.ClientConfig) KeyValueClient {
-	return &_KeyValueCaller{protobuf.NewClient("KeyValue", clientConfig)}
+// NewKeyValueYarpcClient builds a new yarpc client for the KeyValue service.
+func NewKeyValueYarpcClient(clientConfig transport.ClientConfig) KeyValueYarpcClient {
+	return &_KeyValueYarpcCaller{protobuf.NewClient("KeyValue", clientConfig)}
 }
 
-// KeyValueServer is the server-side interface for the KeyValue service.
-type KeyValueServer interface {
+// KeyValueYarpcServer is the yarpc server-side interface for the KeyValue service.
+type KeyValueYarpcServer interface {
 	GetValue(context.Context, *GetValueRequest) (*GetValueResponse, error)
 	SetValue(context.Context, *SetValueRequest) (*SetValueResponse, error)
 }
 
-// BuildKeyValueProcedures prepares an implementation of the KeyValue service for registration.
-func BuildKeyValueProcedures(server KeyValueServer) []transport.Procedure {
-	handler := &_KeyValueHandler{server}
+// BuildKeyValueYarpcProcedures prepares an implementation of the KeyValue service for yarpc registration.
+func BuildKeyValueYarpcProcedures(server KeyValueYarpcServer) []transport.Procedure {
+	handler := &_KeyValueYarpcHandler{server}
 	return protobuf.BuildProcedures(
 		"KeyValue",
 		map[string]transport.UnaryHandler{
-			"GetValue": protobuf.NewUnaryHandler(handler.GetValue, newKeyValue_GetValueRequest),
-			"SetValue": protobuf.NewUnaryHandler(handler.SetValue, newKeyValue_SetValueRequest),
+			"GetValue": protobuf.NewUnaryHandler(handler.GetValue, newKeyValue_GetValueYarpcRequest),
+			"SetValue": protobuf.NewUnaryHandler(handler.SetValue, newKeyValue_SetValueYarpcRequest),
 		},
 		map[string]transport.OnewayHandler{},
 	)
 }
 
-type _KeyValueCaller struct {
+type _KeyValueYarpcCaller struct {
 	client protobuf.Client
 }
 
-func (c *_KeyValueCaller) GetValue(ctx context.Context, request *GetValueRequest, options ...yarpc.CallOption) (*GetValueResponse, error) {
-	responseMessage, err := c.client.Call(ctx, "GetValue", request, newKeyValue_GetValueResponse, options...)
+func (c *_KeyValueYarpcCaller) GetValue(ctx context.Context, request *GetValueRequest, options ...yarpc.CallOption) (*GetValueResponse, error) {
+	responseMessage, err := c.client.Call(ctx, "GetValue", request, newKeyValue_GetValueYarpcResponse, options...)
 	if responseMessage == nil {
 		return nil, err
 	}
 	response, ok := responseMessage.(*GetValueResponse)
 	if !ok {
-		return nil, protobuf.CastError(emptyKeyValue_GetValueResponse, responseMessage)
+		return nil, protobuf.CastError(emptyKeyValue_GetValueYarpcResponse, responseMessage)
 	}
 	return response, err
 }
 
-func (c *_KeyValueCaller) SetValue(ctx context.Context, request *SetValueRequest, options ...yarpc.CallOption) (*SetValueResponse, error) {
-	responseMessage, err := c.client.Call(ctx, "SetValue", request, newKeyValue_SetValueResponse, options...)
+func (c *_KeyValueYarpcCaller) SetValue(ctx context.Context, request *SetValueRequest, options ...yarpc.CallOption) (*SetValueResponse, error) {
+	responseMessage, err := c.client.Call(ctx, "SetValue", request, newKeyValue_SetValueYarpcResponse, options...)
 	if responseMessage == nil {
 		return nil, err
 	}
 	response, ok := responseMessage.(*SetValueResponse)
 	if !ok {
-		return nil, protobuf.CastError(emptyKeyValue_SetValueResponse, responseMessage)
+		return nil, protobuf.CastError(emptyKeyValue_SetValueYarpcResponse, responseMessage)
 	}
 	return response, err
 }
 
-type _KeyValueHandler struct {
-	server KeyValueServer
+type _KeyValueYarpcHandler struct {
+	server KeyValueYarpcServer
 }
 
-func (h *_KeyValueHandler) GetValue(ctx context.Context, requestMessage proto.Message) (proto.Message, error) {
+func (h *_KeyValueYarpcHandler) GetValue(ctx context.Context, requestMessage proto.Message) (proto.Message, error) {
 	var request *GetValueRequest
 	var ok bool
 	if requestMessage != nil {
 		request, ok = requestMessage.(*GetValueRequest)
 		if !ok {
-			return nil, protobuf.CastError(emptyKeyValue_GetValueRequest, requestMessage)
+			return nil, protobuf.CastError(emptyKeyValue_GetValueYarpcRequest, requestMessage)
 		}
 	}
 	response, err := h.server.GetValue(ctx, request)
@@ -112,13 +112,13 @@ func (h *_KeyValueHandler) GetValue(ctx context.Context, requestMessage proto.Me
 	return response, err
 }
 
-func (h *_KeyValueHandler) SetValue(ctx context.Context, requestMessage proto.Message) (proto.Message, error) {
+func (h *_KeyValueYarpcHandler) SetValue(ctx context.Context, requestMessage proto.Message) (proto.Message, error) {
 	var request *SetValueRequest
 	var ok bool
 	if requestMessage != nil {
 		request, ok = requestMessage.(*SetValueRequest)
 		if !ok {
-			return nil, protobuf.CastError(emptyKeyValue_SetValueRequest, requestMessage)
+			return nil, protobuf.CastError(emptyKeyValue_SetValueYarpcRequest, requestMessage)
 		}
 	}
 	response, err := h.server.SetValue(ctx, request)
@@ -128,89 +128,89 @@ func (h *_KeyValueHandler) SetValue(ctx context.Context, requestMessage proto.Me
 	return response, err
 }
 
-func newKeyValue_GetValueRequest() proto.Message {
+func newKeyValue_GetValueYarpcRequest() proto.Message {
 	return &GetValueRequest{}
 }
 
-func newKeyValue_GetValueResponse() proto.Message {
+func newKeyValue_GetValueYarpcResponse() proto.Message {
 	return &GetValueResponse{}
 }
 
-func newKeyValue_SetValueRequest() proto.Message {
+func newKeyValue_SetValueYarpcRequest() proto.Message {
 	return &SetValueRequest{}
 }
 
-func newKeyValue_SetValueResponse() proto.Message {
+func newKeyValue_SetValueYarpcResponse() proto.Message {
 	return &SetValueResponse{}
 }
 
 var (
-	emptyKeyValue_GetValueRequest  = &GetValueRequest{}
-	emptyKeyValue_GetValueResponse = &GetValueResponse{}
-	emptyKeyValue_SetValueRequest  = &SetValueRequest{}
-	emptyKeyValue_SetValueResponse = &SetValueResponse{}
+	emptyKeyValue_GetValueYarpcRequest  = &GetValueRequest{}
+	emptyKeyValue_GetValueYarpcResponse = &GetValueResponse{}
+	emptyKeyValue_SetValueYarpcRequest  = &SetValueRequest{}
+	emptyKeyValue_SetValueYarpcResponse = &SetValueResponse{}
 )
 
-// SinkClient is the client-side interface for the Sink service.
-type SinkClient interface {
+// SinkYarpcClient is the yarpc client-side interface for the Sink service.
+type SinkYarpcClient interface {
 	Fire(context.Context, *FireRequest, ...yarpc.CallOption) (yarpc.Ack, error)
 }
 
-// NewSinkClient builds a new client for the Sink service.
-func NewSinkClient(clientConfig transport.ClientConfig) SinkClient {
-	return &_SinkCaller{protobuf.NewClient("Sink", clientConfig)}
+// NewSinkYarpcClient builds a new yarpc client for the Sink service.
+func NewSinkYarpcClient(clientConfig transport.ClientConfig) SinkYarpcClient {
+	return &_SinkYarpcCaller{protobuf.NewClient("Sink", clientConfig)}
 }
 
-// SinkServer is the server-side interface for the Sink service.
-type SinkServer interface {
+// SinkYarpcServer is the yarpc server-side interface for the Sink service.
+type SinkYarpcServer interface {
 	Fire(context.Context, *FireRequest) error
 }
 
-// BuildSinkProcedures prepares an implementation of the Sink service for registration.
-func BuildSinkProcedures(server SinkServer) []transport.Procedure {
-	handler := &_SinkHandler{server}
+// BuildSinkYarpcProcedures prepares an implementation of the Sink service for yarpc registration.
+func BuildSinkYarpcProcedures(server SinkYarpcServer) []transport.Procedure {
+	handler := &_SinkYarpcHandler{server}
 	return protobuf.BuildProcedures(
 		"Sink",
 		map[string]transport.UnaryHandler{},
 		map[string]transport.OnewayHandler{
-			"Fire": protobuf.NewOnewayHandler(handler.Fire, newSink_FireRequest),
+			"Fire": protobuf.NewOnewayHandler(handler.Fire, newSink_FireYarpcRequest),
 		},
 	)
 }
 
-type _SinkCaller struct {
+type _SinkYarpcCaller struct {
 	client protobuf.Client
 }
 
-func (c *_SinkCaller) Fire(ctx context.Context, request *FireRequest, options ...yarpc.CallOption) (yarpc.Ack, error) {
+func (c *_SinkYarpcCaller) Fire(ctx context.Context, request *FireRequest, options ...yarpc.CallOption) (yarpc.Ack, error) {
 	return c.client.CallOneway(ctx, "Fire", request, options...)
 }
 
-type _SinkHandler struct {
-	server SinkServer
+type _SinkYarpcHandler struct {
+	server SinkYarpcServer
 }
 
-func (h *_SinkHandler) Fire(ctx context.Context, requestMessage proto.Message) error {
+func (h *_SinkYarpcHandler) Fire(ctx context.Context, requestMessage proto.Message) error {
 	var request *FireRequest
 	var ok bool
 	if requestMessage != nil {
 		request, ok = requestMessage.(*FireRequest)
 		if !ok {
-			return protobuf.CastError(emptySink_FireRequest, requestMessage)
+			return protobuf.CastError(emptySink_FireYarpcRequest, requestMessage)
 		}
 	}
 	return h.server.Fire(ctx, request)
 }
 
-func newSink_FireRequest() proto.Message {
+func newSink_FireYarpcRequest() proto.Message {
 	return &FireRequest{}
 }
 
-func newSink_FireResponse() proto.Message {
+func newSink_FireYarpcResponse() proto.Message {
 	return &yarpcproto.Oneway{}
 }
 
 var (
-	emptySink_FireRequest  = &FireRequest{}
-	emptySink_FireResponse = &yarpcproto.Oneway{}
+	emptySink_FireYarpcRequest  = &FireRequest{}
+	emptySink_FireYarpcResponse = &yarpcproto.Oneway{}
 )

--- a/internal/examples/protobuf/main.go
+++ b/internal/examples/protobuf/main.go
@@ -113,7 +113,7 @@ func doClient(
 			if _, err := sinkYarpcClient.Fire(ctx, &examplepb.FireRequest{value}); err != nil {
 				fmt.Printf("fire %s failed: %s\n", value, err.Error())
 			}
-			if err := sinkServer.WaitFireDone(); err != nil {
+			if err := sinkYarpcServer.WaitFireDone(); err != nil {
 				fmt.Println(err)
 			}
 			continue

--- a/internal/examples/protobuf/main.go
+++ b/internal/examples/protobuf/main.go
@@ -41,25 +41,25 @@ func main() {
 }
 
 func do() error {
-	keyValueServer := example.NewKeyValueServer()
-	sinkServer := example.NewSinkServer()
+	keyValueYarpcServer := example.NewKeyValueYarpcServer()
+	sinkYarpcServer := example.NewSinkYarpcServer()
 	// TChannel will be used for unary
 	// HTTP wil be used for oneway
 	return example.WithClients(
 		testutils.TransportTypeTChannel,
-		keyValueServer,
-		sinkServer,
-		func(keyValueClient examplepb.KeyValueClient, sinkClient examplepb.SinkClient) error {
-			return doClient(keyValueClient, sinkClient, keyValueServer, sinkServer)
+		keyValueYarpcServer,
+		sinkYarpcServer,
+		func(keyValueYarpcClient examplepb.KeyValueYarpcClient, sinkYarpcClient examplepb.SinkYarpcClient) error {
+			return doClient(keyValueYarpcClient, sinkYarpcClient, keyValueYarpcServer, sinkYarpcServer)
 		},
 	)
 }
 
 func doClient(
-	keyValueClient examplepb.KeyValueClient,
-	sinkClient examplepb.SinkClient,
-	keyValueServer *example.KeyValueServer,
-	sinkServer *example.SinkServer,
+	keyValueYarpcClient examplepb.KeyValueYarpcClient,
+	sinkYarpcClient examplepb.SinkYarpcClient,
+	keyValueYarpcServer *example.KeyValueYarpcServer,
+	sinkYarpcServer *example.SinkYarpcServer,
 ) error {
 	scanner := bufio.NewScanner(os.Stdin)
 	for scanner.Scan() {
@@ -80,7 +80,7 @@ func doClient(
 			key := args[0]
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
-			if response, err := keyValueClient.GetValue(ctx, &examplepb.GetValueRequest{key}); err != nil {
+			if response, err := keyValueYarpcClient.GetValue(ctx, &examplepb.GetValueRequest{key}); err != nil {
 				fmt.Printf("get %s failed: %s\n", key, err.Error())
 			} else {
 				fmt.Println(key, "=", response.Value)
@@ -98,7 +98,7 @@ func doClient(
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
-			if _, err := keyValueClient.SetValue(ctx, &examplepb.SetValueRequest{key, value}); err != nil {
+			if _, err := keyValueYarpcClient.SetValue(ctx, &examplepb.SetValueRequest{key, value}); err != nil {
 				fmt.Printf("set %s = %s failed: %v\n", key, value, err.Error())
 			}
 			continue
@@ -110,7 +110,7 @@ func doClient(
 			value := args[0]
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
-			if _, err := sinkClient.Fire(ctx, &examplepb.FireRequest{value}); err != nil {
+			if _, err := sinkYarpcClient.Fire(ctx, &examplepb.FireRequest{value}); err != nil {
 				fmt.Printf("fire %s failed: %s\n", value, err.Error())
 			}
 			continue
@@ -119,7 +119,7 @@ func doClient(
 				fmt.Println("usage: fired-values")
 				continue
 			}
-			fmt.Println(strings.Join(sinkServer.Values(), " "))
+			fmt.Println(strings.Join(sinkYarpcServer.Values(), " "))
 			continue
 		case "exit":
 			return nil


### PR DESCRIPTION
Here's the problem: grpc code generation happens with the actual go/gogo plugin, and will generate grpc types to the same package. Grpc also has types `FooClient` and `FooServer`. My goal is for users of protoc-gen-yarpc-go to choose where they generate, whether it be the same package as their generated message structs, or somewhere else. Requiring generation to be in another directory adds another cost to migrating to protobuf (which you want to minimize, people have enough trouble with protoc as it is), and also makes it so that the expected way to use protoc-gen-yarpc-go (generate to the same location, especially if you make one protoc call ie `protoc --go_out=plugins=grpc:. --yarpc-go_out=. proto`) will not work.

I think this is the right solution to make sure there is no collision. Note that the general use of https://github.com/grpc-ecosystem/grpc-gateway is to generate code to the same package as well.