### PR TITLE
Fix nil middleware chaining in dispatcher construction

### DIFF
--- a/internal/inboundmiddleware/chain.go
+++ b/internal/inboundmiddleware/chain.go
@@ -31,6 +31,9 @@ import (
 func UnaryChain(mw ...middleware.UnaryInbound) middleware.UnaryInbound {
 	unchained := make([]middleware.UnaryInbound, 0, len(mw))
 	for _, m := range mw {
+		if m == nil {
+			continue
+		}
 		if c, ok := m.(unaryChain); ok {
 			unchained = append(unchained, c...)
 			continue
@@ -77,6 +80,9 @@ func (x unaryChainExec) Handle(ctx context.Context, req *transport.Request, resw
 func OnewayChain(mw ...middleware.OnewayInbound) middleware.OnewayInbound {
 	unchained := make([]middleware.OnewayInbound, 0, len(mw))
 	for _, m := range mw {
+		if m == nil {
+			continue
+		}
 		if c, ok := m.(onewayChain); ok {
 			unchained = append(unchained, c...)
 			continue
@@ -90,7 +96,7 @@ func OnewayChain(mw ...middleware.OnewayInbound) middleware.OnewayInbound {
 	case 1:
 		return unchained[0]
 	default:
-		return onewayChain(mw)
+		return onewayChain(unchained)
 	}
 }
 

--- a/internal/inboundmiddleware/chain_test.go
+++ b/internal/inboundmiddleware/chain_test.go
@@ -64,8 +64,8 @@ func TestUnaryChain(t *testing.T) {
 		desc string
 		mw   middleware.UnaryInbound
 	}{
-		{"flat chain", UnaryChain(before, retryUnaryInbound, after)},
-		{"nested chain", UnaryChain(before, UnaryChain(retryUnaryInbound, after))},
+		{"flat chain", UnaryChain(before, retryUnaryInbound, after, nil)},
+		{"nested chain", UnaryChain(before, UnaryChain(retryUnaryInbound, nil, after))},
 	}
 
 	for _, tt := range tests {
@@ -114,8 +114,8 @@ func TestOnewayChain(t *testing.T) {
 		desc string
 		mw   middleware.OnewayInbound
 	}{
-		{"flat chain", OnewayChain(before, retryOnewayInbound, after)},
-		{"nested chain", OnewayChain(before, OnewayChain(retryOnewayInbound, after))},
+		{"flat chain", OnewayChain(before, retryOnewayInbound, after, nil)},
+		{"nested chain", OnewayChain(before, OnewayChain(retryOnewayInbound, nil, after))},
 	}
 
 	for _, tt := range tests {

--- a/internal/outboundmiddleware/chain.go
+++ b/internal/outboundmiddleware/chain.go
@@ -32,6 +32,9 @@ import (
 func UnaryChain(mw ...middleware.UnaryOutbound) middleware.UnaryOutbound {
 	unchained := make([]middleware.UnaryOutbound, 0, len(mw))
 	for _, m := range mw {
+		if m == nil {
+			continue
+		}
 		if c, ok := m.(unaryChain); ok {
 			unchained = append(unchained, c...)
 			continue
@@ -101,6 +104,9 @@ func (x unaryChainExec) Introspect() introspection.OutboundStatus {
 func OnewayChain(mw ...middleware.OnewayOutbound) middleware.OnewayOutbound {
 	unchained := make([]middleware.OnewayOutbound, 0, len(mw))
 	for _, m := range mw {
+		if m == nil {
+			continue
+		}
 		if c, ok := m.(onewayChain); ok {
 			unchained = append(unchained, c...)
 			continue

--- a/internal/outboundmiddleware/chain_test.go
+++ b/internal/outboundmiddleware/chain_test.go
@@ -66,8 +66,8 @@ func TestUnaryChain(t *testing.T) {
 		desc string
 		mw   middleware.UnaryOutbound
 	}{
-		{"flat chain", UnaryChain(before, retryUnaryOutbound, after)},
-		{"nested chain", UnaryChain(before, UnaryChain(retryUnaryOutbound, after))},
+		{"flat chain", UnaryChain(before, retryUnaryOutbound, nil, after)},
+		{"nested chain", UnaryChain(before, UnaryChain(retryUnaryOutbound, after, nil))},
 	}
 
 	for _, tt := range tests {
@@ -120,8 +120,8 @@ func TestOnewayChain(t *testing.T) {
 		desc string
 		mw   middleware.OnewayOutbound
 	}{
-		{"flat chain", OnewayChain(before, retryOnewayOutbound, after)},
-		{"flat chain", OnewayChain(before, OnewayChain(retryOnewayOutbound, after))},
+		{"flat chain", OnewayChain(before, retryOnewayOutbound, nil, after)},
+		{"flat chain", OnewayChain(before, OnewayChain(retryOnewayOutbound, after, nil))},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Chaining nil middleware isn't safe. This PR makes the chaining functions automatically strip nils.