### PR TITLE
build: Third party PRs should not `docker push`

### DIFF
--- a/scripts/travis-docker-push.sh
+++ b/scripts/travis-docker-push.sh
@@ -5,6 +5,11 @@ set -e
 DIR="$(cd "$(dirname "${0}")/.." && pwd)"
 cd "${DIR}"
 
+if [ -z "$DOCKER_EMAIL" ] || [ -z "$DOCKER_USER" ] || [ -z "$DOCKER_PASS" ]; then
+	echo "Skipping docker push because credentials aren't available."
+	exit 0
+fi
+
 DOCKER_COMPOSE_REPO="${1}:latest"
 COMMIT="${TRAVIS_COMMIT::8}"
 REPO="yarpc/yarpc-go"


### PR DESCRIPTION
Third-party PRs (PRs created from branches that are not part of the
YARPC Go repo) don't have access to secrets specified in the .travis.yml
so the Docker username/password will be empty when attempting to do a
Docker push.

This has been causing #755 to fail.