### PR TITLE
mapdecode: Add support for field hooks

### DIFF
--- a/internal/mapdecode/CHANGELOG.md
+++ b/internal/mapdecode/CHANGELOG.md
@@ -4,6 +4,8 @@ Releases
 v0.2.0 (unreleased)
 -------------------
 
+-   Added `FieldHook` to intercept values before they are decoded into specific
+    struct fields.
 -   Decode now parses strings if they are found in place of a float, boolean,
     or integer.
 

--- a/internal/mapdecode/decode_test.go
+++ b/internal/mapdecode/decode_test.go
@@ -323,6 +323,19 @@ func TestFieldHook(t *testing.T) {
 			want: myStruct{YAMLField: "bar"},
 		},
 		{
+			desc:     "field name override all caps",
+			give:     map[string]interface{}{"YAMLKEY": "foo"},
+			giveOpts: []Option{YAML()},
+			setupHook: func(h *mockFieldHook) {
+				h.Expect(_typeOfEmptyInterface, structField{
+					Name: "YAMLField",
+					Type: typeOfString,
+					Tag:  `yaml:"yamlKey"`,
+				}, reflectEq{"foo"}).Return(valueOf("bar"), nil)
+			},
+			want: myStruct{YAMLField: "bar"},
+		},
+		{
 			desc: "hook errors",
 			give: map[string]interface{}{
 				"someInt":          1,

--- a/internal/mapdecode/decode_test.go
+++ b/internal/mapdecode/decode_test.go
@@ -22,9 +22,12 @@ package mapdecode
 
 import (
 	"errors"
+	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -233,4 +236,235 @@ func TestDecode(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFieldHook(t *testing.T) {
+	type myStruct struct {
+		SomeInt          int
+		SomeString       string
+		PtrToPtrToString **string
+
+		YAMLField string `yaml:"yamlKey"`
+
+		unexportedField string
+	}
+
+	typeOfInt := reflect.TypeOf(0)
+	typeOfString := reflect.TypeOf("hi")
+	typeOfPtrPtrString := reflect.PtrTo(reflect.PtrTo(typeOfString))
+
+	tests := []struct {
+		desc      string
+		setupHook func(*mockFieldHook)
+		give      interface{}
+		giveOpts  []Option // options besides FieldHook
+
+		want       myStruct
+		wantErrors []string
+	}{
+		{
+			desc: "not a map",
+			give: []interface{}{
+				map[string]interface{}{"a": 1},
+				map[string]interface{}{"b": 2},
+			},
+			wantErrors: []string{"expected a map, got 'slice'"},
+		},
+		{
+			desc:       "wrong map key",
+			give:       map[int]interface{}{1: "a"},
+			wantErrors: []string{"needs a map with string keys, has 'int' keys"},
+		},
+		{
+			desc: "string key",
+			give: map[string]interface{}{},
+		},
+		{
+			desc: "interface{} key",
+			give: map[interface{}]interface{}{},
+		},
+		{
+			desc: "unexported field",
+			give: map[string]string{"unexportedField": "hi"},
+		},
+		{
+			desc: "in-place updates",
+			give: map[string]interface{}{
+				"someInt":          1,
+				"PtrToPtrToString": "hello",
+			},
+			setupHook: func(h *mockFieldHook) {
+				h.Expect(_typeOfEmptyInterface, structField{
+					Name: "SomeInt",
+					Type: typeOfInt,
+				}, reflectEq{1}).Return(valueOf(42), nil)
+
+				h.Expect(_typeOfEmptyInterface, structField{
+					Name: "PtrToPtrToString",
+					Type: typeOfPtrPtrString,
+				}, reflectEq{"hello"}).Return(valueOf("world"), nil)
+			},
+			want: myStruct{
+				SomeInt:          42,
+				PtrToPtrToString: ptrToPtrToString("world"),
+			},
+		},
+		{
+			desc:     "field name override",
+			give:     map[string]interface{}{"yamlKey": "foo"},
+			giveOpts: []Option{YAML()},
+			setupHook: func(h *mockFieldHook) {
+				h.Expect(_typeOfEmptyInterface, structField{
+					Name: "YAMLField",
+					Type: typeOfString,
+					Tag:  `yaml:"yamlKey"`,
+				}, reflectEq{"foo"}).Return(valueOf("bar"), nil)
+			},
+			want: myStruct{YAMLField: "bar"},
+		},
+		{
+			desc: "hook errors",
+			give: map[string]interface{}{
+				"someInt":          1,
+				"PtrToPtrToString": "hello",
+			},
+			setupHook: func(h *mockFieldHook) {
+				h.Expect(_typeOfEmptyInterface, structField{
+					Name: "SomeInt",
+					Type: typeOfInt,
+				}, reflectEq{1}).Return(reflect.Value{}, errors.New("great sadness"))
+
+				h.Expect(_typeOfEmptyInterface, structField{
+					Name: "PtrToPtrToString",
+					Type: typeOfPtrPtrString,
+				}, reflectEq{"hello"}).Return(reflect.Value{}, errors.New("more sadness"))
+			},
+			wantErrors: []string{
+				`error reading into field "SomeInt": great sadness`,
+				`error reading into field "PtrToPtrToString": more sadness`,
+			},
+		},
+		{
+			desc: "type changing updates",
+			give: map[string]int{
+				"SomeInt":    42,
+				"someString": 3,
+			},
+			setupHook: func(h *mockFieldHook) {
+				h.Expect(typeOfInt, structField{
+					Name: "SomeInt",
+					Type: typeOfInt,
+				}, reflectEq{42}).Return(reflect.ValueOf(100), nil)
+
+				h.Expect(typeOfInt, structField{
+					Name: "SomeString",
+					Type: typeOfString,
+				}, reflectEq{3}).Return(reflect.ValueOf("hello"), nil)
+			},
+			want: myStruct{SomeInt: 100, SomeString: "hello"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			mockHook := newMockFieldHook(mockCtrl)
+			if tt.setupHook != nil {
+				tt.setupHook(mockHook)
+			}
+
+			var dest myStruct
+			err := Decode(
+				&dest, tt.give,
+				append(tt.giveOpts, FieldHook(mockHook.Hook()))...)
+
+			if len(tt.wantErrors) == 0 {
+				require.NoError(t, err, "expected success")
+				assert.Equal(t, tt.want, dest, "result mismatch")
+				return
+			}
+
+			require.Error(t, err, "expected error")
+			for _, msg := range tt.wantErrors {
+				assert.Contains(t, err.Error(), msg)
+			}
+		})
+	}
+}
+
+// mockFieldHook is a mock to control a function with the signature,
+//
+// 	func(reflect.Type, reflect.StructField, reflect.Value) (reflect.Value, error)
+//
+// Expectations may be set on this function with the Expect function.
+type mockFieldHook struct{ c *gomock.Controller }
+
+func newMockFieldHook(ctrl *gomock.Controller) *mockFieldHook {
+	return &mockFieldHook{c: ctrl}
+}
+
+// Hook returns the FieldHookFunc backed by this mock.
+func (m *mockFieldHook) Hook() FieldHookFunc {
+	return FieldHookFunc(m.Call)
+}
+
+// Expect sets up a call expectation on the hook.
+func (m *mockFieldHook) Expect(from, to, data interface{}) *gomock.Call {
+	return m.c.RecordCall(m, "Call", from, to, data)
+}
+
+func (m *mockFieldHook) Call(from reflect.Type, to reflect.StructField, data reflect.Value) (reflect.Value, error) {
+	results := m.c.Call(m, "Call", from, to, data)
+	out := results[0].(reflect.Value)
+	err, _ := results[1].(error)
+	return out, err
+}
+
+func ptrToPtrToString(s string) **string {
+	p := &s
+	return &p
+}
+
+func valueOf(x interface{}) reflect.Value {
+	return reflect.ValueOf(x)
+}
+
+// structField is a gomock.Matcher that matches a StructField with the given
+// parameters.
+type structField struct {
+	Name string
+	Type reflect.Type
+	Tag  string
+}
+
+func (m structField) String() string {
+	return fmt.Sprintf("StructField{Name: %q, Type: %v}", m.Name, m.Type)
+}
+
+func (m structField) Matches(x interface{}) bool {
+	s, ok := x.(reflect.StructField)
+	if !ok {
+		return false
+	}
+
+	return s.Name == m.Name && s.Type == m.Type && string(s.Tag) == m.Tag
+}
+
+// reflectEq is a gomock.Matcher that matches a reflect.Value whose underlying
+// value matches the given value.
+type reflectEq struct{ Value interface{} }
+
+func (m reflectEq) String() string {
+	return fmt.Sprintf("equal to %#v", m.Value)
+}
+
+func (m reflectEq) Matches(x interface{}) bool {
+	v, ok := x.(reflect.Value)
+	if !ok {
+		return false
+	}
+
+	return reflect.DeepEqual(m.Value, v.Interface())
 }

--- a/internal/mapdecode/hooks.go
+++ b/internal/mapdecode/hooks.go
@@ -221,7 +221,7 @@ func fieldHook(opts *options) reflectHook {
 
 			// Field name override was specified.
 			tagParts := strings.Split(structField.Tag.Get(opts.TagName), ",")
-			if len(tagParts) > 0 && tagParts[0] != "" {
+			if tagParts[0] != "" {
 				fieldName = tagParts[0]
 			}
 

--- a/internal/mapdecode/hooks.go
+++ b/internal/mapdecode/hooks.go
@@ -217,6 +217,11 @@ func fieldHook(opts *options) reflectHook {
 				continue
 			}
 
+			// This field resolution logic is adapted from mapstructure's own
+			// logic.
+			//
+			// See https://github.com/mitchellh/mapstructure/blob/53818660ed4955e899c0bcafa97299a388bd7c8e/mapstructure.go#L741
+
 			fieldName := structField.Name
 
 			// Field name override was specified.

--- a/internal/mapdecode/hooks.go
+++ b/internal/mapdecode/hooks.go
@@ -211,7 +211,7 @@ func fieldHook(opts *options) reflectHook {
 		var errors []error
 		for i := 0; i < to.NumField(); i++ {
 			structField := to.Field(i)
-			if structField.PkgPath != "" {
+			if structField.PkgPath != "" && !structField.Anonymous {
 				// This field is not exported so we won't be able to decode
 				// into it.
 				continue

--- a/internal/mapdecode/hooks.go
+++ b/internal/mapdecode/hooks.go
@@ -24,12 +24,22 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/mitchellh/mapstructure"
+	"go.uber.org/multierr"
 )
 
-var _typeOfDuration = reflect.TypeOf(time.Duration(0))
+var (
+	_typeOfDuration       = reflect.TypeOf(time.Duration(0))
+	_typeOfEmptyInterface = reflect.TypeOf((*interface{})(nil)).Elem()
+)
+
+// FieldHookFunc is a hook called while decoding a specific struct field. It
+// receives the source type, information about the target field, and the
+// source data.
+type FieldHookFunc func(from reflect.Type, to reflect.StructField, data reflect.Value) (reflect.Value, error)
 
 // reflectHook is similar to mapstructure's decode hooks except it operates on
 // the reflected values rather than interface{}.
@@ -174,4 +184,125 @@ func strconvHook(from, to reflect.Type, data reflect.Value) (reflect.Value, erro
 	}
 
 	return data, nil
+}
+
+// fieldHook applies the user-specified FieldHookFunc to all struct fields.
+func fieldHook(opts *options) reflectHook {
+	hook := opts.FieldHook
+	return func(from, to reflect.Type, data reflect.Value) (reflect.Value, error) {
+		if to.Kind() != reflect.Struct || from.Kind() != reflect.Map {
+			return data, nil
+		}
+
+		// We can only decode map[string]* and map[interface{}]* into structs.
+		if k := from.Key().Kind(); k != reflect.String && k != reflect.Interface {
+			return data, nil
+		}
+
+		// This map tracks type-changing updates to items in the map.
+		//
+		// If the source map has a rigid type for values (map[string]string
+		// rather than map[string]interface{}), we can't make replacements to
+		// values in-place if a hook changed the type of a value. So we will
+		// make a copy of the source map with a more liberal type and inject
+		// these updates into the copy.
+		updates := make(map[interface{}]interface{})
+
+		var errors []error
+		for i := 0; i < to.NumField(); i++ {
+			structField := to.Field(i)
+			if structField.PkgPath != "" {
+				// This field is not exported so we won't be able to decode
+				// into it.
+				continue
+			}
+
+			fieldName := structField.Name
+
+			// Field name override was specified.
+			tagParts := strings.Split(structField.Tag.Get(opts.TagName), ",")
+			if len(tagParts) > 0 && tagParts[0] != "" {
+				fieldName = tagParts[0]
+			}
+
+			// Get the value for this field from the source map, if any.
+			key := reflect.ValueOf(fieldName)
+			value := data.MapIndex(key)
+			if !value.IsValid() {
+				// Case-insensitive linear search if the name doesn't match
+				// as-is.
+				for _, kV := range data.MapKeys() {
+					// Kind() == Interface if map[interface{}]* so we use
+					// Interface().(string) to handle interface{} and string
+					// keys.
+					k, ok := kV.Interface().(string)
+					if !ok {
+						continue
+					}
+
+					if strings.EqualFold(k, fieldName) {
+						key = kV
+						value = data.MapIndex(kV)
+						break
+					}
+				}
+			}
+
+			if !value.IsValid() {
+				// No value specified for this field in source map.
+				continue
+			}
+
+			newValue, err := hook(value.Type(), structField, value)
+			if err != nil {
+				errors = append(errors, fmt.Errorf(
+					"error reading into field %q: %v", fieldName, err))
+				continue
+			}
+
+			if newValue == value {
+				continue
+			}
+
+			// If we can, assign in-place.
+			if newValue.Type().AssignableTo(value.Type()) {
+				// XXX(abg): Is it okay to make updates to the source map?
+				data.SetMapIndex(key, newValue)
+			} else {
+				updates[key.Interface()] = newValue.Interface()
+			}
+		}
+
+		if len(errors) > 0 {
+			return data, multierr.Combine(errors...)
+		}
+
+		// No more changes to make.
+		if len(updates) == 0 {
+			return data, nil
+		}
+
+		// Equivalent to,
+		//
+		// 	newData := make(map[$key]interface{})
+		// 	for k, v := range data {
+		// 		if newV, ok := updates[k]; ok {
+		// 			newData[k] = newV
+		// 		} else {
+		// 			newData[k] = v
+		// 		}
+		// 	}
+		newData := reflect.MakeMap(reflect.MapOf(from.Key(), _typeOfEmptyInterface))
+		for _, key := range data.MapKeys() {
+			var value reflect.Value
+			if v, ok := updates[key.Interface()]; ok {
+				value = reflect.ValueOf(v)
+			} else {
+				value = data.MapIndex(key)
+			}
+			newData.SetMapIndex(key, value)
+		}
+
+		return newData, nil
+	}
 }


### PR DESCRIPTION
Field hooks are called while decoding maps into structs with information
about the field being decoded into and the value being decoded. Field
hooks can return a different value to affect later decode steps.

We will use this to implement opt-in interpolation for fields tagged in
a certain way.