### PR TITLE
More work on api/yarpcerrors

### DIFF
--- a/api/yarpcerrors/errors.go
+++ b/api/yarpcerrors/errors.go
@@ -33,7 +33,7 @@ func IsYARPCError(err error) bool {
 	return ErrorCode(err) != CodeOK
 }
 
-// ToYARPCError is a convienence function with the following logic:
+// ToYARPCError is a convenience function with the following logic:
 //
 // - If err is nil, ToYARPCError returns nil
 // - If err is a YARPC error, ToYARPCError returns err with no changes.

--- a/api/yarpcerrors/errors.go
+++ b/api/yarpcerrors/errors.go
@@ -25,20 +25,32 @@ import (
 	"fmt"
 )
 
-// IsYARPCError returns true if the given error is a non-nil YARPC error.
+// IsYARPCError is a convenience function that returns true if the given error
+// is a non-nil YARPC error.
+//
+// This is equivalent to yarpcerrors.ErrorCode(err) == yarpcerrors.CodeOK.
 func IsYARPCError(err error) bool {
+	return ErrorCode(err) != CodeOK
+}
+
+// ToYARPCError is a convienence function with the following logic:
+//
+// - If err is nil, ToYARPCError returns nil
+// - If err is a YARPC error, ToYARPCError returns err with no changes.
+// - If err is not a YARPC error, ToYARPCError returns a new YARPC error with code
+//   CodeUnknown and message err.Error().
+func ToYARPCError(err error) error {
 	if err == nil {
-		return false
+		return nil
 	}
-	_, ok := err.(*yarpcError)
-	return ok
+	if IsYARPCError(err) {
+		return err
+	}
+	return UnknownErrorf(err.Error())
 }
 
 // ErrorCode returns the Code for the given error, or CodeOK if the given
 // error is not a YARPC error.
