### PR TITLE
config: Make VariableResolver injectable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ v1.8.0 (unreleased)
 
 -   x/config: The service name is no longer part of the configuration and must
     be passed as an argument to the `LoadConfig*` or `NewDispatcher*` methods.
+-   x/config: Configuration structures may now annotate primitive fields with
+    `config:",interpolate"` to support reading environment variables in them.
+    See the `TransportSpec` documentation for more information.
 -   Options `thrift.Multiplexed` and `thrift.Enveloped` may now be provided for
     Thrift clients constructed by `yarpc.InjectClients` by adding a `thrift`
     tag to the corresponding struct field with the name of the option. See the

--- a/x/config/configurator.go
+++ b/x/config/configurator.go
@@ -52,7 +52,7 @@ type Configurator struct {
 // against it using the RegisterTransport, RegisterChooser, and RegisterBinder
 // functions.
 func New(opts ...Option) *Configurator {
-	c := Configurator{
+	c := &Configurator{
 		knownTransports: make(map[string]*compiledTransportSpec),
 		knownChoosers:   make(map[string]*compiledChooserSpec),
 		knownBinders:    make(map[string]*compiledBinderSpec),
@@ -60,10 +60,10 @@ func New(opts ...Option) *Configurator {
 	}
 
 	for _, opt := range opts {
-		opt(&c)
+		opt(c)
 	}
 
-	return &c
+	return c
 }
 
 // RegisterTransport registers a TransportSpec with the given Configurator. An

--- a/x/config/configurator.go
+++ b/x/config/configurator.go
@@ -25,8 +25,10 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 
 	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/internal/interpolate"
 
 	"go.uber.org/multierr"
 	"gopkg.in/yaml.v2"
@@ -41,6 +43,7 @@ type Configurator struct {
 	knownTransports map[string]*compiledTransportSpec
 	knownChoosers   map[string]*compiledChooserSpec
 	knownBinders    map[string]*compiledBinderSpec
+	resolver        interpolate.VariableResolver
 }
 
 // New sets up a new empty Configurator. The returned Configurator does not
@@ -48,12 +51,19 @@ type Configurator struct {
 // Individual TransportSpecs, ChooserSpecs, and BinderSpecs must be registered
 // against it using the RegisterTransport, RegisterChooser, and RegisterBinder
 // functions.
-func New() *Configurator {
-	return &Configurator{
+func New(opts ...Option) *Configurator {
+	c := Configurator{
 		knownTransports: make(map[string]*compiledTransportSpec),
 		knownChoosers:   make(map[string]*compiledChooserSpec),
 		knownBinders:    make(map[string]*compiledBinderSpec),
+		resolver:        os.LookupEnv,
 	}
+
+	for _, opt := range opts {
+		opt(&c)
+	}
+
+	return &c
 }
 
 // RegisterTransport registers a TransportSpec with the given Configurator. An
@@ -195,7 +205,7 @@ func (c *Configurator) NewDispatcher(serviceName string, data interface{}) (*yar
 }
 
 func (c *Configurator) load(serviceName string, cfg *yarpcConfig) (_ yarpc.Config, err error) {
-	b := newBuilder(serviceName, &Kit{name: serviceName, c: c})
+	b := newBuilder(serviceName, &Kit{name: serviceName, c: c}, c.resolver)
 
 	for _, inbound := range cfg.Inbounds {
 		if e := c.loadInboundInto(b, inbound); e != nil {

--- a/x/config/configurator_test.go
+++ b/x/config/configurator_test.go
@@ -21,7 +21,6 @@
 package config
 
 import (
-	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -40,18 +39,6 @@ func TestConfiguratorRegisterTransportMissingName(t *testing.T) {
 	err := New().RegisterTransport(TransportSpec{})
 	require.Error(t, err, "expected failure")
 	assert.Contains(t, err.Error(), "name is required")
-}
-
-func setenv(t *testing.T, key, value string) (restore func()) {
-	oldValue, ok := os.LookupEnv(key)
-	require.NoError(t, os.Setenv(key, value))
-	return func() {
-		if ok {
-			os.Setenv(key, oldValue)
-		} else {
-			os.Unsetenv(key)
-		}
-	}
 }
 
 func TestConfigurator(t *testing.T) {
@@ -1099,12 +1086,7 @@ func TestConfigurator(t *testing.T) {
 			defer mockCtrl.Finish()
 
 			tt := tc.test(t, mockCtrl)
-			cfg := New()
-
-			for key, value := range tt.env {
-				restore := setenv(t, key, value)
-				defer restore()
-			}
+			cfg := New(InterpolationResolver(mapVariableResolver(tt.env)))
 
 			if tt.specs != nil {
 				for _, spec := range tt.specs {

--- a/x/config/decode.go
+++ b/x/config/decode.go
@@ -60,8 +60,8 @@ func (m attributeMap) Get(name string, dst interface{}) (ok bool, err error) {
 	return true, err
 }
 
-func (m attributeMap) Decode(dst interface{}) error {
-	return decodeInto(dst, m)
+func (m attributeMap) Decode(dst interface{}, opts ...mapdecode.Option) error {
+	return decodeInto(dst, m, opts...)
 }
 
 type yarpcConfig struct {

--- a/x/config/option.go
+++ b/x/config/option.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package config
+
+// Option customizes a Configurator.
+type Option func(*Configurator)
+
+// InterpolationResolver changes how interpolated variables in the
+// configuration are resolved. By default, environment variables are used.
+//
+// Variables will be interpolated using this function if a parsed
+// field inside a configuration structure was annotated with
+// config:",interpolate" or config:"$name,interpolate" where $name is encoded
+// name of that field.
+//
+// See TransportSpec documentation for more information.
+func InterpolationResolver(f func(k string) (v string, ok bool)) Option {
+	return func(c *Configurator) {
+		c.resolver = f
+	}
+}


### PR DESCRIPTION
Instead of always using `os.LookupEnv`, `config.New` now accepts an
option to customize the resolver.

This also allows us to stop setting environment variables in tests.