### PR TITLE
Add exponential backoff generator (with jitter)

### DIFF
--- a/internal/backoff/backoff.go
+++ b/internal/backoff/backoff.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package backoff
+
+import "time"
+
+// Strategy defines a function that will return a
+// backoff time given an attempt number.
+type Strategy func(attempts uint) time.Duration

--- a/internal/backoff/exponential.go
+++ b/internal/backoff/exponential.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package backoff
+
+import (
+	"errors"
+	"math/rand"
+	"time"
+
+	"go.uber.org/multierr"
+)
+
+// ExponentialOption defines options that can be applied to an
+// exponential backoff stragety
+type ExponentialOption func(*exponentialOptions)
+
+// exponentialOptions are the configuration options for an exponential backoff
+type exponentialOptions struct {
+	base, min, max time.Duration
+	rand           *rand.Rand
+	minMaxDiff     int64
+}
+
+func (e exponentialOptions) validate() (err error) {
+	if e.base <= 0 {
+		err = multierr.Append(err, errors.New("invalid base for exponential backoff, need greater than zero"))
+	}
+	if e.min < 0 {
+		err = multierr.Append(err, errors.New("invalid min for exponential backoff, need greater than or equal to zero"))
+	}
+	if e.max < 0 {
+		err = multierr.Append(err, errors.New("invalid max for exponential backoff, need greater than or equal to zero"))
+	}
+	if e.max < e.min {
+		err = multierr.Append(err, errors.New("exponential max value must be greater than min value"))
+	}
+	return err
+}
+
+var defaultExponentialOpts = exponentialOptions{
+	base: time.Millisecond,
+	max:  time.Hour, // :shrug:
+	rand: rand.New(rand.NewSource(time.Now().UnixNano())),
+}
+
+// BaseJump sets the default "jump" the exponential backoff strategy will use.
+func BaseJump(t time.Duration) ExponentialOption {
+	return func(options *exponentialOptions) {
+		options.base = t
+	}
+}
+
+// MaxBackoff sets the max backoff that will ever be used in backoff.
+func MaxBackoff(t time.Duration) ExponentialOption {
+	return func(options *exponentialOptions) {
+		options.max = t
+	}
+}
+
+// MinBackoff sets the min backoff that will ever be used in backoff.
+func MinBackoff(t time.Duration) ExponentialOption {
+	return func(options *exponentialOptions) {
+		options.min = t
+	}
+}
+
+// randGenerator is an internal option for overriding the random number
+// generator.
+func randGenerator(rand *rand.Rand) ExponentialOption {
+	return func(options *exponentialOptions) {
+		options.rand = rand
+	}
+}
+
+// Exponential is an exponential backoff strategy with jitter.  Under the
+// aws backoff strategies this is a "Full Jitter" backoff implementation
+// https://www.awsarchitectureblog.com/2015/03/backoff.html
+// It is a stateless implementation and is safe to use concurrently.
+type Exponential struct {
+	opts exponentialOptions
+}
+
+// NewExponential returns a new Exponential Backoff Strategy.
+func NewExponential(opts ...ExponentialOption) (*Exponential, error) {
+	options := defaultExponentialOpts
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	if err := options.validate(); err != nil {
+		return nil, err
+	}
+	options.minMaxDiff = options.max.Nanoseconds() - options.min.Nanoseconds()
+
+	return &Exponential{
+		opts: options,
+	}, nil
+}
+
+// Duration takes an attempt number and returns the duration the caller should
+// wait.
+func (e *Exponential) Duration(attempts uint) time.Duration {
+	backoffSansMin := (1 << attempts) * e.opts.base.Nanoseconds()
+
+	// either the bit shift went negative, or we went past the max
+	// duration we're willing to backoff.
+	// In both cases we should go to our max value
+	if backoffSansMin > e.opts.minMaxDiff || backoffSansMin <= 0 {
+		backoffSansMin = e.opts.minMaxDiff
+	}
+
+	return e.opts.min + time.Duration(e.opts.rand.Int63n(backoffSansMin+1))
+}

