### PR TITLE
tchannel/config: Add default tracer

### DIFF
--- a/transport/tchannel/config.go
+++ b/transport/tchannel/config.go
@@ -23,6 +23,8 @@ package tchannel
 import (
 	"fmt"
 
+	opentracing "github.com/opentracing/opentracing-go"
+
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/peer/hostport"
 	"go.uber.org/yarpc/x/config"
@@ -92,6 +94,10 @@ func (ts *transportSpec) Spec() config.TransportSpec {
 
 func (ts *transportSpec) buildTransport(tc *TransportConfig, k *config.Kit) (transport.Transport, error) {
 	var cfg transportConfig
+	// Default configuration.
+	cfg.tracer = opentracing.GlobalTracer()
+	cfg.name = k.ServiceName()
+
 	for _, o := range ts.transportOptions {
 		o(&cfg)
 	}

--- a/transport/tchannel/config.go
+++ b/transport/tchannel/config.go
@@ -23,11 +23,11 @@ package tchannel
 import (
 	"fmt"
 
-	opentracing "github.com/opentracing/opentracing-go"
-
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/peer/hostport"
 	"go.uber.org/yarpc/x/config"
+
+	opentracing "github.com/opentracing/opentracing-go"
 )
 
 const transportName = "tchannel"
@@ -96,7 +96,6 @@ func (ts *transportSpec) buildTransport(tc *TransportConfig, k *config.Kit) (tra
 	var cfg transportConfig
 	// Default configuration.
 	cfg.tracer = opentracing.GlobalTracer()
-	cfg.name = k.ServiceName()
 
 	for _, o := range ts.transportOptions {
 		o(&cfg)


### PR DESCRIPTION
  Currently, the tracer is set to nil if we don't pass it in the options.
By default we want to initialize it to GlobalTracer.