### PR TITLE
mentionbot: Assign and request a review

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -4,5 +4,6 @@
   ],
   "assignToReviewer": true,
   "createReviewRequest": true,
+  "skipTitle": "WIP:",
   "createComment": false
 }

--- a/.mention-bot
+++ b/.mention-bot
@@ -1,0 +1,8 @@
+{
+  "requiredOrgs": [
+    "yarpc"
+  ],
+  "assignToReviewer": true,
+  "createReviewRequest": true,
+  "createComment": false
+}


### PR DESCRIPTION
This changes mentionbot to assign the PR and request a review from the
people it determines should review it instead of just posting a comment
mentioning them.

Also, I changed it to request reviews from only those people that are in
the YARPC org.