### PR TITLE
codecov: Set range to 50-90

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,6 +2,8 @@ codecov:
   branch: dev
 
 coverage:
+  range: 50...90
+
   status:
     project:
       default: off


### PR DESCRIPTION
This makes it so that anything at 50% coverage or lower shows up as red
and anything 90% or higher shows up as green. Since we're aiming for 90
to begin with, this will help find low hanging fruits much better than
the default range of 70-100. We can readjust this once we hit 90.