### PR TITLE
config: Support the Cherami transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ v1.8.0 (unreleased)
 -   http: Added support for configuring the HTTP transport using x/config.
 -   tchannel: Added support for configuring the TChannel transport using
     x/config.
+-   x/cherami: Renamed the `InboundConfig` and `OutboundConfig` structures to
+    `InboundOptions` and `OutboundOptions`.
+-   x/cherami: Added support for configuring the Cherami transport using
+    x/config.
 -   Options `thrift.Multiplexed` and `thrift.Enveloped` may now be provided for
     Thrift clients constructed by `yarpc.InjectClients` by adding a `thrift`
     tag to the corresponding struct field with the name of the option. See the

--- a/internal/crossdock/client/dispatcher/dispatcher.go
+++ b/internal/crossdock/client/dispatcher/dispatcher.go
@@ -115,7 +115,7 @@ func CreateOnewayDispatcher(t crossdock.T, handler raw.OnewayHandler) (*yarpc.Di
 		err = transport.Start()
 		fatals.NoError(err, "couldn't start cherami transport")
 
-		outbound = transport.NewOutbound(cherami.OutboundConfig{
+		outbound = transport.NewOutbound(cherami.OutboundOptions{
 			Destination: `/test/dest`})
 	default:
 		fatals.Fail("", "unknown transport %q", trans)

--- a/internal/crossdock/server/oneway/server.go
+++ b/internal/crossdock/server/oneway/server.go
@@ -142,7 +142,7 @@ func initCheramiInbound() (*cherami.Inbound, error) {
 		return nil, err
 	}
 
-	return cheramiTransport.NewInbound(cherami.InboundConfig{
+	return cheramiTransport.NewInbound(cherami.InboundOptions{
 		Destination:   destination,
 		ConsumerGroup: consumerGroup,
 	}), nil

--- a/transport/x/cherami/config.go
+++ b/transport/x/cherami/config.go
@@ -1,0 +1,269 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cherami
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/x/config"
+
+	"github.com/uber/cherami-client-go/client/cherami"
+)
+
+const (
+	_destinationSuffix   = "yarpc_dest"
+	_consumerGroupSuffix = "yarpc_cg"
+)
+
+var errNoPeerList = errors.New(
+	"cannot automatically discover Cherami: " +
+		"no peer list provided: " +
+		"please set the peerList attribute or " +
+		"provide a default peer list using the DefaultPeerList option")
+
+// TransportSpecOption configures the Cherami TransportSpec.
+type TransportSpecOption func(*transportSpec)
+
+// DefaultPeerList specifies the default path at which the TChannel peer list
+// may be found.
+//
+// This value will be used when building Cherami transports that automatically
+// discover Cherami Frontends if the user did not provide their own peer list.
+func DefaultPeerList(path string) TransportSpecOption {
+	return func(ts *transportSpec) {
+		ts.defaultPeerList = path
+	}
+}
+
+// TransportSpec builds a TransportSpec for the Cherami transport.
+// TransportSpecOptions may be passed to this function to configure the
+// behavior of the TransportSpec.
+//
+// 	configurator.MustRegisterTransport(
+// 		cherami.TransportSpec(cherami.DefaultPeerList("/etc/hosts.json")),
+// 	)
+//
+// See TransportConfig, InboundConfig, and OutboundConfig for details on the
+// different configuration parameters supported by this Transport.
+func TransportSpec(opts ...TransportSpecOption) config.TransportSpec {
+	var ts transportSpec
+	for _, opt := range opts {
+		opt(&ts)
+	}
+	return ts.Spec()
+}
+
+// When building inbounds and outbounds, instead of casting
+// transport.Transport to *Transport, we'll cast to the interface
+// cheramiTransport so that we can test against a mock cheramiTransport.
+type cheramiTransport interface {
+	transport.Transport
+
+	NewInbound(InboundOptions) *Inbound
+	NewOutbound(OutboundOptions) *Outbound
+}
+
+var _ cheramiTransport = (*Transport)(nil)
+
+// TransportSpec holds the configurable parts of the Cherami TransportSpec.
+type transportSpec struct {
+	defaultPeerList string
+}
+
+func (ts *transportSpec) Spec() config.TransportSpec {
+	return config.TransportSpec{
+		Name:                "cherami",
+		BuildTransport:      ts.buildTransport,
+		BuildInbound:        ts.buildInbound,
+		BuildOnewayOutbound: ts.buildOnewayOutbound,
+	}
+}
+
+// TransportConfig configures the shared Cherami Transport. This is shared
+// between all Cherami outbounds and inbounds of a Dispatcher.
+//
+// All fields in TransportConfig are optional and this section may be skipped
+// entirely for most use cases.
+type TransportConfig struct {
+	// If specified, this is the address of a specific Cherami Frontend or a
+	// locally hosted development instance. Most users should omit this since
+	// the Cherami Frontend will be discovered automatically.
+	//
+	// 	address: 127.0.0.1:4922
+	Address string `config:"address"`
+
+	// Path to a JSON file containing the TChannel peer list used to
+	// auto-discover Cherami Frontend machines. This may be skipped if a
+	// default peer list was provided on TransportSpec instantiation or if an
+	// Address was provided.
+	//
+	// 	peerList: /etc/hosts.json
+	PeerList string `config:"peerList"`
+
+	// Timeout for requests to the Cherami service. The default timeout should
+	// suffice for most use cases.
+	//
+	// 	timeout: 5s
+	Timeout time.Duration `config:"timeout"`
+
+	// Name of the Cherami deployment to which requests should be sent. Some
+	// valid values are, "prod", "staging", "staging2", and "dev".
+	//
+	// 	deploymentStr: dev
+	//
+	// Defaults to "prod".
+	DeploymentStr string `config:"deploymentStr"`
+}
+
+// Parses the IP address and port from the given address.
+func parseIPAndPort(address string) (ip string, port int, _ error) {
+	if address == "" {
+		return ip, port, errors.New("address is unspecified")
+	}
+
+	idx := strings.LastIndexByte(address, ':')
+	if idx == -1 {
+		return ip, port, fmt.Errorf("invalid address %q: port was not specified", address)
+	}
+
+	ip = address[:idx]
+	portStr := address[idx+1:]
+	port64, err := strconv.ParseInt(portStr, 10, 32)
+	if err != nil {
+		return ip, port, fmt.Errorf("invalid port %q in address %q: %v", portStr, address, err)
+	}
+
+	return ip, int(port64), nil
+}
+
+func (ts *transportSpec) buildTransport(
+	tc *TransportConfig, kit *config.Kit,
+) (transport.Transport, error) {
+	opts := cherami.ClientOptions{DeploymentStr: tc.DeploymentStr, Timeout: tc.Timeout}
+
+	var client cherami.Client
+	switch {
+	case len(tc.Address) > 0: // Explicit Cherami frontend
+		ip, port, err := parseIPAndPort(tc.Address)
+		if err != nil {
+			return nil, err
+		}
+
+		client, err = cherami.NewClient(kit.ServiceName(), ip, int(port), &opts)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"failed to create Cherami client with address %q: %v", tc.Address, err)
+		}
+	case len(tc.PeerList) > 0 || len(ts.defaultPeerList) > 0: // Auto-discover Cherami
+		peerList := ts.defaultPeerList
+		if len(tc.PeerList) > 0 {
+			peerList = tc.PeerList
+		}
+
+		var err error
+		client, err = cherami.NewHyperbahnClient(kit.ServiceName(), peerList, &opts)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"failed to create Cherami client with peer list %q: %v", peerList, err)
+		}
+	default:
+		return nil, errors.New("either an `address` or a `peerList` must be specified")
+	}
+
+	return NewTransport(client), nil
+}
+
+// InboundConfig configures a Cherami Inbound.
+//
+// 	inbounds:
+// 	  cherami:
+// 	    destination: /myservice/yarpc_dest
+// 	    consumerGroup: /myservice/yarpc_cg
+type InboundConfig struct {
+	// Destination from which RPCs for this inbound will be retrieved.
+	//
+	// If unspecified, the destination "/${service}/yarpc_dest" will be used
+	// where ${service} is the name of your YARPC service.
+	Destination string `config:"destination"`
+
+	// Name of the consumer group used to read RPCs from Cherami.
+	//
+	// If unspecified, the consumer group "/${service}/yarpc_cg" will be used
+	// where ${service} is the name of your YARPC service.
+	ConsumerGroup string `config:"consumerGroup"`
+
+	// Number of requests to buffer locally. If requests are short-lived,
+	// setting this to a higher value may improve throughput at the cost of
+	// memory usage.
+	//
+	// Defaults to 10.
+	PrefetchCount int `config:"prefetchCount"`
+}
+
+func (ts *transportSpec) buildInbound(
+	tc *InboundConfig,
+	t transport.Transport,
+	kit *config.Kit,
+) (transport.Inbound, error) {
+	opts := InboundOptions{
+		Destination:   tc.Destination,
+		ConsumerGroup: tc.ConsumerGroup,
+		PrefetchCount: tc.PrefetchCount,
+	}
+
+	if opts.Destination == "" {
+		opts.Destination = fmt.Sprintf("/%v/%v", kit.ServiceName(), _destinationSuffix)
+	}
+
+	if opts.ConsumerGroup == "" {
+		opts.ConsumerGroup = fmt.Sprintf("/%v/%v", kit.ServiceName(), _consumerGroupSuffix)
+	}
+
+	return t.(cheramiTransport).NewInbound(opts), nil
+}
+
+// OutboundConfig configures a Cherami Outbound.
+type OutboundConfig struct {
+	// Destination to which RPCs for this outbound will be written.
+	//
+	// If unspecified, the destination "/${service}/yarpc_dest" will be used
+	// where ${service} is the name of the destination service.
+	Destination string `config:"destination"`
+}
+
+func (ts *transportSpec) buildOnewayOutbound(
+	tc *OutboundConfig,
+	t transport.Transport,
+	kit *config.Kit,
+) (transport.OnewayOutbound, error) {
+	opts := OutboundOptions{Destination: tc.Destination}
+
+	if opts.Destination == "" {
+		opts.Destination = fmt.Sprintf("/%v/%v", kit.ServiceName(), _destinationSuffix)
+	}
+
+	return t.(cheramiTransport).NewOutbound(opts), nil
+}

