### PR TITLE
config/chooser: Explanatory comments for peer list

### DIFF
--- a/x/config/chooser_test.go
+++ b/x/config/chooser_test.go
@@ -431,6 +431,28 @@ func TestChooserConfigurator(t *testing.T) {
 			},
 		},
 		{
+			desc: "too many peer list updaters",
+			given: whitespace.Expand(`
+				outbounds:
+					their-service:
+						unary:
+							fake-transport:
+								nop: "*.*"
+								fake-list:
+									fake-updater:
+										- 127.0.0.1:8080
+										- 127.0.0.1:8081
+									invalid-updater:
+										- 127.0.0.1:8080
+										- 127.0.0.1:8081
+			`),
+			wantErr: []string{
+				`failed to configure unary outbound for "their-service": `,
+				`found too many peer list updaters in config: got`,
+				"fake-updater", "invalid-updater",
+			},
+		},
+		{
 			desc: "invalid peer list updater decode",
 			given: whitespace.Expand(`
 				transports:


### PR DESCRIPTION
This adds some comments to the code for building peer lists so that it's
simpler to understand how this relates to the actual config being
decoded.

In the process, I also added a sanity check to the peer list updater
decoding logic: We ensure that *exactly* on peer list updater was
specified rather than going with the first one we find. Otherwise, we
may have a situation where two peer list updaters were written in the
config and the non-deterministic map iteration picks a random one each
time.