### PR TITLE
hostport: Unwrap lock around notifications

### DIFF
--- a/peer/hostport/hostport.go
+++ b/peer/hostport/hostport.go
@@ -133,8 +133,13 @@ func (p *Peer) EndRequest() {
 
 func (p *Peer) notifyStatusChanged() {
 	p.lock.RLock()
+	subs := make([]peer.Subscriber, 0, len(p.subscribers))
 	for sub := range p.subscribers {
-		sub.NotifyStatusChanged(p)
+		subs = append(subs, sub)
 	}
 	p.lock.RUnlock()
+
+	for _, sub := range subs {
+		sub.NotifyStatusChanged(p)
+	}
 }


### PR DESCRIPTION
This change addresses a potential deadlock in notifying status changes on hostport peers. This prevents deadlock in #1058.