### PR TITLE
Crossdock tests for grpc-go client to yarpc server, and yarpc client to grpc-go server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,11 +45,13 @@ services:
             - BEHAVIOR_JSON=client,server,transport
             - SKIP_JSON=client:java+transport:tchannel,server:java+transport:tchannel
             - BEHAVIOR_THRIFT=client,server,transport
+            - SKIP_THRIFT=client:java+transport:tchannel,server:java+transport:tchannel
             - BEHAVIOR_PROTOBUF=client,server,transport
             - SKIP_PROTOBUF=client:java,client:node,client:python,client:python-sync,server:java,server:node,server:python
             - BEHAVIOR_GRPC=client,server,encoding
             - SKIP_GRPC=client:java,client:node,client:python,client:python-sync,server:java,server:node,server:python
-            - SKIP_THRIFT=client:java+transport:tchannel,server:java+transport:tchannel
+            - BEHAVIOR_GOOGLE_GRPC_CLIENT=client,server,encoding
+            - SKIP_GOOGLE_GRPC_CLIENT=client:java,client:node,client:python,client:python-sync,server:java,server:node,server:python
             - BEHAVIOR_HEADERS=client,server,transport,encoding
             - SKIP_HEADERS=client:java+transport:tchannel,server:java+transport:tchannel,encoding:protobuf
             - BEHAVIOR_ERRORS_HTTPCLIENT=errors_httpclient,server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,8 +52,9 @@ services:
             - SKIP_GRPC=client:java,client:node,client:python,client:python-sync,server:java,server:node,server:python
             - BEHAVIOR_GOOGLE_GRPC_CLIENT=client,server
             - SKIP_GOOGLE_GRPC_CLIENT=client:java,client:node,client:python,client:python-sync,server:java,server:node,server:python
-            - BEHAVIOR_GOOGLE_GRPC_SERVER=client,server
-            - SKIP_GOOGLE_GRPC_SERVER=client:java,client:node,client:python,client:python-sync,server:java,server:node,server:python
+              # TODO: uncomment when transport errors are implemented and we no longer wrap protobuf responses
+              #- BEHAVIOR_GOOGLE_GRPC_SERVER=client,server
+              #- SKIP_GOOGLE_GRPC_SERVER=client:java,client:node,client:python,client:python-sync,server:java,server:node,server:python
             - BEHAVIOR_HEADERS=client,server,transport,encoding
             - SKIP_HEADERS=client:java+transport:tchannel,server:java+transport:tchannel,encoding:protobuf
             - BEHAVIOR_ERRORS_HTTPCLIENT=errors_httpclient,server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,8 +50,10 @@ services:
             - SKIP_PROTOBUF=client:java,client:node,client:python,client:python-sync,server:java,server:node,server:python
             - BEHAVIOR_GRPC=client,server,encoding
             - SKIP_GRPC=client:java,client:node,client:python,client:python-sync,server:java,server:node,server:python
-            - BEHAVIOR_GOOGLE_GRPC_CLIENT=client,server,encoding
+            - BEHAVIOR_GOOGLE_GRPC_CLIENT=client,server
             - SKIP_GOOGLE_GRPC_CLIENT=client:java,client:node,client:python,client:python-sync,server:java,server:node,server:python
+            - BEHAVIOR_GOOGLE_GRPC_SERVER=client,server
+            - SKIP_GOOGLE_GRPC_SERVER=client:java,client:node,client:python,client:python-sync,server:java,server:node,server:python
             - BEHAVIOR_HEADERS=client,server,transport,encoding
             - SKIP_HEADERS=client:java+transport:tchannel,server:java+transport:tchannel,encoding:protobuf
             - BEHAVIOR_ERRORS_HTTPCLIENT=errors_httpclient,server

