### PR TITLE
Make service name validation more explicit

### DIFF
--- a/internal/servicename.go
+++ b/internal/servicename.go
@@ -41,9 +41,9 @@ func ValidateServiceName(name string) error {
 		return errors.New("service name must be at least two characters long")
 	}
 	return multierr.Combine(
+		checkHyphens(name),
 		checkFirstCharacter(name),
 		checkForbiddenCharacters(name),
-		checkHyphens(name),
 		checkUUIDs(name),
 	)
 }

--- a/internal/servicename.go
+++ b/internal/servicename.go
@@ -21,27 +21,66 @@
 package internal
 
 import (
-	"fmt"
+	"errors"
 	"regexp"
 )
 
-var (
-	// Must starts with [a-z].
-	// Can contain [a-z] and 0-9] with non-consecutive dashes.
-	validNameRegex = regexp.MustCompile("^[a-z]+([a-z0-9]|[^-]-)*[^-]$")
+// We disallow UUIDs explicitly, though they're otherwise valid patterns.
+var uuidRegex = regexp.MustCompile("[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}")
 
-	// We disallow UUIDs explicitly (they would be accepted by validNameRegex alone)
-	uuidRegex = regexp.MustCompile("[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}")
-)
-
-// ValidateServiceName returns an error if the given name is not a valid
-// service name.
+// ValidateServiceName returns an error if the given servive name is invalid.
+// Valid names are at least two characters long, start with [a-z], contain only
+// [0-9a-z] and non-consecutive hyphens, and end in [0-9a-z].
 func ValidateServiceName(name string) error {
-	if !validNameRegex.MatchString(name) {
-		return fmt.Errorf("service name must begin with a letter and consist only of dash-delimited lower-case ASCII alphanumeric words")
+	if len(name) < 2 {
+		return errors.New("service name must be at least two characters long")
+	}
+	if err := checkFirstCharacter(name); err != nil {
+		return err
+	}
+	if err := checkForbiddenCharacters(name); err != nil {
+		return err
+	}
+	if err := checkHyphens(name); err != nil {
+		return err
 	}
 	if uuidRegex.MatchString(name) {
-		return fmt.Errorf("service name must not contain a UUID")
+		return errors.New("service name must not contain a UUID")
+	}
+	return nil
+}
+
+func checkHyphens(name string) error {
+	for i := 1; i < len(name); i++ {
+		if name[i-1] == '-' && name[i] == '-' {
+			return errors.New("service name must not contain consecutive hyphens")
+		}
+	}
+	if name[len(name)-1] == '-' {
+		return errors.New("service name must not end in a hyphen")
+	}
+	return nil
+}
+
+func checkFirstCharacter(name string) error {
+	if name[0] < 'a' || name[0] > 'z' {
+		return errors.New("service names must start with [a-z]")
+	}
+	return nil
+}
+
+func checkForbiddenCharacters(name string) error {
+	for _, c := range name {
+		switch {
+		case 'a' <= c && c <= 'z':
+			continue
+		case '0' <= c && c <= '9':
+			continue
+		case c == '-':
+			continue
+		default:
+			return errors.New("service name may only contain [0-9a-z] and non-consecutive hyphens")
+		}
 	}
 	return nil
 }

--- a/internal/servicename_test.go
+++ b/internal/servicename_test.go
@@ -65,7 +65,6 @@ func TestInvalidServiceNames(t *testing.T) {
 		"no--duplication",
 		"no---duplication",
 		"endswithadash-",
-		"endswithemoji😢",
 		"endswithasterisk*",
 		"internal*-asterisk",
 	}

--- a/internal/servicename_test.go
+++ b/internal/servicename_test.go
@@ -28,6 +28,7 @@ import (
 
 func TestValidServiceNames(t *testing.T) {
 	tests := []string{
+		"aa",
 		"superskipper",
 		"supper-skipper",
 		"supperskipper83",
@@ -37,12 +38,13 @@ func TestValidServiceNames(t *testing.T) {
 		"a77gb7e4-51cb-4808-a9ef-875568bde54aeviluuid", // not valid UUID
 	}
 	for _, n := range tests {
-		assert.NoError(t, ValidateServiceName(n), n)
+		assert.NoError(t, ValidateServiceName(n), "Expected %q to be a valid service name.", n)
 	}
 }
 
 func TestInvalidServiceNames(t *testing.T) {
 	tests := []string{
+		"a",
 		"a77ab7e4-51cb-4808-a9ef-875568bde54a",
 		"urn:uuid:a77ab7e4-51cb-4808-a9ef-875568bde54a",
 		"26695a10-a384-48e7-8867-6d48b7fae80a",
@@ -63,8 +65,11 @@ func TestInvalidServiceNames(t *testing.T) {
 		"no--duplication",
 		"no---duplication",
 		"endswithadash-",
+		"endswithemoji😢",
+		"endswithasterisk*",
+		"internal*-asterisk",
 	}
 	for _, n := range tests {
-		assert.Error(t, ValidateServiceName(n), n)
+		assert.Error(t, ValidateServiceName(n), "Expected %q to be an invalid service name", n)
 	}
 }


### PR DESCRIPTION
While it's possible to express YARPC's service name validation with a single
regexp, we've failed to do so despite extra-careful review from multiple smart
cookies. This PR switches from regular expressions to a more-explicit,
multiple-pass approach that is (IMO) much more obvious.

This fixes T916721.