### PR TITLE
Socks5 Proxy Support

### DIFF
--- a/transport/http/transport.go
+++ b/transport/http/transport.go
@@ -35,7 +35,6 @@ import (
 	"go.uber.org/yarpc/peer/hostport"
 
 	"github.com/opentracing/opentracing-go"
-	"golang.org/x/net/proxy"
 )
 
 type transportConfig struct {

--- a/transport/http/transport_test.go
+++ b/transport/http/transport_test.go
@@ -297,3 +297,11 @@ func TestTransportClientWithMaxIdleConnections(t *testing.T) {
 
 	assert.NotNil(t, transport.client)
 }
+
+func TestTransportClientWithSocks5Proxy(t *testing.T) {
+	// Unfortunately the client.transport.Dialer is obfuscated in the client, so we can't really
+	// assert this worked.
+	transport := NewTransport(Socks5Proxy("localhost"))
+	err := transport.Start()
+	assert.Nil(t, err)
+}

--- a/transport/http/transport_test.go
+++ b/transport/http/transport_test.go
@@ -301,7 +301,7 @@ func TestTransportClientWithMaxIdleConnections(t *testing.T) {
 func TestTransportClientWithSocks5Proxy(t *testing.T) {
 	// Unfortunately the client.transport.Dialer is obfuscated in the client, so we can't really
 	// assert this worked.
-	transport := NewTransport(Socks5Proxy("localhost"))
+	transport := NewTransport(Socks5ProxyHostPort("localhost:1234"))
 	err := transport.Start()
 	assert.Nil(t, err)
 }


### PR DESCRIPTION
For using yarpc with Socks5 Proxy:

`http.NewTransport(http.Socks5Proxy("myproxy:myport"))`