### PR TITLE
tchannel: Connection state management (again)

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 491c0872fdae119d4a27c024404d2a14769ddaa56cc02421d12ed88aa34a7718
-updated: 2017-06-06T14:56:46.171893-07:00
+hash: 8d20f47cede94524a67ec67de448ea1555af62810bfe9e5b0b24969f54028a3d
+updated: 2017-06-08T15:28:54.939128389-07:00
 imports:
 - name: github.com/apache/thrift
   version: b2a4d4ae21c789b689dd162deb819665567f481c
@@ -44,12 +44,12 @@ imports:
   subpackages:
   - gomock
 - name: github.com/golang/protobuf
-  version: 5a0f697c9ed9d68fef0116532c6e05cfeae00e55
+  version: 7a211bcf3bce0e3f1d74f9894916e6f116ae83b4
   subpackages:
   - proto
   - ptypes/any
 - name: github.com/gorilla/websocket
-  version: a91eba7f97777409bc2c443f5534d41dd20c5720
+  version: 3ab3a8b8831546bd18fd182c20687ca853b2bb13
 - name: github.com/grpc-ecosystem/grpc-opentracing
   version: 6c130eed1e297e1aa4d415a50c90d0c81c52677e
   subpackages:
@@ -67,7 +67,7 @@ imports:
   - log
   - mocktracer
 - name: github.com/pborman/uuid
-  version: 1b00554d822231195d1babd97ff4a781231955c9
+  version: a97ce2ca70fa5a848076093f05e639a89ca34d06
 - name: github.com/pmezard/go-difflib
   version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
@@ -92,7 +92,7 @@ imports:
   subpackages:
   - xfs
 - name: github.com/Sirupsen/logrus
-  version: 68cec9f21fbf3ea8d8f98c044bc6ce05f17b267a
+  version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
 - name: github.com/stretchr/objx
   version: 1a9d0bb9f541897e62256577b352fdbc1fb4fd94
 - name: github.com/stretchr/testify
@@ -102,7 +102,7 @@ imports:
   - mock
   - require
 - name: github.com/uber-common/bark
-  version: 148dd9dfbd0feb293fc81593a8c10c99877f81bc
+  version: d52ffa061726911f47fcd3d9e8b9b55f22794772
 - name: github.com/uber-go/atomic
   version: e682c1008ac17bf26d2e4b5ad6cdd08520ed0b22
 - name: github.com/uber-go/mapdecode
@@ -186,7 +186,7 @@ imports:
   - version
   - wire
 - name: go.uber.org/zap
-  version: fab453050a7a08c35f31fc5fff6f2dbd962285ab
+  version: 9cabc84638b70e564c3dab2766efcb1ded2aac9f
   subpackages:
   - buffer
   - internal/bufferpool
@@ -213,24 +213,24 @@ imports:
   - lex/httplex
   - trace
 - name: golang.org/x/sys
-  version: b90f89a1e7a9c1f6b918820b3daa7f08488c8594
+  version: a55a76086885b80f79961eacb876ebd8caf3868d
   repo: https://github.com/golang/sys
   subpackages:
   - unix
 - name: golang.org/x/text
-  version: ab6d1c143672de99b9dfde433b7f6affb278cc74
+  version: 19e51611da83d6be54ddafce4a4af510cb3e9ea4
   subpackages:
   - secure/bidirule
   - transform
   - unicode/bidi
   - unicode/norm
 - name: golang.org/x/tools
-  version: 92d42b9ff15f625347a13b6aeafd04a33537ce91
+  version: bf4b54dc687c73b6ef63de8b8abf0ad3951e3edc
   repo: https://github.com/golang/tools
   subpackages:
   - go/ast/astutil
 - name: google.golang.org/genproto
-  version: aa2eb687b4d3e17154372564ad8d6bf11c3cf21f
+  version: d80a6e20e776b0b17a324d0ba1ab50a39c8e8944
   subpackages:
   - googleapis/rpc/status
 - name: google.golang.org/grpc
