### PR TITLE
Simplify the custom gRPC codec

### DIFF
--- a/transport/x/grpc/codec.go
+++ b/transport/x/grpc/codec.go
@@ -25,24 +25,24 @@ import "fmt"
 // customCodec pass bytes to/from the wire without modification.
 type customCodec struct{}
 
-// Marshal takes a []byte pointer and passes it through as a []byte.
+// Marshal takes a []byte and passes it through as a []byte.
 func (customCodec) Marshal(obj interface{}) ([]byte, error) {
 	switch value := obj.(type) {
-	case *[]byte:
-		return *value, nil
+	case []byte:
+		return value, nil
 	default:
-		return nil, newCustomCodecCastError(obj)
+		return nil, newCustomCodecMarshalCastError(obj)
 	}
 }
 
-// Unmarshal takes a []byte pointer and writes it to v.
+// Unmarshal takes a []byte pointer as obj and points it to data.
 func (customCodec) Unmarshal(data []byte, obj interface{}) error {
 	switch value := obj.(type) {
 	case *[]byte:
 		*value = data
 		return nil
 	default:
-		return newCustomCodecCastError(obj)
+		return newCustomCodecUnmarshalCastError(obj)
 	}
 }
 
@@ -52,6 +52,10 @@ func (customCodec) String() string {
 	return "proto"
 }
 
-func newCustomCodecCastError(actualObject interface{}) error {
+func newCustomCodecMarshalCastError(actualObject interface{}) error {
+	return fmt.Errorf("expected object to be of type []byte but got %T", actualObject)
+}
+
+func newCustomCodecUnmarshalCastError(actualObject interface{}) error {
 	return fmt.Errorf("expected object to be of type *[]byte but got %T", actualObject)
 }

--- a/transport/x/grpc/codec_test.go
+++ b/transport/x/grpc/codec_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestCustomCodecMarshalBytes(t *testing.T) {
 	value := []byte("test")
-	data, err := customCodec{}.Marshal(&value)
+	data, err := customCodec{}.Marshal(value)
 	assert.Equal(t, value, data)
 	assert.NoError(t, err)
 }
@@ -37,7 +37,7 @@ func TestCustomCodecMarshalCastError(t *testing.T) {
 	value := "test"
 	data, err := customCodec{}.Marshal(&value)
 	assert.Equal(t, []byte(nil), data)
-	assert.Equal(t, newCustomCodecCastError(&value), err)
+	assert.Equal(t, newCustomCodecMarshalCastError(&value), err)
 }
 
 func TestCustomCodecUnmarshalBytes(t *testing.T) {
@@ -51,7 +51,7 @@ func TestCustomCodecUnmarshalCastError(t *testing.T) {
 	var value string
 	err := customCodec{}.Unmarshal([]byte("test"), &value)
 	assert.Equal(t, "", value)
-	assert.Equal(t, newCustomCodecCastError(&value), err)
+	assert.Equal(t, newCustomCodecUnmarshalCastError(&value), err)
 }
 
 func TestCustomCodecString(t *testing.T) {

--- a/transport/x/grpc/handler.go
+++ b/transport/x/grpc/handler.go
@@ -152,5 +152,5 @@ func (h *handler) callUnary(ctx context.Context, transportRequest *transport.Req
 	err := transport.DispatchUnaryHandler(ctx, unaryHandler, time.Now(), transportRequest, responseWriter)
 	err = multierr.Append(err, grpc.SendHeader(ctx, responseWriter.md))
 	data := responseWriter.Bytes()
-	return &data, err
+	return data, err
 }

--- a/transport/x/grpc/outbound.go
+++ b/transport/x/grpc/outbound.go
@@ -125,7 +125,7 @@ func (o *Outbound) invoke(
 	if err := grpc.Invoke(
 		metadata.NewContext(ctx, md),
 		fullMethod,
-		&requestBody,
+		requestBody,
 		responseBody,
 		o.clientConn,
 		callOptions...,


### PR DESCRIPTION
This is coming from work I am doing on grpc-go. We were using a `[]byte` pointer for `Marshal` when there was no actual reason to. For `Unmarshal`, we still need to use a `[]byte` pointer because grpc-go API.