### PR TITLE
Add WithEncoding CallOption to support multiple outbound encodings (chained on top of #1049)

### DIFF
--- a/api/encoding/call_option.go
+++ b/api/encoding/call_option.go
@@ -20,6 +20,8 @@
 
 package encoding
 
+import "go.uber.org/yarpc/api/transport"
+
 // CallOption defines options that may be passed in at call sites to other
 // services.
 //
@@ -54,4 +56,12 @@ func WithRoutingKey(rk string) CallOption {
 // WithRoutingDelegate sets the routing delegate for the request.
 func WithRoutingDelegate(rd string) CallOption {
 	return CallOption{func(o *OutboundCall) { o.routingDelegate = &rd }}
+}
+
+// WithEncoding sets the encoding for the request.
+//
+// Only certain clients will handle this option. If a given client
+// does not handle this option, it will be ignored.
+func WithEncoding(e transport.Encoding) CallOption {
+	return CallOption{func(o *OutboundCall) { o.encoding = &e }}
 }

--- a/api/encoding/outbound_call.go
+++ b/api/encoding/outbound_call.go
@@ -37,6 +37,7 @@ type OutboundCall struct {
 	shardKey        *string
 	routingKey      *string
 	routingDelegate *string
+	encoding        *transport.Encoding
 
 	// If non-nil, response headers should be written here.
 	responseHeaders *map[string]string
@@ -68,6 +69,9 @@ func (c *OutboundCall) WriteToRequest(ctx context.Context, req *transport.Reques
 	}
 	if c.routingDelegate != nil {
 		req.RoutingDelegate = *c.routingDelegate
+	}
+	if c.encoding != nil {
+		req.Encoding = *c.encoding
 	}
 
 	// NB(abg): context and error are unused for now but we want to leave room

--- a/api/encoding/outbound_call_test.go
+++ b/api/encoding/outbound_call_test.go
@@ -120,6 +120,17 @@ func TestOutboundCallWriteToRequest(t *testing.T) {
 				RoutingDelegate: "zzz",
 			},
 		},
+		{
+			desc: "encoding",
+			giveOptions: []CallOption{
+				WithHeader("foo", "bar"),
+				WithEncoding(transport.Encoding("derp")),
+			},
+			wantRequest: transport.Request{
+				Headers:  transport.NewHeaders().With("foo", "bar"),
+				Encoding: transport.Encoding("derp"),
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/call.go
+++ b/call.go
@@ -81,6 +81,14 @@ func WithRoutingDelegate(rd string) CallOption {
 	return CallOption(encoding.WithRoutingDelegate(rd))
 }
 
+// WithEncoding sets the encoding for the request.
+//
+// Only certain clients will handle this option. If a given client
+// does not handle this option, it will be ignored.
+func WithEncoding(e transport.Encoding) CallOption {
+	return CallOption(encoding.WithEncoding(e))
+}
+
 // Call provides information about the current request inside handlers. An
 // instance of Call for the current request can be obtained by calling
 // CallFromContext on the request context.


### PR DESCRIPTION
This adds an option `WithEncoding`, allowing a caller to specify an encoding on a given RPC call. This will be used for protobuf for callers to be able to either use proto or json encodings.