### PR TITLE
Make grpc inbounds and outbounds constructors private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ v1.9.0-dev (unreleased)
     the peer list has been started.
 -   Moved the RoundRobin Peer List out of the /x/ package.
 -   Fix race conditions in hostport.Peer.
+-   transport/x/grpc: Remove NewInbound and NewSingleOutbound in favor of
+    functions on Transport
 
 v1.8.0 (2017-05-01)
 -------------------

--- a/internal/crossdock/client/dispatcher/dispatcher.go
+++ b/internal/crossdock/client/dispatcher/dispatcher.go
@@ -66,7 +66,7 @@ func CreateDispatcherForTransport(t crossdock.T, trans string) *yarpc.Dispatcher
 
 		unaryOutbound = tchannelTransport.NewSingleOutbound(server + ":8082")
 	case "grpc":
-		unaryOutbound = grpc.NewSingleOutbound(server + ":8089")
+		unaryOutbound = grpc.NewTransport().NewSingleOutbound(server + ":8089")
 	default:
 		fatals.Fail("", "unknown transport %q", trans)
 	}

--- a/internal/crossdock/server/yarpc/server.go
+++ b/internal/crossdock/server/yarpc/server.go
@@ -59,7 +59,7 @@ func Start() {
 		Inbounds: yarpc.Inbounds{
 			tchannelTransport.NewInbound(),
 			httpTransport.NewInbound(":8081"),
-			grpc.NewInbound(grpcListener),
+			grpc.NewTransport().NewInbound(grpcListener),
 		},
 	})
 

--- a/internal/examples/json-keyvalue/client/main.go
+++ b/internal/examples/json-keyvalue/client/main.go
@@ -106,7 +106,7 @@ func do() error {
 	case "tchannel":
 		outbound = tchannelTransport.NewSingleOutbound("127.0.0.1:28941")
 	case "grpc":
-		outbound = grpc.NewSingleOutbound("127.0.0.1:24038")
+		outbound = grpc.NewTransport().NewSingleOutbound("127.0.0.1:24038")
 	default:
 		return fmt.Errorf("invalid outbound: %q", outboundName)
 	}

--- a/internal/examples/json-keyvalue/server/main.go
+++ b/internal/examples/json-keyvalue/server/main.go
@@ -109,7 +109,7 @@ func do() error {
 		if err != nil {
 			return err
 		}
-		inbound = grpc.NewInbound(listener)
+		inbound = grpc.NewTransport().NewInbound(listener)
 	default:
 		return fmt.Errorf("invalid inbound: %q", *flagInbound)
 	}

--- a/internal/examples/thrift-keyvalue/keyvalue/client/main.go
+++ b/internal/examples/thrift-keyvalue/keyvalue/client/main.go
@@ -67,7 +67,7 @@ func do() error {
 	case "tchannel":
 		outbound = tchannelTransport.NewSingleOutbound("127.0.0.1:28945")
 	case "grpc":
-		outbound = grpc.NewSingleOutbound("127.0.0.1:24046")
+		outbound = grpc.NewTransport().NewSingleOutbound("127.0.0.1:24046")
 	default:
 		return fmt.Errorf("invalid outbound: %q", outboundName)
 	}

