### PR TITLE
peer: Export and expose peer updater for tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,10 @@ v1.8.0 (unreleased)
     if the response body was empty.
 -   Adds support for the `UnrecognizedProcedureError` error and error checker,
     indicating that the router was unable to find a handler for the request.
--   `peer.Bind` returns a `peer.BoundChooser`. This type is now public for
-    verifying the type of a peer chooser in tests. It also has public
-    `ChooserList` and `Updater` methods for verifying the underlying bound peer
-    list and peer list updater.
--   `peer.BindPeers` returns a `peer.PeersUpdater`. The `PeersUpdater` type
-    is now public for verifying the type of a peer chooser in tests.
+-   `peer.Bind` returns a `*peer.BoundChooser`.  The `BoundChooser` type is now
+    public.
+-   `peer.BindPeers` returns a `*peer.PeersUpdater`.  The `PeersUpdater` type
+    is now public.
 
 
 v1.7.1 (2017-03-29)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ v1.8.0 (unreleased)
     if the response body was empty.
 -   Adds support for the `UnrecognizedProcedureError` error and error checker,
     indicating that the router was unable to find a handler for the request.
+-   `peer.Bind` returns a `peer.BoundChooser`. This type is now public for
+    verifying the type of a peer chooser in tests. It also has public
+    `ChooserList` and `Updater` methods for verifying the underlying bound peer
+    list and peer list updater.
+-   `peer.BindPeers` returns a `peer.PeersUpdater`. The `PeersUpdater` type
+    is now public for verifying the type of a peer chooser in tests.
 
 
 v1.7.1 (2017-03-29)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ v1.7.0 (2017-03-20)
     capturing the lifecycle of its dependencies.
 -   Adds a peer.ChooserList interface to the API, for convenience when passing
     instances with both capabilities (suitable for outbounds, suitable for peer
-    providers).
+    list updaters).
 
 
 v1.6.0 (2017-03-08)
@@ -341,7 +341,7 @@ v1.0.0-rc3 (2016-12-09)
     strings are not `peer.Chooser` instances.
 
     This version introduces support for peer choosers, peer lists, and peer
-    providers for HTTP outbounds. This is made possible by the above
+    list updaters for HTTP outbounds. This is made possible by the above
     change that introduces a concrete instance of a Transport for each
     protocol, which deduplicates peer instances across all inbounds and
     outbounds, making connection sharing and load balancing possible,

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ gRPC transport, a Protobuf encoding, and a round robin peer chooser.
 YARPC for Go plans to provide a load balancer that uses
 a least-pending-requests strategy.
 Peer choosers can implement any strategy, including load balancing or sharding,
-in turn backed by a pluggable peer provider.
+in turn bound to any peer list updater, like an address file watcher.
 
 Regardless of transport, every RPC has some common properties: caller name,
 service name, procedure name, encoding name, deadline or TTL, headers, baggage
@@ -218,9 +218,9 @@ TODO
 - routing delegate (route by tenancy baggage)
 - handle-or-forward (route by shard key)
 - transport bridge (http to tchannel)
-- custom peer chooser (sharding)
-- custom peer list (round robin for example)
-- custom peer provider (dns srv records)
+- custom peer chooser-list (sharding)
+- custom peer chooser-list (round robin for example)
+- custom peer list updater (dns srv records)
 -->
 
 ## Development Status: Stable

--- a/api/peer/doc.go
+++ b/api/peer/doc.go
@@ -24,21 +24,23 @@
 // The `go.uber.org/yarpc/peer` package tree provides the corresponding
 // implementations.
 //
-// Some transports support the notion of peers.
+// Outbounds for some transports support selecting a different peer from a peer
+// list for each individual request, for example load balancers and for pinning
+// requests to a consistent peer.
 // A peer instance models the host and port of a remote listening socket for a
 // particular transport protocol, like HTTP and TChannel.
 // For example, YARPC might have a TChannel peer instance to track connections
 // to 127.0.0.1:4040.
 //
