### PR TITLE
codecov: Disable tracking patch coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -13,12 +13,7 @@ coverage:
       experimental:
         target: 70%
         flags: experimental
-    patch:
-      default: off
-      main:
-        target: 80%
-      experimental:
-        target: 70%
+    patch: no
 
 ignore:
   # All packages with .nocover files in them MUST be listed here


### PR DESCRIPTION
This asks codecov to not complain about how much of the code in a PR was
covered as long as the coverage targets for the project are being met.