### PR TITLE
config/tchannel: Improve configuration format

### DIFF
--- a/transport/http/config_test.go
+++ b/transport/http/config_test.go
@@ -316,10 +316,10 @@ func TestTransportSpec(t *testing.T) {
 
 		for svc, want := range outbound.wantOutbounds {
 			ob, ok := cfg.Outbounds[svc].Unary.(*Outbound)
-			if assert.True(t, ok, "expected *Outbound for %q, got %T", cfg.Outbounds[svc].Unary) {
+			if assert.True(t, ok, "expected *Outbound for %q, got %T", svc, cfg.Outbounds[svc].Unary) {
 				// Verify that we install a oneway too
 				_, ok := cfg.Outbounds[svc].Oneway.(*Outbound)
-				assert.True(t, ok, "expected *Outbound for %q oneway, got %T", cfg.Outbounds[svc].Oneway)
+				assert.True(t, ok, "expected *Outbound for %q oneway, got %T", svc, cfg.Outbounds[svc].Oneway)
 
 				assert.Equal(t, want.URLTemplate, ob.urlTemplate.String(), "outbound URLTemplate should match")
 				assert.Equal(t, want.Headers, ob.headers, "outbound headers should match")

--- a/transport/http/config_test.go
+++ b/transport/http/config_test.go
@@ -266,9 +266,15 @@ func TestTransportSpec(t *testing.T) {
 			env[k] = v
 		}
 		for k, v := range inbound.env {
+			_, ok := env[k]
+			require.False(t, ok,
+				"invalid test: environment variable %q is defined multiple times", k)
 			env[k] = v
 		}
 		for k, v := range outbound.env {
+			_, ok := env[k]
+			require.False(t, ok,
+				"invalid test: environment variable %q is defined multiple times", k)
 			env[k] = v
 		}
 		configurator := config.New(config.InterpolationResolver(mapResolver(env)))

--- a/transport/http/config_test.go
+++ b/transport/http/config_test.go
@@ -338,7 +338,7 @@ func TestTransportSpec(t *testing.T) {
 	for _, transTT := range transportTests {
 		for _, inboundTT := range inboundTests {
 			for _, outboundTT := range outboundTests {
-				// Special case: No inbounds and outbounds so we have nothing
+				// Special case: No inbounds or outbounds so we have nothing
 				// to test.
 				if inboundTT.empty && outboundTT.empty {
 					continue

--- a/transport/http/config_test.go
+++ b/transport/http/config_test.go
@@ -310,6 +310,7 @@ func TestTransportSpec(t *testing.T) {
 		require.NoError(t, err, "expected success while loading config %+v", cfgData)
 
 		if want := inbound.wantInbound; want != nil {
+			assert.Len(t, cfg.Inbounds, 1, "expected exactly one inbound in %+v", cfgData)
 			ib, ok := cfg.Inbounds[0].(*Inbound)
 			if assert.True(t, ok, "expected *Inbound, got %T", cfg.Inbounds[0]) {
 				assert.Equal(t, want.Address, ib.addr, "inbound address should match")

--- a/transport/http/config_test.go
+++ b/transport/http/config_test.go
@@ -300,14 +300,14 @@ func TestTransportSpec(t *testing.T) {
 
 		wantErrors := append(append(trans.wantErrors, inbound.wantErrors...), outbound.wantErrors...)
 		if len(wantErrors) > 0 {
-			require.Error(t, err, "expected failure")
+			require.Error(t, err, "expected failure while loading config %+v", cfgData)
 			for _, msg := range wantErrors {
 				assert.Contains(t, err.Error(), msg)
 			}
 			return
 		}
 
-		require.NoError(t, err, "expected success")
+		require.NoError(t, err, "expected success while loading config %+v", cfgData)
 
 		if want := inbound.wantInbound; want != nil {
 			ib, ok := cfg.Inbounds[0].(*Inbound)

--- a/transport/tchannel/config.go
+++ b/transport/tchannel/config.go
@@ -97,15 +97,15 @@ func (ts *transportSpec) buildTransport(tc *TransportConfig, k *config.Kit) (tra
 	}
 
 	if cfg.name != "" {
-		return nil, fmt.Errorf("TransportSpec does not accept ServiceName")
+		return nil, fmt.Errorf("TChannel TransportSpec does not accept ServiceName")
 	}
 
 	if cfg.addr != "" {
-		return nil, fmt.Errorf("TransportSpec does not accept ListenAddr")
+		return nil, fmt.Errorf("TChannel TransportSpec does not accept ListenAddr")
 	}
 
 	if cfg.ch != nil {
-		return nil, fmt.Errorf("TransportSpec does not accept WithChannel")
+		return nil, fmt.Errorf("TChannel TransportSpec does not accept WithChannel")
 	}
 
 	cfg.name = k.ServiceName()

--- a/transport/tchannel/config.go
+++ b/transport/tchannel/config.go
@@ -26,8 +26,6 @@ import (
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/peer/hostport"
 	"go.uber.org/yarpc/x/config"
-
-	"github.com/opentracing/opentracing-go"
 )
 
 const transportName = "tchannel"
@@ -35,19 +33,21 @@ const transportName = "tchannel"
 // TransportConfig configures a shared TChannel transport. This is shared
 // between all TChannel outbounds and inbounds of a Dispatcher.
 //
-// 	transports:
+// TransportConfig does not have any parameters at this time.
+type TransportConfig struct{}
+
+// InboundConfig configures a TChannel inbound.
+//
+// 	inbounds:
 // 	  tchannel:
 // 	    address: :4040
-type TransportConfig struct {
+//
+// At most one TChannel inbound may be defined in a single YARPC service.
+type InboundConfig struct {
 	// Address to listen on. Defaults to ":0" (all network interfaces and a
 	// random OS-assigned port).
 	Address string `config:"address,interpolate"`
 }
-
-// InboundConfig configures a TChannel inbound.
-//
-// TChannel inbounds do not support any configuration parameters at this time.
-type InboundConfig struct{}
 
 // OutboundConfig configures a TChannel outbound.
 //
@@ -61,7 +61,16 @@ type OutboundConfig struct {
 
 // TransportSpec returns a TransportSpec for the TChannel unary transport.
 func TransportSpec(opts ...Option) config.TransportSpec {
-	return (&transportSpec{}).Spec(opts...)
+	var ts transportSpec
+	for _, o := range opts {
+		switch opt := o.(type) {
+		case TransportOption:
+			ts.transportOptions = append(ts.transportOptions, opt)
+		default:
+			panic(fmt.Sprintf("unknown option of type %T: %v", o, o))
+		}
+	}
+	return ts.Spec()
 }
 
 // transportSpec holds the configurable parts of the TChannel TransportSpec.
@@ -72,17 +81,7 @@ type transportSpec struct {
 	transportOptions []TransportOption
 }
 
-func (ts *transportSpec) Spec(opts ...Option) config.TransportSpec {
-	// Collect transport options
-	for _, o := range opts {
-		switch opt := o.(type) {
-		case TransportOption:
-			ts.transportOptions = append(ts.transportOptions, opt)
-		default:
-			panic(fmt.Sprintf("unknown option of type %T: %v", o, o))
-		}
-	}
-
+func (ts *transportSpec) Spec() config.TransportSpec {
 	return config.TransportSpec{
 		Name:               transportName,
 		BuildTransport:     ts.buildTransport,
@@ -92,26 +91,39 @@ func (ts *transportSpec) Spec(opts ...Option) config.TransportSpec {
 }
 
 func (ts *transportSpec) buildTransport(tc *TransportConfig, k *config.Kit) (transport.Transport, error) {
-	var config transportConfig
-	// Default configuration.
-	config.tracer = opentracing.GlobalTracer()
-	config.name = k.ServiceName()
-
-	// Apply the spec's transport options.
-	for _, opt := range ts.transportOptions {
-		opt(&config)
+	var cfg transportConfig
+	for _, o := range ts.transportOptions {
+		o(&cfg)
 	}
 
-	// Override options with configuration.
-	if tc.Address != "" {
-		config.addr = tc.Address
+	if cfg.name != "" {
+		return nil, fmt.Errorf("TransportSpec does not accept ServiceName")
 	}
 
-	return config.newTransport(), nil
+	if cfg.addr != "" {
+		return nil, fmt.Errorf("TransportSpec does not accept ListenAddr")
+	}
+
+	if cfg.ch != nil {
+		return nil, fmt.Errorf("TransportSpec does not accept WithChannel")
+	}
+
+	cfg.name = k.ServiceName()
+	return cfg.newTransport(), nil
 }
 
-func (ts *transportSpec) buildInbound(_ *InboundConfig, t transport.Transport, k *config.Kit) (transport.Inbound, error) {
-	return t.(*Transport).NewInbound(), nil
+func (ts *transportSpec) buildInbound(c *InboundConfig, t transport.Transport, k *config.Kit) (transport.Inbound, error) {
+	if c.Address == "" {
+		return nil, fmt.Errorf("inbound address is required")
+	}
+
+	trans := t.(*Transport)
+	if trans.addr != "" {
+		return nil, fmt.Errorf("at most one TChannel inbound may be specified")
+	}
+
+	trans.addr = c.Address
+	return trans.NewInbound(), nil
 }
 
 func (ts *transportSpec) buildUnaryOutbound(oc *OutboundConfig, t transport.Transport, k *config.Kit) (transport.UnaryOutbound, error) {
@@ -122,5 +134,3 @@ func (ts *transportSpec) buildUnaryOutbound(oc *OutboundConfig, t transport.Tran
 	}
 	return x.NewOutbound(chooser), nil
 }
-
-// TODO: Document configuration parameters

--- a/transport/tchannel/config.go
+++ b/transport/tchannel/config.go
@@ -119,6 +119,9 @@ func (ts *transportSpec) buildInbound(c *InboundConfig, t transport.Transport, k
 
 	trans := t.(*Transport)
 	if trans.addr != "" {
+		// We ensure that trans.addr is empty when buildTransport is called,
+		// so if the string is non-empty right now, another TChannel inbound
+		// already filled it with a value.
 		return nil, fmt.Errorf("at most one TChannel inbound may be specified")
 	}
 

--- a/transport/tchannel/config_test.go
+++ b/transport/tchannel/config_test.go
@@ -151,7 +151,8 @@ func TestTransportSpec(t *testing.T) {
 				},
 			},
 			wantErrors: []string{
-				"no recognized peer list in config: got least-pending",
+				`failed to configure unary outbound for "myservice"`,
+				`failed to read attribute "least-pending": wat`,
 			},
 		},
 	}

--- a/transport/tchannel/config_test.go
+++ b/transport/tchannel/config_test.go
@@ -232,8 +232,8 @@ func TestTransportSpec(t *testing.T) {
 
 	for _, inboundTT := range inboundTests {
 		for _, outboundTT := range outboundTests {
-			// Special case: No inbounds and outbounds so we have nothing
-			// to test.
+			// Special case: No inbounds or outbounds so we have nothing to
+			// test.
 			if inboundTT.empty && outboundTT.empty {
 				continue
 			}

--- a/transport/tchannel/config_test.go
+++ b/transport/tchannel/config_test.go
@@ -194,7 +194,7 @@ func TestTransportSpec(t *testing.T) {
 		cfg, err := configurator.LoadConfig("foo", cfgData)
 
 		if len(inbound.wantErrors) > 0 {
-			require.Error(t, err, "expected failure")
+			require.Error(t, err, "expected failure while loading config %+v", cfgData)
 			for _, msg := range inbound.wantErrors {
 				assert.Contains(t, err.Error(), msg)
 			}
@@ -202,14 +202,14 @@ func TestTransportSpec(t *testing.T) {
 		}
 
 		if len(outbound.wantErrors) > 0 {
-			require.Error(t, err, "expected failure")
+			require.Error(t, err, "expected failure while loading config %+v", cfgData)
 			for _, msg := range outbound.wantErrors {
 				assert.Contains(t, err.Error(), msg)
 			}
 			return
 		}
 
-		require.NoError(t, err, "expected success")
+		require.NoError(t, err, "expected success while loading config %+v", cfgData)
 		if want := inbound.wantTransport; want != nil {
 			ib, ok := cfg.Inbounds[0].(*Inbound)
 			if assert.True(t, ok, "expected *Inbound, got %T", cfg.Inbounds[0]) {

--- a/transport/tchannel/config_test.go
+++ b/transport/tchannel/config_test.go
@@ -173,6 +173,9 @@ func TestTransportSpec(t *testing.T) {
 			env[k] = v
 		}
 		for k, v := range outbound.env {
+			_, ok := env[k]
+			require.False(t, ok,
+				"invalid test: environment variable %q is defined multiple times", k)
 			env[k] = v
 		}
 		configurator := config.New(config.InterpolationResolver(mapResolver(env)))

--- a/transport/tchannel/config_test.go
+++ b/transport/tchannel/config_test.go
@@ -211,6 +211,7 @@ func TestTransportSpec(t *testing.T) {
 
 		require.NoError(t, err, "expected success while loading config %+v", cfgData)
 		if want := inbound.wantTransport; want != nil {
+			assert.Len(t, cfg.Inbounds, 1, "expected exactly one inbound in %+v", cfgData)
 			ib, ok := cfg.Inbounds[0].(*Inbound)
 			if assert.True(t, ok, "expected *Inbound, got %T", cfg.Inbounds[0]) {
 				trans := ib.transport

--- a/transport/tchannel/config_test.go
+++ b/transport/tchannel/config_test.go
@@ -1,0 +1,241 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tchannel
+
+import (
+	"fmt"
+	"testing"
+
+	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/x/config"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	tchanneltest "github.com/uber/tchannel-go/testutils"
+)
+
+func TestTransportSpec(t *testing.T) {
+	someChannel := tchanneltest.NewServer(t, nil)
+	defer someChannel.Close()
+
+	type attrs map[string]interface{}
+
+	type wantTransport struct {
+		Address string
+	}
+
+	type inboundTest struct {
+		desc string            // description
+		cfg  attrs             // inbounds section of the config
+		env  map[string]string // environment variables
+		opts []Option          // transport spec options
+
+		empty bool // whether this test case is empty
+
+		wantErrors []string
+
+		// Inbounds don't have any properties that affect the Inbound object.
+		// We'll assert things about the transport only.
+		wantTransport *wantTransport
+	}
+
+	type outboundTest struct {
+		desc string            // description
+		cfg  attrs             // outbounds section of the config
+		env  map[string]string // environment variables
+		opts []Option          // transport spec options
+
+		empty bool // whether this test case is empty
+
+		wantErrors    []string
+		wantOutbounds []string
+	}
+
+	inboundTests := []inboundTest{
+		{desc: "no inbound", empty: true},
+		{
+			desc:          "simple inbound",
+			cfg:           attrs{"tchannel": attrs{"address": ":4040"}},
+			wantTransport: &wantTransport{Address: ":4040"},
+		},
+		{
+			desc:          "inbound interpolation",
+			cfg:           attrs{"tchannel": attrs{"address": ":${PORT}"}},
+			env:           map[string]string{"PORT": "4041"},
+			wantTransport: &wantTransport{Address: ":4041"},
+		},
+		{
+			desc:       "empty address",
+			cfg:        attrs{"tchannel": attrs{"address": ""}},
+			wantErrors: []string{"inbound address is required"},
+		},
+		{
+			desc:       "missing address",
+			cfg:        attrs{"tchannel": attrs{}},
+			wantErrors: []string{"inbound address is required"},
+		},
+		{
+			desc: "too many inbounds",
+			cfg: attrs{
+				"tchannel":  attrs{"address": ":4040"},
+				"tchannel2": attrs{"address": ":4041", "type": "tchannel"},
+			},
+			wantErrors: []string{"at most one TChannel inbound may be specified"},
+		},
+		{
+			desc:       "WithChannel fails",
+			cfg:        attrs{"tchannel": attrs{"address": ":4040"}},
+			opts:       []Option{WithChannel(someChannel)},
+			wantErrors: []string{"TransportSpec does not accept WithChannel"},
+		},
+		{
+			desc:       "ServiceName fails",
+			cfg:        attrs{"tchannel": attrs{"address": ":4040"}},
+			opts:       []Option{ServiceName("zzzzzzzzz")},
+			wantErrors: []string{"TransportSpec does not accept ServiceName"},
+		},
+		{
+			desc:       "ListenAddr fails",
+			cfg:        attrs{"tchannel": attrs{"address": ":4040"}},
+			opts:       []Option{ListenAddr(":8080")},
+			wantErrors: []string{"TransportSpec does not accept ListenAddr"},
+		},
+	}
+
+	outboundTests := []outboundTest{
+		{desc: "no outbound", empty: true},
+		{
+			desc: "simple outbound",
+			cfg: attrs{
+				"myservice": attrs{
+					"tchannel": attrs{
+						"peer": "127.0.0.1:4040",
+					},
+				},
+			},
+		},
+		{
+			desc: "outbound interpolation",
+			env:  map[string]string{"SERVICE_PORT": "4040"},
+			cfg: attrs{
+				"myservice": attrs{
+					"tchannel": attrs{
+						"peer": "127.0.0.1:${SERVICE_PORT}",
+					},
+				},
+			},
+		},
+		{
+			desc: "outbound bad peer list",
+			cfg: attrs{
+				"myservice": attrs{
+					"tchannel": attrs{"least-pending": "wat"},
+				},
+			},
+			wantErrors: []string{
+				"no recognized peer list in config: got least-pending",
+			},
+		},
+	}
+
+	runTest := func(t *testing.T, inbound inboundTest, outbound outboundTest) {
+		env := make(map[string]string)
+		for k, v := range inbound.env {
+			env[k] = v
+		}
+		for k, v := range outbound.env {
+			env[k] = v
+		}
+		configurator := config.New(config.InterpolationResolver(mapResolver(env)))
+
+		opts := append(inbound.opts, outbound.opts...)
+		err := configurator.RegisterTransport(TransportSpec(opts...))
+		require.NoError(t, err, "failed to register transport spec")
+
+		cfgData := make(attrs)
+		if inbound.cfg != nil {
+			cfgData["inbounds"] = inbound.cfg
+		}
+		if outbound.cfg != nil {
+			cfgData["outbounds"] = outbound.cfg
+		}
+		cfg, err := configurator.LoadConfig("foo", cfgData)
+
+		if len(inbound.wantErrors) > 0 {
+			require.Error(t, err, "expected failure")
+			for _, msg := range inbound.wantErrors {
+				assert.Contains(t, err.Error(), msg)
+			}
+			return
+		}
+
+		if len(outbound.wantErrors) > 0 {
+			require.Error(t, err, "expected failure")
+			for _, msg := range outbound.wantErrors {
+				assert.Contains(t, err.Error(), msg)
+			}
+			return
+		}
+
+		require.NoError(t, err, "expected success")
+		if want := inbound.wantTransport; want != nil {
+			ib, ok := cfg.Inbounds[0].(*Inbound)
+			if assert.True(t, ok, "expected *Inbound, got %T", cfg.Inbounds[0]) {
+				trans := ib.transport
+				assert.Equal(t, "foo", trans.name, "service name must match")
+				assert.Equal(t, want.Address, trans.addr, "transport address must match")
+			}
+		}
+
+		for _, svc := range outbound.wantOutbounds {
+			_, ok := cfg.Outbounds[svc].Unary.(*Outbound)
+			assert.True(t, ok, "expected *Outbound for %q, got %T", svc, cfg.Outbounds[svc].Unary)
+		}
+
+		d := yarpc.NewDispatcher(cfg)
+		require.NoError(t, d.Start(), "failed to start dispatcher")
+		require.NoError(t, d.Stop(), "failed to stop dispatcher")
+	}
+
+	for _, inboundTT := range inboundTests {
+		for _, outboundTT := range outboundTests {
+			// Special case: No inbounds and outbounds so we have nothing
+			// to test.
+			if inboundTT.empty && outboundTT.empty {
+				continue
+			}
+
+			desc := fmt.Sprintf("%v/%v", inboundTT.desc, outboundTT.desc)
+			t.Run(desc, func(t *testing.T) {
+				runTest(t, inboundTT, outboundTT)
+			})
+		}
+	}
+}
+
+func mapResolver(m map[string]string) func(string) (string, bool) {
+	return func(k string) (v string, ok bool) {
+		if m != nil {
+			v, ok = m[k]
+		}
+		return
+	}
+}

--- a/transport/tchannel/config_test.go
+++ b/transport/tchannel/config_test.go
@@ -114,19 +114,19 @@ func TestTransportSpec(t *testing.T) {
 			desc:       "WithChannel fails",
 			cfg:        attrs{"tchannel": attrs{"address": ":4040"}},
 			opts:       []Option{WithChannel(someChannel)},
-			wantErrors: []string{"TransportSpec does not accept WithChannel"},
+			wantErrors: []string{"TChannel TransportSpec does not accept WithChannel"},
 		},
 		{
 			desc:       "ServiceName fails",
 			cfg:        attrs{"tchannel": attrs{"address": ":4040"}},
 			opts:       []Option{ServiceName("zzzzzzzzz")},
-			wantErrors: []string{"TransportSpec does not accept ServiceName"},
+			wantErrors: []string{"TChannel TransportSpec does not accept ServiceName"},
 		},
 		{
 			desc:       "ListenAddr fails",
 			cfg:        attrs{"tchannel": attrs{"address": ":4040"}},
 			opts:       []Option{ListenAddr(":8080")},
-			wantErrors: []string{"TransportSpec does not accept ListenAddr"},
+			wantErrors: []string{"TChannel TransportSpec does not accept ListenAddr"},
 		},
 	}
 

--- a/transport/tchannel/config_test.go
+++ b/transport/tchannel/config_test.go
@@ -32,6 +32,16 @@ import (
 	tchanneltest "github.com/uber/tchannel-go/testutils"
 )
 
+type badOption struct{}
+
+func (badOption) tchannelOption() {}
+
+func TestTransportSpecInvalidOption(t *testing.T) {
+	assert.Panics(t, func() {
+		TransportSpec(badOption{})
+	})
+}
+
 func TestTransportSpec(t *testing.T) {
 	someChannel := tchanneltest.NewServer(t, nil)
 	defer someChannel.Close()

--- a/transport/tchannel/options.go
+++ b/transport/tchannel/options.go
@@ -66,8 +66,11 @@ func Tracer(tracer opentracing.Tracer) TransportOption {
 // these will be left unchanged.
 //
 // If this option is not passed, the Transport will build and manage its own
-// Channel. The behavior of that Tchannel may be customized using the
+// Channel. The behavior of that TChannel may be customized using the
 // ListenAddr and ServiceName options.
+//
+// This option is disallowed for NewTransport and transports constructed with
+// the YARPC configuration system.
 func WithChannel(ch Channel) TransportOption {
 	return func(t *transportConfig) {
 		t.ch = ch
@@ -80,7 +83,8 @@ func WithChannel(ch Channel) TransportOption {
 // 	transport := NewChannelTransport(ServiceName("myservice"), ListenAddr(":4040"))
 //
 // This option has no effect if WithChannel was used and the TChannel was
-// already listening.
+// already listening, and it is disallowed for transports constructed with the
+// YARPC configuration system.
 func ListenAddr(addr string) TransportOption {
 	return func(t *transportConfig) {
 		t.addr = addr
@@ -96,11 +100,8 @@ func ListenAddr(addr string) TransportOption {
 // Transport will build its own TChannel Chanel and use this name for that
 // Channel.
 //
-// This option MUST be specified if WithChannel was not used. Note that this
-// is the name of the LOCAL service, not the service you are trying to send
-// requests to.
-//
-// This option has no effect if WithChannel was used.
+// This option has no effect if WithChannel was used, and it is disallowed for
+// transports constructed with the YARPC configuration system.
 func ServiceName(name string) TransportOption {
 	return func(t *transportConfig) {
 		t.name = name

--- a/transport/x/cherami/config_test.go
+++ b/transport/x/cherami/config_test.go
@@ -361,14 +361,14 @@ func TestTransportSpec(t *testing.T) {
 
 		wantErrors := append(append(trans.wantErrors, inbound.wantErrors...), outbound.wantErrors...)
 		if len(wantErrors) > 0 {
-			require.Error(t, err, "expected failure")
+			require.Error(t, err, "expected failure while loading config %+v", cfgData)
 			for _, msg := range wantErrors {
 				assert.Contains(t, err.Error(), msg)
 			}
 			return
 		}
 
-		require.NoError(t, err, "expected success")
+		require.NoError(t, err, "expected success while loading config %+v", cfgData)
 
 		if want := inbound.wantInbound; want != nil {
 			ib, ok := cfg.Inbounds[0].(*Inbound)

--- a/transport/x/cherami/config_test.go
+++ b/transport/x/cherami/config_test.go
@@ -395,7 +395,7 @@ func TestTransportSpec(t *testing.T) {
 	for _, transTT := range transportTests {
 		for _, inboundTT := range inboundTests {
 			for _, outboundTT := range outboundTests {
-				// Special case: No inbounds and outbounds so we have nothing
+				// Special case: No inbounds or outbounds so we have nothing
 				// to test.
 				if inboundTT.empty && outboundTT.empty {
 					continue

--- a/transport/x/cherami/config_test.go
+++ b/transport/x/cherami/config_test.go
@@ -324,9 +324,15 @@ func TestTransportSpec(t *testing.T) {
 			env[k] = v
 		}
 		for k, v := range inbound.env {
+			_, ok := env[k]
+			require.False(t, ok,
+				"invalid test: environment variable %q is defined multiple times", k)
 			env[k] = v
 		}
 		for k, v := range outbound.env {
+			_, ok := env[k]
+			require.False(t, ok,
+				"invalid test: environment variable %q is defined multiple times", k)
 			env[k] = v
 		}
 		configurator := config.New(config.InterpolationResolver(mapResolver(env)))

--- a/transport/x/cherami/config_test.go
+++ b/transport/x/cherami/config_test.go
@@ -371,6 +371,7 @@ func TestTransportSpec(t *testing.T) {
 		require.NoError(t, err, "expected success while loading config %+v", cfgData)
 
 		if want := inbound.wantInbound; want != nil {
+			assert.Len(t, cfg.Inbounds, 1, "expected exactly one inbound in %+v", cfgData)
 			ib, ok := cfg.Inbounds[0].(*Inbound)
 			if assert.True(t, ok, "expected *Inbound, got %T", cfg.Inbounds[0]) {
 				assert.Equal(t, want.Destination, ib.opts.Destination,


### PR DESCRIPTION
This changes the TChannel configuration to be more usable. Previously,
the address to listen on was provided in the `transports` section
because that's how the TChannel transport works. This meant there was
nothing to configure for the TChannel inbound and you'd have to add a
`tchannel: {}`  entry to it.

    inbounds:
      tchannel: {}
    transports:
      tchannel:
        address: :4040

With this change, we're changing the format to accept the address in the
inbounds section, making the transport section empty/irrelevant for now.

    inbounds:
      tchannel:
        address: :4040

As a result of this, at most one TChannel inbound may be specified for a
service.