--- a/internal/backoff/exponential_test.go
+++ b/internal/backoff/exponential_test.go
@@ -1,0 +1,273 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package backoff
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExponential(t *testing.T) {
+	type backoffAttempt struct {
+		msg            string
+		giveAttempt    uint
+		giveRandResult int64
+		wantBackoff    time.Duration
+	}
+	type testStruct struct {
+		msg string
+
+		giveBase time.Duration
+		giveMin  time.Duration
+		giveMax  time.Duration
+
+		attempts []backoffAttempt
+
+		wantErrors []string
+	}
+	tests := []testStruct{
+		{
+			msg:      "invalid base",
+			giveBase: time.Duration(0),
+			giveMax:  time.Duration(0),
+			giveMin:  time.Duration(0),
+			wantErrors: []string{
+				"invalid base for exponential backoff, need greater than zero",
+			},
+		},
+		{
+			msg:      "invalid min",
+			giveBase: time.Duration(1000),
+			giveMax:  time.Duration(0),
+			giveMin:  time.Duration(-100),
+			wantErrors: []string{
+				"invalid min for exponential backoff, need greater than or equal to zero",
+			},
+		},
+		{
+			msg:      "invalid max & min",
+			giveBase: time.Duration(1000),
+			giveMax:  time.Duration(-1),
+			giveMin:  time.Duration(-100),
+			wantErrors: []string{
+				"invalid min for exponential backoff, need greater than or equal to zero",
+				"invalid max for exponential backoff, need greater than or equal to zero",
+			},
+		},
+		{
+			msg:      "invalid with max less than min",
+			giveBase: time.Duration(1000),
+			giveMax:  time.Millisecond,
+			giveMin:  time.Second,
+			wantErrors: []string{
+				"exponential max value must be greater than min value",
+			},
+		},
+		{
+			msg:      "valid durations",
+			giveBase: time.Nanosecond,
+			giveMax:  time.Nanosecond * 100,
+			giveMin:  time.Duration(0),
+			attempts: []backoffAttempt{
+				{
+					msg:            "zero attempt max backoff",
+					giveAttempt:    0,
+					giveRandResult: int64(1 << 0),
+					wantBackoff:    time.Nanosecond,
+				},
+				{
+					msg:            "zero attempt min backoff",
+					giveAttempt:    0,
+					giveRandResult: 0,
+					wantBackoff:    time.Duration(0),
+				},
+				{
+					msg:            "zero attempt min backoff (with wrapped rand value)",
+					giveAttempt:    0,
+					giveRandResult: int64(1<<0) + 1,
+					wantBackoff:    time.Duration(0),
+				},
+				{
+					msg:            "one attempt max backoff",
+					giveAttempt:    1,
+					giveRandResult: int64(1 << 1),
+					wantBackoff:    time.Nanosecond * 2,
+				},
+				{
+					msg:            "two attempts max backoff",
+					giveAttempt:    2,
+					giveRandResult: int64(1 << 2),
+					wantBackoff:    time.Duration(int64(1 << 2)),
+				},
+				{
+					msg:            "three attempts max backoff",
+					giveAttempt:    3,
+					giveRandResult: int64(1 << 3),
+					wantBackoff:    time.Duration(int64(1 << 3)),
+				},
+				{
+					msg:            "four attempts max backoff",
+					giveAttempt:    4,
+					giveRandResult: int64(1 << 4),
+					wantBackoff:    time.Duration(int64(1 << 4)),
+				},
+				{
+					msg:            "four attempts min backoff (with wrapped rand value)",
+					giveAttempt:    4,
+					giveRandResult: int64(1<<4) + 1,
+					wantBackoff:    time.Duration(0),
+				},
+				{
+					msg:            "attempts range higher than max value",
+					giveAttempt:    30,
+					giveRandResult: 100,
+					wantBackoff:    time.Nanosecond * 100,
+				},
+				{
+					msg:            "attempts range higher than max value (with wrapped rand value)",
+					giveAttempt:    30,
+					giveRandResult: 100 + 1,
+					wantBackoff:    time.Duration(0),
+				},
+				{
+					msg:            "attempts that cause overflows should go to max",
+					giveAttempt:    63, // 1<<63 == -9223372036854775808
+					giveRandResult: 100,
+					wantBackoff:    time.Nanosecond * 100,
+				},
+				{
+					msg:            "attempts that cause overflows should go to max (with wrapped rand)",
+					giveAttempt:    63, // 1<<63 == -9223372036854775808
+					giveRandResult: 100 + 1,
+					wantBackoff:    time.Duration(0),
+				},
+				{
+					msg:            "attempts that go beyond overflows should go to max",
+					giveAttempt:    64, // 1<<64 == 0
+					giveRandResult: 100,
+					wantBackoff:    time.Nanosecond * 100,
+				},
+				{
+					msg:            "attempts that go beyond overflows should go to max (with wrapped rand)",
+					giveAttempt:    64, // 1<<64 == 0
+					giveRandResult: 100 + 1,
+					wantBackoff:    time.Duration(0),
+				},
+				{
+					msg:            "max value with a random value that i choose",
+					giveAttempt:    14,
+					giveRandResult: 68,
+					wantBackoff:    time.Duration(68),
+				},
+			},
+		},
+		{
+			msg:      "valid duration with min",
+			giveBase: time.Nanosecond,
+			giveMax:  time.Nanosecond * 100,
+			giveMin:  time.Nanosecond * 10,
+			attempts: []backoffAttempt{
+				{
+					msg:            "zero attempt max backoff",
+					giveAttempt:    0,
+					giveRandResult: int64(1 << 0),
+					wantBackoff:    time.Nanosecond * 11,
+				},
+				{
+					msg:            "zero attempt min backoff",
+					giveAttempt:    0,
+					giveRandResult: 0,
+					wantBackoff:    time.Nanosecond * 10,
+				},
+				{
+					msg:            "one attempt max backoff",
+					giveAttempt:    1,
+					giveRandResult: int64(1 << 1),
+					wantBackoff:    time.Nanosecond * 12,
+				},
+				{
+					msg:            "two attempts max backoff",
+					giveAttempt:    2,
+					giveRandResult: int64(1 << 2),
+					wantBackoff:    time.Nanosecond * 14,
+				},
+				{
+					msg:            "three attempts max backoff",
+					giveAttempt:    3,
+					giveRandResult: int64(1 << 3),
+					wantBackoff:    time.Nanosecond * 18,
+				},
+				{
+					msg:            "four attempts max backoff",
+					giveAttempt:    4,
+					giveRandResult: int64(1 << 4),
+					wantBackoff:    time.Nanosecond * 26,
+				},
+				{
+					msg:            "four attempts min backoff (with wrapped rand value)",
+					giveAttempt:    4,
+					giveRandResult: int64(1<<4) + 1,
+					wantBackoff:    time.Nanosecond * 10,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			randSrc := &mutableRandSrc{val: 0}
+			exp, err := NewExponential(
+				BaseJump(tt.giveBase),
+				MinBackoff(tt.giveMin),
+				MaxBackoff(tt.giveMax),
+				randGenerator(rand.New(randSrc)),
+			)
+			if err != nil {
+				assert.True(t, len(tt.wantErrors) > 0, "got unexpected error: %s", err.Error())
+				for _, wantErr := range tt.wantErrors {
+					assert.Contains(t, err.Error(), wantErr)
+				}
+				return
+			}
+			require.True(t, len(tt.wantErrors) == 0, "didn't get expected error")
+			for _, attempt := range tt.attempts {
+				randSrc.val = attempt.giveRandResult
+				assert.Equal(t, attempt.wantBackoff, exp.Duration(attempt.giveAttempt), "backoff for backoffAttempt %q did not match", attempt.msg)
+			}
+		})
+	}
+}
+
+// mutableRandSrc implements the rand.Source interface so we can get our random
+// number generator to return whatever we want.
+type mutableRandSrc struct {
+	val int64
+}
+
+func (r *mutableRandSrc) Int63() int64 {
+	return r.val
+}
+
+func (*mutableRandSrc) Seed(int64) {}


### PR DESCRIPTION
Summary: For both connection state (@kriskowal) and retries (myself) we
need an exponential backoff strategy to power these use cases.  This PR
introduces a stateless exponential full jitter backoff strategy that can
be used in both cases and beyond.
(full jitter as defined by: https://www.awsarchitectureblog.com/2015/03/backoff.html)

Test Plan: Wrote tests, had to override the rand number generator.