### PR TITLE
Update peerlist-peerupdater config structure

### DIFF
--- a/transport/http/config_test.go
+++ b/transport/http/config_test.go
@@ -255,7 +255,7 @@ func TestTransportSpec(t *testing.T) {
 			},
 			wantErrors: []string{
 				"cannot configure peer chooser for HTTP outbound",
-				"no recognized peer list in config: got least-pending",
+				`failed to read attribute "least-pending"`,
 			},
 		},
 	}

--- a/x/config/chooser.go
+++ b/x/config/chooser.go
@@ -102,21 +102,18 @@ func (pc PeerList) buildPeerList(transport peer.Transport, identify func(string)
 }
 
 func getPeerListInfo(etc attributeMap, kit *Kit) (name string, config attributeMap, err error) {
-	names := etc.keys()
-	if len(names) == 0 {
+	names := etc.Keys()
+	switch len(names) {
+	case 0:
 		return "", nil, fmt.Errorf("no peer list provided in config, need one of: %+v", kit.peerListSpecNames())
-	}
-	if len(names) > 1 {
+	default:
 		return "", nil, fmt.Errorf("unrecognized attributes in outbound config: %+v", etc)
+	case 1:
+		// Empty, use logic below
 	}
-	peerListName := names[0]
-
-	var peerListConfig attributeMap
-	if _, err := etc.Pop(peerListName, &peerListConfig); err != nil {
-		return "", nil, err
-	}
-
-	return peerListName, peerListConfig, nil
+	name = names[0]
+	_, err = etc.Pop(name, &config)
+	return
 }
 
 func buildPeerListUpdater(c attributeMap, identify func(string) peer.Identifier, kit *Kit) (peer.Binder, error) {

--- a/x/config/chooser_test.go
+++ b/x/config/chooser_test.go
@@ -389,6 +389,26 @@ func TestChooserConfigurator(t *testing.T) {
 			},
 		},
 		{
+			desc: "invalid peer list decode",
+			given: whitespace.Expand(`
+				transports:
+					fake-transport:
+						nop: ":1234"
+				outbounds:
+					their-service:
+						unary:
+							fake-transport:
+								nop: "*.*"
+								fake-list:
+									- 127.0.0.1:8080
+									- 127.0.0.1:8081
+			`),
+			wantErr: []string{
+				`failed to configure unary outbound for "their-service": `,
+				`failed to read attribute "fake-list"`,
+			},
+		},
+		{
 			desc: "invalid peer list updater",
 			given: whitespace.Expand(`
 				outbounds:

--- a/x/config/chooser_test.go
+++ b/x/config/chooser_test.go
@@ -385,7 +385,7 @@ func TestChooserConfigurator(t *testing.T) {
 			`),
 			wantErr: []string{
 				`failed to configure unary outbound for "their-service": `,
-				`no recognized peer list in config: got bogus-list; need one of fake-list, least-pending, round-robin`,
+				`no recognized peer list "bogus-list"; need one of fake-list, least-pending, round-robin`,
 			},
 		},
 		{
@@ -506,7 +506,11 @@ func TestChooserConfigurator(t *testing.T) {
 			`),
 			wantErr: []string{
 				`failed to configure unary outbound for "their-service": `,
-				`no recognized peer list in config: `,
+				`no peer list provided in config`,
+				`need one of`,
+				`fake-list`,
+				`least-pending`,
+				`round-robin`,
 			},
 		},
 	}

--- a/x/config/chooser_test.go
+++ b/x/config/chooser_test.go
@@ -148,8 +148,8 @@ func TestChooserConfigurator(t *testing.T) {
 							fake-transport:
 								nop: "*.*"
 								fake-list:
-									fake-updater: fake-news
-									watch: true
+									fake-updater:
+										watch: true
 			`),
 			test: func(t *testing.T, c yarpc.Config) {
 				outbound, ok := c.Outbounds["their-service"]
@@ -237,7 +237,7 @@ func TestChooserConfigurator(t *testing.T) {
 						unary:
 							fake-transport:
 								round-robin:
-									fake-updater: fake-news
+									fake-updater: {}
 			`),
 			test: func(t *testing.T, c yarpc.Config) {
 				outbound := c.Outbounds["their-service"]
@@ -256,7 +256,7 @@ func TestChooserConfigurator(t *testing.T) {
 						unary:
 							fake-transport:
 								least-pending:
-									fake-updater: fake-news
+									fake-updater: {}
 			`),
 			test: func(t *testing.T, c yarpc.Config) {
 				outbound := c.Outbounds["their-service"]
@@ -381,7 +381,7 @@ func TestChooserConfigurator(t *testing.T) {
 						unary:
 							fake-transport:
 								bogus-list:
-									fake-updater: fake-news
+									fake-updater: {}
 			`),
 			wantErr: []string{
 				`failed to configure unary outbound for "their-service": `,
@@ -415,7 +415,27 @@ func TestChooserConfigurator(t *testing.T) {
 			`),
 			wantErr: []string{
 				`failed to configure unary outbound for "their-service": `,
-				`unrecognized attributes in peer list config: `,
+				`unrecognized attributes in outbound config: `,
+				`conspicuously`,
+				`present`,
+			},
+		},
+		{
+			desc: "extraneous transport config in combination with list config",
+			given: whitespace.Expand(`
+				outbounds:
+					their-service:
+						unary:
+							fake-transport:
+								conspicuously: present
+								fake-list:
+									peers:
+										- 127.0.0.1:8080
+										- 127.0.0.1:8081
+			`),
+			wantErr: []string{
+				`failed to configure unary outbound for "their-service": `,
+				`unrecognized attributes in outbound config: `,
 				`conspicuously`,
 				`present`,
 			},
@@ -435,9 +455,8 @@ func TestChooserConfigurator(t *testing.T) {
 			`),
 			wantErr: []string{
 				`failed to configure unary outbound for "their-service": `,
-				`unrecognized attributes in peer list config: `,
+				`has invalid keys:`,
 				`conspicuously`,
-				`present`,
 			},
 		},
 		{
@@ -448,9 +467,9 @@ func TestChooserConfigurator(t *testing.T) {
 						unary:
 							fake-transport:
 								fake-list:
-									fake-updater: fake-news
-									watch: true
-									conspicuously: present
+									fake-updater:
+										watch: true
+										conspicuously: present
 			`),
 			wantErr: []string{
 				`failed to configure unary outbound for "their-service": `,

--- a/x/config/decode.go
+++ b/x/config/decode.go
@@ -60,6 +60,14 @@ func (m attributeMap) Get(name string, dst interface{}) (ok bool, err error) {
 	return true, err
 }
 
+func (m attributeMap) keys() []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
 func (m attributeMap) Decode(dst interface{}, opts ...mapdecode.Option) error {
 	return decodeInto(dst, m, opts...)
 }

--- a/x/config/decode.go
+++ b/x/config/decode.go
@@ -60,7 +60,7 @@ func (m attributeMap) Get(name string, dst interface{}) (ok bool, err error) {
 	return true, err
 }
 
-func (m attributeMap) keys() []string {
+func (m attributeMap) Keys() []string {
 	keys := make([]string, 0, len(m))
 	for key := range m {
 		keys = append(keys, key)

--- a/x/config/kit.go
+++ b/x/config/kit.go
@@ -21,8 +21,11 @@
 package config
 
 import (
+	"errors"
+	"fmt"
 	"reflect"
 	"sort"
+	"strings"
 )
 
 // Kit carries internal dependencies for building peer lists.
@@ -41,8 +44,17 @@ func (k *Kit) ServiceName() string { return k.name }
 
 var _typeOfKit = reflect.TypeOf((*Kit)(nil))
 
-func (k *Kit) peerListSpec(name string) *compiledPeerListSpec {
-	return k.c.knownPeerLists[name]
+func (k *Kit) peerListSpec(name string) (*compiledPeerListSpec, error) {
+	if spec := k.c.knownPeerLists[name]; spec != nil {
+		return spec, nil
+	}
+
+	msg := fmt.Sprintf("no recognized peer list %q", name)
+	if available := k.peerListSpecNames(); len(available) > 0 {
+		msg = fmt.Sprintf("%s; need one of %s", msg, strings.Join(available, ", "))
+	}
+
+	return nil, errors.New(msg)
 }
 
 func (k *Kit) peerListSpecNames() (names []string) {


### PR DESCRIPTION
Summary: This diff updates the config structure for peer lists
and peer updaters to standardize the namespaces for their options.

So we go from
```
outbounds:
  their-service:
    unary:
      http:
        httpOption1: blah1
        httpOption2: blah2
        listOption1:
        listOption2:
        list:
          updaterOption1: blah2
          updaterOption2: blah2
          updater: blahblah
```
to: 
```
outbounds:
  their-service:
    unary:
      http:
        httpOption1: blah1
        httpOption2: blah2
        list:
          listOption1:
          listOption2:
          updater: 
            updater: blahblah # This is now an option
            updaterOption1: blah2
            updaterOption2: blah2
```