### PR TITLE
http/out: Support AddHeader option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ v1.8.0 (unreleased)
     is now public.
 -   Adds an accessor to Dispatcher which provides access to the inbound
     middleware used by that Dispatcher.
+-   http: Added an `AddHeader` option to HTTP outbounds to send certain headers
+    for all requests.
 
 
 v1.7.1 (2017-03-29)

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -70,7 +70,16 @@ func URLTemplate(template string) OutboundOption {
 // header in outgoung requests.
 //
 // 	httpTransport.NewOutbound(chooser, http.AddHeader("X-Token", "TOKEN"))
+//
+// Note that headers starting with "Rpc-" are reserved by YARPC. This function
+// will panic if the header starts with "Rpc-".
 func AddHeader(key, value string) OutboundOption {
+	if strings.HasPrefix(strings.ToLower(key), "rpc-") {
+		panic(fmt.Errorf(
+			"invalid header name %q: "+
+				`headers starting with "Rpc-" are reserved by YARPC`, key))
+	}
+
 	return func(o *Outbound) {
 		if o.headers == nil {
 			o.headers = make(http.Header)

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -66,6 +66,19 @@ func URLTemplate(template string) OutboundOption {
 	}
 }
 
+// AddHeader specifies that an HTTP outbound should always include the given
+// header in outgoung requests.
+//
+// 	httpTransport.NewOutbound(chooser, http.AddHeader("X-Token", "TOKEN"))
+func AddHeader(key, value string) OutboundOption {
+	return func(o *Outbound) {
+		if o.headers == nil {
+			o.headers = make(http.Header)
+		}
+		o.headers.Add(key, value)
+	}
+}
+
 // NewOutbound builds an HTTP outbound which sends requests to peers supplied
 // by the given peer.Chooser. The URL template for used for the different
 // peers may be customized using the URLTemplate option.
@@ -127,6 +140,9 @@ type Outbound struct {
 	urlTemplate *url.URL
 	tracer      opentracing.Tracer
 	transport   *Transport
+
+	// Headers to add to all outgoing requests.
+	headers http.Header
 
 	once sync.LifecycleOnce
 }
@@ -323,6 +339,13 @@ func (o *Outbound) withOpentracingSpan(ctx context.Context, req *http.Request, t
 }
 
 func (o *Outbound) withCoreHeaders(req *http.Request, treq *transport.Request, ttl time.Duration) *http.Request {
+	// Add default headers to all requests.
+	for k, vs := range o.headers {
+		for _, v := range vs {
+			req.Header.Add(k, v)
+		}
+	}
+
 	req.Header.Set(CallerHeader, treq.Caller)
 	req.Header.Set(ServiceHeader, treq.Service)
 	req.Header.Set(ProcedureHeader, treq.Procedure)

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -97,6 +97,7 @@ func TestOutboundHeaders(t *testing.T) {
 		desc    string
 		context context.Context
 		headers transport.Headers
+		opts    []OutboundOption
 
 		wantHeaders map[string]string
 	}{
@@ -106,6 +107,19 @@ func TestOutboundHeaders(t *testing.T) {
 			wantHeaders: map[string]string{
 				"Rpc-Header-Foo": "bar",
 				"Rpc-Header-Baz": "Qux",
+			},
+		},
+		{
+			desc:    "extra headers",
+			headers: transport.NewHeaders().With("x", "y"),
+			opts: []OutboundOption{
+				AddHeader("X-Foo", "bar"),
+				AddHeader("X-BAR", "BAZ"),
+			},
+			wantHeaders: map[string]string{
+				"Rpc-Header-X": "y",
+				"X-Foo":        "bar",
+				"X-Bar":        "BAZ",
 			},
 		},
 	}
@@ -131,7 +145,7 @@ func TestOutboundHeaders(t *testing.T) {
 			defer cancel()
 		}
 
-		out := httpTransport.NewSingleOutbound(server.URL)
+		out := httpTransport.NewSingleOutbound(server.URL, tt.opts...)
 		assert.Len(t, out.Transports(), 1, "transports must contain the transport")
 		// we use == instead of assert.Equal because we want to do a pointer
 		// comparison

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -92,6 +92,18 @@ func TestCallSuccess(t *testing.T) {
 	}
 }
 
+func TestAddReservedHeader(t *testing.T) {
+	tests := []string{
+		"Rpc-Foo",
+		"rpc-header-foo",
+		"RPC-Bar",
+	}
+
+	for _, tt := range tests {
+		assert.Panics(t, func() { AddHeader(tt, "bar") })
+	}
+}
+
 func TestOutboundHeaders(t *testing.T) {
 	tests := []struct {
 		desc    string


### PR DESCRIPTION
This adds an `AddHeader` option to HTTP outbounds. This accounts for use
cases where you're trying to call an existing service via YARPC where
the service expects a specific static header to always be present in
outgoing requests.

Note that this feature is intentionally very limited: We don't want to
leak transport-specific details at call sites so we require that the
headers are static and that they are specified at transport construction
time.

Related: T865043