### PR TITLE
config/TransportSpec: Support Presets

### DIFF
--- a/transport/http/config_test.go
+++ b/transport/http/config_test.go
@@ -258,6 +258,19 @@ func TestTransportSpec(t *testing.T) {
 				`failed to read attribute "least-pending"`,
 			},
 		},
+		{
+			desc: "unknown preset",
+			cfg: attrs{
+				"myservice": attrs{
+					"http": attrs{"with": "derp"},
+				},
+			},
+			wantErrors: []string{
+				`failed to configure unary outbound for "myservice":`,
+				"cannot configure peer chooser for HTTP outbound:",
+				`no recognized peer list preset "derp"`,
+			},
+		},
 	}
 
 	runTest := func(t *testing.T, trans transportTest, inbound inboundTest, outbound outboundTest) {

--- a/x/config/chooser.go
+++ b/x/config/chooser.go
@@ -50,7 +50,7 @@ type peerList struct {
 // the configuration for the single-peer case from its "url" attribute.
 func (pc PeerList) Empty() bool {
 	c := pc.peerList
-	return c.Peer == "" && len(c.Etc) == 0
+	return c.Peer == "" && c.Preset == "" && len(c.Etc) == 0
 }
 
 // BuildPeerList translates a chooser configuration into a peer chooser, backed

--- a/x/config/chooser.go
+++ b/x/config/chooser.go
@@ -40,8 +40,9 @@ type PeerList struct {
 // peerList is the private representation of PeerList that captures
 // decoded configuration without revealing it on the public type.
 type peerList struct {
-	Peer string       `config:"peer,interpolate"`
-	Etc  attributeMap `config:",squash"`
+	Peer   string       `config:"peer,interpolate"`
+	Preset string       `config:"with,interpolate"`
+	Etc    attributeMap `config:",squash"`
 }
 
 // Empty returns whether the peer list configuration is empty.
@@ -57,8 +58,8 @@ func (pc PeerList) Empty() bool {
 func (pc PeerList) BuildPeerList(transport peer.Transport, identify func(string) peer.Identifier, kit *Kit) (peer.Chooser, error) {
 	c := pc.peerList
 	// Establish a peer selection strategy.
-
-	if c.Peer != "" {
+	switch {
+	case c.Peer != "":
 		// myoutbound:
 		//   outboundopt1: ...
 		//   outboundopt2: ...
@@ -67,15 +68,29 @@ func (pc PeerList) BuildPeerList(transport peer.Transport, identify func(string)
 			return nil, fmt.Errorf("unrecognized attributes in outbound config: %+v", c.Etc)
 		}
 		return peerbind.NewSingle(identify(c.Peer), transport), nil
+	case c.Preset != "":
+		// myoutbound:
+		//   outboundopt1: ...
+		//   outboundopt2: ...
+		//   with: somepreset
+		if len(c.Etc) > 0 {
+			return nil, fmt.Errorf("unrecognized attributes in outbound config: %+v", c.Etc)
+		}
+
+		preset, err := kit.peerListPreset(c.Preset)
+		if err != nil {
+			return nil, err
+		}
+
+		return preset.Build(transport, kit)
+	default:
+		// myoutbound:
+		//   outboundopt1: ...
+		//   outboundopt2: ...
+		//   my-peer-list:
+		//     ...
+		return pc.buildPeerList(transport, identify, kit)
 	}
-
-	// myoutbound:
-	//   outboundopt1: ...
-	//   outboundopt2: ...
-	//   my-peer-list:
-	//     ...
-	return pc.buildPeerList(transport, identify, kit)
-
 }
 
 func (pc PeerList) buildPeerList(transport peer.Transport, identify func(string) peer.Identifier, kit *Kit) (peer.Chooser, error) {

--- a/x/config/chooser_test.go
+++ b/x/config/chooser_test.go
@@ -155,7 +155,7 @@ func TestChooserConfigurator(t *testing.T) {
 						unary:
 							fake-transport:
 								nop: "*.*"
-								with: fake
+								with: fake-preset
 			`),
 			test: func(t *testing.T, c yarpc.Config) {
 				outbound, ok := c.Outbounds["their-service"]
@@ -603,7 +603,7 @@ func TestChooserConfigurator(t *testing.T) {
 					their-service:
 						unary:
 							fake-transport:
-								with: fake
+								with: fake-preset
 								conspicuously: present
 			`),
 			wantErr: []string{

--- a/x/config/kit_test.go
+++ b/x/config/kit_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKitWithTransportSpec(t *testing.T) {
+	root := &Kit{name: "foo"}
+	assert.Nil(t, root.transportSpec, "transportSpec must be nil")
+	assert.Equal(t, "foo", root.ServiceName())
+
+	child := root.withTransportSpec(&compiledTransportSpec{})
+	assert.Nil(t, root.transportSpec, "transportSpec must be nil")
+	assert.Equal(t, "foo", child.ServiceName())
+	assert.NotNil(t, child.transportSpec, "transportSpec must be nil")
+
+	child.name = "bar"
+	assert.Equal(t, "foo", root.ServiceName())
+	assert.Equal(t, "bar", child.ServiceName())
+}

--- a/x/config/spec.go
+++ b/x/config/spec.go
@@ -385,11 +385,14 @@ func compileTransportSpec(spec *TransportSpec) (*compiledTransportSpec, error) {
 		out.OnewayOutbound = appendError(compileOnewayOutboundConfig(spec.BuildOnewayOutbound))
 	}
 
-	if len(spec.PeerListPresets) > 0 {
-		out.PeerListPresets = make(map[string]*compiledPeerListPreset)
+	if len(spec.PeerListPresets) == 0 {
+		return &out, err
 	}
+
+	presets := make(map[string]*compiledPeerListPreset, len(spec.PeerListPresets))
+	out.PeerListPresets = presets
 	for _, p := range spec.PeerListPresets {
-		if _, ok := out.PeerListPresets[p.Name]; ok {
+		if _, ok := presets[p.Name]; ok {
 			err = multierr.Append(err, fmt.Errorf(
 				"found multiple peer lists with the name %q under transport %q",
 				p.Name, spec.Name))
@@ -403,7 +406,7 @@ func compileTransportSpec(spec *TransportSpec) (*compiledTransportSpec, error) {
 			continue
 		}
 
-		out.PeerListPresets[p.Name] = cp
+		presets[p.Name] = cp
 	}
 
 	return &out, err

--- a/yarpctest/fake_config.go
+++ b/yarpctest/fake_config.go
@@ -126,7 +126,7 @@ func NewFakeConfigurator() *config.Configurator {
 // a FakePeerListUpdater.
 func FakePeerListPreset() config.PeerListPreset {
 	return config.PeerListPreset{
-		Name: "fake",
+		Name: "fake-preset",
 		BuildPeerList: func(peer.Transport, *config.Kit) (peer.Chooser, error) {
 			return peerbind.Bind(
 				NewFakePeerList(), func(peer.List) transport.Lifecycle {


### PR DESCRIPTION
TransportSpecs may now define a static list of named PeerList presets
which may be provided in place of an explicit peer list and updater.

    configurator.RegisterTransport(config.TransportSpec{
        ...,
        PeerListPresets: []config.PeerListPreset{
            {
                Name: "autodns",
                BuildPeerList: ..,
            },
            {
                Name: "testproxy",
                BuildPeerList: ..,
            },
        },
    })

Presets defined on a TransportSpec may be used in the config by using
the `with` key in the outbound configuration.

    outbounds:
      myservice:
        http:
          url: http://host/yarpc/v1
          with: testproxy