-// Some transports, like HTTP and TChannel support peer selection on their outbounds.
-// A `peer.Chooser` allows an outbound to obtain a peer for a given context and
-// request, and also manages the lifecycle of all components it needs to do so.
+// Some transports, like HTTP and TChannel support peer selection on their
+// outbounds.  A `peer.Chooser` allows an outbound to obtain a peer for a given
+// request and also manages the lifecycle of all components it uses.
 // A peer chooser is typically also a `peer.List`, thus a `peer.ChooserList`.
 //
 // Peer list updaters send `Update` message to a `peer.List` to add and remove
-// tracked peer identifiers.
+// peers.
 // Peer list updaters have no specific interface, but must in practice
-// implement `transport.Lifecycle` to bound when they start and stop sending
+// implement `transport.Lifecycle` to bookend when they start and stop sending
 // updates.
 // A `peer.Binder` is a function that binds a `peer.List` to a peer list
 // updater and returns the `transport.Lifecycle` of the peer list updater.

--- a/api/peer/doc.go
+++ b/api/peer/doc.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package peer contains interfaces pertaining to peers, peer lists, peer list
+// updaters, and generally how to choose a peer for an outbound request.
+//
+// The `go.uber.org/yarpc/peer` package tree provides the corresponding
+// implementations.
+//
+// Some transports support the notion of peers.
+// A peer instance models the host and port of a remote listening socket for a
+// particular transport protocol, like HTTP and TChannel.
+// For example, YARPC might have a TChannel peer instance to track connections
+// to 127.0.0.1:4040.
+//
+// Some transports, like HTTP and TChannel support peer selection on their outbounds.
+// A `peer.Chooser` allows an outbound to obtain a peer for a given context and
+// request, and also manages the lifecycle of all components it needs to do so.
+// A peer chooser is typically also a `peer.List`, thus a `peer.ChooserList`.
+//
+// Peer list updaters send `Update` message to a `peer.List` to add and remove
+// tracked peer identifiers.
+// Peer list updaters have no specific interface, but must in practice
+// implement `transport.Lifecycle` to bound when they start and stop sending
+// updates.
+// A `peer.Binder` is a function that binds a `peer.List` to a peer list
+// updater and returns the `transport.Lifecycle` of the peer list updater.
+//
+// Not all `transport.Transport` instances support peer lists.
+// To support peer selection, they must also implement `peer.Transport`, which
+// has the `RetainPeer` and `ReleasePeer` methods, so a peer list can
+// hold strong references to peers maintained by a transport, and receive
+// notifications when peers start connecting, become available, become
+// unavailable, and when their pending request count changes.
+//
+// A peer list must provide a `peer.Subscriber` for each peer it retains or
+// releases.
+// The subscriber may be the peer list itself, though most peer lists contain
+// an internal representation of each of their retained peers for book-keeping
+// and sorting which benefits from receiving notifications for state changes
+// directly.
+package peer

--- a/api/peer/errors.go
+++ b/api/peer/errors.go
@@ -91,7 +91,7 @@ func (e ErrInvalidTransportConversion) Error() string {
 	return fmt.Sprintf("cannot convert transport (%v) to type %s", e.Transport, e.ExpectedType)
 }
 
-// ErrPeerAddAlreadyInList is returned to peer providers if the
+// ErrPeerAddAlreadyInList is returned to peer list updater if the
 // peerlist is already tracking a peer for the added identifier
 type ErrPeerAddAlreadyInList string
 
@@ -99,7 +99,7 @@ func (e ErrPeerAddAlreadyInList) Error() string {
 	return fmt.Sprintf("can't add peer %q because is already in peerlist", string(e))
 }
 
-// ErrPeerRemoveNotInList is returned to peer providers if the peerlist
+// ErrPeerRemoveNotInList is returned to peer list updater if the peerlist
 // is not tracking the peer to remove for a given identifier
 type ErrPeerRemoveNotInList string
 

