### PR TITLE
WIP: Add experimental gob encoding

### DIFF
--- a/encoding/x/gob/constants.go
+++ b/encoding/x/gob/constants.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package gob
+
+import "go.uber.org/yarpc/api/transport"
+
+// Encoding is the name of this encoding.
+const Encoding transport.Encoding = "gob"

--- a/encoding/x/gob/doc.go
+++ b/encoding/x/gob/doc.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package gob provides the gob encoding for YARPC.
+//
+// To make outbound requests using this encoding,
+//
+// 	client := gob.New(clientConfig)
+// 	var resBody GetValueResponse
+// 	err := client.Call(ctx, "getValue", &GetValueRequest{...}, &resBody)
+//
+// To register a gob procedure, define functions in the format,
+//
+// 	f(ctx context.Context, body $reqBody) ($resBody, error)
+//
+// Where '$reqBody' and '$resBody' are either pointers to structs representing
+// your request and response objects, or map[string]interface{}.
+//
+// Use the Procedure function to build procedures to register against a
+// Router.
+//
+//  dispatcher.Register(gob.Procedure("getValue", GetValue))
+//  dispatcher.Register(gob.Procedure("setValue", SetValue))
+//
+// Similarly, to register a oneway gob procedure, define functions in the
+// format,
+//
+// 	f(ctx context.Context, body $reqBody) error
+//
+// Where $reqBody is a map[string]interface{} or pointer to a struct.
+//
+// Use the OnewayProcedure function to build procedures to register against a
+// Router.
+//
+//  dispatcher.Register(gob.OnewayProcedure("setValue", SetValue))
+//  dispatcher.Register(gob.OnewayProcedure("runTask", RunTask))
+//
+package gob

--- a/encoding/x/gob/inbound.go
+++ b/encoding/x/gob/inbound.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package gob
+
+import (
+	"context"
+	"encoding/gob"
+	"reflect"
+
+	encodingapi "go.uber.org/yarpc/api/encoding"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/encoding"
+)
+
+// gobHandler adapts a user-provided high-level handler into a transport-level
+// Handler.
+//
+// The wrapped function must already be in the correct format:
+//
+// 	f(ctx context.Context, body $reqBody) ($resBody, error)
+type gobHandler struct {
+	reader  requestReader
+	handler reflect.Value
+}
+
+func (h gobHandler) Handle(ctx context.Context, treq *transport.Request, rw transport.ResponseWriter) error {
+	if err := encoding.Expect(treq, Encoding); err != nil {
+		return err
+	}
+
+	ctx, call := encodingapi.NewInboundCall(ctx)
+	if err := call.ReadFromRequest(treq); err != nil {
+		return err
+	}
+
+	reqBody, err := h.reader.Read(gob.NewDecoder(treq.Body))
+	if err != nil {
+		return encoding.RequestBodyDecodeError(treq, err)
+	}
+
+	results := h.handler.Call([]reflect.Value{reflect.ValueOf(ctx), reqBody})
+
+	if err := results[1].Interface(); err != nil {
+		return err.(error)
+	}
+
+	if err := call.WriteToResponse(rw); err != nil {
+		return err
+	}
+
+	result := results[0].Interface()
+	if err := gob.NewEncoder(rw).Encode(result); err != nil {
+		return encoding.ResponseBodyEncodeError(treq, err)
+	}
+
+	return nil
+}
+
+func (h gobHandler) HandleOneway(ctx context.Context, treq *transport.Request) error {
+	if err := encoding.Expect(treq, Encoding); err != nil {
+		return err
+	}
+
+	ctx, call := encodingapi.NewInboundCall(ctx)
+	if err := call.ReadFromRequest(treq); err != nil {
+		return err
+	}
+
+	reqBody, err := h.reader.Read(gob.NewDecoder(treq.Body))
+	if err != nil {
+		return encoding.RequestBodyDecodeError(treq, err)
+	}
+
+	results := h.handler.Call([]reflect.Value{reflect.ValueOf(ctx), reqBody})
+
+	if err := results[0].Interface(); err != nil {
+		return err.(error)
+	}
+
+	return nil
+}
+
+// requestReader is used to parse a gob request argument from a gob decoder.
+type requestReader interface {
+	Read(*gob.Decoder) (reflect.Value, error)
+}
+
+type structReader struct {
+	// Type of the struct (not a pointer to the struct)
+	Type reflect.Type
+}
+
+func (r structReader) Read(d *gob.Decoder) (reflect.Value, error) {
+	value := reflect.New(r.Type)
+	err := d.Decode(value.Interface())
+	return value, err
+}
+
+type mapReader struct {
+	Type reflect.Type // Type of the map
+}
+
+func (r mapReader) Read(d *gob.Decoder) (reflect.Value, error) {
+	value := reflect.New(r.Type)
+	err := d.Decode(value.Interface())
+	return value.Elem(), err
+}
+
+type ifaceEmptyReader struct{}
+
+func (ifaceEmptyReader) Read(d *gob.Decoder) (reflect.Value, error) {
+	value := reflect.New(_interfaceEmptyType)
+	err := d.Decode(value.Interface())
+	return value.Elem(), err
+}

