### PR TITLE
build: Echo ragel build commands

### DIFF
--- a/build/deps.mk
+++ b/build/deps.mk
@@ -65,10 +65,10 @@ $(RAGEL_TAR):
 
 $(RAGEL): $(RAGEL_TAR)
 	@mkdir -p $(BIN)
-	@cd $(RAGEL_LIB); tar xzf $(RAGEL_TAR)
-	@cd $(RAGEL_LIB)/ragel-$(RAGEL_VERSION); ./configure --prefix=$(RAGEL_LIB) --disable-manual
-	@cd $(RAGEL_LIB)/ragel-$(RAGEL_VERSION); make install
-	@cp $(RAGEL_LIB)/bin/ragel $(RAGEL)
+	cd $(RAGEL_LIB); tar xzf $(RAGEL_TAR)
+	cd $(RAGEL_LIB)/ragel-$(RAGEL_VERSION); ./configure --prefix=$(RAGEL_LIB) --disable-manual
+	cd $(RAGEL_LIB)/ragel-$(RAGEL_VERSION); make install
+	cp $(RAGEL_LIB)/bin/ragel $(RAGEL)
 
 $(GLIDE_TAR):
 	@mkdir -p $(GLIDE_LIB)


### PR DESCRIPTION
The other `make predeps` binaries do not suppress printing of build commands
that are suppressed in the build of ragel.