### PR TITLE
Fix flaky TChannel tracing depth tests

### DIFF
--- a/transport/tracer_test.go
+++ b/transport/tracer_test.go
@@ -71,7 +71,7 @@ func (h handler) echoEcho(ctx context.Context) error {
 
 func (h handler) createContextWithBaggage(tracer opentracing.Tracer) (context.Context, func()) {
 	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+	ctx, cancel := context.WithTimeout(ctx, time.Second)
 
 	span := tracer.StartSpan("test")
 	// no defer span.Finish()
@@ -157,6 +157,10 @@ func TestHTTPTracer(t *testing.T) {
 func TestTChannelTracer(t *testing.T) {
 	tracer := mocktracer.New()
 	dispatcher := createTChannelDispatcher(tracer, t)
+	// Make this assertion at the end of the defer stack, when the channel has
+	// been shut down. This ensures that all message exchanges have been shut
+	// down, which means that all spans have been closed.
+	defer AssertDepth1Spans(t, tracer)
 
 	client := json.New(dispatcher.ClientConfig("yarpc-test"))
 	handler := handler{client: client, t: t}
@@ -170,8 +174,6 @@ func TestTChannelTracer(t *testing.T) {
 
 	err := handler.echo(ctx)
 	assert.NoError(t, err)
-
-	AssertDepth1Spans(t, tracer)
 }
 
 func AssertDepth1Spans(t *testing.T, tracer *mocktracer.MockTracer) {
@@ -207,13 +209,16 @@ func TestHTTPTracerDepth2(t *testing.T) {
 
 	err := handler.echoEcho(ctx)
 	assert.NoError(t, err)
-
 	AssertDepth2Spans(t, tracer)
 }
 
 func TestTChannelTracerDepth2(t *testing.T) {
 	tracer := mocktracer.New()
 	dispatcher := createTChannelDispatcher(tracer, t)
+	// Make this assertion at the end of the defer stack, when the channel has
+	// been shut down. This ensures that all message exchanges have been shut
+	// down, which means that all spans have been closed.
+	defer AssertDepth2Spans(t, tracer)
 
 	client := json.New(dispatcher.ClientConfig("yarpc-test"))
 	handler := handler{client: client, t: t}
@@ -227,8 +232,6 @@ func TestTChannelTracerDepth2(t *testing.T) {
 
 	err := handler.echoEcho(ctx)
 	assert.NoError(t, err)
-
-	AssertDepth2Spans(t, tracer)
 }
 
 func AssertDepth2Spans(t *testing.T, tracer *mocktracer.MockTracer) {


### PR DESCRIPTION
These tests are flaky because TChannel can't close spans until it's done sending
the final frame. This behavior is reasonable, since we won't know that we're
done with a call until we're done sending. However, it introduces some timing
uncertainty in tests, since we can finish a call and make our assertions before
the TChannel message exchange is done with its tracing work.

This is (I think) easily solvable by stopping the dispatcher and channel before
making any assertions, since closing a channel cleanly shuts down all message
exchanges.

Fixes #854. At least, I think it does - I can't repro the Travis failures locally, even
with `go test -count 100000`.