### PR TITLE
config: Rename PeerList to PeerChooser

### DIFF
--- a/transport/http/config.go
+++ b/transport/http/config.go
@@ -147,7 +147,7 @@ func (ts *transportSpec) buildInbound(ic *InboundConfig, t transport.Transport, 
 //              - 127.0.0.1:8080
 //              - 127.0.0.1:8081
 type OutboundConfig struct {
-	config.PeerList
+	config.PeerChooser
 
 	// URL to which requests will be sent for this outbound. This field is
 	// required.
@@ -179,7 +179,7 @@ func (ts *transportSpec) buildOutbound(oc *OutboundConfig, t transport.Transport
 		return x.NewSingleOutbound(oc.URL, opts...), nil
 	}
 
-	chooser, err := oc.PeerList.BuildPeerList(x, hostport.Identify, k)
+	chooser, err := oc.BuildPeerChooser(x, hostport.Identify, k)
 	if err != nil {
 		return nil, fmt.Errorf("cannot configure peer chooser for HTTP outbound: %v", err)
 	}

--- a/transport/http/config_test.go
+++ b/transport/http/config_test.go
@@ -314,7 +314,7 @@ func TestTransportSpec(t *testing.T) {
 			wantErrors: []string{
 				`failed to configure unary outbound for "myservice":`,
 				"cannot configure peer chooser for HTTP outbound:",
-				`no recognized peer list preset "derp"`,
+				`no recognized peer chooser preset "derp"`,
 			},
 		},
 	}

--- a/transport/tchannel/config.go
+++ b/transport/tchannel/config.go
@@ -58,7 +58,7 @@ type InboundConfig struct {
 // 	    tchannel:
 // 	      peer: 127.0.0.1:4040
 type OutboundConfig struct {
-	config.PeerList
+	config.PeerChooser
 }
 
 // TransportSpec returns a TransportSpec for the TChannel unary transport.
@@ -136,7 +136,7 @@ func (ts *transportSpec) buildInbound(c *InboundConfig, t transport.Transport, k
 
 func (ts *transportSpec) buildUnaryOutbound(oc *OutboundConfig, t transport.Transport, k *config.Kit) (transport.UnaryOutbound, error) {
 	x := t.(*Transport)
-	chooser, err := oc.PeerList.BuildPeerList(x, hostport.Identify, k)
+	chooser, err := oc.BuildPeerChooser(x, hostport.Identify, k)
 	if err != nil {
 		return nil, err
 	}

--- a/x/config/chooser_test.go
+++ b/x/config/chooser_test.go
@@ -145,7 +145,7 @@ func TestChooserConfigurator(t *testing.T) {
 			},
 		},
 		{
-			desc: "peer list preset",
+			desc: "peer chooser preset",
 			given: whitespace.Expand(`
 				transports:
 					fake-transport:
@@ -447,7 +447,7 @@ func TestChooserConfigurator(t *testing.T) {
 			},
 		},
 		{
-			desc: "invalid peer list preset",
+			desc: "invalid peer chooser preset",
 			given: whitespace.Expand(`
 				outbounds:
 					their-service:
@@ -457,7 +457,7 @@ func TestChooserConfigurator(t *testing.T) {
 			`),
 			wantErr: []string{
 				`failed to configure unary outbound for "their-service": `,
-				`no recognized peer list preset "bogus"`,
+				`no recognized peer chooser preset "bogus"`,
 				`need one of`,
 				`fake`,
 			},
@@ -760,7 +760,7 @@ func TestBuildPeerListInvalidKit(t *testing.T) {
 	// We build a fake InboundConfig that embeds the PeerList. This will let
 	// us call PeerList.BuildPeerList with the wrong Kit.
 	type inboundConfig struct {
-		config.PeerList
+		config.PeerChooser
 	}
 
 	configer := yarpctest.NewFakeConfigurator()
@@ -770,7 +770,7 @@ func TestBuildPeerListInvalidKit(t *testing.T) {
 			return transporttest.NewMockTransport(mockCtrl), nil
 		},
 		BuildInbound: func(cfg *inboundConfig, _ transport.Transport, k *config.Kit) (transport.Inbound, error) {
-			_, err := cfg.PeerList.BuildPeerList(peertest.NewMockTransport(mockCtrl), hostport.Identify, k)
+			_, err := cfg.BuildPeerChooser(peertest.NewMockTransport(mockCtrl), hostport.Identify, k)
 			assert.Error(t, err, "BuildPeerList should fail with an invalid Kit")
 			return transporttest.NewMockInbound(mockCtrl), err
 		},

--- a/x/config/kit.go
+++ b/x/config/kit.go
@@ -67,23 +67,23 @@ func (k *Kit) peerListSpec(name string) (*compiledPeerListSpec, error) {
 	return nil, errors.New(msg)
 }
 
-func (k *Kit) peerListPreset(name string) (*compiledPeerListPreset, error) {
+func (k *Kit) peerChooserPreset(name string) (*compiledPeerChooserPreset, error) {
 	if k.transportSpec == nil {
 		// Currently, transportspec is set only if we're inside build*Outbound.
 		return nil, errors.New(
 			"invalid Kit: make sure you passed in the same Kit your Build function received")
 	}
 
-	if spec := k.transportSpec.PeerListPresets[name]; spec != nil {
+	if spec := k.transportSpec.PeerChooserPresets[name]; spec != nil {
 		return spec, nil
 	}
 
-	available := make([]string, 0, len(k.transportSpec.PeerListPresets))
-	for name := range k.transportSpec.PeerListPresets {
+	available := make([]string, 0, len(k.transportSpec.PeerChooserPresets))
+	for name := range k.transportSpec.PeerChooserPresets {
 		available = append(available, name)
 	}
 
-	msg := fmt.Sprintf("no recognized peer list preset %q", name)
+	msg := fmt.Sprintf("no recognized peer chooser preset %q", name)
 	if len(available) > 0 {
 		msg = fmt.Sprintf("%s; need one of %s", msg, strings.Join(available, ", "))
 	}

--- a/yarpctest/fake_config.go
+++ b/yarpctest/fake_config.go
@@ -39,14 +39,14 @@ func buildFakeTransport(c *FakeTransportConfig, kit *config.Kit) (transport.Tran
 
 // FakeOutboundConfig configures the FakeOutbound.
 type FakeOutboundConfig struct {
-	config.PeerList
+	config.PeerChooser
 
 	Nop string `config:"nop"`
 }
 
 func buildFakeOutbound(c *FakeOutboundConfig, t transport.Transport, kit *config.Kit) (transport.UnaryOutbound, error) {
 	x := t.(*FakeTransport)
-	chooser, err := c.PeerList.BuildPeerList(x, hostport.Identify, kit)
+	chooser, err := c.BuildPeerChooser(x, hostport.Identify, kit)
 	if err != nil {
 		return nil, err
 	}
@@ -60,8 +60,8 @@ func FakeTransportSpec() config.TransportSpec {
 		Name:               "fake-transport",
 		BuildTransport:     buildFakeTransport,
 		BuildUnaryOutbound: buildFakeOutbound,
-		PeerListPresets: []config.PeerListPreset{
-			FakePeerListPreset(),
+		PeerChooserPresets: []config.PeerChooserPreset{
+			FakePeerChooserPreset(),
 		},
 	}
 }
@@ -122,12 +122,12 @@ func NewFakeConfigurator() *config.Configurator {
 	return configurator
 }
 
-// FakePeerListPreset is a PeerListPreset which builds a FakePeerList buind to
+// FakePeerChooserPreset is a PeerChooserPreset which builds a FakePeerList buind to
 // a FakePeerListUpdater.
-func FakePeerListPreset() config.PeerListPreset {
-	return config.PeerListPreset{
+func FakePeerChooserPreset() config.PeerChooserPreset {
+	return config.PeerChooserPreset{
 		Name: "fake-preset",
-		BuildPeerList: func(peer.Transport, *config.Kit) (peer.Chooser, error) {
+		BuildPeerChooser: func(peer.Transport, *config.Kit) (peer.Chooser, error) {
 			return peerbind.Bind(
 				NewFakePeerList(), func(peer.List) transport.Lifecycle {
 					return NewFakePeerListUpdater()


### PR DESCRIPTION
This renames the config.PeerList struct which users embed in their
outbounds to config.PeerChooser since that's what it actually
represents. As a result of this, the BuildPeerList method on it was
renamed to BuildPeerChooser and the PeerListPreset struct (and the
corresponding attribute in TransportSpec) was renamed to
PeerChooserPreset(s).