@@ -250,8 +250,10 @@ imports:
   - status
   - tap
   - transport
+- name: gopkg.in/bsm/ratelimit.v1
+  version: db14e161995a5177acef654cb0dd785e8ee8bc22
 - name: gopkg.in/redis.v5
-  version: a16aeec10ff407b1e7be6dd35797ccf5426ef0f0
+  version: b6bfe529a846fbb9a58c832ce71c61b6fde12c15
   subpackages:
   - internal
   - internal/consistenthash
@@ -259,10 +261,10 @@ imports:
   - internal/pool
   - internal/proto
 - name: gopkg.in/yaml.v2
-  version: cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b
+  version: a83829b6f1293c91addabc89d0571c246397bbf4
 testImports:
 - name: github.com/golang/lint
-  version: c5fb716d6688a859aae56d26d3e6070808df29f7
+  version: cb00e5669539f047b2f4c53a421a01b0c8e172c6
   subpackages:
   - golint
 - name: github.com/kisielk/errcheck

--- a/glide.yaml
+++ b/glide.yaml
@@ -37,7 +37,7 @@ import:
 - package: github.com/uber/jaeger-client-go
   version: '>=1, <3'
 - package: github.com/uber/tchannel-go
-  version: ^1.4
+  version: ^1
 - package: github.com/uber-go/tally
   version: ^3
 - package: go.uber.org/atomic
@@ -76,6 +76,7 @@ testImport:
 - package: github.com/kisielk/gotool
 - package: github.com/wadey/gocovmerge
 - package: go.uber.org/tools
+  version: master
   subpackages:
   - parallel-exec
   - update-license

--- a/internal/backoff/exponential.go
+++ b/internal/backoff/exponential.go
@@ -60,13 +60,13 @@ func newRand() *rand.Rand {
 }
 
 var defaultExponentialOpts = exponentialOptions{
-	first:   100 * time.Millisecond,
+	first:   10 * time.Millisecond,
 	max:     time.Minute,
 	newRand: newRand,
 }
 
 // DefaultExponential is an exponential backoff.Strategy with full jitter.
-// The first attempt has a range of 0 to 100ms and each successive attempt
+// The first attempt has a range of 0 to 10ms and each successive attempt
 // doubles the range of the possible delay.
 //
 // Exponential strategies are not thread safe.

