### PR TITLE
Parallelize circleci builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,22 +13,13 @@ jobs:
       - restore_cache:
           key: yarpc-go
       - run:
-          name: crossdock
-          command: make ci
-          environment:
-            - CI_TYPES: crossdock
-      - run:
-          name: 1.8 lint test examples
-          command: make ci
-          environment:
-            - CI_TYPES: deps lint test examples
-            - DOCKER_GO_VERSION: 1.8
-      - run:
-          name: 1.7 cover
-          command: make ci
-          environment:
-            - CI_TYPES: deps cover
-            - DOCKER_GO_VERSION: 1.7
+         name: run make ci
+         command:
+           case $CIRCLE_NODE_INDEX in
+           0) CI_TYPES=crossdock make ci ;;
+           1) DOCKER_GO_VERSION=1.8 CI_TYPES="deps lint test examples" make ci ;;
+           2) DOCKER_GO_VERSION=1.7 CI_TYPES="deps lint test examples" make ci ;;
+           esac
       - save_cache:
           key: yarpc-go
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,9 @@ jobs:
       - checkout
       - setup_remote_docker:
           reusable: true
-          exclusive: false
+          # run tests run on separate docker engines to avoid interference and
+          # and resource contention
+          exclusive: true
       - restore_cache:
           key: yarpc-go
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
            case $CIRCLE_NODE_INDEX in
            0) CI_TYPES=crossdock make ci ;;
            1) DOCKER_GO_VERSION=1.8 CI_TYPES="deps lint test examples" make ci ;;
-           2) DOCKER_GO_VERSION=1.7 CI_TYPES="deps lint test examples" make ci ;;
+           2) DOCKER_GO_VERSION=1.7 CI_TYPES="deps cover" make ci ;;
            esac
       - save_cache:
           key: yarpc-go


### PR DESCRIPTION
Optimize CircleCI builds a bit more, namely by doing the following:

* Run each variant of `make ci` runs once on separate node
* Using a different docker engine for each node.  Setting `exclusive: false` means that the same Docker Engine will be shared across multiple build executions - resulting into test interference and resource contention.  Will still get the benefits of layer caching - but it may take a couple of builds to get a warm cache across all engines.