### PR TITLE
config/kit: Make service name available

### DIFF
--- a/x/config/configurator.go
+++ b/x/config/configurator.go
@@ -83,7 +83,7 @@ func (c *Configurator) MustRegisterTransport(t TransportSpec) {
 // LoadConfigFromYAML loads a yarpc.Config from YAML. Use LoadConfig if you
 // have your own map[string]interface{} or map[interface{}]interface{} to
 // provide.
-func (c *Configurator) LoadConfigFromYAML(r io.Reader) (yarpc.Config, error) {
+func (c *Configurator) LoadConfigFromYAML(serviceName string, r io.Reader) (yarpc.Config, error) {
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		return yarpc.Config{}, err
@@ -93,7 +93,7 @@ func (c *Configurator) LoadConfigFromYAML(r io.Reader) (yarpc.Config, error) {
 	if err := yaml.Unmarshal(b, &data); err != nil {
 		return yarpc.Config{}, err
 	}
-	return c.LoadConfig(data)
+	return c.LoadConfig(serviceName, data)
 }
 
 // LoadConfig loads a yarpc.Config from a map[string]interface{} or
@@ -101,18 +101,18 @@ func (c *Configurator) LoadConfigFromYAML(r io.Reader) (yarpc.Config, error) {
 //
 // See the module documentation for the shape the map[string]interface{} is
 // expected to conform to.
-func (c *Configurator) LoadConfig(data interface{}) (yarpc.Config, error) {
+func (c *Configurator) LoadConfig(serviceName string, data interface{}) (yarpc.Config, error) {
 	var cfg yarpcConfig
 	if err := decode.Decode(&cfg, data); err != nil {
 		return yarpc.Config{}, err
 	}
-	return c.load(&cfg)
+	return c.load(serviceName, &cfg)
 }
 
 // NewDispatcherFromYAML builds a Dispatcher from the given YAML
 // configuration.
-func (c *Configurator) NewDispatcherFromYAML(r io.Reader) (*yarpc.Dispatcher, error) {
-	cfg, err := c.LoadConfigFromYAML(r)
+func (c *Configurator) NewDispatcherFromYAML(serviceName string, r io.Reader) (*yarpc.Dispatcher, error) {
+	cfg, err := c.LoadConfigFromYAML(serviceName, r)
 	if err != nil {
 		return nil, err
 	}
@@ -120,18 +120,18 @@ func (c *Configurator) NewDispatcherFromYAML(r io.Reader) (*yarpc.Dispatcher, er
 }
 
 // NewDispatcher builds a new Dispatcher from the given configuration data.
-func (c *Configurator) NewDispatcher(data interface{}) (*yarpc.Dispatcher, error) {
-	cfg, err := c.LoadConfig(data)
+func (c *Configurator) NewDispatcher(serviceName string, data interface{}) (*yarpc.Dispatcher, error) {
+	cfg, err := c.LoadConfig(serviceName, data)
 	if err != nil {
 		return nil, err
 	}
 	return yarpc.NewDispatcher(cfg), nil
 }
 
-func (c *Configurator) load(cfg *yarpcConfig) (yarpc.Config, error) {
+func (c *Configurator) load(serviceName string, cfg *yarpcConfig) (yarpc.Config, error) {
 	var (
 		errors []error
-		b      = newBuilder(cfg.Name, &Kit{c: c})
+		b      = newBuilder(serviceName, &Kit{name: serviceName, c: c})
 	)
 
 	for _, inbound := range cfg.Inbounds {

--- a/x/config/decode.go
+++ b/x/config/decode.go
@@ -65,7 +65,6 @@ func (m attributeMap) Decode(dst interface{}) error {
 }
 
 type yarpcConfig struct {
-	Name       string                  `config:"name"`
 	Inbounds   inbounds                `config:"inbounds"`
 	Outbounds  clientConfigs           `config:"outbounds"`
 	Transports map[string]attributeMap `config:"transports"`

--- a/x/config/doc.go
+++ b/x/config/doc.go
@@ -35,7 +35,7 @@
 // Use LoadConfigFromYAML to load a yarpc.Config from YAML and pass that to
 // yarpc.NewDispatcher.
 //
-// 	c, err := cfg.LoadConfigFromYAML(yamlConfig)
+// 	c, err := cfg.LoadConfigFromYAML("myservice", yamlConfig)
 // 	if err != nil {
 // 		log.Fatal(err)
 // 	}
@@ -45,7 +45,7 @@
 // the parsed data to LoadConfig instead.
 //
 // 	var m map[string]interface{} = ...
-// 	c, err := cfg.LoadConfig(m)
+// 	c, err := cfg.LoadConfig("myservice", m)
 // 	if err != nil {
 // 		log.Fatal(err)
 // 	}
@@ -54,7 +54,7 @@
 // NewDispatcher or NewDispatcherFromYAML may be used to get a
 // yarpc.Dispatcher directly instead of a yarpc.Config.
 //
-// 	dispatcher, err := cfg.NewDispatcherFromYAML(yamlConfig)
+// 	dispatcher, err := cfg.NewDispatcherFromYAML("myservice", yamlConfig)
 //
 // Configuration parameters for the different transports, inbounds, and
 // outbounds are defined in the TransportSpecs that were registered against
@@ -68,10 +68,9 @@
 // purposes but other markup formats may be parsed into map[string]interface{}
 // as long as the information provided is the same.
 //
-// The configuration accepts the following top-level attributes: name,
-// transports, inbounds, and outbounds.
+// The configuration accepts the following top-level attributes: transports,
+// inbounds, and outbounds.
 //
-// 	name: myservice
 // 	inbounds:
 // 	  # ...
 // 	outbounds:
@@ -79,9 +78,8 @@
 // 	transports:
 // 	  # ...
 //
-// Where name specifies the name of the current service. See the following
-// sections for details on the transports, inbounds, and outbounds keys in the
-// configuration.
+// See the following sections for details on the transports, inbounds, and
+// outbounds keys in the configuration.
 //
 // Inbound Configuration
 //

--- a/x/config/kit.go
+++ b/x/config/kit.go
@@ -26,6 +26,12 @@ import "reflect"
 // plugins.
 type Kit struct {
 	c *Configurator
+
+	name string
 }
+
+// ServiceName returns the name of the service for which components are being
+// built.
+func (k *Kit) ServiceName() string { return k.name }
 
 var _typeOfKit = reflect.TypeOf((*Kit)(nil))

--- a/x/config/mock_transport_spec_test.go
+++ b/x/config/mock_transport_spec_test.go
@@ -21,6 +21,7 @@
 package config
 
 import (
+	"fmt"
 	"reflect"
 
 	"go.uber.org/yarpc/api/transport"
@@ -185,3 +186,21 @@ func (anyKitMatcher) String() string {
 }
 
 var anyKit = anyKitMatcher{}
+
+// kitMatcher matches attributes of a kit
+type kitMatcher struct {
+	ServiceName string
+}
+
+func (m kitMatcher) Matches(x interface{}) bool {
+	k, ok := x.(*Kit)
+	if !ok {
+		return false
+	}
+
+	return k.ServiceName() == m.ServiceName
+}
+
+func (m kitMatcher) String() string {
+	return fmt.Sprintf("kit{name: %q}", m.ServiceName)
+}


### PR DESCRIPTION
This adds a `ServiceName()` method to `config.Kit` so that component
builders can use the service name if needed when building the component.