### PR TITLE
pally: Add no-op metric implementations

### DIFF
--- a/internal/pally/nop.go
+++ b/internal/pally/nop.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package pally
+
+import "time"
+
+// NewNopCounter returns a no-op Counter.
+func NewNopCounter() Counter { return nop{} }
+
+// NewNopCounterVector returns a no-op CounterVector.
+func NewNopCounterVector() CounterVector { return nopCounterVec{} }
+
+// NewNopGauge returns a no-op Gauge.
+func NewNopGauge() Gauge { return nop{} }
+
+// NewNopGaugeVector returns a no-op GaugeVector.
+func NewNopGaugeVector() GaugeVector { return nopGaugeVec{} }
+
+// NewNopLatencies returns a no-op Latencies.
+func NewNopLatencies() Latencies { return nop{} }
+
+// NewNopLatenciesVector returns a no-op LatenciesVector.
+func NewNopLatenciesVector() LatenciesVector { return nopLatenciesVec{} }
+
+type nop struct{}
+
+func (nop) Inc() int64              { return 0 }
+func (nop) Dec() int64              { return 0 }
+func (nop) Add(_ int64) int64       { return 0 }
+func (nop) Sub(_ int64) int64       { return 0 }
+func (nop) Store(_ int64)           {}
+func (nop) Load() int64             { return 0 }
+func (nop) Observe(_ time.Duration) {}
+
+type nopCounterVec struct{}
+
+func (nopCounterVec) Get(...string) (Counter, error) { return nop{}, nil }
+func (nopCounterVec) MustGet(...string) Counter      { return nop{} }
+
+type nopGaugeVec struct{}
+
+func (nopGaugeVec) Get(...string) (Gauge, error) { return nop{}, nil }
+func (nopGaugeVec) MustGet(...string) Gauge      { return nop{} }
+
+type nopLatenciesVec struct{}
+
+func (nopLatenciesVec) Get(...string) (Latencies, error) { return nop{}, nil }
+func (nopLatenciesVec) MustGet(...string) Latencies      { return nop{} }

--- a/internal/pally/nop_test.go
+++ b/internal/pally/nop_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package pally
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNopCounter(t *testing.T) {
+	assertNopCounter(t, NewNopCounter())
+}
+
+func TestNopCounterVector(t *testing.T) {
+	vec := NewNopCounterVector()
+	c, err := vec.Get("foo", "bar")
+	require.NoError(t, err, "Failed Get from no-op CounterVector.")
+	assert.NotPanics(t, func() { vec.MustGet("foo", "bar") }, "Failed MustGet from no-op CounterVector.")
+	assertNopCounter(t, c)
+}
+
+func TestNopGauge(t *testing.T) {
+	assertNopGauge(t, NewNopGauge())
+}
+
+func TestNopGaugeVector(t *testing.T) {
+	vec := NewNopGaugeVector()
+	g, err := vec.Get("foo", "bar")
+	require.NoError(t, err, "Failed Get from no-op GaugeVector.")
+	assert.NotPanics(t, func() { vec.MustGet("foo", "bar") }, "Failed MustGet from no-op GaugeVector.")
+	assertNopGauge(t, g)
+}
+
+func TestNopLatencies(t *testing.T) {
+	assertNopLatencies(t, NewNopLatencies())
+}
+
+func TestNopLatenciesVector(t *testing.T) {
+	vec := NewNopLatenciesVector()
+	lat, err := vec.Get("foo", "bar")
+	require.NoError(t, err, "Failed Get from no-op LatenciesVector.")
+	assert.NotPanics(t, func() { vec.MustGet("foo", "bar") }, "Failed MustGet from no-op LatenciesVector.")
+	assertNopLatencies(t, lat)
+}
+
+func assertNopCounter(t testing.TB, c Counter) {
+	assert.Equal(t, int64(0), c.Add(42), "Unexpected result from no-op Add.")
+	assert.Equal(t, int64(0), c.Inc(), "Unexpected result from no-op Inc.")
+	assert.Equal(t, int64(0), c.Load(), "Unexpected result from no-op Load.")
+}
+
+func assertNopGauge(t testing.TB, g Gauge) {
+	g.Store(42)
+	assert.Equal(t, int64(0), g.Add(42), "Unexpected result from no-op Add.")
+	assert.Equal(t, int64(0), g.Sub(1), "Unexpected result from no-op Sub.")
+	assert.Equal(t, int64(0), g.Inc(), "Unexpected result from no-op Inc.")
+	assert.Equal(t, int64(0), g.Dec(), "Unexpected result from no-op Dec.")
+	assert.Equal(t, int64(0), g.Load(), "Unexpected result from no-op Load.")
+}
+
+func assertNopLatencies(t testing.TB, lat Latencies) {
+	assert.NotPanics(
+		t,
+		func() { NewNopLatencies().Observe(time.Second) },
+		"Unexpected panic using no-op latencies.",
+	)
+}


### PR DESCRIPTION
For metrics collection middleware to gracefully handle errors constructing
metrics, we'll want fallback no-op implementations of the Pally interfaces.

Relevant to T841911.