### PR TITLE
[Retry Middleware][Part 8] PolicyProvider for registering retry Policies

### DIFF
--- a/internal/retry/policyprovider.go
+++ b/internal/retry/policyprovider.go
@@ -27,8 +27,8 @@ import (
 )
 
 type serviceProcedure struct {
-	service   string
-	procedure string
+	Service   string
+	Procedure string
 }
 
 // procedurePolicyProvider is a new PolicyProvider that
@@ -39,7 +39,6 @@ type serviceProcedure struct {
 // to specify the default retry policy.
 type procedurePolicyProvider struct {
 	serviceProcedureToPolicy map[serviceProcedure]*Policy
-	serviceToPolicy          map[string]*Policy
 	defaultPolicy            *Policy
 }
 
@@ -47,24 +46,20 @@ func newProcedurePolicyProvider() *procedurePolicyProvider {
 	defaultCopy := defaultPolicy
 	return &procedurePolicyProvider{
 		serviceProcedureToPolicy: make(map[serviceProcedure]*Policy),
-		serviceToPolicy:          make(map[string]*Policy),
 		defaultPolicy:            &defaultCopy,
 	}
 }
 
-func (ppp *procedurePolicyProvider) registerServiceProcedure(service, procedure string, pol *Policy) *procedurePolicyProvider {
+func (ppp *procedurePolicyProvider) registerServiceProcedure(service, procedure string, pol *Policy) {
 	ppp.serviceProcedureToPolicy[serviceProcedure{service, procedure}] = pol
-	return ppp
 }
 
-func (ppp *procedurePolicyProvider) registerService(service string, pol *Policy) *procedurePolicyProvider {
-	ppp.serviceToPolicy[service] = pol
-	return ppp
+func (ppp *procedurePolicyProvider) registerService(service string, pol *Policy) {
+	ppp.serviceProcedureToPolicy[serviceProcedure{Service: service}] = pol
 }
 
-func (ppp *procedurePolicyProvider) registerDefault(pol *Policy) *procedurePolicyProvider {
+func (ppp *procedurePolicyProvider) registerDefault(pol *Policy) {
 	ppp.defaultPolicy = pol
-	return ppp
 }
 
 // GetPolicy returns a policy for the provided context and request.
@@ -72,7 +67,7 @@ func (ppp *procedurePolicyProvider) GetPolicy(_ context.Context, req *transport.
 	if pol, ok := ppp.serviceProcedureToPolicy[serviceProcedure{req.Service, req.Procedure}]; ok {
 		return pol
 	}
-	if pol, ok := ppp.serviceToPolicy[req.Service]; ok {
+	if pol, ok := ppp.serviceProcedureToPolicy[serviceProcedure{Service: req.Service}]; ok {
 		return pol
 	}
 	return ppp.defaultPolicy

--- a/internal/retry/policyprovider.go
+++ b/internal/retry/policyprovider.go
@@ -51,7 +51,7 @@ func newProcedurePolicyProvider() *procedurePolicyProvider {
 }
 
 func (ppp *procedurePolicyProvider) registerServiceProcedure(service, procedure string, pol *Policy) {
-	ppp.serviceProcedureToPolicy[serviceProcedure{service, procedure}] = pol
+	ppp.serviceProcedureToPolicy[serviceProcedure{Service: service, Procedure: procedure}] = pol
 }
 
 func (ppp *procedurePolicyProvider) registerService(service string, pol *Policy) {

--- a/internal/retry/policyprovider.go
+++ b/internal/retry/policyprovider.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package retry
+
+import (
+	"context"
+
+	"go.uber.org/yarpc/api/transport"
+)
+
+type serviceProcedure struct {
+	service   string
+	procedure string
+}
+
+// newProcedurePolicyProvider creates a new PolicyProvider that
+// has the ability to convert a context and transport request to
+// determine which retry policy to use.
+// The PolicyProvider has the ability to register policies based
+// on service and procedure attributes.  It also has the ability
+// to specify the default retry policy.
+func newProcedurePolicyProvider() *procedurePolicyProvider {
+	return &procedurePolicyProvider{
+		serviceProcedureToPolicy: make(map[serviceProcedure]*Policy),
+		serviceToPolicy:          make(map[string]*Policy),
+		defaultPolicy:            &defaultPolicy,
+	}
+}
+
+type procedurePolicyProvider struct {
+	serviceProcedureToPolicy map[serviceProcedure]*Policy
+	serviceToPolicy          map[string]*Policy
+	defaultPolicy            *Policy
+}
+
+func (ppp *procedurePolicyProvider) registerServiceProcedure(service, procedure string, pol *Policy) *procedurePolicyProvider {
+	sp := serviceProcedure{
+		service:   service,
+		procedure: procedure,
+	}
+	ppp.serviceProcedureToPolicy[sp] = pol
+	return ppp
+}
+
+func (ppp *procedurePolicyProvider) registerService(service string, pol *Policy) *procedurePolicyProvider {
+	ppp.serviceToPolicy[service] = pol
+	return ppp
+}
+
+func (ppp *procedurePolicyProvider) registerDefault(pol *Policy) *procedurePolicyProvider {
+	ppp.defaultPolicy = pol
+	return ppp
+}
+
+// GetPolicy returns a policy for the provided context and request.
+func (ppp *procedurePolicyProvider) GetPolicy(_ context.Context, req *transport.Request) *Policy {
+	sp := serviceProcedure{
+		service:   req.Service,
+		procedure: req.Procedure,
+	}
+	if pol, ok := ppp.serviceProcedureToPolicy[sp]; ok {
+		return pol
+	}
+	if pol, ok := ppp.serviceToPolicy[req.Service]; ok {
+		return pol
+	}
+	return ppp.defaultPolicy
+}

--- a/internal/retry/retry_action_test.go
+++ b/internal/retry/retry_action_test.go
@@ -90,9 +90,10 @@ func (r RequestAction) Apply(t *testing.T, mw middleware.UnaryOutbound) {
 		require.NotNil(t, resp)
 		assert.Equal(t, r.wantApplicationError, resp.ApplicationError)
 	} else {
-		require.NotNil(t, resp)
-		body, err := ioutil.ReadAll(resp.Body)
 		assert.NoError(t, err)
+		require.NotNil(t, resp)
+		body, decodeErr := ioutil.ReadAll(resp.Body)
+		assert.NoError(t, decodeErr)
 		assert.Equal(t, r.wantBody, string(body))
 	}
 }

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -22,7 +22,6 @@ package retry
 
 import (
 	"bytes"
-	"context"
 	"testing"
 	"time"
 
@@ -38,17 +37,19 @@ func TestMiddleware(t *testing.T) {
 	type testStruct struct {
 		msg string
 
-		retries      uint
-		retryTimeout time.Duration
-		retryBackoff backoff.Strategy
+		policyProvider *procedurePolicyProvider
 
 		actions []MiddlewareAction
 	}
 	tests := []testStruct{
 		{
-			msg:          "no retry",
-			retries:      1,
-			retryTimeout: testtime.Millisecond * 500,
+			msg: "no retry",
+			policyProvider: newProcedurePolicyProvider().registerDefault(
+				NewPolicy(
+					Retries(1),
+					MaxRequestTimeout(time.Millisecond*500),
+				),
+			),
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -70,9 +71,13 @@ func TestMiddleware(t *testing.T) {
 			},
 		},
 		{
-			msg:          "single retry",
-			retries:      1,
-			retryTimeout: testtime.Millisecond * 500,
+			msg: "single retry",
+			policyProvider: newProcedurePolicyProvider().registerDefault(
+				NewPolicy(
+					Retries(1),
+					MaxRequestTimeout(time.Millisecond*500),
+				),
+			),
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -100,9 +105,13 @@ func TestMiddleware(t *testing.T) {
 			},
 		},
 		{
-			msg:          "multiple retries",
-			retries:      4,
-			retryTimeout: testtime.Millisecond * 500,
+			msg: "multiple retries",
+			policyProvider: newProcedurePolicyProvider().registerDefault(
+				NewPolicy(
+					Retries(4),
+					MaxRequestTimeout(time.Millisecond*500),
+				),
+			),
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -148,9 +157,13 @@ func TestMiddleware(t *testing.T) {
 			},
 		},
 		{
-			msg:          "immediate hard failure",
-			retries:      1,
-			retryTimeout: testtime.Millisecond * 500,
+			msg: "immediate hard failure",
+			policyProvider: newProcedurePolicyProvider().registerDefault(
+				NewPolicy(
+					Retries(1),
+					MaxRequestTimeout(time.Millisecond*500),
+				),
+			),
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -172,9 +185,13 @@ func TestMiddleware(t *testing.T) {
 			},
 		},
 		{
-			msg:          "retry once, then hard failure",
-			retries:      1,
-			retryTimeout: testtime.Millisecond * 500,
+			msg: "retry once, then hard failure",
+			policyProvider: newProcedurePolicyProvider().registerDefault(
+				NewPolicy(
+					Retries(1),
+					MaxRequestTimeout(time.Millisecond*500),
+				),
+			),
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -202,9 +219,13 @@ func TestMiddleware(t *testing.T) {
 			},
 		},
 		{
-			msg:          "ctx timeout less than retry timeout",
-			retries:      1,
-			retryTimeout: testtime.Millisecond * 500,
+			msg: "ctx timeout less than retry timeout",
+			policyProvider: newProcedurePolicyProvider().registerDefault(
+				NewPolicy(
+					Retries(1),
+					MaxRequestTimeout(time.Millisecond*500),
+				),
+			),
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -227,9 +248,13 @@ func TestMiddleware(t *testing.T) {
 			},
 		},
 		{
-			msg:          "ctx timeout less than retry timeout",
-			retries:      1,
-			retryTimeout: testtime.Millisecond * 50,
+			msg: "ctx timeout less than retry timeout",
+			policyProvider: newProcedurePolicyProvider().registerDefault(
+				NewPolicy(
+					Retries(1),
+					MaxRequestTimeout(time.Millisecond*50),
+				),
+			),
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -260,9 +285,13 @@ func TestMiddleware(t *testing.T) {
 			},
 		},
 		{
-			msg:          "no ctx timeout",
-			retries:      1,
-			retryTimeout: testtime.Millisecond * 50,
+			msg: "no ctx timeout",
+			policyProvider: newProcedurePolicyProvider().registerDefault(
+				NewPolicy(
+					Retries(1),
+					MaxRequestTimeout(time.Millisecond*50),
+				),
+			),
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -292,9 +321,13 @@ func TestMiddleware(t *testing.T) {
 			},
 		},
 		{
-			msg:          "exhaust retries",
-			retries:      1,
-			retryTimeout: testtime.Millisecond * 50,
+			msg: "exhaust retries",
+			policyProvider: newProcedurePolicyProvider().registerDefault(
+				NewPolicy(
+					Retries(1),
+					MaxRequestTimeout(time.Millisecond*50),
+				),
+			),
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -324,9 +357,13 @@ func TestMiddleware(t *testing.T) {
 			},
 		},
 		{
-			msg:          "Reset Error",
-			retries:      1,
-			retryTimeout: testtime.Millisecond * 50,
+			msg: "Reset Error",
+			policyProvider: newProcedurePolicyProvider().registerDefault(
+				NewPolicy(
+					Retries(1),
+					MaxRequestTimeout(time.Millisecond*50),
+				),
+			),
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -350,10 +387,14 @@ func TestMiddleware(t *testing.T) {
 			},
 		},
 		{
-			msg:          "backoff timeout",
-			retries:      1,
-			retryTimeout: testtime.Millisecond * 50,
-			retryBackoff: newFixedBackoff(testtime.Millisecond * 25),
+			msg: "backoff timeout",
+			policyProvider: newProcedurePolicyProvider().registerDefault(
+				NewPolicy(
+					Retries(1),
+					MaxRequestTimeout(time.Millisecond*50),
+					BackoffStrategy(newFixedBackoff(time.Millisecond*25)),
+				),
+			),
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -384,10 +425,14 @@ func TestMiddleware(t *testing.T) {
 			},
 		},
 		{
-			msg:          "sequential backoff timeout",
-			retries:      2,
-			retryTimeout: testtime.Millisecond * 100,
-			retryBackoff: newSequentialBackoff(testtime.Millisecond * 50),
+			msg: "sequential backoff timeout",
+			policyProvider: newProcedurePolicyProvider().registerDefault(
+				NewPolicy(
+					Retries(2),
+					MaxRequestTimeout(time.Millisecond*100),
+					BackoffStrategy(newSequentialBackoff(time.Millisecond*50)),
+				),
+			),
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -429,10 +474,14 @@ func TestMiddleware(t *testing.T) {
 			},
 		},
 		{
-			msg:          "backoff context will timeout",
-			retries:      2,
-			retryTimeout: testtime.Millisecond * 30,
-			retryBackoff: newFixedBackoff(testtime.Millisecond * 5000),
+			msg: "backoff context will timeout",
+			policyProvider: newProcedurePolicyProvider().registerDefault(
+				NewPolicy(
+					Retries(2),
+					MaxRequestTimeout(time.Millisecond*30),
+					BackoffStrategy(newFixedBackoff(time.Millisecond*5000)),
+				),
+			),
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -458,10 +507,14 @@ func TestMiddleware(t *testing.T) {
 			},
 		},
 		{
-			msg:          "concurrent retries",
-			retries:      2,
-			retryTimeout: testtime.Millisecond * 50,
-			retryBackoff: newFixedBackoff(testtime.Millisecond * 25),
+			msg: "concurrent retries",
+			policyProvider: newProcedurePolicyProvider().registerDefault(
+				NewPolicy(
+					Retries(2),
+					MaxRequestTimeout(time.Millisecond*50),
+					BackoffStrategy(newFixedBackoff(time.Millisecond*25)),
+				),
+			),
 			actions: []MiddlewareAction{
 				ConcurrentAction{
 					Actions: []MiddlewareAction{
@@ -541,20 +594,127 @@ func TestMiddleware(t *testing.T) {
 				},
 			},
 		},
+		{
+			msg: "multiple retry policies",
+			policyProvider: newProcedurePolicyProvider().registerDefault(
+				NewPolicy(
+					Retries(2),
+					MaxRequestTimeout(time.Millisecond*20),
+					BackoffStrategy(newFixedBackoff(time.Millisecond*25)),
+				),
+			).registerService(
+				"serviceRoute",
+				NewPolicy(
+					Retries(1),
+					MaxRequestTimeout(time.Millisecond*50),
+					BackoffStrategy(newFixedBackoff(time.Millisecond*50)),
+				),
+			).registerServiceProcedure(
+				"serviceRoute",
+				"procedureRoute",
+				NewPolicy(
+					Retries(0),
+					MaxRequestTimeout(time.Millisecond*100),
+				),
+			).registerServiceProcedure(
+				"serviceRoute",
+				"fakeProcedureRoute",
+				NewPolicy(
+					Retries(100),
+					MaxRequestTimeout(time.Millisecond*10000),
+				),
+			),
+			actions: []MiddlewareAction{
+				ConcurrentAction{
+					Actions: []MiddlewareAction{
+						RequestAction{
+							request: &transport.Request{
+								Service:   "nonServiceRoute",
+								Procedure: "nonProcedureRoute",
+								Body:      bytes.NewBufferString("body1"),
+							},
+							reqTimeout: time.Millisecond * 200,
+							events: []*OutboundEvent{
+								{
+									WantTimeout:    time.Millisecond * 20,
+									WantService:    "nonServiceRoute",
+									WantProcedure:  "nonProcedureRoute",
+									WantBody:       "body1",
+									WaitForTimeout: true,
+									GiveError:      errors.ClientTimeoutError("serv", "proc", time.Millisecond*20),
+								},
+								{
+									WantTimeout:    time.Millisecond * 20,
+									WantService:    "nonServiceRoute",
+									WantProcedure:  "nonProcedureRoute",
+									WantBody:       "body1",
+									WaitForTimeout: true,
+									GiveError:      errors.ClientTimeoutError("serv", "proc", time.Millisecond*20),
+								},
+								{
+									WantTimeout:   time.Millisecond * 20,
+									WantService:   "nonServiceRoute",
+									WantProcedure: "nonProcedureRoute",
+									WantBody:      "body1",
+									GiveError:     errors.ClientTimeoutError("serv", "proc", time.Millisecond*20),
+								},
+							},
+							wantError: errors.ClientTimeoutError("serv", "proc", time.Millisecond*20).Error(),
+						},
+						RequestAction{
+							request: &transport.Request{
+								Service:   "serviceRoute",
+								Procedure: "nonProcedureRoute",
+								Body:      bytes.NewBufferString("body2"),
+							},
+							reqTimeout: time.Millisecond * 200,
+							events: []*OutboundEvent{
+								{
+									WantTimeout:    time.Millisecond * 50,
+									WantService:    "serviceRoute",
+									WantProcedure:  "nonProcedureRoute",
+									WantBody:       "body2",
+									WaitForTimeout: true,
+									GiveError:      errors.ClientTimeoutError("serv", "proc", time.Millisecond*50),
+								},
+								{
+									WantTimeout:   time.Millisecond * 50,
+									WantService:   "serviceRoute",
+									WantProcedure: "nonProcedureRoute",
+									WantBody:      "body2",
+									GiveError:     errors.ClientTimeoutError("serv", "proc", time.Millisecond*50),
+								},
+							},
+							wantError: errors.ClientTimeoutError("serv", "proc", time.Millisecond*50).Error(),
+						},
+						RequestAction{
+							request: &transport.Request{
+								Service:   "serviceRoute",
+								Procedure: "procedureRoute",
+								Body:      bytes.NewBufferString("body3"),
+							},
+							reqTimeout: time.Millisecond * 200,
+							events: []*OutboundEvent{
+								{
+									WantTimeout:   time.Millisecond * 100,
+									WantService:   "serviceRoute",
+									WantProcedure: "procedureRoute",
+									WantBody:      "body3",
+									GiveError:     errors.ClientTimeoutError("serv", "proc", time.Millisecond*100),
+								},
+							},
+							wantError: errors.ClientTimeoutError("serv", "proc", time.Millisecond*100).Error(),
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.msg, func(t *testing.T) {
 			retry := NewUnaryMiddleware(
-				WithPolicyProvider(
-					func(context.Context, *transport.Request) *Policy {
-						return NewPolicy(
-							Retries(tt.retries),
-							MaxRequestTimeout(tt.retryTimeout),
-							BackoffStrategy(tt.retryBackoff),
-						)
-					},
-				),
+				WithPolicyProvider(tt.policyProvider.GetPolicy),
 			)
 
 			ApplyMiddlewareActions(t, retry, tt.actions)

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -47,7 +47,7 @@ func TestMiddleware(t *testing.T) {
 			policyProvider: newProcedurePolicyProvider().registerDefault(
 				NewPolicy(
 					Retries(1),
-					MaxRequestTimeout(time.Millisecond*500),
+					MaxRequestTimeout(testtime.Millisecond*500),
 				),
 			),
 			actions: []MiddlewareAction{
@@ -75,7 +75,7 @@ func TestMiddleware(t *testing.T) {
 			policyProvider: newProcedurePolicyProvider().registerDefault(
 				NewPolicy(
 					Retries(1),
-					MaxRequestTimeout(time.Millisecond*500),
+					MaxRequestTimeout(testtime.Millisecond*500),
 				),
 			),
 			actions: []MiddlewareAction{
@@ -109,7 +109,7 @@ func TestMiddleware(t *testing.T) {
 			policyProvider: newProcedurePolicyProvider().registerDefault(
 				NewPolicy(
 					Retries(4),
-					MaxRequestTimeout(time.Millisecond*500),
+					MaxRequestTimeout(testtime.Millisecond*500),
 				),
 			),
 			actions: []MiddlewareAction{
@@ -161,7 +161,7 @@ func TestMiddleware(t *testing.T) {
 			policyProvider: newProcedurePolicyProvider().registerDefault(
 				NewPolicy(
 					Retries(1),
-					MaxRequestTimeout(time.Millisecond*500),
+					MaxRequestTimeout(testtime.Millisecond*500),
 				),
 			),
 			actions: []MiddlewareAction{
@@ -189,7 +189,7 @@ func TestMiddleware(t *testing.T) {
 			policyProvider: newProcedurePolicyProvider().registerDefault(
 				NewPolicy(
 					Retries(1),
-					MaxRequestTimeout(time.Millisecond*500),
+					MaxRequestTimeout(testtime.Millisecond*500),
 				),
 			),
 			actions: []MiddlewareAction{
@@ -223,7 +223,7 @@ func TestMiddleware(t *testing.T) {
 			policyProvider: newProcedurePolicyProvider().registerDefault(
 				NewPolicy(
 					Retries(1),
-					MaxRequestTimeout(time.Millisecond*500),
+					MaxRequestTimeout(testtime.Millisecond*500),
 				),
 			),
 			actions: []MiddlewareAction{
@@ -252,7 +252,7 @@ func TestMiddleware(t *testing.T) {
 			policyProvider: newProcedurePolicyProvider().registerDefault(
 				NewPolicy(
 					Retries(1),
-					MaxRequestTimeout(time.Millisecond*50),
+					MaxRequestTimeout(testtime.Millisecond*50),
 				),
 			),
 			actions: []MiddlewareAction{
@@ -289,7 +289,7 @@ func TestMiddleware(t *testing.T) {
 			policyProvider: newProcedurePolicyProvider().registerDefault(
 				NewPolicy(
 					Retries(1),
-					MaxRequestTimeout(time.Millisecond*50),
+					MaxRequestTimeout(testtime.Millisecond*50),
 				),
 			),
 			actions: []MiddlewareAction{
@@ -325,7 +325,7 @@ func TestMiddleware(t *testing.T) {
 			policyProvider: newProcedurePolicyProvider().registerDefault(
 				NewPolicy(
 					Retries(1),
-					MaxRequestTimeout(time.Millisecond*50),
+					MaxRequestTimeout(testtime.Millisecond*50),
 				),
 			),
 			actions: []MiddlewareAction{
@@ -361,7 +361,7 @@ func TestMiddleware(t *testing.T) {
 			policyProvider: newProcedurePolicyProvider().registerDefault(
 				NewPolicy(
 					Retries(1),
-					MaxRequestTimeout(time.Millisecond*50),
+					MaxRequestTimeout(testtime.Millisecond*50),
 				),
 			),
 			actions: []MiddlewareAction{
@@ -391,8 +391,8 @@ func TestMiddleware(t *testing.T) {
 			policyProvider: newProcedurePolicyProvider().registerDefault(
 				NewPolicy(
 					Retries(1),
-					MaxRequestTimeout(time.Millisecond*50),
-					BackoffStrategy(newFixedBackoff(time.Millisecond*25)),
+					MaxRequestTimeout(testtime.Millisecond*50),
+					BackoffStrategy(newFixedBackoff(testtime.Millisecond*25)),
 				),
 			),
 			actions: []MiddlewareAction{
@@ -429,8 +429,8 @@ func TestMiddleware(t *testing.T) {
 			policyProvider: newProcedurePolicyProvider().registerDefault(
 				NewPolicy(
 					Retries(2),
-					MaxRequestTimeout(time.Millisecond*100),
-					BackoffStrategy(newSequentialBackoff(time.Millisecond*50)),
+					MaxRequestTimeout(testtime.Millisecond*100),
+					BackoffStrategy(newSequentialBackoff(testtime.Millisecond*50)),
 				),
 			),
 			actions: []MiddlewareAction{
@@ -478,8 +478,8 @@ func TestMiddleware(t *testing.T) {
 			policyProvider: newProcedurePolicyProvider().registerDefault(
 				NewPolicy(
 					Retries(2),
-					MaxRequestTimeout(time.Millisecond*30),
-					BackoffStrategy(newFixedBackoff(time.Millisecond*5000)),
+					MaxRequestTimeout(testtime.Millisecond*30),
+					BackoffStrategy(newFixedBackoff(testtime.Millisecond*5000)),
 				),
 			),
 			actions: []MiddlewareAction{
@@ -511,8 +511,8 @@ func TestMiddleware(t *testing.T) {
 			policyProvider: newProcedurePolicyProvider().registerDefault(
 				NewPolicy(
 					Retries(2),
-					MaxRequestTimeout(time.Millisecond*50),
-					BackoffStrategy(newFixedBackoff(time.Millisecond*25)),
+					MaxRequestTimeout(testtime.Millisecond*50),
+					BackoffStrategy(newFixedBackoff(testtime.Millisecond*25)),
 				),
 			),
 			actions: []MiddlewareAction{
@@ -599,29 +599,29 @@ func TestMiddleware(t *testing.T) {
 			policyProvider: newProcedurePolicyProvider().registerDefault(
 				NewPolicy(
 					Retries(2),
-					MaxRequestTimeout(time.Millisecond*20),
-					BackoffStrategy(newFixedBackoff(time.Millisecond*25)),
+					MaxRequestTimeout(testtime.Millisecond*20),
+					BackoffStrategy(newFixedBackoff(testtime.Millisecond*25)),
 				),
 			).registerService(
 				"serviceRoute",
 				NewPolicy(
 					Retries(1),
-					MaxRequestTimeout(time.Millisecond*50),
-					BackoffStrategy(newFixedBackoff(time.Millisecond*50)),
+					MaxRequestTimeout(testtime.Millisecond*50),
+					BackoffStrategy(newFixedBackoff(testtime.Millisecond*50)),
 				),
 			).registerServiceProcedure(
 				"serviceRoute",
 				"procedureRoute",
 				NewPolicy(
 					Retries(0),
-					MaxRequestTimeout(time.Millisecond*100),
+					MaxRequestTimeout(testtime.Millisecond*100),
 				),
 			).registerServiceProcedure(
 				"serviceRoute",
 				"fakeProcedureRoute",
 				NewPolicy(
 					Retries(100),
-					MaxRequestTimeout(time.Millisecond*10000),
+					MaxRequestTimeout(testtime.Millisecond*10000),
 				),
 			),
 			actions: []MiddlewareAction{
@@ -633,33 +633,33 @@ func TestMiddleware(t *testing.T) {
 								Procedure: "nonProcedureRoute",
 								Body:      bytes.NewBufferString("body1"),
 							},
-							reqTimeout: time.Millisecond * 200,
+							reqTimeout: testtime.Millisecond * 200,
 							events: []*OutboundEvent{
 								{
-									WantTimeout:    time.Millisecond * 20,
+									WantTimeout:    testtime.Millisecond * 20,
 									WantService:    "nonServiceRoute",
 									WantProcedure:  "nonProcedureRoute",
 									WantBody:       "body1",
 									WaitForTimeout: true,
-									GiveError:      errors.ClientTimeoutError("serv", "proc", time.Millisecond*20),
+									GiveError:      errors.ClientTimeoutError("serv", "proc", testtime.Millisecond*20),
 								},
 								{
-									WantTimeout:    time.Millisecond * 20,
+									WantTimeout:    testtime.Millisecond * 20,
 									WantService:    "nonServiceRoute",
 									WantProcedure:  "nonProcedureRoute",
 									WantBody:       "body1",
 									WaitForTimeout: true,
-									GiveError:      errors.ClientTimeoutError("serv", "proc", time.Millisecond*20),
+									GiveError:      errors.ClientTimeoutError("serv", "proc", testtime.Millisecond*20),
 								},
 								{
-									WantTimeout:   time.Millisecond * 20,
+									WantTimeout:   testtime.Millisecond * 20,
 									WantService:   "nonServiceRoute",
 									WantProcedure: "nonProcedureRoute",
 									WantBody:      "body1",
-									GiveError:     errors.ClientTimeoutError("serv", "proc", time.Millisecond*20),
+									GiveError:     errors.ClientTimeoutError("serv", "proc", testtime.Millisecond*20),
 								},
 							},
-							wantError: errors.ClientTimeoutError("serv", "proc", time.Millisecond*20).Error(),
+							wantError: errors.ClientTimeoutError("serv", "proc", testtime.Millisecond*20).Error(),
 						},
 						RequestAction{
 							request: &transport.Request{
@@ -667,25 +667,25 @@ func TestMiddleware(t *testing.T) {
 								Procedure: "nonProcedureRoute",
 								Body:      bytes.NewBufferString("body2"),
 							},
-							reqTimeout: time.Millisecond * 200,
+							reqTimeout: testtime.Millisecond * 200,
 							events: []*OutboundEvent{
 								{
-									WantTimeout:    time.Millisecond * 50,
+									WantTimeout:    testtime.Millisecond * 50,
 									WantService:    "serviceRoute",
 									WantProcedure:  "nonProcedureRoute",
 									WantBody:       "body2",
 									WaitForTimeout: true,
-									GiveError:      errors.ClientTimeoutError("serv", "proc", time.Millisecond*50),
+									GiveError:      errors.ClientTimeoutError("serv", "proc", testtime.Millisecond*50),
 								},
 								{
-									WantTimeout:   time.Millisecond * 50,
+									WantTimeout:   testtime.Millisecond * 50,
 									WantService:   "serviceRoute",
 									WantProcedure: "nonProcedureRoute",
 									WantBody:      "body2",
-									GiveError:     errors.ClientTimeoutError("serv", "proc", time.Millisecond*50),
+									GiveError:     errors.ClientTimeoutError("serv", "proc", testtime.Millisecond*50),
 								},
 							},
-							wantError: errors.ClientTimeoutError("serv", "proc", time.Millisecond*50).Error(),
+							wantError: errors.ClientTimeoutError("serv", "proc", testtime.Millisecond*50).Error(),
 						},
 						RequestAction{
 							request: &transport.Request{
@@ -693,17 +693,17 @@ func TestMiddleware(t *testing.T) {
 								Procedure: "procedureRoute",
 								Body:      bytes.NewBufferString("body3"),
 							},
-							reqTimeout: time.Millisecond * 200,
+							reqTimeout: testtime.Millisecond * 200,
 							events: []*OutboundEvent{
 								{
-									WantTimeout:   time.Millisecond * 100,
+									WantTimeout:   testtime.Millisecond * 100,
 									WantService:   "serviceRoute",
 									WantProcedure: "procedureRoute",
 									WantBody:      "body3",
-									GiveError:     errors.ClientTimeoutError("serv", "proc", time.Millisecond*100),
+									GiveError:     errors.ClientTimeoutError("serv", "proc", testtime.Millisecond*100),
 								},
 							},
-							wantError: errors.ClientTimeoutError("serv", "proc", time.Millisecond*100).Error(),
+							wantError: errors.ClientTimeoutError("serv", "proc", testtime.Millisecond*100).Error(),
 						},
 					},
 				},

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -44,12 +44,12 @@ func TestMiddleware(t *testing.T) {
 	tests := []testStruct{
 		{
 			msg: "no retry",
-			policyProvider: newProcedurePolicyProvider().registerDefault(
+			policyProvider: newPolicyProviderBuilder().registerDefault(
 				NewPolicy(
 					Retries(1),
 					MaxRequestTimeout(testtime.Millisecond*500),
 				),
-			),
+			).provider,
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -72,12 +72,12 @@ func TestMiddleware(t *testing.T) {
 		},
 		{
 			msg: "single retry",
-			policyProvider: newProcedurePolicyProvider().registerDefault(
+			policyProvider: newPolicyProviderBuilder().registerDefault(
 				NewPolicy(
 					Retries(1),
 					MaxRequestTimeout(testtime.Millisecond*500),
 				),
-			),
+			).provider,
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -106,12 +106,12 @@ func TestMiddleware(t *testing.T) {
 		},
 		{
 			msg: "multiple retries",
-			policyProvider: newProcedurePolicyProvider().registerDefault(
+			policyProvider: newPolicyProviderBuilder().registerDefault(
 				NewPolicy(
 					Retries(4),
 					MaxRequestTimeout(testtime.Millisecond*500),
 				),
-			),
+			).provider,
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -158,12 +158,12 @@ func TestMiddleware(t *testing.T) {
 		},
 		{
 			msg: "immediate hard failure",
-			policyProvider: newProcedurePolicyProvider().registerDefault(
+			policyProvider: newPolicyProviderBuilder().registerDefault(
 				NewPolicy(
 					Retries(1),
 					MaxRequestTimeout(testtime.Millisecond*500),
 				),
-			),
+			).provider,
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -186,12 +186,12 @@ func TestMiddleware(t *testing.T) {
 		},
 		{
 			msg: "retry once, then hard failure",
-			policyProvider: newProcedurePolicyProvider().registerDefault(
+			policyProvider: newPolicyProviderBuilder().registerDefault(
 				NewPolicy(
 					Retries(1),
 					MaxRequestTimeout(testtime.Millisecond*500),
 				),
-			),
+			).provider,
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -220,12 +220,12 @@ func TestMiddleware(t *testing.T) {
 		},
 		{
 			msg: "ctx timeout less than retry timeout",
-			policyProvider: newProcedurePolicyProvider().registerDefault(
+			policyProvider: newPolicyProviderBuilder().registerDefault(
 				NewPolicy(
 					Retries(1),
 					MaxRequestTimeout(testtime.Millisecond*500),
 				),
-			),
+			).provider,
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -249,12 +249,12 @@ func TestMiddleware(t *testing.T) {
 		},
 		{
 			msg: "ctx timeout less than retry timeout",
-			policyProvider: newProcedurePolicyProvider().registerDefault(
+			policyProvider: newPolicyProviderBuilder().registerDefault(
 				NewPolicy(
 					Retries(1),
 					MaxRequestTimeout(testtime.Millisecond*50),
 				),
-			),
+			).provider,
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -286,12 +286,12 @@ func TestMiddleware(t *testing.T) {
 		},
 		{
 			msg: "no ctx timeout",
-			policyProvider: newProcedurePolicyProvider().registerDefault(
+			policyProvider: newPolicyProviderBuilder().registerDefault(
 				NewPolicy(
 					Retries(1),
 					MaxRequestTimeout(testtime.Millisecond*50),
 				),
-			),
+			).provider,
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -322,12 +322,12 @@ func TestMiddleware(t *testing.T) {
 		},
 		{
 			msg: "exhaust retries",
-			policyProvider: newProcedurePolicyProvider().registerDefault(
+			policyProvider: newPolicyProviderBuilder().registerDefault(
 				NewPolicy(
 					Retries(1),
 					MaxRequestTimeout(testtime.Millisecond*50),
 				),
-			),
+			).provider,
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -358,12 +358,12 @@ func TestMiddleware(t *testing.T) {
 		},
 		{
 			msg: "Reset Error",
-			policyProvider: newProcedurePolicyProvider().registerDefault(
+			policyProvider: newPolicyProviderBuilder().registerDefault(
 				NewPolicy(
 					Retries(1),
 					MaxRequestTimeout(testtime.Millisecond*50),
 				),
-			),
+			).provider,
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -388,13 +388,13 @@ func TestMiddleware(t *testing.T) {
 		},
 		{
 			msg: "backoff timeout",
-			policyProvider: newProcedurePolicyProvider().registerDefault(
+			policyProvider: newPolicyProviderBuilder().registerDefault(
 				NewPolicy(
 					Retries(1),
 					MaxRequestTimeout(testtime.Millisecond*50),
 					BackoffStrategy(newFixedBackoff(testtime.Millisecond*25)),
 				),
-			),
+			).provider,
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -426,13 +426,13 @@ func TestMiddleware(t *testing.T) {
 		},
 		{
 			msg: "sequential backoff timeout",
-			policyProvider: newProcedurePolicyProvider().registerDefault(
+			policyProvider: newPolicyProviderBuilder().registerDefault(
 				NewPolicy(
 					Retries(2),
 					MaxRequestTimeout(testtime.Millisecond*100),
 					BackoffStrategy(newSequentialBackoff(testtime.Millisecond*50)),
 				),
-			),
+			).provider,
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -475,13 +475,13 @@ func TestMiddleware(t *testing.T) {
 		},
 		{
 			msg: "backoff context will timeout",
-			policyProvider: newProcedurePolicyProvider().registerDefault(
+			policyProvider: newPolicyProviderBuilder().registerDefault(
 				NewPolicy(
 					Retries(2),
 					MaxRequestTimeout(testtime.Millisecond*30),
 					BackoffStrategy(newFixedBackoff(testtime.Millisecond*5000)),
 				),
-			),
+			).provider,
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -508,13 +508,13 @@ func TestMiddleware(t *testing.T) {
 		},
 		{
 			msg: "concurrent retries",
-			policyProvider: newProcedurePolicyProvider().registerDefault(
+			policyProvider: newPolicyProviderBuilder().registerDefault(
 				NewPolicy(
 					Retries(2),
 					MaxRequestTimeout(testtime.Millisecond*50),
 					BackoffStrategy(newFixedBackoff(testtime.Millisecond*25)),
 				),
-			),
+			).provider,
 			actions: []MiddlewareAction{
 				ConcurrentAction{
 					Actions: []MiddlewareAction{
@@ -596,7 +596,7 @@ func TestMiddleware(t *testing.T) {
 		},
 		{
 			msg: "multiple retry policies",
-			policyProvider: newProcedurePolicyProvider().registerDefault(
+			policyProvider: newPolicyProviderBuilder().registerDefault(
 				NewPolicy(
 					Retries(2),
 					MaxRequestTimeout(testtime.Millisecond*20),
@@ -623,7 +623,7 @@ func TestMiddleware(t *testing.T) {
 					Retries(100),
 					MaxRequestTimeout(testtime.Millisecond*10000),
 				),
-			),
+			).provider,
 			actions: []MiddlewareAction{
 				ConcurrentAction{
 					Actions: []MiddlewareAction{
@@ -756,4 +756,29 @@ func (f *fixedBackoff) Backoff() backoff.Backoff {
 
 func (f *fixedBackoff) Duration(_ uint) time.Duration {
 	return f.boff
+}
+
+type policyProviderBuilder struct {
+	provider *procedurePolicyProvider
+}
+
+func newPolicyProviderBuilder() *policyProviderBuilder {
+	return &policyProviderBuilder{
+		provider: newProcedurePolicyProvider(),
+	}
+}
+
+func (pb *policyProviderBuilder) registerServiceProcedure(service, procedure string, pol *Policy) *policyProviderBuilder {
+	pb.provider.registerServiceProcedure(service, procedure, pol)
+	return pb
+}
+
+func (pb *policyProviderBuilder) registerService(service string, pol *Policy) *policyProviderBuilder {
+	pb.provider.registerService(service, pol)
+	return pb
+}
+
+func (pb *policyProviderBuilder) registerDefault(pol *Policy) *policyProviderBuilder {
+	pb.provider.registerDefault(pol)
+	return pb
 }


### PR DESCRIPTION
Summary: This diff introduces a retry policy provider that allows us to
register retry policies that will be applied for all requests.  The
order of importance is:

1) service+procedure match
2) service match
3) default policy

This will allow us to create retry policies that can be applied to
specific services and procedures, including a fallback if we don't
recognize the service or procedure.

Test Plan: expanded the retry tests to take a PolicyProvider and used
that to write a new for every routing use case.