### PR TITLE
Work on yarpcerrors Codes for transports

### DIFF
--- a/transport/http/codes.go
+++ b/transport/http/codes.go
@@ -23,9 +23,8 @@ package http
 import "go.uber.org/yarpc/api/yarpcerrors"
 
 var (
-	// CodeToHTTPStatusCode maps all Codes
-	// to their corresponding HTTP status code.
-	CodeToHTTPStatusCode = map[yarpcerrors.Code]int{
+	// CodeToStatusCode maps all Codes to their corresponding HTTP status code.
+	CodeToStatusCode = map[yarpcerrors.Code]int{
 		yarpcerrors.CodeOK:                 200,
 		yarpcerrors.CodeCancelled:          499,
 		yarpcerrors.CodeUnknown:            500,
@@ -45,9 +44,8 @@ var (
 		yarpcerrors.CodeUnauthenticated:    401,
 	}
 
-	// HTTPStatusCodeToCodes maps HTTP status codes to a slice
-	// of their corresponding Codes.
-	HTTPStatusCodeToCodes = map[int][]yarpcerrors.Code{
+	// StatusCodeToCodes maps HTTP status codes to a slice of their corresponding Codes.
+	StatusCodeToCodes = map[int][]yarpcerrors.Code{
 		200: {yarpcerrors.CodeOK},
 		400: {
 			yarpcerrors.CodeInvalidArgument,
@@ -74,17 +72,17 @@ var (
 	}
 )
 
-// HTTPStatusCodeToBestCode does a best-effort conversion from the given HTTP status
+// StatusCodeToBestCode does a best-effort conversion from the given HTTP status
 // code to a Code.
 //
 // If one Code maps to the given HTTP status code, that Code is returned.
 // If more than one Code maps to the given HTTP status Code, one Code is returned.
 // If the Code is >=400 and < 500, yarpcerrors.CodeInvalidArgument is returned.
 // Else, yarpcerrors.CodeUnknown is returned.
-func HTTPStatusCodeToBestCode(httpStatusCode int) yarpcerrors.Code {
-	codes, ok := HTTPStatusCodeToCodes[httpStatusCode]
+func StatusCodeToBestCode(statusCode int) yarpcerrors.Code {
+	codes, ok := StatusCodeToCodes[statusCode]
 	if !ok || len(codes) == 0 {
-		if httpStatusCode >= 400 && httpStatusCode < 500 {
+		if statusCode >= 400 && statusCode < 500 {
 			return yarpcerrors.CodeInvalidArgument
 		}
 		return yarpcerrors.CodeUnknown

--- a/transport/http/codes.go
+++ b/transport/http/codes.go
@@ -20,16 +20,12 @@
 
 package http
 
-import (
-	"fmt"
-
-	"go.uber.org/yarpc/api/yarpcerrors"
-)
-
-// TODO: Should we expose the maps as public variables to document the mappings?
+import "go.uber.org/yarpc/api/yarpcerrors"
 
 var (
-	_codeToHTTPStatusCode = map[yarpcerrors.Code]int{
+	// CodeToHTTPStatusCode maps all Codes
+	// to their corresponding HTTP status code.
+	CodeToHTTPStatusCode = map[yarpcerrors.Code]int{
 		yarpcerrors.CodeOK:                 200,
 		yarpcerrors.CodeCancelled:          499,
 		yarpcerrors.CodeUnknown:            500,
@@ -49,7 +45,9 @@ var (
 		yarpcerrors.CodeUnauthenticated:    401,
 	}
 
-	_httpStatusCodeToCodes = map[int][]yarpcerrors.Code{
+	// HTTPStatusCodeToCodes maps HTTP status codes to a slice
+	// of their corresponding Codes.
+	HTTPStatusCodeToCodes = map[int][]yarpcerrors.Code{
 		200: {yarpcerrors.CodeOK},
 		400: {
 			yarpcerrors.CodeInvalidArgument,
@@ -66,8 +64,8 @@ var (
 		429: {yarpcerrors.CodeResourceExhausted},
 		499: {yarpcerrors.CodeCancelled},
 		500: {
-			yarpcerrors.CodeUnknown,
 			yarpcerrors.CodeInternal,
+			yarpcerrors.CodeUnknown,
 			yarpcerrors.CodeDataLoss,
 		},
 		501: {yarpcerrors.CodeUnimplemented},
@@ -76,28 +74,20 @@ var (
 	}
 )
 
-// codeToHTTPStatusCode returns the HTTP status code for the given Code,
-// or error if the Code is unknown.
-func codeToHTTPStatusCode(code yarpcerrors.Code) (int, error) {
-	statusCode, ok := _codeToHTTPStatusCode[code]
-	if !ok {
-		return 0, fmt.Errorf("unknown code: %v", code)
+// HTTPStatusCodeToBestCode does a best-effort conversion from the given HTTP status
+// code to a Code.
+//
+// If one Code maps to the given HTTP status code, that Code is returned.
+// If more than one Code maps to the given HTTP status Code, one Code is returned.
+// If the Code is >=400 and < 500, yarpcerrors.CodeInvalidArgument is returned.
+// Else, yarpcerrors.CodeUnknown is returned.
+func HTTPStatusCodeToBestCode(httpStatusCode int) yarpcerrors.Code {
+	codes, ok := HTTPStatusCodeToCodes[httpStatusCode]
+	if !ok || len(codes) == 0 {
+		if httpStatusCode >= 400 && httpStatusCode < 500 {
+			return yarpcerrors.CodeInvalidArgument
+		}
+		return yarpcerrors.CodeUnknown
 	}
-	return statusCode, nil
-}
-
-// TODO: Is there any use to this? The original thinking was that it would be nice
-// to have a function that returns the most "general" yarpcerrors.Code for the given HTTP
-// status code, but this doesn't really work in practice.
-
-// httpStatusCodeToCodes returns the Codes that correspond to the given HTTP status
-// code, or nil if no Codes correspond to the given HTTP status code.
-func httpStatusCodeToCodes(httpStatusCode int) []yarpcerrors.Code {
-	codes, ok := _httpStatusCodeToCodes[httpStatusCode]
-	if !ok {
-		return nil
-	}
-	c := make([]yarpcerrors.Code, len(codes))
-	copy(c, codes)
-	return c
+	return codes[0]
 }

--- a/transport/http/codes_test.go
+++ b/transport/http/codes_test.go
@@ -27,13 +27,15 @@ import (
 )
 
 func TestCodes(t *testing.T) {
-	for code, httpStatusCode := range _codeToHTTPStatusCode {
+	for code, httpStatusCode := range CodeToHTTPStatusCode {
 		t.Run(code.String(), func(t *testing.T) {
-			getHTTPStatusCode, err := codeToHTTPStatusCode(code)
-			require.NoError(t, err)
+			getHTTPStatusCode, ok := CodeToHTTPStatusCode[code]
+			require.True(t, ok)
 			require.Equal(t, httpStatusCode, getHTTPStatusCode)
-			getCodes := httpStatusCodeToCodes(httpStatusCode)
+			getCodes, ok := HTTPStatusCodeToCodes[httpStatusCode]
+			require.True(t, ok)
 			require.Contains(t, getCodes, code)
+			require.Contains(t, getCodes, HTTPStatusCodeToBestCode(httpStatusCode))
 		})
 	}
 }

--- a/transport/http/codes_test.go
+++ b/transport/http/codes_test.go
@@ -27,15 +27,15 @@ import (
 )
 
 func TestCodes(t *testing.T) {
-	for code, httpStatusCode := range CodeToHTTPStatusCode {
+	for code, statusCode := range CodeToStatusCode {
 		t.Run(code.String(), func(t *testing.T) {
-			getHTTPStatusCode, ok := CodeToHTTPStatusCode[code]
+			getStatusCode, ok := CodeToStatusCode[code]
 			require.True(t, ok)
-			require.Equal(t, httpStatusCode, getHTTPStatusCode)
-			getCodes, ok := HTTPStatusCodeToCodes[httpStatusCode]
+			require.Equal(t, statusCode, getStatusCode)
+			getCodes, ok := StatusCodeToCodes[statusCode]
 			require.True(t, ok)
 			require.Contains(t, getCodes, code)
-			require.Contains(t, getCodes, HTTPStatusCodeToBestCode(httpStatusCode))
+			require.Contains(t, getCodes, StatusCodeToBestCode(statusCode))
 		})
 	}
 }

--- a/transport/tchannel/codes.go
+++ b/transport/tchannel/codes.go
@@ -38,8 +38,8 @@ var (
 		yarpcerrors.CodeDeadlineExceeded:  tchannel.ErrCodeTimeout,
 		yarpcerrors.CodeUnimplemented:     tchannel.ErrCodeBadRequest,
 		yarpcerrors.CodeInternal:          tchannel.ErrCodeUnexpected,
-		yarpcerrors.CodeUnavailable:       tchannel.ErrCodeNetwork,
-		yarpcerrors.CodeDataLoss:          tchannel.ErrCodeUnexpected,
+		yarpcerrors.CodeUnavailable:       tchannel.ErrCodeDeclined,
+		yarpcerrors.CodeDataLoss:          tchannel.ErrCodeProtocol,
 		yarpcerrors.CodeResourceExhausted: tchannel.ErrCodeBusy,
 	}
 

--- a/transport/tchannel/codes.go
+++ b/transport/tchannel/codes.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tchannel
+
+import (
+	"go.uber.org/yarpc/api/yarpcerrors"
+
+	"github.com/uber/tchannel-go"
+)
+
+var (
+	// CodeToTChannelCode maps Codes to their corresponding TChannel SystemErrCode.
+	//
+	// This only covers system-level errors, so if the code is not in the map,
+	// it should not result in TChannel returning a system-level error.
+	CodeToTChannelCode = map[yarpcerrors.Code]tchannel.SystemErrCode{
+		// this is a 400-level code, what to do?
+		yarpcerrors.CodeCancelled: tchannel.ErrCodeCancelled,
+		yarpcerrors.CodeUnknown:   tchannel.ErrCodeUnexpected,
+		// this is a 400-level code, what to do?
+		yarpcerrors.CodeInvalidArgument:  tchannel.ErrCodeBadRequest,
+		yarpcerrors.CodeDeadlineExceeded: tchannel.ErrCodeTimeout,
+		yarpcerrors.CodeUnimplemented:    tchannel.ErrCodeBadRequest,
+		yarpcerrors.CodeInternal:         tchannel.ErrCodeUnexpected,
+		yarpcerrors.CodeUnavailable:      tchannel.ErrCodeNetwork,
+		yarpcerrors.CodeDataLoss:         tchannel.ErrCodeUnexpected,
+	}
+
+	// TChannelCodeToCode maps TChannel SystemErrCodes to their corresponding Code.
+	TChannelCodeToCode = map[tchannel.SystemErrCode]yarpcerrors.Code{
+		tchannel.ErrCodeTimeout: yarpcerrors.CodeDeadlineExceeded,
+		// this is a 400-level code, what to do?
+		tchannel.ErrCodeCancelled:  yarpcerrors.CodeCancelled,
+		tchannel.ErrCodeBusy:       yarpcerrors.CodeUnavailable,
+		tchannel.ErrCodeDeclined:   yarpcerrors.CodeUnavailable,
+		tchannel.ErrCodeUnexpected: yarpcerrors.CodeInternal,
+		// this is a 400-level code, what to do?
+		tchannel.ErrCodeBadRequest: yarpcerrors.CodeInvalidArgument,
+		tchannel.ErrCodeNetwork:    yarpcerrors.CodeUnavailable,
+		tchannel.ErrCodeProtocol:   yarpcerrors.CodeInternal,
+	}
+)

--- a/transport/tchannel/codes.go
+++ b/transport/tchannel/codes.go
@@ -32,27 +32,24 @@ var (
 	// This only covers system-level errors, so if the code is not in the map,
 	// it should not result in TChannel returning a system-level error.
 	CodeToTChannelCode = map[yarpcerrors.Code]tchannel.SystemErrCode{
-		// this is a 400-level code, what to do?
-		yarpcerrors.CodeCancelled: tchannel.ErrCodeCancelled,
-		yarpcerrors.CodeUnknown:   tchannel.ErrCodeUnexpected,
-		// this is a 400-level code, what to do?
-		yarpcerrors.CodeInvalidArgument:  tchannel.ErrCodeBadRequest,
-		yarpcerrors.CodeDeadlineExceeded: tchannel.ErrCodeTimeout,
-		yarpcerrors.CodeUnimplemented:    tchannel.ErrCodeBadRequest,
-		yarpcerrors.CodeInternal:         tchannel.ErrCodeUnexpected,
-		yarpcerrors.CodeUnavailable:      tchannel.ErrCodeNetwork,
-		yarpcerrors.CodeDataLoss:         tchannel.ErrCodeUnexpected,
+		yarpcerrors.CodeCancelled:         tchannel.ErrCodeCancelled,
+		yarpcerrors.CodeUnknown:           tchannel.ErrCodeUnexpected,
+		yarpcerrors.CodeInvalidArgument:   tchannel.ErrCodeBadRequest,
+		yarpcerrors.CodeDeadlineExceeded:  tchannel.ErrCodeTimeout,
+		yarpcerrors.CodeUnimplemented:     tchannel.ErrCodeBadRequest,
+		yarpcerrors.CodeInternal:          tchannel.ErrCodeUnexpected,
+		yarpcerrors.CodeUnavailable:       tchannel.ErrCodeNetwork,
+		yarpcerrors.CodeDataLoss:          tchannel.ErrCodeUnexpected,
+		yarpcerrors.CodeResourceExhausted: tchannel.ErrCodeBusy,
 	}
 
 	// TChannelCodeToCode maps TChannel SystemErrCodes to their corresponding Code.
 	TChannelCodeToCode = map[tchannel.SystemErrCode]yarpcerrors.Code{
-		tchannel.ErrCodeTimeout: yarpcerrors.CodeDeadlineExceeded,
-		// this is a 400-level code, what to do?
+		tchannel.ErrCodeTimeout:    yarpcerrors.CodeDeadlineExceeded,
 		tchannel.ErrCodeCancelled:  yarpcerrors.CodeCancelled,
 		tchannel.ErrCodeBusy:       yarpcerrors.CodeUnavailable,
 		tchannel.ErrCodeDeclined:   yarpcerrors.CodeUnavailable,
 		tchannel.ErrCodeUnexpected: yarpcerrors.CodeInternal,
-		// this is a 400-level code, what to do?
 		tchannel.ErrCodeBadRequest: yarpcerrors.CodeInvalidArgument,
 		tchannel.ErrCodeNetwork:    yarpcerrors.CodeUnavailable,
 		tchannel.ErrCodeProtocol:   yarpcerrors.CodeInternal,

--- a/transport/x/grpc/codes.go
+++ b/transport/x/grpc/codes.go
@@ -21,15 +21,14 @@
 package grpc
 
 import (
-	"fmt"
-
 	"go.uber.org/yarpc/api/yarpcerrors"
 
 	"google.golang.org/grpc/codes"
 )
 
 var (
-	_codeToGRPCCode = map[yarpcerrors.Code]codes.Code{
+	// CodeToGRPCCode maps all Codes to their corresponding gRPC Code.
+	CodeToGRPCCode = map[yarpcerrors.Code]codes.Code{
 		yarpcerrors.CodeOK:                 codes.OK,
 		yarpcerrors.CodeCancelled:          codes.Canceled,
 		yarpcerrors.CodeUnknown:            codes.Unknown,
@@ -49,7 +48,8 @@ var (
 		yarpcerrors.CodeUnauthenticated:    codes.Unauthenticated,
 	}
 
-	_grpcCodeToCode = map[codes.Code]yarpcerrors.Code{
+	// GRPCCodeToCode maps all gRPC Codes to their corresponding Code.
+	GRPCCodeToCode = map[codes.Code]yarpcerrors.Code{
 		codes.OK:                 yarpcerrors.CodeOK,
 		codes.Canceled:           yarpcerrors.CodeCancelled,
 		codes.Unknown:            yarpcerrors.CodeUnknown,
@@ -69,23 +69,3 @@ var (
 		codes.Unauthenticated:    yarpcerrors.CodeUnauthenticated,
 	}
 )
-
-// codeToGRPCCode returns the gRPC Code for the given Code,
-// or error if the Code is unknown.
-func codeToGRPCCode(code yarpcerrors.Code) (codes.Code, error) {
-	grpcCode, ok := _codeToGRPCCode[code]
-	if !ok {
-		return 0, fmt.Errorf("unknown code: %v", code)
-	}
-	return grpcCode, nil
-}
-
-// grpcCodeToCode returns the Code for the given gRPC Code,
-// or error if the gRPC Code is unknown.
-func grpcCodeToCode(grpcCode codes.Code) (yarpcerrors.Code, error) {
-	code, ok := _grpcCodeToCode[grpcCode]
-	if !ok {
-		return 0, fmt.Errorf("unknown gRPC code: %v", grpcCode)
-	}
-	return code, nil
-}

--- a/transport/x/grpc/codes_test.go
+++ b/transport/x/grpc/codes_test.go
@@ -27,13 +27,13 @@ import (
 )
 
 func TestCodes(t *testing.T) {
-	for code, grpcCode := range _codeToGRPCCode {
+	for code, grpcCode := range CodeToGRPCCode {
 		t.Run(code.String(), func(t *testing.T) {
-			getGRPCCode, err := codeToGRPCCode(code)
-			require.NoError(t, err)
+			getGRPCCode, ok := CodeToGRPCCode[code]
+			require.True(t, ok)
 			require.Equal(t, grpcCode, getGRPCCode)
-			getCode, err := grpcCodeToCode(grpcCode)
-			require.NoError(t, err)
+			getCode, ok := GRPCCodeToCode[grpcCode]
+			require.True(t, ok)
 			require.Equal(t, code, getCode)
 		})
 	}


### PR DESCRIPTION
This PR does a few things, some from #1098:

- Make the maps for `yarpcerrors.Code`s in http and gRPC public. This is so the maps are documented, and so I can use them in templates for documentation I want to write for the new errors API, I want to have a template for Markdown documentation that documents the `Code` mappings, and to auto-generate it.
- Add a map for TChannel. This map is tentative - we can review it a bit now, but will need to double-check everything for #1098. This was pulled from #1098.
- Add the function `HTTPStatusCodeToBestCode` to attempt to map HTTP status codes to `Code`s. This is used in #1098.
- Remove functions I don't really use in #1098.