### PR TITLE
config: Interpolate fields tagged with interpolate

### DIFF
--- a/x/config/configurator.go
+++ b/x/config/configurator.go
@@ -27,7 +27,6 @@ import (
 	"io/ioutil"
 
 	"go.uber.org/yarpc"
-	"go.uber.org/yarpc/internal/mapdecode"
 
 	"go.uber.org/multierr"
 	"gopkg.in/yaml.v2"
@@ -170,7 +169,7 @@ func (c *Configurator) LoadConfigFromYAML(serviceName string, r io.Reader) (yarp
 // expected to conform to.
 func (c *Configurator) LoadConfig(serviceName string, data interface{}) (yarpc.Config, error) {
 	var cfg yarpcConfig
-	if err := mapdecode.Decode(&cfg, data, _mapdecodeOpts...); err != nil {
+	if err := decodeInto(&cfg, data); err != nil {
 		return yarpc.Config{}, err
 	}
 	return c.load(serviceName, &cfg)

--- a/x/config/decode.go
+++ b/x/config/decode.go
@@ -27,10 +27,6 @@ import (
 	"go.uber.org/yarpc/internal/mapdecode"
 )
 
-var _mapdecodeOpts = []mapdecode.Option{
-	mapdecode.TagName("config"),
-}
-
 type attributeMap map[string]interface{}
 
 func (m attributeMap) PopString(name string) (s string, err error) {
@@ -57,7 +53,7 @@ func (m attributeMap) Get(name string, dst interface{}) (ok bool, err error) {
 		return ok, nil
 	}
 
-	err = mapdecode.Decode(dst, v, _mapdecodeOpts...)
+	err = decodeInto(dst, v)
 	if err != nil {
 		err = fmt.Errorf("failed to read attribute %q: %v", name, v)
 	}
@@ -65,7 +61,7 @@ func (m attributeMap) Get(name string, dst interface{}) (ok bool, err error) {
 }
 
 func (m attributeMap) Decode(dst interface{}) error {
-	return mapdecode.Decode(dst, m, _mapdecodeOpts...)
+	return decodeInto(dst, m)
 }
 
 type yarpcConfig struct {

--- a/x/config/mapdecode.go
+++ b/x/config/mapdecode.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package config
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+
+	"go.uber.org/yarpc/internal/interpolate"
+	"go.uber.org/yarpc/internal/mapdecode"
+)
+
+const (
+	_tagName           = "config"
+	_interpolateOption = "interpolate"
+)
+
+func decodeInto(dst, src interface{}) error {
+	return mapdecode.Decode(dst, src,
+		mapdecode.TagName(_tagName),
+		mapdecode.FieldHook(interpolateHook))
+}
+
+func interpolateHook(from reflect.Type, to reflect.StructField, data reflect.Value) (reflect.Value, error) {
+	shouldInterpolate := false
+
+	options := strings.Split(to.Tag.Get(_tagName), ",")[1:]
+	for _, option := range options {
+		if option == _interpolateOption {
+			shouldInterpolate = true
+			break
+		}
+	}
+
+	if !shouldInterpolate {
+		return data, nil
+	}
+
+	// Use Interface().(string) so that we handle the case where data is an
+	// interface{} holding a string.
+	v, ok := data.Interface().(string)
+	if !ok {
+		// Cannot interpolate non-string type. This shouldn't be an error
+		// because an integer field may be marked as interpolatable and may
+		// have received an integer as expected.
+		return data, nil
+	}
+
+	s, err := interpolate.Parse(v)
+	if err != nil {
+		return data, fmt.Errorf("failed to parse %q for interpolation: %v", v, err)
+	}
+
+	newV, err := s.Render(os.LookupEnv)
+	if err != nil {
+		return data, fmt.Errorf("failed to render %q with environment variables: %v", v, err)
+	}
+
+	return reflect.ValueOf(newV), nil
+}

--- a/x/config/mapdecode_test.go
+++ b/x/config/mapdecode_test.go
@@ -1,0 +1,208 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInterpolateHook(t *testing.T) {
+	type someStruct struct {
+		SomeString   string        `config:",interpolate"`
+		SomeInt      int           `config:",interpolate"`
+		SomeFloat    float32       `config:",interpolate"`
+		SomeDuration time.Duration `config:",interpolate"`
+
+		Key string `config:"name,interpolate"`
+
+		// We don't support interpolation for lists and maps yet.
+		SomeMap  map[string]string `config:",interpolate"`
+		SomeList []string          `config:",interpolate"`
+
+		// Uninterpolated fields
+		AnotherString string
+	}
+
+	tests := []struct {
+		desc string
+		give interface{}
+		env  map[string]string
+
+		want       someStruct
+		wantErrors []string
+	}{
+		{
+			desc: "bad string",
+			give: map[string]interface{}{
+				"someString": "hello ${NAME:world",
+			},
+			wantErrors: []string{`failed to parse "hello ${NAME:world" for interpolation`},
+		},
+		{
+			desc: "bad string uninterpolated field",
+			give: map[string]interface{}{
+				"anotherString": "hello ${NAME:world",
+			},
+			want: someStruct{AnotherString: "hello ${NAME:world"},
+		},
+		{
+			desc: "missing variable",
+			give: map[string]interface{}{"someString": "hello ${NAME}"},
+			wantErrors: []string{
+				`failed to render "hello ${NAME}" with environment variables`,
+			},
+		},
+		{
+			desc: "string",
+			give: map[string]interface{}{
+				"someString": "hello ${NAME:world}",
+			},
+			env:  map[string]string{"NAME": "foo"},
+			want: someStruct{SomeString: "hello foo"},
+		},
+		{
+			desc: "string default",
+			give: map[string]interface{}{
+				"someString": "hello ${NAME:world}",
+			},
+			want: someStruct{SomeString: "hello world"},
+		},
+		{
+			desc: "int",
+			give: map[string]interface{}{"someInt": "12${FOO:}5"},
+			env:  map[string]string{"FOO": "34"},
+			want: someStruct{SomeInt: 12345},
+		},
+		{
+			desc: "int default",
+			give: map[string]interface{}{"someInt": "12${FOO:}5"},
+			want: someStruct{SomeInt: 125},
+		},
+		{
+			desc: "float",
+			give: map[string]interface{}{"SOMEFLOAT": "12${BAR:}.${BAZ:0}"},
+			env:  map[string]string{"BAR": "34", "BAZ": "56"},
+			want: someStruct{SomeFloat: 1234.56},
+		},
+		{
+			desc: "float default",
+			give: map[string]interface{}{"SOMEFLOAT": "12${BAR:}.${BAZ:0}"},
+			want: someStruct{SomeFloat: 12},
+		},
+		{
+			desc: "duration",
+			give: map[string]interface{}{"someDuration": "5${UNIT:s}"},
+			env:  map[string]string{"UNIT": "m"},
+			want: someStruct{SomeDuration: 5 * time.Minute},
+		},
+		{
+			desc: "duration default",
+			give: map[string]interface{}{"someDuration": "5${UNIT:s}"},
+			want: someStruct{SomeDuration: 5 * time.Second},
+		},
+		{
+			desc: "name override",
+			give: map[string]interface{}{"name": "foo ${BAR:baz}"},
+			env:  map[string]string{"BAR": "foo"},
+			want: someStruct{Key: "foo foo"},
+		},
+		{
+			desc: "name override default",
+			give: map[string]interface{}{"name": "foo ${BAR:baz}"},
+			want: someStruct{Key: "foo baz"},
+		},
+		{
+			desc: "uninterpolated field",
+			give: map[string]interface{}{"AnotherString": "hello ${NAME}"},
+			env:  map[string]string{"NAME": "world"},
+			want: someStruct{AnotherString: "hello ${NAME}"},
+		},
+		{
+			desc: "map",
+			give: map[string]interface{}{
+				"someMap": map[string]interface{}{
+					"foo": "${BAR}",
+					"baz": "${QUX}",
+				},
+			},
+			env: map[string]string{
+				"BAR": "foo",
+				"QUX": "baz",
+			},
+			want: someStruct{
+				SomeMap: map[string]string{
+					"foo": "${BAR}",
+					"baz": "${QUX}",
+				},
+			},
+		},
+		{
+			desc: "list",
+			give: map[string]interface{}{
+				"someList": []interface{}{
+					"foo",
+					"${BAR}",
+					"baz",
+					"${QUX}",
+				},
+			},
+			env: map[string]string{
+				"BAR": "foo",
+				"QUX": "baz",
+			},
+			want: someStruct{
+				SomeList: []string{
+					"foo",
+					"${BAR}",
+					"baz",
+					"${QUX}",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			for key, value := range tt.env {
+				restore := setenv(t, key, value)
+				defer restore()
+			}
+
+			var dest someStruct
+			err := decodeInto(&dest, tt.give)
+
+			if len(tt.wantErrors) > 0 {
+				require.Error(t, err)
+				for _, msg := range tt.wantErrors {
+					assert.Contains(t, err.Error(), msg)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, dest)
+		})
+	}
+}

--- a/x/config/spec.go
+++ b/x/config/spec.go
@@ -107,6 +107,8 @@ import (
 // 		- host: anotherhost
 // 		  port: 8080
 //
+// Customizing Field Names
+//
 // If a field name differs from the name of the field inside the
 // configuration data, a `config` tag may be added to the struct to specify a
 // different name.
@@ -119,6 +121,38 @@ import (
 //
 // 	myinbound:
 // 	  peer: foo
+//
+// Environment Variables
+//
+// In addition to specifying the field name, the `config` tag may also include
+// an `interpolate` option to request interpolation from environment variables
+// present in the provided value at decode time. This option may be applied to
+// primitive types (strings, integers, booleans, floats, and time.Duration)
+// only.
+//
+// For example in,
+//
+// 	type MyInboundConfig struct {
+// 		QueueName string `config:"queue,interpolate"`
+// 		Timeout time.Duration `config:",interpolate"`
+// 		// If the name is left empty, the default name is used.
+// 	}
+//
+// The values for both QueueName and Timeout may contain strings in the form
+// ${NAME} to be replaced with the value of that environment variable. The
+// form ${NAME:default} may be used to provide a default value if the
+// environment variable is not set.
+//
+// 	myinbound:
+// 	  queue: inbound-requests-${STAGE:dev}
+// 	  timeout: ${REQUEST_TIMEOUT:5s}
+//
+// The above states that the queue inbound-requests-dev should be used by
+// default, but if the STAGE environment variable is set, the queue
+// inbound-requests-${STAGE} should be used. Similarly, it also states that a
+// timeout of 5 seconds should be used by default, unless the REQUEST_TIMEOUT
+// environment variable is set in which case the timeout specified in the
+// environment variable should be used.
 type TransportSpec struct {
 	// Name of the transport
 	Name string


### PR DESCRIPTION
This adds supports to x/config for including values from environment
variables while decoding if the target struct field is tagged with the
`interpolate` option.

In,

    type config struct {
        Address string `config:",interpolate"`
    }

Strings in the form `${FOO}` or `${FOO:bar}` will be interpolated using
internal/interpolate with environment variables being used to resolve
variables.

Depends on #942