### PR TITLE
lifecycle: Expose stopping state (restored)

### DIFF
--- a/internal/sync/lifecycle.go
+++ b/internal/sync/lifecycle.go
@@ -164,6 +164,7 @@ func (l *lifecycleOnce) WhenRunning(ctx context.Context) error {
 func (l *lifecycleOnce) Stop(f func() error) error {
 	if l.state.CAS(int32(Idle), int32(Stopped)) {
 		close(l.startCh)
+		close(l.stoppingCh)
 		close(l.stopCh)
 		return nil
 	}


### PR DESCRIPTION
Restoring #1078 but now in stack for TChannel connection management.

This problem resurfaced because closing a stoppingCh in the Stop(stop) callback does not cover the case where a lifecycle is stopped without having ever been started.