### PR TITLE
crossdock: enable java

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.1'
 
 services:
     crossdock:
-        image: crossdock/crossdock:filter-crossdock
+        image: crossdock/crossdock
         dns_search: .
         depends_on:
           cherami:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.1'
 
 services:
     crossdock:
-        image: crossdock/crossdock
+        image: crossdock/crossdock:filter-crossdock
         dns_search: .
         depends_on:
           cherami:
@@ -16,7 +16,7 @@ services:
             - redis
             - cherami
         environment:
-            - WAIT_FOR=java,go,node,python,python-sync
+            - WAIT_FOR=go,java,node,python,python-sync
 
             - AXIS_CLIENT=go,java,node,python,python-sync
             - AXIS_SERVER=go,java,node,python
@@ -41,19 +41,30 @@ services:
             - AXIS_CTXAVAILABLETRANSPORTS=http;tchannel
 
             - BEHAVIOR_RAW=client,server,transport
+            - BEHAVIOR_SKIP_RAW=client=java+transport=tchannel,server=java+transport=tchannel
             - BEHAVIOR_JSON=client,server,transport
+            - BEHAVIOR_SKIP_JSON=client=java+transport=tchannel,server=java+transport=tchannel
             - BEHAVIOR_THRIFT=client,server,transport
+            - BEHAVIOR_SKIP_THRIFT=client=java+transport=tchannel,server=java+transport=tchannel
             - BEHAVIOR_HEADERS=client,server,transport,encoding
+            - BEHAVIOR_SKIP_HEADERS=client=java+transport=tchannel,server=java+transport=tchannel
             - BEHAVIOR_ERRORS_HTTPCLIENT=errors_httpclient,server
+            - BEHAVIOR_SKIP_ERRORS_HTTPCLIENT=server=java
             # BEHAVIOR_ERRORSHTTPIN TODO
             - BEHAVIOR_ERRORS_TCHCLIENT=errors_tchclient,server
+            - BEHAVIOR_SKIP_ERRORS_TCHCLIENT=server=java
             # BEHAVIOR_ERRORSTCHIN TODO
             - BEHAVIOR_TCHCLIENT=client,server,encoding
+            - BEHAVIOR_SKIP_TCHCLIENT=client=java,server=java
             - BEHAVIOR_TCHSERVER=client,server,encoding
+            - BEHAVIOR_SKIP_TCHSERVER=client=java,server=java
             # BEHAVIOR_HTTPCLIENT TODO
             - BEHAVIOR_HTTPSERVER=client,httpserver
+            - BEHAVIOR_SKIP_HTTPSERVER=client=java
             - BEHAVIOR_THRIFTGAUNTLET=gauntlet,server,transport
+            - BEHAVIOR_SKIP_THRIFTGAUNTLET=server=java+transport=tchannel
             - BEHAVIOR_TIMEOUT=client,server,transport
+            - BEHAVIOR_SKIP_TIMEOUT=client=java,server=java
             # BEHAVIOR_INBOUNDTTL TODO
             - BEHAVIOR_CTXPROPAGATION=ctxclient,ctxserver,transport,ctxavailabletransports
             - BEHAVIOR_APACHETHRIFT=apachethriftclient,apachethriftserver

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,10 +16,10 @@ services:
             - redis
             - cherami
         environment:
-            - WAIT_FOR=go,node,python,python-sync
+            - WAIT_FOR=java,go,node,python,python-sync
 
-            - AXIS_CLIENT=go,node,python,python-sync
-            - AXIS_SERVER=go,node,python
+            - AXIS_CLIENT=go,java,node,python,python-sync
+            - AXIS_SERVER=go,java,node,python
             - AXIS_TRANSPORT=http,tchannel
             - AXIS_ENCODING=raw,json,thrift
             - AXIS_ERRORS_HTTPCLIENT=go # pending update to node test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,8 @@ services:
             - BEHAVIOR_HTTPSERVER=client,httpserver
             - BEHAVIOR_SKIP_HTTPSERVER=client=java
             - BEHAVIOR_THRIFTGAUNTLET=gauntlet,server,transport
