### PR TITLE
Fix peer retain/release order when stop/stop binder.

### DIFF
--- a/peer/bind.go
+++ b/peer/bind.go
@@ -95,11 +95,11 @@ func (c *BoundChooser) Stop() error {
 func (c *BoundChooser) stop() error {
 	var errs error
 
-	if err := c.chooser.Stop(); err != nil {
+	if err := c.binding.Stop(); err != nil {
 		errs = multierr.Append(errs, err)
 	}
 
-	if err := c.binding.Stop(); err != nil {
+	if err := c.chooser.Stop(); err != nil {
 		errs = multierr.Append(errs, err)
 	}
 

--- a/peer/bind_test.go
+++ b/peer/bind_test.go
@@ -27,6 +27,8 @@ import (
 	"go.uber.org/yarpc/api/peer/peertest"
 	. "go.uber.org/yarpc/peer"
 	"go.uber.org/yarpc/peer/hostport"
+	"go.uber.org/yarpc/peer/x/peerheap"
+	"go.uber.org/yarpc/yarpctest"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -69,4 +71,23 @@ func TestBind(t *testing.T) {
 
 	list.EXPECT().IsRunning().Return(false)
 	assert.Equal(t, false, chooser.IsRunning(), "chooser should not be running")
+}
+
+func TestBindRealList(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	transport := yarpctest.NewFakeTransport()
+	list := peerheap.New(transport)
+
+	chooser := Bind(list, BindPeers([]peer.Identifier{
+		hostport.PeerIdentifier("x"),
+		hostport.PeerIdentifier("y"),
+	}))
+
+	assert.False(t, chooser.IsRunning(), "chooser should not be running")
+	assert.NoError(t, chooser.Start(), "start without error")
+	assert.True(t, chooser.IsRunning(), "chooser should be running")
+	assert.NoError(t, chooser.Stop(), "start without error")
+	assert.False(t, chooser.IsRunning(), "chooser should not be running")
 }

--- a/yarpctest/fake.go
+++ b/yarpctest/fake.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpctest
+
+// This file provides fake implementations of most YARPC building blocks for
+// the purpose of testing configuration using custom transports, choosers, and
+// binders..
+
+import (
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/api/transport"
+	intsync "go.uber.org/yarpc/internal/sync"
+	"go.uber.org/yarpc/peer/hostport"
+)
+
+// NewFakeTransport returns a fake transport.
+func NewFakeTransport() *FakeTransport {
+	return &FakeTransport{
+		Lifecycle: intsync.NewNopLifecycle(),
+	}
+}
+
+// FakeTransport is a fake transport.
+type FakeTransport struct {
+	transport.Lifecycle
+}
+
+// RetainPeer returns a fake peer.
+func (t *FakeTransport) RetainPeer(id peer.Identifier, ps peer.Subscriber) (peer.Peer, error) {
+	return &FakePeer{id: id.(hostport.PeerIdentifier)}, nil
+}
+
+// ReleasePeer does nothing.
+func (t *FakeTransport) ReleasePeer(id peer.Identifier, ps peer.Subscriber) error {
+	return nil
+}
+
+// FakePeer is a fake peer with an identifier.
+type FakePeer struct {
+	id hostport.PeerIdentifier
+}
+
+// Identifier returns the fake peer identifier.
+func (p *FakePeer) Identifier() string {
+	return string(p.id)
+}
+
+// Status returns the fake peer status.
+func (p *FakePeer) Status() peer.Status {
+	return peer.Status{
+		ConnectionStatus:    peer.Available,
+		PendingRequestCount: 0,
+	}
+}
+
+// StartRequest does nothing.
+func (p *FakePeer) StartRequest() {
+}
+
+// EndRequest does nothing.
+func (p *FakePeer) EndRequest() {
+}


### PR DESCRIPTION
This change addresses a bug in the peer.BindPeers implementation, since peer lists are sensitive to the order in which they are started and stopped. The peer list releases all known peers when it is stopped. The peer list updater then releases them again, inciting a cryptic "deadline exceeded" error.

This fix reverse the order of stopping the bound list and updater. When you start the binding, it starts the list then the list updater. When you stop the binding, it stops the updater *first* and then the list, ensuring that the peers have not been wiped before it is stopped.

To further harden this system, peer lists should also become more resilient by separating the retained peer identifiers from the actually retained peers, so that it's more flexible about whether peers are retained while it's running. We should also walk back that context deadline in the peer list—that was a mistake.

This change also introduces a fake transport, which I’m developing as a more flexible alternative to mocks in the outbound peer list configuration tests. There will be more to come and this is the subset of what I wrote that is relevant for this test alone.