### PR TITLE
Add file to make sure internal/protoplugin is picked up for code coverage

### DIFF
--- a/encoding/x/protobuf/protoc-gen-yarpc-go/internal/testing/testing.go
+++ b/encoding/x/protobuf/protoc-gen-yarpc-go/internal/testing/testing.go
@@ -20,4 +20,7 @@
 
 package testing
 
-import _ "go.uber.org/yarpc/encoding/x/protobuf/protoc-gen-yarpc-go/internal/lib" // needed to make sure this is picked up for code coverage
+import (
+	// this is to make sure scripts/cover.sh picks this up with .Deps
+	_ "go.uber.org/yarpc/encoding/x/protobuf/protoc-gen-yarpc-go/internal/lib"
+)

--- a/encoding/x/protobuf/protoc-gen-yarpc-go/internal/testing/testing.go
+++ b/encoding/x/protobuf/protoc-gen-yarpc-go/internal/testing/testing.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package testing
+
+import _ "go.uber.org/yarpc/encoding/x/protobuf/protoc-gen-yarpc-go/internal/lib" // needed to make sure this is picked up for code coverage


### PR DESCRIPTION
I was browsing codecov and saw that lines I knew were covered in `internal/protoplugin` from `encoding/x/protobuf/protoc-gen-yarpc-go/internal/testing` were not being marked as covered. `scripts/cover.sh` calls `go list` to get the dependencies, but this does not pick up dependencies that are only in test files. This file make sure that these dependencies are picked up. I do something similar in https://github.com/yarpc/yarpc-go/blob/dev/encoding/x/protobuf/testing/testing.go.

We should make sure that if we build a code coverage tool, this case is handled without dummy golang files - cross-package coverage is important, especially for integration testing.