### PR TITLE
http: Support connection state management

### DIFF
--- a/transport/http/constants.go
+++ b/transport/http/constants.go
@@ -20,7 +20,11 @@
 
 package http
 
+import "time"
+
 const transportName = "http"
+
+var defaultConnTimeout = 500 * time.Millisecond
 
 // HTTP headers used in requests and responses to send YARPC metadata.
 const (

--- a/transport/http/peer.go
+++ b/transport/http/peer.go
@@ -1,0 +1,156 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package http
+
+import (
+	"net"
+	"time"
+
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/peer/hostport"
+)
+
+type httpPeer struct {
+	*hostport.Peer
+
+	transport *Transport
+	addr      string
+	changed   chan struct{}
+	released  chan struct{}
+	timer     *time.Timer
+}
+
+func newPeer(pid hostport.PeerIdentifier, t *Transport) *httpPeer {
+	// Create a defused timer for later use.
+	timer := time.NewTimer(0)
+	if !timer.Stop() {
+		<-timer.C
+	}
+
+	return &httpPeer{
+		Peer:      hostport.NewPeer(pid, t),
+		transport: t,
+		addr:      pid.Identifier(),
+		changed:   make(chan struct{}, 1),
+		released:  make(chan struct{}, 0),
+		timer:     timer,
+	}
+}
+
+// The HTTP transport polls for whether a peer is available by attempting to
+// connect. The transport does not preserve the connection because HTTP servers
+// may behave oddly if they don't receive a request immediately.
+// Instead, we treat the peer as available until proven otherwise with a fresh
+// connection attempt.
+func (p *httpPeer) isAvailable() bool {
+	// If there's no open connection, we probe by connecting.
+	dialer := &net.Dialer{Timeout: p.transport.connTimeout}
+	conn, err := dialer.Dial("tcp", p.addr)
+	if conn != nil {
+		conn.Close()
+	}
+	if conn != nil && err == nil {
+		return true
+	}
+	return false
+}
+
+func (p *httpPeer) OnDisconnected() {
+	p.Peer.SetStatus(peer.Unavailable)
+
+	// Kick the state change channel (if it hasn't been kicked already).
+	select {
+	case p.changed <- struct{}{}:
+	default:
+	}
+}
+
+func (p *httpPeer) Release() {
+	close(p.released)
+}
+
+func (p *httpPeer) MaintainConn() {
+	var attempts uint
+
+	backoff := p.transport.connBackoffStrategy.Backoff()
+
+	// Wait for start (so we can be certain that we have a channel).
+	<-p.transport.once.Started()
+
+	// Attempt to retain an open connection to each peer so long as it is
+	// retained.
+	for {
+		p.Peer.SetStatus(peer.Connecting)
+		if p.isAvailable() {
+			p.Peer.SetStatus(peer.Available)
+			// Reset on success
+			attempts = 0
+			if !p.waitForChange() {
+				break
+			}
+		} else {
+			p.Peer.SetStatus(peer.Unavailable)
+			// Back-off on fail
+			if !p.sleep(backoff.Duration(attempts)) {
+				break
+			}
+			attempts++
+		}
+	}
+	p.Peer.SetStatus(peer.Unavailable)
+
+	p.transport.connectorsGroup.Done()
+}
+
+// waitForChange waits for the transport to send a peer connection status
+// change notification, but exits early if the transport releases the peer or
+// stops.  waitForChange returns whether it is resuming due to a connection
+// status change event.
+func (p *httpPeer) waitForChange() (changed bool) {
+	// Wait for a connection status change
+	select {
+	case <-p.changed:
+		return true
+	case <-p.released:
+		return false
+	case <-p.transport.once.Stopping():
+		return false
+	}
+}
+
+// sleep waits for a duration, but exits early if the transport releases the
+// peer or stops.  sleep returns whether it successfully waited the entire
+// duration.
+func (p *httpPeer) sleep(delay time.Duration) (completed bool) {
+	p.timer.Reset(delay)
+
+	select {
+	case <-p.timer.C:
+		return true
+	case <-p.released:
+	case <-p.transport.once.Stopping():
+	}
+
+	if !p.timer.Stop() {
+		<-p.timer.C
+	}
+	return false
+}

--- a/transport/http/peer_test.go
+++ b/transport/http/peer_test.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package http_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/backoff"
+	"go.uber.org/yarpc/internal/integrationtest"
+	"go.uber.org/yarpc/peer/hostport"
+	"go.uber.org/yarpc/transport/http"
+
+	"github.com/opentracing/opentracing-go"
+)
+
+func newTransport() peer.Transport {
+	return http.NewTransport(
+		http.Tracer(opentracing.NoopTracer{}),
+		http.KeepAlive(20*time.Millisecond),
+		http.ConnTimeout(time.Millisecond),
+		http.ConnBackoff(backoff.None),
+	)
+}
+
+var spec = integrationtest.TransportSpec{
+	Identify: hostport.Identify,
+	NewServerTransport: func(t *testing.T, addr string) peer.Transport {
+		return newTransport()
+	},
+	NewClientTransport: func(t *testing.T) peer.Transport {
+		return newTransport()
+	},
+	NewUnaryOutbound: func(x peer.Transport, pc peer.Chooser) transport.UnaryOutbound {
+		return x.(*http.Transport).NewOutbound(pc)
+	},
+	NewInbound: func(x peer.Transport, addr string) transport.Inbound {
+		return x.(*http.Transport).NewInbound(addr)
+	},
+	Addr: func(x peer.Transport, ib transport.Inbound) string {
+		return ib.(*http.Inbound).Addr().String()
+	},
+}
+
+func TestHTTPWithRoundRobin(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+
+	permanent, permanentAddr := spec.NewServer(t, ":0")
+	defer permanent.Stop()
+
+	temporary, temporaryAddr := spec.NewServer(t, ":0")
+	defer temporary.Stop()
+
+	// Construct a client with a bank of peers. We will keep one running all
+	// the time. We'll shut one down temporarily.
+	// The round robin peer list should only choose peers that have
+	// successfully connected.
+	client, c := spec.NewClient(t, []string{
+		permanentAddr,
+		temporaryAddr,
+	})
+	defer client.Stop()
+
+	integrationtest.Blast(ctx, t, c)
+
+	// Shut down one task in the peer list.
+	temporary.Stop()
+	// One of these requests may fail since one of the peers has gone down but
+	// the HTTP transport will not know until a request is attempted.
+	integrationtest.Call(ctx, c)
+	integrationtest.Call(ctx, c)
+	// All subsequent should succeed since the peer should be removed on
+	// connection fail.
+	integrationtest.Blast(ctx, t, c)
+
+	// Restore the server on the temporary port.
+	restored, _ := spec.NewServer(t, temporaryAddr)
+	defer restored.Stop()
+	integrationtest.Blast(ctx, t, c)
+}
+
+func TestIntegration(t *testing.T) {
+	spec.Test(t)
+}

