### PR TITLE
Copy edit transport options

### DIFF
--- a/transport/http/config_test.go
+++ b/transport/http/config_test.go
@@ -429,10 +429,10 @@ type wantHTTPClient struct {
 // useFakeBuildClient verifies the configuration we use to build an HTTP
 // client.
 func useFakeBuildClient(t *testing.T, want *wantHTTPClient) TransportOption {
-	return buildClient(func(cfg *transportConfig) *http.Client {
-		assert.Equal(t, want.KeepAlive, cfg.keepAlive, "http.Client: KeepAlive should match")
-		assert.Equal(t, want.MaxIdleConnsPerHost, cfg.maxIdleConnsPerHost,
+	return buildClient(func(options *transportOptions) *http.Client {
+		assert.Equal(t, want.KeepAlive, options.keepAlive, "http.Client: KeepAlive should match")
+		assert.Equal(t, want.MaxIdleConnsPerHost, options.maxIdleConnsPerHost,
 			"http.Client: MaxIdleConnsPerHost should match")
-		return buildHTTPClient(cfg)
+		return buildHTTPClient(options)
 	})
 }

--- a/transport/tchannel/channel_transport.go
+++ b/transport/tchannel/channel_transport.go
@@ -47,25 +47,25 @@ var errChannelOrServiceNameIsRequired = errors.New(
 // and peer managament.
 // Use NewTransport and its NewOutbound to support YARPC peer.Choosers.
 func NewChannelTransport(opts ...TransportOption) (*ChannelTransport, error) {
-	var config transportConfig
-	config.tracer = opentracing.GlobalTracer()
+	var options transportOptions
+	options.tracer = opentracing.GlobalTracer()
 	for _, opt := range opts {
-		opt(&config)
+		opt(&options)
 	}
 
 	// Attempt to construct a channel on behalf of the caller if none given.
 	// Defer the error until Start since NewChannelTransport does not have
 	// an error return.
 	var err error
-	ch := config.ch
+	ch := options.ch
 
 	if ch == nil {
-		if config.name == "" {
+		if options.name == "" {
 			err = errChannelOrServiceNameIsRequired
 		} else {
-			opts := tchannel.ChannelOptions{Tracer: config.tracer}
-			ch, err = tchannel.NewChannel(config.name, &opts)
-			config.ch = ch
+			opts := tchannel.ChannelOptions{Tracer: options.tracer}
+			ch, err = tchannel.NewChannel(options.name, &opts)
+			options.ch = ch
 		}
 	}
 
@@ -73,15 +73,15 @@ func NewChannelTransport(opts ...TransportOption) (*ChannelTransport, error) {
 		return nil, err
 	}
 
-	return config.newChannelTransport(), nil
+	return options.newChannelTransport(), nil
 }
 
-func (config transportConfig) newChannelTransport() *ChannelTransport {
+func (options transportOptions) newChannelTransport() *ChannelTransport {
 	return &ChannelTransport{
 		once:   sync.Once(),
-		ch:     config.ch,
-		addr:   config.addr,
-		tracer: config.tracer,
+		ch:     options.ch,
+		addr:   options.addr,
+		tracer: options.tracer,
 	}
 }
 

--- a/transport/tchannel/config.go
+++ b/transport/tchannel/config.go
@@ -93,28 +93,28 @@ func (ts *transportSpec) Spec() config.TransportSpec {
 }
 
 func (ts *transportSpec) buildTransport(tc *TransportConfig, k *config.Kit) (transport.Transport, error) {
-	var cfg transportConfig
+	var options transportOptions
 	// Default configuration.
-	cfg.tracer = opentracing.GlobalTracer()
+	options.tracer = opentracing.GlobalTracer()
 
-	for _, o := range ts.transportOptions {
-		o(&cfg)
+	for _, opt := range ts.transportOptions {
+		opt(&options)
 	}
 
-	if cfg.name != "" {
+	if options.name != "" {
 		return nil, fmt.Errorf("TChannel TransportSpec does not accept ServiceName")
 	}
 
-	if cfg.addr != "" {
+	if options.addr != "" {
 		return nil, fmt.Errorf("TChannel TransportSpec does not accept ListenAddr")
 	}
 
-	if cfg.ch != nil {
+	if options.ch != nil {
 		return nil, fmt.Errorf("TChannel TransportSpec does not accept WithChannel")
 	}
 
-	cfg.name = k.ServiceName()
-	return cfg.newTransport(), nil
+	options.name = k.ServiceName()
+	return options.newTransport(), nil
 }
 
 func (ts *transportSpec) buildInbound(c *InboundConfig, t transport.Transport, k *config.Kit) (transport.Inbound, error) {

--- a/transport/tchannel/options.go
+++ b/transport/tchannel/options.go
@@ -31,15 +31,9 @@ type Option interface {
 
 var _ Option = (TransportOption)(nil)
 
-// transportConfig is suitable for conveying options to TChannel transport
-// constructors.
-// At time of writing, there is only a ChannelTransport constructor, which
-// supports options like WithChannel that only apply to this constructor form.
-// The transportConfig should also be suitable, albeit with extraneous properties,
-// if used for NewTransport, which will return a Transport suitable for YARPC
-// peer lists.
-// TODO update above when NewTransport is real.
-type transportConfig struct {
+// transportOptions is suitable for conveying options to TChannel transport
+// constructors (NewTransport and NewChannelTransport).
+type transportOptions struct {
 	ch     Channel
 	tracer opentracing.Tracer
 	addr   string
@@ -47,7 +41,7 @@ type transportConfig struct {
 }
 
 // TransportOption customizes the behavior of a TChannel Transport.
-type TransportOption func(*transportConfig)
+type TransportOption func(*transportOptions)
 
 // TransportOption makes all TransportOptions recognizeable as Option so
 // TransportSpec will accept them.
@@ -56,7 +50,7 @@ func (TransportOption) tchannelOption() {}
 // Tracer specifies the request tracer used for RPCs passing through the
 // TChannel transport.
 func Tracer(tracer opentracing.Tracer) TransportOption {
-	return func(t *transportConfig) {
+	return func(t *transportOptions) {
 		t.tracer = tracer
 	}
 }
@@ -72,8 +66,8 @@ func Tracer(tracer opentracing.Tracer) TransportOption {
 // This option is disallowed for NewTransport and transports constructed with
 // the YARPC configuration system.
 func WithChannel(ch Channel) TransportOption {
-	return func(t *transportConfig) {
-		t.ch = ch
+	return func(options *transportOptions) {
+		options.ch = ch
 	}
 }
 
@@ -86,8 +80,8 @@ func WithChannel(ch Channel) TransportOption {
 // already listening, and it is disallowed for transports constructed with the
 // YARPC configuration system.
 func ListenAddr(addr string) TransportOption {
-	return func(t *transportConfig) {
-		t.addr = addr
+	return func(options *transportOptions) {
+		options.addr = addr
 	}
 }
 
@@ -103,7 +97,7 @@ func ListenAddr(addr string) TransportOption {
 // This option has no effect if WithChannel was used, and it is disallowed for
 // transports constructed with the YARPC configuration system.
 func ServiceName(name string) TransportOption {
-	return func(t *transportConfig) {
-		t.name = name
+	return func(options *transportOptions) {
+		options.name = name
 	}
 }

--- a/transport/tchannel/transport.go
+++ b/transport/tchannel/transport.go
@@ -60,25 +60,25 @@ type Transport struct {
 // Either the local service name (with the ServiceName option) or a user-owned
 // TChannel (with the WithChannel option) MUST be specified.
 func NewTransport(opts ...TransportOption) (*Transport, error) {
-	var config transportConfig
-	config.tracer = opentracing.GlobalTracer()
+	var options transportOptions
+	options.tracer = opentracing.GlobalTracer()
 	for _, opt := range opts {
-		opt(&config)
+		opt(&options)
 	}
 
-	if config.ch != nil {
+	if options.ch != nil {
 		return nil, fmt.Errorf("NewTransport does not accept WithChannel, use NewChannelTransport")
 	}
 
-	return config.newTransport(), nil
+	return options.newTransport(), nil
 }
 
-func (config transportConfig) newTransport() *Transport {
+func (o transportOptions) newTransport() *Transport {
 	return &Transport{
 		once:   intsync.Once(),
-		name:   config.name,
-		addr:   config.addr,
-		tracer: config.tracer,
+		name:   o.name,
+		addr:   o.addr,
+		tracer: o.tracer,
 		peers:  make(map[string]*hostport.Peer),
 	}
 }


### PR DESCRIPTION
With the introduction of configuration, some of our internal naming conventions
shared by TChannel and HTTP transports have accidentally become confusing.

This change cleanly separates "options" and "config" by changing the name
"transportConfig" to "transportOptions" since it is a struct that captures the
application of transport option functions and is distinct from the
`TransportConfig` that exists to capture configuration attributes from YAML
documents.

This also updates stale comments regarding transport options in TChannel.