### PR TITLE
Add golang 1.9 for development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,10 @@ matrix:
       sudo: required
       services:
         - docker
+    - env: CI_TYPES='deps examples lint test' SUPPRESS_CROSSDOCK=1 DOCKER_GO_VERSION=1.9
+      sudo: required
+      services:
+        - docker
 before_install:
   - make travis-docker-load
 script:

--- a/Dockerfile.1.9
+++ b/Dockerfile.1.9
@@ -1,0 +1,12 @@
+FROM golang:1.9beta1
+
+ENV SUPPRESS_DOCKER 1
+WORKDIR /go/src/go.uber.org/yarpc
+RUN apt-get update -yq && apt-get install -yq jq unzip
+ADD dockerdeps.mk /go/src/go.uber.org/yarpc/
+ADD build/base.mk build/deps.mk /go/src/go.uber.org/yarpc/build/
+RUN make -f dockerdeps.mk predeps
+ADD scripts/vendor-build.sh /go/src/go.uber.org/yarpc/scripts/
+ADD glide.yaml glide.lock /go/src/go.uber.org/yarpc/
+RUN make -f dockerdeps.mk deps
+ADD . /go/src/go.uber.org/yarpc/


### PR DESCRIPTION
Golang 1.9 is tentatively being released on August 1st, and the first beta is already out, so we might as well start testing against it. This adds a Dockerfile for golang 1.9beta1, and adds golang 1.9 testing to Travis CI. Note that local development is not affected by default, the default golang version is still 1.8. To use 1.9, do `DOCKER_GO_VERSION=1.9 make test`.