### PR TITLE
mapdecode: Fix squashed map selection bug

### DIFF
--- a/internal/mapdecode/mapstructure/mapstructure.go
+++ b/internal/mapdecode/mapstructure/mapstructure.go
@@ -738,7 +738,7 @@ func (d *Decoder) decodeStruct(name string, data interface{}, val reflect.Value)
 					}
 
 					squashedMapField = &fieldType
-					squashedMapValue = val.Field(i)
+					squashedMapValue = structVal.Field(i)
 				default:
 					errors = appendErrors(errors,
 						fmt.Errorf("%s: unsupported type for squash: %s", fieldType.Name, fieldKind))


### PR DESCRIPTION
This fixes a bug in squashed map support that we introduced and fixed in
mitchellh/mapstructure#78.