### PR TITLE
Fix string formatting in panic

### DIFF
--- a/dispatcher.go
+++ b/dispatcher.go
@@ -108,7 +108,7 @@ func NewDispatcher(cfg Config) *Dispatcher {
 		panic("yarpc.NewDispatcher expects a service name")
 	}
 	if err := internal.ValidateServiceName(cfg.Name); err != nil {
-		panic("yarpc.NewDispatcher expects a valid service name: %s" + err.Error())
+		panic("yarpc.NewDispatcher expects a valid service name: " + err.Error())
 	}
 
 	logger := zap.NewNop()


### PR DESCRIPTION
We've left a string-formatting placeholder in the message even though we're not using `fmt.Sprint`.