### PR TITLE
Inbound parsing ShardKey, RoutingKey, and RoutingDelegate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ v1.10.0 (unreleased)
 -   Improves resilience of HTTP and TChannel by broadcasting peer availability
     to peer lists like round robin. A round robin or least pending peer list
     blocks requests until a peer becomes available.
+-   Add support for reading ShardKey, RoutingKey, and RoutingDelegate for
+    inbound http and tchannel calls.
 
 
 v1.9.0 (2017-06-08)

--- a/api/transport/transporttest/reqres.go
+++ b/api/transport/transporttest/reqres.go
@@ -93,6 +93,21 @@ func (m RequestMatcher) Matches(got interface{}) bool {
 		return false
 	}
 
+	if l.ShardKey != r.ShardKey {
+		m.t.Logf("Shard Key mismatch: %s != %s", l.ShardKey, r.ShardKey)
+		return false
+	}
+
+	if l.RoutingKey != r.RoutingKey {
+		m.t.Logf("Routing Key mismatch: %s != %s", l.RoutingKey, r.RoutingKey)
+		return false
+	}
+
+	if l.RoutingDelegate != r.RoutingDelegate {
+		m.t.Logf("Routing Delegate mismatch: %s != %s", l.RoutingDelegate, r.RoutingDelegate)
+		return false
+	}
+
 	// len check to handle nil vs empty cases gracefully.
 	if l.Headers.Len() != r.Headers.Len() {
 		if !reflect.DeepEqual(l.Headers, r.Headers) {

--- a/transport/http/handler.go
+++ b/transport/http/handler.go
@@ -75,12 +75,15 @@ func (h handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 func (h handler) callHandler(w http.ResponseWriter, req *http.Request, start time.Time) error {
 	treq := &transport.Request{
-		Caller:    popHeader(req.Header, CallerHeader),
-		Service:   popHeader(req.Header, ServiceHeader),
-		Procedure: popHeader(req.Header, ProcedureHeader),
-		Encoding:  transport.Encoding(popHeader(req.Header, EncodingHeader)),
-		Headers:   applicationHeaders.FromHTTPHeaders(req.Header, transport.Headers{}),
-		Body:      req.Body,
+		Caller:          popHeader(req.Header, CallerHeader),
+		Service:         popHeader(req.Header, ServiceHeader),
+		Procedure:       popHeader(req.Header, ProcedureHeader),
+		Encoding:        transport.Encoding(popHeader(req.Header, EncodingHeader)),
+		ShardKey:        popHeader(req.Header, ShardKeyHeader),
+		RoutingKey:      popHeader(req.Header, RoutingKeyHeader),
+		RoutingDelegate: popHeader(req.Header, RoutingDelegateHeader),
+		Headers:         applicationHeaders.FromHTTPHeaders(req.Header, transport.Headers{}),
+		Body:            req.Body,
 	}
 	if err := transport.ValidateRequest(treq); err != nil {
 		return err

--- a/transport/http/handler_test.go
+++ b/transport/http/handler_test.go
@@ -51,6 +51,9 @@ func TestHandlerSuccess(t *testing.T) {
 	headers.Set(TTLMSHeader, "1000")
 	headers.Set(ProcedureHeader, "nyuck")
 	headers.Set(ServiceHeader, "curly")
+	headers.Set(ShardKeyHeader, "shard")
+	headers.Set(RoutingKeyHeader, "routekey")
+	headers.Set(RoutingDelegateHeader, "routedelegate")
 
 	router := transporttest.NewMockRouter(mockCtrl)
 	rpcHandler := transporttest.NewMockUnaryHandler(mockCtrl)
@@ -67,11 +70,14 @@ func TestHandlerSuccess(t *testing.T) {
 		),
 		transporttest.NewRequestMatcher(
 			t, &transport.Request{
-				Caller:    "moe",
-				Service:   "curly",
-				Encoding:  raw.Encoding,
-				Procedure: "nyuck",
-				Body:      bytes.NewReader([]byte("Nyuck Nyuck")),
+				Caller:          "moe",
+				Service:         "curly",
+				Encoding:        raw.Encoding,
+				Procedure:       "nyuck",
+				ShardKey:        "shard",
+				RoutingKey:      "routekey",
+				RoutingDelegate: "routedelegate",
+				Body:            bytes.NewReader([]byte("Nyuck Nyuck")),
 			},
 		),
 		gomock.Any(),

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -43,6 +43,10 @@ type inboundCall interface {
 	ServiceName() string
 	CallerName() string
 	MethodString() string
+	ShardKey() string
+	RoutingKey() string
+	RoutingDelegate() string
+
 	Format() tchannel.Format
 
 	Arg2Reader() (tchannel.ArgReader, error)
@@ -117,10 +121,13 @@ func (h handler) callHandler(ctx context.Context, call inboundCall, start time.T
 	}
 
 	treq := &transport.Request{
-		Caller:    call.CallerName(),
-		Service:   call.ServiceName(),
-		Encoding:  transport.Encoding(call.Format()),
-		Procedure: call.MethodString(),
+		Caller:          call.CallerName(),
+		Service:         call.ServiceName(),
+		Encoding:        transport.Encoding(call.Format()),
+		Procedure:       call.MethodString(),
+		ShardKey:        call.ShardKey(),
+		RoutingKey:      call.RoutingKey(),
+		RoutingDelegate: call.RoutingDelegate(),
 	}
 
 	ctx, headers, err := readRequestHeaders(ctx, call.Format(), call.Arg2Reader)

--- a/transport/tchannel/handler_test.go
+++ b/transport/tchannel/handler_test.go
@@ -82,12 +82,15 @@ func TestHandlerErrors(t *testing.T) {
 			transporttest.NewContextMatcher(t),
 			transporttest.NewRequestMatcher(t,
 				&transport.Request{
-					Caller:    "caller",
-					Service:   "service",
-					Headers:   transport.HeadersFromMap(tt.wantHeaders),
-					Encoding:  transport.Encoding(tt.format),
-					Procedure: "hello",
-					Body:      bytes.NewReader([]byte("world")),
+					Caller:          "caller",
+					Service:         "service",
+					Headers:         transport.HeadersFromMap(tt.wantHeaders),
+					Encoding:        transport.Encoding(tt.format),
+					Procedure:       "hello",
+					ShardKey:        "shard",
+					RoutingKey:      "routekey",
+					RoutingDelegate: "routedelegate",
+					Body:            bytes.NewReader([]byte("world")),
 				}),
 			gomock.Any(),
 		).Return(nil)
@@ -97,13 +100,16 @@ func TestHandlerErrors(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
 		defer cancel()
 		tchHandler.handle(ctx, &fakeInboundCall{
-			service: "service",
-			caller:  "caller",
-			format:  tt.format,
-			method:  "hello",
-			arg2:    tt.headers,
-			arg3:    []byte("world"),
-			resp:    respRecorder,
+			service:         "service",
+			caller:          "caller",
+			format:          tt.format,
+			method:          "hello",
+			shardkey:        "shard",
+			routingkey:      "routekey",
+			routingdelegate: "routedelegate",
+			arg2:            tt.headers,
+			arg3:            []byte("world"),
+			resp:            respRecorder,
 		})
 
 		assert.NoError(t, respRecorder.systemErr, "did not expect an error")

--- a/transport/tchannel/tchannel_utils_test.go
+++ b/transport/tchannel/tchannel_utils_test.go
@@ -65,17 +65,23 @@ func (w *bufferArgWriter) Flush() error { return nil }
 //
 // Provide nil for arg2 or arg3 to get Arg2Reader or Arg3Reader to fail.
 type fakeInboundCall struct {
-	service    string
-	caller     string
-	method     string
-	format     tchannel.Format
-	arg2, arg3 []byte
-	resp       inboundCallResponse
+	service         string
+	caller          string
+	method          string
+	shardkey        string
+	routingkey      string
+	routingdelegate string
+	format          tchannel.Format
+	arg2, arg3      []byte
+	resp            inboundCallResponse
 }
 
 func (i *fakeInboundCall) ServiceName() string           { return i.service }
 func (i *fakeInboundCall) CallerName() string            { return i.caller }
 func (i *fakeInboundCall) MethodString() string          { return i.method }
+func (i *fakeInboundCall) ShardKey() string              { return i.shardkey }
+func (i *fakeInboundCall) RoutingKey() string            { return i.routingkey }
+func (i *fakeInboundCall) RoutingDelegate() string       { return i.routingdelegate }
 func (i *fakeInboundCall) Format() tchannel.Format       { return i.format }
 func (i *fakeInboundCall) Response() inboundCallResponse { return i.resp }
 


### PR DESCRIPTION
Summary: Found out while trying to read the shardkey from a service that
we don't parse the shard key on inbound requests in both tchannel and
http.  This pr adds that parsing.

Test Plan: wrote tests