--- a/internal/crossdock/client/googlegrpc/googlegrpc.go
+++ b/internal/crossdock/client/googlegrpc/googlegrpc.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package googlegrpc
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.uber.org/yarpc/internal/crossdock/client/params"
+	"go.uber.org/yarpc/internal/crossdock/client/random"
+	"go.uber.org/yarpc/internal/crossdock/crossdockpb"
+	"go.uber.org/yarpc/transport/x/grpc/grpcheader"
+
+	"github.com/crossdock/crossdock-go"
+	"google.golang.org/grpc"
+)
+
+var contextWrapper = grpcheader.NewContextWrapper().
+	WithCaller("client").
+	WithService("yarpc-test").
+	WithEncoding("proto")
+
+// Run tests a grpc-go call to the yarpc server.
+func Run(t crossdock.T) {
+	//client := crossdockpb.NewEchoClient(grpc.)
+	fatals := crossdock.Fatals(t)
+
+	server := t.Param(params.Server)
+	fatals.NotEmpty(server, "server is required")
+
+	clientConn, err := grpc.Dial(fmt.Sprintf("%s:8090", server), grpc.WithInsecure())
+	fatals.NoError(err, "grpc.Dial failed")
+
+	client := crossdockpb.NewEchoClient(clientConn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	token := random.String(5)
+
+	pong, err := client.Echo(contextWrapper.Wrap(ctx), &crossdockpb.Ping{Beep: token})
+
+	crossdock.Fatals(t).NoError(err, "call to Echo::echo failed: %v", err)
+	crossdock.Assert(t).Equal(token, pong.Boop, "server said: %v", pong.Boop)
+}

--- a/internal/crossdock/client/googlegrpcclient/googlegrpcclient.go
+++ b/internal/crossdock/client/googlegrpcclient/googlegrpcclient.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package googlegrpc
+package googlegrpcclient
 
 import (
 	"context"

--- a/internal/crossdock/client/googlegrpcclient/googlegrpcclient.go
+++ b/internal/crossdock/client/googlegrpcclient/googlegrpcclient.go
@@ -41,7 +41,6 @@ var wrap = grpcheader.NewContextWrapper().
 
 // Run tests a grpc-go call to the yarpc server.
 func Run(t crossdock.T) {
-	//client := crossdockpb.NewEchoClient(grpc.)
 	fatals := crossdock.Fatals(t)
 
 	server := t.Param(params.Server)

--- a/internal/crossdock/client/googlegrpcclient/googlegrpcclient.go
+++ b/internal/crossdock/client/googlegrpcclient/googlegrpcclient.go
@@ -46,7 +46,7 @@ func Run(t crossdock.T) {
 	server := t.Param(params.Server)
 	fatals.NotEmpty(server, "server is required")
 
-	clientConn, err := grpc.Dial(fmt.Sprintf("%s:8090", server), grpc.WithInsecure())
+	clientConn, err := grpc.Dial(fmt.Sprintf("%s:8089", server), grpc.WithInsecure())
 	fatals.NoError(err, "grpc.Dial failed")
 
 	client := crossdockpb.NewEchoClient(clientConn)

--- a/internal/crossdock/client/googlegrpcserver/googlegrpcserver.go
+++ b/internal/crossdock/client/googlegrpcserver/googlegrpcserver.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package googlegrpcclient
+package googlegrpcserver
 
 import (
 	"context"
@@ -34,10 +34,10 @@ import (
 	"google.golang.org/grpc"
 )
 
-var wrap = grpcheader.NewContextWrapper().
+var contextWrapper = grpcheader.NewContextWrapper().
 	WithCaller("client").
 	WithService("yarpc-test").
-	WithEncoding("proto").Wrap
+	WithEncoding("proto")
 
 // Run tests a grpc-go call to the yarpc server.
 func Run(t crossdock.T) {
@@ -57,7 +57,7 @@ func Run(t crossdock.T) {
 
 	token := random.String(5)
 
-	pong, err := client.Echo(wrap(ctx), &crossdockpb.Ping{Beep: token})
+	pong, err := client.Echo(contextWrapper.Wrap(ctx), &crossdockpb.Ping{Beep: token})
 
 	crossdock.Fatals(t).NoError(err, "call to Echo::echo failed: %v", err)
 	crossdock.Assert(t).Equal(token, pong.Boop, "server said: %v", pong.Boop)

--- a/internal/crossdock/client/googlegrpcserver/googlegrpcserver.go
+++ b/internal/crossdock/client/googlegrpcserver/googlegrpcserver.go
@@ -59,7 +59,7 @@ func Run(t crossdock.T) {
 
 	token := random.String(5)
 
-	pong, err := client.Echo(contextWrapper.Wrap(ctx), &crossdockpb.Ping{Beep: token})
+	pong, err := client.Echo(ctx, &crossdockpb.Ping{Beep: token})
 
 	crossdock.Fatals(t).NoError(err, "call to Echo::echo failed: %v", err)
 	crossdock.Assert(t).Equal(token, pong.Boop, "server said: %v", pong.Boop)

--- a/internal/crossdock/client/start.go
+++ b/internal/crossdock/client/start.go
@@ -27,7 +27,7 @@ import (
 	"go.uber.org/yarpc/internal/crossdock/client/errorshttpclient"
 	"go.uber.org/yarpc/internal/crossdock/client/errorstchclient"
 	"go.uber.org/yarpc/internal/crossdock/client/gauntlet"
-	"go.uber.org/yarpc/internal/crossdock/client/googlegrpc"
+	"go.uber.org/yarpc/internal/crossdock/client/googlegrpcclient"
 	"go.uber.org/yarpc/internal/crossdock/client/grpc"
 	"go.uber.org/yarpc/internal/crossdock/client/headers"
 	"go.uber.org/yarpc/internal/crossdock/client/httpserver"
@@ -45,7 +45,7 @@ var behaviors = crossdock.Behaviors{
 	"json":                  echo.JSON,
 	"thrift":                echo.Thrift,
 	"protobuf":              echo.Protobuf,
-	"google_grpc_client":    googlegrpc.Run,
+	"google_grpc_client":    googlegrpcclient.Run,
 	"grpc":                  grpc.Run,
 	"headers":               headers.Run,
 	"errors_httpclient":     errorshttpclient.Run,

--- a/internal/crossdock/client/start.go
+++ b/internal/crossdock/client/start.go
@@ -28,6 +28,7 @@ import (
 	"go.uber.org/yarpc/internal/crossdock/client/errorstchclient"
 	"go.uber.org/yarpc/internal/crossdock/client/gauntlet"
 	"go.uber.org/yarpc/internal/crossdock/client/googlegrpcclient"
+	"go.uber.org/yarpc/internal/crossdock/client/googlegrpcserver"
 	"go.uber.org/yarpc/internal/crossdock/client/grpc"
 	"go.uber.org/yarpc/internal/crossdock/client/headers"
 	"go.uber.org/yarpc/internal/crossdock/client/httpserver"
@@ -46,6 +47,7 @@ var behaviors = crossdock.Behaviors{
 	"thrift":                echo.Thrift,
 	"protobuf":              echo.Protobuf,
 	"google_grpc_client":    googlegrpcclient.Run,
+	"google_grpc_server":    googlegrpcserver.Run,
 	"grpc":                  grpc.Run,
 	"headers":               headers.Run,
 	"errors_httpclient":     errorshttpclient.Run,

--- a/internal/crossdock/client/start.go
+++ b/internal/crossdock/client/start.go
@@ -27,6 +27,7 @@ import (
 	"go.uber.org/yarpc/internal/crossdock/client/errorshttpclient"
 	"go.uber.org/yarpc/internal/crossdock/client/errorstchclient"
 	"go.uber.org/yarpc/internal/crossdock/client/gauntlet"
+	"go.uber.org/yarpc/internal/crossdock/client/googlegrpc"
 	"go.uber.org/yarpc/internal/crossdock/client/grpc"
 	"go.uber.org/yarpc/internal/crossdock/client/headers"
 	"go.uber.org/yarpc/internal/crossdock/client/httpserver"
@@ -44,6 +45,7 @@ var behaviors = crossdock.Behaviors{
 	"json":                  echo.JSON,
 	"thrift":                echo.Thrift,
 	"protobuf":              echo.Protobuf,
+	"google_grpc_client":    googlegrpc.Run,
 	"grpc":                  grpc.Run,
 	"headers":               headers.Run,
 	"errors_httpclient":     errorshttpclient.Run,

--- a/internal/crossdock/server/googlegrpc/echo.go
+++ b/internal/crossdock/server/googlegrpc/echo.go
@@ -18,36 +18,23 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package server
+package googlegrpc
 
 import (
-	"go.uber.org/yarpc/internal/crossdock/server/apachethrift"
-	"go.uber.org/yarpc/internal/crossdock/server/googlegrpc"
-	"go.uber.org/yarpc/internal/crossdock/server/http"
-	"go.uber.org/yarpc/internal/crossdock/server/oneway"
-	"go.uber.org/yarpc/internal/crossdock/server/tch"
-	"go.uber.org/yarpc/internal/crossdock/server/yarpc"
+	"go.uber.org/yarpc/internal/crossdock/crossdockpb"
+
+	"golang.org/x/net/context"
 )
 
-// Start starts all required Crossdock test servers
-func Start() {
-	tch.Start()
-	yarpc.Start()
-	http.Start()
-	apachethrift.Start()
-	oneway.Start()
-	googlegrpc.Start()
+type echoServer struct{}
+
+func newEchoServer() *echoServer {
+	return &echoServer{}
 }
 
-// Stop stops all required Crossdock test servers
-func Stop() {
-	tch.Stop()
-	yarpc.Stop()
-	http.Stop()
-	apachethrift.Stop()
-	oneway.Stop()
-	googlegrpc.Stop()
+func (*echoServer) Echo(_ context.Context, request *crossdockpb.Ping) (*crossdockpb.Pong, error) {
+	if request == nil {
+		return nil, nil
+	}
+	return &crossdockpb.Pong{Boop: request.Beep}, nil
 }
-
-// TODO(abg): We should probably use defers to ensure things that started up
-// successfully are stopped before we exit.


### PR DESCRIPTION
Note that the yarpc client to grpc-go server does not work yet, but the code is still being added here - there are issues with how we have optional unwrapped protobuf responses, which will go away when we have transport errors implemented. The actual client-side test code is almost identical to other crossdock tests.