### PR TITLE
cleanup: Will not revisit TChannel service name

### DIFF
--- a/transport/tchannel/transport.go
+++ b/transport/tchannel/transport.go
@@ -69,10 +69,6 @@ func NewTransport(opts ...TransportOption) (*Transport, error) {
 	if config.ch != nil {
 		return nil, fmt.Errorf("NewTransport does not accept WithChannel, use NewChannelTransport")
 	}
-	// TODO consider surfacing again, instead of err on start
-	// if config.name == "" {
-	// 	return nil, errChannelOrServiceNameIsRequired
-	// }
 
 	return config.newTransport(), nil
 }


### PR DESCRIPTION
Having evaluated this note to self, we should try to relax the need for specifying the service name on the TChannel transport. TChannel needed this value to construct a sub channel, but we are using the root peer list and a root handler directly now. Consequently, we can eventually relax the error that TChannel's constructor emits if the service name is missing, and will not need to reintroduce the same error here.