### PR TITLE
config: Interpolate values for Peer Choosers and Peer Updaters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ v1.9.0-dev (unreleased)
 -   transport/x/grpc: Remove NewInbound and NewSingleOutbound in favor of
     functions on Transport
 -   x/config: Fix bug where embedded struct fields could not be interpolated.
+-   x/config: Fix bug where Chooser and Updater fields could not be interpolated.
 -   Pool inbound thrift request buffers to reduce allocations.
 
 

--- a/x/config/builder.go
+++ b/x/config/builder.go
@@ -25,7 +25,6 @@ import (
 
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/internal/interpolate"
 
 	"go.uber.org/multierr"
 )
@@ -57,19 +56,15 @@ type builder struct {
 	transports map[string]*buildable
 	inbounds   []buildableInbound
 	clients    map[string]*buildableOutbounds
-
-	// Used to resolve interpolated variables.
-	resolver interpolate.VariableResolver
 }
 
-func newBuilder(name string, kit *Kit, resolver interpolate.VariableResolver) *builder {
+func newBuilder(name string, kit *Kit) *builder {
 	return &builder{
 		Name:           name,
 		kit:            kit,
 		needTransports: make(map[string]*compiledTransportSpec),
 		transports:     make(map[string]*buildable),
 		clients:        make(map[string]*buildableOutbounds),
-		resolver:       resolver,
 	}
 }
 
@@ -86,7 +81,7 @@ func (b *builder) Build() (yarpc.Config, error) {
 		var err error
 		if !ok {
 			// No configuration provided for the transport. Use an empty map.
-			cv, err = spec.Transport.Decode(attributeMap{}, interpolateWith(b.resolver))
+			cv, err = spec.Transport.Decode(attributeMap{}, interpolateWith(b.kit.resolver))
 			if err != nil {
 				return yarpc.Config{}, err
 			}
@@ -181,7 +176,7 @@ func buildOnewayOutbound(o *buildableOutbound, t transport.Transport, k *Kit) (t
 }
 
 func (b *builder) AddTransportConfig(spec *compiledTransportSpec, attrs attributeMap) error {
-	cv, err := spec.Transport.Decode(attrs, interpolateWith(b.resolver))
+	cv, err := spec.Transport.Decode(attrs, interpolateWith(b.kit.resolver))
 	if err != nil {
 		return fmt.Errorf("failed to decode transport configuration: %v", err)
 	}
@@ -196,7 +191,7 @@ func (b *builder) AddInboundConfig(spec *compiledTransportSpec, attrs attributeM
 	}
 
 	b.needTransport(spec)
-	cv, err := spec.Inbound.Decode(attrs, interpolateWith(b.resolver))
+	cv, err := spec.Inbound.Decode(attrs, interpolateWith(b.kit.resolver))
 	if err != nil {
 		return fmt.Errorf("failed to decode inbound configuration: %v", err)
 	}
@@ -243,7 +238,7 @@ func (b *builder) AddUnaryOutbound(
 	}
 
 	b.needTransport(spec)
-	cv, err := spec.UnaryOutbound.Decode(attrs, interpolateWith(b.resolver))
+	cv, err := spec.UnaryOutbound.Decode(attrs, interpolateWith(b.kit.resolver))
 	if err != nil {
 		return fmt.Errorf("failed to decode unary outbound configuration: %v", err)
 	}
@@ -266,7 +261,7 @@ func (b *builder) AddOnewayOutbound(
 	}
 
 	b.needTransport(spec)
-	cv, err := spec.OnewayOutbound.Decode(attrs, interpolateWith(b.resolver))
+	cv, err := spec.OnewayOutbound.Decode(attrs, interpolateWith(b.kit.resolver))
 	if err != nil {
 		return fmt.Errorf("failed to decode oneway outbound configuration: %v", err)
 	}

--- a/x/config/chooser.go
+++ b/x/config/chooser.go
@@ -189,7 +189,7 @@ func (pc PeerChooser) buildPeerChooser(transport peer.Transport, identify func(s
 		return nil, err
 	}
 
-	chooserBuilder, err := peerListSpec.PeerList.Decode(peerListConfig)
+	chooserBuilder, err := peerListSpec.PeerList.Decode(peerListConfig, interpolateWith(kit.resolver))
 	if err != nil {
 		return nil, err
 	}
@@ -295,7 +295,7 @@ func buildPeerListUpdater(c attributeMap, identify func(string) peer.Identifier,
 
 	// This decodes all attributes on the peer list updater block, including the
 	// field with the name of the peer list updater.
-	peerListUpdaterBuilder, err := peerListUpdaterSpec.PeerListUpdater.Decode(peerListUpdaterConfig)
+	peerListUpdaterBuilder, err := peerListUpdaterSpec.PeerListUpdater.Decode(peerListUpdaterConfig, interpolateWith(kit.resolver))
 	if err != nil {
 		return nil, err
 	}

--- a/x/config/configurator.go
+++ b/x/config/configurator.go
@@ -213,7 +213,7 @@ func (c *Configurator) NewDispatcher(serviceName string, data interface{}) (*yar
 }
 
 func (c *Configurator) load(serviceName string, cfg *yarpcConfig) (_ yarpc.Config, err error) {
-	b := newBuilder(serviceName, &Kit{name: serviceName, c: c}, c.resolver)
+	b := newBuilder(serviceName, &Kit{name: serviceName, c: c, resolver: c.resolver})
 
 	for _, inbound := range cfg.Inbounds {
 		if e := c.loadInboundInto(b, inbound); e != nil {

--- a/x/config/kit.go
+++ b/x/config/kit.go
@@ -26,6 +26,8 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+
+	"go.uber.org/yarpc/internal/interpolate"
 )
 
 // Kit is an opaque object that carries context for the Configurator. Build
@@ -34,6 +36,9 @@ type Kit struct {
 	c *Configurator
 
 	name string
+
+	// Used to resolve interpolated variables.
+	resolver interpolate.VariableResolver
 
 	// TransportSpec currently being used. This may or may not be set.
 	transportSpec *compiledTransportSpec

--- a/yarpctest/fake_config.go
+++ b/yarpctest/fake_config.go
@@ -68,10 +68,11 @@ func FakeTransportSpec() config.TransportSpec {
 
 // FakePeerListConfig configures the FakePeerList.
 type FakePeerListConfig struct {
+	Nop string `config:"nop,interpolate"`
 }
 
 func buildFakePeerList(c *FakePeerListConfig, t peer.Transport, kit *config.Kit) (peer.ChooserList, error) {
-	return NewFakePeerList(), nil
+	return NewFakePeerList(ListNop(c.Nop)), nil
 }
 
 // FakePeerListSpec returns a configurator spec for the fake-list FakePeerList
@@ -89,6 +90,7 @@ func FakePeerListSpec() config.PeerListSpec {
 // NewFakePeerListUpdater when you build a peer list with this config.
 type FakePeerListUpdaterConfig struct {
 	FakeUpdater string `config:"fake-updater"`
+	Nop         string `config:"nop,interpolate"`
 	Watch       bool   `config:"watch"`
 }
 
@@ -96,6 +98,9 @@ func buildFakePeerListUpdater(c *FakePeerListUpdaterConfig, kit *config.Kit) (pe
 	var opts []FakePeerListUpdaterOption
 	if c.Watch {
 		opts = append(opts, Watch)
+	}
+	if c.Nop != "" {
+		opts = append(opts, UpdaterNop(c.Nop))
 	}
 	return func(pl peer.List) transport.Lifecycle {
 		return NewFakePeerListUpdater(opts...)

--- a/yarpctest/fake_peer_list.go
+++ b/yarpctest/fake_peer_list.go
@@ -29,16 +29,32 @@ import (
 	intsync "go.uber.org/yarpc/internal/sync"
 )
 
+// FakePeerListOption is an option for NewFakePeerList.
+type FakePeerListOption func(*FakePeerList)
+
+// ListNop is a fake option for NewFakePeerList that sets a nop var. It's fake.
+func ListNop(nop string) func(*FakePeerList) {
+	return func(u *FakePeerList) {
+		u.nop = nop
+	}
+}
+
 // FakePeerList is a fake peer list.
 type FakePeerList struct {
 	transport.Lifecycle
+
+	nop string
 }
 
 // NewFakePeerList returns a fake peer list.
-func NewFakePeerList() *FakePeerList {
-	return &FakePeerList{
+func NewFakePeerList(opts ...FakePeerListOption) *FakePeerList {
+	pl := &FakePeerList{
 		Lifecycle: intsync.NewNopLifecycle(),
 	}
+	for _, opt := range opts {
+		opt(pl)
+	}
+	return pl
 }
 
 // Choose pretends to choose a peer, but actually always returns an error. It's fake.
@@ -49,4 +65,9 @@ func (c *FakePeerList) Choose(ctx context.Context, req *transport.Request) (peer
 // Update pretends to add or remove peers.
 func (c *FakePeerList) Update(up peer.ListUpdates) error {
 	return nil
+}
+
+// Nop returns the Peer List's nop variable.
+func (c *FakePeerList) Nop() string {
+	return c.nop
 }

--- a/yarpctest/fake_peer_list_updater.go
+++ b/yarpctest/fake_peer_list_updater.go
@@ -33,11 +33,19 @@ func Watch(u *FakePeerListUpdater) {
 	u.watch = true
 }
 
+// UpdaterNop is a fake option for NewFakePeerListUpdater that sets a nop var. It's fake.
+func UpdaterNop(nop string) func(*FakePeerListUpdater) {
+	return func(u *FakePeerListUpdater) {
+		u.nop = nop
+	}
+}
+
 // FakePeerListUpdater is a fake peer list updater.  It doesn't actually update
 // a peer list.
 type FakePeerListUpdater struct {
 	transport.Lifecycle
 	watch bool
+	nop   string
 }
 
 // NewFakePeerListUpdater returns a new FakePeerListUpdater, applying any
@@ -56,4 +64,9 @@ func NewFakePeerListUpdater(opts ...FakePeerListUpdaterOption) *FakePeerListUpda
 // fake.
 func (u *FakePeerListUpdater) Watch() bool {
 	return u.watch
+}
+
+// Nop returns the nop variable.
+func (u *FakePeerListUpdater) Nop() string {
+	return u.nop
 }


### PR DESCRIPTION
Summary: Discovered that the "interpolate" option in config did not
function for attributes on peer chooser and peer updater configs.  This
pr updates the config code such that interpolation resolver is stored on
the kit, and thus usable when decoding the chooser and updater.

Test Plan: Added the test section first, it failed, then I updated the
code to pass the tests.