### PR TITLE
chown the mounted volume after generation

### DIFF
--- a/build/docker.mk
+++ b/build/docker.mk
@@ -5,7 +5,8 @@ DOCKER_IMAGE := uber/yarpc-go-$(DOCKER_GO_VERSION)
 ifdef DOCKER_HOST
 DOCKER_BUILD_FLAGS ?= --compress
 endif
-DOCKER_RUN_FLAGS ?= -e V -e RUN -e EXAMPLES_JOBS
+DOCKER_RUN_FLAGS ?= -e V -e RUN -e EXAMPLES_JOBS -e WITHIN_DOCKER=1
+DOCKER_VOLUMES=-v $(shell pwd):/go/src/go.uber.org/yarpc
 
 .PHONY: deps
 deps: $(DOCKER) ## install all dependencies
@@ -17,7 +18,7 @@ build: deps ## go build all packages
 
 .PHONY: generate
 generate: deps ## call generation script
-	PATH=$$PATH:$(BIN) docker run -v $(shell pwd):/go/src/go.uber.org/yarpc $(DOCKER_RUN_FLAGS) $(DOCKER_IMAGE) make generate
+	PATH=$$PATH:$(BIN) docker run $(DOCKER_VOLUMES) $(DOCKER_RUN_FLAGS) $(DOCKER_IMAGE) make generate
 
 .PHONY: nogogenerate
 nogogenerate: deps ## check to make sure go:generate is not used
@@ -77,4 +78,4 @@ examples: deps ## run all examples tests
 
 .PHONY: shell
 shell: deps ## go into a bash shell in docker with the repository linked as a volume
-	PATH=$$PATH:$(BIN) docker run -it $(DOCKER_RUN_FLAGS) $(DOCKER_IMAGE) /bin/bash
+	PATH=$$PATH:$(BIN) docker run -it $(DOCKER_VOLUMES) $(DOCKER_RUN_FLAGS) $(DOCKER_IMAGE) /bin/bash

--- a/build/docker.mk
+++ b/build/docker.mk
@@ -6,7 +6,7 @@ ifdef DOCKER_HOST
 DOCKER_BUILD_FLAGS ?= --compress
 endif
 DOCKER_RUN_FLAGS ?= -e V -e RUN -e EXAMPLES_JOBS -e WITHIN_DOCKER=1
-DOCKER_VOLUMES=-v $(shell pwd):/go/src/go.uber.org/yarpc
+DOCKER_VOLUME_FLAGS=-v $(shell pwd):/go/src/go.uber.org/yarpc
 
 .PHONY: deps
 deps: $(DOCKER) ## install all dependencies
@@ -18,7 +18,7 @@ build: deps ## go build all packages
 
 .PHONY: generate
 generate: deps ## call generation script
-	PATH=$$PATH:$(BIN) docker run $(DOCKER_VOLUMES) $(DOCKER_RUN_FLAGS) $(DOCKER_IMAGE) make generate
+	PATH=$$PATH:$(BIN) docker run $(DOCKER_VOLUME_FLAGS) $(DOCKER_RUN_FLAGS) $(DOCKER_IMAGE) make generate
 
 .PHONY: nogogenerate
 nogogenerate: deps ## check to make sure go:generate is not used
@@ -78,4 +78,4 @@ examples: deps ## run all examples tests
 
 .PHONY: shell
 shell: deps ## go into a bash shell in docker with the repository linked as a volume
-	PATH=$$PATH:$(BIN) docker run -it $(DOCKER_VOLUMES) $(DOCKER_RUN_FLAGS) $(DOCKER_IMAGE) /bin/bash
+	PATH=$$PATH:$(BIN) docker run -it $(DOCKER_VOLUME_FLAGS) $(DOCKER_RUN_FLAGS) $(DOCKER_IMAGE) /bin/bash

--- a/build/local.mk
+++ b/build/local.mk
@@ -34,6 +34,9 @@ build: __eval_packages ## go build all packages
 generate: $(GEN_BINS) $(GEN_BINS_INTERNAL) ## call generation script
 	@go get github.com/golang/mock/mockgen
 	@PATH=$(BIN):$$PATH ./scripts/generate.sh
+ifdef WITHIN_DOCKER
+	@chown -R --reference . .
+endif
 
 .PHONY: nogogenerate
 nogogenerate: __eval_go_files ## check to make sure go:generate is not used


### PR DESCRIPTION
For `make generate` with Docker we mount the local workdir withing the
container. Any files written from withing the container will be owned by
whatever user is loggued in (alwaysr root in our case). The container is
already root on the workdir. We can the chown recursively the workdir to the
owner of the workdir.

The chown only runs withing the docker container. For this to work, a new env
var `WITHIN_DOCKER` is passed to the container.

Note: for what I know. On Mac, you run a linux virtual machine, which in turns
runs containers. You are loggued as root on the linux VM, so you have no
resstrictions. And the virtual machine shares the filesystem between Mac and
the linux VM by rewriting on the fly permissions from the owner of the VM to
root.