### PR TITLE
Add support for PeerListConfig

### DIFF
--- a/internal/whitespace/expand.go
+++ b/internal/whitespace/expand.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package whitespace
+
+import "strings"
+
+// Expand converts leading tabs to two spaces, such that YAML accepts the whole
+// block.
+func Expand(s string) string {
+	lines := strings.Split(s, "\n")
+	for i, l := range lines {
+		lines[i] = expandLine(l)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func expandLine(l string) string {
+	for i, c := range l {
+		if c != '\t' {
+			return strings.Repeat("  ", i) + l[i:]
+		}
+	}
+	return ""
+}

--- a/peer/x/roundrobin/config.go
+++ b/peer/x/roundrobin/config.go
@@ -18,49 +18,36 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package config
+package roundrobin
 
 import (
-	"reflect"
-	"sort"
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/x/config"
 )
 
-// Kit carries internal dependencies for building peer lists.
-// The kit gets threaded through transport, outbound, and inbound builders
-// so they can thread the kit through functions like BuildPeerList on a
-// PeerListConfig.
-type Kit struct {
-	c *Configurator
-
-	name string
-}
-
-// ServiceName returns the name of the service for which components are being
-// built.
-func (k *Kit) ServiceName() string { return k.name }
-
-var _typeOfKit = reflect.TypeOf((*Kit)(nil))
-
-func (k *Kit) peerListSpec(name string) *compiledPeerListSpec {
-	return k.c.knownPeerLists[name]
-}
-
-func (k *Kit) peerListSpecNames() (names []string) {
-	for name := range k.c.knownPeerLists {
-		names = append(names, name)
+// Spec returns a configuration specification for the round-robin peer list
+// implementation, making it possible to select the least recently chosen peer
+// with transports that use outbound peer list configuration (like HTTP).
+//
+//  cfg := config.New()
+//  cfg.MustRegisterPeerList(roundrobin.Spec())
+//
+// This enables the round-robin peer list:
+//
+//  outbounds:
+//    otherservice:
+//      unary:
+//        http:
+//          url: https://host:port/rpc
+//          round-robin:
+//            peers:
+//              - 127.0.0.1:8080
+//              - 127.0.0.1:8081
+func Spec() config.PeerListSpec {
+	return config.PeerListSpec{
+		Name: "round-robin",
+		BuildPeerList: func(c struct{}, t peer.Transport, k *config.Kit) (peer.ChooserList, error) {
+			return New(t), nil
+		},
 	}
-	sort.Strings(names)
-	return
-}
-
-func (k *Kit) peerListUpdaterSpec(name string) *compiledPeerListUpdaterSpec {
-	return k.c.knownPeerListUpdaters[name]
-}
-
-func (k *Kit) peerListUpdaterSpecNames() (names []string) {
-	for name := range k.c.knownPeerListUpdaters {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	return
 }

--- a/x/config/builder.go
+++ b/x/config/builder.go
@@ -119,14 +119,14 @@ func (b *builder) Build() (yarpc.Config, error) {
 		if o := c.Unary; o != nil {
 			ob.Unary, err = buildUnaryOutbound(o.Value, transports[o.Transport], b.kit)
 			if err != nil {
-				errs = multierr.Append(errs, err)
+				errs = multierr.Append(errs, fmt.Errorf(`failed to configure unary outbound for %q: %v`, ccname, err))
 				continue
 			}
 		}
 		if o := c.Oneway; o != nil {
 			ob.Oneway, err = buildOnewayOutbound(o.Value, transports[o.Transport], b.kit)
 			if err != nil {
-				errs = multierr.Append(errs, err)
+				errs = multierr.Append(errs, fmt.Errorf(`failed to configure oneway outbound for %q: %v`, ccname, err))
 				continue
 			}
 		}

--- a/x/config/chooser.go
+++ b/x/config/chooser.go
@@ -1,0 +1,173 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package config
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"go.uber.org/yarpc/api/peer"
+	peerbind "go.uber.org/yarpc/peer"
+)
+
+// PeerList facilitates decoding and building peer choosers.
+// The peer chooser combines a peer list (for the peer selection strategy, like
+// least-pending or round-robin) with a peer list binder (like static peers or
+// dynamic peers from DNS or watching a file in a particular format).
+type PeerList struct {
+	peerListConfig
+}
+
+// peerListConfig is the private representation of PeerList that captures
+// decoded configuration without revealing it on the public type.
+type peerListConfig struct {
+	Peer string       `config:"peer,interpolate"`
+	Etc  attributeMap `config:",squash"`
+}
+
+// BuildPeerList translates a chooser configuration into a peer chooser, backed
+// by a peer list bound to a peer list binder.
+func (pc PeerList) BuildPeerList(transport peer.Transport, identify func(string) peer.Identifier, kit *Kit) (peer.Chooser, error) {
+	c := pc.peerListConfig
+	// Establish a peer selection strategy.
+
+	// Special case for single-peer outbounds.
+	if c.Peer != "" {
+
+		if len(c.Etc) > 0 {
+			return nil, fmt.Errorf("unrecognized attributes in peer list config: %+v", c.Etc)
+		}
+
+		return peerbind.NewSingle(identify(c.Peer), transport), nil
+	}
+
+	// All multi-peer choosers may combine a peer list (for sharding or
+	// load-balancing) and a peer list updater.
+
+	// Find a property name that corresponds to a peer chooser/list and construct it.
+	for peerListName := range c.Etc {
+		peerListSpec := kit.peerListSpec(peerListName)
+		if peerListSpec == nil {
+			continue
+		}
+
+		var peerListUpdaterConfig attributeMap
+		if _, err := c.Etc.Pop(peerListName, &peerListUpdaterConfig); err != nil {
+			return nil, err
+		}
+
+		peerListUpdater, err := buildPeerListUpdater(peerListUpdaterConfig, identify, kit)
+		if err != nil {
+			return nil, err
+		}
+
+		chooserBuilder, err := peerListSpec.PeerList.Decode(c.Etc)
+		if err != nil {
+			return nil, err
+		}
+
+		result, err := chooserBuilder.Build(transport, kit)
+		if err != nil {
+			return nil, err
+		}
+
+		peerList := result.(peer.ChooserList)
+
+		return peerbind.Bind(peerList, peerListUpdater), nil
+	}
+
+	return nil, fmt.Errorf(
+		"no recognized peer list in config: got %s; need one of %s",
+		strings.Join(c.names(), ", "),
+		strings.Join(kit.peerListSpecNames(), ", "),
+	)
+}
+
+func (c peerListConfig) names() (names []string) {
+	for name := range c.Etc {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return
+}
+
+func buildPeerListUpdater(c attributeMap, identify func(string) peer.Identifier, kit *Kit) (peer.Binder, error) {
+	var peers []string
+	_, err := c.Pop("peers", &peers)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(peers) > 0 {
+
+		if len(c) > 0 {
+			return nil, fmt.Errorf("unrecognized attributes in peer list config: %+v", c)
+		}
+
+		return peerbind.BindPeers(identifyAll(identify, peers)), nil
+	}
+
+	for peerListUpdaterName := range c {
+		peerListUpdaterSpec := kit.peerListUpdaterSpec(peerListUpdaterName)
+		if peerListUpdaterSpec == nil {
+			continue
+		}
+
+		// This decodes all attributes on the peer list updater block, including
+		// the field with the name of the peer list updater.
+		peerListUpdaterBuilder, err := peerListUpdaterSpec.PeerListUpdater.Decode(c)
+		if err != nil {
+			return nil, err
+		}
+
+		result, err := peerListUpdaterBuilder.Build(kit)
+		if err != nil {
+			return nil, err
+		}
+
+		binder := result.(peer.Binder)
+
+		return binder, nil
+	}
+
+	return nil, fmt.Errorf(
+		"no recognized peer list updater in config: got %s; need one of %s",
+		strings.Join(configNames(c), ", "),
+		strings.Join(kit.peerListUpdaterSpecNames(), ", "),
+	)
+}
+
+func configNames(c attributeMap) (names []string) {
+	for name := range c {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return
+}
+
+func identifyAll(identify func(string) peer.Identifier, peers []string) []peer.Identifier {
+	pids := make([]peer.Identifier, len(peers))
+	for i, peer := range peers {
+		pids[i] = identify(peer)
+	}
+	return pids
+}

--- a/x/config/configurator_test.go
+++ b/x/config/configurator_test.go
@@ -28,6 +28,7 @@ import (
 
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport/transporttest"
+	"go.uber.org/yarpc/internal/whitespace"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -74,7 +75,7 @@ func TestConfigurator(t *testing.T) {
 		{
 			desc: "unknown inbound",
 			test: func(*testing.T, *gomock.Controller) (tt testCase) {
-				tt.give = expand(`
+				tt.give = whitespace.Expand(`
 					inbounds:
 						bar: {}
 				`)
@@ -88,7 +89,7 @@ func TestConfigurator(t *testing.T) {
 		{
 			desc: "unknown implicit outbound",
 			test: func(*testing.T, *gomock.Controller) (tt testCase) {
-				tt.give = expand(`
+				tt.give = whitespace.Expand(`
 					outbounds:
 						myservice:
 							http: {url: "http://localhost:8080/yarpc"}
@@ -103,7 +104,7 @@ func TestConfigurator(t *testing.T) {
 		{
 			desc: "unknown unary outbound",
 			test: func(*testing.T, *gomock.Controller) (tt testCase) {
-				tt.give = expand(`
+				tt.give = whitespace.Expand(`
 					outbounds:
 						someservice:
 							unary:
@@ -120,7 +121,7 @@ func TestConfigurator(t *testing.T) {
 		{
 			desc: "unknown oneway outbound",
 			test: func(*testing.T, *gomock.Controller) (tt testCase) {
-				tt.give = expand(`
+				tt.give = whitespace.Expand(`
 					outbounds:
 						keyvalue:
 							oneway:
@@ -139,7 +140,7 @@ func TestConfigurator(t *testing.T) {
 				type fooTransportConfig struct{ Items []int }
 
 				tt.serviceName = "foo"
-				tt.give = expand(`
+				tt.give = whitespace.Expand(`
 					transports:
 						bar:
 							items: [1, 2, 3]
@@ -162,7 +163,7 @@ func TestConfigurator(t *testing.T) {
 				type transportConfig struct{ KeepAlive time.Duration }
 				type inboundConfig struct{ Address string }
 
-				tt.give = expand(`
+				tt.give = whitespace.Expand(`
 					inbounds:
 						http: {address: ":80"}
 					transports:
@@ -191,7 +192,7 @@ func TestConfigurator(t *testing.T) {
 			test: func(t *testing.T, mockCtrl *gomock.Controller) (tt testCase) {
 				type inboundConfig struct{ Address string }
 				tt.serviceName = "myservice"
-				tt.give = expand(`
+				tt.give = whitespace.Expand(`
 					inbounds:
 						http: {address: ":80"}
 				`)
@@ -225,7 +226,7 @@ func TestConfigurator(t *testing.T) {
 		{
 			desc: "inbounds unsupported",
 			test: func(t *testing.T, mockCtrl *gomock.Controller) (tt testCase) {
-				tt.give = expand(`
+				tt.give = whitespace.Expand(`
 					inbounds:
 						outgoing-only:
 							foo: bar
@@ -248,7 +249,7 @@ func TestConfigurator(t *testing.T) {
 			test: func(t *testing.T, mockCtrl *gomock.Controller) (tt testCase) {
 				type inboundConfig struct{ Address string }
 				tt.serviceName = "foo"
-				tt.give = expand(`
+				tt.give = whitespace.Expand(`
 					inbounds:
 						http:
 							address: ":8080"
@@ -297,7 +298,7 @@ func TestConfigurator(t *testing.T) {
 			test: func(t *testing.T, mockCtrl *gomock.Controller) (tt testCase) {
 				type inboundConfig struct{ Address string }
 				tt.serviceName = "foo"
-				tt.give = expand(`
+				tt.give = whitespace.Expand(`
 					inbounds:
 						http:
 							disabled: true
@@ -339,7 +340,7 @@ func TestConfigurator(t *testing.T) {
 			desc: "inbound error",
 			test: func(t *testing.T, mockCtrl *gomock.Controller) (tt testCase) {
 				tt.serviceName = "foo"
-				tt.give = expand(`
+				tt.give = whitespace.Expand(`
 					inbounds:
 						foo:
 							unexpected: bar
@@ -362,7 +363,7 @@ func TestConfigurator(t *testing.T) {
 		{
 			desc: "implicit outbound no support",
 			test: func(t *testing.T, mockCtrl *gomock.Controller) (tt testCase) {
-				tt.give = expand(`
+				tt.give = whitespace.Expand(`
 					outbounds:
 						myservice:
 							sink:
@@ -385,7 +386,7 @@ func TestConfigurator(t *testing.T) {
 			test: func(t *testing.T, mockCtrl *gomock.Controller) (tt testCase) {
 				type outboundConfig struct{ Address string }
 				tt.serviceName = "foo"
-				tt.give = expand(`
+				tt.give = whitespace.Expand(`
 					outbounds:
 						bar:
 							tchannel:
@@ -430,7 +431,7 @@ func TestConfigurator(t *testing.T) {
 				type transportConfig struct{ Address string }
 				type outboundConfig struct{ Queue string }
 				tt.serviceName = "foo"
-				tt.give = expand(`
+				tt.give = whitespace.Expand(`
 					outbounds:
 						bar:
 							redis:
@@ -480,7 +481,7 @@ func TestConfigurator(t *testing.T) {
 				type transportConfig struct{ KeepAlive time.Duration }
 				type outboundConfig struct{ URL string }
 				tt.serviceName = "foo"
-				tt.give = expand(`
+				tt.give = whitespace.Expand(`
 					outbounds:
 						baz:
 							http:
@@ -533,7 +534,7 @@ func TestConfigurator(t *testing.T) {
 			desc: "implicit outbound error",
 			test: func(t *testing.T, mockCtrl *gomock.Controller) (tt testCase) {
 				type outboundConfig struct{ URL string }
-				tt.give = expand(`
+				tt.give = whitespace.Expand(`
 					outbounds:
 						qux:
 							http:
@@ -569,7 +570,7 @@ func TestConfigurator(t *testing.T) {
 				)
 
 				tt.serviceName = "myservice"
-				tt.give = expand(`
+				tt.give = whitespace.Expand(`
 					transports:
 						http:
 							keepAlive: 5m
@@ -655,7 +656,7 @@ func TestConfigurator(t *testing.T) {
 			desc: "explicit unary error",
 			test: func(t *testing.T, mockCtrl *gomock.Controller) (tt testCase) {
 				type outboundConfig struct{ URL string }
-				tt.give = expand(`
+				tt.give = whitespace.Expand(`
 					outbounds:
 						hello:
 							unary:
@@ -686,7 +687,7 @@ func TestConfigurator(t *testing.T) {
 			desc: "explicit oneway error",
 			test: func(t *testing.T, mockCtrl *gomock.Controller) (tt testCase) {
 				type outboundConfig struct{ Address string }
-				tt.give = expand(`
+				tt.give = whitespace.Expand(`
 					outbounds:
 						hello:
 							oneway:
@@ -714,7 +715,7 @@ func TestConfigurator(t *testing.T) {
 			desc: "explicit unary not supported",
 			test: func(t *testing.T, mockCtrl *gomock.Controller) (tt testCase) {
 				type outboundConfig struct{ Queue string }
-				tt.give = expand(`
+				tt.give = whitespace.Expand(`
 					outbounds:
 						bar:
 							unary:
@@ -740,7 +741,7 @@ func TestConfigurator(t *testing.T) {
 			desc: "explicit oneway not supported",
 			test: func(t *testing.T, mockCtrl *gomock.Controller) (tt testCase) {
 				type outboundConfig struct{ Address string }
-				tt.give = expand(`
+				tt.give = whitespace.Expand(`
 					outbounds:
 						bar:
 							oneway:
@@ -767,7 +768,7 @@ func TestConfigurator(t *testing.T) {
 			test: func(t *testing.T, mockCtrl *gomock.Controller) (tt testCase) {
 				type outboundConfig struct{ URL string }
 				tt.serviceName = "foo"
-				tt.give = expand(`
+				tt.give = whitespace.Expand(`
 					outbounds:
 						bar:
 							http:
@@ -849,7 +850,7 @@ func TestConfigurator(t *testing.T) {
 				}
 
 				tt.serviceName = "foo"
-				tt.give = expand(`
+				tt.give = whitespace.Expand(`
 					transports:
 						redis:
 							serverAddress: ${REDIS_ADDRESS}:${REDIS_PORT}
@@ -898,7 +899,7 @@ func TestConfigurator(t *testing.T) {
 				}
 
 				tt.serviceName = "hi"
-				tt.give = expand(`
+				tt.give = whitespace.Expand(`
 					inbounds:
 						http:
 							port: 1${HTTP_PORT}
@@ -937,7 +938,7 @@ func TestConfigurator(t *testing.T) {
 				}
 
 				tt.serviceName = "foo"
-				tt.give = expand(`
+				tt.give = whitespace.Expand(`
 					inbounds:
 						http:
 							port: 80
@@ -975,7 +976,7 @@ func TestConfigurator(t *testing.T) {
 				}
 
 				tt.serviceName = "hi"
-				tt.give = expand(`
+				tt.give = whitespace.Expand(`
 					inbounds:
 						http:
 							address: :${HTTP_PORT
@@ -1006,7 +1007,7 @@ func TestConfigurator(t *testing.T) {
 				}
 
 				tt.serviceName = "hi"
-				tt.give = expand(`
+				tt.give = whitespace.Expand(`
 					inbounds:
 						http:
 							address: :${HTTP_PORT}
@@ -1037,7 +1038,7 @@ func TestConfigurator(t *testing.T) {
 				}
 
 				tt.serviceName = "foo"
-				tt.give = expand(`
+				tt.give = whitespace.Expand(`
 					inbounds:
 						http:
 							timeout: ${TIMEOUT}

--- a/x/config/spec.go
+++ b/x/config/spec.go
@@ -530,7 +530,7 @@ func compilePeerListUpdaterSpec(spec *PeerListUpdaterSpec) (*compiledPeerListUpd
 		return nil, errors.New("BuildPeerListUpdater is required")
 	}
 
-	buildPeerListUpdater, err := compilePeerListUpdaterConfig(spec.BuildPeerListUpdater)
+	buildPeerListUpdater, err := compilePeerListUpdaterConfig(spec.Name, spec.BuildPeerListUpdater)
 	if err != nil {
 		return nil, err
 	}
@@ -539,7 +539,7 @@ func compilePeerListUpdaterSpec(spec *PeerListUpdaterSpec) (*compiledPeerListUpd
 	return &out, nil
 }
 
-func compilePeerListUpdaterConfig(build interface{}) (*configSpec, error) {
+func compilePeerListUpdaterConfig(name string, build interface{}) (*configSpec, error) {
 	v := reflect.ValueOf(build)
 	t := v.Type()
 
@@ -551,8 +551,6 @@ func compilePeerListUpdaterConfig(build interface{}) (*configSpec, error) {
 		err = fmt.Errorf("must accept exactly two arguments, found %v", t.NumIn())
 	case !isDecodable(t.In(0)):
 		err = fmt.Errorf("must accept a struct or struct pointer as its first argument, found %v", t.In(0))
-	// TODO additionally, the peer list updater config struct must have a field
-	// with the name of the peer list updater.
 	case t.In(1) != _typeOfKit:
 		err = fmt.Errorf("must accept a %v as its second argument, found %v", _typeOfKit, t.In(1))
 	case t.NumOut() != 2:

--- a/x/config/util_for_test.go
+++ b/x/config/util_for_test.go
@@ -22,7 +22,6 @@ package config
 
 import (
 	"reflect"
-	"strings"
 
 	"github.com/golang/mock/gomock"
 )
@@ -65,22 +64,4 @@ func builderFunc(c *gomock.Controller, o interface{}, name string, argTypes []re
 			return callResults
 		},
 	).Interface()
-}
-
-// converts leading tabs to two spaces, such that YAML accepts the whole block.
-func expand(s string) string {
-	lines := strings.Split(s, "\n")
-	for i, l := range lines {
-		lines[i] = expandLine(l)
-	}
-	return strings.Join(lines, "\n")
-}
-
-func expandLine(l string) string {
-	for i, c := range l {
-		if c != '\t' {
-			return strings.Repeat("  ", i) + l[i:]
-		}
-	}
-	return ""
 }

--- a/yarpctest/fake_config.go
+++ b/yarpctest/fake_config.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpctest
+
+import (
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/peer/hostport"
+	"go.uber.org/yarpc/x/config"
+)
+
+// FakeTransportConfig configures the FakeTransport.
+type FakeTransportConfig struct {
+	Address string `config:"address"`
+}
+
+func buildFakeTransport(c *FakeTransportConfig, kit *config.Kit) (transport.Transport, error) {
+	return NewFakeTransport(FakeTransportAddress(c.Address)), nil
+}
+
+// FakeOutboundConfig configures the FakeOutbound.
+type FakeOutboundConfig struct {
+	Pattern string                `config:"pattern"`
+	Choose  config.PeerListConfig `config:"choose"`
+}
+
+func buildFakeOutbound(c *FakeOutboundConfig, t transport.Transport, kit *config.Kit) (transport.UnaryOutbound, error) {
+	x := t.(*FakeTransport)
+	chooser, err := c.Choose.BuildChooser(x, hostport.Identify, kit)
+	if err != nil {
+		return nil, err
+	}
+	return x.NewOutbound(chooser, Pattern(c.Pattern)), nil
+}
+
+// FakeTransportSpec returns a configurator spec for the fake-transport
+// transport type, suitable for passing to Configurator.MustRegisterTransport.
+func FakeTransportSpec() config.TransportSpec {
+	return config.TransportSpec{
+		Name:               "fake-transport",
+		BuildTransport:     buildFakeTransport,
+		BuildUnaryOutbound: buildFakeOutbound,
+	}
+}
+
+// FakePeerListConfig configures the FakePeerList.
+type FakePeerListConfig struct {
+}
+
+func buildFakePeerList(c *FakePeerListConfig, t peer.Transport, kit *config.Kit) (peer.ChooserList, error) {
+	return NewFakePeerList(), nil
+}
+
+// FakePeerListSpec returns a configurator spec for the fake-list FakePeerList
+// peer selection strategy, suitable for passing to
+// Configurator.MustRegisterPeerList.
+func FakePeerListSpec() config.PeerListSpec {
+	return config.PeerListSpec{
+		Name:          "fake-list",
+		BuildPeerList: buildFakePeerList,
+	}
+}
+
+// FakePeerListUpdaterConfig configures a fake-updater FakePeerListUpdater.
+// It has a fake "watch" property that adds the Watch option for
+// NewFakePeerListUpdater when you build a peer list with this config.
+type FakePeerListUpdaterConfig struct {
+	FakeUpdater string `config:"fake-updater"`
+	Watch       bool   `config:"watch"`
+}
+
+func buildFakePeerListUpdater(c *FakePeerListUpdaterConfig, kit *config.Kit) (peer.Binder, error) {
+	var opts []FakePeerListUpdaterOption
+	if c.Watch {
+		opts = append(opts, Watch)
+	}
+	return func(pl peer.List) transport.Lifecycle {
+		return NewFakePeerListUpdater(opts...)
+	}, nil
+}
+
+// FakePeerListUpdaterSpec returns a configurator spec for the fake-updater
+// FakePeerListUpdater type, suitable for passing to Configurator.MustRegisterPeerListUpdaterSpec.
+func FakePeerListUpdaterSpec() config.PeerListUpdaterSpec {
+	return config.PeerListUpdaterSpec{
+		Name:                 "fake-updater",
+		BuildPeerListUpdater: buildFakePeerListUpdater,
+	}
+}
+
+// NewFakeConfigurator returns a configurator with fake-transport,
+// fake-peer-list, fake-peer-list-updater, round-robin, and least-pending specs
+// already registered, suitable for testing the configurator.
+func NewFakeConfigurator() *config.Configurator {
+	configurator := config.New()
+	configurator.MustRegisterTransport(FakeTransportSpec())
+	configurator.MustRegisterPeerList(FakePeerListSpec())
+	configurator.MustRegisterPeerListUpdater(FakePeerListUpdaterSpec())
+	return configurator
+}


### PR DESCRIPTION
This change adds support for peer chooser config: to set up peer lists like round-robin and least-pending, or peer updaters like the static peers binder.

This also includes the specs for roundrobin and peerheap.

I’ve also taken the opportunity to clarify some terminology, so there are fewer nouns in the main thrust. Outbounds take a peer chooser. The peer chooser is a combination of a peer list bound to a peer list updater.

Blocking:
- [x] Rebase #955 out
- [x] Address TODOs regarding better error messages
- [x] Remove "choose:" title and unindent subsections
- [x] Interpolate environment variables in peer config.