### PR TITLE
[Retry Middleware][Part 4] Add basic Retry middleware

### DIFF
--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package retry
 
 import (
@@ -8,36 +28,67 @@ import (
 	"go.uber.org/yarpc/internal/ioutil"
 )
 
-// MiddlewareOptions enumerates the options for retry middleware.
-type MiddlewareOptions struct {
+// middlewareOptions enumerates the options for retry middleware.
+type middlewareOptions struct {
 	// Retries is the number of attempts we will retry (after the
 	// initial attempt.
-	Retries int
+	retries int
 
 	// Timeout is the Timeout we will enforce per request (if this
 	// is less than the context deadline, we'll use that instead).
-	Timeout time.Duration
+	timeout time.Duration
+}
+
+var defaultMiddlewareOptions = middlewareOptions{
+	retries: 1,
+	timeout: time.Second,
+}
+
+// MiddlewareOption customizes the behavior of a retry middleware.
+type MiddlewareOption func(*middlewareOptions)
+
+// Retries is the number of attempts we will retry (after the
+// initial attempt.
+//
+// Defaults to 1.
+func Retries(retries int) MiddlewareOption {
+	return func(options *middlewareOptions) {
+		options.retries = retries
+	}
+}
+
+// PerRequestTimeout is the Timeout we will enforce per request (if this
+// is less than the context deadline, we'll use that instead).
+//
+// Defaults to 1 second.
+func PerRequestTimeout(timeout time.Duration) MiddlewareOption {
+	return func(options *middlewareOptions) {
+		options.timeout = timeout
+	}
 }
 
 // NewUnaryMiddleware creates a new Retry Middleware
-func NewUnaryMiddleware(opts MiddlewareOptions) *OutboundMiddleware {
-	return &OutboundMiddleware{opts}
+func NewUnaryMiddleware(opts ...MiddlewareOption) *OutboundMiddleware {
+	options := defaultMiddlewareOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+	return &OutboundMiddleware{options}
 }
 
 // OutboundMiddleware is a retry middleware that wraps a UnaryOutbound with
 // Middleware.
 type OutboundMiddleware struct {
-	opts MiddlewareOptions
+	opts middlewareOptions
 }
 
 // Call implements the middleware.UnaryOutbound interface.
 func (r *OutboundMiddleware) Call(ctx context.Context, request *transport.Request, out transport.UnaryOutbound) (resp *transport.Response, err error) {
 	rereader, finish := ioutil.NewRereader(request.Body)
 	defer finish()
+	request.Body = rereader
 
-	for i := 0; i < r.opts.Retries+1; i++ {
-		request.Body = rereader
-
+	for i := 0; i < r.opts.retries+1; i++ {
 		subCtx, cancel := context.WithTimeout(ctx, r.getTimeout(ctx))
 		resp, err = out.Call(subCtx, request)
 		cancel() // Clear the new ctx immdediately after the call
@@ -48,7 +99,7 @@ func (r *OutboundMiddleware) Call(ctx context.Context, request *transport.Reques
 
 		// Reset the rereader so we can do another request.
 		if resetErr := rereader.Reset(); resetErr != nil {
-			// TODO find a way to wrap the resetErr and the err
+			// TODO(#1080) Append the reset error to the err.
 			err = resetErr
 			return resp, err
 		}
@@ -61,15 +112,16 @@ func (r *OutboundMiddleware) Call(ctx context.Context, request *transport.Reques
 func (r *OutboundMiddleware) getTimeout(ctx context.Context) time.Duration {
 	ctxDeadline, ok := ctx.Deadline()
 	if !ok {
-		return r.opts.Timeout
+		return r.opts.timeout
 	}
 	now := time.Now()
-	if ctxDeadline.After(now.Add(r.opts.Timeout)) {
-		return r.opts.Timeout
+	if ctxDeadline.After(now.Add(r.opts.timeout)) {
+		return r.opts.timeout
 	}
 	return ctxDeadline.Sub(now)
 }
 
 func isRetryable(err error) bool {
+	// TODO(#1080) Update Error assertions to be more granular.
 	return transport.IsUnexpectedError(err) || transport.IsTimeoutError(err)
 }

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -1,0 +1,75 @@
+package retry
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/ioutil"
+)
+
+// MiddlewareOptions enumerates the options for retry middleware.
+type MiddlewareOptions struct {
+	// Retries is the number of attempts we will retry (after the
+	// initial attempt.
+	Retries int
+
+	// Timeout is the Timeout we will enforce per request (if this
+	// is less than the context deadline, we'll use that instead).
+	Timeout time.Duration
+}
+
+// NewUnaryMiddleware creates a new Retry Middleware
+func NewUnaryMiddleware(opts MiddlewareOptions) *OutboundMiddleware {
+	return &OutboundMiddleware{opts}
+}
+
+// OutboundMiddleware is a retry middleware that wraps a UnaryOutbound with
+// Middleware.
+type OutboundMiddleware struct {
+	opts MiddlewareOptions
+}
+
+// Call implements the middleware.UnaryOutbound interface.
+func (r *OutboundMiddleware) Call(ctx context.Context, request *transport.Request, out transport.UnaryOutbound) (resp *transport.Response, err error) {
+	rereader, finish := ioutil.NewRereader(request.Body)
+	defer finish()
+
+	for i := 0; i < r.opts.Retries+1; i++ {
+		request.Body = rereader
+
+		subCtx, cancel := context.WithTimeout(ctx, r.getTimeout(ctx))
+		resp, err = out.Call(subCtx, request)
+		cancel() // Clear the new ctx immdediately after the call
+
+		if err == nil || !isRetryable(err) {
+			return resp, err
+		}
+
+		// Reset the rereader so we can do another request.
+		if resetErr := rereader.Reset(); resetErr != nil {
+			// TODO find a way to wrap the resetErr and the err
+			err = resetErr
+			return resp, err
+		}
+
+		// TODO add backoff semantics
+	}
+	return resp, err
+}
+
+func (r *OutboundMiddleware) getTimeout(ctx context.Context) time.Duration {
+	ctxDeadline, ok := ctx.Deadline()
+	if !ok {
+		return r.opts.Timeout
+	}
+	now := time.Now()
+	if ctxDeadline.After(now.Add(r.opts.Timeout)) {
+		return r.opts.Timeout
+	}
+	return ctxDeadline.Sub(now)
+}
+
+func isRetryable(err error) bool {
+	return transport.IsUnexpectedError(err) || transport.IsTimeoutError(err)
+}

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -1,0 +1,335 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package retry
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/errors"
+	. "go.uber.org/yarpc/internal/yarpctest/outboundtest"
+	"go.uber.org/yarpc/yarpctest"
+)
+
+func TestMiddleware(t *testing.T) {
+	type testStruct struct {
+		msg string
+
+		request    *transport.Request
+		reqTimeout time.Duration
+
+		retries      int
+		retrytimeout time.Duration
+
+		events []OutboundEvent
+
+		wantError            string
+		wantApplicationError bool
+		wantBody             string
+	}
+	tests := []testStruct{
+		{
+			msg: "no retry",
+			request: &transport.Request{
+				Service:   "serv",
+				Procedure: "proc",
+				Body:      bytes.NewBufferString("body"),
+			},
+			reqTimeout:   time.Second,
+			retries:      1,
+			retrytimeout: time.Millisecond * 500,
+			events: []OutboundEvent{
+				{
+					WantService:   "serv",
+					WantProcedure: "proc",
+					WantBody:      "body",
+					GiveRespBody:  "respbody",
+				},
+			},
+			wantBody: "respbody",
+		},
+		{
+			msg: "single retry",
+			request: &transport.Request{
+				Service:   "serv",
+				Procedure: "proc",
+				Body:      bytes.NewBufferString("body"),
+			},
+			reqTimeout:   time.Second,
+			retries:      1,
+			retrytimeout: time.Millisecond * 500,
+			events: []OutboundEvent{
+				{
+					WantService:   "serv",
+					WantProcedure: "proc",
+					WantBody:      "body",
+					GiveError:     errors.RemoteUnexpectedError("unknown error"),
+				},
+				{
+					WantService:   "serv",
+					WantProcedure: "proc",
+					WantBody:      "body",
+					GiveRespBody:  "respbody",
+				},
+			},
+			wantBody: "respbody",
+		},
+		{
+			msg: "multiple retries",
+			request: &transport.Request{
+				Service:   "serv",
+				Procedure: "proc",
+				Body:      bytes.NewBufferString("body"),
+			},
+			reqTimeout:   time.Second,
+			retries:      4,
+			retrytimeout: time.Millisecond * 500,
+			events: []OutboundEvent{
+				{
+					WantService:   "serv",
+					WantProcedure: "proc",
+					WantBody:      "body",
+					GiveError:     errors.RemoteUnexpectedError("unknown error"),
+				},
+				{
+					WantService:   "serv",
+					WantProcedure: "proc",
+					WantBody:      "body",
+					GiveError:     errors.ClientTimeoutError("serv", "proc", time.Millisecond*300),
+				},
+				{
+					WantService:   "serv",
+					WantProcedure: "proc",
+					WantBody:      "body",
+					GiveError:     errors.RemoteTimeoutError("remote timed out"),
+				},
+				{
+					WantService:   "serv",
+					WantProcedure: "proc",
+					WantBody:      "body",
+					GiveError:     errors.RemoteUnexpectedError("unknown error"),
+				},
+				{
+					WantService:   "serv",
+					WantProcedure: "proc",
+					WantBody:      "body",
+					GiveRespBody:  "respbody",
+				},
+			},
+			wantBody: "respbody",
+		},
+		{
+			msg: "immediate hard failure",
+			request: &transport.Request{
+				Service:   "serv",
+				Procedure: "proc",
+				Body:      bytes.NewBufferString("body"),
+			},
+			reqTimeout:   time.Second,
+			retries:      1,
+			retrytimeout: time.Millisecond * 500,
+			events: []OutboundEvent{
+				{
+					WantService:   "serv",
+					WantProcedure: "proc",
+					WantBody:      "body",
+					GiveError:     errors.RemoteBadRequestError("bad request!"),
+				},
+			},
+			wantError: errors.RemoteBadRequestError("bad request!").Error(),
+		},
+		{
+			msg: "retry once, then hard failure",
+			request: &transport.Request{
+				Service:   "serv",
+				Procedure: "proc",
+				Body:      bytes.NewBufferString("body"),
+			},
+			reqTimeout:   time.Second,
+			retries:      1,
+			retrytimeout: time.Millisecond * 500,
+			events: []OutboundEvent{
+				{
+					WantService:   "serv",
+					WantProcedure: "proc",
+					WantBody:      "body",
+					GiveError:     errors.RemoteUnexpectedError("unknown error"),
+				},
+				{
+					WantService:   "serv",
+					WantProcedure: "proc",
+					WantBody:      "body",
+					GiveError:     errors.RemoteBadRequestError("bad request!"),
+				},
+			},
+			wantError: errors.RemoteBadRequestError("bad request!").Error(),
+		},
+		{
+			msg: "ctx timeout less than retry timeout",
+			request: &transport.Request{
+				Service:   "serv",
+				Procedure: "proc",
+				Body:      bytes.NewBufferString("body"),
+			},
+			reqTimeout:   time.Millisecond * 300,
+			retries:      1,
+			retrytimeout: time.Millisecond * 500,
+			events: []OutboundEvent{
+				{
+					WantTimeout:   time.Millisecond * 300,
+					WantService:   "serv",
+					WantProcedure: "proc",
+					WantBody:      "body",
+					GiveRespBody:  "respbody",
+				},
+			},
+			wantBody: "respbody",
+		},
+		{
+			msg: "ctx timeout less than retry timeout",
+			request: &transport.Request{
+				Service:   "serv",
+				Procedure: "proc",
+				Body:      bytes.NewBufferString("body"),
+			},
+			reqTimeout:   time.Millisecond * 75,
+			retries:      1,
+			retrytimeout: time.Millisecond * 50,
+			events: []OutboundEvent{
+				{
+					WantTimeout:    time.Millisecond * 50,
+					WantService:    "serv",
+					WantProcedure:  "proc",
+					WantBody:       "body",
+					WaitForTimeout: true,
+					GiveError:      errors.ClientTimeoutError("serv", "proc", time.Millisecond*50),
+				},
+				{
+					WantTimeout:   time.Millisecond * 25,
+					WantService:   "serv",
+					WantProcedure: "proc",
+					WantBody:      "body",
+					GiveRespBody:  "respbody",
+				},
+			},
+			wantBody: "respbody",
+		},
+		{
+			msg: "no ctx timeout",
+			request: &transport.Request{
+				Service:   "serv",
+				Procedure: "proc",
+				Body:      bytes.NewBufferString("body"),
+			},
+			retries:      1,
+			retrytimeout: time.Millisecond * 50,
+			events: []OutboundEvent{
+				{
+					WantTimeout:    time.Millisecond * 50,
+					WantService:    "serv",
+					WantProcedure:  "proc",
+					WantBody:       "body",
+					WaitForTimeout: true,
+					GiveError:      errors.ClientTimeoutError("serv", "proc", time.Millisecond*50),
+				},
+				{
+					WantTimeout:   time.Millisecond * 50,
+					WantService:   "serv",
+					WantProcedure: "proc",
+					WantBody:      "body",
+					GiveRespBody:  "respbody",
+				},
+			},
+			wantBody: "respbody",
+		},
+		{
+			msg: "exhaust retries",
+			request: &transport.Request{
+				Service:   "serv",
+				Procedure: "proc",
+				Body:      bytes.NewBufferString("body"),
+			},
+			reqTimeout:   time.Millisecond * 400,
+			retries:      1,
+			retrytimeout: time.Millisecond * 50,
+			events: []OutboundEvent{
+				{
+					WantTimeout:   time.Millisecond * 50,
+					WantService:   "serv",
+					WantProcedure: "proc",
+					WantBody:      "body",
+					GiveError:     errors.RemoteUnexpectedError("unexpected error 1"),
+				},
+				{
+					WantTimeout:   time.Millisecond * 50,
+					WantService:   "serv",
+					WantProcedure: "proc",
+					WantBody:      "body",
+					GiveError:     errors.RemoteUnexpectedError("unexpected error 2"),
+				},
+			},
+			wantError: errors.RemoteUnexpectedError("unexpected error 2").Error(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			callable := NewOutboundEventCallable(t, tt.events)
+			defer callable.Cleanup()
+
+			trans := yarpctest.NewFakeTransport()
+			out := trans.NewOutbound(yarpctest.NewFakePeerList(), yarpctest.OutboundCallOverride(callable.Call))
+			out.Start()
+
+			retry := NewUnaryMiddleware(
+				MiddlewareOptions{
+					Retries: tt.retries,
+					Timeout: tt.retrytimeout,
+				},
+			)
+
+			ctx := context.Background()
+			if tt.reqTimeout != 0 {
+				newCtx, cancel := context.WithTimeout(ctx, tt.reqTimeout)
+				defer cancel()
+				ctx = newCtx
+			}
+			resp, err := retry.Call(ctx, tt.request, out)
+			if tt.wantError != "" {
+				assert.EqualError(t, err, tt.wantError)
+				require.NotNil(t, resp)
+				assert.Equal(t, tt.wantApplicationError, resp.ApplicationError)
+			} else {
+				require.NotNil(t, resp)
+				body, err := ioutil.ReadAll(resp.Body)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantBody, string(body))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Summary: This adds basic Unary Retry middleware for YARPC outbounds.  So far we can specify
number of retries and the timeout of each request.  I'll add backoff semantics in
the next PR.