### PR TITLE
Support configuration for TChannel peer lists

### DIFF
--- a/transport/tchannel/channel_transport.go
+++ b/transport/tchannel/channel_transport.go
@@ -65,15 +65,24 @@ func NewChannelTransport(opts ...TransportOption) (*ChannelTransport, error) {
 		} else {
 			opts := tchannel.ChannelOptions{Tracer: config.tracer}
 			ch, err = tchannel.NewChannel(config.name, &opts)
+			config.ch = ch
 		}
 	}
 
+	if err != nil {
+		return nil, err
+	}
+
+	return config.newChannelTransport(), nil
+}
+
+func (config transportConfig) newChannelTransport() *ChannelTransport {
 	return &ChannelTransport{
 		once:   sync.Once(),
-		ch:     ch,
+		ch:     config.ch,
 		addr:   config.addr,
 		tracer: config.tracer,
-	}, err
+	}
 }
 
 // ChannelTransport maintains TChannel peers and creates inbounds and outbounds for

--- a/transport/tchannel/options.go
+++ b/transport/tchannel/options.go
@@ -22,6 +22,15 @@ package tchannel
 
 import "github.com/opentracing/opentracing-go"
 
+// Option allows customizing the YARPC TChannel transport.
+// TransportSpec() accepts any TransportOption, and may in the future also
+// accept inbound and outbound options.
+type Option interface {
+	tchannelOption()
+}
+
+var _ Option = (TransportOption)(nil)
+
 // transportConfig is suitable for conveying options to TChannel transport
 // constructors.
 // At time of writing, there is only a ChannelTransport constructor, which
@@ -39,6 +48,10 @@ type transportConfig struct {
 
 // TransportOption customizes the behavior of a TChannel Transport.
 type TransportOption func(*transportConfig)
+
+// TransportOption makes all TransportOptions recognizeable as Option so
+// TransportSpec will accept them.
+func (TransportOption) tchannelOption() {}
 
 // Tracer specifies the request tracer used for RPCs passing through the
 // TChannel transport.
@@ -77,7 +90,7 @@ func ListenAddr(addr string) TransportOption {
 // ServiceName informs the NewChannelTransport constructor which service
 // name to use if it needs to construct a root Channel object, as when called
 // without the WithChannel option.
-
+//
 // ServiceName specifies the name of the current service for the YARPC-owned
 // TChannel Channel. If the WithChannel option is not specified, the TChannel
 // Transport will build its own TChannel Chanel and use this name for that

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -65,6 +65,11 @@ func (t *Transport) NewSingleOutbound(addr string) *Outbound {
 	return t.NewOutbound(chooser)
 }
 
+// Chooser returns the outbound's peer chooser.
+func (o *Outbound) Chooser() peer.Chooser {
+	return o.chooser
+}
+
 // Call sends an RPC over this TChannel outbound.
 func (o *Outbound) Call(ctx context.Context, req *transport.Request) (*transport.Response, error) {
 	if err := o.transport.once.WhenRunning(ctx); err != nil {

--- a/transport/tchannel/transport.go
+++ b/transport/tchannel/transport.go
@@ -74,13 +74,17 @@ func NewTransport(opts ...TransportOption) (*Transport, error) {
 	// 	return nil, errChannelOrServiceNameIsRequired
 	// }
 
+	return config.newTransport(), nil
+}
+
+func (config transportConfig) newTransport() *Transport {
 	return &Transport{
 		once:   intsync.Once(),
 		name:   config.name,
 		addr:   config.addr,
 		tracer: config.tracer,
 		peers:  make(map[string]*hostport.Peer),
-	}, nil
+	}
 }
 
 // ListenAddr exposes the listen address of the transport.

--- a/x/config/chooser.go
+++ b/x/config/chooser.go
@@ -60,7 +60,6 @@ func (pc PeerList) BuildPeerList(transport peer.Transport, identify func(string)
 
 	// Special case for single-peer outbounds.
 	if c.Peer != "" {
-
 		if len(c.Etc) > 0 {
 			return nil, fmt.Errorf("unrecognized attributes in peer list config: %+v", c.Etc)
 		}
@@ -126,11 +125,9 @@ func buildPeerListUpdater(c attributeMap, identify func(string) peer.Identifier,
 	}
 
 	if len(peers) > 0 {
-
 		if len(c) > 0 {
 			return nil, fmt.Errorf("unrecognized attributes in peer list config: %+v", c)
 		}
-
 		return peerbind.BindPeers(identifyAll(identify, peers)), nil
 	}
 

--- a/yarpctest/fake_config.go
+++ b/yarpctest/fake_config.go
@@ -24,9 +24,6 @@ import (
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/peer/hostport"
-	"go.uber.org/yarpc/peer/x/peerheap"
-	"go.uber.org/yarpc/peer/x/roundrobin"
-	"go.uber.org/yarpc/transport/http"
 	"go.uber.org/yarpc/x/config"
 )
 
@@ -111,15 +108,12 @@ func FakePeerListUpdaterSpec() config.PeerListUpdaterSpec {
 }
 
 // NewFakeConfigurator returns a configurator with fake-transport,
-// fake-peer-list, fake-peer-list-updater, round-robin, and least-pending specs
-// already registered, suitable for testing the configurator.
+// fake-peer-list, and fake-peer-list-updater specs already registered,
+// suitable for testing the configurator.
 func NewFakeConfigurator() *config.Configurator {
 	configurator := config.New()
 	configurator.MustRegisterTransport(FakeTransportSpec())
-	configurator.MustRegisterTransport(http.TransportSpec())
 	configurator.MustRegisterPeerList(FakePeerListSpec())
-	configurator.MustRegisterPeerList(peerheap.Spec())
-	configurator.MustRegisterPeerList(roundrobin.Spec())
 	configurator.MustRegisterPeerListUpdater(FakePeerListUpdaterSpec())
 	return configurator
 }


### PR DESCRIPTION
This change adds support for configuring TChannel peers. The user can construct a TChannelSpec with the TChannel WithChannel option to thread an existing TChannel instance, in which case it uses Channel{Transport,Inbound,Outbound} instead of the usual {Transport,Inbound,Outbound}. With ChannelTransport, you cannot configure a peer chooser.

- [x] rebase out the need for nested "choose:" for PeerListConfig