### PR TITLE
pally: Add histograms for tracking latency

### DIFF
--- a/internal/pally/histogram.go
+++ b/internal/pally/histogram.go
@@ -1,0 +1,226 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package pally
+
+import (
+	"fmt"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/uber-go/tally"
+	"go.uber.org/atomic"
+)
+
+type bucket struct {
+	atomic.Int64
+
+	last  int64
+	upper int64 // inclusive
+}
+
+func (b *bucket) diff() int64 {
+	cur := b.Load()
+	diff := cur - b.last
+	b.last = cur
+	return diff
+}
+
+type buckets []*bucket
+
+func (bs buckets) get(val int64) *bucket {
+	// Binary search to find the correct bucket for this observation.
+	i, j := 0, len(bs)
+	for i < j {
+		h := i + (j-i)/2
+		if val > bs[h].upper {
+			i = h + 1
+		} else {
+			j = h
+		}
+	}
+	return bs[i]
+}
+
+type histogram struct {
+	buckets buckets
+	sum     atomic.Int64
+
+	opts              LatencyOpts
+	desc              *prometheus.Desc
+	tally             tally.Histogram
+	variableLabelVals []string
+}
+
+func newHistogram(opts LatencyOpts) *histogram {
+	return &histogram{
+		buckets: opts.buckets(),
+		opts:    opts,
+		desc:    opts.describe(),
+	}
+}
+
+func (h *histogram) Observe(d time.Duration) {
+	n := int64(d / h.opts.Unit)
+	bucket := h.buckets.get(n)
+	bucket.Inc()
+	h.sum.Add(n)
+}
+
+func (h *histogram) push(scope tally.Scope) {
+	if h.opts.DisableTally {
+		return
+	}
+	if h.tally == nil {
+		labels := h.opts.copyLabels()
+		for i, key := range h.opts.VariableLabels {
+			labels[key] = h.variableLabelVals[i]
+		}
+		h.tally = scope.Tagged(labels).Histogram(
+			h.opts.Name,
+			tally.DurationBuckets(h.opts.Buckets),
+		)
+	}
+	for _, bucket := range h.buckets {
+		diff := bucket.diff()
+		// TODO: either add a Tally API to observe multiple values or roll our
+		// own counter-based histogram implementation.
+		for i := int64(0); i < diff; i++ {
+			h.tally.RecordDuration(time.Duration(bucket.upper) * h.opts.Unit)
+		}
+	}
+}
+
+func (h *histogram) Collect(ch chan<- prometheus.Metric) {
+	// TODO: Implement prometheus.Metric directly, which avoids all these
+	// allocations.
+	n := uint64(0)
+	prom := make(map[float64]uint64, len(h.buckets)-1)
+	for _, b := range h.buckets {
+		n += uint64(b.Load())
+		if b.upper == math.MaxInt64 {
+			// Prometheus doesn't want us to export the final catch-all bucket.
+			continue
+		}
+		prom[float64(b.upper)] += n
+	}
+	m, err := prometheus.NewConstHistogram(
+		h.desc,
+		n,
+		float64(h.sum.Load()),
+		prom,
+		h.variableLabelVals...,
+	)
+	if err == nil {
+		ch <- m
+	}
+}
+
+func (h *histogram) Describe(ch chan<- *prometheus.Desc) {
+	ch <- h.desc
+}
+
+type histogramVector struct {
+	opts LatencyOpts
+	desc *prometheus.Desc
+	bs   buckets
+
+	histogramsMu sync.RWMutex
+	histograms   map[string]*histogram
+}
+
+func newHistogramVector(opts LatencyOpts) *histogramVector {
+	return &histogramVector{
+		opts:       opts,
+		desc:       opts.describe(),
+		bs:         opts.buckets(),
+		histograms: make(map[string]*histogram, _defaultVectorSize),
+	}
+}
+
+func (vec *histogramVector) MustGet(labels ...string) Latencies {
+	l, err := vec.Get(labels...)
+	if err != nil {
+		panic(fmt.Sprintf("failed to get Latencies with labels %v: %v", labels, err))
+	}
+	return l
+}
+
+func (vec *histogramVector) Get(labels ...string) (Latencies, error) {
+	digester := newDigester()
+	for _, s := range labels {
+		digester.add(ScrubLabelValue(s))
+	}
+
+	vec.histogramsMu.RLock()
+	m, ok := vec.histograms[string(digester.digest())]
+	vec.histogramsMu.RUnlock()
+	if ok {
+		digester.free()
+		return m, nil
+	}
+
+	vec.histogramsMu.Lock()
+	m, err := vec.newHistogram(digester.digest(), labels)
+	vec.histogramsMu.Unlock()
+	digester.free()
+
+	return m, err
+}
+
+func (vec *histogramVector) newHistogram(key []byte, variableLabelVals []string) (*histogram, error) {
+	m, ok := vec.histograms[string(key)]
+	if ok {
+		return m, nil
+	}
+	if len(vec.opts.VariableLabels) != len(variableLabelVals) {
+		return nil, errInconsistentCardinality
+	}
+	m = &histogram{
+		buckets:           vec.bs,
+		opts:              vec.opts,
+		desc:              vec.desc,
+		variableLabelVals: scrubLabelValues(variableLabelVals),
+	}
+	vec.histograms[string(key)] = m
+	return m, nil
+}
+
+func (vec *histogramVector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- vec.desc
+}
+
+func (vec *histogramVector) Collect(ch chan<- prometheus.Metric) {
+	vec.histogramsMu.RLock()
+	for _, m := range vec.histograms {
+		m.Collect(ch)
+	}
+	vec.histogramsMu.RUnlock()
+}
+
+func (vec *histogramVector) push(scope tally.Scope) {
+	vec.histogramsMu.RLock()
+	for _, m := range vec.histograms {
+		m.push(scope)
+	}
+	vec.histogramsMu.RUnlock()
+}

