### PR TITLE
make: Fix verifycodecovignores

### DIFF
--- a/build/docker.mk
+++ b/build/docker.mk
@@ -47,6 +47,10 @@ staticcheck: deps ## check staticchck
 errcheck: deps ## check errcheck
 	PATH=$$PATH:$(BIN) docker run $(DOCKER_RUN_FLAGS) $(DOCKER_IMAGE) make errcheck
 
+.PHONY: verifycodecovignores
+verifycodecovignores: deps ## check verifycodecovignores
+	PATH=$$PATH:$(BIN) docker run $(DOCKER_RUN_FLAGS) $(DOCKER_IMAGE) make verifycodecovignores
+
 .PHONY: verifyversion
 verifyversion: deps ## verify the version in the changelog is the same as in version.go
 	PATH=$$PATH:$(BIN) docker run $(DOCKER_RUN_FLAGS) $(DOCKER_IMAGE) make verifyversion

--- a/build/local.mk
+++ b/build/local.mk
@@ -105,10 +105,10 @@ verifyversion: ## verify the version in the changelog is the same as in version.
 
 .PHONY: verifycodecovignores
 verifycodecovignores: ## verify that .codecov.yml contains all .nocover packages
-	@find . -name vendor -prune -o -name .nocover -exec dirname '{}' ';' \
+	@find . '(' -name vendor -o -name .glide ')' -prune -o -name .nocover -exec dirname '{}' ';' \
 		| cut -b2- \
 		| while read f; do \
-			if ! grep "$$f" .codecov.yml &>/dev/null; then \
+			if ! grep "$$f" .codecov.yml >/dev/null; then \
 				echo ".codecov.yml is out of date: add $$f to it"; \
 				exit 1; \
 			fi \

--- a/build/local.mk
+++ b/build/local.mk
@@ -110,6 +110,7 @@ verifycodecovignores: ## verify that .codecov.yml contains all .nocover packages
 		| while read f; do \
 			if ! grep "$$f" .codecov.yml &>/dev/null; then \
 				echo ".codecov.yml is out of date: add $$f to it"; \
+				exit 1; \
 			fi \
 		done
 


### PR DESCRIPTION
The verifycodecovignores `make` job wasn't actually failing if a file
was missing from the `.codecov.yml` ignores.