### PR TITLE
Add .git to .dockerignore and remove generatenodiff from lint

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@
 *.so
 *.exe
 *.prof
+.git
 .glide
 cover
 cover.html

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.so
 *.exe
 *.prof
+/.git
 /.glide
 /cover
 /cover.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
       sudo: required
       services:
         - docker
-    - env: CI_TYPES='deps generatenodiff examples goveralls' SUPPRESS_DOCKER=1 SUPPRESS_CROSSDOCK=1
+    - env: CI_TYPES='deps examples goveralls' SUPPRESS_DOCKER=1 SUPPRESS_CROSSDOCK=1
       go: 1.7
     - env: CI_TYPES='deps examples lint test' SUPPRESS_CROSSDOCK=1 DOCKER_GO_VERSION=1.8
       sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ matrix:
       sudo: required
       services:
         - docker
+    - env: CI_TYPES='deps generatenodiff' SUPPRESS_DOCKER=1 SUPPRESS_CROSSDOCK=1
+      go: 1.8
 before_install:
   - make travis-docker-load
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
       sudo: required
       services:
         - docker
-    - env: CI_TYPES='deps examples goveralls' SUPPRESS_DOCKER=1 SUPPRESS_CROSSDOCK=1
+    - env: CI_TYPES='deps generatenodiff examples goveralls' SUPPRESS_DOCKER=1 SUPPRESS_CROSSDOCK=1
       go: 1.7
     - env: CI_TYPES='deps examples lint test' SUPPRESS_CROSSDOCK=1 DOCKER_GO_VERSION=1.8
       sudo: required

--- a/build/local.mk
+++ b/build/local.mk
@@ -103,7 +103,7 @@ verifyversion: ## verify the version in the changelog is the same as in version.
 	fi
 
 .PHONY: lint
-lint: generatenodiff nogogenerate gofmt govet golint staticcheck errcheck verifyversion ## run all linters
+lint: nogogenerate gofmt govet golint staticcheck errcheck verifyversion ## run all linters
 
 .PHONY: test
 test: $(THRIFTRW) __eval_packages ## run all tests


### PR DESCRIPTION
This makes the docker build context considerably smaller. In the future, I can rewrite `make generatenodiff` to not use `git`. Note that this change may be temporary, and there may be other reasons to have the .git directory inside the build in the future.