--- a/internal/pally/histogram.go
+++ b/internal/pally/histogram.go
@@ -142,7 +142,6 @@ func (h *histogram) Describe(ch chan<- *prometheus.Desc) {
 type histogramVector struct {
 	opts LatencyOpts
 	desc *prometheus.Desc
-	bs   buckets
 
 	histogramsMu sync.RWMutex
 	histograms   map[string]*histogram
@@ -152,7 +151,6 @@ func newHistogramVector(opts LatencyOpts) *histogramVector {
 	return &histogramVector{
 		opts:       opts,
 		desc:       opts.describe(),
-		bs:         opts.buckets(),
 		histograms: make(map[string]*histogram, _defaultVectorSize),
 	}
 }
@@ -196,7 +194,7 @@ func (vec *histogramVector) newHistogram(key []byte, variableLabelVals []string)
 		return nil, errInconsistentCardinality
 	}
 	m = &histogram{
-		buckets:           vec.bs,
+		buckets:           vec.opts.buckets(),
 		opts:              vec.opts,
 		desc:              vec.desc,
 		variableLabelVals: scrubLabelValues(variableLabelVals),

--- a/internal/pally/histogram_test.go
+++ b/internal/pally/histogram_test.go
@@ -1,0 +1,209 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package pally
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLatencies(t *testing.T) {
+	r := NewRegistry(Labeled(Labels{"service": "users"}))
+	lat, err := r.NewLatencies(LatencyOpts{
+		Opts: Opts{
+			Name:        "test_latency_ns",
+			Help:        "Some help.",
+			ConstLabels: Labels{"foo": "bar"},
+		},
+		Unit:    time.Nanosecond,
+		Buckets: []time.Duration{10, 50, 100},
+	})
+	require.NoError(t, err, "Unexpected error constructing counter.")
+
+	scope := newTestScope()
+	stop, err := r.Push(scope, _tick)
+	require.NoError(t, err, "Unexpected error starting Tally push.")
+
+	lat.Observe(-1)
+	lat.Observe(0)
+	lat.Observe(10)
+	lat.Observe(75)
+	lat.Observe(150)
+
+	time.Sleep(5 * _tick)
+	stop()
+
+	export := TallyExpectation{
+		Type:   "latencies",
+		Name:   "test_latency_ns",
+		Labels: Labels{"foo": "bar", "service": "users"},
+		Durations: map[time.Duration]int64{
+			0:   0,
+			10:  3,
+			50:  0,
+			100: 1,
+			time.Duration(math.MaxInt64): 1,
+		},
+	}
+	export.Test(t, scope)
+
+	assertPrometheusText(t, r, "# HELP test_latency_ns Some help.\n"+
+		"# TYPE test_latency_ns histogram\n"+
+		`test_latency_ns_bucket{foo="bar",service="users",le="10"} 3`+"\n"+
+		`test_latency_ns_bucket{foo="bar",service="users",le="50"} 3`+"\n"+
+		`test_latency_ns_bucket{foo="bar",service="users",le="100"} 4`+"\n"+
+		`test_latency_ns_bucket{foo="bar",service="users",le="+Inf"} 5`+"\n"+
+		`test_latency_ns_sum{foo="bar",service="users"} 234`+"\n"+
+		`test_latency_ns_count{foo="bar",service="users"} 5`)
+}
+
+func TestLatenciesVector(t *testing.T) {
+	tests := []struct {
+		desc      string
+		opts      LatencyOpts
+		f         func(testing.TB, *Registry, LatencyOpts)
+		wantTally TallyExpectation
+		wantProm  string
+	}{
+		{
+			desc: "valid labels",
+			opts: LatencyOpts{
+				Opts: Opts{
+					Name:           "test_latency_ms",
+					Help:           "Some help.",
+					VariableLabels: []string{"var"},
+				},
+				Unit:    time.Millisecond,
+				Buckets: []time.Duration{time.Second, time.Minute},
+			},
+			f: func(t testing.TB, r *Registry, opts LatencyOpts) {
+				vec, err := r.NewLatenciesVector(opts)
+				require.NoError(t, err, "Unexpected error constructing vector.")
+				lat, err := vec.Get("x")
+				require.NoError(t, err, "Unexpected error getting a counter with correct number of labels.")
+				lat.Observe(time.Millisecond)
+				vec.MustGet("x").Observe(time.Millisecond)
+			},
+			wantTally: TallyExpectation{
+				Type:   "latencies",
+				Name:   "test_latency_ms",
+				Labels: Labels{"var": "x"},
+				Durations: map[time.Duration]int64{
+					0:                            0,
+					time.Second:                  2,
+					time.Minute:                  0,
+					time.Duration(math.MaxInt64): 0,
+				},
+			},
+			wantProm: "# HELP test_latency_ms Some help.\n" +
+				"# TYPE test_latency_ms histogram\n" +
+				`test_latency_ms_bucket{var="x",le="1000"} 2` + "\n" +
+				`test_latency_ms_bucket{var="x",le="60000"} 2` + "\n" +
+				`test_latency_ms_bucket{var="x",le="+Inf"} 2` + "\n" +
+				`test_latency_ms_sum{var="x"} 2` + "\n" +
+				`test_latency_ms_count{var="x"} 2`,
+		},
+		{
+			desc: "invalid labels",
+			opts: LatencyOpts{
+				Opts: Opts{
+					Name:           "test_latency_ms",
+					Help:           "Some help.",
+					VariableLabels: []string{"var"},
+				},
+				Unit:    time.Millisecond,
+				Buckets: []time.Duration{time.Second, time.Minute},
+			},
+			f: func(t testing.TB, r *Registry, opts LatencyOpts) {
+				vec, err := r.NewLatenciesVector(opts)
+				require.NoError(t, err, "Unexpected error constructing vector.")
+				lat, err := vec.Get("x!")
+				require.NoError(t, err, "Unexpected error getting a counter with correct number of labels.")
+				lat.Observe(time.Millisecond)
+				vec.MustGet("x!").Observe(time.Millisecond)
+			},
+			wantTally: TallyExpectation{
+				Type:   "latencies",
+				Name:   "test_latency_ms",
+				Labels: Labels{"var": "x-"},
+				Durations: map[time.Duration]int64{
+					0:                            0,
+					time.Second:                  2,
+					time.Minute:                  0,
+					time.Duration(math.MaxInt64): 0,
+				},
+			},
+			wantProm: "# HELP test_latency_ms Some help.\n" +
+				"# TYPE test_latency_ms histogram\n" +
+				`test_latency_ms_bucket{var="x-",le="1000"} 2` + "\n" +
+				`test_latency_ms_bucket{var="x-",le="60000"} 2` + "\n" +
+				`test_latency_ms_bucket{var="x-",le="+Inf"} 2` + "\n" +
+				`test_latency_ms_sum{var="x-"} 2` + "\n" +
+				`test_latency_ms_count{var="x-"} 2`,
+		},
+		{
+			desc: "wrong number of label values",
+			opts: LatencyOpts{
+				Opts: Opts{
+					Name:           "test_latency_ms",
+					Help:           "Some help.",
+					VariableLabels: []string{"var"},
+				},
+				Unit:    time.Millisecond,
+				Buckets: []time.Duration{time.Second, time.Minute},
+			},
+			f: func(t testing.TB, r *Registry, opts LatencyOpts) {
+				vec, err := r.NewLatenciesVector(opts)
+				require.NoError(t, err, "Unexpected error constructing vector.")
+				_, err = vec.Get("x", "y")
+				require.Error(t, err, "Unexpected success calling Get with incorrect number of labels.")
+				require.Panics(
+					t,
+					func() { vec.MustGet("x", "y").Observe(time.Millisecond) },
+					"Expected a panic using MustGet with the wrong number of labels.",
+				)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			r := NewRegistry()
+
+			scope := newTestScope()
+			stop, err := r.Push(scope, _tick)
+			require.NoError(t, err, "Unexpected error starting Tally push.")
+			defer stop()
+
+			tt.f(t, r, tt.opts)
+
+			time.Sleep(5 * _tick)
+			tt.wantTally.Test(t, scope)
+
+			assertPrometheusText(t, r, tt.wantProm)
+		})
+
+	}
+
+}

--- a/internal/pally/metric.go
+++ b/internal/pally/metric.go
@@ -21,6 +21,8 @@
 package pally
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/uber-go/tally"
 )
@@ -64,6 +66,23 @@ type GaugeVector interface {
 	// package-level documentation on vectors.
 	Get(...string) (Gauge, error)
 	MustGet(...string) Gauge
+}
+
+// Latencies approximates a latency distribution with a histogram.
+//
+// Latencies are exported to both Prometheus and Tally using their native
+// histogram types.
+type Latencies interface {
+	Observe(time.Duration)
+}
+
+// A LatenciesVector is a collection of Latencies that share a name and some
+// constant labels, but also have an enumerated set of variable labels.
+type LatenciesVector interface {
+	// For a description of Get, MustGet, and vector types in general, see the
+	// package-level documentation on vectors.
+	Get(...string) (Latencies, error)
+	MustGet(...string) Latencies
 }
 
 type metric interface {

--- a/internal/pally/opts.go
+++ b/internal/pally/opts.go
@@ -90,8 +90,15 @@ func (o Opts) copyLabels() map[string]string {
 type LatencyOpts struct {
 	Opts
 
-	Unit    time.Duration
-	Buckets []time.Duration // upper bounds
+	// Latencies are exported to Prometheus as a simple number, not a duration.
+	// Unit specifies the desired granularity for latency observations. For
+	// example, an observation of time.Second with a unit of time.Millisecond is
+	// exported to Prometheus as 1000. Typically, the unit should also be part
+	// of the metric name; in this example, latency_ms is a good name.
+	Unit time.Duration
+	// Upper bounds for the histogram buckets. A catch-all bucket for large
+	// observations is automatically created, if necessary.
+	Buckets []time.Duration
 }
 
 func (l LatencyOpts) buckets() buckets {

--- a/internal/pally/registry.go
+++ b/internal/pally/registry.go
@@ -164,6 +164,28 @@ func (r *Registry) MustGauge(opts Opts) Gauge {
 	return g
 }
 
+// NewLatencies constructs a new Latencies.
+func (r *Registry) NewLatencies(opts LatencyOpts) (Latencies, error) {
+	opts.Opts = r.addConstLabels(opts.Opts)
+	if err := opts.validate(); err != nil {
+		return nil, err
+	}
+	h := newHistogram(opts)
+	if err := r.register(h); err != nil {
+		return nil, err
+	}
+	return h, nil
+}
+
+// MustLatencies constructs a new Latencies. It panics if it encounters an error.
+func (r *Registry) MustLatencies(opts LatencyOpts) Latencies {
+	l, err := r.NewLatencies(opts)
+	if err != nil {
+		panic(fmt.Sprintf("failed to create Latencies with options %+v: %v", opts, err))
+	}
+	return l
+}
+
 // NewCounterVector constructs a new CounterVector.
 func (r *Registry) NewCounterVector(opts Opts) (CounterVector, error) {
 	opts = r.addConstLabels(opts)
@@ -208,6 +230,29 @@ func (r *Registry) MustGaugeVector(opts Opts) GaugeVector {
 		panic(fmt.Sprintf("failed to create GaugeVector with options %+v: %v", opts, err))
 	}
 	return v
+}
+
+// NewLatenciesVector constructs a new LatenciesVector.
+func (r *Registry) NewLatenciesVector(opts LatencyOpts) (LatenciesVector, error) {
+	opts.Opts = r.addConstLabels(opts.Opts)
+	if err := opts.validateVector(); err != nil {
+		return nil, err
+	}
+	vec := newHistogramVector(opts)
+	if err := r.register(vec); err != nil {
+		return nil, err
+	}
+	return vec, nil
+}
+
+// MustLatenciesVector constructs a new LatenciesVector. It panics if it
+// encounters an error.
+func (r *Registry) MustLatenciesVector(opts LatencyOpts) LatenciesVector {
+	vec, err := r.NewLatenciesVector(opts)
+	if err != nil {
+		panic(fmt.Sprintf("failed to create LatenciesVector with options %+v: %v", opts, err))
+	}
+	return vec
 }
 
 // ServeHTTP implements http.Handler.


### PR DESCRIPTION
To round out the basic metric types, we need some way to track RPC latencies.
The best approach is to use histograms - it's both more correct and closer to the
stats that Muttley collects.

This PR adds scalar and vectorized histograms to Pally, along with test
coverage. (See the package-level Pally documentation for an explanation of
vector types).

Down the road, we'll need to come back and optimize the Tally export path; right
now, we take the simple approach of just calling
`tally.Histogram.ObserveDuration` multiple times with the same value. This isn't
ideal, since it forces Tally to binary search for the correct histogram bucket
repeatedly.

Reviewers, the details of this code require some understanding of the [Prometheus](https://godoc.org/github.com/prometheus/client_golang/prometheus#Histogram
) and [Tally](https://godoc.org/github.com/uber-go/tally#Histogram) histogram implementations.

This is one sub-task of T841911.