### PR TITLE
Fix make cover

### DIFF
--- a/scripts/cover.sh
+++ b/scripts/cover.sh
@@ -73,7 +73,7 @@ for pkg in "$@"; do
 
   echo " - go test -race ${args} \"${pkg}\"" >> "${commands_file}"
 done
-parallel-exec --fast-fail --no-log --max-concurrent-cmds 4 --dir "${DIR}" "${commands_file}" 2>&1 \
+parallel-exec --fast-fail --max-concurrent-cmds 4 --dir "${DIR}" "${commands_file}" 2>&1 \
 		| grep -v 'warning: no packages being tested depend on'
 
 # Merge cross-package coverage and then split the result into main and

--- a/scripts/cover.sh
+++ b/scripts/cover.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
 DIR="$(cd "$(dirname "${0}")/.." && pwd)"
 cd "${DIR}"
@@ -73,7 +73,7 @@ for pkg in "$@"; do
 
   echo " - go test -race ${args} \"${pkg}\"" >> "${commands_file}"
 done
-parallel-exec --fast-fail --max-concurrent-cmds 4 --dir "${DIR}" "${commands_file}" 2>&1 \
+parallel-exec --fast-fail --no-log --max-concurrent-cmds 4 --dir "${DIR}" "${commands_file}" 2>&1 \
 		| grep -v 'warning: no packages being tested depend on'
 
 # Merge cross-package coverage and then split the result into main and


### PR DESCRIPTION
Recently, we've had a bunch of PRs that show code coverage dropping when not expected to. I've looked into it, and what was happening was that when a test fails, `scripts/cover.sh` was not failing as we would expect. This means that only partial results were being uploaded to Codecov. The cause was that our invocation of tests comes down to this line in `scripts/cover.sh`:

```
parallel-exec --fast-fail --no-log --max-concurrent-cmds 4 --dir "${DIR}" "${commands_file}" 2>&1 | grep -v 'warning: no packages being tested depend on'
```

Notice the pipe to `grep` - we have `set -e` in the script, which should fail a script if any command in the script fails, but this was piping to `grep`, and if the final command succeeds, the entire piped set of commands is said to succeed by default. You have to do `set -o pipefail` to make it so that if any command fails, the entire piped set of commands fails - `parallel-exec` was properly failing if any individual command failed, so by doing `set -o pipefail`, this now properly will fail if a test fails (I verified this locally). I also added `set -u` to check for unset variables http://redsymbol.net/articles/unofficial-bash-strict-mode