### PR TITLE
WIP: Generic IDL introspection

### DIFF
--- a/api/middleware/inbound.go
+++ b/api/middleware/inbound.go
@@ -24,7 +24,11 @@ import (
 	"context"
 
 	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/introspection"
 )
+
+var _ introspection.IntrospectableHandler = (*unaryHandlerWithMiddleware)(nil)
+var _ introspection.IntrospectableHandler = (*onewayHandlerWithMiddleware)(nil)
 
 // UnaryInbound defines a transport-level middleware for
 // `UnaryHandler`s.
@@ -69,6 +73,13 @@ type unaryHandlerWithMiddleware struct {
 
 func (h unaryHandlerWithMiddleware) Handle(ctx context.Context, req *transport.Request, resw transport.ResponseWriter) error {
 	return h.i.Handle(ctx, req, resw, h.h)
+}
+
+func (h unaryHandlerWithMiddleware) Introspect() *introspection.Handler {
+	if i, ok := h.h.(introspection.IntrospectableHandler); ok {
+		return i.Introspect()
+	}
+	return nil
 }
 
 type nopUnaryInbound struct{}
@@ -120,6 +131,13 @@ type onewayHandlerWithMiddleware struct {
 
 func (h onewayHandlerWithMiddleware) HandleOneway(ctx context.Context, req *transport.Request) error {
 	return h.i.HandleOneway(ctx, req, h.h)
+}
+
+func (h onewayHandlerWithMiddleware) Introspect() *introspection.Handler {
+	if i, ok := h.h.(introspection.IntrospectableHandler); ok {
+		return i.Introspect()
+	}
+	return nil
 }
 
 type nopOnewayInbound struct{}

--- a/internal/introspection/handler.go
+++ b/internal/introspection/handler.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package introspection
+
+type IntrospectableHandler interface {
+	Introspect() *Handler
+}
+
+type Handler struct {
+	IDLEntryPoint *IDLModule
+}

--- a/internal/introspection/handler.go
+++ b/internal/introspection/handler.go
@@ -27,5 +27,5 @@ type IntrospectableHandler interface {
 
 // Handler is the introspection reported by IntrospectableHandler.
 type Handler struct {
-	IDLEntryPoint *IDLModule
+	IDLEntryPoint *IDLFile
 }

--- a/internal/introspection/handler.go
+++ b/internal/introspection/handler.go
@@ -20,10 +20,12 @@
 
 package introspection
 
+// IntrospectableHandler is what you think it is.
 type IntrospectableHandler interface {
 	Introspect() *Handler
 }
 
+// Handler is the introspection reported by IntrospectableHandler.
 type Handler struct {
 	IDLEntryPoint *IDLModule
 }

--- a/internal/introspection/idlmodule.go
+++ b/internal/introspection/idlmodule.go
@@ -1,0 +1,167 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package introspection
+
+import "strings"
+
+// IDLModule is a generic IDL module. For example, a thrift file or a protobuf
+// one.
+type IDLModule struct {
+	FilePath   string      `json:"filePath"`
+	SHA1       string      `json:"sha1"`
+	Includes   []IDLModule `json:"includes,omitempty"`
+	RawContent string      `json:"rawContent,omitempty"`
+}
+
+// Flatmap iterates recursively over the idl module and its includes. The cb
+// function is called onces for every unique idl module (based on FilePath).
+// Iteration is aborted if cb returns true.
+func (im *IDLModule) Flatmap(cb func(*IDLModule) bool) {
+	ft := newIDLFlattener(cb)
+	ft.Collect(im)
+}
+
+// IDLModules is a sortable slice of IDLModule.
+type IDLModules []IDLModule
+
+func (ims IDLModules) Len() int {
+	return len(ims)
+}
+
+func (ims IDLModules) Less(i int, j int) bool {
+	return ims[i].FilePath < ims[j].FilePath
+}
+
+func (ims IDLModules) Swap(i int, j int) {
+	ims[i], ims[j] = ims[j], ims[i]
+}
+
+// IDLTree builds an IDL tree from a slice of Module.
+func (ims IDLModules) IDLTree() IDLTree {
+	tb := newIDLTreeBuilder()
+	for i := range ims {
+		tb.Collect(&ims[i])
+	}
+	return tb.Root
+}
+
+// Flatmap iterates recursively over every idl modules. The cb function is
+// called onces for every unique idl module (based on FilePath). Iteration is
+// aborted if cb returns true.
+func (ims IDLModules) Flatmap(cb func(*IDLModule) bool) {
+	ft := newIDLFlattener(cb)
+	for i := range ims {
+		ft.Collect(&ims[i])
+	}
+}
+
+// IDLTree is a tree of IDLs. A tree can have directories. Dir maps directory
+// names to IDLtrees. And of course, a tree can have any number of idl modules.
+type IDLTree struct {
+	Dir     map[string]*IDLTree `json:"dir,omitempty"`
+	Modules IDLModules          `json:"modules,omitempty"`
+}
+
+// Compact replaces any tree with a single directory and no IDLModules by it's
+// single child. The the lone directory name is appended to the parent's
+// directory. I would write an example, but go doc would likely fuck up
+// rendering it anyway.
+func (it *IDLTree) Compact() {
+	for _, l1tree := range it.Dir {
+		l1tree.Compact()
+	}
+	for l1dir, l1tree := range it.Dir {
+		if len(l1tree.Dir) == 1 && len(l1tree.Modules) == 0 {
+			for l2dir, l2tree := range l1tree.Dir {
+				compactedDir := l1dir + "/" + l2dir
+				it.Dir = map[string]*IDLTree{compactedDir: l2tree}
+				break
+			}
+		}
+	}
+}
+
+type idlFlattener struct {
+	seen map[string]struct{}
+	cb   func(*IDLModule) bool
+}
+
+func newIDLFlattener(cb func(*IDLModule) bool) idlFlattener {
+	return idlFlattener{
+		seen: make(map[string]struct{}),
+		cb:   cb,
+	}
+}
+
+func (idf *idlFlattener) Collect(m *IDLModule) {
+	if _, ok := idf.seen[m.FilePath]; !ok {
+		idf.seen[m.FilePath] = struct{}{}
+		if idf.cb(m) {
+			return
+		}
+	}
+	for i := range m.Includes {
+		idf.Collect(&m.Includes[i])
+	}
+}
+
+type idlTreeBuilder struct {
+	seen map[string]struct{}
+	Root IDLTree
+}
+
+func newIDLTreeBuilder() idlTreeBuilder {
+	return idlTreeBuilder{
+		seen: make(map[string]struct{}),
+	}
+}
+
+func (ib *idlTreeBuilder) Collect(m *IDLModule) {
+	if _, ok := ib.seen[m.FilePath]; ok {
+		return
+	}
+
+	ib.seen[m.FilePath] = struct{}{}
+	n := &ib.Root
+	parts := strings.Split(m.FilePath, "/")
+	for i, part := range parts {
+		if i == len(parts)-1 {
+			continue
+		}
+		if n.Dir == nil {
+			newNode := IDLTree{}
+			n.Dir = map[string]*IDLTree{part: &newNode}
+			n = &newNode
+		} else {
+			if subNode, ok := n.Dir[part]; ok {
+				n = subNode
+			} else {
+				newNode := IDLTree{}
+				n.Dir[part] = &newNode
+				n = &newNode
+			}
+		}
+	}
+	n.Modules = append(n.Modules, *m)
+	for i := range m.Includes {
+		ib.Collect(&m.Includes[i])
+	}
+}


### PR DESCRIPTION
This adds an API for generic IDL introspection. Here, an idl is just a file with an optional list of idl includes. A set of method is provided to conveniently build a tree of IDLs from IDLs with includes.

Another PR will integrate thrift IDL to generic IDL conversion.