### PR TITLE
cover.sh: Only measure library code

### DIFF
--- a/scripts/cover.sh
+++ b/scripts/cover.sh
@@ -86,6 +86,6 @@ reset_waitpids
 # Merge cross-package coverage and then split the result into main and
 # experimental coverages.
 gocovmerge "$COVER"/*.out \
-	| grep -v 'internal/examples' \
+	| grep -v 'internal/examples\|/[a-z]\+test\b' \
 	| tee >(grep -v /x/ > coverage.main.txt) \
 	| (echo 'mode: atomic'; grep /x/) > coverage.x.txt

--- a/scripts/cover.sh
+++ b/scripts/cover.sh
@@ -85,9 +85,10 @@ reset_waitpids
 
 # Merge cross-package coverage and then split the result into main and
 # experimental coverages.
+#
+# We ignore packages in the form "footest" and any mock files.
 gocovmerge "$COVER"/*.out \
-	| grep -v '/internal/examples/\|/internal/tests/' \
-	| grep -v '/[a-z]\+test/' \  # packages in the form "footest"
-	| grep -v 'mock_.*\.go' \  # mock files
+	| grep -v '/internal/examples/\|/internal/tests/\|/mocks/' \
+	| grep -v '/[a-z]\+test/' \
 	| tee >(grep -v /x/ > coverage.main.txt) \
 	| (echo 'mode: atomic'; grep /x/) > coverage.x.txt

--- a/scripts/cover.sh
+++ b/scripts/cover.sh
@@ -31,14 +31,18 @@ if [[ -d "$COVER" ]]; then
 fi
 mkdir -p "$COVER"
 
+ignorePkgs=""
+
 # If a package directory has a .nocover file, don't count it when calculating
 # coverage.
 filter=""
 for pkg in "$@"; do
 	if [[ -f "$GOPATH/src/$pkg/.nocover" ]]; then
 		if [[ -n "$filter" ]]; then
+			ignorePkgs="$ignorePkgs\|"
 			filter="$filter, "
 		fi
+		ignorePkgs="$ignorePkgs$pkg/"
 		filter="$filter\"$pkg\": true"
 	fi
 done
@@ -90,5 +94,6 @@ reset_waitpids
 gocovmerge "$COVER"/*.out \
 	| grep -v '/internal/examples/\|/internal/tests/\|/mocks/' \
 	| grep -v '/[a-z]\+test/' \
+	| grep -v "$ignorePkgs" \
 	| tee >(grep -v /x/ > coverage.main.txt) \
 	| (echo 'mode: atomic'; grep /x/) > coverage.x.txt

--- a/scripts/cover.sh
+++ b/scripts/cover.sh
@@ -86,6 +86,8 @@ reset_waitpids
 # Merge cross-package coverage and then split the result into main and
 # experimental coverages.
 gocovmerge "$COVER"/*.out \
-	| grep -v 'internal/examples\|/[a-z]\+test\b' \
+	| grep -v '/internal/examples/\|/internal/tests/' \
+	| grep -v '/[a-z]\+test/' \  # packages in the form "footest"
+	| grep -v 'mock_.*\.go' \  # mock files
 	| tee >(grep -v /x/ > coverage.main.txt) \
 	| (echo 'mode: atomic'; grep /x/) > coverage.x.txt


### PR DESCRIPTION
This changes cover.sh to to ignore coverage numbers for crossdock and
examples code and APIs that are experimental. Further, it now takes test
imports and cross-package test imports into account while calculating
coverage.

The result is that the code coverage will reflect exactly what our
customers expect: "What is the code coverage of the YARPC library?".

Furthermore, experimental packages will require less scrutiny, which
will allow leaning on golden-path tests to favor velocity but also force
them to meet a high bar when leaving `x/`.