### PR TITLE
Add support for configuring HTTP peer lists

### DIFF
--- a/transport/http/option.go
+++ b/transport/http/option.go
@@ -20,7 +20,7 @@
 
 package http
 
-// Option allows customizing YARPC HTTP transport. Any InboundOption,
+// Option allows customizing the YARPC HTTP transport. Any InboundOption,
 // OutboundOption, or TransportOption is a valid Option.
 type Option interface {
 	httpOption()

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -147,6 +147,11 @@ func (o *Outbound) Transports() []transport.Transport {
 	return []transport.Transport{o.transport}
 }
 
+// Chooser returns the outbound's peer chooser.
+func (o *Outbound) Chooser() peer.Chooser {
+	return o.chooser
+}
+
 // Start the HTTP outbound
 func (o *Outbound) Start() error {
 	return o.once.Start(o.chooser.Start)

--- a/yarpctest/fake_config.go
+++ b/yarpctest/fake_config.go
@@ -26,6 +26,7 @@ import (
 	"go.uber.org/yarpc/peer/hostport"
 	"go.uber.org/yarpc/peer/x/peerheap"
 	"go.uber.org/yarpc/peer/x/roundrobin"
+	"go.uber.org/yarpc/transport/http"
 	"go.uber.org/yarpc/x/config"
 )
 
@@ -115,6 +116,7 @@ func FakePeerListUpdaterSpec() config.PeerListUpdaterSpec {
 func NewFakeConfigurator() *config.Configurator {
 	configurator := config.New()
 	configurator.MustRegisterTransport(FakeTransportSpec())
+	configurator.MustRegisterTransport(http.TransportSpec())
 	configurator.MustRegisterPeerList(FakePeerListSpec())
 	configurator.MustRegisterPeerList(peerheap.Spec())
 	configurator.MustRegisterPeerList(roundrobin.Spec())


### PR DESCRIPTION
This change adds support for configuring an HTTP peer chooser.

- [x] remove "choose:" subsection from each config.