### PR TITLE
WIP: Have http and tchannel transports optionally take in a net.Listener

### DIFF
--- a/transport/http/inbound.go
+++ b/transport/http/inbound.go
@@ -53,6 +53,8 @@ func Mux(pattern string, mux *http.ServeMux) InboundOption {
 
 // NewInbound builds a new HTTP inbound that listens on the given address and
 // sharing this transport.
+//
+// Note that this will change to take a net.Listener in 2.0.
 func (t *Transport) NewInbound(addr string, opts ...InboundOption) *Inbound {
 	i := &Inbound{
 		once:   sync.Once(),
@@ -65,10 +67,26 @@ func (t *Transport) NewInbound(addr string, opts ...InboundOption) *Inbound {
 	return i
 }
 
+// NewInboundForListener builds a new HTTP inbound that listens on the given listener.
+//
+// Note that this will be NewInbound in 2.0.
+func (t *Transport) NewInboundForListener(listener net.Listener, opts ...InboundOption) *Inbound {
+	i := &Inbound{
+		once:     sync.Once(),
+		listener: listener,
+		tracer:   t.tracer,
+	}
+	for _, opt := range opts {
+		opt(i)
+	}
+	return i
+}
+
 // Inbound receives YARPC requests using an HTTP server. It may be constructed
 // using the NewInbound method on the Transport.
 type Inbound struct {
 	addr       string
+	listener   net.Listener
 	mux        *http.ServeMux
 	muxPattern string
 	server     *intnet.HTTPServer
@@ -118,11 +136,17 @@ func (i *Inbound) start() error {
 	}
 
 	i.server = intnet.NewHTTPServer(&http.Server{
-		Addr:    i.addr,
-		Handler: httpHandler,
+		Handler: http.Handler,
 	})
-	if err := i.server.ListenAndServe(); err != nil {
-		return err
+	if i.listener != nil {
+		if err := i.server.Serve(i.listener); err != nil {
+			return err
+		}
+	} else {
+		i.server.Addr = i.addr
+		if err := i.server.ListenAndServe(); err != nil {
+			return err
+		}
 	}
 
 	i.addr = i.server.Listener().Addr().String() // in case it changed

--- a/transport/http/inbound.go
+++ b/transport/http/inbound.go
@@ -136,7 +136,7 @@ func (i *Inbound) start() error {
 	}
 
 	i.server = intnet.NewHTTPServer(&http.Server{
-		Handler: http.Handler,
+		Handler: httpHandler,
 	})
 	if i.listener != nil {
 		if err := i.server.Serve(i.listener); err != nil {

--- a/transport/tchannel/channel.go
+++ b/transport/tchannel/channel.go
@@ -21,6 +21,8 @@
 package tchannel
 
 import (
+	"net"
+
 	"github.com/uber/tchannel-go"
 	"golang.org/x/net/context"
 )
@@ -39,6 +41,7 @@ type Channel interface {
 	Close()
 	GetSubChannel(serviceName string, opts ...tchannel.SubChannelOption) *tchannel.SubChannel
 	ListenAndServe(hostPort string) error
+	Serve(listener net.Listener) error
 	PeerInfo() tchannel.LocalPeerInfo
 	RootPeers() *tchannel.RootPeerList
 	ServiceName() string

--- a/transport/tchannel/options.go
+++ b/transport/tchannel/options.go
@@ -85,7 +85,7 @@ func ListenAddr(addr string) TransportOption {
 // Listener specifies the listener that TChannel should listen on.
 func Listener(listener net.Listener) TransportOption {
 	return func(t *transportConfig) {
-		t.listener - listener
+		t.listener = listener
 	}
 }
 

--- a/transport/tchannel/options.go
+++ b/transport/tchannel/options.go
@@ -20,7 +20,11 @@
 
 package tchannel
 
-import "github.com/opentracing/opentracing-go"
+import (
+	"net"
+
+	"github.com/opentracing/opentracing-go"
+)
 
 // transportConfig is suitable for conveying options to TChannel transport
 // constructors.
@@ -31,10 +35,11 @@ import "github.com/opentracing/opentracing-go"
 // peer lists.
 // TODO update above when NewTransport is real.
 type transportConfig struct {
-	ch     Channel
-	tracer opentracing.Tracer
-	addr   string
-	name   string
+	ch       Channel
+	tracer   opentracing.Tracer
+	addr     string
+	listener net.Listener
+	name     string
 }
 
 // TransportOption customizes the behavior of a TChannel Transport.
@@ -68,9 +73,19 @@ func WithChannel(ch Channel) TransportOption {
 //
 // This option has no effect if WithChannel was used and the TChannel was
 // already listening.
+//
+// This is deprecated in favor of Listener.
+// If Listener is also specified, this option will be ignored.
 func ListenAddr(addr string) TransportOption {
 	return func(t *transportConfig) {
 		t.addr = addr
+	}
+}
+
+// Listener specifies the listener that TChannel should listen on.
+func Listener(listener net.Listener) TransportOption {
+	return func(t *transportConfig) {
+		t.listener - listener
 	}
 }
 

--- a/transport/tchannel/transport.go
+++ b/transport/tchannel/transport.go
@@ -171,7 +171,7 @@ func (t *Transport) start() error {
 	t.ch = ch
 
 	if t.listener != nil {
-		if err := t.ch.Serve(listener); err != nil {
+		if err := t.ch.Serve(t.listener); err != nil {
 			return err
 		}
 	} else {

--- a/transport/tchannel/transport.go
+++ b/transport/tchannel/transport.go
@@ -22,6 +22,7 @@ package tchannel
 
 import (
 	"fmt"
+	"net"
 	"sync"
 
 	"go.uber.org/yarpc/api/peer"
@@ -43,11 +44,12 @@ type Transport struct {
 	lock sync.Mutex
 	once intsync.LifecycleOnce
 
-	ch     Channel
-	router transport.Router
-	tracer opentracing.Tracer
-	name   string
-	addr   string
+	ch       Channel
+	router   transport.Router
+	tracer   opentracing.Tracer
+	name     string
+	addr     string
+	listener net.Listener
 
 	peers map[string]*hostport.Peer
 }
@@ -75,11 +77,12 @@ func NewTransport(opts ...TransportOption) (*Transport, error) {
 	// }
 
 	return &Transport{
-		once:   intsync.Once(),
-		name:   config.name,
-		addr:   config.addr,
-		tracer: config.tracer,
-		peers:  make(map[string]*hostport.Peer),
+		once:     intsync.Once(),
+		name:     config.name,
+		addr:     config.addr,
+		listener: config.listener,
+		tracer:   config.tracer,
+		peers:    make(map[string]*hostport.Peer),
 	}, nil
 }
 
@@ -167,27 +170,32 @@ func (t *Transport) start() error {
 	}
 	t.ch = ch
 
-	// Default to ListenIP if addr wasn't given.
-	addr := t.addr
-	if addr == "" {
-		listenIP, err := tchannel.ListenIP()
-		if err != nil {
+	if t.listener != nil {
+		if err := t.ch.Serve(listener); err != nil {
 			return err
 		}
+	} else {
+		// Default to ListenIP if addr wasn't given.
+		addr := t.addr
+		if addr == "" {
+			listenIP, err := tchannel.ListenIP()
+			if err != nil {
+				return err
+			}
 
-		addr = listenIP.String() + ":0"
-		// TODO(abg): Find a way to export this to users
-	}
+			addr = listenIP.String() + ":0"
+			// TODO(abg): Find a way to export this to users
+		}
 
-	// TODO(abg): If addr was just the port (":4040"), we want to use
-	// ListenIP() + ":4040" rather than just ":4040".
+		// TODO(abg): If addr was just the port (":4040"), we want to use
+		// ListenIP() + ":4040" rather than just ":4040".
 
-	if err := t.ch.ListenAndServe(addr); err != nil {
-		return err
+		if err := t.ch.ListenAndServe(addr); err != nil {
+			return err
+		}
 	}
 
 	t.addr = t.ch.PeerInfo().HostPort
-
 	return nil
 }
 


### PR DESCRIPTION
This is just a concept, feel free to reject. This is re: https://github.com/yarpc/yarpc-go/pull/866, I would also add this to grpc if we thought this was the way to go.

Note this is technically a breaking change because `Serve(net.Listener) error` is added to `tchannel.Channel`. I don't know if this is OK, but if not, I can make a `ChannelExtended` interface or such that includes this method, and we can change this in 2.0.