### PR TITLE
[Retry Middleware][Part 6] Add support for multiple retry "policies"

### DIFF
--- a/internal/retry/policy.go
+++ b/internal/retry/policy.go
@@ -34,9 +34,9 @@ import (
 type PolicyProvider func(context.Context, *transport.Request) *Policy
 
 var defaultPolicy = Policy{
-	retries:         0,
-	timeout:         time.Second,
-	backoffStrategy: ibackoff.None,
+	retries:           0,
+	maxRequestTimeout: time.Second,
+	backoffStrategy:   ibackoff.None,
 }
 
 // Policy defines how a retry will be applied.  It contains all the information
@@ -46,9 +46,10 @@ type Policy struct {
 	// initial attempt.
 	retries uint
 
-	// timeout is the Timeout we will enforce per request (if this
-	// is less than the context deadline, we'll use that instead).
-	timeout time.Duration
+	// maxRequestTimeout is the Timeout we will enforce per request (if this
+	// is more than the context deadline, we'll use the context deadline
+	// instead).
+	maxRequestTimeout time.Duration
 
 	// backoffStrategy is a backoff strategy that will be called after every
 	// retry.
@@ -77,13 +78,13 @@ func Retries(retries uint) PolicyOption {
 	}
 }
 
-// PerRequestTimeout is the Timeout we will enforce per request (if this
+// MaxRequestTimeout is the Timeout we will enforce per request (if this
 // is greater than the context deadline, we'll use that instead).
 //
 // Defaults to 1 second.
-func PerRequestTimeout(timeout time.Duration) PolicyOption {
+func MaxRequestTimeout(timeout time.Duration) PolicyOption {
 	return func(pol *Policy) {
-		pol.timeout = timeout
+		pol.maxRequestTimeout = timeout
 	}
 }
 

--- a/internal/retry/policy.go
+++ b/internal/retry/policy.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package retry
 
 import (

--- a/internal/retry/policy.go
+++ b/internal/retry/policy.go
@@ -1,0 +1,80 @@
+package retry
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/yarpc/api/backoff"
+	"go.uber.org/yarpc/api/transport"
+	ibackoff "go.uber.org/yarpc/internal/backoff"
+)
+
+// PolicyProvider returns a retry policy to use for the request,
+// if no policy is available it should return a default policy.
+type PolicyProvider func(context.Context, *transport.Request) *Policy
+
+var defaultPolicy = Policy{
+	retries:         0,
+	timeout:         time.Second,
+	backoffStrategy: ibackoff.None,
+}
+
+// Policy defines how a retry will be applied.  It contains all the information
+// needed to preform a retry.
+type Policy struct {
+	// retries is the number of attempts we will retry (after the
+	// initial attempt.
+	retries uint
+
+	// timeout is the Timeout we will enforce per request (if this
+	// is less than the context deadline, we'll use that instead).
+	timeout time.Duration
+
+	// backoffStrategy is a backoff strategy that will be called after every
+	// retry.
+	backoffStrategy backoff.Strategy
+}
+
+// NewPolicy creates a new retry Policy that can be used in retry middleware.
+func NewPolicy(opts ...PolicyOption) *Policy {
+	policy := defaultPolicy
+	for _, opt := range opts {
+		opt(&policy)
+	}
+	return &policy
+}
+
+// PolicyOption customizes the behavior of a retry policy.
+type PolicyOption func(*Policy)
+
+// Retries is the number of attempts we will retry (after the
+// initial attempt.
+//
+// Defaults to 1.
+func Retries(retries uint) PolicyOption {
+	return func(pol *Policy) {
+		pol.retries = retries
+	}
+}
+
+// PerRequestTimeout is the Timeout we will enforce per request (if this
+// is less than the context deadline, we'll use that instead).
+//
+// Defaults to 1 second.
+func PerRequestTimeout(timeout time.Duration) PolicyOption {
+	return func(pol *Policy) {
+		pol.timeout = timeout
+	}
+}
+
+// BackoffStrategy sets the backoff strategy that will be used after each
+// failed request.
+//
+// Defaults to no backoff.
+func BackoffStrategy(strategy backoff.Strategy) PolicyOption {
+	return func(pol *Policy) {
+		if strategy != nil {
+			pol.backoffStrategy = strategy
+		}
+	}
+}

--- a/internal/retry/policy.go
+++ b/internal/retry/policy.go
@@ -78,7 +78,7 @@ func Retries(retries uint) PolicyOption {
 }
 
 // PerRequestTimeout is the Timeout we will enforce per request (if this
-// is less than the context deadline, we'll use that instead).
+// is greater than the context deadline, we'll use that instead).
 //
 // Defaults to 1 second.
 func PerRequestTimeout(timeout time.Duration) PolicyOption {

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -24,65 +24,31 @@ import (
 	"context"
 	"time"
 
-	"go.uber.org/yarpc/api/backoff"
 	"go.uber.org/yarpc/api/transport"
-	ibackoff "go.uber.org/yarpc/internal/backoff"
 	"go.uber.org/yarpc/internal/ioutil"
 )
-
-// middlewareOptions enumerates the options for retry middleware.
-type middlewareOptions struct {
-	// Retries is the number of attempts we will retry (after the
-	// initial attempt.
-	retries uint
-
-	// Timeout is the Timeout we will enforce per request (if this
-	// is less than the context deadline, we'll use that instead).
-	timeout time.Duration
-
-	// backoffStrategy is a backoff strategy that will be called after every
-	// retry.
-	backoffStrategy backoff.Strategy
-}
-
-var defaultMiddlewareOptions = middlewareOptions{
-	retries:         0,
-	timeout:         time.Second,
-	backoffStrategy: ibackoff.None,
-}
 
 // MiddlewareOption customizes the behavior of a retry middleware.
 type MiddlewareOption func(*middlewareOptions)
 
-// Retries is the number of attempts we will retry (after the
-// initial attempt.
-//
-// Defaults to 1.
-func Retries(retries uint) MiddlewareOption {
-	return func(options *middlewareOptions) {
-		options.retries = retries
-	}
+// middlewareOptions enumerates the options for retry middleware.
+type middlewareOptions struct {
+	// policyProvider is a function that will provide a Retry policy
+	// for a context and request.
+	policyProvider PolicyProvider
 }
 
-// PerRequestTimeout is the Timeout we will enforce per request (if this
-// is less than the context deadline, we'll use that instead).
-//
-// Defaults to 1 second.
-func PerRequestTimeout(timeout time.Duration) MiddlewareOption {
-	return func(options *middlewareOptions) {
-		options.timeout = timeout
-	}
+var defaultMiddlewareOptions = middlewareOptions{
+	policyProvider: func(context.Context, *transport.Request) *Policy {
+		return &defaultPolicy
+	},
 }
 
-// BackoffStrategy sets the backoff strategy that will be used after each
-// failed request.
-//
-// Defaults to no backoff.
-func BackoffStrategy(strategy backoff.Strategy) MiddlewareOption {
-	return func(options *middlewareOptions) {
-		if strategy != nil {
-			options.backoffStrategy = strategy
-		}
+// WithPolicyProvider allows a custom retry policy to be used in the retry
+// middleware.
+func WithPolicyProvider(provider PolicyProvider) MiddlewareOption {
+	return func(opts *middlewareOptions) {
+		opts.policyProvider = provider
 	}
 }
 
@@ -103,13 +69,14 @@ type OutboundMiddleware struct {
 
 // Call implements the middleware.UnaryOutbound interface.
 func (r *OutboundMiddleware) Call(ctx context.Context, request *transport.Request, out transport.UnaryOutbound) (resp *transport.Response, err error) {
+	policy := r.getPolicy(ctx, request)
 	rereader, finish := ioutil.NewRereader(request.Body)
 	defer finish()
 	request.Body = rereader
-	boff := r.opts.backoffStrategy.Backoff()
+	boff := policy.backoffStrategy.Backoff()
 
-	for i := uint(0); i < r.opts.retries+1; i++ {
-		timeout, _ := getTimeLeft(ctx, r.opts.timeout)
+	for i := uint(0); i < policy.retries+1; i++ {
+		timeout, _ := getTimeLeft(ctx, policy.timeout)
 		subCtx, cancel := context.WithTimeout(ctx, timeout)
 		resp, err = out.Call(subCtx, request)
 		cancel() // Clear the new ctx immdediately after the call
@@ -132,6 +99,16 @@ func (r *OutboundMiddleware) Call(ctx context.Context, request *transport.Reques
 		time.Sleep(boffDur)
 	}
 	return resp, err
+}
+
+func (r *OutboundMiddleware) getPolicy(ctx context.Context, request *transport.Request) *Policy {
+	if r.opts.policyProvider == nil {
+		return &defaultPolicy
+	}
+	if pol := r.opts.policyProvider(ctx, request); pol != nil {
+		return pol
+	}
+	return &defaultPolicy
 }
 
 // getTimeLeft will return the amount of time left in the context or the

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -76,7 +76,7 @@ func (r *OutboundMiddleware) Call(ctx context.Context, request *transport.Reques
 	boff := policy.backoffStrategy.Backoff()
 
 	for i := uint(0); i < policy.retries+1; i++ {
-		timeout, _ := getTimeLeft(ctx, policy.timeout)
+		timeout, _ := getTimeLeft(ctx, policy.maxRequestTimeout)
 		subCtx, cancel := context.WithTimeout(ctx, timeout)
 		resp, err = out.Call(subCtx, request)
 		cancel() // Clear the new ctx immdediately after the call

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -433,9 +433,15 @@ func TestMiddleware(t *testing.T) {
 			}
 
 			retry := NewUnaryMiddleware(
-				Retries(tt.retries),
-				PerRequestTimeout(tt.retrytimeout),
-				BackoffStrategy(tt.retryBackoff),
+				WithPolicyProvider(
+					func(context.Context, *transport.Request) *Policy {
+						return NewPolicy(
+							Retries(tt.retries),
+							PerRequestTimeout(tt.retrytimeout),
+							BackoffStrategy(tt.retryBackoff),
+						)
+					},
+				),
 			)
 
 			ctx := context.Background()

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -437,7 +437,7 @@ func TestMiddleware(t *testing.T) {
 					func(context.Context, *transport.Request) *Policy {
 						return NewPolicy(
 							Retries(tt.retries),
-							PerRequestTimeout(tt.retrytimeout),
+							MaxRequestTimeout(tt.retrytimeout),
 							BackoffStrategy(tt.retryBackoff),
 						)
 					},


### PR DESCRIPTION
Summary: Currently the retry middleware is one size fits all.  This was
partially because we thought we would apply middleware to each outbound
individually.  Unfortunately because we need to apply this middleware
before metrics/logging (which are outbound agnostic) the retry
middleware needs to be applicable to all outbounds with a single
instance.  We can accomplish this by moving the retry options into a
retry.Policy and having the retry Middleware take a "PolicyProvider"
which will determine which policy should be applied for each outbound
(if there's no policy we'll fall back to a default).

This PR refactors the retry middleware to be powered by policies. In the
next PR I'll add a PolicyProvider where we can register service level
policies or procedure level policies.

Test Plan: All the tests still pass.