### PR TITLE
codecov: Explicitly ignore .nocover packages

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -11,3 +11,33 @@ coverage:
       experimental:
         target: 70%
         flags: experimental
+
+ignore:
+  # All packages with .nocover files in them MUST be listed here
+ - /encoding/thrift/internal/
+ - /encoding/x/protobuf/internal/wirepb/
+ - /internal/crossdock/client/dispatcher/
+ - /internal/crossdock/crossdockpb/
+ - /internal/crossdock/thrift/
+ - /internal/crossdock/thrift/echo/
+ - /internal/crossdock/thrift/echo/echoclient/
+ - /internal/crossdock/thrift/echo/echoserver/
+ - /internal/crossdock/thrift/echo/yarpc/
+ - /internal/crossdock/thrift/gauntlet/
+ - /internal/crossdock/thrift/gauntlet/secondserviceclient/
+ - /internal/crossdock/thrift/gauntlet/secondserviceserver/
+ - /internal/crossdock/thrift/gauntlet/thrifttestclient/
+ - /internal/crossdock/thrift/gauntlet/thrifttestserver/
+ - /internal/crossdock/thrift/gauntlet/yarpc/
+ - /internal/crossdock/thrift/gen-go/
+ - /internal/crossdock/thrift/gen-go/echo/
+ - /internal/crossdock/thrift/gen-go/gauntlet_apache/
+ - /internal/crossdock/thrift/gen-go/gauntlet_tchannel/
+ - /internal/crossdock/thrift/oneway/
+ - /internal/crossdock/thrift/oneway/onewayclient/
+ - /internal/crossdock/thrift/oneway/onewayserver/
+ - /internal/crossdock/thrift/oneway/yarpc/
+ - /internal/examples/protobuf/examplepb/
+ - /internal/mapdecode/mapstructure/
+ - /internal/service-test/
+ - /yarpcproto/

--- a/build/local.mk
+++ b/build/local.mk
@@ -103,8 +103,18 @@ verifyversion: ## verify the version in the changelog is the same as in version.
 		exit 1; \
 	fi
 
+.PHONY: verifycodecovignores
+verifycodecovignores: ## verify that .codecov.yml contains all .nocover packages
+	@find . -name vendor -prune -o -name .nocover -exec dirname '{}' ';' \
+		| cut -b2- \
+		| while read f; do \
+			if ! grep "$$f" .codecov.yml &>/dev/null; then \
+				echo ".codecov.yml is out of date: add $$f to it"; \
+			fi \
+		done
+
 .PHONY: lint
-lint: generatenodiff nogogenerate gofmt govet golint staticcheck errcheck verifyversion ## run all linters
+lint: generatenodiff nogogenerate gofmt govet golint staticcheck errcheck verifyversion verifycodecovignores ## run all linters
 
 .PHONY: test
 test: $(THRIFTRW) __eval_packages ## run all tests


### PR DESCRIPTION
This adds all packages with a .nocover file explicitly into the list of
directories ignored by codecov. This should make our coverage output more
meaningful.