--- a/internal/integrationtest/util.go
+++ b/internal/integrationtest/util.go
@@ -1,0 +1,260 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package integrationtest
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/encoding/raw"
+	peerbind "go.uber.org/yarpc/peer"
+	"go.uber.org/yarpc/peer/roundrobin"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	maxAttempts        = 1000
+	concurrentAttempts = 100
+)
+
+// TransportSpec specifies how to create test clients and servers for a transport.
+type TransportSpec struct {
+	NewServerTransport func(t *testing.T, addr string) peer.Transport
+	NewClientTransport func(t *testing.T) peer.Transport
+	NewInbound         func(xport peer.Transport, addr string) transport.Inbound
+	NewUnaryOutbound   func(xport peer.Transport, pc peer.Chooser) transport.UnaryOutbound
+	Identify           func(addr string) peer.Identifier
+	Addr               func(xport peer.Transport, inbound transport.Inbound) string
+}
+
+// Test runs reusable tests with the transport spec.
+func (s TransportSpec) Test(t *testing.T) {
+	t.Run("reuseConnRoundRobin", s.TestConcurrentClientsRoundRobin)
+	t.Run("backoffConnRoundRobin", s.TestBackoffConnRoundRobin)
+	t.Run("reconRoundRobin", s.TestReconnRoundRobin)
+	t.Run("connectAndStopRoundRobin", s.TestConnectAndStopRoundRobin)
+}
+
+// NewClient returns a running dispatcher and a raw client for the echo
+// procedure.
+func (s TransportSpec) NewClient(t *testing.T, addrs []string) (*yarpc.Dispatcher, raw.Client) {
+	ids := make([]peer.Identifier, len(addrs))
+	for i, addr := range addrs {
+		ids[i] = s.Identify(addr)
+	}
+
+	xport := s.NewClientTransport(t)
+
+	pl := roundrobin.New(xport)
+	pc := peerbind.Bind(pl, peerbind.BindPeers(ids))
+	ob := s.NewUnaryOutbound(xport, pc)
+	dispatcher := yarpc.NewDispatcher(yarpc.Config{
+		Name: "client",
+		Outbounds: yarpc.Outbounds{
+			"service": transport.Outbounds{
+				ServiceName: "service",
+				Unary:       ob,
+			},
+		},
+	})
+	require.NoError(t, dispatcher.Start(), "start client dispatcher")
+	rawClient := raw.New(dispatcher.ClientConfig("service"))
+	return dispatcher, rawClient
+}
+
+// NewServer creates an echo server using the given inbound from any transport.
+func (s TransportSpec) NewServer(t *testing.T, addr string) (*yarpc.Dispatcher, string) {
+	xport := s.NewServerTransport(t, addr)
+	inbound := s.NewInbound(xport, addr)
+
+	dispatcher := yarpc.NewDispatcher(yarpc.Config{
+		Name:     "service",
+		Inbounds: yarpc.Inbounds{inbound},
+	})
+
+	handle := func(ctx context.Context, req []byte) ([]byte, error) {
+		return req, nil
+	}
+
+	dispatcher.Register(raw.Procedure("echo", handle))
+	require.NoError(t, dispatcher.Start(), "start server dispatcher")
+
+	return dispatcher, s.Addr(xport, inbound)
+}
+
+// TestConnectAndStopRoundRobin is a test that any transport can apply to
+// exercise a transport dropping connections if the transport is stopped before
+// a pending request can complete.
+func (s TransportSpec) TestConnectAndStopRoundRobin(t *testing.T) {
+	addr := "127.0.0.1:31172"
+
+	client, rawClient := s.NewClient(t, []string{addr})
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
+		defer cancel()
+		assert.Error(t, Call(ctx, rawClient))
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	assert.NoError(t, client.Stop())
+
+	<-done
+}
+
+// TestConcurrentClientsRoundRobin is a reusable test that any transport can
+// apply to cover connection reuse.
+func (s TransportSpec) TestConcurrentClientsRoundRobin(t *testing.T) {
+	var wg sync.WaitGroup
+	count := concurrentAttempts
+
+	server, addr := s.NewServer(t, ":0")
+	defer server.Stop()
+
+	client, rawClient := s.NewClient(t, []string{addr})
+	defer client.Stop()
+
+	wg.Add(count)
+	call := func() {
+		defer wg.Done()
+		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
+		defer cancel()
+		assert.NoError(t, Call(ctx, rawClient))
+	}
+	for i := 0; i < count; i++ {
+		go call()
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	wg.Wait()
+}
+
+// TestBackoffConnRoundRobin is a reusable test that any transport can apply to
+// cover connection management backoff.
+func (s TransportSpec) TestBackoffConnRoundRobin(t *testing.T) {
+	addr := "127.0.0.1:31782"
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		client, rawClient := s.NewClient(t, []string{addr})
+		defer client.Stop()
+
+		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(ctx, time.Second)
+		defer cancel()
+
+		// Eventually succeeds, when the server comes online.
+		assert.NoError(t, Call(ctx, rawClient))
+	}()
+
+	// Give the client time to make multiple connection attempts.
+	time.Sleep(10 * time.Millisecond)
+	server, _ := s.NewServer(t, addr)
+	defer server.Stop()
+
+	<-done
+}
+
+// TestReconnRoundRobin is a reusable test that exercises any
+// transport's ability to reconnect to a peer if it is temporarily unavailable
+// while being retained.
+func (s TransportSpec) TestReconnRoundRobin(t *testing.T) {
+	server, addr := s.NewServer(t, ":0")
+	// server.Stop() is explicit in this test.
+
+	client, rawClient := s.NewClient(t, []string{addr})
+	defer client.Stop()
+
+	// Induce a connection
+	func() {
+		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+		defer cancel()
+		assert.NoError(t, Call(ctx, rawClient))
+	}()
+
+	// Stop the server so a subsequent request must fail
+	server.Stop()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		CallUntilSuccess(t, rawClient, 100*time.Millisecond)
+	}()
+
+	// Restart the server so it can reconnect.
+	time.Sleep(20 * time.Millisecond)
+	restoredServer, _ := s.NewServer(t, addr)
+	defer restoredServer.Stop()
+
+	<-done
+}
+
+// Blast sends a blast of calls to the client and verifies that they do not
+// err.
+func Blast(ctx context.Context, t *testing.T, rawClient raw.Client) {
+	for i := 0; i < 10; i++ {
+		assert.NoError(t, Call(ctx, rawClient))
+	}
+}
+
+// CallUntilSuccess sends a request until it succeeds.
+func CallUntilSuccess(t *testing.T, rawClient raw.Client, interval time.Duration) {
+	for i := 0; i < maxAttempts; i++ {
+		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(ctx, interval)
+		err := Call(ctx, rawClient)
+		cancel()
+		if err == nil {
+			return
+		}
+	}
+	assert.Fail(t, "call until success failed multiple times")
+}
+
+// Call sends an echo request to the client.
+func Call(ctx context.Context, rawClient raw.Client) error {
+	ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+	defer cancel()
+	res, err := rawClient.Call(ctx, "echo", []byte("hello"))
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(res, []byte("hello")) {
+		return fmt.Errorf("unexpected response %+v", res)
+	}
+	return nil
+}

