### PR TITLE
glide: Specify Apache Thrift repo path

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -3,6 +3,7 @@ updated: 2017-04-19T15:13:50.386855787-07:00
 imports:
 - name: github.com/apache/thrift
   repo: git://git.apache.org/thrift.git
+  vcs: git
   version: b2a4d4ae21c789b689dd162deb819665567f481c
   subpackages:
   - lib/go/thrift

--- a/glide.lock
+++ b/glide.lock
@@ -2,6 +2,7 @@ hash: 733dbe39a05cf3d6d9bb4250d170d4e0f2e7627924f45cbfc9ebeca9eaadc228
 updated: 2017-04-19T15:13:50.386855787-07:00
 imports:
 - name: github.com/apache/thrift
+  repo: git://git.apache.org/thrift.git
   version: b2a4d4ae21c789b689dd162deb819665567f481c
   subpackages:
   - lib/go/thrift

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,6 +3,7 @@ homepage: https://github.com/yarpc/yarpc-go
 license: MIT
 import:
 - package: github.com/apache/thrift
+  repo: git://git.apache.org/thrift.git
   version: ^0.9.3
 - package: github.com/crossdock/crossdock-go
   version: master

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,6 +4,7 @@ license: MIT
 import:
 - package: github.com/apache/thrift
   repo: git://git.apache.org/thrift.git
+  vcs: git
   version: ^0.9.3
 - package: github.com/crossdock/crossdock-go
   version: master


### PR DESCRIPTION
The official Apache Thrift GitHub mirror seems to have disappeared.
This points Glide to their official repo instead.