### PR TITLE
Add ragel to make predeps

### DIFF
--- a/build/deps.mk
+++ b/build/deps.mk
@@ -131,7 +131,7 @@ GOCOVMERGE = $(BIN)/gocovmerge
 GOVERALLS = $(BIN)/goveralls
 
 .PHONY: predeps
-predeps: $(GLIDE) $(THRIFT) $(PROTOC)
+predeps: $(GLIDE) $(THRIFT) $(PROTOC) $(RAGEL)
 
 .PHONY: deps
 deps: predeps glide $(GEN_BINS) $(EXTRA_BINS) ## install all dependencies


### PR DESCRIPTION
`make predeps` is used to help with caching binaries that do not depend on `glide install` when building Docker images:

https://github.com/yarpc/yarpc-go/blob/9f8be5dbc113ba551c61aef4cec9104b84139a56/Dockerfile.1.7#L8
https://github.com/yarpc/yarpc-go/blob/9f8be5dbc113ba551c61aef4cec9104b84139a56/Dockerfile.1.8#L8
https://github.com/yarpc/yarpc-go/blob/9f8be5dbc113ba551c61aef4cec9104b84139a56/dockerdeps.mk

By adding `$(RAGEL)` to `make predeps`, we make it so that changes to `glide.yaml` or `glide.lock` do not end up with ragel being reinstalled.