### PR TITLE
Add logging to outbound unary calls

### DIFF
--- a/dispatcher.go
+++ b/dispatcher.go
@@ -30,6 +30,7 @@ import (
 	"go.uber.org/yarpc/internal/clientconfig"
 	"go.uber.org/yarpc/internal/inboundmiddleware"
 	"go.uber.org/yarpc/internal/observerware"
+	"go.uber.org/yarpc/internal/outboundmiddleware"
 	"go.uber.org/yarpc/internal/request"
 	intsync "go.uber.org/yarpc/internal/sync"
 
@@ -133,10 +134,11 @@ func NewDispatcher(cfg Config) *Dispatcher {
 }
 
 func addObservingMiddleware(cfg Config, logger *zap.Logger) Config {
-	cfg.InboundMiddleware.Unary = inboundmiddleware.UnaryChain(observerware.NewUnaryInbound(
-		logger,
-		observerware.NewNopContextExtractor(),
-	), cfg.InboundMiddleware.Unary)
+	unary := observerware.NewUnary(logger, observerware.NewNopContextExtractor())
+
+	cfg.InboundMiddleware.Unary = inboundmiddleware.UnaryChain(unary, cfg.InboundMiddleware.Unary)
+	cfg.OutboundMiddleware.Unary = outboundmiddleware.UnaryChain(unary, cfg.OutboundMiddleware.Unary)
+
 	return cfg
 }
 

--- a/internal/observerware/common_test.go
+++ b/internal/observerware/common_test.go
@@ -27,18 +27,6 @@ import (
 	"go.uber.org/yarpc/api/transport"
 )
 
-type fakeInboundMiddleware struct {
-	err error
-}
-
-func (m fakeInboundMiddleware) Handle(_ context.Context, _ *transport.Request, _ transport.ResponseWriter, _ transport.UnaryHandler) error {
-	return m.err
-}
-
-func (m fakeInboundMiddleware) HandleOneway(_ context.Context, _ *transport.Request, _ transport.OnewayHandler) error {
-	return m.err
-}
-
 type fakeHandler struct {
 	err error
 }
@@ -49,6 +37,19 @@ func (h fakeHandler) Handle(_ context.Context, _ *transport.Request, _ transport
 
 func (h fakeHandler) HandleOneway(_ context.Context, _ *transport.Request, _ transport.ResponseWriter) error {
 	return h.err
+}
+
+type fakeOutbound struct {
+	transport.Outbound
+
+	err error
+}
+
+func (o fakeOutbound) Call(_ context.Context, req *transport.Request) (*transport.Response, error) {
+	if o.err != nil {
+		return nil, o.err
+	}
+	return &transport.Response{}, nil
 }
 
 func stubTime() func() {

--- a/internal/observerware/middleware.go
+++ b/internal/observerware/middleware.go
@@ -32,7 +32,7 @@ import (
 // For tests.
 var _timeNow = time.Now
 
-// Unary is middleware for unary handlers.
+// Unary is middleware for unary RPCs.
 type Unary struct {
 	logger  *zap.Logger
 	extract ContextExtractor

--- a/internal/observerware/middleware.go
+++ b/internal/observerware/middleware.go
@@ -32,29 +32,27 @@ import (
 // For tests.
 var _timeNow = time.Now
 
-// UnaryInbound is middleware for unary inbound handlers.
-type UnaryInbound struct {
+// Unary is middleware for unary handlers.
+type Unary struct {
 	logger  *zap.Logger
 	extract ContextExtractor
 }
 
-// NewUnaryInbound constructs a UnaryInbound.
-func NewUnaryInbound(logger *zap.Logger, extract ContextExtractor) *UnaryInbound {
-	return &UnaryInbound{
-		logger:  logger.With(zap.String("rpcType", "unary inbound")),
+// NewUnary constructs a Unary.
+func NewUnary(logger *zap.Logger, extract ContextExtractor) *Unary {
+	return &Unary{
+		logger:  logger.With(zap.String("rpcType", "unary")),
 		extract: extract,
 	}
 }
 
 // Handle implements middleware.UnaryInbound.
-func (m *UnaryInbound) Handle(ctx context.Context, req *transport.Request, w transport.ResponseWriter, h transport.UnaryHandler) error {
-	// TODO (shah): Add timing info to the request struct so that we don't lose
-	// time spent in the transport.
+func (m *Unary) Handle(ctx context.Context, req *transport.Request, w transport.ResponseWriter, h transport.UnaryHandler) error {
 	start := _timeNow()
 	err := h.Handle(ctx, req, w)
 	elapsed := _timeNow().Sub(start)
 
-	if ce := m.logger.Check(zap.DebugLevel, "Handled request."); ce != nil {
+	if ce := m.logger.Check(zap.DebugLevel, "Handled inbound request."); ce != nil {
 		ce.Write(
 			m.extract(ctx),
 			zap.Object("request", req),
@@ -64,4 +62,22 @@ func (m *UnaryInbound) Handle(ctx context.Context, req *transport.Request, w tra
 		)
 	}
 	return err
+}
+
+// Call implements middleware.UnaryOutbound.
+func (m *Unary) Call(ctx context.Context, req *transport.Request, out transport.UnaryOutbound) (*transport.Response, error) {
+	start := _timeNow()
+	res, err := out.Call(ctx, req)
+	elapsed := _timeNow().Sub(start)
+
+	if ce := m.logger.Check(zap.DebugLevel, "Made outbound call."); ce != nil {
+		ce.Write(
+			m.extract(ctx),
+			zap.Object("request", req),
+			zap.Duration("latency", elapsed),
+			zap.Bool("successful", err == nil),
+			zap.Error(err),
+		)
+	}
+	return res, err
 }


### PR DESCRIPTION
This PR addresses the next step of T841919.

It takes the existing logging middleware, which only works for unary inbound
calls, and extends it to also work for unary outbound calls. This required a
little refactoring and renaming, since I didn't initially realize that the
method names for inbound and outbound middlewares don't clash.