### PR TITLE
http: Transports() should return a transport

### DIFF
--- a/transport/http/inbound.go
+++ b/transport/http/inbound.go
@@ -55,9 +55,10 @@ func Mux(pattern string, mux *http.ServeMux) InboundOption {
 // sharing this transport.
 func (t *Transport) NewInbound(addr string, opts ...InboundOption) *Inbound {
 	i := &Inbound{
-		once:   sync.Once(),
-		addr:   addr,
-		tracer: t.tracer,
+		once:      sync.Once(),
+		addr:      addr,
+		tracer:    t.tracer,
+		transport: t,
 	}
 	for _, opt := range opts {
 		opt(i)
@@ -74,6 +75,7 @@ type Inbound struct {
 	server     *intnet.HTTPServer
 	router     transport.Router
 	tracer     opentracing.Tracer
+	transport  *Transport
 
 	once sync.LifecycleOnce
 }
@@ -93,8 +95,7 @@ func (i *Inbound) SetRouter(router transport.Router) {
 
 // Transports returns the inbound's HTTP transport.
 func (i *Inbound) Transports() []transport.Transport {
-	// TODO factor out transport and return it here.
-	return []transport.Transport{}
+	return []transport.Transport{i.transport}
 }
 
 // Start starts the inbound with a given service detail, opening a listening

--- a/transport/http/inbound_test.go
+++ b/transport/http/inbound_test.go
@@ -45,6 +45,12 @@ import (
 func TestStartAddrInUse(t *testing.T) {
 	t1 := NewTransport()
 	i1 := t1.NewInbound(":0")
+
+	assert.Len(t, i1.Transports(), 1, "transports must contain the transport")
+	// we use == instead of assert.Equal because we want to do a pointer
+	// comparison
+	assert.True(t, t1 == i1.Transports()[0], "transports must match")
+
 	i1.SetRouter(new(transporttest.MockRouter))
 	require.NoError(t, i1.Start(), "inbound 1 must start without an error")
 	t2 := NewTransport()

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -79,6 +79,7 @@ func (t *Transport) NewOutbound(chooser peer.Chooser, opts ...OutboundOption) *O
 		chooser:     chooser,
 		urlTemplate: defaultURLTemplate,
 		tracer:      t.tracer,
+		transport:   t,
 	}
 	for _, opt := range opts {
 		opt(o)
@@ -133,6 +134,7 @@ type Outbound struct {
 	chooser     peer.Chooser
 	urlTemplate *url.URL
 	tracer      opentracing.Tracer
+	transport   *Transport
 
 	once sync.LifecycleOnce
 }
@@ -150,8 +152,7 @@ func (o *Outbound) setURLTemplate(URL string) {
 
 // Transports returns the outbound's HTTP transport.
 func (o *Outbound) Transports() []transport.Transport {
-	// TODO factor out transport and return it here.
-	return []transport.Transport{}
+	return []transport.Transport{o.transport}
 }
 
 // Start the HTTP outbound

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -132,6 +132,10 @@ func TestOutboundHeaders(t *testing.T) {
 		}
 
 		out := httpTransport.NewSingleOutbound(server.URL)
+		assert.Len(t, out.Transports(), 1, "transports must contain the transport")
+		// we use == instead of assert.Equal because we want to do a pointer
+		// comparison
+		assert.True(t, httpTransport == out.Transports()[0], "transports must match")
 
 		require.NoError(t, out.Start(), "failed to start outbound")
 		defer out.Stop()


### PR DESCRIPTION
This changes the HTTP inbound and outbound to actually return the
transport that created them.

Resolves #674

This relies on #924 to handle the case where the top-level `NewOutbound`
function is called which builds its own `Outbound`.