### PR TITLE
Add back protobuf to encodings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
             - AXIS_CLIENT=go,java,node,python,python-sync
             - AXIS_SERVER=go,java,node,python
             - AXIS_TRANSPORT=http,tchannel
-            - AXIS_ENCODING=raw,json,thrift
+            - AXIS_ENCODING=raw,json,thrift,protobuf
             - AXIS_ERRORS_HTTPCLIENT=go # pending update to node test
             # AXIS_ERRORS_HTTPSERVER TODO
             - AXIS_ERRORS_TCHCLIENT=go


### PR DESCRIPTION
In https://github.com/yarpc/yarpc-go/pull/1003, I forgot to add `protobuf` the the encodings, now that I skip `protobuf` in most of the testing. This adds it.