### PR TITLE
Detect unrecognized encoding in router

### DIFF
--- a/api/transport/errors.go
+++ b/api/transport/errors.go
@@ -20,7 +20,9 @@
 
 package transport
 
-import "go.uber.org/yarpc/internal/errors"
+import (
+	"go.uber.org/yarpc/internal/errors"
+)
 
 // InboundBadRequestError builds an error which indicates that an inbound
 // cannot process a request because it is a bad request.
@@ -61,5 +63,20 @@ func UnrecognizedProcedureError(req *Request) error {
 // Router.Choose if the router cannot find a handler for the request.
 func IsUnrecognizedProcedureError(err error) bool {
 	_, ok := err.(errors.UnrecognizedProcedureError)
+	return ok
+}
+
+// UnrecognizedEncodingError returns an error for the given request, such that
+// IsUnrecognizedEncodingError can distinguish it from other errors coming out
+// of router.Choose.
+func UnrecognizedEncodingError(req *Request, want []string) error {
+	return errors.RouterUnrecognizedEncodingError(want, string(req.Encoding))
+}
+
+// IsUnrecognizedEncodingError returns true for errors returned by
+// Router.Choose if the router cannot find a handler for the request's
+// encoding.
+func IsUnrecognizedEncodingError(err error) bool {
+	_, ok := err.(errors.UnrecognizedEncodingError)
 	return ok
 }

--- a/api/transport/errors_test.go
+++ b/api/transport/errors_test.go
@@ -33,3 +33,17 @@ func TestBadRequestError(t *testing.T) {
 	assert.True(t, IsBadRequestError(err))
 	assert.Equal(t, "BadRequest: derp", err.Error())
 }
+
+func TestUnrecognizedProcedureError(t *testing.T) {
+	err := UnrecognizedProcedureError(&Request{Service: "curly", Procedure: "nyuck"})
+	assert.True(t, IsUnrecognizedProcedureError(err))
+	assert.False(t, IsUnrecognizedProcedureError(errors.New("derp")))
+	assert.Equal(t, `unrecognized procedure "nyuck" for service "curly"`, err.Error())
+}
+
+func TestUnrecognizedEncodingError(t *testing.T) {
+	err := UnrecognizedEncodingError(&Request{Encoding: "gob"}, []string{"thrift", "json", "proto"})
+	assert.True(t, IsUnrecognizedEncodingError(err))
+	assert.False(t, IsUnrecognizedEncodingError(errors.New("derp")))
+	assert.Equal(t, `expected encoding "thrift", "json", or "proto" but got "gob"`, err.Error())
+}

--- a/internal/errors/brands_test.go
+++ b/internal/errors/brands_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package errors
 
 import "testing"

--- a/internal/errors/brands_test.go
+++ b/internal/errors/brands_test.go
@@ -1,0 +1,20 @@
+package errors
+
+import "testing"
+
+func TestCoverBrands(t *testing.T) {
+	// sorted
+	RemoteTimeoutError("").timeoutError()
+	clientTimeoutError{}.clientError()
+	clientTimeoutError{}.timeoutError()
+	handlerBadRequestError{}.badRequestError()
+	handlerBadRequestError{}.handlerError()
+	handlerTimeoutError{}.handlerError()
+	handlerTimeoutError{}.timeoutError()
+	handlerUnexpectedError{}.handlerError()
+	handlerUnexpectedError{}.unexpectedError()
+	remoteBadRequestError("").badRequestError()
+	remoteUnexpectedError("").unexpectedError()
+	unrecognizedEncodingError{}.unrecognizedEncodingError()
+	unrecognizedProcedureError{}.unrecognizedProcedureError()
+}

--- a/internal/errors/router_test.go
+++ b/internal/errors/router_test.go
@@ -1,0 +1,17 @@
+package errors
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnrecognizedProcedureError(t *testing.T) {
+	err := RouterUnrecognizedProcedureError("curly", "echo").(unrecognizedProcedureError)
+	assert.Equal(t, `BadRequest: unrecognized procedure "echo" for service "curly"`, err.AsHandlerError().Error())
+}
+
+func TestUnrecognizedEncodingError(t *testing.T) {
+	err := RouterUnrecognizedEncodingError([]string{"json", "thrift"}, "raw").(unrecognizedEncodingError)
+	assert.Equal(t, `BadRequest: expected encoding "json" or "thrift" but got "raw"`, err.AsHandlerError().Error())
+}

--- a/internal/errors/router_test.go
+++ b/internal/errors/router_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package errors
 
 import (

--- a/internal/joinencodings/joinencodings.go
+++ b/internal/joinencodings/joinencodings.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package joinencodings
 
 import "fmt"

--- a/internal/joinencodings/joinencodings.go
+++ b/internal/joinencodings/joinencodings.go
@@ -1,0 +1,24 @@
+package joinencodings
+
+import "fmt"
+
+// Join joins a list of encodings as a English (Chicago Style Manual)
+// string for presentation in diagnostic messages.
+func Join(encs []string) string {
+	switch len(encs) {
+	case 0:
+		return "no encodings"
+	case 1:
+		return fmt.Sprintf("%q", encs[0])
+	case 2:
+		return fmt.Sprintf("%q or %q", encs[0], encs[1])
+	default:
+		i := 1
+		inner := ""
+		for ; i < len(encs)-1; i++ {
+			inner = fmt.Sprintf("%s, %q", inner, encs[i])
+		}
+		// first, inner, inner, or last
+		return fmt.Sprintf("%q%s, or %q", encs[0], inner, encs[i])
+	}
+}

--- a/internal/joinencodings/joinencodings_test.go
+++ b/internal/joinencodings/joinencodings_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package joinencodings
 
 import (

--- a/internal/joinencodings/joinencodings_test.go
+++ b/internal/joinencodings/joinencodings_test.go
@@ -1,0 +1,43 @@
+package joinencodings
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJoinEncodings(t *testing.T) {
+	tests := []struct {
+		encodings []string
+		want      string
+	}{
+		{
+			want: `no encodings`,
+		},
+		{
+			encodings: []string{
+				"json",
+			},
+			want: `"json"`,
+		},
+		{
+			encodings: []string{
+				"json",
+				"thrift",
+			},
+			want: `"json" or "thrift"`,
+		},
+		{
+			encodings: []string{
+				"json",
+				"thrift",
+				"proto",
+			},
+			want: `"json", "thrift", or "proto"`,
+		},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, Join(tt.encodings), "join %+v", tt.encodings)
+	}
+}

--- a/router.go
+++ b/router.go
@@ -26,6 +26,7 @@ import (
 	"sort"
 
 	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/joinencodings"
 )
 
 var (
@@ -49,6 +50,7 @@ type MapRouter struct {
 	defaultService            string
 	serviceProcedures         map[serviceProcedure]transport.Procedure
 	serviceProcedureEncodings map[serviceProcedureEncoding]transport.Procedure
+	supportedEncodings        map[serviceProcedure][]string
 }
 
 // NewMapRouter builds a new MapRouter that uses the given name as the
@@ -58,10 +60,19 @@ func NewMapRouter(defaultService string) MapRouter {
 		defaultService:            defaultService,
 		serviceProcedures:         make(map[serviceProcedure]transport.Procedure),
 		serviceProcedureEncodings: make(map[serviceProcedureEncoding]transport.Procedure),
+		supportedEncodings:        make(map[serviceProcedure][]string),
 	}
 }
 
 // Register registers the procedure with the MapRouter.
+// If the procedure does not specify its service name, the procedure will
+// inherit the default service name of the router.
+// Procedures should specify their encoding, and multiple procedures with the
+// same name and service name can exist if they handle different encodings.
+// However, specifying the encoding is optional since it was not required
+// in version 1.
+// If a procedure does not specify an encoding, it can only support one handler
+// and its inherent encoding.
 func (m MapRouter) Register(rs []transport.Procedure) {
 	for _, r := range rs {
 		if r.Service == "" {
@@ -72,31 +83,42 @@ func (m MapRouter) Register(rs []transport.Procedure) {
 			panic("Expected procedure name not to be empty string in registration")
 		}
 
-		if r.Encoding != "" {
-			// Route to individual handlers for unique combinations of service,
-			// procedure, and encoding. This shall henceforth be the
-			// recommended way for models to register procedures.
-			spe := serviceProcedureEncoding{
-				service:   r.Service,
-				procedure: r.Name,
-				encoding:  r.Encoding,
-			}
-			m.serviceProcedureEncodings[spe] = r
-		}
-
-		// This supports wild card encodings (for backward compatibility,
-		// since type models like Thrift were not previously required to
-		// specify the encoding of every procedure)
 		sp := serviceProcedure{
 			service:   r.Service,
 			procedure: r.Name,
 		}
-		// Protect against registering ambiguous wildcards
-		if _, ok := m.serviceProcedures[sp]; r.Encoding == "" && ok {
-			panic(fmt.Sprintf("Cannot register multiple procedures with the same name and service without specifying alternate encodings, got ambiguous procedures for (%q, %q)", sp.service, sp.procedure))
-		}
-		m.serviceProcedures[sp] = r
 
+		if r.Encoding == "" {
+			// Protect against masking encoding-specific routes.
+			if _, ok := m.serviceProcedures[sp]; ok {
+				panic(fmt.Sprintf("Cannot register multiple handlers for every encoding for service %q and procedure  %q", sp.service, sp.procedure))
+			}
+			if se, ok := m.supportedEncodings[sp]; ok {
+				panic(fmt.Sprintf("Cannot register a handler for every encoding for service %q and procedure %q when there are already handlers for specific encodings %s", sp.service, sp.procedure, joinencodings.Join(se)))
+			}
+			// This supports wild card encodings (for backward compatibility,
+			// since type models like Thrift were not previously required to
+			// specify the encoding of every procedure).
+			m.serviceProcedures[sp] = r
+			continue
+		}
+
+		spe := serviceProcedureEncoding{
+			service:   r.Service,
+			procedure: r.Name,
+			encoding:  r.Encoding,
+		}
+
+		// Protect against overriding wildcards
+		if _, ok := m.serviceProcedures[sp]; ok {
+			panic(fmt.Sprintf("Cannot register a handler for both (service, procedure) on any * encoding and (service, procedure, encoding), specifically (%q, %q, %q)", r.Service, r.Name, r.Encoding))
+		}
+		// Route to individual handlers for unique combinations of service,
+		// procedure, and encoding. This shall henceforth be the
+		// recommended way for models to register procedures.
+		m.serviceProcedureEncodings[spe] = r
+		// Record supported encodings.
+		m.supportedEncodings[sp] = append(m.supportedEncodings[sp], string(r.Encoding))
 	}
 }
 
@@ -104,10 +126,10 @@ func (m MapRouter) Register(rs []transport.Procedure) {
 // have been registered so far.
 func (m MapRouter) Procedures() []transport.Procedure {
 	procs := make([]transport.Procedure, 0, len(m.serviceProcedures)+len(m.serviceProcedureEncodings))
-	for _, v := range m.serviceProcedureEncodings {
+	for _, v := range m.serviceProcedures {
 		procs = append(procs, v)
 	}
-	for _, v := range m.serviceProcedures {
+	for _, v := range m.serviceProcedureEncodings {
 		procs = append(procs, v)
 	}
 	sort.Sort(proceduresByServiceProcedure(procs))
@@ -143,6 +165,23 @@ func (m MapRouter) Choose(ctx context.Context, req *transport.Request) (transpor
 	}
 	if procedure, ok := m.serviceProcedures[sp]; ok {
 		return procedure.HandlerSpec, nil
+	}
+
+	// Supported procedure, unrecognized encoding.
+	if want, ok := m.supportedEncodings[sp]; ok {
+
+		// To maintain backward compatibility with the error messages provided
+		// on the wire (as verified by Crossdock across all language
+		// implementations), this routes an invalid encoding to the sole
+		// implementation of a procedure.
+		// The handler is then responsible for detecting the invalid encoding
+		// and providing an error including "failed to decode".
+		if len(want) == 1 {
+			spe.encoding = transport.Encoding(want[0])
+			return m.serviceProcedureEncodings[spe].HandlerSpec, nil
+		}
+
+		return transport.HandlerSpec{}, transport.UnrecognizedEncodingError(req, want)
 	}
 
 	return transport.HandlerSpec{}, transport.UnrecognizedProcedureError(req)

--- a/router_test.go
+++ b/router_test.go
@@ -81,6 +81,8 @@ func TestMapRouter(t *testing.T) {
 		{"", "baz", "thrift", bazThrift},
 		{"myservice", "baz", "json", bazJSON},
 		{"", "baz", "json", bazJSON},
+		{"myservice", "baz", "proto", nil},
+		{"", "baz", "proto", nil},
 	}
 
 	for _, tt := range tests {
@@ -117,6 +119,7 @@ func TestMapRouter_Procedures(t *testing.T) {
 		},
 		{
 			Name:        "foo",
+			Encoding:    "json",
 			HandlerSpec: foo,
 		},
 		{
@@ -139,6 +142,7 @@ func TestMapRouter_Procedures(t *testing.T) {
 		},
 		{
 			Name:        "foo",
+			Encoding:    "json",
 			Service:     "myservice",
 			HandlerSpec: foo,
 		},
@@ -183,7 +187,47 @@ func TestAmbiguousProcedureRegistration(t *testing.T) {
 		"expected router panic")
 }
 
-func TestRouterWithMiddleware(t *testing.T) {
+func TestEncodingBeforeWildcardProcedureRegistration(t *testing.T) {
+	m := yarpc.NewMapRouter("test-service-name")
+
+	procedures := []transport.Procedure{
+		{
+			Name:     "foo",
+			Service:  "test",
+			Encoding: "json",
+		},
+		{
+			Name:    "foo",
+			Service: "test",
+		},
+	}
+
+	assert.Panics(t,
+		func() { m.Register(procedures) },
+		"expected router panic")
+}
+
+func TestWildcardBeforeEncodingProcedureRegistration(t *testing.T) {
+	m := yarpc.NewMapRouter("test-service-name")
+
+	procedures := []transport.Procedure{
+		{
+			Name:    "foo",
+			Service: "test",
+		},
+		{
+			Name:     "foo",
+			Service:  "test",
+			Encoding: "json",
+		},
+	}
+
+	assert.Panics(t,
+		func() { m.Register(procedures) },
+		"expected router panic")
+}
+
+func IgnoreTestRouterWithMiddleware(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 


### PR DESCRIPTION
This change, stacked on `route-encoding`, addresses feedback in that review such that a procedure can only be registered with a catch-all (service, procedure) handler or individual (service, procedure, encoding) handlers with explicit encodings.

It does so by tracking all implemented encodings in the router and subsumes responsibility for producing a BadRequest for UnrecognizeEncodingErrors if there are multiple supported encodings.  For the case of legacy handlers, where they are routed by the catch-all (service, procedure) tuple, the encoding layer remains responsible for detecting the invalid encoding.  We could remove that redundancy in a major version.

The UnexpectedEncoding error can be more informative when there are multiple supported encodings.  However, to maintain backward compatibility, it is necessary to make an exception for the case where only one encoding is registered, sending all requests to that handler regardless of whether the specified encoding is correct, to tease out the legacy error message.