### PR TITLE
codecov: Patches need to match project targets

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -13,6 +13,12 @@ coverage:
       experimental:
         target: 70%
         flags: experimental
+    patch:
+      default: off
+      main:
+        target: 80%
+      experimental:
+        target: 70%
 
 ignore:
   # All packages with .nocover files in them MUST be listed here


### PR DESCRIPTION
By default, patches have the target "auto" which requires that all new
code is covered at least as much as the current coverage. This isn't
always feasible.

Instead, we'll enforce the same coverage requirements to patches as the
project itself.