### PR TITLE
WIP: Expose IDL introspection on the dispatcher

### DIFF
--- a/internal/introspection/dispatcher.go
+++ b/internal/introspection/dispatcher.go
@@ -25,7 +25,7 @@ package introspection
 type DispatcherStatus struct {
 	Name            string           `json:"name"`
 	ID              string           `json:"id"`
-	Procedures      []Procedure      `json:"procedures"`
+	Procedures      Procedures       `json:"procedures"`
 	Inbounds        []InboundStatus  `json:"inbounds"`
 	Outbounds       []OutboundStatus `json:"outbounds"`
 	PackageVersions []PackageVersion `json:"packageVersions"`


### PR DESCRIPTION
With the available IDL introspection on handlers. We can now expose it during dispatcher introspection. Few methods are provided to help writing debug pages and the yarpc meta handler.