### PR TITLE
lifecycle: Expose stopping state

### DIFF
--- a/internal/sync/lifecycle.go
+++ b/internal/sync/lifecycle.go
@@ -164,6 +164,7 @@ func (l *lifecycleOnce) WhenRunning(ctx context.Context) error {
 func (l *lifecycleOnce) Stop(f func() error) error {
 	if l.state.CAS(int32(Idle), int32(Stopped)) {
 		close(l.startCh)
+		close(l.stoppingCh)
 		close(l.stopCh)
 		return nil
 	}


### PR DESCRIPTION
Some lifecycle objects will manage goroutines.  These objects need a way to signal to those goroutines that they should wrap up their work and exit, such that the lifecycle object can block during stop until all of its goroutines have exited.  This change adds a "stopping" channel that can be used to signal to workers that they should wrap up and exit.