### PR TITLE
Move observer outbound middleware to the end of the middleware chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ v1.9.0-dev (unreleased)
 -   Fix race conditions in hostport.Peer.
 -   transport/x/grpc: Remove NewInbound and NewSingleOutbound in favor of
     functions on Transport
+-   x/config: Fix bug where embedded struct fields could not be interpolated.
+
 
 v1.8.0 (2017-05-01)
 -------------------

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -101,8 +101,8 @@ func addObservingMiddleware(cfg Config, registry *pally.Registry, logger *zap.Lo
 	cfg.InboundMiddleware.Unary = inboundmiddleware.UnaryChain(observer, cfg.InboundMiddleware.Unary)
 	cfg.InboundMiddleware.Oneway = inboundmiddleware.OnewayChain(observer, cfg.InboundMiddleware.Oneway)
 
-	cfg.OutboundMiddleware.Unary = outboundmiddleware.UnaryChain(observer, cfg.OutboundMiddleware.Unary)
-	cfg.OutboundMiddleware.Oneway = outboundmiddleware.OnewayChain(observer, cfg.OutboundMiddleware.Oneway)
+	cfg.OutboundMiddleware.Unary = outboundmiddleware.UnaryChain(cfg.OutboundMiddleware.Unary, observer)
+	cfg.OutboundMiddleware.Oneway = outboundmiddleware.OnewayChain(cfg.OutboundMiddleware.Oneway, observer)
 
 	return cfg
 }


### PR DESCRIPTION
Summary: Currently if you define outbound middleware, it will get
applied after the observer middleware is applied.  Which means the
observer middleware does not actually represent how many requests were
sent.  This PR moves the observer middleware to be the last middleware
in the chain that will be applied immediately before the outbound call.