### PR TITLE
Fix race conditions in hostport Peer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ v1.9.0-dev (unreleased)
 -   x/roundrobin: Added support for taking peer list updates before and after
     the peer list has been started.
 -   Moved the RoundRobin Peer List out of the /x/ package.
-
+-   Fix race conditions in hostport.Peer.
 
 v1.8.0 (2017-05-01)
 -------------------

--- a/peer/hostport/hostport_test.go
+++ b/peer/hostport/hostport_test.go
@@ -22,6 +22,7 @@ package hostport
 
 import (
 	"testing"
+	"time"
 
 	"go.uber.org/yarpc/api/peer"
 	. "go.uber.org/yarpc/api/peer/peertest"
@@ -247,6 +248,27 @@ func TestPeer(t *testing.T) {
 			expectedStatus: peer.Status{
 				PendingRequestCount: 0,
 				ConnectionStatus:    peer.Unavailable,
+			},
+		},
+		{
+			msg: "concurrent update and subscribe",
+			SubDefinitions: []SubscriberDefinition{
+				{ID: "1", ExpectedNotifyCount: 2},
+			},
+			actions: []PeerAction{
+				PeerConcurrentAction{
+					Actions: []PeerAction{
+						SubscribeAction{SubscriberID: "1", ExpectedSubCount: 1},
+						SetStatusAction{InputStatus: peer.Available},
+						SetStatusAction{InputStatus: peer.Available},
+					},
+					Wait: time.Millisecond * 70,
+				},
+			},
+			expectedSubscribers: []string{"1"},
+			expectedStatus: peer.Status{
+				PendingRequestCount: 0,
+				ConnectionStatus:    peer.Available,
 			},
 		},
 	}


### PR DESCRIPTION
Summary: In some internal testing we noticed that go test -race was showing race
conditions in the code.  With closer inspection we found that the hostport subscribers
and connectionState were not thread-safe.  This PR adds a read-write mutex around the
peer's subscriber list, and wraps the connectionState in an atomic.

Test Plan: Wrote a concurrent test that failed with race conditions, the change removed
the race condition failures