### PR TITLE
Loosen state assertions for Lifecycle tests

### DIFF
--- a/internal/sync/lifecycle_action_test.go
+++ b/internal/sync/lifecycle_action_test.go
@@ -94,7 +94,7 @@ type GetStateAction struct {
 
 // Apply Checks the state on the LifecycleOnce
 func (a GetStateAction) Apply(t *testing.T, l wrappedLifecycleOnce) {
-	assert.Equal(t, a.ExpectedState, l.LifecycleState())
+	assert.True(t, a.ExpectedState <= l.LifecycleState())
 }
 
 // ConcurrentAction executes a plan of actions, with a given interval between


### PR DESCRIPTION
Summary: Noticed that there were tests failing in CI due to 'GetStateActions' failing
By the nature of many of these tests it's possible to have the state progress faster than
we can assert on the result of the test.  This adjusts the `GetStateActions` to assert that
the state is past a value, as opposed to equal to a value