### PR TITLE
Add common backoff config

### DIFF
--- a/x/config/backoff.go
+++ b/x/config/backoff.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package config
+
+import (
+	"time"
+
+	backoffapi "go.uber.org/yarpc/api/backoff"
+	"go.uber.org/yarpc/internal/backoff"
+)
+
+// Backoff specifies a backoff strategy, particularly for retries.
+// The only supported strategy at time of writing is "exponential" with full
+// jitter. This structure may be extended in the future to support registering
+// alternate backoff strategies.
+//
+//  exponential:
+//    first: 100ms
+//    max: 30s
+type Backoff struct {
+	Exponential ExponentialBackoff `config:"exponential"`
+}
+
+// Strategy returns a backoff strategy constructor (in terms of the number of
+// attempts already made) and the given configuration, or an error.
+func (c Backoff) Strategy() (backoffapi.Strategy, error) {
+	return c.Exponential.Strategy()
+}
+
+// ExponentialBackoff details the exponential with full jitter backoff
+// strategy.
+// "first" defines the range of possible durations for the first attempt.
+// Each subsequent attempt has twice the range of possible jittered delay
+// duration.
+// The range of possible values will not exceed "max", inclusive.
+//
+//   first: 100ms
+//   max: 30s
+type ExponentialBackoff struct {
+	First time.Duration `config:"first"`
+	Max   time.Duration `config:"max"`
+}
+
+// Strategy returns an exponential backoff strategy (in terms of the number of
+// attempts already made) and the given configuration.
+func (c ExponentialBackoff) Strategy() (backoffapi.Strategy, error) {
+	var opts []backoff.ExponentialOption
+
+	if c.First > 0 {
+		opts = append(opts, backoff.FirstBackoff(c.First))
+	}
+	if c.Max > 0 {
+		opts = append(opts, backoff.MaxBackoff(c.Max))
+	}
+
+	return backoff.NewExponential(opts...)
+}

--- a/x/config/backoff_test.go
+++ b/x/config/backoff_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package config
+
+import (
+	"testing"
+	"time"
+
+	"go.uber.org/yarpc/internal/whitespace"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func TestBackoffConfig(t *testing.T) {
+	type testCase struct {
+		name string
+		give string
+		env  map[string]string
+		want Backoff
+		err  bool
+	}
+
+	tests := []testCase{
+		{
+			name: "empty",
+		},
+		{
+			name: "specified",
+			give: `
+				exponential:
+					first: 1s
+					max: 2s
+			`,
+			want: Backoff{
+				Exponential: ExponentialBackoff{
+					First: time.Second,
+					Max:   2 * time.Second,
+				},
+			},
+		},
+		{
+			name: "bogus",
+			give: `
+				whatevenis: true
+			`,
+			err: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			text := whitespace.Expand(tt.give)
+			var data map[string]interface{}
+			require.NoError(t, yaml.Unmarshal([]byte(text), &data))
+
+			var config Backoff
+			err := decodeInto(&config, data, interpolateWith(mapVariableResolver(tt.env)))
+
+			if err == nil {
+				_, err = config.Strategy()
+			}
+
+			if tt.err {
+				require.NotNil(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, config, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change introduces a configuration struct for backoff strategies, which we can use for connection management in applicable transports, as well as retry policies.

The configuration struct currently only supports exponential backoff but is designed to leave room for registering backoff config specs, in the way we register specs for other things like presets and transports.