### PR TITLE
errors: Expose UnrecognizedProcedure behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ v1.8.0 (unreleased)
     Thrift package documentation for more details.
 -   Fixed a bug where the TChannel inbound would not write the response headers
     if the response body was empty.
+-   Adds support for the `UnrecognizedProcedureError` error and error checker,
+    indicating that the router was unable to find a handler for the request.
 
 
 v1.7.1 (2017-03-29)

--- a/api/transport/errors.go
+++ b/api/transport/errors.go
@@ -49,3 +49,17 @@ func IsTimeoutError(err error) bool {
 	_, ok := err.(errors.TimeoutError)
 	return ok
 }
+
+// UnrecognizedProcedureError returns an error for the given request,
+// such that IsUnrecognizedProcedureError can distinguish it from other errors
+// coming out of router.Choose.
+func UnrecognizedProcedureError(req *Request) error {
+	return errors.RouterUnrecognizedProcedureError(req.Service, req.Procedure)
+}
+
+// IsUnrecognizedProcedureError returns true for errors returned by
+// Router.Choose if the router cannot find a handler for the request.
+func IsUnrecognizedProcedureError(err error) bool {
+	_, ok := err.(errors.UnrecognizedProcedureError)
+	return ok
+}

--- a/internal/errors/router.go
+++ b/internal/errors/router.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package errors
+
+import "fmt"
+
+// UnrecognizedProcedureError indicates that a request could not be handled locally because
+// the router contained no handler for the request.
+type UnrecognizedProcedureError interface {
+	error
+
+	unrecognizedProcedureError()
+}
+
+// RouterUnrecognizedProcedureError returns an error indicating that the router
+// could find no corresponding handler for the request.
+func RouterUnrecognizedProcedureError(service, procedure string) error {
+	return unrecognizedProcedureError{
+		Service:   service,
+		Procedure: procedure,
+	}
+}
+
+// unrecognizedProcedureError is a failure to process a request because the
+// procedure and/or service name was unrecognized.
+type unrecognizedProcedureError struct {
+	Service   string
+	Procedure string
+}
+
+func (unrecognizedProcedureError) unrecognizedProcedureError() {}
+
+func (e unrecognizedProcedureError) Error() string {
+	return fmt.Sprintf(`unrecognized procedure %q for service %q`, e.Procedure, e.Service)
+}
+
+// AsHandlerError for unrecognizedProcedureError.
+func (e unrecognizedProcedureError) AsHandlerError() HandlerError {
+	return HandlerBadRequestError(e)
+}

--- a/internal/errors/transport.go
+++ b/internal/errors/transport.go
@@ -92,22 +92,6 @@ func AsHandlerError(service, procedure string, err error) error {
 	}
 }
 
-// UnrecognizedProcedureError is a failure to process a request because the
-// procedure and/or service name was unrecognized.
-type UnrecognizedProcedureError struct {
-	Service   string
-	Procedure string
-}
-
-func (e UnrecognizedProcedureError) Error() string {
-	return fmt.Sprintf(`unrecognized procedure %q for service %q`, e.Procedure, e.Service)
-}
-
-// AsHandlerError for UnrecognizedProcedureError.
-func (e UnrecognizedProcedureError) AsHandlerError() HandlerError {
-	return HandlerBadRequestError(e)
-}
-
 // ProcedureFailedError is a failure to execute a procedure due to an
 // unexpected error.
 type ProcedureFailedError struct {

--- a/router.go
+++ b/router.go
@@ -25,7 +25,6 @@ import (
 	"sort"
 
 	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/internal/errors"
 )
 
 var (
@@ -84,7 +83,8 @@ func (m MapRouter) Procedures() []transport.Procedure {
 }
 
 // Choose retrives the HandlerSpec for the service and procedure noted on the
-// transport request, or returns an error.
+// transport request, or returns an unrecognized procedure error (testable with
+// transport.IsUnrecognizedProcedureError(err)).
 func (m MapRouter) Choose(ctx context.Context, req *transport.Request) (transport.HandlerSpec, error) {
 	service, procedure := req.Service, req.Procedure
 	if service == "" {
@@ -99,10 +99,7 @@ func (m MapRouter) Choose(ctx context.Context, req *transport.Request) (transpor
 		return procedure.HandlerSpec, nil
 	}
 
-	return transport.HandlerSpec{}, errors.UnrecognizedProcedureError{
-		Service:   service,
-		Procedure: procedure,
-	}
+	return transport.HandlerSpec{}, transport.UnrecognizedProcedureError(req)
 }
 
 type proceduresByServiceProcedure []transport.Procedure


### PR DESCRIPTION
This change surfaces transport.UnrecognizedProcedureError(req) and transport.IsUnrecognizedProcedureError(err)

Fixes #902