### PR TITLE
Document transport.ResponseWriter to not be thread safe

### DIFF
--- a/api/transport/response.go
+++ b/api/transport/response.go
@@ -30,6 +30,8 @@ type Response struct {
 }
 
 // ResponseWriter allows Handlers to write responses in a streaming fashion.
+//
+// Functions on ResponseWriter are not thread-safe.
 type ResponseWriter interface {
 	io.Writer
 


### PR DESCRIPTION
We have implementations of `transport.ResponseWriter` that are not thread safe. I wanted to explicitly document this. This is from #1098.