-//
-// While a YARPC error will never have CodeOK as an error code, this should not be
-// used to test if an error is a YARPC error, use IsYARPCError instead.
 func ErrorCode(err error) Code {
 	if err == nil {
 		return CodeOK
@@ -77,7 +89,12 @@ func ErrorMessage(err error) string {
 }
 
 // NamedErrorf returns a new yarpc error with code CodeUnknown and the given name.
+//
 // This should be used for user-defined errors.
+//
+// The name must only contain lowercase letters from a-z and dashes (-), and
+// cannot start or end in a dash. If the name is something else, an error with
+// code CodeInternal will be returned.
 func NamedErrorf(name string, format string, args ...interface{}) error {
 	return FromHeaders(CodeUnknown, name, fmt.Sprintf(format, args...))
 }
@@ -167,9 +184,16 @@ func UnauthenticatedErrorf(format string, args ...interface{}) error {
 // If the specified code is CodeOK, this will return nil.
 // If the specified code is not CodeUnknown, this will not set the name field.
 //
+// The name must only contain lowercase letters from a-z and dashes (-), and
+// cannot start or end in a dash. If the name is something else, an error with
+// code CodeInternal will be returned.
+//
 // This function should not be used by server implementations, use the individual
 // error constructors instead. This should only be used by transport implementations.
 func FromHeaders(code Code, name string, message string) error {
+	if err := validateName(name); err != nil {
+		return err
+	}
 	switch code {
 	case CodeOK:
 		return nil
@@ -186,6 +210,10 @@ func FromHeaders(code Code, name string, message string) error {
 		}
 	}
 }
+
+// ** All constructors of yarpcErrors must always set a Code that is not CodeOK. **
+//
+// Currently, the only constructor of yarpcErrors is FromHeaders, which enforces this.
 
 type yarpcError struct {
 	// Code is the code of the error. This should never be set to CodeOK.

--- a/api/yarpcerrors/errors.go
+++ b/api/yarpcerrors/errors.go
@@ -28,7 +28,7 @@ import (
 // IsYARPCError is a convenience function that returns true if the given error
 // is a non-nil YARPC error.
 //
-// This is equivalent to yarpcerrors.ErrorCode(err) == yarpcerrors.CodeOK.
+// This is equivalent to yarpcerrors.ErrorCode(err) != yarpcerrors.CodeOK.
 func IsYARPCError(err error) bool {
 	return ErrorCode(err) != CodeOK
 }

--- a/api/yarpcerrors/name.go
+++ b/api/yarpcerrors/name.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpcerrors
+
+var (
+	_validNameRunes = map[rune]bool{
+		'a': true,
+		'b': true,
+		'c': true,
+		'd': true,
+		'e': true,
+		'f': true,
+		'g': true,
+		'h': true,
+		'i': true,
+		'j': true,
+		'k': true,
+		'l': true,
+		'm': true,
+		'n': true,
+		'o': true,
+		'p': true,
+		'q': true,
+		'r': true,
+		's': true,
+		't': true,
+		'u': true,
+		'v': true,
+		'w': true,
+		'x': true,
+		'y': true,
+		'z': true,
+		'-': true,
+	}
+)
+
+func validateName(name string) error {
+	if name == "" {
+		return nil
+	}
+	// I think that name is a global reference to a slice effectively, so len(name) has some overheade
+	// https://stackoverflow.com/questions/26634554/go-multiple-len-calls-vs-performance
+	// https://blog.golang.org/strings
+	lenNameMinusOne := len(name) - 1
+	for i, b := range name {
+		if (i == 0 || i == lenNameMinusOne) && b == '-' {
+			return InternalErrorf("invalid error name, must only start or end with lowercase letters: %s", name)
+		}
+		if _, ok := _validNameRunes[b]; !ok {
+			return InternalErrorf("invalid error name, must only contain lowercase letters and dashes: %s", name)
+		}
+	}
+	return nil
+}

--- a/api/yarpcerrors/name.go
+++ b/api/yarpcerrors/name.go
@@ -20,38 +20,6 @@
 
 package yarpcerrors
 
-var (
-	_validNameRunes = map[rune]bool{
-		'a': true,
-		'b': true,
-		'c': true,
-		'd': true,
-		'e': true,
-		'f': true,
-		'g': true,
-		'h': true,
-		'i': true,
-		'j': true,
-		'k': true,
-		'l': true,
-		'm': true,
-		'n': true,
-		'o': true,
-		'p': true,
-		'q': true,
-		'r': true,
-		's': true,
-		't': true,
-		'u': true,
-		'v': true,
-		'w': true,
-		'x': true,
-		'y': true,
-		'z': true,
-		'-': true,
-	}
-)
-
 func validateName(name string) error {
 	if name == "" {
 		return nil
@@ -64,7 +32,7 @@ func validateName(name string) error {
 		if (i == 0 || i == lenNameMinusOne) && b == '-' {
 			return InternalErrorf("invalid error name, must only start or end with lowercase letters: %s", name)
 		}
-		if _, ok := _validNameRunes[b]; !ok {
+		if !((b >= 'a' && b <= 'z') || b == '-') {
 			return InternalErrorf("invalid error name, must only contain lowercase letters and dashes: %s", name)
 		}
 	}

--- a/api/yarpcerrors/name_test.go
+++ b/api/yarpcerrors/name_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpcerrors
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateName(t *testing.T) {
+	testValidateName(t, "", false)
+	testValidateName(t, "hello", false)
+	testValidateName(t, "hello-foo", false)
+	testValidateName(t, "-", true)
+	testValidateName(t, "-hello", true)
+	testValidateName(t, "hello-", true)
+	testValidateName(t, "Hello", true)
+}
+
+func testValidateName(t *testing.T, name string, expectError bool) {
+	if expectError {
+		assert.Equal(t, CodeInternal, ErrorCode(validateName(name)), "expected error for %s", name)
+	} else {
+		assert.NoError(t, validateName(name), "expected no error for %s", name)
+	}
+}


### PR DESCRIPTION
This PR does a few things:

- Explicitly document `IsYARPCError(err)` to be equivalent to `ErrorCode(err) == CodeOK`. I have a bunch of TODOs on #1098 that comment that this is not explicit, so there is a mismatch between using `IsYARPCError` and expecting an error code from `ErrorCode` that is not `CodeOK`.
- Add the function `ToYARPCError`. This is a convenience function that makes sure you have a YARPC error, this will remove a lot of logic in transport implementations.
- Add validation for user-defined names to only be lowercase letters from a-z and dashes.
- Add some documentation noting that all `yarpcErrors` created cannot have `Code` set to `CodeOK`.