### PR TITLE
config/http: Support outbound headers

### DIFF
--- a/transport/http/config.go
+++ b/transport/http/config.go
@@ -153,23 +153,23 @@ type OutboundConfig struct {
 	// required.
 	URL string `config:"url,interpolate"`
 
-	// HTTP headers that will be sent with all requests made through this
+	// HTTP headers that will be added to all requests made through this
 	// outbound.
 	//
 	//  http:
 	//    url: "http://localhost:8080/yarpc"
-	//    headers:
+	//    addHeaders:
 	//      X-Caller: myserice
 	//      X-Token: foo
-	Headers map[string]string `config:"headers"`
+	AddHeaders map[string]string `config:"addHeaders"`
 }
 
 func (ts *transportSpec) buildOutbound(oc *OutboundConfig, t transport.Transport, k *config.Kit) (*Outbound, error) {
 	x := t.(*Transport)
 
 	opts := ts.OutboundOptions
-	if len(oc.Headers) > 0 {
-		for k, v := range oc.Headers {
+	if len(oc.AddHeaders) > 0 {
+		for k, v := range oc.AddHeaders {
 			opts = append(opts, AddHeader(k, v))
 		}
 	}

--- a/transport/http/config.go
+++ b/transport/http/config.go
@@ -39,8 +39,6 @@ import (
 // interpreted. This allows configuration parameters to override Option
 // provided to TransportSpec.
 func TransportSpec(opts ...Option) config.TransportSpec {
-	// TODO: Presets. Support "with:" and allow passing those in using
-	// varargs on TransportSpec().
 	var ts transportSpec
 	for _, o := range opts {
 		switch opt := o.(type) {
@@ -154,14 +152,31 @@ type OutboundConfig struct {
 	// URL to which requests will be sent for this outbound. This field is
 	// required.
 	URL string `config:"url,interpolate"`
+
+	// HTTP headers that will be sent with all requests made through this
+	// outbound.
+	//
+	//  http:
+	//    url: "http://localhost:8080/yarpc"
+	//    headers:
+	//      X-Caller: myserice
+	//      X-Token: foo
+	Headers map[string]string `config:"headers"`
 }
 
 func (ts *transportSpec) buildOutbound(oc *OutboundConfig, t transport.Transport, k *config.Kit) (*Outbound, error) {
 	x := t.(*Transport)
 
+	opts := ts.OutboundOptions
+	if len(oc.Headers) > 0 {
+		for k, v := range oc.Headers {
+			opts = append(opts, AddHeader(k, v))
+		}
+	}
+
 	// Special case where the URL implies the single peer.
 	if oc.Empty() {
-		return x.NewSingleOutbound(oc.URL, ts.OutboundOptions...), nil
+		return x.NewSingleOutbound(oc.URL, opts...), nil
 	}
 
 	chooser, err := oc.PeerList.BuildPeerList(x, hostport.Identify, k)
@@ -169,7 +184,6 @@ func (ts *transportSpec) buildOutbound(oc *OutboundConfig, t transport.Transport
 		return nil, fmt.Errorf("cannot configure peer chooser for HTTP outbound: %v", err)
 	}
 
-	opts := ts.OutboundOptions
 	if oc.URL != "" {
 		opts = append(opts, URLTemplate(oc.URL))
 	}

--- a/transport/http/config_test.go
+++ b/transport/http/config_test.go
@@ -249,7 +249,7 @@ func TestTransportSpec(t *testing.T) {
 				"myservice": attrs{
 					"http": attrs{
 						"url": "http://localhost/",
-						"headers": attrs{
+						"addHeaders": attrs{
 							"x-token":   "token-3",
 							"X-Token-2": "token-2",
 						},
@@ -271,9 +271,9 @@ func TestTransportSpec(t *testing.T) {
 			cfg: attrs{
 				"myservice": attrs{
 					"http": attrs{
-						"url":     "http://localhost/yarpc",
-						"peer":    "127.0.0.1:8080",
-						"headers": attrs{"x-token": "token"},
+						"url":        "http://localhost/yarpc",
+						"peer":       "127.0.0.1:8080",
+						"addHeaders": attrs{"x-token": "token"},
 					},
 				},
 			},

--- a/transport/http/config_test.go
+++ b/transport/http/config_test.go
@@ -241,6 +241,52 @@ func TestTransportSpec(t *testing.T) {
 			},
 		},
 		{
+			desc: "outbound header config",
+			opts: []Option{
+				AddHeader("X-Token", "token-1"),
+			},
+			cfg: attrs{
+				"myservice": attrs{
+					"http": attrs{
+						"url": "http://localhost/",
+						"headers": attrs{
+							"x-token":   "token-3",
+							"X-Token-2": "token-2",
+						},
+					},
+				},
+			},
+			wantOutbounds: map[string]wantOutbound{
+				"myservice": {
+					URLTemplate: "http://localhost/",
+					Headers: http.Header{
+						"X-Token":   {"token-1", "token-3"},
+						"X-Token-2": {"token-2"},
+					},
+				},
+			},
+		},
+		{
+			desc: "outbound header config with peer",
+			cfg: attrs{
+				"myservice": attrs{
+					"http": attrs{
+						"url":     "http://localhost/yarpc",
+						"peer":    "127.0.0.1:8080",
+						"headers": attrs{"x-token": "token"},
+					},
+				},
+			},
+			wantOutbounds: map[string]wantOutbound{
+				"myservice": {
+					URLTemplate: "http://localhost/yarpc",
+					Headers: http.Header{
+						"X-Token": {"token"},
+					},
+				},
+			},
+		},
+		{
 			desc: "outbound peer build error",
 			cfg: attrs{
 				"myservice": attrs{


### PR DESCRIPTION
This adds support for specfying static outbound-specific HTTP headers in
the HTTP config.

Resolves #998