### PR TITLE
http: NewOutbound should use Transport.NewOutbound

### DIFF
--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -94,15 +94,7 @@ func (t *Transport) NewOutbound(chooser peer.Chooser, opts ...OutboundOption) *O
 // objects. Also note that the Chooser MUST have started before Outbound.Start
 // is called.
 func NewOutbound(chooser peer.Chooser, opts ...OutboundOption) *Outbound {
-	o := &Outbound{
-		chooser:     chooser,
-		urlTemplate: defaultURLTemplate,
-		tracer:      opentracing.GlobalTracer(),
-	}
-	for _, opt := range opts {
-		opt(o)
-	}
-	return o
+	return NewTransport().NewOutbound(chooser, opts...)
 }
 
 // NewSingleOutbound builds an outbound which sends YARPC requests over HTTP


### PR DESCRIPTION
It's not clear to me why the top-level `http.NewOutbound` function built
its own outbound instead of building a new `*http.Transport` and using
the `NewOutbound` method on that.