### PR TITLE
Move pally testing helpers into a subpackage

### DIFF
--- a/internal/pally/counter_test.go
+++ b/internal/pally/counter_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/yarpc/internal/pally/pallytest"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -59,7 +61,7 @@ func TestCounter(t *testing.T) {
 	}
 	export.Test(t, scope)
 
-	assertPrometheusText(t, r, "# HELP test_counter Some help.\n"+
+	pallytest.AssertPrometheus(t, r, "# HELP test_counter Some help.\n"+
 		"# TYPE test_counter counter\n"+
 		`test_counter{foo="bar",service="users"} 4`)
 }

--- a/internal/pally/histogram_test.go
+++ b/internal/pally/histogram_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/yarpc/internal/pally/pallytest"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -68,7 +70,7 @@ func TestLatencies(t *testing.T) {
 	}
 	export.Test(t, scope)
 
-	assertPrometheusText(t, r, "# HELP test_latency_ns Some help.\n"+
+	pallytest.AssertPrometheus(t, r, "# HELP test_latency_ns Some help.\n"+
 		"# TYPE test_latency_ns histogram\n"+
 		`test_latency_ns_bucket{foo="bar",service="users",le="10"} 3`+"\n"+
 		`test_latency_ns_bucket{foo="bar",service="users",le="50"} 3`+"\n"+
@@ -201,7 +203,7 @@ func TestLatenciesVector(t *testing.T) {
 			time.Sleep(5 * _tick)
 			tt.wantTally.Test(t, scope)
 
-			assertPrometheusText(t, r, tt.wantProm)
+			pallytest.AssertPrometheus(t, r, tt.wantProm)
 		})
 
 	}
@@ -234,7 +236,7 @@ func TestLatenciesVectorIndependence(t *testing.T) {
 	x.Observe(time.Millisecond)
 	y.Observe(time.Millisecond)
 
-	assertPrometheusText(t, r, "# HELP test_latency_ms Some help.\n"+
+	pallytest.AssertPrometheus(t, r, "# HELP test_latency_ms Some help.\n"+
 		"# TYPE test_latency_ms histogram\n"+
 		`test_latency_ms_bucket{var="x",le="1000"} 1`+"\n"+
 		`test_latency_ms_bucket{var="x",le="+Inf"} 1`+"\n"+

--- a/internal/pally/registry_test.go
+++ b/internal/pally/registry_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/yarpc/internal/pally/pallytest"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/stretchr/testify/assert"
@@ -33,7 +35,6 @@ import (
 	"github.com/uber-go/tally"
 	"github.com/uber-go/tally/m3"
 	"go.uber.org/atomic"
-	"go.uber.org/yarpc/internal/pally/pallytest"
 )
 
 func TestSimpleMetricDuplicates(t *testing.T) {

--- a/internal/pally/registry_test.go
+++ b/internal/pally/registry_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/uber-go/tally"
 	"github.com/uber-go/tally/m3"
 	"go.uber.org/atomic"
+	"go.uber.org/yarpc/internal/pally/pallytest"
 )
 
 func TestSimpleMetricDuplicates(t *testing.T) {
@@ -99,7 +100,7 @@ func TestFederatedMetrics(t *testing.T) {
 		"# TYPE foo counter\n" +
 		"foo 1"
 
-	assertPrometheusText(t, promhttp.HandlerFor(prom, promhttp.HandlerOpts{}), expected)
+	pallytest.AssertPrometheus(t, promhttp.HandlerFor(prom, promhttp.HandlerOpts{}), expected)
 }
 
 func TestConstLabelValidation(t *testing.T) {
@@ -113,7 +114,7 @@ func TestConstLabelValidation(t *testing.T) {
 		Help: "help",
 	})
 	require.NoError(t, err, "Unexpected error creating a counter.")
-	assertPrometheusText(t, r, "# HELP test help\n"+
+	pallytest.AssertPrometheus(t, r, "# HELP test help\n"+
 		"# TYPE test counter\n"+
 		`test{ok="yes"} 0`)
 }

--- a/internal/pally/utils_test.go
+++ b/internal/pally/utils_test.go
@@ -21,10 +21,6 @@
 package pally
 
 import (
-	"io/ioutil"
-	"net/http"
-	"net/http/httptest"
-	"strings"
 	"testing"
 	"time"
 
@@ -37,23 +33,6 @@ const _tick = 10 * time.Millisecond
 
 func newTestScope() tally.TestScope {
 	return tally.NewTestScope("" /* prefix */, nil /* tags */)
-}
-
-func scrape(t testing.TB, registry http.Handler) (int, string) {
-	server := httptest.NewServer(registry)
-	defer server.Close()
-
-	resp, err := http.Get(server.URL)
-	require.NoError(t, err, "Unexpected error scraping Prometheus endpoint.")
-	body, err := ioutil.ReadAll(resp.Body)
-	require.NoError(t, err, "Unexpected error reading response body.")
-	return resp.StatusCode, string(body)
-}
-
-func assertPrometheusText(t testing.TB, registry http.Handler, expected string) {
-	code, body := scrape(t, registry)
-	assert.Equal(t, http.StatusOK, code, "Unexpected HTTP response code from Prometheus scrape.")
-	assert.Equal(t, expected, strings.TrimSpace(body), "Unexpected plain-text Prometheus scrape.")
 }
 
 type TallyExpectation struct {

--- a/internal/pally/vector_test.go
+++ b/internal/pally/vector_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/yarpc/internal/pally/pallytest"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -186,7 +188,7 @@ func TestSimpleVectors(t *testing.T) {
 			time.Sleep(5 * _tick)
 			tt.wantTally.Test(t, scope)
 
-			assertPrometheusText(t, r, tt.wantProm)
+			pallytest.AssertPrometheus(t, r, tt.wantProm)
 		})
 	}
 }


### PR DESCRIPTION
This is a small prefactor to support metrics in the observing middleware. We'll want to re-use these testing helpers from pally, so start by splitting them out into a `pallytest` package.