--- a/transport/http/transport.go
+++ b/transport/http/transport.go
@@ -26,8 +26,10 @@ import (
 	"sync"
 	"time"
 
+	backoffapi "go.uber.org/yarpc/api/backoff"
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/backoff"
 	intsync "go.uber.org/yarpc/internal/sync"
 	"go.uber.org/yarpc/peer/hostport"
 
@@ -37,6 +39,8 @@ import (
 type transportOptions struct {
 	keepAlive           time.Duration
 	maxIdleConnsPerHost int
+	connTimeout         time.Duration
+	connBackoffStrategy backoffapi.Strategy
 	tracer              opentracing.Tracer
 	buildClient         func(*transportOptions) *http.Client
 }
@@ -44,7 +48,15 @@ type transportOptions struct {
 var defaultTransportOptions = transportOptions{
 	keepAlive:           30 * time.Second,
 	maxIdleConnsPerHost: 2,
+	connTimeout:         defaultConnTimeout,
+	connBackoffStrategy: backoff.DefaultExponential,
 	buildClient:         buildHTTPClient,
+}
+
+func newTransportOptions() transportOptions {
+	options := defaultTransportOptions
+	options.tracer = opentracing.GlobalTracer()
+	return options
 }
 
 // TransportOption customizes the behavior of an HTTP transport.
@@ -74,6 +86,28 @@ func MaxIdleConnsPerHost(i int) TransportOption {
 	}
 }
 
+// ConnTimeout is the time that the transport will wait for a connection attempt.
+// If a peer has been retained by a peer list, connection attempts are
+// performed in a goroutine off the request path.
+//
+// The default is half a second.
+func ConnTimeout(d time.Duration) TransportOption {
+	return func(options *transportOptions) {
+		options.connTimeout = d
+	}
+}
+
+// ConnBackoff specifies the connection backoff strategy for delays between
+// connection attempts for each peer.
+//
+// The default is exponential backoff starting with 10ms fully jittered,
+// doubling each attempt, with a maximum interval of 30s.
+func ConnBackoff(s backoffapi.Strategy) TransportOption {
+	return func(options *transportOptions) {
+		options.connBackoffStrategy = s
+	}
+}
+
 // Tracer configures a tracer for the transport and all its inbounds and
 // outbounds.
 func Tracer(tracer opentracing.Tracer) TransportOption {
@@ -92,17 +126,21 @@ func buildClient(f func(*transportOptions) *http.Client) TransportOption {
 
 // NewTransport creates a new HTTP transport for managing peers and sending requests
 func NewTransport(opts ...TransportOption) *Transport {
-	options := defaultTransportOptions
-	options.tracer = opentracing.GlobalTracer()
+	options := newTransportOptions()
 	for _, opt := range opts {
 		opt(&options)
 	}
+	return options.newTransport()
+}
 
+func (o *transportOptions) newTransport() *Transport {
 	return &Transport{
-		once:   intsync.Once(),
-		client: options.buildClient(&options),
-		peers:  make(map[string]*hostport.Peer),
-		tracer: options.tracer,
+		once:                intsync.Once(),
+		client:              o.buildClient(o),
+		connTimeout:         o.connTimeout,
+		connBackoffStrategy: o.connBackoffStrategy,
+		peers:               make(map[string]*httpPeer),
+		tracer:              o.tracer,
 	}
 }
 
@@ -130,7 +168,11 @@ type Transport struct {
 	once intsync.LifecycleOnce
 
 	client *http.Client
-	peers  map[string]*hostport.Peer
+	peers  map[string]*httpPeer
+
+	connTimeout         time.Duration
+	connBackoffStrategy backoffapi.Strategy
+	connectorsGroup     sync.WaitGroup
 
 	tracer opentracing.Tracer
 }
@@ -147,7 +189,8 @@ func (a *Transport) Start() error {
 // Stop stops the HTTP transport.
 func (a *Transport) Stop() error {
 	return a.once.Stop(func() error {
-		return nil // Nothing to do
+		a.connectorsGroup.Wait()
+		return nil
 	})
 }
 
@@ -175,15 +218,15 @@ func (a *Transport) RetainPeer(pid peer.Identifier, sub peer.Subscriber) (peer.P
 }
 
 // **NOTE** should only be called while the lock write mutex is acquired
-func (a *Transport) getOrCreatePeer(pid hostport.PeerIdentifier) *hostport.Peer {
+func (a *Transport) getOrCreatePeer(pid hostport.PeerIdentifier) *httpPeer {
 	if p, ok := a.peers[pid.Identifier()]; ok {
 		return p
 	}
 
-	p := hostport.NewPeer(pid, a)
-	p.SetStatus(peer.Available)
-
+	p := newPeer(pid, a)
 	a.peers[p.Identifier()] = p
+	a.connectorsGroup.Add(1)
+	go p.MaintainConn()
 
 	return p
 }
@@ -207,6 +250,7 @@ func (a *Transport) ReleasePeer(pid peer.Identifier, sub peer.Subscriber) error 
 
 	if p.NumSubscribers() == 0 {
 		delete(a.peers, pid.Identifier())
+		p.Release()
 	}
 
 	return nil


### PR DESCRIPTION
This change introduces support for HTTP connection state management including the test infrastructure for validating both HTTP and TChannel integrated with a RoundRobin peer list, which is capable of taking peers in and out of rotation based on their connection state.

To ensure mutual coverage, the integration tests are run both in the integrationtest package and in the package under test (http).