### PR TITLE
Call yarpc.RegisterClientBuilder in protoc-gen-yarpc-go

### DIFF
--- a/encoding/x/protobuf/protoc-gen-yarpc-go/internal/testing/testing.pb.yarpc.go
+++ b/encoding/x/protobuf/protoc-gen-yarpc-go/internal/testing/testing.pb.yarpc.go
@@ -26,6 +26,7 @@ package testing
 
 import (
 	"context"
+	"reflect"
 
 	"github.com/gogo/protobuf/proto"
 	"go.uber.org/yarpc"
@@ -214,3 +215,16 @@ var (
 	emptySink_FireYarpcRequest  = &FireRequest{}
 	emptySink_FireYarpcResponse = &yarpcproto.Oneway{}
 )
+
+func init() {
+	yarpc.RegisterClientBuilder(
+		func(clientConfig transport.ClientConfig, structField reflect.StructField) KeyValueYarpcClient {
+			return NewKeyValueYarpcClient(clientConfig, protobuf.ClientBuilderOptions(clientConfig, structField)...)
+		},
+	)
+	yarpc.RegisterClientBuilder(
+		func(clientConfig transport.ClientConfig, structField reflect.StructField) SinkYarpcClient {
+			return NewSinkYarpcClient(clientConfig, protobuf.ClientBuilderOptions(clientConfig, structField)...)
+		},
+	)
+}

--- a/encoding/x/protobuf/protoc-gen-yarpc-go/internal/testing/testing.pb.yarpc.go.golden
+++ b/encoding/x/protobuf/protoc-gen-yarpc-go/internal/testing/testing.pb.yarpc.go.golden
@@ -6,6 +6,7 @@ package testing
 
 import (
 	"context"
+	"reflect"
 
 	"github.com/gogo/protobuf/proto"
 	"go.uber.org/yarpc"
@@ -194,3 +195,16 @@ var (
 	emptySink_FireYarpcRequest  = &FireRequest{}
 	emptySink_FireYarpcResponse = &yarpcproto.Oneway{}
 )
+
+func init() {
+	yarpc.RegisterClientBuilder(
+		func(clientConfig transport.ClientConfig, structField reflect.StructField) KeyValueYarpcClient {
+			return NewKeyValueYarpcClient(clientConfig, protobuf.ClientBuilderOptions(clientConfig, structField)...)
+		},
+	)
+	yarpc.RegisterClientBuilder(
+		func(clientConfig transport.ClientConfig, structField reflect.StructField) SinkYarpcClient {
+			return NewSinkYarpcClient(clientConfig, protobuf.ClientBuilderOptions(clientConfig, structField)...)
+		},
+	)
+}

--- a/encoding/x/protobuf/types.go
+++ b/encoding/x/protobuf/types.go
@@ -23,6 +23,8 @@ package protobuf
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"strings"
 
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
@@ -144,6 +146,19 @@ func NewOnewayHandler(
 	newRequest func() proto.Message,
 ) transport.OnewayHandler {
 	return newOnewayHandler(handleOneway, newRequest)
+}
+
+// ClientBuilderOptions returns ClientOptions that yarpc.InjectClients should use for a
+// specific client given information about the field into which the client is being injected.
+func ClientBuilderOptions(_ transport.ClientConfig, structField reflect.StructField) []ClientOption {
+	var opts []ClientOption
+	for _, opt := range uniqueLowercaseStrings(strings.Split(structField.Tag.Get("proto"), ",")) {
+		switch opt {
+		case "use_json":
+			opts = append(opts, UseJSON)
+		}
+	}
+	return opts
 }
 
 // CastError returns an error saying that generated code could not properly cast a proto.Message to it's expected type.

--- a/encoding/x/protobuf/types.go
+++ b/encoding/x/protobuf/types.go
@@ -154,7 +154,7 @@ func ClientBuilderOptions(_ transport.ClientConfig, structField reflect.StructFi
 	var opts []ClientOption
 	for _, opt := range uniqueLowercaseStrings(strings.Split(structField.Tag.Get("proto"), ",")) {
 		switch opt {
-		case "use_json":
+		case "json":
 			opts = append(opts, UseJSON)
 		}
 	}

--- a/encoding/x/protobuf/types_test.go
+++ b/encoding/x/protobuf/types_test.go
@@ -29,5 +29,5 @@ import (
 
 func TestClientBuilderOptions(t *testing.T) {
 	assert.Nil(t, ClientBuilderOptions(nil, reflect.StructField{Tag: `service:"keyvalue"`}))
-	assert.Equal(t, []ClientOption{UseJSON}, ClientBuilderOptions(nil, reflect.StructField{Tag: `service:"keyvalue" proto:"use_json"`}))
+	assert.Equal(t, []ClientOption{UseJSON}, ClientBuilderOptions(nil, reflect.StructField{Tag: `service:"keyvalue" proto:"json"`}))
 }

--- a/encoding/x/protobuf/types_test.go
+++ b/encoding/x/protobuf/types_test.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package protobuf
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClientBuilderOptions(t *testing.T) {
+	assert.Nil(t, ClientBuilderOptions(nil, reflect.StructField{Tag: `service:"keyvalue"`}))
+	assert.Equal(t, []ClientOption{UseJSON}, ClientBuilderOptions(nil, reflect.StructField{Tag: `service:"keyvalue" proto:"use_json"`}))
+}

--- a/encoding/x/protobuf/util.go
+++ b/encoding/x/protobuf/util.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package protobuf
+
+import "strings"
+
+func uniqueLowercaseStrings(s []string) []string {
+	m := make(map[string]bool, len(s))
+	for _, e := range s {
+		if e != "" {
+			m[strings.ToLower(e)] = true
+		}
+	}
+	c := make([]string, 0, len(m))
+	for key := range m {
+		c = append(c, key)
+	}
+	return c
+}

--- a/encoding/x/protobuf/util_test.go
+++ b/encoding/x/protobuf/util_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package protobuf
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUniqueLowercaseStrings(t *testing.T) {
+	tests := []struct {
+		give []string
+		want []string
+	}{
+		{
+			give: []string{"foo", "bar", "baz"},
+			want: []string{"foo", "bar", "baz"},
+		},
+		{
+			give: []string{"foo", "BAR", "bAz"},
+			want: []string{"foo", "bar", "baz"},
+		},
+		{
+			give: []string{"foo", "BAR", "bAz", "bar"},
+			want: []string{"foo", "bar", "baz"},
+		},
+	}
+	for _, tt := range tests {
+		got := uniqueLowercaseStrings(tt.give)
+		sort.Strings(tt.want)
+		sort.Strings(got)
+		assert.Equal(t, tt.want, got)
+	}
+}

--- a/internal/crossdock/crossdockpb/crossdock.pb.yarpc.go
+++ b/internal/crossdock/crossdockpb/crossdock.pb.yarpc.go
@@ -26,6 +26,7 @@ package crossdockpb
 
 import (
 	"context"
+	"reflect"
 
 	"github.com/gogo/protobuf/proto"
 	"go.uber.org/yarpc"
@@ -173,3 +174,16 @@ var (
 	emptyOneway_EchoYarpcRequest  = &Token{}
 	emptyOneway_EchoYarpcResponse = &yarpcproto.Oneway{}
 )
+
+func init() {
+	yarpc.RegisterClientBuilder(
+		func(clientConfig transport.ClientConfig, structField reflect.StructField) EchoYarpcClient {
+			return NewEchoYarpcClient(clientConfig, protobuf.ClientBuilderOptions(clientConfig, structField)...)
+		},
+	)
+	yarpc.RegisterClientBuilder(
+		func(clientConfig transport.ClientConfig, structField reflect.StructField) OnewayYarpcClient {
+			return NewOnewayYarpcClient(clientConfig, protobuf.ClientBuilderOptions(clientConfig, structField)...)
+		},
+	)
+}

--- a/internal/examples/protobuf/examplepb/example.pb.yarpc.go
+++ b/internal/examples/protobuf/examplepb/example.pb.yarpc.go
@@ -26,6 +26,7 @@ package examplepb
 
 import (
 	"context"
+	"reflect"
 
 	"github.com/gogo/protobuf/proto"
 	"go.uber.org/yarpc"
@@ -214,3 +215,16 @@ var (
 	emptySink_FireYarpcRequest  = &FireRequest{}
 	emptySink_FireYarpcResponse = &yarpcproto.Oneway{}
 )
+
+func init() {
+	yarpc.RegisterClientBuilder(
+		func(clientConfig transport.ClientConfig, structField reflect.StructField) KeyValueYarpcClient {
+			return NewKeyValueYarpcClient(clientConfig, protobuf.ClientBuilderOptions(clientConfig, structField)...)
+		},
+	)
+	yarpc.RegisterClientBuilder(
+		func(clientConfig transport.ClientConfig, structField reflect.StructField) SinkYarpcClient {
+			return NewSinkYarpcClient(clientConfig, protobuf.ClientBuilderOptions(clientConfig, structField)...)
+		},
+	)
+}


### PR DESCRIPTION
This PR adds:

- The function `protobuf.ClientBuilderOptions`, similar to the equivalent thrift function
- A call to `yarpcRegisterClientBuilder` in generated code from `protoc-gen-yarpc-go`
- Testing for both.