### PR TITLE
mapdecode: Squash embedded structs

### DIFF
--- a/internal/mapdecode/CHANGELOG.md
+++ b/internal/mapdecode/CHANGELOG.md
@@ -9,6 +9,7 @@ v0.2.0 (unreleased)
     struct fields.
 -   Decode now parses strings if they are found in place of a float, boolean,
     or integer.
+-   Embedded structs and maps will now be inlined into their parent structs.
 
 
 v0.1.0 (2017-03-31)

--- a/internal/mapdecode/README_FIRST.md
+++ b/internal/mapdecode/README_FIRST.md
@@ -8,3 +8,4 @@ The vendored mapstructure library is commit
 cc8532a8e9a55ea36402aa21efdf403a60d34096 with the following PRs on top:
 
 -   https://github.com/mitchellh/mapstructure/pull/78
+-   https://github.com/mitchellh/mapstructure/pull/80

--- a/internal/mapdecode/decode.go
+++ b/internal/mapdecode/decode.go
@@ -180,8 +180,9 @@ func decodeFrom(opts *options, src interface{}) Into {
 		)
 
 		cfg := mapstructure.DecoderConfig{
-			ErrorUnused: !opts.IgnoreUnused,
-			Result:      dest,
+			ErrorUnused:    !opts.IgnoreUnused,
+			Result:         dest,
+			SquashEmbedded: true,
 			DecodeHook: fromDecodeHookFunc(
 				supportPointers(composeDecodeHooks(hooks)),
 			),

--- a/internal/mapdecode/mapstructure/mapstructure_test.go
+++ b/internal/mapdecode/mapstructure/mapstructure_test.go
@@ -32,6 +32,14 @@ type Embedded struct {
 	Vunique string
 }
 
+type EmbeddedNoSquash struct {
+	// Opt out of squashing for one embedded type but not another.
+	Basic `mapstructure:",nosquash"`
+	MapAlias
+
+	Vunique string
+}
+
 type EmbeddedPointer struct {
 	*Basic
 	Vunique string
@@ -50,6 +58,13 @@ type EmbeddedSlice struct {
 }
 
 type MapAlias map[string]interface{}
+
+type EmbeddedMap struct {
+	MapAlias
+
+	Vfoo  string
+	Vlist []string
+}
 
 type EmbeddedMapSquash struct {
 	MapAlias `mapstructure:",squash"`
@@ -293,6 +308,78 @@ func TestDecode_Embedded(t *testing.T) {
 	}
 }
 
+func TestDecode_SquashEmbedded_Embedded(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]interface{}{
+		"vbool":   true,
+		"vint":    42,
+		"vstring": "foo",
+		"vunique": "bar",
+	}
+
+	var result Embedded
+
+	decoder, err := NewDecoder(&DecoderConfig{Result: &result, SquashEmbedded: true})
+	if err != nil {
+		t.Fatalf("got an err: %s", err.Error())
+	}
+
+	if err := decoder.Decode(input); err != nil {
+		t.Fatalf("got an err: %s", err.Error())
+	}
+
+	if !result.Vbool {
+		t.Errorf("vbool value should be 'true': %#v", result.Vbool)
+	}
+
+	if result.Vint != 42 {
+		t.Errorf("vint value should be '42': %#v", result.Vint)
+	}
+
+	if result.Vstring != "foo" {
+		t.Errorf("vstring value should be 'foo': %#v", result.Vstring)
+	}
+
+	if result.Vunique != "bar" {
+		t.Errorf("vunique value should be 'bar': %#v", result.Vunique)
+	}
+}
+
+func TestDecode_SquashEmbedded_EmbeddedNoSquash(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]interface{}{
+		"vstring": "foo",
+		"Basic": map[string]interface{}{
+			"vstring": "innerfoo",
+		},
+		"vunique": "bar",
+	}
+
+	var result EmbeddedNoSquash
+	decoder, err := NewDecoder(&DecoderConfig{Result: &result, SquashEmbedded: true})
+	if err != nil {
+		t.Fatalf("got an err: %s", err.Error())
+	}
+
+	if err := decoder.Decode(input); err != nil {
+		t.Fatalf("got an err: %s", err.Error())
+	}
+
+	if result.Vstring != "innerfoo" {
+		t.Errorf("vstring value should be 'innerfoo': %#v", result.Vstring)
+	}
+
+	if result.Vunique != "bar" {
+		t.Errorf("vunique value should be 'bar': %#v", result.Vunique)
+	}
+
+	if result.MapAlias["vstring"] != "foo" {
+		t.Errorf("MapAlias.vstring value should be 'foo': %#v", result.MapAlias["vstring"])
+	}
+}
+
 func TestDecode_EmbeddedPointer(t *testing.T) {
 	t.Parallel()
 
@@ -341,6 +428,38 @@ func TestDecode_EmbeddedSlice(t *testing.T) {
 
 	if result.Vunique != "bar" {
 		t.Errorf("vunique value should be 'bar': %#v", result.Vunique)
+	}
+}
+
+func TestDecode_SquashEmbedded_EmbeddedMap(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]interface{}{
+		"vbool":   true,
+		"vfoo":    "42",
+		"vlist":   []interface{}{"1", "2", "3"},
+		"vunique": "bar",
+	}
+
+	var result EmbeddedMap
+
+	decoder, err := NewDecoder(&DecoderConfig{Result: &result, SquashEmbedded: true})
+	if err != nil {
+		t.Fatalf("got an err: %s", err.Error())
+	}
+
+	if err := decoder.Decode(input); err != nil {
+		t.Fatalf("got an err: %s", err.Error())
+	}
+
+	wantResult := EmbeddedMap{
+		MapAlias: MapAlias{"vbool": true, "vunique": "bar"},
+		Vfoo:     "42",
+		Vlist:    []string{"1", "2", "3"},
+	}
+
+	if !reflect.DeepEqual(wantResult, result) {
+		t.Errorf("result mismatch: %#v", result)
 	}
 }
 


### PR DESCRIPTION
This pulls mitchellh/mapstructure#80 into our vendored copy of
mapstructure and enables the newly added flag in mapdecode.

We always want embedded structs to be inlined.