--- a/api/peer/list.go
+++ b/api/peer/list.go
@@ -35,9 +35,9 @@ type Chooser interface {
 	Choose(context.Context, *transport.Request) (peer Peer, onFinish func(error), err error)
 }
 
-// List listens to adds and removes of Peers from a PeerProvider
+// List listens to adds and removes of Peers from a peer list updater.
 // A Chooser will implement the List interface in order to receive
-// updates to the list of Peers it is keeping track of
+// updates to the list of Peers it is keeping track of.
 type List interface {
 	// Update performs the additions and removals to the Peer List
 	Update(updates ListUpdates) error
@@ -60,10 +60,11 @@ type ListUpdates struct {
 }
 
 // Binder is a callback for peer.Bind that accepts a peer list and binds it to
-// a peer provider for the duration of the returned lifecycle.
-// The lifecycle that the binder returns should start and stop binding peers to
-// the list.
-// The binder must not block on updating the list, because that will typically
-// block until the peer list has started. The binder must arrange for
-// the first list update to occur when the returned lifecycle starts.
+// a peer list updater for the duration of the returned peer list updater.
+// The peer list updater must implement the lifecycle interface, and start and
+// stop updates over that lifecycle.
+// The binder must not block on updating the list, because update may block
+// until the peer list has started.
+// The binder must return a peer list updater that will begin updating when it
+// starts, and stop updating when it stops.
 type Binder func(List) transport.Lifecycle

--- a/doc.go
+++ b/doc.go
@@ -37,7 +37,7 @@
 // YARPC for Go plans to provide a Protobuf 3 encoding, a gRPC transport, and a
 // load balancer that uses a least-pending-requests strategy.
 // Peer choosers can implement any strategy, including load balancing or sharding,
-// in turn backed by a pluggable peer provider.
+// in turn bound to any peer list updater.
 //
 // Regardless of transport, every RPC has some common properties: caller name,
 // service name, procedure name, encoding name, deadline or TTL, headers,

--- a/peer/doc.go
+++ b/peer/doc.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package peer contains components for managing peers.
+//
+// The `go.uber.org/yarpc/api/peer` package provides the corresponding
+// interfaces that these components implement.
+//
+// The HTTP and TChannel `NewOutbound` methods accept a `peer.Chooser`.
+// To bind an outbound to a single peer, pass a `peer.NewSingle(id)`.
+//
+// To bind an outbound to multiple peers, you will need a peer list, like
+// `roundrobin` (to pick the least recently chosen peer) or `peerheap` (to
+// choose the peer with the fewest pending requests).
+// Assuming you choose `peerheap`, to bind multiple peers you would pass
+// `peer.Bind(peerheap.New(transport), peer.BindPeers(ids))`.
+//
+// Each transport can define its own domain of peer identifiers, but most will
+// use a host:port address for the remote listening socket.
+// The `"go.uber.org/yarpc/peer/hostport"` package implements the common
+// `hostport.PeerIdentifier` and `hostport.Peer`.
+package peer

--- a/peer/x/peerheap/list.go
+++ b/peer/x/peerheap/list.go
@@ -104,8 +104,8 @@ func New(transport peer.Transport, opts ...HeapOption) *List {
 	}
 }
 
-// Update satisfies the peer.List interface, so a peer provider can manage the
-// retained peers.
+// Update satisfies the peer.List interface, so a peer list updater can manage
+// the retained peers.
 func (pl *List) Update(updates peer.ListUpdates) error {
 	ctx, cancel := context.WithTimeout(context.Background(), pl.startupWait)
 	defer cancel()


### PR DESCRIPTION
This change updates documentation, makes peer.PeersUpdater public (static peer list that adds peers on start and removes peers on stop), and exposes ChooserList() and Updater() on peer.BoundChooser so we can make assertions about how a chooser has been configured in upcoming test cases.