### PR TITLE
Expose Lifecycle start and stop channels

### DIFF
--- a/internal/sync/lifecycle.go
+++ b/internal/sync/lifecycle.go
@@ -65,6 +65,8 @@ type LifecycleOnce interface {
 	LifecycleState() LifecycleState
 	IsRunning() bool
 	WhenRunning(context.Context) error
+	Stopped() <-chan struct{}
+	Started() <-chan struct{}
 }
 
 type lifecycleOnce struct {
@@ -180,6 +182,16 @@ func (l *lifecycleOnce) Stop(f func() error) error {
 
 	<-l.stopCh
 	return l.loadError()
+}
+
+// Started returns a channel that will close when the lifecycle starts.
+func (l *lifecycleOnce) Started() <-chan struct{} {
+	return l.startCh
+}
+
+// Stopped returns a channel that will close when the lifecycle stops.
+func (l *lifecycleOnce) Stopped() <-chan struct{} {
+	return l.stopCh
 }
 
 func (l *lifecycleOnce) setError(err error) {

--- a/internal/sync/lifecycle_test.go
+++ b/internal/sync/lifecycle_test.go
@@ -53,10 +53,77 @@ func TestLifecycleOnce(t *testing.T) {
 			expectedFinalState: Running,
 		},
 		{
+			msg: "Start and Started",
+			actions: []LifecycleAction{
+				ConcurrentAction{
+					Actions: []LifecycleAction{
+						StartAction{ExpectedState: Running},
+						Actions{
+							WaitForStartAction,
+							GetStateAction{ExpectedState: Running},
+						},
+					},
+				},
+			},
+			expectedFinalState: Running,
+		},
+		{
 			msg: "Stop",
 			actions: []LifecycleAction{
 				StartAction{ExpectedState: Running},
 				StopAction{ExpectedState: Stopped},
+			},
+			expectedFinalState: Stopped,
+		},
+		{
+			msg: "Stop and Stopped",
+			actions: []LifecycleAction{
+				ConcurrentAction{
+					Actions: []LifecycleAction{
+						StopAction{ExpectedState: Stopped},
+						Actions{
+							WaitForStopAction,
+							GetStateAction{ExpectedState: Stopped},
+						},
+					},
+				},
+			},
+			expectedFinalState: Stopped,
+		},
+		{
+			msg: "Error and Stopped",
+			actions: []LifecycleAction{
+				ConcurrentAction{
+					Actions: []LifecycleAction{
+						StartAction{
+							Err:           fmt.Errorf("abort"),
+							ExpectedErr:   fmt.Errorf("abort"),
+							ExpectedState: Errored,
+						},
+						Actions{
+							WaitForStopAction,
+							GetStateAction{ExpectedState: Errored},
+						},
+					},
+				},
+			},
+			expectedFinalState: Errored,
+		},
+		{
+			msg: "Start, Stop, and Stopped",
+			actions: []LifecycleAction{
+				ConcurrentAction{
+					Actions: []LifecycleAction{
+						Actions{
+							StartAction{ExpectedState: Running},
+							StopAction{ExpectedState: Stopped},
+						},
+						Actions{
+							WaitForStopAction,
+							GetStateAction{ExpectedState: Stopped},
+						},
+					},
+				},
 			},
 			expectedFinalState: Stopped,
 		},


### PR DESCRIPTION
This change just exposes these channels. The upcomming connection management changes need these channels to synchronize connection management workers, so they start when the transport starts, and abort back-off and waiting for peer state change if the transport shuts down while they are waiting.