### PR TITLE
YARPC fakes for configurator tests

### DIFF
--- a/yarpctest/fake.go
+++ b/yarpctest/fake.go
@@ -31,16 +31,29 @@ import (
 	"go.uber.org/yarpc/peer/hostport"
 )
 
+type FakeTransportOption func(*FakeTransport)
+
+func FakeTransportAddress(addr string) FakeTransportOption {
+	return func(t *FakeTransport) {
+		t.Address = addr
+	}
+}
+
 // NewFakeTransport returns a fake transport.
-func NewFakeTransport() *FakeTransport {
-	return &FakeTransport{
+func NewFakeTransport(opts ...FakeTransportOption) *FakeTransport {
+	t := &FakeTransport{
 		Lifecycle: intsync.NewNopLifecycle(),
 	}
+	for _, opt := range opts {
+		opt(t)
+	}
+	return t
 }
 
 // FakeTransport is a fake transport.
 type FakeTransport struct {
 	transport.Lifecycle
+	address string
 }
 
 // RetainPeer returns a fake peer.

--- a/yarpctest/fake_outbound.go
+++ b/yarpctest/fake_outbound.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpctest
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/api/transport"
+	intsync "go.uber.org/yarpc/internal/sync"
+)
+
+// FakeOutboundOption is an option for FakeTransport.NewOutbound.
+type FakeOutboundOption func(*FakeOutbound)
+
+// NopOutboundOption returns an option to set the "nopOption" for a
+// FakeTransport.NewOutbound.
+// The nopOption has no effect exists only to verify that the option was
+// passed, via `FakeOutbound.NopOption()`.
+func NopOutboundOption(nopOption string) FakeOutboundOption {
+	return func(o *FakeOutbound) {
+		o.nopOption = nopOption
+	}
+}
+
+// NewOutbound returns a FakeOutbound with a given peer chooser and options.
+func (t *FakeTransport) NewOutbound(c peer.Chooser, opts ...FakeOutboundOption) *FakeOutbound {
+	o := &FakeOutbound{
+		once:      intsync.Once(),
+		transport: t,
+		chooser:   c,
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+	return o
+}
+
+// FakeOutbound is a unary outbound for the FakeTransport. It is fake.
+type FakeOutbound struct {
+	once      intsync.LifecycleOnce
+	transport *FakeTransport
+	chooser   peer.Chooser
+	nopOption string
+}
+
+// Chooser returns theis FakeOutbound's peer chooser.
+func (o *FakeOutbound) Chooser() peer.Chooser {
+	return o.chooser
+}
+
+// NopOption returns this FakeOutbound's nopOption. It is fake.
+func (o *FakeOutbound) NopOption() string {
+	return o.nopOption
+}
+
+// Start starts the fake outbound and its chooser.
+func (o *FakeOutbound) Start() error {
+	return o.once.Start(o.chooser.Start)
+}
+
+// Stop stops the fake outbound and its chooser.
+func (o *FakeOutbound) Stop() error {
+	return o.once.Stop(o.chooser.Stop)
+}
+
+// IsRunning returns whether the fake outbound is running.
+func (o *FakeOutbound) IsRunning() bool {
+	return o.once.IsRunning()
+}
+
+// Transports returns the FakeTransport that owns this outbound.
+func (o *FakeOutbound) Transports() []transport.Transport {
+	return []transport.Transport{o.transport}
+}
+
+// Call pretends to send a unary RPC, but actually just returns an error.
+func (o *FakeOutbound) Call(ctx context.Context, req *transport.Request) (*transport.Response, error) {
+	return nil, fmt.Errorf(`FakeOutbound does not support calls. It's fake`)
+}

--- a/yarpctest/fake_peer.go
+++ b/yarpctest/fake_peer.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpctest
+
+import (
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/peer/hostport"
+)
+
+// FakePeer is a fake peer with an identifier.
+type FakePeer struct {
+	id hostport.PeerIdentifier
+}
+
+// Identifier returns the fake peer identifier.
+func (p *FakePeer) Identifier() string {
+	return string(p.id)
+}
+
+// Status returns the fake peer status.
+func (p *FakePeer) Status() peer.Status {
+	return peer.Status{
+		ConnectionStatus:    peer.Available,
+		PendingRequestCount: 0,
+	}
+}
+
+// StartRequest does nothing.
+func (p *FakePeer) StartRequest() {
+}
+
+// EndRequest does nothing.
+func (p *FakePeer) EndRequest() {
+}

--- a/yarpctest/fake_peer_list.go
+++ b/yarpctest/fake_peer_list.go
@@ -21,51 +21,32 @@
 package yarpctest
 
 import (
+	"context"
+	"fmt"
+
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
 	intsync "go.uber.org/yarpc/internal/sync"
-	"go.uber.org/yarpc/peer/hostport"
 )
 
-// FakeTransportOption is an option for NewFakeTransport.
-type FakeTransportOption func(*FakeTransport)
-
-// NopTransportOption returns a no-op option for NewFakeTransport.
-// The option exists to verify that options work.
-func NopTransportOption(nopOption string) FakeTransportOption {
-	return func(t *FakeTransport) {
-		t.nopOption = nopOption
-	}
+// FakePeerList is a fake peer list.
+type FakePeerList struct {
+	transport.Lifecycle
 }
 
-// NewFakeTransport returns a fake transport.
-func NewFakeTransport(opts ...FakeTransportOption) *FakeTransport {
-	t := &FakeTransport{
+// NewFakePeerList returns a fake peer list.
+func NewFakePeerList() *FakePeerList {
+	return &FakePeerList{
 		Lifecycle: intsync.NewNopLifecycle(),
 	}
-	for _, opt := range opts {
-		opt(t)
-	}
-	return t
 }
 
-// FakeTransport is a fake transport.
-type FakeTransport struct {
-	transport.Lifecycle
-	nopOption string
+// Choose pretends to choose a peer, but actually always returns an error. It's fake.
+func (c *FakePeerList) Choose(ctx context.Context, req *transport.Request) (peer.Peer, func(error), error) {
+	return nil, nil, fmt.Errorf(`fake peer list can't actually choose peers`)
 }
 
-// NopOption returns the configured nopOption. It's fake.
-func (t *FakeTransport) NopOption() string {
-	return t.nopOption
-}
-
-// RetainPeer returns a fake peer.
-func (t *FakeTransport) RetainPeer(id peer.Identifier, ps peer.Subscriber) (peer.Peer, error) {
-	return &FakePeer{id: id.(hostport.PeerIdentifier)}, nil
-}
-
-// ReleasePeer does nothing.
-func (t *FakeTransport) ReleasePeer(id peer.Identifier, ps peer.Subscriber) error {
+// Update pretends to add or remove peers.
+func (c *FakePeerList) Update(up peer.ListUpdates) error {
 	return nil
 }

--- a/yarpctest/fake_peer_list_updater.go
+++ b/yarpctest/fake_peer_list_updater.go
@@ -21,51 +21,39 @@
 package yarpctest
 
 import (
-	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
 	intsync "go.uber.org/yarpc/internal/sync"
-	"go.uber.org/yarpc/peer/hostport"
 )
 
-// FakeTransportOption is an option for NewFakeTransport.
-type FakeTransportOption func(*FakeTransport)
+// FakePeerListUpdaterOption is an option for NewFakePeerListUpdater.
+type FakePeerListUpdaterOption func(*FakePeerListUpdater)
 
-// NopTransportOption returns a no-op option for NewFakeTransport.
-// The option exists to verify that options work.
-func NopTransportOption(nopOption string) FakeTransportOption {
-	return func(t *FakeTransport) {
-		t.nopOption = nopOption
-	}
+// Watch is a fake option for NewFakePeerListUpdater that enables "watch". It's fake.
+func Watch(u *FakePeerListUpdater) {
+	u.watch = true
 }
 
-// NewFakeTransport returns a fake transport.
-func NewFakeTransport(opts ...FakeTransportOption) *FakeTransport {
-	t := &FakeTransport{
+// FakePeerListUpdater is a fake peer list updater.  It doesn't actually update
+// a peer list.
+type FakePeerListUpdater struct {
+	transport.Lifecycle
+	watch bool
+}
+
+// NewFakePeerListUpdater returns a new FakePeerListUpdater, applying any
+// passed options.
+func NewFakePeerListUpdater(opts ...FakePeerListUpdaterOption) *FakePeerListUpdater {
+	u := &FakePeerListUpdater{
 		Lifecycle: intsync.NewNopLifecycle(),
 	}
 	for _, opt := range opts {
-		opt(t)
+		opt(u)
 	}
-	return t
+	return u
 }
 
-// FakeTransport is a fake transport.
-type FakeTransport struct {
-	transport.Lifecycle
-	nopOption string
-}
-
-// NopOption returns the configured nopOption. It's fake.
-func (t *FakeTransport) NopOption() string {
-	return t.nopOption
-}
-
-// RetainPeer returns a fake peer.
-func (t *FakeTransport) RetainPeer(id peer.Identifier, ps peer.Subscriber) (peer.Peer, error) {
-	return &FakePeer{id: id.(hostport.PeerIdentifier)}, nil
-}
-
-// ReleasePeer does nothing.
-func (t *FakeTransport) ReleasePeer(id peer.Identifier, ps peer.Subscriber) error {
-	return nil
+// Watch returns whether the peer list updater was configured to "watch". It is
+// fake.
+func (u *FakePeerListUpdater) Watch() bool {
+	return u.watch
 }

--- a/yarpctest/fake_transport.go
+++ b/yarpctest/fake_transport.go
@@ -20,10 +20,6 @@
 
 package yarpctest
 
-// This file provides fake implementations of most YARPC building blocks for
-// the purpose of testing configuration using custom transports, choosers, and
-// binders..
-
 import (
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
@@ -64,30 +60,4 @@ func (t *FakeTransport) RetainPeer(id peer.Identifier, ps peer.Subscriber) (peer
 // ReleasePeer does nothing.
 func (t *FakeTransport) ReleasePeer(id peer.Identifier, ps peer.Subscriber) error {
 	return nil
-}
-
-// FakePeer is a fake peer with an identifier.
-type FakePeer struct {
-	id hostport.PeerIdentifier
-}
-
-// Identifier returns the fake peer identifier.
-func (p *FakePeer) Identifier() string {
-	return string(p.id)
-}
-
-// Status returns the fake peer status.
-func (p *FakePeer) Status() peer.Status {
-	return peer.Status{
-		ConnectionStatus:    peer.Available,
-		PendingRequestCount: 0,
-	}
-}
-
-// StartRequest does nothing.
-func (p *FakePeer) StartRequest() {
-}
-
-// EndRequest does nothing.
-func (p *FakePeer) EndRequest() {
 }


### PR DESCRIPTION
This change introduces more fakes for the YARPC API. These are, so far, intended for use in config tests. I’ve broken these changes into a separate PR for reviewability, though they are preamble to https://github.com/yarpc/yarpc-go/pull/956.

The motivation for using fakes here is to provide both interface and behavior compliance for YARPC entities that can be constructed through configuration. Using mocks, it was only possible to create a system that satisfied the interfaces, but could not be verified by running the system’s lifecycle. These fakes allow us to connect a real round robin peer chooser and peers updater to a fake transport and outbound, among other scenarios.

The fake implementations give us a basis for providing stronger assertions going forward, like verifying that a peer list updater provides a logically consistent sequence of updates.