--- a/internal/integrationtest/util_test.go
+++ b/internal/integrationtest/util_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package integrationtest_test
+
+import (
+	"testing"
+	"time"
+
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/backoff"
+	"go.uber.org/yarpc/internal/integrationtest"
+	"go.uber.org/yarpc/peer/hostport"
+	"go.uber.org/yarpc/transport/tchannel"
+
+	"github.com/stretchr/testify/require"
+)
+
+var spec = integrationtest.TransportSpec{
+	Identify: hostport.Identify,
+	NewServerTransport: func(t *testing.T, addr string) peer.Transport {
+		x, err := tchannel.NewTransport(
+			tchannel.ServiceName("service"),
+			tchannel.ListenAddr(addr),
+		)
+		require.NoError(t, err, "must construct transport")
+		return x
+	},
+	NewInbound: func(x peer.Transport, addr string) transport.Inbound {
+		return x.(*tchannel.Transport).NewInbound()
+	},
+	NewClientTransport: func(t *testing.T) peer.Transport {
+		x, err := tchannel.NewTransport(
+			tchannel.ServiceName("client"),
+			tchannel.ConnTimeout(10*time.Millisecond),
+			tchannel.ConnBackoff(backoff.None),
+		)
+		require.NoError(t, err, "must construct transport")
+		return x
+	},
+	NewUnaryOutbound: func(x peer.Transport, pc peer.Chooser) transport.UnaryOutbound {
+		return x.(*tchannel.Transport).NewOutbound(pc)
+	},
+	Addr: func(x peer.Transport, ib transport.Inbound) string {
+		return x.(*tchannel.Transport).ListenAddr()
+	},
+}
+
+func TestIntegrationWithTChannel(t *testing.T) {
+	spec.Test(t)
+}

--- a/transport/tchannel/config.go
+++ b/transport/tchannel/config.go
@@ -22,21 +22,27 @@ package tchannel
 
 import (
 	"fmt"
+	"time"
 
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/peer/hostport"
 	"go.uber.org/yarpc/x/config"
-
-	opentracing "github.com/opentracing/opentracing-go"
 )
