### PR TITLE
Update the gRPC codec string return value to not represent the encoding

### DIFF
--- a/transport/x/grpc/codec.go
+++ b/transport/x/grpc/codec.go
@@ -47,9 +47,11 @@ func (customCodec) Unmarshal(data []byte, obj interface{}) error {
 }
 
 func (customCodec) String() string {
-	// TODO: faking this as proto to be compatible with existing grpc clients
-	// https://github.com/yarpc/yarpc-go/issues/911
-	return "proto"
+	// setting this to what amounts to a nonsense value
+	// the encoding should always be inferred from the headers
+	// setting this to a name that is not an encoding will assure
+	// we get an error if this is used as the encoding value
+	return "yarpc"
 }
 
 func newCustomCodecMarshalCastError(actualObject interface{}) error {

--- a/transport/x/grpc/codec.go
+++ b/transport/x/grpc/codec.go
@@ -47,10 +47,10 @@ func (customCodec) Unmarshal(data []byte, obj interface{}) error {
 }
 
 func (customCodec) String() string {
-	// setting this to what amounts to a nonsense value
-	// the encoding should always be inferred from the headers
-	// setting this to a name that is not an encoding will assure
-	// we get an error if this is used as the encoding value
+	// Setting this to what amounts to a nonsense value.
+	// The encoding should always be inferred from the headers.
+	// Setting this to a name that is not an encoding will assure
+	// we get an error if this is used as the encoding value.
 	return "yarpc"
 }
 

--- a/transport/x/grpc/codec_test.go
+++ b/transport/x/grpc/codec_test.go
@@ -55,5 +55,5 @@ func TestCustomCodecUnmarshalCastError(t *testing.T) {
 }
 
 func TestCustomCodecString(t *testing.T) {
-	assert.Equal(t, "proto", customCodec{}.String())
+	assert.Equal(t, "yarpc", customCodec{}.String())
 }


### PR DESCRIPTION
This changes the gRPC `Codec#String` return value from `proto` to `yarpc`. There's some ambiguity from the grpc-go docs about how `Codec#String` is handled, and from my experience with developing on grpc-go, we plainly want to make sure this is not used as the content subtype for now. This "makes sure" there are no issues with our usage of grpc-go.