### PR TITLE
thrift: Disable buffer pooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Releases
 ========
 
+v1.7.1 (unreleased)
+-------------------
+
+-   Thrift: Fixed a bug where deserialization of large lists would return
+    corrupted data at high throughputs.
+
 
 v1.7.0 (2017-03-20)
 -----------------------

--- a/encoding/thrift/constants.go
+++ b/encoding/thrift/constants.go
@@ -24,3 +24,5 @@ import "go.uber.org/yarpc/api/transport"
 
 // Encoding is the name of this encoding.
 const Encoding transport.Encoding = "thrift"
+
+const _defaultBufferSize = 1024 // 1k

--- a/encoding/thrift/inbound.go
+++ b/encoding/thrift/inbound.go
@@ -26,7 +26,6 @@ import (
 
 	encodingapi "go.uber.org/yarpc/api/encoding"
 	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/internal/buffer"
 	"go.uber.org/yarpc/internal/encoding"
 
 	"go.uber.org/thriftrw/protocol"
@@ -57,8 +56,7 @@ func (t thriftUnaryHandler) Handle(ctx context.Context, treq *transport.Request,
 		return err
 	}
 
-	buf := buffer.Get()
-	defer buffer.Put(buf)
+	buf := bytes.NewBuffer(make([]byte, 0, _defaultBufferSize))
 	if _, err := buf.ReadFrom(treq.Body); err != nil {
 		return err
 	}
@@ -130,8 +128,7 @@ func (t thriftOnewayHandler) HandleOneway(ctx context.Context, treq *transport.R
 		return err
 	}
 
-	buf := buffer.Get()
-	defer buffer.Put(buf)
+	buf := bytes.NewBuffer(make([]byte, 0, _defaultBufferSize))
 	if _, err := buf.ReadFrom(treq.Body); err != nil {
 		return err
 	}

--- a/encoding/thrift/outbound.go
+++ b/encoding/thrift/outbound.go
@@ -29,7 +29,6 @@ import (
 	encodingapi "go.uber.org/yarpc/api/encoding"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/thrift/internal"
-	"go.uber.org/yarpc/internal/buffer"
 	"go.uber.org/yarpc/internal/encoding"
 
 	"go.uber.org/thriftrw/envelope"
@@ -146,8 +145,7 @@ func (c thriftClient) Call(ctx context.Context, reqBody envelope.Enveloper, opts
 		return wire.Value{}, err
 	}
 
-	buf := buffer.Get()
-	defer buffer.Put(buf)
+	buf := bytes.NewBuffer(make([]byte, 0, _defaultBufferSize))
 	if _, err = buf.ReadFrom(tres.Body); err != nil {
 		return wire.Value{}, err
 	}

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package yarpc // import "go.uber.org/yarpc"
 
 // Version is the current version of YARPC.
-const Version = "1.7.0"
+const Version = "1.7.1"


### PR DESCRIPTION
This stops the Thrift encoding from pooling buffers because currently
the buffers are returned to the pool before their lifetime is over.
This is because lists, sets and maps in ThriftRW's `wire.Value`s are
lazy; they don't attempt to deserialize until the contents are
requested, which happens when the generic `wire.Value` representation is
converted into generated types using `FromWire`.

To help visualize this,

    // YARPC defines a function that returns a wire.Value, using a
    // pooled buffer during deserialization.
    func Call() wire.Value {
        buf := buffer.Get()
        defer buffer.Put(buf)

        value := decode(buf)
        return value
    }

    // The generated client calls into YARPC to get the decoded
    // wire.Value. It then deserializes the wire.Value into the
    // generated MyType.
    func MyCall() MyType {
        value := yarpc.Call()

        var x MyType
        x.FromWire(value)  -----
        return x
    }

    // MyType contains a list of some other type which it reads from the
    // wire.Value lazy list.
    FromWire(v wire.Value) {
        v.GetList().ForEach(func(item wire.Value) {
            appendToSelf(...)
        })
    }

    // The lazy list now attempts to decode the items from the list into
    // wire.Values on demand, starting at the position it previously
    // recorded.
    func ForEach(f func(wire.Value)) {
        for i := 0; i < length; i++ {
            value := decodeAt(startingPosition)
            f(value)
        }
    }

By the time we get to FromWire, we have already returned the buffer to
the pool so anything ForEach reads from the buffer is now wrong.

---

This is a stopgap to fix this problem in production. We can figure out
another pooling strategy later.

CC @yarpc/golang