### PR TITLE
Strip thrift warnings in scripts/generate.sh

### DIFF
--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -57,6 +57,11 @@ generated_by_ragel() {
 	mv "$f" "$1"
 }
 
+# Strip thrift warnings.
+strip_thrift_warnings() {
+  grep -v '^\[WARNING:' | sed '/^\s*$/d'
+}
+
 mockgen -destination=api/middleware/middlewaretest/router.go -package=middlewaretest go.uber.org/yarpc/api/middleware Router
 mockgen -destination=api/peer/peertest/list.go -package=peertest go.uber.org/yarpc/api/peer Chooser,List,ChooserList
 mockgen -destination=api/peer/peertest/peer.go -package=peertest go.uber.org/yarpc/api/peer Identifier,Peer
@@ -88,9 +93,9 @@ thriftrw --no-recurse --plugin=yarpc --out=encoding/thrift/thriftrw-plugin-yarpc
 thriftrw --no-recurse --plugin=yarpc --out=encoding/thrift/thriftrw-plugin-yarpc/internal/tests encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic.thrift
 
 thrift-gen --generateThrift --outputDir internal/crossdock/thrift/gen-go --inputFile internal/crossdock/thrift/echo.thrift
-thrift-gen --generateThrift --outputDir internal/crossdock/thrift/gen-go --inputFile internal/crossdock/thrift/gauntlet_tchannel.thrift
+thrift-gen --generateThrift --outputDir internal/crossdock/thrift/gen-go --inputFile internal/crossdock/thrift/gauntlet_tchannel.thrift | strip_thrift_warnings
 
-thrift --gen go:thrift_import=github.com/apache/thrift/lib/go/thrift --out internal/crossdock/thrift/gen-go internal/crossdock/thrift/gauntlet_apache.thrift
+thrift --gen go:thrift_import=github.com/apache/thrift/lib/go/thrift --out internal/crossdock/thrift/gen-go internal/crossdock/thrift/gauntlet_apache.thrift | strip_thrift_warnings
 
 protoc_go yarpcproto/yarpc.proto
 protoc_go encoding/x/protobuf/internal/wirepb/wire.proto

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -59,7 +59,7 @@ generated_by_ragel() {
 
 # Strip thrift warnings.
 strip_thrift_warnings() {
-  grep -v '^\[WARNING:' | sed '/^\s*$/d'
+  grep -v '^\[WARNING:.*emphasize the signedness' | sed '/^\s*$/d'
 }
 
 mockgen -destination=api/middleware/middlewaretest/router.go -package=middlewaretest go.uber.org/yarpc/api/middleware Router


### PR DESCRIPTION
This has been annoying me for a while.

Before:

```
$ make lint
[WARNING:/Users/peteredge/go/src/go.uber.org/yarpc/internal/crossdock/thrift/gauntlet_tchannel.thrift:69] The "byte" type is a compatibility alias for "i8". Use "i8" to emphasize the signedness of this type.

[WARNING:/Users/peteredge/go/src/go.uber.org/yarpc/internal/crossdock/thrift/gauntlet_apache.thrift:69] The "byte" type is a compatibility alias for "i8". Use "i8" to emphasize the signedness of this type.

yarpc-go (development): v1.10.0-dev
```

After:

```
$ make lint
yarpc-go (development): v1.10.0-dev
```