### PR TITLE
docs: Fix itemized lists

### DIFF
--- a/api/middleware/inbound.go
+++ b/api/middleware/inbound.go
@@ -29,14 +29,10 @@ import (
 // UnaryInbound defines a transport-level middleware for
 // `UnaryHandler`s.
 //
-// UnaryInbound middleware MAY
-//
-// - change the context
-// - change the request
-// - call the ResponseWriter
-// - modify the response body by wrapping the ResponseWriter
-// - handle the returned error
-// - call the given handler zero or more times
+// UnaryInbound middleware MAY do zero or more of the following: change the
+// context, change the request, call the ResponseWriter, modify the response
+// body by wrapping the ResponseWriter, handle the returned error, call the
+// given handler zero or more times.
 //
 // UnaryInbound middleware MUST be thread-safe.
 //
@@ -84,12 +80,9 @@ func (nopUnaryInbound) Handle(ctx context.Context, req *transport.Request, resw 
 // OnewayInbound defines a transport-level middleware for
 // `OnewayHandler`s.
 //
-// OnewayInbound middleware MAY
-//
-// - change the context
-// - change the request
-// - handle the returned error
-// - call the given handler zero or more times
+// OnewayInbound middleware MAY do zero or more of the following: change the
+// context, change the request, handle the returned error, call the given
+// handler zero or more times.
 //
 // OnewayInbound middleware MUST be thread-safe.
 //

--- a/api/middleware/outbound.go
+++ b/api/middleware/outbound.go
@@ -30,18 +30,12 @@ import (
 // UnaryOutbound defines transport-level middleware for
 // `UnaryOutbound`s.
 //
-// UnaryOutbound middleware MAY
+// UnaryOutbound middleware MAY do zero or more of the following: change the
+// context, change the request, change the returned response, handle the
+// returned error, call the given outbound zero or more times.
 //
-// - change the context
-// - change the request
-// - change the returned response
-// - handle the returned error
-// - call the given outbound zero or more times
-//
-// UnaryOutbound middleware MUST
-//
-// - always return a non-nil Response or error.
-// - be thread-safe
+// UnaryOutbound middleware MUST always return a non-nil Response or error,
+// and they MUST be thread-safe
 //
 // UnaryOutbound middleware is re-used across requests and MAY be called
 // multiple times on the same request.
@@ -110,18 +104,12 @@ func (nopUnaryOutbound) Call(ctx context.Context, request *transport.Request, ou
 
 // OnewayOutbound defines transport-level middleware for `OnewayOutbound`s.
 //
-// OnewayOutbound middleware MAY
+// OnewayOutbound middleware MAY do zero or more of the following: change the
+// context, change the request, change the returned ack, handle the returned
+// error, call the given outbound zero or more times.
 //
-// - change the context
-// - change the request
-// - change the returned ack
-// - handle the returned error
-// - call the given outbound zero or more times
-//
-// OnewayOutbound middleware MUST
-//
-// - always return an Ack (nil or not) or an error.
-// - be thread-safe
+// OnewayOutbound middleware MUST always return an Ack (nil or not) or an
+// error, and they MUST be thread-safe.
 //
 // OnewayOutbound middleware is re-used across requests and MAY be called
 // multiple times on the same request.

--- a/api/transport/outbound.go
+++ b/api/transport/outbound.go
@@ -66,14 +66,17 @@ type OnewayOutbound interface {
 
 // Outbounds encapsulates the outbound specification for a service.
 //
-// This includes the service name that will be used for outbound requests
-// as well as the Outbound that will be used to transport the request.  The
-// outbound will be one of:
-//
-// - Unary (send request and wait for response)
-// - Oneway (send request and continue once downstream acknowledges request)
+// This includes the service name that will be used for outbound requests as
+// well as the Outbound that will be used to transport the request.  The
+// outbound will be one of Unary and Oneway.
 type Outbounds struct {
 	ServiceName string
-	Unary       UnaryOutbound
-	Oneway      OnewayOutbound
+
+	// If set, this is the unary outbound which sends a request and waits for
+	// the response.
+	Unary UnaryOutbound
+
+	// If set, this is the oneway outbound which sends the request and
+	// continues once the message has been delivered.
+	Oneway OnewayOutbound
 }

--- a/api/transport/transporttest/reqres.go
+++ b/api/transport/transporttest/reqres.go
@@ -34,12 +34,9 @@ import (
 // RequestMatcher may be used in gomock argument lists to assert that two
 // requests match.
 //
-// Requests are considered to be matching if:
-//
-// - All their primitive parameters match.
-// - The headers of the received request include all the headers from the
-//   source request. It may include extra headers.
-// - The contents of the request bodies are the same.
+// Requests are considered to be matching if: all their primitive parameters
+// match, the headers of the received request include all the headers from the
+// source request, and the contents of the request bodies are the same.
 type RequestMatcher struct {
 	t    *testing.T
 	req  *transport.Request

--- a/internal/crossdock/client/ctxpropagation/behavior.go
+++ b/internal/crossdock/client/ctxpropagation/behavior.go
@@ -44,7 +44,9 @@ import (
 // Behavior parameters:
 //
 // - ctxclient: Address of this client.
+//
 // - ctxserver: Address of the crossdock test subject server.
+//
 // - transport: The transport to make requests to the test subject with.
 //
 // This behavior sets up a server in-process which the Phone procedure on the


### PR DESCRIPTION
godoc doesn't support itemized lists so lists in the form,

    // - foo
    // - bar

Render as a single paragraph "- foo - bar". This fixes all referencs I
could find with a single search for "// -".

Resolves #724