### PR TITLE
Test time dialation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ go_import_path: go.uber.org/yarpc
 env:
   global:
     - XDG_CACHE_HOME=$HOME/.cache
+    - TEST_TIME_SCALE=5
 cache:
   directories:
     - $XDG_CACHE_HOME/yarpc-go

--- a/api/middleware/inbound_test.go
+++ b/api/middleware/inbound_test.go
@@ -25,12 +25,12 @@ import (
 	"context"
 	"errors"
 	"testing"
-	"time"
 
 	"go.uber.org/yarpc/api/middleware"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/api/transport/transporttest"
 	"go.uber.org/yarpc/encoding/raw"
+	"go.uber.org/yarpc/internal/testtime"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -43,7 +43,7 @@ func TestUnaryNopInboundMiddleware(t *testing.T) {
 	h := transporttest.NewMockUnaryHandler(mockCtrl)
 	wrappedH := middleware.ApplyUnaryInbound(h, middleware.NopUnaryInbound)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
 	defer cancel()
 	req := &transport.Request{
 		Caller:    "somecaller",
@@ -66,7 +66,7 @@ func TestOnewayNopInboundMiddleware(t *testing.T) {
 	h := transporttest.NewMockOnewayHandler(mockCtrl)
 	wrappedH := middleware.ApplyOnewayInbound(h, middleware.NopOnewayInbound)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
 	defer cancel()
 	req := &transport.Request{
 		Caller:    "somecaller",

--- a/api/middleware/outbound_test.go
+++ b/api/middleware/outbound_test.go
@@ -25,12 +25,12 @@ import (
 	"context"
 	"io/ioutil"
 	"testing"
-	"time"
 
 	"go.uber.org/yarpc/api/middleware"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/api/transport/transporttest"
 	"go.uber.org/yarpc/encoding/raw"
+	"go.uber.org/yarpc/internal/testtime"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -43,7 +43,7 @@ func TestUnaryNopOutboundMiddleware(t *testing.T) {
 	o := transporttest.NewMockUnaryOutbound(mockCtrl)
 	wrappedO := middleware.ApplyUnaryOutbound(o, middleware.NopUnaryOutbound)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
 	defer cancel()
 	req := &transport.Request{
 		Caller:    "somecaller",
@@ -69,7 +69,7 @@ func TestOnewayNopOutboundMiddleware(t *testing.T) {
 	o := transporttest.NewMockOnewayOutbound(mockCtrl)
 	wrappedO := middleware.ApplyOnewayOutbound(o, middleware.NopOnewayOutbound)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
 	defer cancel()
 	req := &transport.Request{
 		Caller:    "somecaller",

--- a/api/peer/peertest/peerlistaction.go
+++ b/api/peer/peertest/peerlistaction.go
@@ -29,6 +29,7 @@ import (
 
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/testtime"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -78,7 +79,7 @@ func (a ChooseMultiAction) Apply(t *testing.T, pl peer.Chooser, deps ListActionD
 	for _, expectedPeer := range a.ExpectedPeers {
 		action := ChooseAction{
 			ExpectedPeer:        expectedPeer,
-			InputContextTimeout: 20 * time.Millisecond,
+			InputContextTimeout: 20 * testtime.Millisecond,
 		}
 		action.Apply(t, pl, deps)
 	}
@@ -175,7 +176,7 @@ func (a ConcurrentAction) Apply(t *testing.T, pl peer.Chooser, deps ListActionDe
 		}(action)
 
 		if a.Wait > 0 {
-			time.Sleep(a.Wait)
+			testtime.Sleep(a.Wait)
 		}
 	}
 

--- a/encoding/raw/inbound_test.go
+++ b/encoding/raw/inbound_test.go
@@ -24,11 +24,11 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/api/transport/transporttest"
+	"go.uber.org/yarpc/internal/testtime"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -107,7 +107,7 @@ func TestRawHandler(t *testing.T) {
 		}
 		close(writer)
 
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
 		defer cancel()
 
 		err := handler.Handle(ctx, &transport.Request{

--- a/encoding/thrift/inbound_test.go
+++ b/encoding/thrift/inbound_test.go
@@ -25,10 +25,10 @@ import (
 	"context"
 	"io"
 	"testing"
-	"time"
 
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/api/transport/transporttest"
+	"go.uber.org/yarpc/internal/testtime"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -124,7 +124,7 @@ func TestThriftHandler(t *testing.T) {
 				}).Return(nil)
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
 		defer cancel()
 
 		handler := func(ctx context.Context, w wire.Value) (Response,

--- a/encoding/thrift/outbound_test.go
+++ b/encoding/thrift/outbound_test.go
@@ -27,12 +27,12 @@ import (
 	"io"
 	"io/ioutil"
 	"testing"
-	"time"
 
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/api/transport/transporttest"
 	"go.uber.org/yarpc/internal/clientconfig"
 	"go.uber.org/yarpc/internal/procedure"
+	"go.uber.org/yarpc/internal/testtime"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -156,7 +156,7 @@ func TestClient(t *testing.T) {
 				}).Return(nil)
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
 		defer cancel()
 
 		trans := transporttest.NewMockUnaryOutbound(mockCtrl)

--- a/encoding/thrift/thriftrw-plugin-yarpc/roundtrip_test.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/roundtrip_test.go
@@ -27,7 +27,6 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-	"time"
 
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
@@ -45,6 +44,7 @@ import (
 	"go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendemptyserver"
 	"go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendonlyclient"
 	"go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendonlyserver"
+	"go.uber.org/yarpc/internal/testtime"
 	"go.uber.org/yarpc/transport/http"
 
 	"github.com/stretchr/testify/assert"
@@ -329,7 +329,7 @@ func testRoundTrip(t *testing.T, enveloped, multiplexed bool) {
 			method := client.MethodByName(tt.method)
 			assert.True(t, method.IsValid(), "Method %q not found", tt.method)
 
-			ctx, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
+			ctx, cancel := context.WithTimeout(ctx, 200*testtime.Millisecond)
 			defer cancel()
 
 			args := append([]interface{}{ctx}, tt.methodArgs...)

--- a/encoding/x/protobuf/testing/testing_test.go
+++ b/encoding/x/protobuf/testing/testing_test.go
@@ -23,12 +23,12 @@ package testing
 import (
 	"context"
 	"testing"
-	"time"
 
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/internal/examples/protobuf/example"
 	"go.uber.org/yarpc/internal/examples/protobuf/examplepb"
 	"go.uber.org/yarpc/internal/examples/protobuf/exampleutil"
+	"go.uber.org/yarpc/internal/testtime"
 	"go.uber.org/yarpc/internal/testutils"
 	"go.uber.org/yarpc/transport/x/grpc/grpcheader"
 
@@ -111,7 +111,7 @@ func testIntegration(
 }
 
 func getValue(keyValueYarpcClient examplepb.KeyValueYarpcClient, key string, options ...yarpc.CallOption) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
 	defer cancel()
 	response, err := keyValueYarpcClient.GetValue(ctx, &examplepb.GetValueRequest{key}, options...)
 	if err != nil {
@@ -121,14 +121,14 @@ func getValue(keyValueYarpcClient examplepb.KeyValueYarpcClient, key string, opt
 }
 
 func setValue(keyValueYarpcClient examplepb.KeyValueYarpcClient, key string, value string, options ...yarpc.CallOption) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
 	defer cancel()
 	_, err := keyValueYarpcClient.SetValue(ctx, &examplepb.SetValueRequest{key, value}, options...)
 	return err
 }
 
 func getValueGRPC(keyValueGRPCClient examplepb.KeyValueClient, contextWrapper *grpcheader.ContextWrapper, key string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
 	defer cancel()
 	response, err := keyValueGRPCClient.GetValue(contextWrapper.Wrap(ctx), &examplepb.GetValueRequest{key})
 	if err != nil {
@@ -138,14 +138,14 @@ func getValueGRPC(keyValueGRPCClient examplepb.KeyValueClient, contextWrapper *g
 }
 
 func setValueGRPC(keyValueGRPCClient examplepb.KeyValueClient, contextWrapper *grpcheader.ContextWrapper, key string, value string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
 	defer cancel()
 	_, err := keyValueGRPCClient.SetValue(contextWrapper.Wrap(ctx), &examplepb.SetValueRequest{key, value})
 	return err
 }
 
 func fire(sinkYarpcClient examplepb.SinkYarpcClient, value string, options ...yarpc.CallOption) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
 	defer cancel()
 	_, err := sinkYarpcClient.Fire(ctx, &examplepb.FireRequest{value}, options...)
 	return err

--- a/internal/inboundmiddleware/chain_test.go
+++ b/internal/inboundmiddleware/chain_test.go
@@ -25,11 +25,11 @@ import (
 	"context"
 	"errors"
 	"testing"
-	"time"
 
 	"go.uber.org/yarpc/api/middleware"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/api/transport/transporttest"
+	"go.uber.org/yarpc/internal/testtime"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -73,7 +73,7 @@ func TestUnaryChain(t *testing.T) {
 			before.Count, after.Count = 0, 0
 			mockCtrl := gomock.NewController(t)
 			defer mockCtrl.Finish()
-			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
 			defer cancel()
 
 			req := &transport.Request{
@@ -123,7 +123,7 @@ func TestOnewayChain(t *testing.T) {
 			before.Count, after.Count = 0, 0
 			mockCtrl := gomock.NewController(t)
 			defer mockCtrl.Finish()
-			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
 			defer cancel()
 
 			req := &transport.Request{

--- a/internal/integrationtest/util_test.go
+++ b/internal/integrationtest/util_test.go
@@ -22,12 +22,12 @@ package integrationtest_test
 
 import (
 	"testing"
-	"time"
 
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/backoff"
 	"go.uber.org/yarpc/internal/integrationtest"
+	"go.uber.org/yarpc/internal/testtime"
 	"go.uber.org/yarpc/peer/hostport"
 	"go.uber.org/yarpc/transport/tchannel"
 
@@ -50,7 +50,7 @@ var spec = integrationtest.TransportSpec{
 	NewClientTransport: func(t *testing.T) peer.Transport {
 		x, err := tchannel.NewTransport(
 			tchannel.ServiceName("client"),
-			tchannel.ConnTimeout(10*time.Millisecond),
+			tchannel.ConnTimeout(10*testtime.Millisecond),
 			tchannel.ConnBackoff(backoff.None),
 		)
 		require.NoError(t, err, "must construct transport")

--- a/internal/net/httpserver_test.go
+++ b/internal/net/httpserver_test.go
@@ -28,6 +28,8 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/yarpc/internal/testtime"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -99,6 +101,6 @@ func TestStopError(t *testing.T) {
 	server := NewHTTPServer(&http.Server{Addr: ":0"})
 	require.NoError(t, server.ListenAndServe())
 	require.NoError(t, server.Listener().Close())
-	time.Sleep(5 * time.Millisecond)
+	time.Sleep(5 * testtime.Millisecond)
 	require.Error(t, server.Stop())
 }

--- a/internal/outboundmiddleware/chain_test.go
+++ b/internal/outboundmiddleware/chain_test.go
@@ -26,11 +26,11 @@ import (
 	"errors"
 	"io/ioutil"
 	"testing"
-	"time"
 
 	"go.uber.org/yarpc/api/middleware"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/api/transport/transporttest"
+	"go.uber.org/yarpc/internal/testtime"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -75,7 +75,7 @@ func TestUnaryChain(t *testing.T) {
 			before.Count, after.Count = 0, 0
 			mockCtrl := gomock.NewController(t)
 			defer mockCtrl.Finish()
-			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
 			defer cancel()
 
 			req := &transport.Request{
@@ -128,7 +128,7 @@ func TestOnewayChain(t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
 			defer mockCtrl.Finish()
-			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
 			defer cancel()
 
 			var res transport.Ack

--- a/internal/pally/counter_test.go
+++ b/internal/pally/counter_test.go
@@ -22,9 +22,9 @@ package pally
 
 import (
 	"testing"
-	"time"
 
 	"go.uber.org/yarpc/internal/pally/pallytest"
+	"go.uber.org/yarpc/internal/testtime"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -47,7 +47,7 @@ func TestCounter(t *testing.T) {
 	counter.Add(2)
 	assert.Equal(t, int64(3), counter.Load(), "Unexpected in-memory counter value.")
 
-	time.Sleep(5 * _tick)
+	testtime.Sleep(5 * _tick)
 	counter.Inc()
 	assert.Equal(t, int64(4), counter.Load(), "Unexpected in-memory counter value after sleep.")
 

--- a/internal/pally/gauge_test.go
+++ b/internal/pally/gauge_test.go
@@ -22,9 +22,9 @@ package pally
 
 import (
 	"testing"
-	"time"
 
 	"go.uber.org/yarpc/internal/pally/pallytest"
+	"go.uber.org/yarpc/internal/testtime"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -47,7 +47,7 @@ func TestGauge(t *testing.T) {
 	gauge.Store(42)
 	assert.Equal(t, int64(42), gauge.Load(), "Unexpected in-memory gauge value.")
 
-	time.Sleep(5 * _tick)
+	testtime.Sleep(5 * _tick)
 	gauge.Store(4)
 	assert.Equal(t, int64(4), gauge.Load(), "Unexpected in-memory gauge value after sleep.")
 

--- a/internal/retry/retry_action_test.go
+++ b/internal/retry/retry_action_test.go
@@ -30,6 +30,7 @@ import (
 
 	"go.uber.org/yarpc/api/middleware"
 	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/testtime"
 	. "go.uber.org/yarpc/internal/yarpctest/outboundtest"
 	"go.uber.org/yarpc/yarpctest"
 
@@ -67,7 +68,7 @@ func (r RequestAction) Apply(t *testing.T, mw middleware.UnaryOutbound) {
 
 	ctx := context.Background()
 	if r.reqTimeout != 0 {
-		newCtx, cancel := context.WithTimeout(ctx, r.reqTimeout)
+		newCtx, cancel := context.WithTimeout(ctx, testtime.Scale(r.reqTimeout))
 		defer cancel()
 		ctx = newCtx
 	}
@@ -108,7 +109,7 @@ func (a ConcurrentAction) Apply(t *testing.T, mw middleware.UnaryOutbound) {
 		}(action)
 
 		if a.Wait > 0 {
-			time.Sleep(a.Wait)
+			testtime.Sleep(a.Wait)
 		}
 	}
 

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -30,6 +30,7 @@ import (
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/errors"
 	iioutil "go.uber.org/yarpc/internal/ioutil"
+	"go.uber.org/yarpc/internal/testtime"
 	. "go.uber.org/yarpc/internal/yarpctest/outboundtest"
 )
 
@@ -38,7 +39,7 @@ func TestMiddleware(t *testing.T) {
 		msg string
 
 		retries      uint
-		retrytimeout time.Duration
+		retryTimeout time.Duration
 		retryBackoff backoff.Strategy
 
 		actions []MiddlewareAction
@@ -47,7 +48,7 @@ func TestMiddleware(t *testing.T) {
 		{
 			msg:          "no retry",
 			retries:      1,
-			retrytimeout: time.Millisecond * 500,
+			retryTimeout: time.Millisecond * 500,
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -71,7 +72,7 @@ func TestMiddleware(t *testing.T) {
 		{
 			msg:          "single retry",
 			retries:      1,
-			retrytimeout: time.Millisecond * 500,
+			retryTimeout: time.Millisecond * 500,
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -101,7 +102,7 @@ func TestMiddleware(t *testing.T) {
 		{
 			msg:          "multiple retries",
 			retries:      4,
-			retrytimeout: time.Millisecond * 500,
+			retryTimeout: time.Millisecond * 500,
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -149,7 +150,7 @@ func TestMiddleware(t *testing.T) {
 		{
 			msg:          "immediate hard failure",
 			retries:      1,
-			retrytimeout: time.Millisecond * 500,
+			retryTimeout: time.Millisecond * 500,
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -173,7 +174,7 @@ func TestMiddleware(t *testing.T) {
 		{
 			msg:          "retry once, then hard failure",
 			retries:      1,
-			retrytimeout: time.Millisecond * 500,
+			retryTimeout: time.Millisecond * 500,
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -203,7 +204,7 @@ func TestMiddleware(t *testing.T) {
 		{
 			msg:          "ctx timeout less than retry timeout",
 			retries:      1,
-			retrytimeout: time.Millisecond * 500,
+			retryTimeout: time.Millisecond * 500,
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -227,7 +228,7 @@ func TestMiddleware(t *testing.T) {
 		{
 			msg:          "ctx timeout less than retry timeout",
 			retries:      1,
-			retrytimeout: time.Millisecond * 50,
+			retryTimeout: time.Millisecond * 50,
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -258,7 +259,7 @@ func TestMiddleware(t *testing.T) {
 		{
 			msg:          "no ctx timeout",
 			retries:      1,
-			retrytimeout: time.Millisecond * 50,
+			retryTimeout: time.Millisecond * 50,
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -288,7 +289,7 @@ func TestMiddleware(t *testing.T) {
 		{
 			msg:          "exhaust retries",
 			retries:      1,
-			retrytimeout: time.Millisecond * 50,
+			retryTimeout: time.Millisecond * 50,
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -318,7 +319,7 @@ func TestMiddleware(t *testing.T) {
 		{
 			msg:          "Reset Error",
 			retries:      1,
-			retrytimeout: time.Millisecond * 50,
+			retryTimeout: time.Millisecond * 50,
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -343,7 +344,7 @@ func TestMiddleware(t *testing.T) {
 		{
 			msg:          "backoff timeout",
 			retries:      1,
-			retrytimeout: time.Millisecond * 50,
+			retryTimeout: time.Millisecond * 50,
 			retryBackoff: newFixedBackoff(time.Millisecond * 25),
 			actions: []MiddlewareAction{
 				RequestAction{
@@ -375,7 +376,7 @@ func TestMiddleware(t *testing.T) {
 		{
 			msg:          "sequential backoff timeout",
 			retries:      2,
-			retrytimeout: time.Millisecond * 100,
+			retryTimeout: time.Millisecond * 100,
 			retryBackoff: newSequentialBackoff(time.Millisecond * 50),
 			actions: []MiddlewareAction{
 				RequestAction{
@@ -414,7 +415,7 @@ func TestMiddleware(t *testing.T) {
 		{
 			msg:          "backoff context will timeout",
 			retries:      2,
-			retrytimeout: time.Millisecond * 30,
+			retryTimeout: time.Millisecond * 30,
 			retryBackoff: newFixedBackoff(time.Millisecond * 5000),
 			actions: []MiddlewareAction{
 				RequestAction{
@@ -440,7 +441,7 @@ func TestMiddleware(t *testing.T) {
 		{
 			msg:          "concurrent retries",
 			retries:      2,
-			retrytimeout: time.Millisecond * 50,
+			retryTimeout: time.Millisecond * 50,
 			retryBackoff: newFixedBackoff(time.Millisecond * 25),
 			actions: []MiddlewareAction{
 				ConcurrentAction{
@@ -525,7 +526,7 @@ func TestMiddleware(t *testing.T) {
 					func(context.Context, *transport.Request) *Policy {
 						return NewPolicy(
 							Retries(tt.retries),
-							MaxRequestTimeout(tt.retrytimeout),
+							MaxRequestTimeout(testtime.Scale(tt.retryTimeout)),
 							BackoffStrategy(tt.retryBackoff),
 						)
 					},

--- a/internal/sync/lifecycle_action_test.go
+++ b/internal/sync/lifecycle_action_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/yarpc/internal/testtime"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/uber-go/atomic"
 )
@@ -54,7 +56,7 @@ func (a StartAction) Apply(t *testing.T, l wrappedLifecycleOnce) {
 	err := l.Start(func() error {
 		assert.False(t, l.running.Swap(true), "expected no other running action")
 		if a.Wait > 0 {
-			time.Sleep(a.Wait)
+			testtime.Sleep(a.Wait)
 		}
 		assert.True(t, l.running.Swap(false), "expected no other running action")
 		return a.Err
@@ -77,7 +79,7 @@ func (a StopAction) Apply(t *testing.T, l wrappedLifecycleOnce) {
 	err := l.Stop(func() error {
 		assert.False(t, l.running.Swap(true), "expected no other running action")
 		if a.Wait > 0 {
-			time.Sleep(a.Wait)
+			testtime.Sleep(a.Wait)
 		}
 		assert.True(t, l.running.Swap(false), "expected no other running action")
 		return a.Err
@@ -177,7 +179,7 @@ func (a ConcurrentAction) Apply(t *testing.T, l wrappedLifecycleOnce) {
 		}(action)
 
 		if a.Wait > 0 {
-			time.Sleep(a.Wait)
+			testtime.Sleep(a.Wait)
 		}
 	}
 
@@ -189,7 +191,7 @@ type WaitAction time.Duration
 
 // Apply waits the specified duration.
 func (a WaitAction) Apply(t *testing.T, l wrappedLifecycleOnce) {
-	time.Sleep(time.Duration(a))
+	testtime.Sleep(time.Duration(a))
 }
 
 // ApplyLifecycleActions runs all the LifecycleActions on the LifecycleOnce

--- a/internal/testtime/scale.go
+++ b/internal/testtime/scale.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package testtime provides ways to scale time for tests running on CPU
+// starved systems.
+package testtime
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+)
+
+var (
+	// X is the multiplier from the TEST_TIME_SCALE environment variable.
+	X = 1.0
+	// Millisecond is a millisecond dialated into test time by TEST_TIME_SCALE.
+	Millisecond = time.Millisecond
+	// Second is a second dialated into test time by TEST_TIME_SCALE.
+	Second = time.Second
+)
+
+func init() {
+	if v := os.Getenv("TEST_TIME_SCALE"); v != "" {
+		fv, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			panic(err)
+		}
+		X = fv
+		fmt.Fprintln(os.Stderr, "Scaling test time by factor", X)
+	}
+
+	Millisecond = Scale(time.Millisecond)
+	Second = Scale(time.Second)
+}
+
+// Scale returns the timeout multiplied by any set multiplier.
+func Scale(timeout time.Duration) time.Duration {
+	return time.Duration(X * float64(timeout))
+}
+
+// Sleep sleeps the given duration in test time scale.
+func Sleep(duration time.Duration) {
+	time.Sleep(Scale(duration))
+}

--- a/internal/testtime/scale.go
+++ b/internal/testtime/scale.go
@@ -32,9 +32,9 @@ import (
 var (
 	// X is the multiplier from the TEST_TIME_SCALE environment variable.
 	X = 1.0
-	// Millisecond is a millisecond dialated into test time by TEST_TIME_SCALE.
+	// Millisecond is a millisecond dilated into test time by TEST_TIME_SCALE.
 	Millisecond = time.Millisecond
-	// Second is a second dialated into test time by TEST_TIME_SCALE.
+	// Second is a second dilated into test time by TEST_TIME_SCALE.
 	Second = time.Second
 )
 

--- a/internal/yarpctest/outboundtest/outbound_event_test.go
+++ b/internal/yarpctest/outboundtest/outbound_event_test.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/testtime"
 	iyarpctest "go.uber.org/yarpc/internal/yarpctest"
 	"go.uber.org/yarpc/yarpctest"
 
@@ -245,7 +246,7 @@ func TestOutboundEvent(t *testing.T) {
 			testResult := iyarpctest.WithFakeTestingT(func(ft require.TestingT) {
 				ctx := context.Background()
 				if tt.reqTimeout != 0 {
-					newCtx, cancel := context.WithTimeout(ctx, tt.reqTimeout)
+					newCtx, cancel := context.WithTimeout(ctx, testtime.Scale(tt.reqTimeout))
 					defer cancel()
 					ctx = newCtx
 				}
@@ -380,7 +381,7 @@ func TestOutboundCallable(t *testing.T) {
 
 				ctx := context.Background()
 				if tt.reqTimeout != 0 {
-					newCtx, cancel := context.WithTimeout(ctx, tt.reqTimeout)
+					newCtx, cancel := context.WithTimeout(ctx, testtime.Scale(tt.reqTimeout))
 					defer cancel()
 					ctx = newCtx
 				}

--- a/peer/hostport/peeraction_test.go
+++ b/peer/hostport/peeraction_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/internal/testtime"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -140,7 +141,7 @@ func (a PeerConcurrentAction) Apply(t *testing.T, p *Peer, d *Dependencies) {
 		}(action)
 
 		if a.Wait > 0 {
-			time.Sleep(a.Wait)
+			testtime.Sleep(a.Wait)
 		}
 	}
 

--- a/transport/http/inbound_test.go
+++ b/transport/http/inbound_test.go
@@ -30,12 +30,12 @@ import (
 	"os"
 	"syscall"
 	"testing"
-	"time"
 
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/api/transport/transporttest"
 	"go.uber.org/yarpc/encoding/raw"
 	"go.uber.org/yarpc/internal/routertest"
+	"go.uber.org/yarpc/internal/testtime"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -139,7 +139,7 @@ func TestInboundMux(t *testing.T) {
 	require.NoError(t, o.Start(), "failed to start outbound")
 	defer o.Stop()
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
 	defer cancel()
 	_, err = o.Call(ctx, &transport.Request{
 		Caller:    "foo",

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -29,10 +29,10 @@ import (
 	"strconv"
 	"sync"
 	"testing"
-	"time"
 
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/raw"
+	"go.uber.org/yarpc/internal/testtime"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -46,7 +46,7 @@ func TestCallSuccess(t *testing.T) {
 			ttl := req.Header.Get(TTLMSHeader)
 			ttlms, err := strconv.Atoi(ttl)
 			assert.NoError(t, err, "can parse TTL header")
-			assert.InDelta(t, ttlms, 1000, 5, "ttl header within tolerance")
+			assert.InDelta(t, ttlms, testtime.X*1000.0, testtime.X*5.0, "ttl header within tolerance")
 
 			assert.Equal(t, "caller", req.Header.Get(CallerHeader))
 			assert.Equal(t, "service", req.Header.Get(ServiceHeader))
@@ -70,7 +70,7 @@ func TestCallSuccess(t *testing.T) {
 	require.NoError(t, out.Start(), "failed to start outbound")
 	defer out.Stop()
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
 	defer cancel()
 	res, err := out.Call(ctx, &transport.Request{
 		Caller:    "caller",
@@ -153,7 +153,7 @@ func TestOutboundHeaders(t *testing.T) {
 		ctx := tt.context
 		if ctx == nil {
 			var cancel context.CancelFunc
-			ctx, cancel = context.WithTimeout(context.Background(), time.Second)
+			ctx, cancel = context.WithTimeout(context.Background(), testtime.Second)
 			defer cancel()
 		}
 
@@ -225,7 +225,7 @@ func TestOutboundApplicationError(t *testing.T) {
 		defer out.Stop()
 
 		ctx := context.Background()
-		ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+		ctx, cancel := context.WithTimeout(ctx, 100*testtime.Millisecond)
 		defer cancel()
 
 		res, err := out.Call(ctx, &transport.Request{
@@ -274,7 +274,7 @@ func TestCallFailures(t *testing.T) {
 		require.NoError(t, out.Start(), "failed to start outbound")
 		defer out.Stop()
 
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
 		defer cancel()
 		_, err := out.Call(ctx, &transport.Request{
 			Caller:    "caller",
@@ -339,7 +339,7 @@ func TestCallWithoutStarting(t *testing.T) {
 	httpTransport := NewTransport()
 	out := httpTransport.NewSingleOutbound("http://127.0.0.1:9999")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 200*testtime.Millisecond)
 	defer cancel()
 	_, err := out.Call(
 		ctx,

--- a/transport/http/transport_test.go
+++ b/transport/http/transport_test.go
@@ -22,10 +22,10 @@ package http
 
 import (
 	"testing"
-	"time"
 
 	"go.uber.org/yarpc/api/peer"
 	. "go.uber.org/yarpc/api/peer/peertest"
+	"go.uber.org/yarpc/internal/testtime"
 	"go.uber.org/yarpc/peer/hostport"
 
 	"github.com/crossdock/crossdock-go/assert"
@@ -285,7 +285,7 @@ func TestTransportClient(t *testing.T) {
 func TestTransportClientWithKeepAlive(t *testing.T) {
 	// Unfortunately the KeepAlive is obfuscated in the client, so we can't really
 	// assert this worked.
-	transport := NewTransport(KeepAlive(time.Second))
+	transport := NewTransport(KeepAlive(testtime.Second))
 
 	assert.NotNil(t, transport.client)
 }

--- a/transport/roundtrip_test.go
+++ b/transport/roundtrip_test.go
@@ -33,6 +33,7 @@ import (
 	"go.uber.org/yarpc/api/transport/transporttest"
 	"go.uber.org/yarpc/encoding/raw"
 	"go.uber.org/yarpc/internal/errors"
+	"go.uber.org/yarpc/internal/testtime"
 	"go.uber.org/yarpc/transport/http"
 	tch "go.uber.org/yarpc/transport/tchannel"
 
@@ -254,7 +255,7 @@ func TestSimpleRoundTrip(t *testing.T) {
 				return err
 			})
 
-			ctx, cancel := context.WithTimeout(rootCtx, 200*time.Millisecond)
+			ctx, cancel := context.WithTimeout(rootCtx, 200*testtime.Millisecond)
 			defer cancel()
 
 			router := staticRouter{Handler: handler}
@@ -333,7 +334,7 @@ func TestSimpleRoundTripOneway(t *testing.T) {
 
 				// Pretend to work: this delay should not slow down tests since it is a
 				// server-side operation
-				time.Sleep(5 * time.Second)
+				testtime.Sleep(5 * time.Second)
 
 				// close the channel, telling the client (which should not be waiting for
 				// a response) that the handler finished executing

--- a/transport/tchannel/channel_inbound_test.go
+++ b/transport/tchannel/channel_inbound_test.go
@@ -26,12 +26,12 @@ import (
 	"fmt"
 	"io/ioutil"
 	"testing"
-	"time"
 
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/json"
 	"go.uber.org/yarpc/encoding/raw"
+	"go.uber.org/yarpc/internal/testtime"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -127,7 +127,7 @@ func TestChannelInboundExistingMethods(t *testing.T) {
 	defer x.Stop()
 
 	// Make a call to the "echo" method which should call our pre-registered method.
-	ctx, cancel := tjson.NewContext(time.Second)
+	ctx, cancel := tjson.NewContext(testtime.Second)
 	defer cancel()
 
 	var resp map[string]string
@@ -168,7 +168,7 @@ func TestChannelInboundMaskedMethods(t *testing.T) {
 	defer x.Stop()
 
 	// Make a call to the "echo" method which should call our pre-registered method.
-	ctx, cancel := tjson.NewContext(time.Second)
+	ctx, cancel := tjson.NewContext(testtime.Second)
 	defer cancel()
 
 	var resp map[string]string
@@ -224,7 +224,7 @@ func TestChannelInboundSubServices(t *testing.T) {
 		{"subservice2", "hello"},
 		{"subservice2", "monde"},
 	} {
-		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		ctx, cancel := context.WithTimeout(context.Background(), 200*testtime.Millisecond)
 		defer cancel()
 		res, err := o.Call(
 			ctx,

--- a/transport/tchannel/channel_outbound_test.go
+++ b/transport/tchannel/channel_outbound_test.go
@@ -29,6 +29,7 @@ import (
 
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/raw"
+	"go.uber.org/yarpc/internal/testtime"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -124,7 +125,7 @@ func TestChannelOutboundHeaders(t *testing.T) {
 					if ctx == nil {
 						ctx = context.Background()
 					}
-					ctx, cancel := context.WithTimeout(ctx, time.Second)
+					ctx, cancel := context.WithTimeout(ctx, testtime.Second)
 					defer cancel()
 
 					res, err := out.Call(
@@ -173,7 +174,7 @@ func TestChannelCallSuccess(t *testing.T) {
 
 			dl, ok := ctx.Deadline()
 			assert.True(t, ok, "deadline expected")
-			assert.WithinDuration(t, time.Now(), dl, 200*time.Millisecond)
+			assert.WithinDuration(t, time.Now(), dl, 200*testtime.Millisecond)
 
 			err = writeArgs(call.Response(),
 				[]byte{
@@ -193,7 +194,7 @@ func TestChannelCallSuccess(t *testing.T) {
 			require.NoError(t, out.Start(), "failed to start outbound")
 			defer out.Stop()
 
-			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+			ctx, cancel := context.WithTimeout(context.Background(), 200*testtime.Millisecond)
 			defer cancel()
 			res, err := out.Call(
 				ctx,
@@ -274,7 +275,7 @@ func TestChannelCallFailures(t *testing.T) {
 					require.NoError(t, out.Start(), "failed to start outbound")
 					defer out.Stop()
 
-					ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+					ctx, cancel := context.WithTimeout(context.Background(), 200*testtime.Millisecond)
 					defer cancel()
 					_, err = out.Call(
 						ctx,
@@ -315,7 +316,7 @@ func TestChannelCallError(t *testing.T) {
 
 			dl, ok := ctx.Deadline()
 			assert.True(t, ok, "deadline expected")
-			assert.WithinDuration(t, time.Now(), dl, 200*time.Millisecond)
+			assert.WithinDuration(t, time.Now(), dl, 200*testtime.Millisecond)
 
 			call.Response().SetApplicationError()
 
@@ -336,7 +337,7 @@ func TestChannelCallError(t *testing.T) {
 			require.NoError(t, out.Start(), "failed to start outbound")
 			defer out.Stop()
 
-			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+			ctx, cancel := context.WithTimeout(context.Background(), 200*testtime.Millisecond)
 			defer cancel()
 			res, err := out.Call(
 				ctx,
@@ -435,7 +436,7 @@ func TestChannelCallWithoutStarting(t *testing.T) {
 			// TODO: If we change Start() to establish a connection to the host, this
 			// hostport will have to be changed to a real server.
 
-			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+			ctx, cancel := context.WithTimeout(context.Background(), 200*testtime.Millisecond)
 			defer cancel()
 			_, err = out.Call(
 				ctx,

--- a/transport/tchannel/handler_test.go
+++ b/transport/tchannel/handler_test.go
@@ -26,7 +26,6 @@ import (
 	"errors"
 	"fmt"
 	"testing"
-	"time"
 
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/api/transport/transporttest"
@@ -34,6 +33,7 @@ import (
 	"go.uber.org/yarpc/encoding/raw"
 	"go.uber.org/yarpc/internal/encoding"
 	"go.uber.org/yarpc/internal/routertest"
+	"go.uber.org/yarpc/internal/testtime"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -95,7 +95,7 @@ func TestHandlerErrors(t *testing.T) {
 
 		respRecorder := newResponseRecorder()
 
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
 		defer cancel()
 		tchHandler.handle(ctx, &fakeInboundCall{
 			service: "service",
@@ -198,7 +198,7 @@ func TestHandlerFailures(t *testing.T) {
 			},
 			expectCall: func(h *transporttest.MockUnaryHandler) {
 				h.EXPECT().Handle(
-					transporttest.NewContextMatcher(t, transporttest.ContextTTL(time.Second)),
+					transporttest.NewContextMatcher(t, transporttest.ContextTTL(testtime.Second)),
 					transporttest.NewRequestMatcher(
 						t, &transport.Request{
 							Caller:    "bar",
@@ -235,7 +235,7 @@ func TestHandlerFailures(t *testing.T) {
 					Body:      bytes.NewReader([]byte("{}")),
 				}
 				h.EXPECT().Handle(
-					transporttest.NewContextMatcher(t, transporttest.ContextTTL(time.Second)),
+					transporttest.NewContextMatcher(t, transporttest.ContextTTL(testtime.Second)),
 					transporttest.NewRequestMatcher(t, req),
 					gomock.Any(),
 				).Return(
@@ -253,7 +253,7 @@ func TestHandlerFailures(t *testing.T) {
 		{
 			desc: "handler timeout",
 			ctxFunc: func() (context.Context, context.CancelFunc) {
-				return context.WithTimeout(context.Background(), time.Millisecond)
+				return context.WithTimeout(context.Background(), testtime.Millisecond)
 			},
 			sendCall: &fakeInboundCall{
 				service: "foo",
@@ -273,7 +273,7 @@ func TestHandlerFailures(t *testing.T) {
 				}
 				h.EXPECT().Handle(
 					transporttest.NewContextMatcher(
-						t, transporttest.ContextTTL(time.Millisecond)),
+						t, transporttest.ContextTTL(testtime.Millisecond)),
 					transporttest.NewRequestMatcher(t, req),
 					gomock.Any(),
 				).Do(func(ctx context.Context, _ *transport.Request, _ transport.ResponseWriter) {
@@ -304,7 +304,7 @@ func TestHandlerFailures(t *testing.T) {
 				}
 				h.EXPECT().Handle(
 					transporttest.NewContextMatcher(
-						t, transporttest.ContextTTL(time.Second)),
+						t, transporttest.ContextTTL(testtime.Second)),
 					transporttest.NewRequestMatcher(t, req),
 					gomock.Any(),
 				).Do(func(context.Context, *transport.Request, transport.ResponseWriter) {
@@ -319,7 +319,7 @@ func TestHandlerFailures(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
 		if tt.ctx != nil {
 			ctx = tt.ctx
 		} else if tt.ctxFunc != nil {

--- a/transport/tchannel/inbound_test.go
+++ b/transport/tchannel/inbound_test.go
@@ -25,12 +25,12 @@ import (
 	"context"
 	"io/ioutil"
 	"testing"
-	"time"
 
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/api/transport/transporttest"
 	"go.uber.org/yarpc/encoding/raw"
+	"go.uber.org/yarpc/internal/testtime"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -113,7 +113,7 @@ func TestInboundSubServices(t *testing.T) {
 		{"subservice2", "hello"},
 		{"subservice2", "monde"},
 	} {
-		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		ctx, cancel := context.WithTimeout(context.Background(), 200*testtime.Millisecond)
 		defer cancel()
 		res, err := o.Call(
 			ctx,
@@ -169,7 +169,7 @@ func TestArbitraryInboundServiceOutboundCallerName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.msg, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+			ctx, cancel := context.WithTimeout(context.Background(), 200*testtime.Millisecond)
 			defer cancel()
 			res, err := o.Call(
 				ctx,

--- a/transport/tchannel/outbound_test.go
+++ b/transport/tchannel/outbound_test.go
@@ -29,6 +29,7 @@ import (
 
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/raw"
+	"go.uber.org/yarpc/internal/testtime"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -91,7 +92,7 @@ func TestOutboundHeaders(t *testing.T) {
 		if ctx == nil {
 			ctx = context.Background()
 		}
-		ctx, cancel := context.WithTimeout(ctx, time.Second)
+		ctx, cancel := context.WithTimeout(ctx, testtime.Second)
 		defer cancel()
 
 		res, err := out.Call(
@@ -137,7 +138,7 @@ func TestCallSuccess(t *testing.T) {
 
 			dl, ok := ctx.Deadline()
 			assert.True(t, ok, "deadline expected")
-			assert.WithinDuration(t, time.Now(), dl, 200*time.Millisecond)
+			assert.WithinDuration(t, time.Now(), dl, 200*testtime.Millisecond)
 
 			err = writeArgs(call.Response(),
 				[]byte{
@@ -156,7 +157,7 @@ func TestCallSuccess(t *testing.T) {
 	require.NoError(t, out.Start(), "failed to start outbound")
 	defer out.Stop()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 200*testtime.Millisecond)
 	defer cancel()
 	res, err := out.Call(
 		ctx,
@@ -231,7 +232,7 @@ func TestCallFailures(t *testing.T) {
 		require.NoError(t, out.Start(), "failed to start outbound")
 		defer out.Stop()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		ctx, cancel := context.WithTimeout(context.Background(), 200*testtime.Millisecond)
 		defer cancel()
 		_, err = out.Call(
 			ctx,
@@ -269,7 +270,7 @@ func TestCallError(t *testing.T) {
 
 			dl, ok := ctx.Deadline()
 			assert.True(t, ok, "deadline expected")
-			assert.WithinDuration(t, time.Now(), dl, 200*time.Millisecond)
+			assert.WithinDuration(t, time.Now(), dl, 200*testtime.Millisecond)
 
 			call.Response().SetApplicationError()
 
@@ -289,7 +290,7 @@ func TestCallError(t *testing.T) {
 	require.NoError(t, out.Start(), "failed to start outbound")
 	defer out.Stop()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 200*testtime.Millisecond)
 	defer cancel()
 	res, err := out.Call(
 		ctx,
@@ -379,7 +380,7 @@ func TestCallWithoutStarting(t *testing.T) {
 	// TODO: If we change Start() to establish a connection to the host, this
 	// hostport will have to be changed to a real server.
 
-	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 200*testtime.Millisecond)
 	defer cancel()
 	_, err = out.Call(
 		ctx,

--- a/transport/tchannel/peer_test.go
+++ b/transport/tchannel/peer_test.go
@@ -24,12 +24,12 @@ import (
 	"context"
 	"net"
 	"testing"
-	"time"
 
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/backoff"
 	"go.uber.org/yarpc/internal/integrationtest"
+	"go.uber.org/yarpc/internal/testtime"
 	"go.uber.org/yarpc/peer/hostport"
 	"go.uber.org/yarpc/transport/tchannel"
 
@@ -52,7 +52,7 @@ var spec = integrationtest.TransportSpec{
 	NewClientTransport: func(t *testing.T) peer.Transport {
 		x, err := tchannel.NewTransport(
 			tchannel.ServiceName("client"),
-			tchannel.ConnTimeout(10*time.Millisecond),
+			tchannel.ConnTimeout(10*testtime.Millisecond),
 			tchannel.ConnBackoff(backoff.None),
 		)
 		require.NoError(t, err, "must construct transport")
@@ -74,7 +74,7 @@ var spec = integrationtest.TransportSpec{
 // handshake.
 func TestWithRoundRobin(t *testing.T) {
 	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	ctx, cancel := context.WithTimeout(ctx, testtime.Second)
 	defer cancel()
 
 	permanent, permanentAddr := spec.NewServer(t, "")

--- a/transport/tracer_test.go
+++ b/transport/tracer_test.go
@@ -23,12 +23,12 @@ package transport_test
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/encoding/json"
+	"go.uber.org/yarpc/internal/testtime"
 	"go.uber.org/yarpc/transport/http"
 	ytchannel "go.uber.org/yarpc/transport/tchannel"
 
@@ -71,7 +71,7 @@ func (h handler) echoEcho(ctx context.Context) error {
 
 func (h handler) createContextWithBaggage(tracer opentracing.Tracer) (context.Context, func()) {
 	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	ctx, cancel := context.WithTimeout(ctx, testtime.Second)
 
 	span := tracer.StartSpan("test")
 	// no defer span.Finish()

--- a/transport/x/grpc/integration_test.go
+++ b/transport/x/grpc/integration_test.go
@@ -26,13 +26,13 @@ import (
 	"net"
 	"strings"
 	"testing"
-	"time"
 
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/x/protobuf"
 	"go.uber.org/yarpc/internal/clientconfig"
 	"go.uber.org/yarpc/internal/examples/protobuf/example"
 	"go.uber.org/yarpc/internal/examples/protobuf/examplepb"
+	"go.uber.org/yarpc/internal/testtime"
 	"go.uber.org/yarpc/transport/x/grpc/grpcheader"
 
 	"github.com/stretchr/testify/assert"
@@ -169,7 +169,7 @@ func newTestEnv(inboundOptions []InboundOption, outboundOptions []OutboundOption
 }
 
 func (e *testEnv) GetValueYarpc(ctx context.Context, key string) (string, error) {
-	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, testtime.Second)
 	defer cancel()
 	response, err := e.KeyValueYarpcClient.GetValue(ctx, &examplepb.GetValueRequest{key})
 	if err != nil {
@@ -179,14 +179,14 @@ func (e *testEnv) GetValueYarpc(ctx context.Context, key string) (string, error)
 }
 
 func (e *testEnv) SetValueYarpc(ctx context.Context, key string, value string) error {
-	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, testtime.Second)
 	defer cancel()
 	_, err := e.KeyValueYarpcClient.SetValue(ctx, &examplepb.SetValueRequest{key, value})
 	return err
 }
 
 func (e *testEnv) GetValueGRPC(ctx context.Context, key string) (string, error) {
-	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, testtime.Second)
 	defer cancel()
 	response, err := e.KeyValueGRPCClient.GetValue(e.ContextWrapper.Wrap(ctx), &examplepb.GetValueRequest{key})
 	if err != nil {
@@ -196,7 +196,7 @@ func (e *testEnv) GetValueGRPC(ctx context.Context, key string) (string, error) 
 }
 
 func (e *testEnv) SetValueGRPC(ctx context.Context, key string, value string) error {
-	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, testtime.Second)
 	defer cancel()
 	_, err := e.KeyValueGRPCClient.SetValue(e.ContextWrapper.Wrap(ctx), &examplepb.SetValueRequest{key, value})
 	return err

--- a/transport/x/redis/inbound_test.go
+++ b/transport/x/redis/inbound_test.go
@@ -22,9 +22,9 @@ package redis
 
 import (
 	"testing"
-	"time"
 
 	"go.uber.org/yarpc/api/transport/transporttest"
+	"go.uber.org/yarpc/internal/testtime"
 	"go.uber.org/yarpc/transport/x/redis/redistest"
 
 	"github.com/golang/mock/gomock"
@@ -33,7 +33,7 @@ import (
 
 func TestOperationOrder(t *testing.T) {
 	queueKey, processingKey := "queueKey", "processingKey"
-	timeout := time.Second
+	timeout := testtime.Second
 
 	mockCtrl := gomock.NewController(t)
 	client := redistest.NewMockClient(mockCtrl)

--- a/transport/x/redis/outbound_test.go
+++ b/transport/x/redis/outbound_test.go
@@ -25,10 +25,10 @@ import (
 	"context"
 	"sync"
 	"testing"
-	"time"
 
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/raw"
+	"go.uber.org/yarpc/internal/testtime"
 	"go.uber.org/yarpc/transport/x/redis/redistest"
 
 	"github.com/golang/mock/gomock"
@@ -52,7 +52,7 @@ func TestCall(t *testing.T) {
 	assert.NoError(t, err, "could not start redis outbound")
 
 	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, testtime.Second)
 	defer cancel()
 
 	ack, err := out.CallOneway(ctx, &transport.Request{
@@ -128,7 +128,7 @@ func TestCallWithoutStarting(t *testing.T) {
 	out := NewOnewayOutbound(client, "queueKey")
 
 	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	ctx, cancel := context.WithTimeout(ctx, 10*testtime.Millisecond)
 	defer cancel()
 
 	ack, err := out.CallOneway(

--- a/x/config/chooser_test.go
+++ b/x/config/chooser_test.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"strings"
 	"testing"
-	"time"
 
 	"go.uber.org/yarpc"
 	peerapi "go.uber.org/yarpc/api/peer"
@@ -33,6 +32,7 @@ import (
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/api/transport/transporttest"
 	"go.uber.org/yarpc/internal/interpolate"
+	"go.uber.org/yarpc/internal/testtime"
 	"go.uber.org/yarpc/internal/whitespace"
 	"go.uber.org/yarpc/peer"
 	"go.uber.org/yarpc/peer/hostport"
@@ -276,7 +276,7 @@ func TestChooserConfigurator(t *testing.T) {
 				require.True(t, binder.IsRunning(), "binder is running")
 
 				ctx := context.Background()
-				ctx, cancel := context.WithTimeout(ctx, time.Second)
+				ctx, cancel := context.WithTimeout(ctx, testtime.Second)
 				defer cancel()
 				peer, onFinish, err := chooser.Choose(ctx, nil)
 				require.NoError(t, err, "error choosing peer")


### PR DESCRIPTION
This change introduces test time dilation. On CI, test timeouts will scale up by a factor of 5.

The first commit contains the new code. The second commit contains the mechanical transformation of all tests that use time.

This is the solution that TChannel and related projects use to make deterministic timed tests succeed reliably in CPU starved CI systems, and avoids the significantly higher burden of synchronizing these tests with a fake clock.