### PR TITLE
[retry middleware][part 3] Testing infrastructure for outbounds

### DIFF
--- a/internal/yarpctest/outboundtest/outbound_event.go
+++ b/internal/yarpctest/outboundtest/outbound_event.go
@@ -1,0 +1,166 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package outboundtest
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"time"
+
+	"go.uber.org/yarpc/api/transport"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+)
+
+// NewOutboundEventCallable sets up an OutboundEventCallable.
+func NewOutboundEventCallable(t require.TestingT, events []OutboundEvent) *OutboundEventCallable {
+	return &OutboundEventCallable{
+		t:      t,
+		events: events,
+		index:  atomic.NewInt32(0),
+	}
+}
+
+// OutboundEventCallable is an object that can be used in conjunction with a
+// yarpctest.FakeOutbound to create Fake functionality for an outbound through
+// OutboundEvents.
+// Every call to `OutboundEventCallable.Call` will be sent to an event in the
+// OutboundEventCallable's event list.  We will atomically increment the event
+// index every time a request is sent, and we will fail the test if too many or
+// too few requests were called.
+type OutboundEventCallable struct {
+	t      require.TestingT
+	events []OutboundEvent
+	index  *atomic.Int32
+}
+
+// Call implements the yarpctest.OutboundCallable function signature.  It will
+// send all requests to the appropriate event registered in the event slice.
+func (c *OutboundEventCallable) Call(ctx context.Context, req *transport.Request) (*transport.Response, error) {
+	eventIndex := c.index.Inc() - 1
+	require.True(c.t, int(eventIndex) < len(c.events), "attempted to execute event #%d on the outbound, there are only %d events", eventIndex+1, len(c.events))
+	return c.events[eventIndex].Call(ctx, c.t, req)
+}
+
+// Cleanup validates that all events in the OutboundEventCallable were
+// called before we finished the test.
+func (c *OutboundEventCallable) Cleanup() {
+	assert.Equal(
+		c.t,
+		int(c.index.Load()),
+		len(c.events),
+		"did not execute the proper number of outbound calls",
+	)
+}
+
+// OutboundEvent is a struct to validate an individual call to an outbound.
+// It has explicit checks for all request and timeout attributes, and it
+// can return all the information needed from the request.
+type OutboundEvent struct {
+	// context.Deadline validation
+	WantTimeout       time.Duration
+	WantTimeoutBounds time.Duration
+
+	// transport.Request validation
+	WantCaller          string
+	WantService         string
+	WantEncoding        transport.Encoding
+	WantProcedure       string
+	WantShardKey        string
+	WantRoutingKey      string
+	WantRoutingDelegate string
+	WantHeaders         transport.Headers
+
+	// WantBody validates the request's body
+	// It is special because if it is not set, we will not exhaust the
+	// request body's io.Reader, which could cause an error up the stack,
+	// this is by design for edge test cases.
+	WantBody string
+
+	// Indicates that we should block until the context is `Done`
+	WaitForTimeout bool
+
+	// Attributes put into the transport.Response object.
+	GiveError            error
+	GiveApplicationError bool
+	GiveRespHeaders      transport.Headers
+	GiveRespBody         string
+}
+
+// Call will validate a single call to the outbound event based on
+// the OutboundEvent's parameters.
+func (e OutboundEvent) Call(ctx context.Context, t require.TestingT, req *transport.Request) (*transport.Response, error) {
+	if e.WantTimeout != 0 {
+		timeoutBounds := e.WantTimeoutBounds
+		if timeoutBounds == 0 {
+			timeoutBounds = time.Millisecond * 10
+		}
+		deadline, ok := ctx.Deadline()
+		require.True(t, ok, "wanted context deadline, but there was no deadline")
+		deadlineDuration := deadline.Sub(time.Now())
+		assert.True(t, deadlineDuration > (e.WantTimeout-timeoutBounds), "deadline was less than expected, want %q (within %s), got %q", e.WantTimeout, timeoutBounds, deadlineDuration)
+		assert.True(t, deadlineDuration < (e.WantTimeout+timeoutBounds), "deadline was greater than expected, want %q (within %s), got %q", e.WantTimeout, timeoutBounds, deadlineDuration)
+	}
+
+	assertEqualIfSet(t, e.WantCaller, req.Caller, "invalid Caller")
+	assertEqualIfSet(t, e.WantService, req.Service, "invalid Service")
+	assertEqualIfSet(t, string(e.WantEncoding), string(req.Encoding), "invalid Encoding")
+	assertEqualIfSet(t, e.WantProcedure, req.Procedure, "invalid Procedure")
+	assertEqualIfSet(t, e.WantShardKey, req.ShardKey, "invalid ShardKey")
+	assertEqualIfSet(t, e.WantRoutingKey, req.RoutingKey, "invalid RoutingKey")
+	assertEqualIfSet(t, e.WantRoutingDelegate, req.RoutingDelegate, "invalid RoutingDelegate")
+
+	if e.WantHeaders.Len() != 0 {
+		assert.Equal(t, e.WantHeaders.Len(), req.Headers.Len(), "unexpected number of headers")
+		for key, wantVal := range e.WantHeaders.Items() {
+			gotVal, ok := req.Headers.Get(key)
+			assert.True(t, ok, "header key %q was not in request headers", key)
+			assert.Equal(t, wantVal, gotVal, "invalid request header value for %q", key)
+		}
+	}
+
+	if e.WantBody != "" {
+		body, err := ioutil.ReadAll(req.Body)
+		assert.NoError(t, err, "got error reading request body")
+		assert.Equal(t, e.WantBody, string(body), "request body did not match")
+	}
+
+	if e.WaitForTimeout {
+		_, ok := ctx.Deadline()
+		require.True(t, ok, "attempted to wait on context that has no deadline")
+		<-ctx.Done()
+	}
+
+	return &transport.Response{
+		Body:             ioutil.NopCloser(bytes.NewBuffer([]byte(e.GiveRespBody))),
+		Headers:          e.GiveRespHeaders,
+		ApplicationError: e.GiveApplicationError,
+	}, e.GiveError
+}
+
+func assertEqualIfSet(t require.TestingT, want, got string, msgAndArgs ...interface{}) {
+	if want != "" {
+		assert.Equal(t, want, got, msgAndArgs...)
+	}
+}

