### PR TITLE
mapdecode: Support multiple FieldHooks

### DIFF
--- a/internal/mapdecode/decode.go
+++ b/internal/mapdecode/decode.go
@@ -52,7 +52,7 @@ type options struct {
 	TagName      string
 	IgnoreUnused bool
 	Unmarshaler  unmarshaler
-	FieldHook    FieldHookFunc
+	FieldHooks   []FieldHookFunc
 }
 
 // Option customizes the behavior of Decode.
@@ -83,9 +83,13 @@ func IgnoreUnused(ignore bool) Option {
 // Field hooks may return a value of the same type as the source data or the
 // same type as the target. Other value decoding hooks will still be executed
 // on this field.
+//
+// Multiple field hooks may be specified by providing this option multiple
+// times. Hooks are exected in-order, feeding values from one hook to the
+// next.
 func FieldHook(f FieldHookFunc) Option {
 	return func(o *options) {
-		o.FieldHook = f
+		o.FieldHooks = append(o.FieldHooks, f)
 	}
 }
 
@@ -145,7 +149,7 @@ func decodeFrom(opts *options, src interface{}) Into {
 		hooks := make([]reflectHook, 0, 5)
 
 		// fieldHook goes first because it may replace the source data map.
-		if opts.FieldHook != nil {
+		if len(opts.FieldHooks) > 0 {
 			hooks = append(hooks, fieldHook(opts))
 		}
 

--- a/internal/mapdecode/hooks_test.go
+++ b/internal/mapdecode/hooks_test.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package mapdecode
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMultipleFieldHooks(t *testing.T) {
+	var dest struct {
+		Int int
+	}
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	hook1 := newMockFieldHook(mockCtrl)
+	hook2 := newMockFieldHook(mockCtrl)
+
+	typeOfInt := reflect.TypeOf(42)
+
+	hook1.
+		Expect(_typeOfEmptyInterface, structField{
+			Name: "Int",
+			Type: typeOfInt,
+		}, reflectEq{"FOO"}).
+		Return(valueOf("BAR"), nil)
+
+	hook2.
+		Expect(reflect.TypeOf(""), structField{
+			Name: "Int",
+			Type: typeOfInt,
+		}, reflectEq{"BAR"}).
+		Return(valueOf(42), nil)
+
+	err := Decode(&dest, map[string]interface{}{"int": "FOO"},
+		FieldHook(hook1.Hook()),
+		FieldHook(hook2.Hook()),
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, 42, dest.Int)
+}


### PR DESCRIPTION
This adds support for specifying the FieldHook option multiple times.

They are chained in-order similar to how regular hooks are chained.