-
-const transportName = "tchannel"
 
 // TransportConfig configures a shared TChannel transport. This is shared
 // between all TChannel outbounds and inbounds of a Dispatcher.
 //
-// TransportConfig does not have any parameters at this time.
-type TransportConfig struct{}
+//  transports:
+//    tchannel:
+//      connTimeout: 500ms
+//      connBackoff:
+//        exponential:
+//          first: 10ms
+//          max: 30s
+type TransportConfig struct {
+	ConnTimeout time.Duration  `config:"connTimeout"`
+	ConnBackoff config.Backoff `config:"connBackoff"`
+}
 
 // InboundConfig configures a TChannel inbound.
 //
@@ -93,13 +99,21 @@ func (ts *transportSpec) Spec() config.TransportSpec {
 }
 
 func (ts *transportSpec) buildTransport(tc *TransportConfig, k *config.Kit) (transport.Transport, error) {
-	var options transportOptions
-	// Default configuration.
-	options.tracer = opentracing.GlobalTracer()
+	options := newTransportOptions()
 
 	for _, opt := range ts.transportOptions {
 		opt(&options)
 	}
+
+	if tc.ConnTimeout != 0 {
+		options.connTimeout = tc.ConnTimeout
+	}
+
+	strategy, err := tc.ConnBackoff.Strategy()
+	if err != nil {
+		return nil, err
+	}
+	options.connBackoffStrategy = strategy
 
 	if options.name != "" {
 		return nil, fmt.Errorf("TChannel TransportSpec does not accept ServiceName")

--- a/transport/tchannel/constants.go
+++ b/transport/tchannel/constants.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tchannel
+
+import "time"
+
+const transportName = "tchannel"
+
+var defaultConnTimeout = 500 * time.Millisecond

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -158,21 +158,21 @@ func (o *Outbound) callWithPeer(ctx context.Context, req *transport.Request, pee
 	}, nil
 }
 
-func (o *Outbound) getPeerForRequest(ctx context.Context, treq *transport.Request) (*hostport.Peer, func(error), error) {
+func (o *Outbound) getPeerForRequest(ctx context.Context, treq *transport.Request) (*tchannelPeer, func(error), error) {
 	p, onFinish, err := o.chooser.Choose(ctx, treq)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	hpPeer, ok := p.(*hostport.Peer)
+	tp, ok := p.(*tchannelPeer)
 	if !ok {
 		return nil, nil, peer.ErrInvalidPeerConversion{
 			Peer:         p,
-			ExpectedType: "*hostport.Peer",
+			ExpectedType: "*tchannelPeer",
 		}
 	}
 
-	return hpPeer, onFinish, nil
+	return tp, onFinish, nil
 }
 
 // Transports returns the underlying TChannel Transport for this outbound.

--- a/transport/tchannel/peer.go
+++ b/transport/tchannel/peer.go
@@ -1,0 +1,153 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tchannel
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/peer/hostport"
+)
+
+type tchannelPeer struct {
+	*hostport.Peer
+	transport *Transport
+	addr      string
+	changed   chan struct{}
+	released  chan struct{}
+	timer     *time.Timer
+}
+
+func newPeer(pid hostport.PeerIdentifier, t *Transport) *tchannelPeer {
+	// Create a defused timer for later use.
+	timer := time.NewTimer(0)
+	if !timer.Stop() {
+		<-timer.C
+	}
+
+	return &tchannelPeer{
+		addr:      pid.Identifier(),
+		Peer:      hostport.NewPeer(pid, t),
+		transport: t,
+		changed:   make(chan struct{}, 1),
+		released:  make(chan struct{}, 0),
+		timer:     timer,
+	}
+}
+
+func (p *tchannelPeer) MaintainConn() {
+	cancel := func() {}
+
+	backoff := p.transport.connBackoffStrategy.Backoff()
+	var attempts uint
+
+	// Wait for start (so we can be certain that we have a channel).
+	<-p.transport.once.Started()
+	pl := p.transport.peerList()
+	if pl == nil {
+		return
+	}
+
+	// Attempt to retain an open connection to each peer so long as it is
+	// retained.
+	for {
+		tp := pl.GetOrAdd(p.addr)
+
+		inbound, outbound := tp.NumConnections()
+		if inbound+outbound > 0 {
+			p.Peer.SetStatus(peer.Available)
+			// Reset on success
+			attempts = 0
+			if !p.waitForChange() {
+				break
+			}
+
+		} else {
+			p.Peer.SetStatus(peer.Connecting)
+
+			// Attempt to connect
+			ctx := context.Background()
+			ctx, cancel = context.WithTimeout(ctx, p.transport.connTimeout)
+			_, err := tp.Connect(ctx)
+
+			if err == nil {
+				p.Peer.SetStatus(peer.Available)
+			} else {
+				p.Peer.SetStatus(peer.Unavailable)
+				// Back-off on fail
+				if !p.sleep(backoff.Duration(attempts)) {
+					break
+				}
+				attempts++
+			}
+
+		}
+	}
+
+	p.transport.connectorsGroup.Done()
+	cancel()
+}
+
+func (p *tchannelPeer) Release() {
+	close(p.released)
+}
+
+func (p *tchannelPeer) OnStatusChanged() {
+	select {
+	case p.changed <- struct{}{}:
+	default:
+	}
+}
+
+// waitForChange waits for the transport to send a peer connection status
+// change notification, but exits early if the transport releases the peer or
+// stops.  waitForChange returns whether it is resuming due to a connection
+// status change event.
+func (p *tchannelPeer) waitForChange() (changed bool) {
+	select {
+	case <-p.changed:
+		return true
+	case <-p.released:
+		return false
+	case <-p.transport.once.Stopping():
+		return false
+	}
+}
+
+// sleep waits for a duration, but exits early if the transport releases the
+// peer or stops.  sleep returns whether it successfully waited the entire
+// duration.
+func (p *tchannelPeer) sleep(delay time.Duration) (completed bool) {
+	p.timer.Reset(delay)
+
+	select {
+	case <-p.timer.C:
+		return true
+	case <-p.released:
+	case <-p.transport.once.Stopping():
+	}
+
+	if !p.timer.Stop() {
+		<-p.timer.C
+	}
+	return false
+}

--- a/transport/tchannel/peer_test.go
+++ b/transport/tchannel/peer_test.go
@@ -1,0 +1,136 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tchannel_test
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/backoff"
+	"go.uber.org/yarpc/internal/integrationtest"
+	"go.uber.org/yarpc/peer/hostport"
+	"go.uber.org/yarpc/transport/tchannel"
+
+	"github.com/stretchr/testify/require"
+)
+
+var spec = integrationtest.TransportSpec{
+	Identify: hostport.Identify,
+	NewServerTransport: func(t *testing.T, addr string) peer.Transport {
+		x, err := tchannel.NewTransport(
+			tchannel.ServiceName("service"),
+			tchannel.ListenAddr(addr),
+		)
+		require.NoError(t, err, "must construct transport")
+		return x
+	},
+	NewInbound: func(x peer.Transport, addr string) transport.Inbound {
+		return x.(*tchannel.Transport).NewInbound()
+	},
+	NewClientTransport: func(t *testing.T) peer.Transport {
+		x, err := tchannel.NewTransport(
+			tchannel.ServiceName("client"),
+			tchannel.ConnTimeout(10*time.Millisecond),
+			tchannel.ConnBackoff(backoff.None),
+		)
+		require.NoError(t, err, "must construct transport")
+		return x
+	},
+	NewUnaryOutbound: func(x peer.Transport, pc peer.Chooser) transport.UnaryOutbound {
+		return x.(*tchannel.Transport).NewOutbound(pc)
+	},
+	Addr: func(x peer.Transport, ib transport.Inbound) string {
+		return x.(*tchannel.Transport).ListenAddr()
+	},
+}
+
+// TestWithRoundRobin verifies that TChannel appropriately notifies all
+// subscribed peer lists when peers become available and unavailable.
+// It does so by constructing a round robin peer list backed by the TChannel transport,
+// communicating to three servers. One will always work. One will go down
+// temporarily. One will be a bogus TCP port that never completes a TChannel
+// handshake.
+func TestWithRoundRobin(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+
+	permanent, permanentAddr := spec.NewServer(t, "")
+	defer permanent.Stop()
+
+	temporary, temporaryAddr := spec.NewServer(t, "")
+	defer temporary.Stop()
+
+	l, err := net.Listen("tcp", ":0")
+	require.NoError(t, err, "listen for bogus server")
+	invalidAddr := l.Addr().String()
+	defer l.Close()
+
+	// Construct a client with a bank of peers. We will keep one running all
+	// the time. We'll shut one down temporarily. One will be invalid.
+	// The round robin peer list should only choose peers that have
+	// successfully connected.
+	client, c := spec.NewClient(t, []string{
+		permanentAddr,
+		temporaryAddr,
+		invalidAddr,
+	})
+	defer client.Stop()
+
+	// All requests should succeed. The invalid peer never enters the rotation.
+	integrationtest.Blast(ctx, t, c)
+
+	// Shut down one task in the peer list.
+	temporary.Stop()
+	// One of these requests may fail since one of the peers has gone down but
+	// the TChannel transport will not know until a request is attempted.
+	integrationtest.Call(ctx, c)
+	integrationtest.Call(ctx, c)
+	// All subsequent should succeed since the peer should be removed on
+	// connection fail.
+	integrationtest.Blast(ctx, t, c)
+
+	// Restore the server on the temporary port.
+	restored, _ := spec.NewServer(t, temporaryAddr)
+	defer restored.Stop()
+	integrationtest.Blast(ctx, t, c)
+}
+
+func TestIntegration(t *testing.T) {
+	spec.Test(t)
+}
+
+type noSub struct{}
+
+func (noSub) NotifyStatusChanged(pid peer.Identifier) {}
+
+func TestCancelMaintainConn(t *testing.T) {
+	transport, err := tchannel.NewTransport()
+	require.NoError(t, err)
+	transport.Start()
+	transport.Stop()
+	_, err = transport.RetainPeer(hostport.PeerIdentifier("127.0.0.1:66408"), noSub{})
+	require.NoError(t, err)
+}