--- a/internal/yarpctest/outboundtest/outbound_event.go
+++ b/internal/yarpctest/outboundtest/outbound_event.go
@@ -33,15 +33,6 @@ import (
 	"go.uber.org/atomic"
 )
 
-// NewOutboundEventCallable sets up an OutboundEventCallable.
-func NewOutboundEventCallable(t require.TestingT, events []OutboundEvent) *OutboundEventCallable {
-	return &OutboundEventCallable{
-		t:      t,
-		events: events,
-		index:  atomic.NewInt32(0),
-	}
-}
-
 // OutboundEventCallable is an object that can be used in conjunction with a
 // yarpctest.FakeOutbound to create Fake functionality for an outbound through
 // OutboundEvents.
@@ -51,8 +42,17 @@ func NewOutboundEventCallable(t require.TestingT, events []OutboundEvent) *Outbo
 // too few requests were called.
 type OutboundEventCallable struct {
 	t      require.TestingT
-	events []OutboundEvent
+	events []*OutboundEvent
 	index  *atomic.Int32
+}
+
+// NewOutboundEventCallable sets up an OutboundEventCallable.
+func NewOutboundEventCallable(t require.TestingT, events []*OutboundEvent) *OutboundEventCallable {
+	return &OutboundEventCallable{
+		t:      t,
+		events: events,
+		index:  atomic.NewInt32(0),
+	}
 }
 
 // Call implements the yarpctest.OutboundCallable function signature.  It will