-            - BEHAVIOR_SKIP_THRIFTGAUNTLET=server=java+transport=tchannel
+            # Skip gauntlet behavior only for tchannel once java is released
+            - BEHAVIOR_SKIP_THRIFTGAUNTLET=server=java
             - BEHAVIOR_TIMEOUT=client,server,transport
             - BEHAVIOR_SKIP_TIMEOUT=client=java,server=java
             # BEHAVIOR_INBOUNDTTL TODO

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,31 +41,31 @@ services:
             - AXIS_CTXAVAILABLETRANSPORTS=http;tchannel
 
             - BEHAVIOR_RAW=client,server,transport
-            - BEHAVIOR_SKIP_RAW=client=java+transport=tchannel,server=java+transport=tchannel
+            - SKIP_RAW=client:java+transport:tchannel,server:java+transport:tchannel
             - BEHAVIOR_JSON=client,server,transport
-            - BEHAVIOR_SKIP_JSON=client=java+transport=tchannel,server=java+transport=tchannel
+            - SKIP_JSON=client:java+transport:tchannel,server:java+transport:tchannel
             - BEHAVIOR_THRIFT=client,server,transport
-            - BEHAVIOR_SKIP_THRIFT=client=java+transport=tchannel,server=java+transport=tchannel
+            - SKIP_THRIFT=client:java+transport:tchannel,server:java+transport:tchannel
             - BEHAVIOR_HEADERS=client,server,transport,encoding
-            - BEHAVIOR_SKIP_HEADERS=client=java+transport=tchannel,server=java+transport=tchannel
+            - SKIP_HEADERS=client:java+transport:tchannel,server:java+transport:tchannel
             - BEHAVIOR_ERRORS_HTTPCLIENT=errors_httpclient,server
-            - BEHAVIOR_SKIP_ERRORS_HTTPCLIENT=server=java
+            - SKIP_ERRORS_HTTPCLIENT=server:java
             # BEHAVIOR_ERRORSHTTPIN TODO
             - BEHAVIOR_ERRORS_TCHCLIENT=errors_tchclient,server
-            - BEHAVIOR_SKIP_ERRORS_TCHCLIENT=server=java
+            - SKIP_ERRORS_TCHCLIENT=server:java
             # BEHAVIOR_ERRORSTCHIN TODO
             - BEHAVIOR_TCHCLIENT=client,server,encoding
-            - BEHAVIOR_SKIP_TCHCLIENT=client=java,server=java
+            - SKIP_TCHCLIENT=client:java,server:java
             - BEHAVIOR_TCHSERVER=client,server,encoding
-            - BEHAVIOR_SKIP_TCHSERVER=client=java,server=java
+            - SKIP_TCHSERVER=client:java,server:java
             # BEHAVIOR_HTTPCLIENT TODO
             - BEHAVIOR_HTTPSERVER=client,httpserver
-            - BEHAVIOR_SKIP_HTTPSERVER=client=java
+            - SKIP_HTTPSERVER=client:java
             - BEHAVIOR_THRIFTGAUNTLET=gauntlet,server,transport
             # Skip gauntlet behavior only for tchannel once java is released
-            - BEHAVIOR_SKIP_THRIFTGAUNTLET=server=java
+            - SKIP_THRIFTGAUNTLET=server:java
             - BEHAVIOR_TIMEOUT=client,server,transport
-            - BEHAVIOR_SKIP_TIMEOUT=client=java,server=java
+            - SKIP_TIMEOUT=client:java,server:java
             # BEHAVIOR_INBOUNDTTL TODO
             - BEHAVIOR_CTXPROPAGATION=ctxclient,ctxserver,transport,ctxavailabletransports
             - BEHAVIOR_APACHETHRIFT=apachethriftclient,apachethriftserver


### PR DESCRIPTION
  Enable java in crossdock to ensure java doesn't fall behind and maintaining the regression tests on java repo. Java doesn't support tchannel protocol and skip filters ensure to filter those tests. Fixes https://github.com/yarpc/yarpc-go/issues/704