--- a/transport/tchannel/transport.go
+++ b/transport/tchannel/transport.go
@@ -23,7 +23,9 @@ package tchannel
 import (
 	"fmt"
 	"sync"
+	"time"
 
+	backoffapi "go.uber.org/yarpc/api/backoff"
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
 	intsync "go.uber.org/yarpc/internal/sync"
@@ -49,7 +51,13 @@ type Transport struct {
 	name   string
 	addr   string
 
-	peers map[string]*hostport.Peer
+	connTimeout            time.Duration
+	initialConnRetryDelay  time.Duration
+	connRetryBackoffFactor int
+	connectorsGroup        sync.WaitGroup
+	connBackoffStrategy    backoffapi.Strategy
+
+	peers map[string]*tchannelPeer
 }
 
 // NewTransport is a YARPC transport that facilitates sending and receiving
@@ -60,8 +68,8 @@ type Transport struct {
 // Either the local service name (with the ServiceName option) or a user-owned
 // TChannel (with the WithChannel option) MUST be specified.
 func NewTransport(opts ...TransportOption) (*Transport, error) {
-	var options transportOptions
-	options.tracer = opentracing.GlobalTracer()
+	options := newTransportOptions()
+
 	for _, opt := range opts {
 		opt(&options)
 	}
@@ -75,11 +83,13 @@ func NewTransport(opts ...TransportOption) (*Transport, error) {
 
 func (o transportOptions) newTransport() *Transport {
 	return &Transport{
-		once:   intsync.Once(),
-		name:   o.name,
-		addr:   o.addr,
-		tracer: o.tracer,
-		peers:  make(map[string]*hostport.Peer),
+		once:                intsync.Once(),
+		name:                o.name,
+		addr:                o.addr,
+		connTimeout:         o.connTimeout,
+		connBackoffStrategy: o.connBackoffStrategy,
+		peers:               make(map[string]*tchannelPeer),
+		tracer:              o.tracer,
 	}
 }
 
@@ -108,15 +118,16 @@ func (t *Transport) RetainPeer(pid peer.Identifier, sub peer.Subscriber) (peer.P
 }
 
 // **NOTE** should only be called while the lock write mutex is acquired
-func (t *Transport) getOrCreatePeer(pid hostport.PeerIdentifier) *hostport.Peer {
+func (t *Transport) getOrCreatePeer(pid hostport.PeerIdentifier) *tchannelPeer {
 	if p, ok := t.peers[pid.Identifier()]; ok {
 		return p
 	}
 
-	p := hostport.NewPeer(pid, t)
-	p.SetStatus(peer.Available)
-
+	p := newPeer(pid, t)
 	t.peers[p.Identifier()] = p
+	// Start a peer connection loop
+	t.connectorsGroup.Add(1)
+	go p.MaintainConn()
 
 	return p
 }
@@ -140,10 +151,23 @@ func (t *Transport) ReleasePeer(pid peer.Identifier, sub peer.Subscriber) error 
 	}
 
 	if p.NumSubscribers() == 0 {
+		// Release the peer so that the connection retention loop stops.
+		p.Release()
 		delete(t.peers, pid.Identifier())
 	}
 
 	return nil
+}
+
+func (t *Transport) peerList() *tchannel.RootPeerList {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	if t.ch == nil {
+		return nil
+	}
+
+	return t.ch.RootPeers()
 }
 
 // Start starts the TChannel transport. This starts making connections and
@@ -154,12 +178,16 @@ func (t *Transport) Start() error {
 }
 
 func (t *Transport) start() error {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
 	chopts := tchannel.ChannelOptions{
 		Tracer: t.tracer,
 		Handler: handler{
 			router: t.router,
 			tracer: t.tracer,
 		},
+		OnPeerStatusChanged: t.onPeerStatusChanged,
 	}
 	ch, err := tchannel.NewChannel(t.name, &chopts)
 	if err != nil {
@@ -201,10 +229,24 @@ func (t *Transport) Stop() error {
 
 func (t *Transport) stop() error {
 	t.ch.Close()
+	t.connectorsGroup.Wait()
 	return nil
 }
 
 // IsRunning returns whether the TChannel transport is running.
 func (t *Transport) IsRunning() bool {
 	return t.once.IsRunning()
+}
+
+// onPeerStatusChanged receives notifications from TChannel Channel when any
+// peer's status changes.
+func (t *Transport) onPeerStatusChanged(tp *tchannel.Peer) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	p, ok := t.peers[tp.HostPort()]
+	if !ok {
+		return
+	}
+	p.OnStatusChanged()
 }


### PR DESCRIPTION
This resurrects #1058, which Github closed automatically in a fit of passion when I reordered this stack.

This change introduces connection management for TChannel.
The underlying TChannel library surfaces a peer status changed event that we can use to effect reconnect and back-off.

This implementation uses a goroutine for each peer.
The loop wakes whenever connection status changes, after a back-off delay, when
the peer is released.

This necessitates the introduction of an option and configuration property for the connection timeout and backoff strategy. #1089 

The integration tests with the round robin are largely shared with HTTP for overlapping coverage exercise. #1090 