### PR TITLE
tchannel/in: Write response headers on empty body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ v1.8.0 (unreleased)
 
 -   x/config: The service name is no longer part of the configuration and must
     be passed as an argument to the `LoadConfig*` or `NewDispatcher*` methods.
+-   Fixed a bug where the TChannel inbound would not write the response headers
+    if the response body was empty.
 
 
 v1.7.1 (2017-03-29)

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/uber/tchannel-go"
+	"go.uber.org/multierr"
 	ncontext "golang.org/x/net/context"
 )
 
@@ -257,14 +258,11 @@ func (rw *responseWriter) Close() error {
 	err := rw.ensureWroteHeaders()
 
 	if rw.bodyWriter != nil {
-		if closeErr := rw.bodyWriter.Close(); err == nil {
-			err = closeErr
-		}
+		err = multierr.Append(err, rw.bodyWriter.Close())
 	}
 
-	if rw.failedWith != nil && err == nil {
-		err = rw.failedWith
+	if err != nil {
+		return err
 	}
-
-	return err
+	return rw.failedWith
 }

--- a/transport/tchannel/handler_test.go
+++ b/transport/tchannel/handler_test.go
@@ -508,3 +508,18 @@ func TestResponseWriterFailure(t *testing.T) {
 		assert.Error(t, w.Close())
 	}
 }
+
+func TestResponseWriterEmptyBodyHeaders(t *testing.T) {
+	res := newResponseRecorder()
+	w := newResponseWriter(
+		new(transport.Request),
+		&fakeInboundCall{format: tchannel.Raw, resp: res},
+	)
+
+	w.AddHeaders(transport.NewHeaders().With("foo", "bar"))
+	require.NoError(t, w.Close())
+
+	assert.NotEmpty(t, res.arg2.Bytes(), "headers must not be empty")
+	assert.Empty(t, res.arg3.Bytes(), "body must be empty but was %#v", res.arg3.Bytes())
+	assert.False(t, res.applicationError, "application error must be false")
+}


### PR DESCRIPTION
This fixes a bug where the TChannel inbound would not write the response
headers if the response body was empty because `Write()` would never get
called.

Resolves #179