### PR TITLE
Update changelog for #850

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@ Releases
 ========
 
 v1.8.0 (unreleased)
------------------------
+-------------------
 
--   No changes yet.
+-   x/config: The service name is no longer part of the configuration and must
+    be passed as an argument to the `LoadConfig*` or `NewDispatcher*` methods.
 
 
 v1.7.1 (2017-03-29)


### PR DESCRIPTION
Change #850 contained a breaking change to `x/config`. This API is
experimental but we still need to document breaking changes made to it
between versions.