### PR TITLE
Fix docker to unbreak CI when docker isn't installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,5 @@
 include build/base.mk
 ifndef SUPPRESS_DOCKER
-ifneq ($(shell docker version >/dev/null; echo $$?),0)
-$(info -----------------------------------------------------------------)
-$(info Most of our make commands run inside Docker but you do not have)
-$(info Docker Daemon running. Please start the Docker Daemon and try again.)
-$(info See https://docs.docker.com/engine/installation/ to get started with)
-$(info Docker.)
-$(info )
-$(info Alternatively, set SUPPRESS_DOCKER=1 to run the command locally)
-$(info against your system.)
-$(error Docker is not running)
-endif
 include build/dockerdeps.mk
 include build/docker.mk
 else

--- a/build/docker.mk
+++ b/build/docker.mk
@@ -9,7 +9,7 @@ DOCKER_RUN_FLAGS ?= -e V -e RUN -e EXAMPLES_JOBS -e WITHIN_DOCKER=1
 DOCKER_VOLUME_FLAGS=-v $(shell pwd):/go/src/go.uber.org/yarpc
 
 .PHONY: deps
-deps: $(DOCKER) ## install all dependencies
+deps: $(DOCKER) __check_docker ## install all dependencies
 	PATH=$$PATH:$(BIN) docker build $(DOCKER_BUILD_FLAGS) -t $(DOCKER_IMAGE) -f $(DOCKERFILE) .
 
 .PHONY: build
@@ -79,3 +79,14 @@ examples: deps ## run all examples tests
 .PHONY: shell
 shell: deps ## go into a bash shell in docker with the repository linked as a volume
 	PATH=$$PATH:$(BIN) docker run -it $(DOCKER_VOLUME_FLAGS) $(DOCKER_RUN_FLAGS) $(DOCKER_IMAGE) /bin/bash
+
+.PHONY: __check_docker
+__check_docker:
+	@if ! docker version >/dev/null; then \
+		echo "-----------------------------------------------------------------" >&2; \
+		echo "Most of our make commands run inside Docker but you do not appear to have" >&2; \
+		echo "the Docker daemon running. Please start the Docker daemon and try again." >&2; \
+		echo "See https://docs.docker.com/engine/installation/ to get started with Docker." >&2; \
+		echo "Alternatively, set SUPPRESS_DOCKER=1 to run the command locally against your system." >&2; \
+		echo "Docker is not running" >&2; \
+	fi

--- a/build/docker.mk
+++ b/build/docker.mk
@@ -89,4 +89,5 @@ __check_docker:
 		echo "See https://docs.docker.com/engine/installation/ to get started with Docker." >&2; \
 		echo "Alternatively, set SUPPRESS_DOCKER=1 to run the command locally against your system." >&2; \
 		echo "Docker is not running" >&2; \
+		exit 1; \
 	fi

--- a/build/docker.mk
+++ b/build/docker.mk
@@ -82,12 +82,4 @@ shell: deps ## go into a bash shell in docker with the repository linked as a vo
 
 .PHONY: __check_docker
 __check_docker:
-	@if ! docker version >/dev/null; then \
-		echo "-----------------------------------------------------------------" >&2; \
-		echo "Most of our make commands run inside Docker but you do not appear to have" >&2; \
-		echo "the Docker daemon running. Please start the Docker daemon and try again." >&2; \
-		echo "See https://docs.docker.com/engine/installation/ to get started with Docker." >&2; \
-		echo "Alternatively, set SUPPRESS_DOCKER=1 to run the command locally against your system." >&2; \
-		echo "Docker is not running" >&2; \
-		exit 1; \
-	fi
+	@PATH=$$PATH:$(BIN) ./scripts/check-docker.sh

--- a/scripts/check-docker.sh
+++ b/scripts/check-docker.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+docker version >/dev/null
+if [ $? -ne 0 ]; then
+  echo "-----------------------------------------------------------------" >&2
+  echo "Most of our make commands run inside Docker but you do not appear to have" >&2
+  echo "the Docker daemon running. Please start the Docker daemon and try again." >&2
+  echo "See https://docs.docker.com/engine/installation/ to get started with Docker." >&2
+  echo "Alternatively, set SUPPRESS_DOCKER=1 to run the command locally against your system." >&2
+  echo "Docker is not running" >&2
+  exit 1
+fi


### PR DESCRIPTION
All of CircleCI is broken since this fix because this assumes Docker is installed, which our build system handles. I've moved this instead to a check after the `$(DOCKER)` dependency, which should run for every Docker command. Regardless of if we use CircleCI or not, the build system does not assume you have the Docker client installed, and sets it up so you use a specific version of the Docker client.

Note I know I approved of the PR that merged this, but I re-did the build system to execute no potentially long-running commands when you initialize the Makefile - previously, `make` autocomplete was almost unusable, and I want to keep it usable, so we should always defer such checks.