### PR TITLE
Support Non-Running Updates to the RoundRobin Peer List

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ v1.9.0-dev (unreleased)
     `InboundOptions` and `OutboundOptions`.
 -   x/cherami: Added support for configuring the Cherami transport using
     x/config.
+-   x/roundrobin: Added support for taking peer list updates before and after
+    the peer list has been started.
 
 
 v1.8.0 (2017-05-01)

--- a/api/peer/peertest/peerlistaction.go
+++ b/api/peer/peertest/peerlistaction.go
@@ -190,13 +190,22 @@ type NotifyStatusChangeAction struct {
 
 	// NewConnectionStatus is the new ConnectionStatus of the Peer
 	NewConnectionStatus peer.ConnectionStatus
+
+	// Unretained indicates that this notify occurs to a peer that has never been
+	// retained on the transport (to test edge cases).
+	Unretained bool
 }
 
 // Apply will run the NotifyStatusChanged function on the PeerList with the provided Peer
 func (a NotifyStatusChangeAction) Apply(t *testing.T, pl peer.Chooser, deps ListActionDeps) {
-	deps.Peers[a.PeerID].PeerStatus.ConnectionStatus = a.NewConnectionStatus
-
 	plSub := pl.(peer.Subscriber)
+
+	if a.Unretained {
+		plSub.NotifyStatusChanged(MockPeerIdentifier(a.PeerID))
+		return
+	}
+
+	deps.Peers[a.PeerID].PeerStatus.ConnectionStatus = a.NewConnectionStatus
 
 	plSub.NotifyStatusChanged(deps.Peers[a.PeerID])
 }

--- a/peer/x/roundrobin/list_test.go
+++ b/peer/x/roundrobin/list_test.go
@@ -695,6 +695,18 @@ func TestRoundRobinList(t *testing.T) {
 			expectedRunning:            false,
 		},
 		{
+			msg: "remove peer not in list before start",
+			peerListActions: []PeerListAction{
+				UpdateAction{AddedPeerIDs: []string{"1", "2"}},
+				UpdateAction{
+					RemovedPeerIDs: []string{"3"},
+					ExpectedErr:    peer.ErrPeerRemoveNotInList("3"),
+				},
+			},
+			expectedUninitializedPeers: []string{"1", "2"},
+			expectedRunning:            false,
+		},
+		{
 			msg: "update before start",
 			retainedAvailablePeerIDs: []string{"1", "2"},
 			expectedAvailablePeers:   []string{"1", "2"},


### PR DESCRIPTION
Summary: By default, the RoundRobin peer list could only accept updates
while the peer list was "Running".  If it got an update request while it
was not running, the peer list would block that update thread until the
peer list started, or a timeout was reached.

This diff alters the RoundRobin list such that it can support taking
updates to the list before it has been started, and after it has been
stopped.  This is done through an "UninitializedPeerList" that accepts
all updates while the peer list is not started.

On Start/Stop the peers are transfered between the Uninitialized peer
list and the Available/Unavailable lists.

**Additionally** this change made the StartupWait peerlist option obsolete,
so I removed it.

Test Plan: Added more test cases for the round robin to validate updates
before and after start/stop. And updated old tests.