### PR TITLE
[retry Middleware][Part 7] Add concurrent unit test for middleware

### DIFF
--- a/internal/retry/retry_action_test.go
+++ b/internal/retry/retry_action_test.go
@@ -1,0 +1,136 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package retry
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"sync"
+	"testing"
+	"time"
+
+	"go.uber.org/yarpc/api/middleware"
+	"go.uber.org/yarpc/api/transport"
+	. "go.uber.org/yarpc/internal/yarpctest/outboundtest"
+	"go.uber.org/yarpc/yarpctest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// MiddlewareAction is an action applied to a middleware.
+type MiddlewareAction interface {
+	Apply(*testing.T, middleware.UnaryOutbound)
+}
+
+// RequestAction is an Action for sending a request to a
+// unary outbound middleware and asserting on the result.
+type RequestAction struct {
+	msg string
+
+	request    *transport.Request
+	reqTimeout time.Duration
+
+	events []*OutboundEvent
+
+	wantTimeLimit        time.Duration
+	wantError            string
+	wantApplicationError bool
+	wantBody             string
+}
+
+func (r RequestAction) Apply(t *testing.T, mw middleware.UnaryOutbound) {
+	callable := NewOutboundEventCallable(t, r.events)
+	defer callable.Cleanup()
+
+	trans := yarpctest.NewFakeTransport()
+	out := trans.NewOutbound(yarpctest.NewFakePeerList(), yarpctest.OutboundCallOverride(callable.Call))
+	out.Start()
+
+	ctx := context.Background()
+	if r.reqTimeout != 0 {
+		if r.wantTimeLimit == 0 {
+			r.wantTimeLimit = r.reqTimeout + time.Millisecond*10
+		}
+
+		newCtx, cancel := context.WithTimeout(ctx, r.reqTimeout)
+		defer cancel()
+		ctx = newCtx
+	}
+
+	start := time.Now()
+	resp, err := mw.Call(ctx, r.request, out)
+	elapsed := time.Now().Sub(start)
+
+	if r.wantTimeLimit > 0 {
+		assert.True(t, r.wantTimeLimit > elapsed, "execution took to long, wanted %s, took %s", r.wantTimeLimit, elapsed)
+	}
+
+	if r.wantError != "" {
+		assert.EqualError(t, err, r.wantError)
+		require.NotNil(t, resp)
+		assert.Equal(t, r.wantApplicationError, resp.ApplicationError)
+	} else {
+		require.NotNil(t, resp)
+		body, err := ioutil.ReadAll(resp.Body)
+		assert.NoError(t, err)
+		assert.Equal(t, r.wantBody, string(body))
+	}
+}
+
+// ConcurrentAction executes a plan of actions, with a given interval between
+// applying actions, but allowing every action to run concurrently in a
+// goroutine until its independent completion time.
+// The ConcurrentAction allows us to observe overlapping actions.
+type ConcurrentAction struct {
+	Actions []MiddlewareAction
+	Wait    time.Duration
+}
+
+// Apply runs all the ConcurrentAction's actions in goroutines with a delay of `Wait`
+// between each action. Returns when all actions have finished executing
+func (a ConcurrentAction) Apply(t *testing.T, mw middleware.UnaryOutbound) {
+	var wg sync.WaitGroup
+
+	wg.Add(len(a.Actions))
+	for _, action := range a.Actions {
+		go func(ac MiddlewareAction) {
+			defer wg.Done()
+			ac.Apply(t, mw)
+		}(action)
+
+		if a.Wait > 0 {
+			time.Sleep(a.Wait)
+		}
+	}
+
+	wg.Wait()
+}
+
+// ApplyMiddlewareActions runs all the MiddlewareActions on the Unary outbound Middleware
+func ApplyMiddlewareActions(t *testing.T, mw middleware.UnaryOutbound, actions []MiddlewareAction) {
+	for i, action := range actions {
+		t.Run(fmt.Sprintf("action #%d: %T", i, action), func(t *testing.T) {
+			action.Apply(t, mw)
+		})
+	}
+}

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -23,7 +23,6 @@ package retry
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"testing"
 	"time"
 
