### PR TITLE
Expose InboundMiddleware function on the Dispatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ v1.8.0 (unreleased)
     public.
 -   `peer.BindPeers` returns a `*peer.PeersUpdater`.  The `PeersUpdater` type
     is now public.
+-   Adds an accessor to Dispatcher which provides access to the inbound
+    middleware used by that Dispatcher.
 
 
 v1.7.1 (2017-03-29)

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -253,6 +253,13 @@ func (d *Dispatcher) ClientConfig(outboundKey string) transport.ClientConfig {
 	panic(noOutboundForOutboundKey{OutboundKey: outboundKey})
 }
 
+// InboundMiddleware returns the middleware applied to all inbound handlers.
+// Router middleware and fallback handlers can use the InboundMiddleware to
+// wrap custom handlers.
+func (d *Dispatcher) InboundMiddleware() InboundMiddleware {
+	return d.inboundMiddleware
+}
+
 // Register registers zero or more procedures with this dispatcher. Incoming
 // requests to these procedures will be routed to the handlers specified in
 // the given Procedures.

--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -341,6 +341,16 @@ func TestClientConfig(t *testing.T) {
 	assert.Equal(t, "my-test-service", cc.Service())
 }
 
+func TestInboundMiddleware(t *testing.T) {
+	dispatcher := NewDispatcher(Config{
+		Name: "test",
+	})
+
+	mw := dispatcher.InboundMiddleware()
+
+	assert.NotNil(t, mw)
+}
+
 func TestClientConfigWithOutboundServiceNameOverride(t *testing.T) {
 	dispatcher := NewDispatcher(Config{
 		Name: "test",


### PR DESCRIPTION
Summary: In order to support custom routing use cases like service-level routing
we're relying on the middleware.Router customizations to create handlers outside 
of the dispatcher.  Unfortunately this means that any Inbound/Handler middleware 
we add in the dispatcher will not get added to handlers outside the dispatcher.

This PR adds a function that exposes the InboundMiddleware of the dispatcher.

Test Plan: wrote tests.