### PR TITLE
[WIP] Support enveloped and unenveloped calls based on RPC-Thrift-Envelope

### DIFF
--- a/api/transport/request.go
+++ b/api/transport/request.go
@@ -62,6 +62,10 @@ type Request struct {
 
 	// Request payload.
 	Body io.Reader
+
+	// TransportHeaders are other transport headers that the transport may expose
+	// to the encodings.
+	TransportHeaders map[string]string
 }
 
 // MarshalLogObject implements zap.ObjectMarshaler.

--- a/encoding/thrift/inbound.go
+++ b/encoding/thrift/inbound.go
@@ -63,9 +63,15 @@ func (t thriftUnaryHandler) Handle(ctx context.Context, treq *transport.Request,
 		return err
 	}
 
-	// We disable enveloping if either the client or the transport requires it.
+	enveloped := t.Enveloping
+	if thriftEnvelopeStr, ok := treq.TransportHeaders["Thrift-Envelope"]; ok {
+		// If the request has the Thrift envelope header, we should read it regardless
+		// of the configuration on the local side.
+		enveloped = thriftEnvelopeStr == "true"
+	}
+
 	proto := t.Protocol
-	if !t.Enveloping {
+	if !enveloped {
 		proto = disableEnvelopingProtocol{
 			Protocol: proto,
 			Type:     wire.Call, // we only decode requests

--- a/encoding/thrift/outbound.go
+++ b/encoding/thrift/outbound.go
@@ -193,12 +193,14 @@ func (c thriftClient) CallOneway(ctx context.Context, reqBody envelope.Enveloper
 }
 
 func (c thriftClient) buildTransportRequest(reqBody envelope.Enveloper) (*transport.Request, protocol.Protocol, error) {
+	thriftEnvelope := "true"
 	proto := c.p
 	if !c.Enveloping {
 		proto = disableEnvelopingProtocol{
 			Protocol: proto,
 			Type:     wire.Reply, // we only decode replies with this instance
 		}
+		thriftEnvelope = "false"
 	}
 
 	treq := transport.Request{
@@ -206,6 +208,9 @@ func (c thriftClient) buildTransportRequest(reqBody envelope.Enveloper) (*transp
 		Service:   c.cc.Service(),
 		Encoding:  Encoding,
 		Procedure: procedure.ToName(c.thriftService, reqBody.MethodName()),
+		TransportHeaders: map[string]string{
+			"Thrift-Envelope": thriftEnvelope,
+		},
 	}
 
 	value, err := reqBody.ToWire()

--- a/encoding/thrift/thriftrw-plugin-yarpc/2
+++ b/encoding/thrift/thriftrw-plugin-yarpc/2
@@ -1,0 +1,1 @@
+started script

--- a/internal/examples/thrift-keyvalue/keyvalue/client/main.go
+++ b/internal/examples/thrift-keyvalue/keyvalue/client/main.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 	"time"
 
+	"go.uber.org/yarpc/encoding/thrift"
 	"go.uber.org/yarpc/internal/examples/thrift-keyvalue/keyvalue/kv/keyvalueclient"
 
 	"go.uber.org/yarpc"
@@ -50,6 +51,11 @@ func do() error {
 	flag.StringVar(
 		&outboundName,
 		"outbound", "", "name of the outbound to use (http/tchannel/grpc)",
+	)
+	enveloped := false
+	flag.BoolVar(
+		&enveloped,
+		"enveloped", false, "enable thrift envelopes",
 	)
 
 	flag.Parse()
@@ -89,7 +95,11 @@ func do() error {
 	}
 	defer dispatcher.Stop()
 
-	client := keyvalueclient.New(dispatcher.ClientConfig("keyvalue"))
+	var opts []thrift.ClientOption
+	if enveloped {
+		opts = append(opts, thrift.Enveloped)
+	}
+	client := keyvalueclient.New(dispatcher.ClientConfig("keyvalue"), opts...)
 
 	scanner := bufio.NewScanner(os.Stdin)
 	rootCtx := context.Background()

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -248,6 +248,11 @@ func (o *Outbound) callWithPeer(
 	}
 
 	req.Header = applicationHeaders.ToHTTPHeaders(treq.Headers, nil)
+
+	if thriftEnvelope, ok := treq.TransportHeaders["Thrift-Envelope"]; ok {
+		req.Header.Set("RPC-Thrift-Envelope", thriftEnvelope)
+	}
+
 	ctx, req, span, err := o.withOpentracingSpan(ctx, req, treq, start)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This is a hacked together prototype to address #741.

Combined with https://github.com/yarpc/yab/pull/205, this allows yab and a yarpc-go service to work regardless of whether a request is enveloped or not.

It also allows YARPC services/clients to work regardless of encoding. E.g., without this change, when an enveloped client talks to a non-enveloped server:
```
> ./thrift-keyvalue/keyvalue/client/client -outbound http -enveloped
set test hello
invalidating
cache miss
set "test" = "hello" failed: BadRequest: failed to decode "thrift" request body for procedure "KeyValue::setValue" of service "keyvalue" from caller "keyvalue-client": unknown ttype Type(128)
```

or vice versa:
```
> ./thrift-keyvalue/keyvalue/client/client -outbound http
set test hello
invalidating
cache miss
set "test" = "hello" failed: BadRequest: failed to decode "thrift" request body for procedure "KeyValue::setValue" of service "keyvalue" from caller "keyvalue-client": unexpected EOF
```

With this change, all combinations work fine.

We need to come up with a good approach to pass some information from the encoding to the transport on the request. I added an arbitrary `TransportHeaders map[string]string`, but I'm not sure if that's the right approach. Some other options:

**Explicitly add a new `ThriftEnveloped bool` to the `transport.Request`**
I really don't like this option, since it's leaking an option specific to HTTP+Thrift to the generic transport/encoding agnostic `Request` type.

**Use a custom value in the context**
We could create an internal type that both Thrift and HTTP know about which they can store/get from the context instead of the arbitrary `map[string]string`. Both Thrift + HTTP will take a dependency on this internal type (probably will be in a package like `internal/encoding/thrifthttp`).

I don't dislike this option as much as the first, but it's still a little ugly to split up request-specific options between the `transport.Request` and the `context.Context`. I'd prefer if everything was in a single place.

**Provide a context-like key-value store on transport.Request**
Similar to `TransportHeaders map[string]string` but be more like context (arbitrary key types / value types so our types don't clash).

I think this is probably the best option, it's better than `TransportHeaders`which implies that they will be copied to the `req.Headers` or TChannel transport headers.

**Use a reserved value in transport.Headers**
We could store a value under a reserved key such as`__rpc-Thrift-Envelope__` in the `transport.Headers`. The encoding could set this, and the transport would then look for this and remove it. This avoids adding new APIs to the `transport.Request`, but has some drawbacks:
 - We now introduce reserved values in the application header namespace (which we've so far avoided by prefixing all application headers in HTTP)
 - If a transport does not look for this header, it will send it along (e.g., the TChannel transport would not look for this header and it would end up being sent as a normal application header).

I like the simplicity of this option but it's a workaround rather than a proper fix for the issue.

Fixes #741.