--- a/encoding/x/gob/inbound_test.go
+++ b/encoding/x/gob/inbound_test.go
@@ -1,0 +1,137 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package gob
+
+import (
+	"bytes"
+	"context"
+	"encoding/gob"
+	"io"
+	"reflect"
+	"testing"
+
+	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/api/transport/transporttest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type simpleRequest struct {
+	Name       string
+	Attributes map[string]int32
+}
+
+type simpleResponse struct {
+	Success bool
+}
+
+func TestHandleStructSuccess(t *testing.T) {
+	h := func(ctx context.Context, body *simpleRequest) (*simpleResponse, error) {
+		assert.Equal(t, "simpleCall", yarpc.CallFromContext(ctx).Procedure())
+		assert.Equal(t, "foo", body.Name)
+		assert.Equal(t, map[string]int32{"bar": 42}, body.Attributes)
+
+		return &simpleResponse{Success: true}, nil
+	}
+
+	handler := gobHandler{
+		reader:  structReader{reflect.TypeOf(simpleRequest{})},
+		handler: reflect.ValueOf(h),
+	}
+
+	resw := new(transporttest.FakeResponseWriter)
+	err := handler.Handle(context.Background(), &transport.Request{
+		Procedure: "simpleCall",
+		Encoding:  "gob",
+		Body: gobFrom(t, simpleRequest{
+			Name:       "foo",
+			Attributes: map[string]int32{"bar": 42},
+		}),
+	}, resw)
+	require.NoError(t, err)
+
+	var response simpleResponse
+	require.NoError(t, gob.NewDecoder(&resw.Body).Decode(&response))
+
+	assert.Equal(t, simpleResponse{Success: true}, response)
+}
+
+func TestHandleMapSuccess(t *testing.T) {
+	h := func(ctx context.Context, body map[string]interface{}) (map[string]string, error) {
+		assert.Equal(t, 42.0, body["foo"])
+		assert.Equal(t, []string{"a", "b", "c"}, body["bar"])
+
+		return map[string]string{"success": "true"}, nil
+	}
+
+	handler := gobHandler{
+		reader:  mapReader{reflect.TypeOf(make(map[string]interface{}))},
+		handler: reflect.ValueOf(h),
+	}
+
+	resw := new(transporttest.FakeResponseWriter)
+	err := handler.Handle(context.Background(), &transport.Request{
+		Procedure: "foo",
+		Encoding:  "gob",
+		Body: gobFrom(t, map[string]interface{}{
+			"foo": 42.0,
+			"bar": []string{"a", "b", "c"},
+		}),
+	}, resw)
+	require.NoError(t, err)
+
+	var response map[string]string
+	require.NoError(t, gob.NewDecoder(&resw.Body).Decode(&response))
+	assert.Equal(t, "true", response["success"])
+}
+
+func TestHandleSuccessWithResponseHeaders(t *testing.T) {
+	h := func(ctx context.Context, _ *simpleRequest) (*simpleResponse, error) {
+		require.NoError(t, yarpc.CallFromContext(ctx).WriteResponseHeader("foo", "bar"))
+		return &simpleResponse{Success: true}, nil
+	}
+
+	handler := gobHandler{
+		reader:  structReader{reflect.TypeOf(simpleRequest{})},
+		handler: reflect.ValueOf(h),
+	}
+
+	resw := new(transporttest.FakeResponseWriter)
+	err := handler.Handle(context.Background(), &transport.Request{
+		Procedure: "simpleCall",
+		Encoding:  "gob",
+		Body: gobFrom(t, simpleRequest{
+			Name:       "foo",
+			Attributes: map[string]int32{"bar": 42},
+		}),
+	}, resw)
+	require.NoError(t, err)
+
+	assert.Equal(t, transport.NewHeaders().With("foo", "bar"), resw.Headers)
+}
+
+func gobFrom(t *testing.T, v interface{}) io.Reader {
+	var buff bytes.Buffer
+	require.NoError(t, gob.NewEncoder(&buff).Encode(v))
+	return bytes.NewReader(buff.Bytes())
+}

--- a/encoding/x/gob/outbound.go
+++ b/encoding/x/gob/outbound.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package gob
+
+import (
+	"bytes"
+	"context"
+	"encoding/gob"
+
+	"go.uber.org/yarpc"
+	encodingapi "go.uber.org/yarpc/api/encoding"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/encoding"
+)
+
+// Client makes gob requests to a single service.
+type Client interface {
+	// Call performs an outbound gob request.
+	//
+	// resBodyOut is a pointer to a value that can be filled with
+	// gob.Decode
+	//
+	// Returns the response or an error if the request failed.
+	Call(ctx context.Context, procedure string, reqBody interface{}, resBodyOut interface{}, opts ...yarpc.CallOption) error
+	CallOneway(ctx context.Context, procedure string, reqBody interface{}, opts ...yarpc.CallOption) (transport.Ack, error)
+}
+
+// New builds a new gob client.
+func New(c transport.ClientConfig) Client {
+	return gobClient{cc: c}
+}
+
+func init() {
+	yarpc.RegisterClientBuilder(New)
+}
+
+type gobClient struct {
+	cc transport.ClientConfig
+}
+
+func (c gobClient) Call(ctx context.Context, procedure string, reqBody interface{}, resBodyOut interface{}, opts ...yarpc.CallOption) error {
+	call := encodingapi.NewOutboundCall(encoding.FromOptions(opts)...)
+	treq := transport.Request{
+		Caller:    c.cc.Caller(),
+		Service:   c.cc.Service(),
+		Procedure: procedure,
+		Encoding:  Encoding,
+	}
+
+	ctx, err := call.WriteToRequest(ctx, &treq)
+	if err != nil {
+		return err
+	}
+
+	var buff bytes.Buffer
+	if err := gob.NewEncoder(&buff).Encode(reqBody); err != nil {
+		return encoding.RequestBodyEncodeError(&treq, err)
+	}
+
+	treq.Body = &buff
+	tres, err := c.cc.GetUnaryOutbound().Call(ctx, &treq)
+	if err != nil {
+		return err
+	}
+
+	if _, err = call.ReadFromResponse(ctx, tres); err != nil {
+		return err
+	}
+
+	if err := gob.NewDecoder(tres.Body).Decode(resBodyOut); err != nil {
+		return encoding.ResponseBodyDecodeError(&treq, err)
+	}
+
+	return tres.Body.Close()
+}
+
+func (c gobClient) CallOneway(ctx context.Context, procedure string, reqBody interface{}, opts ...yarpc.CallOption) (transport.Ack, error) {
+	call := encodingapi.NewOutboundCall(encoding.FromOptions(opts)...)
+	treq := transport.Request{
+		Caller:    c.cc.Caller(),
+		Service:   c.cc.Service(),
+		Procedure: procedure,
+		Encoding:  Encoding,
+	}
+
+	ctx, err := call.WriteToRequest(ctx, &treq)
+	if err != nil {
+		return nil, err
+	}
+
+	var buff bytes.Buffer
+	if err := gob.NewEncoder(&buff).Encode(reqBody); err != nil {
+		return nil, encoding.RequestBodyEncodeError(&treq, err)
+	}
+	treq.Body = &buff
+
+	return c.cc.GetOnewayOutbound().CallOneway(ctx, &treq)
+}

--- a/encoding/x/gob/outbound_test.go
+++ b/encoding/x/gob/outbound_test.go
@@ -1,0 +1,251 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package gob
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"io/ioutil"
+	"reflect"
+	"testing"
+
+	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/api/transport/transporttest"
+	"go.uber.org/yarpc/internal/clientconfig"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var _typeOfMapInterface = reflect.TypeOf(map[string]interface{}{})
+
+func TestCall(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	ctx := context.Background()
+
+	caller := "caller"
+	service := "service"
+
+	tests := []struct {
+		procedure string
+		headers   map[string]string
+		body      interface{}
+
+		// If nil, want will be used
+		resBody []byte
+
+		// whether the outbound receives the request
+		noCall bool
+
+		// Either want, or wantType and wantErr must be set.
+		want        interface{} // expected response body
+		wantHeaders map[string]string
+		wantType    reflect.Type // type of response body
+		wantErr     string       // error message
+	}{
+		{
+			procedure: "foo",
+			body:      []string{"foo", "bar"},
+			want:      map[string]interface{}{"success": true},
+		},
+		{
+			procedure: "bar",
+			body:      []int{1, 2, 3},
+			resBody:   []byte{1, 2, 3},
+			wantType:  _typeOfMapInterface,
+			wantErr:   `failed to decode "gob" response body for procedure "bar" of service "service"`,
+		},
+		{
+			procedure: "baz",
+			body:      func() {}, // funcs cannot be gob.Marshal'ed
+			noCall:    true,
+			wantType:  _typeOfMapInterface,
+			wantErr:   `failed to encode "gob" request body for procedure "baz" of service "service"`,
+		},
+		{
+			procedure:   "requestHeaders",
+			headers:     map[string]string{"user-id": "42"},
+			body:        map[string]interface{}{},
+			want:        map[string]interface{}{},
+			wantHeaders: map[string]string{"success": "true"},
+		},
+	}
+
+	for _, tt := range tests {
+		outbound := transporttest.NewMockUnaryOutbound(mockCtrl)
+		client := New(clientconfig.MultiOutbound(caller, service,
+			transport.Outbounds{
+				Unary: outbound,
+			}))
+
+		if !tt.noCall {
+			var resBody io.Reader
+			if tt.resBody != nil {
+				resBody = bytes.NewReader(tt.resBody)
+			} else {
+				resBody = gobFrom(t, tt.want)
+			}
+
+			outbound.EXPECT().Call(gomock.Any(),
+				transporttest.NewRequestMatcher(t,
+					&transport.Request{
+						Caller:    caller,
+						Service:   service,
+						Procedure: tt.procedure,
+						Encoding:  Encoding,
+						Headers:   transport.HeadersFromMap(tt.headers),
+						Body:      gobFrom(t, tt.body),
+					}),
+			).Return(
+				&transport.Response{
+					Body:    ioutil.NopCloser(resBody),
+					Headers: transport.HeadersFromMap(tt.wantHeaders),
+				}, nil)
+		}
+
+		var wantType reflect.Type
+		if tt.want != nil {
+			wantType = reflect.TypeOf(tt.want)
+		} else {
+			require.NotNil(t, tt.wantType, "wantType is required if want is nil")
+			wantType = tt.wantType
+		}
+		resBody := reflect.New(wantType)
+
+		var (
+			opts       []yarpc.CallOption
+			resHeaders map[string]string
+		)
+
+		for k, v := range tt.headers {
+			opts = append(opts, yarpc.WithHeader(k, v))
+		}
+		opts = append(opts, yarpc.ResponseHeaders(&resHeaders))
+
+		err := client.Call(ctx, tt.procedure, tt.body, resBody.Interface(), opts...)
+		if tt.wantErr != "" {
+			if assert.Error(t, err) {
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+		} else {
+			if assert.NoError(t, err) {
+				assert.Equal(t, tt.wantHeaders, resHeaders)
+				assert.Equal(t, tt.want, resBody.Elem().Interface())
+			}
+		}
+	}
+}
+
+type successAck struct{}
+
+func (a successAck) String() string {
+	return "success"
+}
+
+func TestCallOneway(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	ctx := context.Background()
+
+	caller := "caller"
+	service := "service"
+
+	tests := []struct {
+		procedure string
+		headers   map[string]string
+		body      interface{}
+
+		// whether the outbound receives the request
+		noCall bool
+
+		wantErr string // error message
+	}{
+		{
+			procedure: "foo",
+			body:      []string{"foo", "bar"},
+		},
+		{
+			procedure: "baz",
+			body:      func() {}, // funcs cannot be gob.Marshal'ed
+			noCall:    true,
+			wantErr:   `failed to encode "gob" request body for procedure "baz" of service "service"`,
+		},
+		{
+			procedure: "requestHeaders",
+			headers:   map[string]string{"user-id": "42"},
+			body:      map[string]interface{}{},
+		},
+	}
+
+	for _, tt := range tests {
+		outbound := transporttest.NewMockOnewayOutbound(mockCtrl)
+		client := New(clientconfig.MultiOutbound(caller, service,
+			transport.Outbounds{
+				Oneway: outbound,
+			}))
+
+		if !tt.noCall {
+			reqMatcher := transporttest.NewRequestMatcher(t,
+				&transport.Request{
+					Caller:    caller,
+					Service:   service,
+					Procedure: tt.procedure,
+					Encoding:  Encoding,
+					Headers:   transport.HeadersFromMap(tt.headers),
+					Body:      gobFrom(t, tt.body),
+				})
+
+			if tt.wantErr != "" {
+				outbound.
+					EXPECT().
+					CallOneway(gomock.Any(), reqMatcher).
+					Return(nil, errors.New(tt.wantErr))
+			} else {
+				outbound.
+					EXPECT().
+					CallOneway(gomock.Any(), reqMatcher).
+					Return(&successAck{}, nil)
+			}
+		}
+
+		var opts []yarpc.CallOption
+
+		for k, v := range tt.headers {
+			opts = append(opts, yarpc.WithHeader(k, v))
+		}
+
+		ack, err := client.CallOneway(ctx, tt.procedure, tt.body, opts...)
+		if tt.wantErr != "" {
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		} else {
+			assert.NoError(t, err, "")
+			assert.Equal(t, ack.String(), "success")
+		}
+	}
+}

--- a/encoding/x/gob/register.go
+++ b/encoding/x/gob/register.go
@@ -1,0 +1,221 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package gob
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"go.uber.org/yarpc/api/transport"
+)
+
+var (
+	_ctxType            = reflect.TypeOf((*context.Context)(nil)).Elem()
+	_errorType          = reflect.TypeOf((*error)(nil)).Elem()
+	_interfaceEmptyType = reflect.TypeOf((*interface{})(nil)).Elem()
+)
+
+// Register calls the RouteTable's Register method.
+//
+// This function exists for backwards compatibility only. It will be removed
+// in a future version.
+//
+// Deprecated: Use the RouteTable's Register method directly.
+func Register(r transport.RouteTable, rs []transport.Procedure) {
+	r.Register(rs)
+}
+
+// Procedure builds a Procedure from the given gob handler. handler must be
+// a function with a signature similar to,
+//
+// 	f(ctx context.Context, body $reqBody) ($resBody, error)
+//
+// Where $reqBody and $resBody are a map[string]interface{} or pointers to
+// structs.
+func Procedure(name string, handler interface{}) []transport.Procedure {
+	return []transport.Procedure{
+		{
+			Name: name,
+			HandlerSpec: transport.NewUnaryHandlerSpec(
+				wrapUnaryHandler(name, handler),
+			),
+			Encoding: Encoding,
+		},
+	}
+}
+
+// OnewayProcedure builds a Procedure from the given gob handler. handler must be
+// a function with a signature similar to,
+//
+// 	f(ctx context.Context, body $reqBody) error
+//
+// Where $reqBody is a map[string]interface{} or pointer to a struct.
+func OnewayProcedure(name string, handler interface{}) []transport.Procedure {
+	return []transport.Procedure{
+		{
+			Name: name,
+			HandlerSpec: transport.NewOnewayHandlerSpec(
+				wrapOnewayHandler(name, handler)),
+			Encoding: Encoding,
+		},
+	}
+}
+
+// wrapUnaryHandler takes a valid gob handler function and converts it into a
+// transport.UnaryHandler.
+func wrapUnaryHandler(name string, handler interface{}) transport.UnaryHandler {
+	reqBodyType := verifyUnarySignature(name, reflect.TypeOf(handler))
+	return newGobHandler(reqBodyType, handler)
+}
+
+// wrapOnewayHandler takes a valid gob handler function and converts it into a
+// transport.OnewayHandler.
+func wrapOnewayHandler(name string, handler interface{}) transport.OnewayHandler {
+	reqBodyType := verifyOnewaySignature(name, reflect.TypeOf(handler))
+	return newGobHandler(reqBodyType, handler)
+}
+
+func newGobHandler(reqBodyType reflect.Type, handler interface{}) gobHandler {
+	var r requestReader
+	if reqBodyType == _interfaceEmptyType {
+		r = ifaceEmptyReader{}
+	} else if reqBodyType.Kind() == reflect.Map {
+		r = mapReader{reqBodyType}
+	} else {
+		// struct ptr
+		r = structReader{reqBodyType.Elem()}
+	}
+
+	return gobHandler{
+		reader:  r,
+		handler: reflect.ValueOf(handler),
+	}
+}
+
+// verifyUnarySignature verifies that the given type matches what we expect from
+// gob unary handlers and returns the request type.
+func verifyUnarySignature(n string, t reflect.Type) reflect.Type {
+	reqBodyType := verifyInputSignature(n, t)
+
+	if t.NumOut() != 2 {
+		panic(fmt.Sprintf(
+			"expected handler for %q to have 2 results but it had %v",
+			n, t.NumOut(),
+		))
+	}
+
+	if t.Out(1) != _errorType {
+		panic(fmt.Sprintf(
+			"handler for %q must return error as its second reuslt, not %v",
+			n, t.Out(1),
+		))
+	}
+
+	resBodyType := t.Out(0)
+
+	if !isValidReqResType(reqBodyType) {
+		panic(fmt.Sprintf(
+			"the second argument of the handler for %q must be "+
+				"a struct pointer, a map[string]interface{}, or interface{}, and not: %v",
+			n, reqBodyType,
+		))
+	}
+
+	if !isValidReqResType(resBodyType) {
+		panic(fmt.Sprintf(
+			"the first result of the handler for %q must be "+
+				"a struct pointer, a map[string]interface{}, or interface{], and not: %v",
+			n, resBodyType,
+		))
+	}
+
+	return reqBodyType
+}
+
+// verifyOnewaySignature verifies that the given type matches what we expect
+// from oneway gob handlers.
+//
+// Returns the request type.
+func verifyOnewaySignature(n string, t reflect.Type) reflect.Type {
+	reqBodyType := verifyInputSignature(n, t)
+
+	if t.NumOut() != 1 {
+		panic(fmt.Sprintf(
+			"expected handler for %q to have 1 result but it had %v",
+			n, t.NumOut(),
+		))
+	}
+
+	if t.Out(0) != _errorType {
+		panic(fmt.Sprintf(
+			"the result of the handler for %q must be of type error, and not: %v",
+			n, t.Out(0),
+		))
+	}
+
+	return reqBodyType
+}
+
+// verifyInputSignature verifies that the given input argument types match
+// what we expect from gob handlers and returns the request body type.
+func verifyInputSignature(n string, t reflect.Type) reflect.Type {
+	if t.Kind() != reflect.Func {
+		panic(fmt.Sprintf(
+			"handler for %q is not a function but a %v", n, t.Kind(),
+		))
+	}
+
+	if t.NumIn() != 2 {
+		panic(fmt.Sprintf(
+			"expected handler for %q to have 2 arguments but it had %v",
+			n, t.NumIn(),
+		))
+	}
+
+	if t.In(0) != _ctxType {
+		panic(fmt.Sprintf(
+			"the first argument of the handler for %q must be of type "+
+				"context.Context, and not: %v", n, t.In(0),
+		))
+
+	}
+
+	reqBodyType := t.In(1)
+
+	if !isValidReqResType(reqBodyType) {
+		panic(fmt.Sprintf(
+			"the second argument of the handler for %q must be "+
+				"a struct pointer, a map[string]interface{}, or interface{}, and not: %v",
+			n, reqBodyType,
+		))
+	}
+
+	return reqBodyType
+}
+
+// isValidReqResType checks if the given type is a pointer to a struct, a
+// map[string]interface{}, or a interface{}.
+func isValidReqResType(t reflect.Type) bool {
+	return (t == _interfaceEmptyType) ||
+		(t.Kind() == reflect.Ptr && t.Elem().Kind() == reflect.Struct) ||
+		(t.Kind() == reflect.Map && t.Key().Kind() == reflect.String)
+}

--- a/encoding/x/gob/register_test.go
+++ b/encoding/x/gob/register_test.go
@@ -1,0 +1,215 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package gob
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWrapUnaryHandlerInvalid(t *testing.T) {
+	tests := []struct {
+		Name string
+		Func interface{}
+	}{
+		{"empty", func() {}},
+		{"not-a-function", 0},
+		{
+			"wrong-args-in",
+			func(context.Context) (*struct{}, error) {
+				return nil, nil
+			},
+		},
+		{
+			"wrong-ctx",
+			func(string, *struct{}) (*struct{}, error) {
+				return nil, nil
+			},
+		},
+		{
+			"wrong-req-body",
+			func(context.Context, string, int) (*struct{}, error) {
+				return nil, nil
+			},
+		},
+		{
+			"wrong-response",
+			func(context.Context, map[string]interface{}) error {
+				return nil
+			},
+		},
+		{
+			"non-pointer-req",
+			func(context.Context, struct{}) (*struct{}, error) {
+				return nil, nil
+			},
+		},
+		{
+			"non-pointer-res",
+			func(context.Context, *struct{}) (struct{}, error) {
+				return struct{}{}, nil
+			},
+		},
+		{
+			"non-string-key",
+			func(context.Context, map[int32]interface{}) (*struct{}, error) {
+				return nil, nil
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		assert.Panics(t, assert.PanicTestFunc(func() {
+			wrapUnaryHandler(tt.Name, tt.Func)
+		}), tt.Name)
+	}
+}
+
+func TestWrapUnaryHandlerValid(t *testing.T) {
+	tests := []struct {
+		Name string
+		Func interface{}
+	}{
+		{
+			"foo",
+			func(context.Context, *struct{}) (*struct{}, error) {
+				return nil, nil
+			},
+		},
+		{
+			"bar",
+			func(context.Context, map[string]interface{}) (*struct{}, error) {
+				return nil, nil
+			},
+		},
+		{
+			"baz",
+			func(context.Context, map[string]interface{}) (map[string]interface{}, error) {
+				return nil, nil
+			},
+		},
+		{
+			"qux",
+			func(context.Context, interface{}) (map[string]interface{}, error) {
+				return nil, nil
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		wrapUnaryHandler(tt.Name, tt.Func)
+	}
+}
+
+func TestWrapOnewayHandlerInvalid(t *testing.T) {
+	tests := []struct {
+		Name string
+		Func interface{}
+	}{
+		{"empty", func() {}},
+		{"not-a-function", 0},
+		{
+			"wrong-args-in",
+			func(context.Context) error {
+				return nil
+			},
+		},
+		{
+			"wrong-ctx",
+			func(string, *struct{}) error {
+				return nil
+			},
+		},
+		{
+			"wrong-req-body",
+			func(context.Context, string, int) error {
+				return nil
+			},
+		},
+		{
+			"wrong-response",
+			func(context.Context, map[string]interface{}) (*struct{}, error) {
+				return nil, nil
+			},
+		},
+		{
+			"wrong-response-val",
+			func(context.Context, map[string]interface{}) int {
+				return 0
+			},
+		},
+		{
+			"non-pointer-req",
+			func(context.Context, struct{}) error {
+				return nil
+			},
+		},
+		{
+			"non-string-key",
+			func(context.Context, map[int32]interface{}) error {
+				return nil
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		assert.Panics(t, assert.PanicTestFunc(func() {
+			wrapOnewayHandler(tt.Name, tt.Func)
+		}))
+	}
+}
+func TestWrapOnewayHandlerValid(t *testing.T) {
+	tests := []struct {
+		Name string
+		Func interface{}
+	}{
+		{
+			"foo",
+			func(context.Context, *struct{}) error {
+				return nil
+			},
+		},
+		{
+			"bar",
+			func(context.Context, map[string]interface{}) error {
+				return nil
+			},
+		},
+		{
+			"baz",
+			func(context.Context, map[string]interface{}) error {
+				return nil
+			},
+		},
+		{
+			"qux",
+			func(context.Context, interface{}) error {
+				return nil
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		wrapOnewayHandler(tt.Name, tt.Func)
+	}
+}


### PR DESCRIPTION
This is in no way ready to merge.

----

Initial take on a gob encoding. This is just a copy-paste of the JSON encoding
with a search-and-replace of json to gob and minor fixes.

Some DRYing up and refining may be necessary before merging.

- [ ] Support procedures with multiple arguments
- [ ] Crossdock
- [ ] Docs for gob-specific use cases
- [ ] Disclaimer about backwards compatibility and gob
- [ ] De-dupe reflection code between JSON and gob

See also T869917