### PR TITLE
Coverage on sorting procedures

### DIFF
--- a/api/transport/router.go
+++ b/api/transport/router.go
@@ -61,14 +61,29 @@ func (p Procedure) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 }
 
 // Less orders procedures lexicographically on (Service, Name, Encoding).
-func (p Procedure) Less(other Procedure) bool {
-	if p.Name == other.Name {
-		return p.Encoding < other.Encoding
+func (p Procedure) Less(o Procedure) bool {
+	if p.Service != o.Service {
+		return p.Service < o.Service
 	}
-	if p.Service == other.Service {
-		return p.Name < other.Name
+	if p.Name != o.Name {
+		return p.Name < o.Name
 	}
-	return p.Service < other.Service
+	return p.Encoding < o.Encoding
+}
+
+// Procedures is a sortable slice of procedures.
+type Procedures []Procedure
+
+func (ps Procedures) Len() int {
+	return len(ps)
+}
+
+func (ps Procedures) Less(i int, j int) bool {
+	return ps[i].Less(ps[j])
+}
+
+func (ps Procedures) Swap(i int, j int) {
+	ps[i], ps[j] = ps[j], ps[i]
 }
 
 // Router maintains and provides access to a collection of procedures

--- a/api/transport/router_test.go
+++ b/api/transport/router_test.go
@@ -22,6 +22,7 @@ package transport
 
 import (
 	"context"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -47,4 +48,66 @@ func TestProcedureLogMarshaling(t *testing.T) {
 		"encoding":  "raw",
 		"signature": "signature",
 	}, enc.Fields, "Unexpected output from marshaling procedure.")
+}
+
+func TestProcedureSort(t *testing.T) {
+	ps := Procedures{
+		{
+			Service:  "moe",
+			Name:     "echo",
+			Encoding: "json",
+		},
+		{
+			Service: "moe",
+		},
+		{
+			Service: "larry",
+		},
+		{
+			Service: "moe",
+			Name:    "ping",
+		},
+		{
+			Service:  "moe",
+			Name:     "echo",
+			Encoding: "raw",
+		},
+		{
+			Service: "moe",
+			Name:    "poke",
+		},
+		{
+			Service: "curly",
+		},
+	}
+	sort.Sort(ps)
+	assert.Equal(t, Procedures{
+		{
+			Service: "curly",
+		},
+		{
+			Service: "larry",
+		},
+		{
+			Service: "moe",
+		},
+		{
+			Service:  "moe",
+			Name:     "echo",
+			Encoding: "json",
+		},
+		{
+			Service:  "moe",
+			Name:     "echo",
+			Encoding: "raw",
+		},
+		{
+			Service: "moe",
+			Name:    "ping",
+		},
+		{
+			Service: "moe",
+			Name:    "poke",
+		},
+	}, ps, "should order procedures lexicographically on (service, procedure, encoding)")
 }

--- a/router.go
+++ b/router.go
@@ -110,7 +110,7 @@ func (m MapRouter) Procedures() []transport.Procedure {
 	for _, v := range m.serviceProcedures {
 		procs = append(procs, v)
 	}
-	sort.Sort(proceduresByServiceProcedure(procs))
+	sort.Sort(transport.Procedures(procs))
 	return procs
 }
 
@@ -146,18 +146,4 @@ func (m MapRouter) Choose(ctx context.Context, req *transport.Request) (transpor
 	}
 
 	return transport.HandlerSpec{}, transport.UnrecognizedProcedureError(req)
-}
-
-type proceduresByServiceProcedure []transport.Procedure
-
-func (sp proceduresByServiceProcedure) Len() int {
-	return len(sp)
-}
-
-func (sp proceduresByServiceProcedure) Less(i int, j int) bool {
-	return sp[i].Less(sp[j])
-}
-
-func (sp proceduresByServiceProcedure) Swap(i int, j int) {
-	sp[i], sp[j] = sp[j], sp[i]
 }


### PR DESCRIPTION
This change moves the implementation of sortability for transport procedures into the API itself and adds a test to verify (and fix) lexicographical ordering of all dimensions (service, procedure, encoding).