--- a/internal/examples/thrift-keyvalue/keyvalue/server/main.go
+++ b/internal/examples/thrift-keyvalue/keyvalue/server/main.go
@@ -103,7 +103,7 @@ func do() error {
 		if err != nil {
 			return err
 		}
-		inbound = grpc.NewInbound(listener)
+		inbound = grpc.NewTransport().NewInbound(listener)
 		go func() {
 			if err := gohttp.ListenAndServe(":3244", nil); err != nil {
 				log.Fatal(err)

--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -168,7 +168,7 @@ func NewClientDispatcher(transportType TransportType, config *DispatcherConfig) 
 		unaryOutbound = httpOutbound
 	case TransportTypeGRPC:
 		onewayOutbound = http.NewTransport().NewSingleOutbound(fmt.Sprintf("http://127.0.0.1:%d", httpPort))
-		unaryOutbound = grpc.NewSingleOutbound(fmt.Sprintf("127.0.0.1:%d", port))
+		unaryOutbound = grpc.NewTransport().NewSingleOutbound(fmt.Sprintf("127.0.0.1:%d", port))
 	default:
 		return nil, fmt.Errorf("invalid TransportType: %v", transportType)
 	}
@@ -216,7 +216,7 @@ func NewServerDispatcher(procedures []transport.Procedure, config *DispatcherCon
 			Inbounds: yarpc.Inbounds{
 				tchannelTransport.NewInbound(),
 				http.NewTransport().NewInbound(fmt.Sprintf("127.0.0.1:%d", httpPort)),
-				grpc.NewInbound(grpcListener),
+				grpc.NewTransport().NewInbound(grpcListener),
 			},
 		},
 	)

--- a/transport/x/grpc/config.go
+++ b/transport/x/grpc/config.go
@@ -113,14 +113,14 @@ func (t *transportSpec) buildInbound(inboundConfig *InboundConfig, _ transport.T
 	if err != nil {
 		return nil, err
 	}
-	return NewInbound(listener, t.InboundOptions...), nil
+	return newInbound(listener, t.InboundOptions...), nil
 }
 
 func (t *transportSpec) buildUnaryOutbound(outboundConfig *OutboundConfig, _ transport.Transport, _ *config.Kit) (transport.UnaryOutbound, error) {
 	if outboundConfig.Address == "" {
 		return nil, newRequiredFieldMissingError("address")
 	}
-	return NewSingleOutbound(outboundConfig.Address, t.OutboundOptions...), nil
+	return newSingleOutbound(outboundConfig.Address, t.OutboundOptions...), nil
 }
 
 func newRequiredFieldMissingError(field string) error {

--- a/transport/x/grpc/inbound.go
+++ b/transport/x/grpc/inbound.go
@@ -48,8 +48,7 @@ type Inbound struct {
 	server         *grpc.Server
 }
 
-// NewInbound returns a new Inbound for the given listener.
-func NewInbound(listener net.Listener, options ...InboundOption) *Inbound {
+func newInbound(listener net.Listener, options ...InboundOption) *Inbound {
 	return &Inbound{internalsync.Once(), sync.Mutex{}, listener, newInboundOptions(options), nil, nil}
 }
 

--- a/transport/x/grpc/inbound_test.go
+++ b/transport/x/grpc/inbound_test.go
@@ -136,7 +136,7 @@ func TestGetServiceDescs(t *testing.T) {
 		},
 	} {
 		t.Run(tt.Name, func(t *testing.T) {
-			inbound := NewInbound(nil)
+			inbound := newInbound(nil)
 			inbound.SetRouter(newTestTransportRouter(tt.Procedures))
 			serviceDescs, err := inbound.getServiceDescs()
 			require.NoError(t, err)

--- a/transport/x/grpc/integration_test.go
+++ b/transport/x/grpc/integration_test.go
@@ -97,12 +97,14 @@ func newTestEnv(inboundOptions []InboundOption, outboundOptions []OutboundOption
 	procedures := examplepb.BuildKeyValueYarpcProcedures(keyValueYarpcServer)
 	testRouter := newTestRouter(procedures)
 
+	t := NewTransport()
+
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		return nil, err
 	}
 
-	inbound := NewInbound(listener, inboundOptions...)
+	inbound := t.NewInbound(listener, inboundOptions...)
 	inbound.SetRouter(testRouter)
 	if err := inbound.Start(); err != nil {
 		return nil, err
@@ -124,7 +126,7 @@ func newTestEnv(inboundOptions []InboundOption, outboundOptions []OutboundOption
 	}()
 	keyValueClient := examplepb.NewKeyValueClient(clientConn)
 
-	outbound := NewSingleOutbound(listener.Addr().String(), outboundOptions...)
+	outbound := t.NewSingleOutbound(listener.Addr().String(), outboundOptions...)
 	if err := outbound.Start(); err != nil {
 		return nil, err
 	}

--- a/transport/x/grpc/outbound.go
+++ b/transport/x/grpc/outbound.go
@@ -52,8 +52,7 @@ type Outbound struct {
 	clientConn      *grpc.ClientConn
 }
 
-// NewSingleOutbound returns a new Outbound for the given adrress.
-func NewSingleOutbound(address string, options ...OutboundOption) *Outbound {
+func newSingleOutbound(address string, options ...OutboundOption) *Outbound {
 	return &Outbound{internalsync.Once(), sync.Mutex{}, address, newOutboundOptions(options), nil}
 }
 

--- a/transport/x/grpc/transport.go
+++ b/transport/x/grpc/transport.go
@@ -57,10 +57,10 @@ func (t *Transport) IsRunning() bool {
 
 // NewInbound returns a new Inbound for the given listener.
 func (t *Transport) NewInbound(listener net.Listener, options ...InboundOption) *Inbound {
-	return NewInbound(listener, options...)
+	return newInbound(listener, options...)
 }
 
 // NewSingleOutbound returns a new Outbound for the given adrress.
 func (t *Transport) NewSingleOutbound(address string, options ...OutboundOption) *Outbound {
-	return NewSingleOutbound(address, options...)
+	return newSingleOutbound(address, options...)
 }


### PR DESCRIPTION
Follow-up for https://github.com/yarpc/yarpc-go/pull/1016, this should complete https://github.com/yarpc/yarpc-go/issues/1015.