### PR TITLE
Handle SUPPRESS_DOCKER in build/travis.mk

### DIFF
--- a/build/travis.mk
+++ b/build/travis.mk
@@ -2,7 +2,9 @@ CROSSDOCK_DOCKER_IMAGE := yarpc_go
 
 DOCKER_CACHE_DIR := $(CACHE)/docker
 CROSSDOCK_DOCKER_CACHE_FILE := $(DOCKER_CACHE_DIR)/$(CROSSDOCK_DOCKER_IMAGE)
+ifndef SUPPRESS_DOCKER
 DOCKER_CACHE_FILE := $(DOCKER_CACHE_DIR)/$(DOCKER_IMAGE)
+endif
 
 DOCKER_RUN_FLAGS += -e TRAVIS_JOB_ID -e TRAVIS_PULL_REQUEST
 
@@ -11,7 +13,9 @@ travis-docker-load: ## load docker images from travis cache
 ifndef SUPPRESS_CROSSDOCK
 	if [ -f $(CROSSDOCK_DOCKER_CACHE_FILE) ]; then gunzip -c $(CROSSDOCK_DOCKER_CACHE_FILE) | docker load; fi
 endif
+ifndef SUPPRESS_DOCKER
 	if [ -f $(DOCKER_CACHE_FILE) ]; then gunzip -c $(DOCKER_CACHE_FILE) | docker load; fi
+endif
 
 .PHONY: travis-docker-save
 travis-docker-save: ## save docker images to travis cache
@@ -21,7 +25,9 @@ ifeq ($(TRAVIS_PULL_REQUEST),false)
 ifndef SUPPRESS_CROSSDOCK
 	PATH=$$PATH:$(BIN) docker save $(shell docker history -q $(CROSSDOCK_DOCKER_IMAGE) | grep -v '<missing>') | gzip > $(CROSSDOCK_DOCKER_CACHE_FILE)
 endif
-	#PATH=$$PATH:$(BIN) docker save $(shell docker history -q $(DOCKER_IMAGE) | grep -v '<missing>') | gzip > $(DOCKER_CACHE_FILE)
+ifndef SUPPRESS_DOCKER
+	PATH=$$PATH:$(BIN) docker save $(shell docker history -q $(DOCKER_IMAGE) | grep -v '<missing>') | gzip > $(DOCKER_CACHE_FILE)
+endif
 endif
 endif
 


### PR DESCRIPTION
This is a fix to handle the build problem I was handling on dev - this makes sure that docker images are only saved or loaded when SUPPRESS_DOCKER is not set.