### PR TITLE
Increase TestRoundTrip timeout time

### DIFF
--- a/encoding/thrift/thriftrw-plugin-yarpc/roundtrip_test.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/roundtrip_test.go
@@ -329,7 +329,7 @@ func testRoundTrip(t *testing.T, enveloped, multiplexed bool) {
 			method := client.MethodByName(tt.method)
 			assert.True(t, method.IsValid(), "Method %q not found", tt.method)
 
-			ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+			ctx, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
 			defer cancel()
 
 			args := append([]interface{}{ctx}, tt.methodArgs...)


### PR DESCRIPTION
This test is flaky and times out sometimes, this doubles the timeout from from 100ms to 200ms.