### PR TITLE
make: Informative message if Docker isn't running

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,12 @@
 include build/base.mk
 ifndef SUPPRESS_DOCKER
+ifneq ($(shell docker version >/dev/null; echo $$?),0)
+$(info -----------------------------------------------------------------)
+$(info Most of our make commands run inside Docker but you do not have)
+$(info Docker running. Please start Docker or set SUPPRESS_DOCKER=1 to)
+$(info run the command against your system, and try again.)
+$(error Docker is not running)
+endif
 include build/dockerdeps.mk
 include build/docker.mk
 else

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,12 @@ ifndef SUPPRESS_DOCKER
 ifneq ($(shell docker version >/dev/null; echo $$?),0)
 $(info -----------------------------------------------------------------)
 $(info Most of our make commands run inside Docker but you do not have)
-$(info Docker running. Please start Docker or set SUPPRESS_DOCKER=1 to)
-$(info run the command against your system, and try again.)
+$(info Docker Daemon running. Please start the Docker Daemon and try again.)
+$(info See https://docs.docker.com/engine/installation/ to get started with)
+$(info Docker.)
+$(info )
+$(info Alternatively, set SUPPRESS_DOCKER=1 to run the command locally)
+$(info against your system.)
 $(error Docker is not running)
 endif
 include build/dockerdeps.mk


### PR DESCRIPTION
Right now, if you run `make test` on a fresh checkout of the repo, you
get,

    PATH=$PATH:$HOME/.yarpc-go/Darwin/x86_64/bin docker build  -t uber/yarpc-go-1.8 -f Dockerfile.1.8 .
    Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?

This change adds a more informative error message to this at the cost of
running `docker version` every time the Makefile is sourced. Failure
should now look like this,

    Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
    -----------------------------------------------------------------
    Most of our make commands run inside Docker but you do not have
    Docker Daemon running. Please start the Docker Daemon and try again.
    See https://docs.docker.com/engine/installation/ to get started with
    Docker.

    Alternatively, set SUPPRESS_DOCKER=1 to run the command locally
    against your system.

    Makefile:8: *** Docker is not running.  Stop.