@@ -110,7 +110,7 @@ type OutboundEvent struct {
 
 // Call will validate a single call to the outbound event based on
 // the OutboundEvent's parameters.
-func (e OutboundEvent) Call(ctx context.Context, t require.TestingT, req *transport.Request) (*transport.Response, error) {
+func (e *OutboundEvent) Call(ctx context.Context, t require.TestingT, req *transport.Request) (*transport.Response, error) {
 	if e.WantTimeout != 0 {
 		timeoutBounds := e.WantTimeoutBounds
 		if timeoutBounds == 0 {

--- a/internal/yarpctest/outboundtest/outbound_event_test.go
+++ b/internal/yarpctest/outboundtest/outbound_event_test.go
@@ -43,7 +43,7 @@ func TestOutboundEvent(t *testing.T) {
 		request    *transport.Request
 		reqTimeout time.Duration
 
-		event OutboundEvent
+		event *OutboundEvent
 
 		wantExecutionStatus  iyarpctest.FakeTestStatus
 		wantExecutionErrors  []string
@@ -67,7 +67,7 @@ func TestOutboundEvent(t *testing.T) {
 				Body:            bytes.NewBufferString("body"),
 			},
 			reqTimeout: time.Second,
-			event: OutboundEvent{
+			event: &OutboundEvent{
 				WantTimeout:         time.Second,
 				WantTimeoutBounds:   time.Millisecond * 20,
 				WantCaller:          "caller",
@@ -98,7 +98,7 @@ func TestOutboundEvent(t *testing.T) {
 				Body:            bytes.NewBufferString("body"),
 			},
 			reqTimeout: time.Second,
-			event: OutboundEvent{
+			event: &OutboundEvent{
 				WantCaller:          "caller",
 				WantService:         "service",
 				WantEncoding:        transport.Encoding("encoding"),
@@ -138,7 +138,7 @@ func TestOutboundEvent(t *testing.T) {
 				Body:            bytes.NewBufferString("body"),
 			},
 			reqTimeout: time.Second,
-			event: OutboundEvent{
+			event: &OutboundEvent{
 				WantTimeout:       time.Second,
 				WantTimeoutBounds: time.Millisecond * 20,
 				WantBody:          "body",
@@ -153,7 +153,7 @@ func TestOutboundEvent(t *testing.T) {
 				Body: bytes.NewBufferString("body"),
 			},
 			reqTimeout: time.Second,
-			event: OutboundEvent{
+			event: &OutboundEvent{
 				WantTimeout:  time.Second,
 				WantBody:     "body",
 				GiveRespBody: "respbody",
@@ -167,7 +167,7 @@ func TestOutboundEvent(t *testing.T) {
 				Body: bytes.NewBufferString("body"),
 			},
 			reqTimeout: time.Second,
-			event: OutboundEvent{
+			event: &OutboundEvent{
 				WantTimeout:  time.Second * 2,
 				WantBody:     "body",
 				GiveRespBody: "respbody",
@@ -184,7 +184,7 @@ func TestOutboundEvent(t *testing.T) {
 				Body: bytes.NewBufferString("body"),
 			},
 			reqTimeout: time.Second * 2,
-			event: OutboundEvent{
+			event: &OutboundEvent{
 				WantTimeout:  time.Second,
 				WantBody:     "body",
 				GiveRespBody: "respbody",
@@ -200,7 +200,7 @@ func TestOutboundEvent(t *testing.T) {
 			request: &transport.Request{
 				Body: bytes.NewBufferString("body"),
 			},
-			event: OutboundEvent{
+			event: &OutboundEvent{
 				WantTimeout:  time.Second,
 				WantBody:     "body",
 				GiveRespBody: "respbody",
@@ -217,7 +217,7 @@ func TestOutboundEvent(t *testing.T) {
 				Body:    bytes.NewBufferString("body"),
 			},
 			reqTimeout: time.Second,
-			event: OutboundEvent{
+			event: &OutboundEvent{
 				WantHeaders:  transport.NewHeaders().With("key", "val"),
 				WantBody:     "body",
 				GiveRespBody: "respbody",
@@ -236,7 +236,7 @@ func TestOutboundEvent(t *testing.T) {
 				Body: bytes.NewBufferString("body22"),
 			},
 			reqTimeout: time.Second,
-			event: OutboundEvent{
+			event: &OutboundEvent{
 				WantBody:     "body",
 				GiveRespBody: "respbody",
 			},
@@ -252,7 +252,7 @@ func TestOutboundEvent(t *testing.T) {
 				Body: bytes.NewBufferString("body"),
 			},
 			reqTimeout: time.Millisecond * 10,
-			event: OutboundEvent{
+			event: &OutboundEvent{
 				WaitForTimeout: true,
 				WantBody:       "body",
 				GiveRespBody:   "respbody",
@@ -265,7 +265,7 @@ func TestOutboundEvent(t *testing.T) {
 			request: &transport.Request{
 				Body: bytes.NewBufferString("body"),
 			},
-			event: OutboundEvent{
+			event: &OutboundEvent{
 				WaitForTimeout: true,
 				WantBody:       "body",
 				GiveRespBody:   "respbody",
@@ -280,7 +280,7 @@ func TestOutboundEvent(t *testing.T) {
 			request: &transport.Request{
 				Body: bytes.NewBufferString("body"),
 			},
-			event: OutboundEvent{
+			event: &OutboundEvent{
 				WantBody:             "body",
 				GiveRespBody:         "respbody",
 				GiveApplicationError: true,
@@ -340,7 +340,7 @@ func TestOutboundCallable(t *testing.T) {
 		reqs       []*transport.Request
 		reqTimeout time.Duration
 
-		events []OutboundEvent
+		events []*OutboundEvent
 
 		wantExecutionStatus iyarpctest.FakeTestStatus
 		wantExecutionErrors []string
@@ -356,7 +356,7 @@ func TestOutboundCallable(t *testing.T) {
 				},
 			},
 			reqTimeout: time.Second,
-			events: []OutboundEvent{
+			events: []*OutboundEvent{
 				{
 					WantService:   "serv",
 					WantProcedure: "proc",
@@ -380,7 +380,7 @@ func TestOutboundCallable(t *testing.T) {
 				},
 			},
 			reqTimeout: time.Second,
-			events: []OutboundEvent{
+			events: []*OutboundEvent{
 				{
 					WantService:   "serv",
 					WantProcedure: "proc",
@@ -403,7 +403,7 @@ func TestOutboundCallable(t *testing.T) {
 				},
 			},
 			reqTimeout: time.Second,
-			events: []OutboundEvent{
+			events: []*OutboundEvent{
 				{
 					WantService:   "serv",
 					WantProcedure: "proc",

--- a/internal/yarpctest/outboundtest/outbound_event_test.go
+++ b/internal/yarpctest/outboundtest/outbound_event_test.go
@@ -1,0 +1,453 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package outboundtest
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io/ioutil"
+	"testing"
+	"time"
+
+	"go.uber.org/yarpc/api/transport"
+	iyarpctest "go.uber.org/yarpc/internal/yarpctest"
+	"go.uber.org/yarpc/yarpctest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOutboundEvent(t *testing.T) {
+	type testStruct struct {
+		msg string
+
+		request    *transport.Request
+		reqTimeout time.Duration
+
+		event OutboundEvent
+
+		wantExecutionStatus  iyarpctest.FakeTestStatus
+		wantExecutionErrors  []string
+		wantError            string
+		wantApplicationError bool
+		wantBody             string
+		wantRespHeaders      transport.Headers
+	}
+	tests := []testStruct{
+		{
+			msg: "successful everything",
+			request: &transport.Request{
+				Caller:          "caller",
+				Service:         "service",
+				Encoding:        transport.Encoding("encoding"),
+				Procedure:       "procedure",
+				ShardKey:        "shard",
+				RoutingKey:      "routekey",
+				RoutingDelegate: "routedel",
+				Headers:         transport.NewHeaders().With("key", "val"),
+				Body:            bytes.NewBufferString("body"),
+			},
+			reqTimeout: time.Second,
+			event: OutboundEvent{
+				WantTimeout:         time.Second,
+				WantTimeoutBounds:   time.Millisecond * 20,
+				WantCaller:          "caller",
+				WantService:         "service",
+				WantEncoding:        transport.Encoding("encoding"),
+				WantProcedure:       "procedure",
+				WantShardKey:        "shard",
+				WantRoutingKey:      "routekey",
+				WantRoutingDelegate: "routedel",
+				WantHeaders:         transport.NewHeaders().With("key", "val"),
+				WantBody:            "body",
+				GiveRespBody:        "respbody",
+			},
+			wantExecutionStatus: iyarpctest.Finished,
+			wantBody:            "respbody",
+		},
+		{
+			msg: "errored request params",
+			request: &transport.Request{
+				Caller:          "caller2",
+				Service:         "service2",
+				Encoding:        transport.Encoding("encoding2"),
+				Procedure:       "procedure2",
+				ShardKey:        "shard2",
+				RoutingKey:      "routekey2",
+				RoutingDelegate: "routedel2",
+				Headers:         transport.NewHeaders().With("key2", "val2"),
+				Body:            bytes.NewBufferString("body"),
+			},
+			reqTimeout: time.Second,
+			event: OutboundEvent{
+				WantCaller:          "caller",
+				WantService:         "service",
+				WantEncoding:        transport.Encoding("encoding"),
+				WantProcedure:       "procedure",
+				WantShardKey:        "shard",
+				WantRoutingKey:      "routekey",
+				WantRoutingDelegate: "routedel",
+				WantHeaders:         transport.NewHeaders().With("key", "val"),
+				WantBody:            "body",
+				GiveRespBody:        "respbody",
+			},
+			wantBody:            "respbody",
+			wantExecutionStatus: iyarpctest.Finished,
+			wantExecutionErrors: []string{
+				"invalid Caller",
+				"invalid Service",
+				"invalid Encoding",
+				"invalid Procedure",
+				"invalid ShardKey",
+				"invalid RoutingKey",
+				"invalid RoutingDelegate",
+				`header key "key" was not in request headers`,
+				`invalid request header value for "key"`,
+			},
+		},
+		{
+			msg: "ignore extra request fields",
+			request: &transport.Request{
+				Caller:          "caller2",
+				Service:         "service2",
+				Encoding:        transport.Encoding("encoding2"),
+				Procedure:       "procedure2",
+				ShardKey:        "shard2",
+				RoutingKey:      "routekey2",
+				RoutingDelegate: "routedel2",
+				Headers:         transport.NewHeaders().With("key2", "val2"),
+				Body:            bytes.NewBufferString("body"),
+			},
+			reqTimeout: time.Second,
+			event: OutboundEvent{
+				WantTimeout:       time.Second,
+				WantTimeoutBounds: time.Millisecond * 20,
+				WantBody:          "body",
+				GiveRespBody:      "respbody",
+			},
+			wantBody:            "respbody",
+			wantExecutionStatus: iyarpctest.Finished,
+		},
+		{
+			msg: "default timeout range",
+			request: &transport.Request{
+				Body: bytes.NewBufferString("body"),
+			},
+			reqTimeout: time.Second,
+			event: OutboundEvent{
+				WantTimeout:  time.Second,
+				WantBody:     "body",
+				GiveRespBody: "respbody",
+			},
+			wantBody:            "respbody",
+			wantExecutionStatus: iyarpctest.Finished,
+		},
+		{
+			msg: "timeout smaller than expected",
+			request: &transport.Request{
+				Body: bytes.NewBufferString("body"),
+			},
+			reqTimeout: time.Second,
+			event: OutboundEvent{
+				WantTimeout:  time.Second * 2,
+				WantBody:     "body",
+				GiveRespBody: "respbody",
+			},
+			wantBody:            "respbody",
+			wantExecutionStatus: iyarpctest.Finished,
+			wantExecutionErrors: []string{
+				"deadline was less than expected",
+			},
+		},
+		{
+			msg: "timeout larger than expected",
+			request: &transport.Request{
+				Body: bytes.NewBufferString("body"),
+			},
+			reqTimeout: time.Second * 2,
+			event: OutboundEvent{
+				WantTimeout:  time.Second,
+				WantBody:     "body",
+				GiveRespBody: "respbody",
+			},
+			wantBody:            "respbody",
+			wantExecutionStatus: iyarpctest.Finished,
+			wantExecutionErrors: []string{
+				"deadline was greater than expected",
+			},
+		},
+		{
+			msg: "wanttimeout with no deadline",
+			request: &transport.Request{
+				Body: bytes.NewBufferString("body"),
+			},
+			event: OutboundEvent{
+				WantTimeout:  time.Second,
+				WantBody:     "body",
+				GiveRespBody: "respbody",
+			},
+			wantExecutionStatus: iyarpctest.Fatal,
+			wantExecutionErrors: []string{
+				"wanted context deadline, but there was no deadline",
+			},
+		},
+		{
+			msg: "invalid number of header keys",
+			request: &transport.Request{
+				Headers: transport.NewHeaders().With("key2", "val2").With("key3", "val3"),
+				Body:    bytes.NewBufferString("body"),
+			},
+			reqTimeout: time.Second,
+			event: OutboundEvent{
+				WantHeaders:  transport.NewHeaders().With("key", "val"),
+				WantBody:     "body",
+				GiveRespBody: "respbody",
+			},
+			wantBody:            "respbody",
+			wantExecutionStatus: iyarpctest.Finished,
+			wantExecutionErrors: []string{
+				"unexpected number of headers",
+				`header key "key" was not in request headers`,
+				`invalid request header value for "key"`,
+			},
+		},
+		{
+			msg: "invalid body",
+			request: &transport.Request{
+				Body: bytes.NewBufferString("body22"),
+			},
+			reqTimeout: time.Second,
+			event: OutboundEvent{
+				WantBody:     "body",
+				GiveRespBody: "respbody",
+			},
+			wantBody:            "respbody",
+			wantExecutionStatus: iyarpctest.Finished,
+			wantExecutionErrors: []string{
+				"request body did not match",
+			},
+		},
+		{
+			msg: "wait for timeout",
+			request: &transport.Request{
+				Body: bytes.NewBufferString("body"),
+			},
+			reqTimeout: time.Millisecond * 10,
+			event: OutboundEvent{
+				WaitForTimeout: true,
+				WantBody:       "body",
+				GiveRespBody:   "respbody",
+			},
+			wantBody:            "respbody",
+			wantExecutionStatus: iyarpctest.Finished,
+		},
+		{
+			msg: "wait for timeout with no deadline",
+			request: &transport.Request{
+				Body: bytes.NewBufferString("body"),
+			},
+			event: OutboundEvent{
+				WaitForTimeout: true,
+				WantBody:       "body",
+				GiveRespBody:   "respbody",
+			},
+			wantExecutionStatus: iyarpctest.Fatal,
+			wantExecutionErrors: []string{
+				"attempted to wait on context that has no deadline",
+			},
+		},
+		{
+			msg: "validate call responses",
+			request: &transport.Request{
+				Body: bytes.NewBufferString("body"),
+			},
+			event: OutboundEvent{
+				WantBody:             "body",
+				GiveRespBody:         "respbody",
+				GiveApplicationError: true,
+				GiveError:            errors.New("test error"),
+				GiveRespHeaders:      transport.NewHeaders().With("key", "val"),
+			},
+			wantBody:             "respbody",
+			wantApplicationError: true,
+			wantError:            "test error",
+			wantRespHeaders:      transport.NewHeaders().With("key", "val"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			testResult := iyarpctest.WithFakeTestingT(func(ft require.TestingT) {
+				ctx := context.Background()
+				if tt.reqTimeout != 0 {
+					newCtx, cancel := context.WithTimeout(ctx, tt.reqTimeout)
+					defer cancel()
+					ctx = newCtx
+				}
+				resp, err := tt.event.Call(ctx, ft, tt.request)
+
+				if tt.wantError != "" {
+					assert.EqualError(t, err, tt.wantError)
+					require.NotNil(t, resp)
+					assert.Equal(t, tt.wantApplicationError, resp.ApplicationError)
+				} else {
+					require.NotNil(t, resp)
+					body, err := ioutil.ReadAll(resp.Body)
+					assert.NoError(t, err)
+					assert.Equal(t, tt.wantBody, string(body))
+				}
+				if tt.wantRespHeaders.Len() != 0 {
+					assert.Equal(t, tt.wantRespHeaders.Len(), resp.Headers.Len(), "unexpected number of headers")
+					for key, wantVal := range tt.wantRespHeaders.Items() {
+						gotVal, ok := resp.Headers.Get(key)
+						assert.True(t, ok, "header key %q was not in response headers", key)
+						assert.Equal(t, wantVal, gotVal, "invalid response header value for %q", key)
+					}
+				}
+			})
+			assert.Equal(t, tt.wantExecutionStatus, testResult.Status)
+			require.Equal(t, len(tt.wantExecutionErrors), len(testResult.Errors))
+			for i, wantErr := range tt.wantExecutionErrors {
+				assert.Contains(t, testResult.Errors[i], wantErr)
+			}
+		})
+	}
+}
+
+func TestOutboundCallable(t *testing.T) {
+	type testStruct struct {
+		msg string
+
+		reqs       []*transport.Request
+		reqTimeout time.Duration
+
+		events []OutboundEvent
+
+		wantExecutionStatus iyarpctest.FakeTestStatus
+		wantExecutionErrors []string
+	}
+	tests := []testStruct{
+		{
+			msg: "equal calls",
+			reqs: []*transport.Request{
+				{
+					Service:   "serv",
+					Procedure: "proc",
+					Body:      bytes.NewBufferString("body"),
+				},
+			},
+			reqTimeout: time.Second,
+			events: []OutboundEvent{
+				{
+					WantService:   "serv",
+					WantProcedure: "proc",
+					WantBody:      "body",
+				},
+			},
+			wantExecutionStatus: iyarpctest.Finished,
+		},
+		{
+			msg: "extra call",
+			reqs: []*transport.Request{
+				{
+					Service:   "serv",
+					Procedure: "proc",
+					Body:      bytes.NewBufferString("body"),
+				},
+				{
+					Service:   "serv",
+					Procedure: "proc",
+					Body:      bytes.NewBufferString("body"),
+				},
+			},
+			reqTimeout: time.Second,
+			events: []OutboundEvent{
+				{
+					WantService:   "serv",
+					WantProcedure: "proc",
+					WantBody:      "body",
+				},
+			},
+			wantExecutionStatus: iyarpctest.Fatal,
+			wantExecutionErrors: []string{
+				"attempted to execute event #2 on the outbound, there are only 1 events",
+				"did not execute the proper number of outbound calls",
+			},
+		},
+		{
+			msg: "not enough calls",
+			reqs: []*transport.Request{
+				{
+					Service:   "serv",
+					Procedure: "proc",
+					Body:      bytes.NewBufferString("body"),
+				},
+			},
+			reqTimeout: time.Second,
+			events: []OutboundEvent{
+				{
+					WantService:   "serv",
+					WantProcedure: "proc",
+					WantBody:      "body",
+				},
+				{
+					WantService:   "serv",
+					WantProcedure: "proc",
+					WantBody:      "body",
+				},
+			},
+			wantExecutionStatus: iyarpctest.Finished,
+			wantExecutionErrors: []string{
+				"did not execute the proper number of outbound calls",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			testResult := iyarpctest.WithFakeTestingT(func(ft require.TestingT) {
+				callable := NewOutboundEventCallable(ft, tt.events)
+				defer callable.Cleanup()
+
+				trans := yarpctest.NewFakeTransport()
+				out := trans.NewOutbound(yarpctest.NewFakePeerList(), yarpctest.OutboundCallOverride(callable.Call))
+				out.Start()
+
+				ctx := context.Background()
+				if tt.reqTimeout != 0 {
+					newCtx, cancel := context.WithTimeout(ctx, tt.reqTimeout)
+					defer cancel()
+					ctx = newCtx
+				}
+
+				for _, req := range tt.reqs {
+					out.Call(ctx, req)
+				}
+			})
+			assert.Equal(t, tt.wantExecutionStatus, testResult.Status)
+			require.Equal(t, len(tt.wantExecutionErrors), len(testResult.Errors))
+			for i, wantErr := range tt.wantExecutionErrors {
+				assert.Contains(t, testResult.Errors[i], wantErr)
+			}
+		})
+	}
+}

--- a/internal/yarpctest/testing.go
+++ b/internal/yarpctest/testing.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpctest
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/stretchr/testify/require"
+)
+
+// FakeTestStatus states how a fake TestingT finished.
+type FakeTestStatus int
+
+const (
+	// Finished is the default. This indicates that it was run to completion
+	// but may have recorded errors using Errorf.
+	Finished FakeTestStatus = iota
+
+	// Fatal indicates that the TestingT aborted early with a FailNow.
+	Fatal
+
+	// Panicked indicates that the TestingT aborted with a panic.
+	Panicked
+)
+
+func (f FakeTestStatus) String() string {
+	switch f {
+	case Finished:
+		return "Finished"
+	case Fatal:
+		return "Fatal"
+	case Panicked:
+		return "Panicked"
+	default:
+		return fmt.Sprintf("FakeTestStatus(%v)", int(f))
+	}
+}
+
+// FakeTestResult contains the result of using a fake TestingT.
+type FakeTestResult struct {
+	Errors []string
+	Status FakeTestStatus
+	Panic  interface{} // non-nil if we panicked
+}
+
+// WithFakeTestingT yields a TestingT that records its results and exposes
+// them in FakeTestResult.
+func WithFakeTestingT(f func(require.TestingT)) *FakeTestResult {
+	var (
+		r FakeTestResult
+		t = fakeTestingT{&r}
+	)
+
+	done := make(chan struct{})
+	go func() {
+		defer func() {
+			if v := recover(); v != nil {
+				t.result.Status = Panicked
+			}
+			close(done)
+		}()
+
+		f(&t)
+	}()
+	<-done
+
+	return &r
+}
+
+type fakeTestingT struct{ result *FakeTestResult }
+
+func (t *fakeTestingT) Errorf(msg string, args ...interface{}) {
+	if len(args) > 0 {
+		msg = fmt.Sprintf(msg, args)
+	}
+	t.result.Errors = append(t.result.Errors, msg)
+}
+
+func (t *fakeTestingT) FailNow() {
+	t.result.Status = Fatal
+
+	// this kills the current goroutine, unwinding deferred functions.
+	runtime.Goexit()
+}


### PR DESCRIPTION
Summary: In the process of building the retry middleware I ended up
building infrastructure that would allow me to assert on the outbound
calls the Retry middleware was making.  I pulled that infrastructure 
into it's own internal package (no need to expose it publicly yet).

Essentially we can now define OutboundEvents which can validate
individual outbound calls and return a pre-determined response.
We hook the OutboundEvents into an OutboundEventCallable which allows
multiple events to be chained together sequentially (and guarantees that
all events were called).

Test Plan: Wrote tests for my test's test stuff.