@@ -32,406 +31,519 @@ import (
 	"go.uber.org/yarpc/internal/errors"
 	iioutil "go.uber.org/yarpc/internal/ioutil"
 	. "go.uber.org/yarpc/internal/yarpctest/outboundtest"
-	"go.uber.org/yarpc/yarpctest"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestMiddleware(t *testing.T) {
 	type testStruct struct {
 		msg string
 
-		request    *transport.Request
-		reqTimeout time.Duration
-
 		retries      uint
 		retrytimeout time.Duration
 		retryBackoff backoff.Strategy
 
-		events []*OutboundEvent
-
-		wantTimeLimit        time.Duration
-		wantError            string
-		wantApplicationError bool
-		wantBody             string
+		actions []MiddlewareAction
 	}
 	tests := []testStruct{
 		{
-			msg: "no retry",
-			request: &transport.Request{
-				Service:   "serv",
-				Procedure: "proc",
-				Body:      bytes.NewBufferString("body"),
-			},
-			reqTimeout:   time.Second,
+			msg:          "no retry",
 			retries:      1,
 			retrytimeout: time.Millisecond * 500,
-			events: []*OutboundEvent{
-				{
-					WantService:   "serv",
-					WantProcedure: "proc",
-					WantBody:      "body",
-					GiveRespBody:  "respbody",
+			actions: []MiddlewareAction{
+				RequestAction{
+					request: &transport.Request{
+						Service:   "serv",
+						Procedure: "proc",
+						Body:      bytes.NewBufferString("body"),
+					},
+					reqTimeout: time.Second,
+					events: []*OutboundEvent{
+						{
+							WantService:   "serv",
+							WantProcedure: "proc",
+							WantBody:      "body",
+							GiveRespBody:  "respbody",
+						},
+					},
+					wantBody: "respbody",
 				},
 			},
-			wantBody: "respbody",
 		},
 		{
-			msg: "single retry",
-			request: &transport.Request{
-				Service:   "serv",
-				Procedure: "proc",
-				Body:      bytes.NewBufferString("body"),
-			},
-			reqTimeout:   time.Second,
+			msg:          "single retry",
 			retries:      1,
 			retrytimeout: time.Millisecond * 500,
-			events: []*OutboundEvent{
-				{
-					WantService:   "serv",
-					WantProcedure: "proc",
-					WantBody:      "body",
-					GiveError:     errors.RemoteUnexpectedError("unknown error"),
-				},
-				{
-					WantService:   "serv",
-					WantProcedure: "proc",
-					WantBody:      "body",
-					GiveRespBody:  "respbody",
+			actions: []MiddlewareAction{
+				RequestAction{
+					request: &transport.Request{
+						Service:   "serv",
+						Procedure: "proc",
+						Body:      bytes.NewBufferString("body"),
+					},
+					reqTimeout: time.Second,
+					events: []*OutboundEvent{
+						{
+							WantService:   "serv",
+							WantProcedure: "proc",
+							WantBody:      "body",
+							GiveError:     errors.RemoteUnexpectedError("unknown error"),
+						},
+						{
+							WantService:   "serv",
+							WantProcedure: "proc",
+							WantBody:      "body",
+							GiveRespBody:  "respbody",
+						},
+					},
+					wantBody: "respbody",
 				},
 			},
-			wantBody: "respbody",
 		},
 		{
-			msg: "multiple retries",
-			request: &transport.Request{
-				Service:   "serv",
-				Procedure: "proc",
-				Body:      bytes.NewBufferString("body"),
-			},
-			reqTimeout:   time.Second,
+			msg:          "multiple retries",
 			retries:      4,
 			retrytimeout: time.Millisecond * 500,
-			events: []*OutboundEvent{
-				{
-					WantService:   "serv",
-					WantProcedure: "proc",
-					WantBody:      "body",
-					GiveError:     errors.RemoteUnexpectedError("unknown error"),
-				},
-				{
-					WantService:   "serv",
-					WantProcedure: "proc",
-					WantBody:      "body",
-					GiveError:     errors.ClientTimeoutError("serv", "proc", time.Millisecond*300),
-				},
-				{
-					WantService:   "serv",
-					WantProcedure: "proc",
-					WantBody:      "body",
-					GiveError:     errors.RemoteTimeoutError("remote timed out"),
-				},
-				{
-					WantService:   "serv",
-					WantProcedure: "proc",
-					WantBody:      "body",
-					GiveError:     errors.RemoteUnexpectedError("unknown error"),
-				},
-				{
-					WantService:   "serv",
-					WantProcedure: "proc",
-					WantBody:      "body",
-					GiveRespBody:  "respbody",
+			actions: []MiddlewareAction{
+				RequestAction{
+					request: &transport.Request{
+						Service:   "serv",
+						Procedure: "proc",
+						Body:      bytes.NewBufferString("body"),
+					},
+					reqTimeout: time.Second,
+					events: []*OutboundEvent{
+						{
+							WantService:   "serv",
+							WantProcedure: "proc",
+							WantBody:      "body",
+							GiveError:     errors.RemoteUnexpectedError("unknown error"),
+						},
+						{
+							WantService:   "serv",
+							WantProcedure: "proc",
+							WantBody:      "body",
+							GiveError:     errors.ClientTimeoutError("serv", "proc", time.Millisecond*300),
+						},
+						{
+							WantService:   "serv",
+							WantProcedure: "proc",
+							WantBody:      "body",
+							GiveError:     errors.RemoteTimeoutError("remote timed out"),
+						},
+						{
+							WantService:   "serv",
+							WantProcedure: "proc",
+							WantBody:      "body",
+							GiveError:     errors.RemoteUnexpectedError("unknown error"),
+						},
+						{
+							WantService:   "serv",
+							WantProcedure: "proc",
+							WantBody:      "body",
+							GiveRespBody:  "respbody",
+						},
+					},
+					wantBody: "respbody",
 				},
 			},
-			wantBody: "respbody",
 		},
 		{
-			msg: "immediate hard failure",
-			request: &transport.Request{
-				Service:   "serv",
-				Procedure: "proc",
-				Body:      bytes.NewBufferString("body"),
-			},
-			reqTimeout:   time.Second,
+			msg:          "immediate hard failure",
 			retries:      1,
 			retrytimeout: time.Millisecond * 500,
-			events: []*OutboundEvent{
-				{
-					WantService:   "serv",
-					WantProcedure: "proc",
-					WantBody:      "body",
-					GiveError:     errors.RemoteBadRequestError("bad request!"),
+			actions: []MiddlewareAction{
+				RequestAction{
+					request: &transport.Request{
+						Service:   "serv",
+						Procedure: "proc",
+						Body:      bytes.NewBufferString("body"),
+					},
+					reqTimeout: time.Second,
+					events: []*OutboundEvent{
+						{
+							WantService:   "serv",
+							WantProcedure: "proc",
+							WantBody:      "body",
+							GiveError:     errors.RemoteBadRequestError("bad request!"),
+						},
+					},
+					wantError: errors.RemoteBadRequestError("bad request!").Error(),
 				},
 			},
-			wantError: errors.RemoteBadRequestError("bad request!").Error(),
 		},
 		{
-			msg: "retry once, then hard failure",
-			request: &transport.Request{
-				Service:   "serv",
-				Procedure: "proc",
-				Body:      bytes.NewBufferString("body"),
-			},
-			reqTimeout:   time.Second,
+			msg:          "retry once, then hard failure",
 			retries:      1,
 			retrytimeout: time.Millisecond * 500,
-			events: []*OutboundEvent{
-				{
-					WantService:   "serv",
-					WantProcedure: "proc",
-					WantBody:      "body",
-					GiveError:     errors.RemoteUnexpectedError("unknown error"),
-				},
-				{
-					WantService:   "serv",
-					WantProcedure: "proc",
-					WantBody:      "body",
-					GiveError:     errors.RemoteBadRequestError("bad request!"),
+			actions: []MiddlewareAction{
+				RequestAction{
+					request: &transport.Request{
+						Service:   "serv",
+						Procedure: "proc",
+						Body:      bytes.NewBufferString("body"),
+					},
+					reqTimeout: time.Second,
+					events: []*OutboundEvent{
+						{
+							WantService:   "serv",
+							WantProcedure: "proc",
+							WantBody:      "body",
+							GiveError:     errors.RemoteUnexpectedError("unknown error"),
+						},
+						{
+							WantService:   "serv",
+							WantProcedure: "proc",
+							WantBody:      "body",
+							GiveError:     errors.RemoteBadRequestError("bad request!"),
+						},
+					},
+					wantError: errors.RemoteBadRequestError("bad request!").Error(),
 				},
 			},
-			wantError: errors.RemoteBadRequestError("bad request!").Error(),
 		},
 		{
-			msg: "ctx timeout less than retry timeout",
-			request: &transport.Request{
-				Service:   "serv",
-				Procedure: "proc",
-				Body:      bytes.NewBufferString("body"),
-			},
-			reqTimeout:   time.Millisecond * 300,
+			msg:          "ctx timeout less than retry timeout",
 			retries:      1,
 			retrytimeout: time.Millisecond * 500,
-			events: []*OutboundEvent{
-				{
-					WantTimeout:   time.Millisecond * 300,
-					WantService:   "serv",
-					WantProcedure: "proc",
-					WantBody:      "body",
-					GiveRespBody:  "respbody",
+			actions: []MiddlewareAction{
+				RequestAction{
+					request: &transport.Request{
+						Service:   "serv",
+						Procedure: "proc",
+						Body:      bytes.NewBufferString("body"),
+					},
+					reqTimeout: time.Millisecond * 300,
+					events: []*OutboundEvent{
+						{
+							WantTimeout:   time.Millisecond * 300,
+							WantService:   "serv",
+							WantProcedure: "proc",
+							WantBody:      "body",
+							GiveRespBody:  "respbody",
+						},
+					},
+					wantBody: "respbody",
 				},
 			},
-			wantBody: "respbody",
 		},
 		{
-			msg: "ctx timeout less than retry timeout",
-			request: &transport.Request{
-				Service:   "serv",
-				Procedure: "proc",
-				Body:      bytes.NewBufferString("body"),
-			},
-			reqTimeout:   time.Millisecond * 75,
+			msg:          "ctx timeout less than retry timeout",
 			retries:      1,
 			retrytimeout: time.Millisecond * 50,
-			events: []*OutboundEvent{
-				{
-					WantTimeout:    time.Millisecond * 50,
-					WantService:    "serv",
-					WantProcedure:  "proc",
-					WantBody:       "body",
-					WaitForTimeout: true,
-					GiveError:      errors.ClientTimeoutError("serv", "proc", time.Millisecond*50),
-				},
-				{
-					WantTimeout:   time.Millisecond * 25,
-					WantService:   "serv",
-					WantProcedure: "proc",
-					WantBody:      "body",
-					GiveRespBody:  "respbody",
+			actions: []MiddlewareAction{
+				RequestAction{
+					request: &transport.Request{
+						Service:   "serv",
+						Procedure: "proc",
+						Body:      bytes.NewBufferString("body"),
+					},
+					reqTimeout: time.Millisecond * 75,
+					events: []*OutboundEvent{
+						{
+							WantTimeout:    time.Millisecond * 50,
+							WantService:    "serv",
+							WantProcedure:  "proc",
+							WantBody:       "body",
+							WaitForTimeout: true,
+							GiveError:      errors.ClientTimeoutError("serv", "proc", time.Millisecond*50),
+						},
+						{
+							WantTimeout:   time.Millisecond * 25,
+							WantService:   "serv",
+							WantProcedure: "proc",
+							WantBody:      "body",
+							GiveRespBody:  "respbody",
+						},
+					},
+					wantBody: "respbody",
 				},
 			},
-			wantBody: "respbody",
 		},
 		{
-			msg: "no ctx timeout",
-			request: &transport.Request{
-				Service:   "serv",
-				Procedure: "proc",
-				Body:      bytes.NewBufferString("body"),
-			},
+			msg:          "no ctx timeout",
 			retries:      1,
 			retrytimeout: time.Millisecond * 50,
-			events: []*OutboundEvent{
-				{
-					WantTimeout:    time.Millisecond * 50,
-					WantService:    "serv",
-					WantProcedure:  "proc",
-					WantBody:       "body",
-					WaitForTimeout: true,
-					GiveError:      errors.ClientTimeoutError("serv", "proc", time.Millisecond*50),
-				},
-				{
-					WantTimeout:   time.Millisecond * 50,
-					WantService:   "serv",
-					WantProcedure: "proc",
-					WantBody:      "body",
-					GiveRespBody:  "respbody",
+			actions: []MiddlewareAction{
+				RequestAction{
+					request: &transport.Request{
+						Service:   "serv",
+						Procedure: "proc",
+						Body:      bytes.NewBufferString("body"),
+					},
+					events: []*OutboundEvent{
+						{
+							WantTimeout:    time.Millisecond * 50,
+							WantService:    "serv",
+							WantProcedure:  "proc",
+							WantBody:       "body",
+							WaitForTimeout: true,
+							GiveError:      errors.ClientTimeoutError("serv", "proc", time.Millisecond*50),
+						},
+						{
+							WantTimeout:   time.Millisecond * 50,
+							WantService:   "serv",
+							WantProcedure: "proc",
+							WantBody:      "body",
+							GiveRespBody:  "respbody",
+						},
+					},
+					wantBody: "respbody",
 				},
 			},
-			wantBody: "respbody",
 		},
 		{
-			msg: "exhaust retries",
-			request: &transport.Request{
-				Service:   "serv",
-				Procedure: "proc",
-				Body:      bytes.NewBufferString("body"),
-			},
-			reqTimeout:   time.Millisecond * 400,
+			msg:          "exhaust retries",
 			retries:      1,
 			retrytimeout: time.Millisecond * 50,
-			events: []*OutboundEvent{
-				{
-					WantTimeout:   time.Millisecond * 50,
-					WantService:   "serv",
-					WantProcedure: "proc",
-					WantBody:      "body",
-					GiveError:     errors.RemoteUnexpectedError("unexpected error 1"),
-				},
-				{
-					WantTimeout:   time.Millisecond * 50,
-					WantService:   "serv",
-					WantProcedure: "proc",
-					WantBody:      "body",
-					GiveError:     errors.RemoteUnexpectedError("unexpected error 2"),
+			actions: []MiddlewareAction{
+				RequestAction{
+					request: &transport.Request{
+						Service:   "serv",
+						Procedure: "proc",
+						Body:      bytes.NewBufferString("body"),
+					},
+					reqTimeout: time.Millisecond * 400,
+					events: []*OutboundEvent{
+						{
+							WantTimeout:   time.Millisecond * 50,
+							WantService:   "serv",
+							WantProcedure: "proc",
+							WantBody:      "body",
+							GiveError:     errors.RemoteUnexpectedError("unexpected error 1"),
+						},
+						{
+							WantTimeout:   time.Millisecond * 50,
+							WantService:   "serv",
+							WantProcedure: "proc",
+							WantBody:      "body",
+							GiveError:     errors.RemoteUnexpectedError("unexpected error 2"),
+						},
+					},
+					wantError: errors.RemoteUnexpectedError("unexpected error 2").Error(),
 				},
 			},
-			wantError: errors.RemoteUnexpectedError("unexpected error 2").Error(),
 		},
 		{
-			msg: "Reset Error",
-			request: &transport.Request{
-				Service:   "serv",
-				Procedure: "proc",
-				Body:      bytes.NewBufferString("body"),
-			},
-			reqTimeout:   time.Millisecond * 400,
+			msg:          "Reset Error",
 			retries:      1,
 			retrytimeout: time.Millisecond * 50,
-			events: []*OutboundEvent{
-				{
-					WantTimeout:   time.Millisecond * 50,
-					WantService:   "serv",
-					WantProcedure: "proc",
-					// We have explicitly not read the body, which will not exhaust the
-					// req body io.Reader.
-					GiveError: errors.RemoteUnexpectedError("unexpected error 1"),
+			actions: []MiddlewareAction{
+				RequestAction{
+					request: &transport.Request{
+						Service:   "serv",
+						Procedure: "proc",
+						Body:      bytes.NewBufferString("body"),
+					},
+					reqTimeout: time.Millisecond * 400,
+					events: []*OutboundEvent{
+						{
+							WantTimeout:   time.Millisecond * 50,
+							WantService:   "serv",
+							WantProcedure: "proc",
+							// We have explicitly not read the body, which will not exhaust the
+							// req body io.Reader.
+							GiveError: errors.RemoteUnexpectedError("unexpected error 1"),
+						},
+					},
+					wantError: iioutil.ErrReset.Error(),
 				},
 			},
-			wantError: iioutil.ErrReset.Error(),
 		},
 		{
-			msg: "backoff timeout",
-			request: &transport.Request{
-				Service:   "serv",
-				Procedure: "proc",
-				Body:      bytes.NewBufferString("body"),
-			},
-			reqTimeout:   time.Millisecond * 100,
+			msg:          "backoff timeout",
 			retries:      1,
 			retrytimeout: time.Millisecond * 50,
 			retryBackoff: newFixedBackoff(time.Millisecond * 25),
-			events: []*OutboundEvent{
-				{
-					WantTimeout:    time.Millisecond * 50,
-					WantService:    "serv",
-					WantProcedure:  "proc",
-					WantBody:       "body",
-					WaitForTimeout: true,
-					GiveError:      errors.ClientTimeoutError("serv", "proc", time.Millisecond*50),
-				},
-				{
-					WantTimeout:   time.Millisecond * 25,
-					WantService:   "serv",
-					WantProcedure: "proc",
-					WantBody:      "body",
-					GiveRespBody:  "respbody",
+			actions: []MiddlewareAction{
+				RequestAction{
+					request: &transport.Request{
+						Service:   "serv",
+						Procedure: "proc",
+						Body:      bytes.NewBufferString("body"),
+					},
+					reqTimeout: time.Millisecond * 100,
+					events: []*OutboundEvent{
+						{
+							WantTimeout:    time.Millisecond * 50,
+							WantService:    "serv",
+							WantProcedure:  "proc",
+							WantBody:       "body",
+							WaitForTimeout: true,
+							GiveError:      errors.ClientTimeoutError("serv", "proc", time.Millisecond*50),
+						},
+						{
+							WantTimeout:   time.Millisecond * 25,
+							WantService:   "serv",
+							WantProcedure: "proc",
+							WantBody:      "body",
+							GiveRespBody:  "respbody",
+						},
+					},
+					wantBody: "respbody",
 				},
 			},
-			wantBody: "respbody",
 		},
 		{
-			msg: "sequential backoff timeout",
-			request: &transport.Request{
-				Service:   "serv",
-				Procedure: "proc",
-				Body:      bytes.NewBufferString("body"),
-			},
-			reqTimeout:   time.Millisecond * 400,
+			msg:          "sequential backoff timeout",
 			retries:      2,
 			retrytimeout: time.Millisecond * 100,
 			retryBackoff: newSequentialBackoff(time.Millisecond * 50),
-			events: []*OutboundEvent{
-				{
-					WantTimeout:       time.Millisecond * 100,
-					WantTimeoutBounds: time.Millisecond * 20,
-					WantService:       "serv",
-					WantProcedure:     "proc",
-					WantBody:          "body",
-					WaitForTimeout:    true,
-					GiveError:         errors.ClientTimeoutError("serv", "proc", time.Millisecond*50),
-				},
-				{
-					WantTimeout:       time.Millisecond * 100,
-					WantTimeoutBounds: time.Millisecond * 20,
-					WantService:       "serv",
-					WantProcedure:     "proc",
-					WantBody:          "body",
-					WaitForTimeout:    true,
-					GiveError:         errors.ClientTimeoutError("serv", "proc", time.Millisecond*50),
-				},
-				{
-					WantTimeout:       time.Millisecond * 50,
-					WantTimeoutBounds: time.Millisecond * 20,
-					WantService:       "serv",
-					WantProcedure:     "proc",
-					WantBody:          "body",
-					GiveRespBody:      "respbody",
+			actions: []MiddlewareAction{
+				RequestAction{
+					request: &transport.Request{
+						Service:   "serv",
+						Procedure: "proc",
+						Body:      bytes.NewBufferString("body"),
+					},
+					reqTimeout: time.Millisecond * 400,
+					events: []*OutboundEvent{
+						{
+							WantTimeout:       time.Millisecond * 100,
+							WantTimeoutBounds: time.Millisecond * 20,
+							WantService:       "serv",
+							WantProcedure:     "proc",
+							WantBody:          "body",
+							WaitForTimeout:    true,
+							GiveError:         errors.ClientTimeoutError("serv", "proc", time.Millisecond*50),
+						},
+						{
+							WantTimeout:       time.Millisecond * 100,
+							WantTimeoutBounds: time.Millisecond * 20,
+							WantService:       "serv",
+							WantProcedure:     "proc",
+							WantBody:          "body",
+							WaitForTimeout:    true,
+							GiveError:         errors.ClientTimeoutError("serv", "proc", time.Millisecond*50),
+						},
+						{
+							WantTimeout:       time.Millisecond * 50,
+							WantTimeoutBounds: time.Millisecond * 20,
+							WantService:       "serv",
+							WantProcedure:     "proc",
+							WantBody:          "body",
+							GiveRespBody:      "respbody",
+						},
+					},
+					wantBody: "respbody",
 				},
 			},
-			wantBody: "respbody",
 		},
 		{
-			msg: "backoff context will timeout",
-			request: &transport.Request{
-				Service:   "serv",
-				Procedure: "proc",
-				Body:      bytes.NewBufferString("body"),
-			},
-			reqTimeout:   time.Millisecond * 60,
+			msg:          "backoff context will timeout",
 			retries:      2,
 			retrytimeout: time.Millisecond * 30,
 			retryBackoff: newFixedBackoff(time.Millisecond * 5000),
-			events: []*OutboundEvent{
-				{
-					WantTimeout:       time.Millisecond * 30,
-					WantTimeoutBounds: time.Millisecond * 10,
-					WantService:       "serv",
-					WantProcedure:     "proc",
-					WantBody:          "body",
-					WaitForTimeout:    true,
-					GiveError:         errors.RemoteUnexpectedError("unexpected error 2"),
+			actions: []MiddlewareAction{
+				RequestAction{
+					request: &transport.Request{
+						Service:   "serv",
+						Procedure: "proc",
+						Body:      bytes.NewBufferString("body"),
+					},
+					reqTimeout: time.Millisecond * 60,
+					events: []*OutboundEvent{
+						{
+							WantTimeout:       time.Millisecond * 30,
+							WantTimeoutBounds: time.Millisecond * 10,
+							WantService:       "serv",
+							WantProcedure:     "proc",
+							WantBody:          "body",
+							WaitForTimeout:    true,
+							GiveError:         errors.RemoteUnexpectedError("unexpected error 2"),
+						},
+					},
+					wantTimeLimit: time.Millisecond * 40,
+					wantError:     errors.RemoteUnexpectedError("unexpected error 2").Error(),
 				},
 			},
-			wantTimeLimit: time.Millisecond * 40,
-			wantError:     errors.RemoteUnexpectedError("unexpected error 2").Error(),
+		},
+		{
+			msg:          "concurrent retries",
+			retries:      2,
+			retrytimeout: time.Millisecond * 50,
+			retryBackoff: newFixedBackoff(time.Millisecond * 25),
+			actions: []MiddlewareAction{
+				ConcurrentAction{
+					Actions: []MiddlewareAction{
+						RequestAction{
+							request: &transport.Request{
+								Service:   "serv",
+								Procedure: "proc",
+								Body:      bytes.NewBufferString("body"),
+							},
+							reqTimeout: time.Millisecond * 100,
+							events: []*OutboundEvent{
+								{
+									WantTimeout:    time.Millisecond * 50,
+									WantService:    "serv",
+									WantProcedure:  "proc",
+									WantBody:       "body",
+									WaitForTimeout: true,
+									GiveError:      errors.ClientTimeoutError("serv", "proc", time.Millisecond*50),
+								},
+								{
+									WantTimeout:   time.Millisecond * 25,
+									WantService:   "serv",
+									WantProcedure: "proc",
+									WantBody:      "body",
+									GiveRespBody:  "respbody",
+								},
+							},
+							wantBody: "respbody",
+						},
+						RequestAction{
+							request: &transport.Request{
+								Service:   "serv2",
+								Procedure: "proc2",
+								Body:      bytes.NewBufferString("body2"),
+							},
+							reqTimeout: time.Second,
+							events: []*OutboundEvent{
+								{
+									WantTimeout:   time.Millisecond * 50,
+									WantService:   "serv2",
+									WantProcedure: "proc2",
+									WantBody:      "body2",
+									GiveError:     errors.RemoteBadRequestError("bad request!"),
+								},
+							},
+							wantError: errors.RemoteBadRequestError("bad request!").Error(),
+						},
+						RequestAction{
+							request: &transport.Request{
+								Service:   "serv3",
+								Procedure: "proc3",
+								Body:      bytes.NewBufferString("body3"),
+							},
+							reqTimeout: time.Millisecond * 100,
+							events: []*OutboundEvent{
+								{
+									WantTimeout:    time.Millisecond * 50,
+									WantService:    "serv3",
+									WantProcedure:  "proc3",
+									WantBody:       "body3",
+									WaitForTimeout: true,
+									GiveError:      errors.ClientTimeoutError("serv3", "proc3", time.Millisecond*50),
+								},
+								{
+									WantTimeout:    time.Millisecond * 25,
+									WantService:    "serv3",
+									WantProcedure:  "proc3",
+									WantBody:       "body3",
+									GiveRespBody:   "respbody",
+									WaitForTimeout: true,
+									GiveError:      errors.ClientTimeoutError("serv3", "proc3", time.Millisecond*25),
+								},
+							},
+							wantError: errors.ClientTimeoutError("serv3", "proc3", time.Millisecond*25).Error(),
+						},
+					},
+				},
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.msg, func(t *testing.T) {
-			callable := NewOutboundEventCallable(t, tt.events)
-			defer callable.Cleanup()
-
-			trans := yarpctest.NewFakeTransport()
-			out := trans.NewOutbound(yarpctest.NewFakePeerList(), yarpctest.OutboundCallOverride(callable.Call))
-			out.Start()
-
-			if tt.wantTimeLimit == 0 {
-				tt.wantTimeLimit = tt.reqTimeout + time.Millisecond*10
-			}
-
 			retry := NewUnaryMiddleware(
 				WithPolicyProvider(
 					func(context.Context, *transport.Request) *Policy {
@@ -444,31 +556,7 @@ func TestMiddleware(t *testing.T) {
 				),
 			)
 
-			ctx := context.Background()
-			if tt.reqTimeout != 0 {
-				newCtx, cancel := context.WithTimeout(ctx, tt.reqTimeout)
-				defer cancel()
-				ctx = newCtx
-			}
-
-			start := time.Now()
-			resp, err := retry.Call(ctx, tt.request, out)
-			elapsed := time.Now().Sub(start)
-
-			if tt.reqTimeout > 0 {
-				assert.True(t, tt.wantTimeLimit > elapsed, "execution took to long, wanted %s, took %s", tt.wantTimeLimit, elapsed)
-			}
-
-			if tt.wantError != "" {
-				assert.EqualError(t, err, tt.wantError)
-				require.NotNil(t, resp)
-				assert.Equal(t, tt.wantApplicationError, resp.ApplicationError)
-			} else {
-				require.NotNil(t, resp)
-				body, err := ioutil.ReadAll(resp.Body)
-				assert.NoError(t, err)
-				assert.Equal(t, tt.wantBody, string(body))
-			}
+			ApplyMiddlewareActions(t, retry, tt.actions)
 		})
 	}
 }


### PR DESCRIPTION
Summary: This diff is part of a refactor I made to the retry middleware
tests.  It formalizes the "request" structure we were using to test
outbound middleware by pulling it into the "action" pattern we've used
around the codebase. With this action pattern I could add a
"ConcurrentAction" which I use to ensure that the retry middleware works
with concurrent callers (and I'll be able to use this in my future pr
to assert that if we have multiple policies they will work
independently).

Test Plan: mostly refactor, tests still pass