### PR TITLE
gRPC Config Start

### DIFF
--- a/transport/x/grpc/config.go
+++ b/transport/x/grpc/config.go
@@ -56,7 +56,7 @@ func TransportSpec(opts ...Option) config.TransportSpec {
 //
 // inbounds:
 //   grpc:
-//     address: ":80
+//     address: ":80"
 type InboundConfig struct {
 	// Address to listen on. This field is required.
 	Address string `config:"address,interpolate"`
@@ -67,7 +67,7 @@ type InboundConfig struct {
 // outbounds:
 //   myservice:
 //     grpc:
-//       address: ":80
+//       address: ":80"
 type OutboundConfig struct {
 	// Address to connect to. This field is required.
 	Address string `config:"address,interpolate"`
@@ -93,7 +93,7 @@ func newTransportSpec(opts ...Option) (*transportSpec, error) {
 	return transportSpec, nil
 }
 
-func (t *transportSpec) buildTransport(_ struct{}, _ *config.Kit) (transport.Transport, error) {
+func (t *transportSpec) buildTransport(struct{}, *config.Kit) (transport.Transport, error) {
 	return noopTransport{}, nil
 }
 

--- a/transport/x/grpc/config.go
+++ b/transport/x/grpc/config.go
@@ -94,7 +94,7 @@ func newTransportSpec(opts ...Option) (*transportSpec, error) {
 }
 
 func (t *transportSpec) buildTransport(_ struct{}, _ *config.Kit) (transport.Transport, error) {
-	return nil, nil
+	return noopTransport{}, nil
 }
 
 func (t *transportSpec) buildInbound(inboundConfig *InboundConfig, _ transport.Transport, _ *config.Kit) (transport.Inbound, error) {
@@ -118,3 +118,9 @@ func (t *transportSpec) buildUnaryOutbound(outboundConfig *OutboundConfig, _ tra
 func newRequiredFieldMissingError(field string) error {
 	return fmt.Errorf("required field missing: %s", field)
 }
+
+type noopTransport struct{}
+
+func (noopTransport) Start() error    { return nil }
+func (noopTransport) Stop() error     { return nil }
+func (noopTransport) IsRunning() bool { return false }

--- a/transport/x/grpc/config.go
+++ b/transport/x/grpc/config.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package grpc
+
+import (
+	"fmt"
+	"net"
+
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/x/config"
+)
+
+const transportName = "grpc"
+
+// TransportSpec
+func TransportSpec(opts ...Option) config.TransportSpec {
+	transportSpec := &transportSpec{}
+	for _, o := range opts {
+		switch opt := o.(type) {
+		case InboundOption:
+			transportSpec.InboundOptions = append(transportSpec.InboundOptions, opt)
+		case OutboundOption:
+			transportSpec.OutboundOptions = append(transportSpec.OutboundOptions, opt)
+		default:
+			panic(fmt.Sprintf("unknown option of type %T: %v", o, o))
+		}
+	}
+	return config.TransportSpec{
+		Name:               transportName,
+		BuildTransport:     transportSpec.buildTransport,
+		BuildInbound:       transportSpec.buildInbound,
+		BuildUnaryOutbound: transportSpec.buildUnaryOutbound,
+	}
+}
+
+// TransportConfig
+type TransportConfig struct{}
+
+// InboundConfig
+type InboundConfig struct {
+	// Address to listen on. This field is required.
+	Address string `config:"address,interpolate"`
+}
+
+// OutboundConfig
+type OutboundConfig struct {
+	// Address to connect to. This field is required.
+	Address string `config:"address,interpolate"`
+}
+
+type transportSpec struct {
+	InboundOptions  []InboundOption
+	OutboundOptions []OutboundOption
+}
+
+func (t *transportSpec) buildTransport(transportConfig *TransportConfig, _ *config.Kit) (transport.Transport, error) {
+	return nil, nil
+}
+
+func (t *transportSpec) buildInbound(inboundConfig *InboundConfig, _ transport.Transport, _ *config.Kit) (transport.Inbound, error) {
+	if inboundConfig.Address == "" {
+		return nil, newRequiredFieldMissingError("address")
+	}
+	listener, err := net.Listen("tcp", inboundConfig.Address)
+	if err != nil {
+		return nil, err
+	}
+	return NewInbound(listener, t.InboundOptions...), nil
+}
+
+func (t *transportSpec) buildUnaryOutbound(outboundConfig *OutboundConfig, _ transport.Transport, _ *config.Kit) (transport.UnaryOutbound, error) {
+	if outboundConfig.Address == "" {
+		return nil, newRequiredFieldMissingError("address")
+	}
+	return NewSingleOutbound(outboundConfig.Address, t.OutboundOptions...), nil
+}
+
+func newRequiredFieldMissingError(field string) error {
+	return fmt.Errorf("required field missing: %s", field)
+}

--- a/transport/x/grpc/config.go
+++ b/transport/x/grpc/config.go
@@ -30,7 +30,15 @@ import (
 
 const transportName = "grpc"
 
-// TransportSpec
+// TransportSpec returns a TransportSpec for the gRPC transport.
+//
+// See InboundConfig and OutboundConfig for details on the
+// different configuration parameters supported by this Transport.
+//
+// Any InboundOption or OutboundOption may be passed to this function.
+// These options will be applied BEFORE configuration parameters are
+// interpreted. This allows configuration parameters to override Options
+// provided to TransportSpec.
 func TransportSpec(opts ...Option) config.TransportSpec {
 	transportSpec := &transportSpec{}
 	for _, o := range opts {
@@ -51,16 +59,22 @@ func TransportSpec(opts ...Option) config.TransportSpec {
 	}
 }
 
-// TransportConfig
-type TransportConfig struct{}
-
-// InboundConfig
+// InboundConfig configures a gRPC Inbound.
+//
+// inbounds:
+//   grpc:
+//     address: ":80
 type InboundConfig struct {
 	// Address to listen on. This field is required.
 	Address string `config:"address,interpolate"`
 }
 
-// OutboundConfig
+// OutboundConfig configures a gRPC Outbound.
+//
+// outbounds:
+//   myservice:
+//     grpc:
+//       address: ":80
 type OutboundConfig struct {
 	// Address to connect to. This field is required.
 	Address string `config:"address,interpolate"`
@@ -71,7 +85,7 @@ type transportSpec struct {
 	OutboundOptions []OutboundOption
 }
 
-func (t *transportSpec) buildTransport(transportConfig *TransportConfig, _ *config.Kit) (transport.Transport, error) {
+func (t *transportSpec) buildTransport(_ struct{}, _ *config.Kit) (transport.Transport, error) {
 	return nil, nil
 }
 

--- a/transport/x/grpc/config.go
+++ b/transport/x/grpc/config.go
@@ -40,16 +40,9 @@ const transportName = "grpc"
 // interpreted. This allows configuration parameters to override Options
 // provided to TransportSpec.
 func TransportSpec(opts ...Option) config.TransportSpec {
-	transportSpec := &transportSpec{}
-	for _, o := range opts {
-		switch opt := o.(type) {
-		case InboundOption:
-			transportSpec.InboundOptions = append(transportSpec.InboundOptions, opt)
-		case OutboundOption:
-			transportSpec.OutboundOptions = append(transportSpec.OutboundOptions, opt)
-		default:
-			panic(fmt.Sprintf("unknown option of type %T: %v", o, o))
-		}
+	transportSpec, err := newTransportSpec(opts...)
+	if err != nil {
+		panic(err.Error())
 	}
 	return config.TransportSpec{
 		Name:               transportName,
@@ -83,6 +76,21 @@ type OutboundConfig struct {
 type transportSpec struct {
 	InboundOptions  []InboundOption
 	OutboundOptions []OutboundOption
+}
+
+func newTransportSpec(opts ...Option) (*transportSpec, error) {
+	transportSpec := &transportSpec{}
+	for _, o := range opts {
+		switch opt := o.(type) {
+		case InboundOption:
+			transportSpec.InboundOptions = append(transportSpec.InboundOptions, opt)
+		case OutboundOption:
+			transportSpec.OutboundOptions = append(transportSpec.OutboundOptions, opt)
+		default:
+			return nil, fmt.Errorf("unknown option of type %T: %v", o, o)
+		}
+	}
+	return transportSpec, nil
 }
 
 func (t *transportSpec) buildTransport(_ struct{}, _ *config.Kit) (transport.Transport, error) {

--- a/transport/x/grpc/config_test.go
+++ b/transport/x/grpc/config_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package grpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewTransportSpecOptions(t *testing.T) {
+	transportSpec, err := newTransportSpec(
+		WithInboundTracer(nil),
+		WithOutboundTracer(nil),
+		WithOutboundTracer(nil),
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(transportSpec.InboundOptions))
+	require.Equal(t, 2, len(transportSpec.OutboundOptions))
+}
+
+func TestConfigBuildInboundRequiredAddress(t *testing.T) {
+	transportSpec := &transportSpec{}
+	_, err := transportSpec.buildInbound(&InboundConfig{}, nil, nil)
+	require.Equal(t, newRequiredFieldMissingError("address"), err)
+}
+
+func TestConfigBuildUnaryOutboundRequiredAddress(t *testing.T) {
+	transportSpec := &transportSpec{}
+	_, err := transportSpec.buildUnaryOutbound(&OutboundConfig{}, nil, nil)
+	require.Equal(t, newRequiredFieldMissingError("address"), err)
+}

--- a/transport/x/grpc/config_test.go
+++ b/transport/x/grpc/config_test.go
@@ -29,6 +29,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestNoopTransport(t *testing.T) {
+	noopTransport := noopTransport{}
+	assert.NoError(t, noopTransport.Start())
+	assert.NoError(t, noopTransport.Stop())
+	assert.False(t, noopTransport.IsRunning())
+}
+
 func TestNewTransportSpecOptions(t *testing.T) {
 	transportSpec, err := newTransportSpec(
 		WithInboundTracer(nil),
@@ -50,6 +57,10 @@ func TestConfigBuildUnaryOutboundRequiredAddress(t *testing.T) {
 	transportSpec := &transportSpec{}
 	_, err := transportSpec.buildUnaryOutbound(&OutboundConfig{}, nil, nil)
 	require.Equal(t, newRequiredFieldMissingError("address"), err)
+}
+
+func TestTransportSpecUnknownOption(t *testing.T) {
+	assert.Panics(t, func() { TransportSpec(testOption{}) })
 }
 
 func TestTransportSpec(t *testing.T) {
@@ -170,3 +181,7 @@ func mapResolver(m map[string]string) func(string) (string, bool) {
 		return
 	}
 }
+
+type testOption struct{}
+
+func (testOption) grpcOption() {}

--- a/transport/x/grpc/config_test.go
+++ b/transport/x/grpc/config_test.go
@@ -23,6 +23,9 @@ package grpc
 import (
 	"testing"
 
+	"go.uber.org/yarpc/x/config"
+
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,4 +50,123 @@ func TestConfigBuildUnaryOutboundRequiredAddress(t *testing.T) {
 	transportSpec := &transportSpec{}
 	_, err := transportSpec.buildUnaryOutbound(&OutboundConfig{}, nil, nil)
 	require.Equal(t, newRequiredFieldMissingError("address"), err)
+}
+
+func TestTransportSpec(t *testing.T) {
+	type attrs map[string]interface{}
+
+	type wantInbound struct {
+		Address string
+	}
+
+	type wantOutbound struct {
+		Address string
+	}
+
+	type test struct {
+		desc          string
+		inboundCfg    attrs
+		outboundCfg   attrs
+		env           map[string]string
+		opts          []Option
+		wantInbound   *wantInbound
+		wantOutbounds map[string]wantOutbound
+		wantErrors    []string
+	}
+
+	tests := []test{
+		{
+			desc:        "simple inbound",
+			inboundCfg:  attrs{"address": ":34567"},
+			wantInbound: &wantInbound{Address: ":34567"},
+		},
+		{
+			desc:        "inbound interpolation",
+			inboundCfg:  attrs{"address": "${HOST:}:${PORT}"},
+			env:         map[string]string{"HOST": "127.0.0.1", "PORT": "34568"},
+			wantInbound: &wantInbound{Address: "127.0.0.1:34568"},
+		},
+		{
+			desc: "simple outbound",
+			outboundCfg: attrs{
+				"myservice": attrs{
+					transportName: attrs{"address": "localhost:4040"},
+				},
+			},
+			wantOutbounds: map[string]wantOutbound{
+				"myservice": {
+					Address: "localhost:4040",
+				},
+			},
+		},
+		{
+			desc: "outbound interpolation",
+			outboundCfg: attrs{
+				"myservice": attrs{
+					transportName: attrs{"address": "${ADDR}"},
+				},
+			},
+			env: map[string]string{"ADDR": "127.0.0.1:80"},
+			wantOutbounds: map[string]wantOutbound{
+				"myservice": {
+					Address: "127.0.0.1:80",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			env := make(map[string]string)
+			for k, v := range tt.env {
+				env[k] = v
+			}
+
+			configurator := config.New(config.InterpolationResolver(mapResolver(env)))
+			err := configurator.RegisterTransport(TransportSpec(tt.opts...))
+			require.NoError(t, err)
+
+			cfgData := make(attrs)
+			if tt.inboundCfg != nil {
+				cfgData["inbounds"] = attrs{transportName: tt.inboundCfg}
+			}
+			if tt.outboundCfg != nil {
+				cfgData["outbounds"] = tt.outboundCfg
+			}
+			cfg, err := configurator.LoadConfig("foo", cfgData)
+			if len(tt.wantErrors) > 0 {
+				require.Error(t, err)
+				for _, msg := range tt.wantErrors {
+					assert.Contains(t, err.Error(), msg)
+				}
+				return
+			}
+			require.NoError(t, err)
+
+			if tt.wantInbound != nil {
+				require.Len(t, cfg.Inbounds, 1)
+				inbound, ok := cfg.Inbounds[0].(*Inbound)
+				require.True(t, ok, "expected *Inbound, got %T", cfg.Inbounds[0])
+				assert.Contains(t, inbound.listener.Addr().String(), tt.wantInbound.Address)
+			} else {
+				assert.Len(t, cfg.Inbounds, 0)
+			}
+			for svc, wantOutbound := range tt.wantOutbounds {
+				ob, ok := cfg.Outbounds[svc]
+				require.True(t, ok, "no outbounds for %s", svc)
+				outbound, ok := ob.Unary.(*Outbound)
+				require.True(t, ok, "expected *Outbound, got %T", ob)
+				assert.Equal(t, wantOutbound.Address, outbound.address)
+			}
+		})
+	}
+}
+
+func mapResolver(m map[string]string) func(string) (string, bool) {
+	return func(k string) (v string, ok bool) {
+		if m != nil {
+			v, ok = m[k]
+		}
+		return
+	}
 }

--- a/transport/x/grpc/config_test.go
+++ b/transport/x/grpc/config_test.go
@@ -98,6 +98,11 @@ func TestTransportSpec(t *testing.T) {
 			wantInbound: &wantInbound{Address: "127.0.0.1:34568"},
 		},
 		{
+			desc:       "bad inbound address",
+			inboundCfg: attrs{"address": "derp"},
+			wantErrors: []string{"address derp"},
+		},
+		{
 			desc: "simple outbound",
 			outboundCfg: attrs{
 				"myservice": attrs{

--- a/transport/x/grpc/options.go
+++ b/transport/x/grpc/options.go
@@ -25,11 +25,24 @@ import (
 	"google.golang.org/grpc"
 )
 
+// Option is an interface shared by InboundOption and OutboundOption
+// allowing either to be recognized by TransportSpec().
+type Option interface {
+	grpcOption()
+}
+
+var _ Option = (InboundOption)(nil)
+var _ Option = (OutboundOption)(nil)
+
 // InboundOption is an option for an inbound.
 type InboundOption func(*inboundOptions)
 
+func (InboundOption) grpcOption() {}
+
 // OutboundOption is an option for an outbound.
 type OutboundOption func(*outboundOptions)
+
+func (OutboundOption) grpcOption() {}
 
 // WithInboundTracer specifies the tracer to use for an inbound.
 func WithInboundTracer(tracer opentracing.Tracer) InboundOption {


### PR DESCRIPTION
- Adds the `grpc.TransportSpec` function to begin work on gRPC config. This is not fully fleshed out yet, especially as the peer API is not yet implemented, but is a start.
- Adds `grpc.Option`, similar to `http.Option` and `tchannel.Option`, to allow both `grpc.InboundOption` and `grpc.OutboundOption` to satisfy a common interface for use as parameters to the `grpc.TransportSpec` function.
- Adds testing for gRPC config. `TestTransportSpec` is mostly copied from `transport/http/config_test.go`, with some cleanup, it should look familiar (tchannel is similar too). I got `config.go` to 100% code coverage for fun.

Note that there is no concept of a common `Transport` in the grpc package, so not sure what to do with `buildTransport`, any advice is appreciated. Right now I implement it, but return a no-op transport, and do not use it in `buildInbound` or `buildUnaryOutbound`.

(Per convo in SF heh) amount of review wanted: small amount. This is just the start of gRPC config, and I want to make sure I am going in the right direction. There will be more work on this before going out of x/.