--- a/transport/x/cherami/config.go
+++ b/transport/x/cherami/config.go
@@ -113,7 +113,7 @@ type TransportConfig struct {
 	// the Cherami Frontend will be discovered automatically.
 	//
 	// 	address: 127.0.0.1:4922
-	Address string `config:"address"`
+	Address string `config:"address,interpolate"`
 
 	// Path to a JSON file containing the TChannel peer list used to
 	// auto-discover Cherami Frontend machines. This may be skipped if a
@@ -121,7 +121,7 @@ type TransportConfig struct {
 	// Address was provided.
 	//
 	// 	peerList: /etc/hosts.json
-	PeerList string `config:"peerList"`
+	PeerList string `config:"peerList,interpolate"`
 
 	// Timeout for requests to the Cherami service. The default timeout should
 	// suffice for most use cases.
@@ -135,7 +135,7 @@ type TransportConfig struct {
 	// 	deploymentStr: dev
 	//
 	// Defaults to "prod".
-	DeploymentStr string `config:"deploymentStr"`
+	DeploymentStr string `config:"deploymentStr,interpolate"`
 }
 
 // Parses the IP address and port from the given address.
@@ -207,13 +207,13 @@ type InboundConfig struct {
 	//
 	// If unspecified, the destination "/${service}/yarpc_dest" will be used
 	// where ${service} is the name of your YARPC service.
-	Destination string `config:"destination"`
+	Destination string `config:"destination,interpolate"`
 
 	// Name of the consumer group used to read RPCs from Cherami.
 	//
 	// If unspecified, the consumer group "/${service}/yarpc_cg" will be used
 	// where ${service} is the name of your YARPC service.
-	ConsumerGroup string `config:"consumerGroup"`
+	ConsumerGroup string `config:"consumerGroup,interpolate"`
 
 	// Number of requests to buffer locally. If requests are short-lived,
 	// setting this to a higher value may improve throughput at the cost of
@@ -251,7 +251,7 @@ type OutboundConfig struct {
 	//
 	// If unspecified, the destination "/${service}/yarpc_dest" will be used
 	// where ${service} is the name of the destination service.
-	Destination string `config:"destination"`
+	Destination string `config:"destination,interpolate"`
 }
 
 func (ts *transportSpec) buildOnewayOutbound(

--- a/transport/x/cherami/config.go
+++ b/transport/x/cherami/config.go
@@ -130,7 +130,7 @@ type TransportConfig struct {
 	Timeout time.Duration `config:"timeout"`
 
 	// Name of the Cherami deployment to which requests should be sent. Some
-	// valid values are, "prod", "staging", "staging2", and "dev".
+	// examples are, "prod", "staging", "staging2", and "dev".
 	//
 	// 	deploymentStr: dev
 	//

--- a/transport/x/cherami/config_test.go
+++ b/transport/x/cherami/config_test.go
@@ -1,0 +1,459 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cherami
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber/cherami-client-go/client/cherami"
+	"go.uber.org/yarpc/x/config"
+)
+
+func TestParseIPAndPort(t *testing.T) {
+	tests := []struct {
+		give     string
+		wantIP   string
+		wantPort int
+		wantErr  string
+	}{
+		{give: "", wantErr: "address is unspecified"},
+		{
+			give:    "hi",
+			wantErr: `invalid address "hi": port was not specified`,
+		},
+		{
+			give:    "localhost:",
+			wantErr: `invalid port "" in address "localhost:":`,
+		},
+		{
+			give:    "localhost:hi",
+			wantErr: `invalid port "hi" in address "localhost:hi":`,
+		},
+		{
+			give:     "localhost:4242",
+			wantIP:   "localhost",
+			wantPort: 4242,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.give, func(t *testing.T) {
+			ip, port, err := parseIPAndPort(tt.give)
+
+			if tt.wantErr != "" {
+				require.Error(t, err, "expected failure")
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantIP, ip, "ip must match")
+			assert.Equal(t, tt.wantPort, port, "port must match")
+		})
+	}
+}
+
+func TestTransportSpec(t *testing.T) {
+	// This test is a cross-product of transport, inbound and outbound test
+	// assertions.
+	//
+	//   transportTests x inboundTests x outboundTests
+	//
+	// Configuration, environment variables, and TransportSpec options are
+	// combined. If any of the entries had non-empty wantErrors, any test case
+	// with that entry is expected to fail.
+	//
+	// Further, the inbound and outbound tests may state that they are
+	// "empty". If they're both empty, the test case will be skipped because a
+	// transport is us
+
+	type attrs map[string]interface{}
+
+	type transportTest struct {
+		desc string                // description
+		cfg  attrs                 // transports.cherami section of the config
+		env  map[string]string     // environment variables
+		opts []TransportSpecOption // transport spec options
+
+		wantErrors []string
+
+		// If non-nil, we expect either a cherami.NewClient call or
+		// cherami.NewHyperbahnClient call.
+		wantClient          *fakeCheramiClient
+		wantHyperbahnClient *fakeCheramiHyperbahnClient
+	}
+
+	type wantInbound struct {
+		Destination   string
+		ConsumerGroup string
+		PrefetchCount int
+	}
+
+	type inboundTest struct {
+		desc string                // description
+		cfg  attrs                 // inbounds.cherami section of the config
+		env  map[string]string     // environment variables
+		opts []TransportSpecOption // transport spec options
+
+		// Whether this test case is empty. If both, the inbound and the
+		// outbound are empty, that test case will be skipped.
+		empty bool
+
+		wantErrors []string
+
+		// If non-nil, we expect a Cherami inbound to be constructed with the
+		// given properties.
+		wantInbound *wantInbound
+	}
+
+	type wantOutbound struct {
+		Destination string
+	}
+
+	type outboundTest struct {
+		desc string                // description
+		cfg  attrs                 // outbounds section of the config
+		env  map[string]string     // environment variables
+		opts []TransportSpecOption // transport spec options
+
+		// Whether this test case is empty. If both, the inbound and the
+		// outbound are empty, that test case will be skipped.
+		empty bool
+
+		wantErrors []string
+
+		// If non-empty, we expect cherami outbounds to be constructed for the
+		// given services with the specified configurations.
+		wantOutbounds map[string]wantOutbound
+	}
+
+	transportTests := []transportTest{
+		{
+			desc:       "no transport",
+			wantErrors: []string{`either an "address" or a "peerList" must be specified`},
+		},
+		{
+			desc:       "invalid address",
+			cfg:        attrs{"address": "hi"},
+			wantErrors: []string{`invalid address "hi": port was not specified`},
+		},
+		{
+			desc: "cherami hyperbahn client",
+			opts: []TransportSpecOption{DefaultPeerList("hosts.json")},
+			wantHyperbahnClient: &fakeCheramiHyperbahnClient{
+				WantBootstrapFile: "hosts.json",
+			},
+		},
+		{
+			desc: "bad cherami hyperbahn client",
+			opts: []TransportSpecOption{DefaultPeerList("hosts.json")},
+			wantHyperbahnClient: &fakeCheramiHyperbahnClient{
+				WantBootstrapFile: "hosts.json",
+				RaiseError:        errors.New("great sadness"),
+			},
+			wantErrors: []string{
+				`failed to create Cherami client with peer list "hosts.json": great sadness`,
+			},
+		},
+		{
+			desc: "cherami hyperbahn client explicit peer list",
+			cfg:  attrs{"peerList": "hosts.dev.json"},
+			opts: []TransportSpecOption{DefaultPeerList("hosts.json")},
+			wantHyperbahnClient: &fakeCheramiHyperbahnClient{
+				WantBootstrapFile: "hosts.dev.json",
+			},
+		},
+		{
+			desc: "cherami local client",
+			cfg:  attrs{"address": "127.0.0.1:4922"},
+			wantClient: &fakeCheramiClient{
+				WantHost: "127.0.0.1",
+				WantPort: 4922,
+			},
+		},
+		{
+			desc: "bad cherami local client",
+			cfg:  attrs{"address": "127.0.0.1:4922"},
+			wantClient: &fakeCheramiClient{
+				WantHost:   "127.0.0.1",
+				WantPort:   4922,
+				RaiseError: errors.New("great sadness"),
+			},
+			wantErrors: []string{
+				`failed to create Cherami client with address "127.0.0.1:4922": great sadness`,
+			},
+		},
+
+		// The following group of tests use the same configuration but
+		// different environment variables.
+		{
+			desc: "transport interpolation: hyperbahn",
+			opts: []TransportSpecOption{DefaultPeerList("hosts.json")},
+			cfg: attrs{
+				"address":       "${CHERAMI_ADDRESS:}",
+				"peerList":      "${CHERAMI_PEER_LIST:}",
+				"deploymentStr": "${CHERAMI_DEPLOYMENT:prod}",
+			},
+			wantHyperbahnClient: &fakeCheramiHyperbahnClient{
+				WantBootstrapFile: "hosts.json",
+				WantOptions: cherami.ClientOptions{
+					DeploymentStr: "prod",
+				},
+			},
+		},
+		{
+			desc: "transport interpolation: local",
+			opts: []TransportSpecOption{DefaultPeerList("hosts.json")},
+			env: map[string]string{
+				"CHERAMI_ADDRESS":    "myserver.local:4922",
+				"CHERAMI_DEPLOYMENT": "dev",
+			},
+			cfg: attrs{
+				"address":       "${CHERAMI_ADDRESS:}",
+				"peerList":      "${CHERAMI_PEER_LIST:}",
+				"deploymentStr": "${CHERAMI_DEPLOYMENT:prod}",
+			},
+			wantClient: &fakeCheramiClient{
+				WantHost: "myserver.local",
+				WantPort: 4922,
+				WantOptions: cherami.ClientOptions{
+					DeploymentStr: "dev",
+				},
+			},
+		},
+	}
+
+	inboundTests := []inboundTest{
+		{desc: "no inbound", empty: true},
+		{
+			desc: "default inbound",
+			cfg:  attrs{},
+			wantInbound: &wantInbound{
+				Destination:   "/foo/yarpc_dest",
+				ConsumerGroup: "/foo/yarpc_cg",
+				PrefetchCount: 10,
+			},
+		},
+		{
+			desc: "explicit inbound",
+			cfg: attrs{
+				"destination":   "/bar/dest",
+				"consumerGroup": "/bar/cg",
+			},
+			wantInbound: &wantInbound{
+				Destination:   "/bar/dest",
+				ConsumerGroup: "/bar/cg",
+				PrefetchCount: 10,
+			},
+		},
+		{
+			desc: "inbound interpolation",
+			cfg: attrs{
+				"destination":   "/baz/yarpc-dest-${NAME}",
+				"consumerGroup": "/baz/yarpc-cg-${NAME}",
+				"prefetchCount": "42",
+			},
+			env: map[string]string{"NAME": "hello"},
+			wantInbound: &wantInbound{
+				Destination:   "/baz/yarpc-dest-hello",
+				ConsumerGroup: "/baz/yarpc-cg-hello",
+				PrefetchCount: 42,
+			},
+		},
+	}
+
+	outboundTests := []outboundTest{
+		{desc: "no outbound", empty: true},
+		{
+			desc: "default outbound",
+			cfg:  attrs{"myservice": attrs{"cherami": attrs{}}},
+			wantOutbounds: map[string]wantOutbound{
+				"myservice": {Destination: "/foo/yarpc_dest"},
+			},
+		},
+		{
+			desc: "explicit outbound",
+			cfg: attrs{
+				"myservice": attrs{
+					"cherami": attrs{"destination": "/bar/dest"},
+				},
+			},
+			wantOutbounds: map[string]wantOutbound{
+				"myservice": {Destination: "/bar/dest"},
+			},
+		},
+		{
+			desc: "outbound interpolation",
+			cfg: attrs{
+				"myservice": attrs{
+					"cherami": attrs{"destination": "/baz/yarpc-dest-${MYSERVICE_NAME}"},
+				},
+			},
+			env: map[string]string{"MYSERVICE_NAME": "hi"},
+			wantOutbounds: map[string]wantOutbound{
+				"myservice": {Destination: "/baz/yarpc-dest-hi"},
+			},
+		},
+	}
+
+	runTest := func(t *testing.T, trans transportTest, inbound inboundTest, outbound outboundTest) {
+		env := make(map[string]string)
+		for k, v := range trans.env {
+			env[k] = v
+		}
+		for k, v := range inbound.env {
+			env[k] = v
+		}
+		for k, v := range outbound.env {
+			env[k] = v
+		}
+		configurator := config.New(config.InterpolationResolver(mapResolver(env)))
+
+		opts := append(append(trans.opts, inbound.opts...), outbound.opts...)
+		if trans.wantClient != nil {
+			opts = append(opts, useFakeCheramiClient(t, trans.wantClient))
+		}
+		if trans.wantHyperbahnClient != nil {
+			opts = append(opts, useFakeCheramiHyperbahnClient(t, trans.wantHyperbahnClient))
+		}
+		err := configurator.RegisterTransport(TransportSpec(opts...))
+		require.NoError(t, err, "failed to register transport spec")
+
+		cfgData := make(attrs)
+		if trans.cfg != nil {
+			cfgData["transports"] = attrs{"cherami": trans.cfg}
+		}
+		if inbound.cfg != nil {
+			cfgData["inbounds"] = attrs{"cherami": inbound.cfg}
+		}
+		if outbound.cfg != nil {
+			cfgData["outbounds"] = outbound.cfg
+		}
+		cfg, err := configurator.LoadConfig("foo", cfgData)
+
+		wantErrors := append(append(trans.wantErrors, inbound.wantErrors...), outbound.wantErrors...)
+		if len(wantErrors) > 0 {
+			require.Error(t, err, "expected failure")
+			for _, msg := range wantErrors {
+				assert.Contains(t, err.Error(), msg)
+			}
+			return
+		}
+
+		require.NoError(t, err, "expected success")
+
+		if want := inbound.wantInbound; want != nil {
+			ib, ok := cfg.Inbounds[0].(*Inbound)
+			if assert.True(t, ok, "expected *Inbound, got %T", cfg.Inbounds[0]) {
+				assert.Equal(t, want.Destination, ib.opts.Destination,
+					"inbound destination should match")
+				assert.Equal(t, want.ConsumerGroup, ib.opts.ConsumerGroup,
+					"inbound consumer group should match")
+				assert.Equal(t, want.PrefetchCount, ib.opts.PrefetchCount,
+					"inbound prefetch count should match")
+			}
+		}
+
+		for svc, want := range outbound.wantOutbounds {
+			ob, ok := cfg.Outbounds[svc].Oneway.(*Outbound)
+			if assert.True(t, ok, "expected *Outbound for %q, got %T", svc, cfg.Outbounds[svc].Oneway) {
+				assert.Equal(t, want.Destination, ob.opts.Destination,
+					"outbound destination for %q should match", svc)
+			}
+		}
+	}
+
+	for _, transTT := range transportTests {
+		for _, inboundTT := range inboundTests {
+			for _, outboundTT := range outboundTests {
+				// Special case: No inbounds and outbounds so we have nothing
+				// to test.
+				if inboundTT.empty && outboundTT.empty {
+					continue
+				}
+
+				desc := fmt.Sprintf("%v/%v/%v", transTT.desc, inboundTT.desc, outboundTT.desc)
+				t.Run(desc, func(t *testing.T) {
+					runTest(t, transTT, inboundTT, outboundTT)
+				})
+			}
+		}
+	}
+}
+
+type fakeCheramiClient struct {
+	WantHost    string
+	WantPort    int
+	WantOptions cherami.ClientOptions
+	RaiseError  error
+}
+
+// Build a cheramiNewClientFunc which expects the given arguments and
+// delegates to the real cherami.NewClient function.
+func useFakeCheramiClient(t *testing.T, c *fakeCheramiClient) TransportSpecOption {
+	return cheramiNewClient(
+		func(serviceName string, host string, port int, options *cherami.ClientOptions) (cherami.Client, error) {
+			assert.Equal(t, c.WantHost, host, "cherami.NewClient: host must match")
+			assert.Equal(t, c.WantPort, port, "cherami.NewClient: port must match")
+			assert.Equal(t, &c.WantOptions, options, "cherami.NewClient: options must match")
+
+			if c.RaiseError != nil {
+				return nil, c.RaiseError
+			}
+
+			return cherami.NewClient(serviceName, host, port, options)
+		})
+}
+
+type fakeCheramiHyperbahnClient struct {
+	WantBootstrapFile string
+	WantOptions       cherami.ClientOptions
+	RaiseError        error
+}
+
+// Build a cheramiNewHyperbahnClientFunc which expects the given arguments and
+// delegates to the real cherami.NewHyperbahnClient function.
+func useFakeCheramiHyperbahnClient(t *testing.T, c *fakeCheramiHyperbahnClient) TransportSpecOption {
+	return cheramiNewHyperbahnClient(
+		func(serviceName string, bootstrapFile string, options *cherami.ClientOptions) (cherami.Client, error) {
+			assert.Equal(t, c.WantBootstrapFile, bootstrapFile, "cherami.NewHyperbahnClient: bootstrapFile must match")
+			assert.Equal(t, &c.WantOptions, options, "cherami.NewHyperbahnClient: options must match")
+
+			if c.RaiseError != nil {
+				return nil, c.RaiseError
+			}
+
+			return cherami.NewHyperbahnClient(serviceName, bootstrapFile, options)
+		})
+}
+
+func mapResolver(m map[string]string) func(string) (string, bool) {
+	return func(k string) (v string, ok bool) {
+		if m != nil {
+			v, ok = m[k]
+		}
+		return
+	}
+}

--- a/transport/x/cherami/example/client.go
+++ b/transport/x/cherami/example/client.go
@@ -68,7 +68,7 @@ func TestCheramiYARPC(t *testing.T) {
 		Name: "client",
 		Outbounds: yarpc.Outbounds{
 			"server": {
-				Oneway: transport.NewOutbound(cherami.OutboundConfig{
+				Oneway: transport.NewOutbound(cherami.OutboundOptions{
 					Destination: destination,
 				}),
 			},

--- a/transport/x/cherami/example/server.go
+++ b/transport/x/cherami/example/server.go
@@ -69,7 +69,7 @@ func (s *Service) Start() error {
 	// Server side needs to start the server dispatcher and register itself which implements the procedures
 	s.dispatcher = yarpc.NewDispatcher(yarpc.Config{
 		Name: "server",
-		Inbounds: yarpc.Inbounds{transport.NewInbound(cherami.InboundConfig{
+		Inbounds: yarpc.Inbounds{transport.NewInbound(cherami.InboundOptions{
 			Destination:   s.config.destination,
 			ConsumerGroup: s.config.consumerGroup,
 		})},

--- a/transport/x/cherami/inbound.go
+++ b/transport/x/cherami/inbound.go
@@ -42,14 +42,14 @@ const (
 	defaultPrefetchCount = 10
 )
 
-// InboundConfig defines the config in order to create a Inbound.
+// InboundOptions defines the config in order to create a Inbound.
 //
 // PrefetchCount controls the number of messages to buffer locally. Inbounds
 // which process messages very fast may want to specify larger value for
 // PrefetchCount for faster throughput. On the flip side larger values for
 // PrefetchCount will result in more messages being buffered locally causing
 // high memory footprint.
-type InboundConfig struct {
+type InboundOptions struct {
 	Destination   string
 	ConsumerGroup string
 	PrefetchCount int
@@ -58,7 +58,7 @@ type InboundConfig struct {
 // Inbound receives Oneway YARPC requests over Cherami.
 type Inbound struct {
 	transport     *Transport
-	config        InboundConfig
+	opts          InboundOptions
 	consumer      cherami.Consumer
 	router        transport.Router
 	tracer        opentracing.Tracer
@@ -69,14 +69,14 @@ type Inbound struct {
 }
 
 // NewInbound builds a new Cherami inbound.
-func (t *Transport) NewInbound(config InboundConfig) *Inbound {
-	if config.PrefetchCount == 0 {
-		config.PrefetchCount = defaultPrefetchCount
+func (t *Transport) NewInbound(opts InboundOptions) *Inbound {
+	if opts.PrefetchCount == 0 {
+		opts.PrefetchCount = defaultPrefetchCount
 	}
 	return &Inbound{
 		once:          sync.Once(),
 		transport:     t,
-		config:        config,
+		opts:          opts,
 		tracer:        t.tracer,
 		client:        t.client,
 		clientFactory: t.clientFactory,
@@ -111,9 +111,9 @@ func (i *Inbound) start() error {
 	}
 
 	consumer, ch, err := i.clientFactory.GetConsumer(i.client, internal.ConsumerConfig{
-		Destination:   i.config.Destination,
-		ConsumerGroup: i.config.ConsumerGroup,
-		PrefetchCount: i.config.PrefetchCount,
+		Destination:   i.opts.Destination,
+		ConsumerGroup: i.opts.ConsumerGroup,
+		PrefetchCount: i.opts.PrefetchCount,
 	})
 	if err != nil {
 		return err

--- a/transport/x/cherami/inbound_test.go
+++ b/transport/x/cherami/inbound_test.go
@@ -36,7 +36,7 @@ func TestInbound(t *testing.T) {
 	mockFactory := &mocks.ClientFactory{}
 	mockFactory.On(`GetConsumer`, mock.Anything, mock.Anything).Return(mockConsumer, nil, nil)
 	transport := NewTransport(nil)
-	inbound := transport.NewInbound(InboundConfig{
+	inbound := transport.NewInbound(InboundOptions{
 		Destination:   `dest`,
 		ConsumerGroup: `cg`,
 	})

--- a/transport/x/cherami/outbound.go
+++ b/transport/x/cherami/outbound.go
@@ -33,15 +33,15 @@ import (
 	"github.com/uber/cherami-client-go/client/cherami"
 )
 
-// OutboundConfig defines the config in order to create a Outbound.
-type OutboundConfig struct {
+// OutboundOptions specifies a Cherami outbound.
+type OutboundOptions struct {
 	Destination string
 }
 
 // Outbound is a outbound that uses Cherami as the transport.
 type Outbound struct {
 	transport     *Transport
-	config        OutboundConfig
+	opts          OutboundOptions
 	publisher     cherami.Publisher
 	tracer        opentracing.Tracer
 	client        cherami.Client
@@ -57,11 +57,11 @@ func (r receipt) String() string {
 }
 
 // NewOutbound builds a new cherami outbound.
-func (t *Transport) NewOutbound(config OutboundConfig) *Outbound {
+func (t *Transport) NewOutbound(opts OutboundOptions) *Outbound {
 	return &Outbound{
 		once:          sync.Once(),
 		transport:     t,
-		config:        config,
+		opts:          opts,
 		tracer:        t.tracer,
 		client:        t.client,
 		clientFactory: t.clientFactory,
@@ -85,7 +85,7 @@ func (o *Outbound) Start() error {
 
 func (o *Outbound) start() error {
 	var err error
-	o.publisher, err = o.clientFactory.GetPublisher(o.client, o.config.Destination)
+	o.publisher, err = o.clientFactory.GetPublisher(o.client, o.opts.Destination)
 	return err
 }
 

--- a/transport/x/cherami/outbound_test.go
+++ b/transport/x/cherami/outbound_test.go
@@ -35,7 +35,7 @@ func TestOutbound(t *testing.T) {
 	mockFactory := &mocks.ClientFactory{}
 	mockFactory.On(`GetPublisher`, nil, mock.Anything, mock.Anything).Return(mockPublisher, nil, nil)
 	transport := NewTransport(nil)
-	outbound := transport.NewOutbound(OutboundConfig{
+	outbound := transport.NewOutbound(OutboundOptions{
 		Destination: `dest`,
 	})
 	outbound.setClientFactory(mockFactory)


### PR DESCRIPTION
This adds support for the Cherami transport to the configuration system
defined in #747.

The InboundConfig and OutboundConfig structs used by the Cherami
NewInbound and NewOutbound constructors were renamed to InboundOptions
and OutboundOptions to free up the *Config names for use by the
configuration system. This was to keep the naming consistent with the
HTTP (#748), Redis (#749), and TChannel (#750) configuration systems.
