### PR TITLE
Fix protobuf examples

### DIFF
--- a/internal/examples/protobuf/main.go
+++ b/internal/examples/protobuf/main.go
@@ -134,13 +134,7 @@ func doClient(
 			value := args[0]
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
-			var err error
-			if *flagGoogleGRPC {
-				_, err = clients.SinkGRPCClient.Fire(ctx, &examplepb.FireRequest{value})
-			} else {
-				_, err = clients.SinkYarpcClient.Fire(ctx, &examplepb.FireRequest{value})
-			}
-			if err != nil {
+			if _, err := clients.SinkYarpcClient.Fire(ctx, &examplepb.FireRequest{value}); err != nil {
 				fmt.Printf("fire %s failed: %s\n", value, err.Error())
 			}
 			if err := sinkYarpcServer.WaitFireDone(); err != nil {

--- a/internal/examples/protobuf/service-test.yaml
+++ b/internal/examples/protobuf/service-test.yaml
@@ -1,5 +1,7 @@
+required_env_vars:
+  - TRANSPORT
 run:
-  - command: ./protobuf
+  - command: ./protobuf -outbound $TRANSPORT $GOOGLE_GRPC
     input: |
       get foo
       get foo


### PR DESCRIPTION
The `TRANSPORT` and `GOOGLE_GRPC` variables were not being properly set for the protobuf examples, so tchannel was always being used. This fixes that, along with not using the google gRPC client for oneway calls.