### PR TITLE
Export logger field in configuration

### DIFF
--- a/dispatcher.go
+++ b/dispatcher.go
@@ -70,9 +70,9 @@ type Config struct {
 	// RouterMiddleware is middleware to control how requests are routed.
 	RouterMiddleware middleware.Router
 
-	// Logger provides a logger for the dispatcher. The default logger is a
+	// ZapLogger provides a logger for the dispatcher. The default logger is a
 	// no-op.
-	Logger *zap.Logger
+	ZapLogger *zap.Logger
 }
 
 // Inbounds contains a list of inbound transports. Each inbound transport
@@ -112,8 +112,8 @@ func NewDispatcher(cfg Config) *Dispatcher {
 	}
 
 	logger := zap.NewNop()
-	if cfg.Logger != nil {
-		logger = cfg.Logger.Named("yarpc").With(
+	if cfg.ZapLogger != nil {
+		logger = cfg.ZapLogger.Named("yarpc").With(
 			zap.Namespace("yarpc"), // isolate yarpc's keys
 			zap.String("dispatcher", cfg.Name),
 		)

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -72,9 +72,7 @@ type Config struct {
 
 	// Logger provides a logger for the dispatcher. The default logger is a
 	// no-op.
-	// TODO(shah): Export this when we're ready to deploy a branch in
-	// demo-yarpc-go.
-	logger *zap.Logger
+	Logger *zap.Logger
 }
 
 // Inbounds contains a list of inbound transports. Each inbound transport
@@ -114,8 +112,8 @@ func NewDispatcher(cfg Config) *Dispatcher {
 	}
 
 	logger := zap.NewNop()
-	if cfg.logger != nil {
-		logger = cfg.logger.Named("yarpc").With(
+	if cfg.Logger != nil {
+		logger = cfg.Logger.Named("yarpc").With(
 			zap.Namespace("yarpc"), // isolate yarpc's keys
 			zap.String("dispatcher", cfg.Name),
 		)

--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -48,7 +48,7 @@ func basicDispatcher(t *testing.T) *Dispatcher {
 			tchannelTransport.NewInbound(),
 			httpTransport.NewInbound(":0"),
 		},
-		Logger: zap.NewNop(),
+		ZapLogger: zap.NewNop(),
 	})
 }
 

--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func basicDispatcher(t *testing.T) *Dispatcher {
@@ -47,6 +48,7 @@ func basicDispatcher(t *testing.T) *Dispatcher {
 			tchannelTransport.NewInbound(),
 			httpTransport.NewInbound(":0"),
 		},
+		Logger: zap.NewNop(),
 	})
 }
 


### PR DESCRIPTION
This PR builds upon #940 and completes more of T841919. It exposes the logging
middleware (introduced in several earlier PRs) to users by exporting the
`Logger` field of YARPC's configuration struct.

To complete YARPC's initial request logging integration, a follow-on PR will
alter our internal init framework to populate the logger field.