### PR TITLE
Canonicalize import group order

### DIFF
--- a/api/encoding/inbound_call_test.go
+++ b/api/encoding/inbound_call_test.go
@@ -25,11 +25,10 @@ import (
 	"sort"
 	"testing"
 
-	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/api/transport/transporttest"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/api/transport/transporttest"
 )
 
 func TestInboundCallReadFromRequest(t *testing.T) {

--- a/api/encoding/outbound_call_test.go
+++ b/api/encoding/outbound_call_test.go
@@ -24,10 +24,9 @@ import (
 	"context"
 	"testing"
 
-	"go.uber.org/yarpc/api/transport"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/api/transport"
 )
 
 func TestOutboundCallWriteToRequest(t *testing.T) {

--- a/api/middleware/inbound_test.go
+++ b/api/middleware/inbound_test.go
@@ -26,14 +26,13 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/yarpc/api/middleware"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/api/transport/transporttest"
 	"go.uber.org/yarpc/encoding/raw"
 	"go.uber.org/yarpc/internal/testtime"
-
-	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestUnaryNopInboundMiddleware(t *testing.T) {

--- a/api/middleware/outbound_test.go
+++ b/api/middleware/outbound_test.go
@@ -26,14 +26,13 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/yarpc/api/middleware"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/api/transport/transporttest"
 	"go.uber.org/yarpc/encoding/raw"
 	"go.uber.org/yarpc/internal/testtime"
-
-	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestUnaryNopOutboundMiddleware(t *testing.T) {

--- a/api/peer/peertest/peerlistaction.go
+++ b/api/peer/peertest/peerlistaction.go
@@ -27,11 +27,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/testtime"
-
-	"github.com/stretchr/testify/assert"
 )
 
 // ListActionDeps are passed through PeerListActions' Apply methods in order

--- a/api/peer/peertest/peers.go
+++ b/api/peer/peertest/peers.go
@@ -24,9 +24,8 @@ import (
 	"fmt"
 	"sync"
 
-	"go.uber.org/yarpc/api/peer"
-
 	"github.com/golang/mock/gomock"
+	"go.uber.org/yarpc/api/peer"
 )
 
 // MockPeerIdentifier is a small wrapper around the PeerIdentifier interfaces for a string

--- a/api/peer/peertest/subscriber.go
+++ b/api/peer/peertest/subscriber.go
@@ -21,9 +21,8 @@
 package peertest
 
 import (
-	"go.uber.org/yarpc/api/peer"
-
 	"github.com/golang/mock/gomock"
+	"go.uber.org/yarpc/api/peer"
 )
 
 // SubscriberDefinition is an abstraction for defining a PeerSubscriber with

--- a/api/peer/peertest/transportaction.go
+++ b/api/peer/peertest/transportaction.go
@@ -24,9 +24,8 @@ import (
 	"fmt"
 	"testing"
 
-	"go.uber.org/yarpc/api/peer"
-
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/yarpc/api/peer"
 )
 
 // TransportDeps are passed through all the TransportActions in order to pass certain

--- a/api/transport/handler.go
+++ b/api/transport/handler.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"go.uber.org/yarpc/internal/errors"
-
 	"go.uber.org/zap/zapcore"
 )
 

--- a/api/transport/request.go
+++ b/api/transport/request.go
@@ -24,7 +24,6 @@ import (
 	"io"
 
 	"go.uber.org/yarpc/internal/errors"
-
 	"go.uber.org/zap/zapcore"
 )
 

--- a/api/transport/request_test.go
+++ b/api/transport/request_test.go
@@ -26,10 +26,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/request"
-
-	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap/zapcore"
 )
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -30,16 +30,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber/tchannel-go"
+	traw "github.com/uber/tchannel-go/raw"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/raw"
 	yhttp "go.uber.org/yarpc/transport/http"
 	ytchannel "go.uber.org/yarpc/transport/tchannel"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/uber/tchannel-go"
-	traw "github.com/uber/tchannel-go/raw"
 	ncontext "golang.org/x/net/context"
 )
 

--- a/config.go
+++ b/config.go
@@ -24,13 +24,12 @@ import (
 	"context"
 	"time"
 
-	"go.uber.org/yarpc/api/middleware"
-	"go.uber.org/yarpc/internal/observability"
-	"go.uber.org/yarpc/internal/pally"
-
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/uber-go/tally"
+	"go.uber.org/yarpc/api/middleware"
+	"go.uber.org/yarpc/internal/observability"
+	"go.uber.org/yarpc/internal/pally"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"sync"
 
+	"go.uber.org/multierr"
 	"go.uber.org/yarpc/api/middleware"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal"
@@ -35,8 +36,6 @@ import (
 	"go.uber.org/yarpc/internal/pally"
 	"go.uber.org/yarpc/internal/request"
 	intsync "go.uber.org/yarpc/internal/sync"
-
-	"go.uber.org/multierr"
 	"go.uber.org/zap"
 )
 

--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -25,17 +25,16 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
 	. "go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/api/transport/transporttest"
 	"go.uber.org/yarpc/internal/observability"
 	"go.uber.org/yarpc/transport/http"
 	"go.uber.org/yarpc/transport/tchannel"
-
-	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 )
 

--- a/encoding/json/inbound_test.go
+++ b/encoding/json/inbound_test.go
@@ -28,12 +28,11 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/api/transport/transporttest"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type simpleRequest struct {

--- a/encoding/json/outbound_test.go
+++ b/encoding/json/outbound_test.go
@@ -28,14 +28,13 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/api/transport/transporttest"
 	"go.uber.org/yarpc/internal/clientconfig"
-
-	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 var _typeOfMapInterface = reflect.TypeOf(map[string]interface{}{})

--- a/encoding/raw/inbound_test.go
+++ b/encoding/raw/inbound_test.go
@@ -25,14 +25,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber/tchannel-go/testutils/testreader"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/api/transport/transporttest"
 	"go.uber.org/yarpc/internal/testtime"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/uber/tchannel-go/testutils/testreader"
 )
 
 func TestRawHandler(t *testing.T) {

--- a/encoding/raw/outbound_test.go
+++ b/encoding/raw/outbound_test.go
@@ -27,14 +27,13 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/uber/tchannel-go/testutils/testreader"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/api/transport/transporttest"
 	"go.uber.org/yarpc/internal/clientconfig"
-
-	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
-	"github.com/uber/tchannel-go/testutils/testreader"
 )
 
 func TestCall(t *testing.T) {

--- a/encoding/thrift/inbound.go
+++ b/encoding/thrift/inbound.go
@@ -24,13 +24,12 @@ import (
 	"bytes"
 	"context"
 
+	"go.uber.org/thriftrw/protocol"
+	"go.uber.org/thriftrw/wire"
 	encodingapi "go.uber.org/yarpc/api/encoding"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/buffer"
 	"go.uber.org/yarpc/internal/encoding"
-
-	"go.uber.org/thriftrw/protocol"
-	"go.uber.org/thriftrw/wire"
 )
 
 // thriftUnaryHandler wraps a Thrift Handler into a transport.UnaryHandler

--- a/encoding/thrift/inbound_test.go
+++ b/encoding/thrift/inbound_test.go
@@ -26,14 +26,13 @@ import (
 	"io"
 	"testing"
 
-	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/api/transport/transporttest"
-	"go.uber.org/yarpc/internal/testtime"
-
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/thriftrw/wire"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/api/transport/transporttest"
+	"go.uber.org/yarpc/internal/testtime"
 )
 
 func TestThriftHandler(t *testing.T) {

--- a/encoding/thrift/inject_test.go
+++ b/encoding/thrift/inject_test.go
@@ -24,10 +24,9 @@ import (
 	"reflect"
 	"testing"
 
-	"go.uber.org/yarpc/api/transport/transporttest"
-
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/yarpc/api/transport/transporttest"
 )
 
 type someInterface interface{}

--- a/encoding/thrift/multiplex_test.go
+++ b/encoding/thrift/multiplex_test.go
@@ -24,10 +24,9 @@ import (
 	"bytes"
 	"testing"
 
-	"go.uber.org/thriftrw/wire"
-
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/thriftrw/wire"
 )
 
 func TestMultiplexedEncode(t *testing.T) {

--- a/encoding/thrift/outbound.go
+++ b/encoding/thrift/outbound.go
@@ -25,16 +25,15 @@ import (
 	"context"
 	"fmt"
 
+	"go.uber.org/thriftrw/envelope"
+	"go.uber.org/thriftrw/protocol"
+	"go.uber.org/thriftrw/wire"
 	"go.uber.org/yarpc"
 	encodingapi "go.uber.org/yarpc/api/encoding"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/thrift/internal"
 	"go.uber.org/yarpc/internal/encoding"
 	"go.uber.org/yarpc/internal/procedure"
-
-	"go.uber.org/thriftrw/envelope"
-	"go.uber.org/thriftrw/protocol"
-	"go.uber.org/thriftrw/wire"
 )
 
 // Client is a generic Thrift client. It speaks in raw Thrift payloads.

--- a/encoding/thrift/outbound_test.go
+++ b/encoding/thrift/outbound_test.go
@@ -28,17 +28,16 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/api/transport/transporttest"
-	"go.uber.org/yarpc/internal/clientconfig"
-	"go.uber.org/yarpc/internal/procedure"
-	"go.uber.org/yarpc/internal/testtime"
-
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/thriftrw/envelope"
 	"go.uber.org/thriftrw/wire"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/api/transport/transporttest"
+	"go.uber.org/yarpc/internal/clientconfig"
+	"go.uber.org/yarpc/internal/procedure"
+	"go.uber.org/yarpc/internal/testtime"
 )
 
 func valueptr(v wire.Value) *wire.Value { return &v }

--- a/encoding/thrift/register.go
+++ b/encoding/thrift/register.go
@@ -24,12 +24,11 @@ import (
 	"context"
 	"fmt"
 
-	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/internal/procedure"
-
 	"go.uber.org/thriftrw/protocol"
 	"go.uber.org/thriftrw/thriftreflect"
 	"go.uber.org/thriftrw/wire"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/procedure"
 )
 
 // Register calls the RouteTable's Register method.

--- a/encoding/thrift/thriftrw-plugin-yarpc/fx_test.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/fx_test.go
@@ -23,12 +23,11 @@ package main
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storeclient"
 	"go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storefx"
 	"go.uber.org/yarpc/transport/http"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestFxClient(t *testing.T) {

--- a/encoding/thrift/thriftrw-plugin-yarpc/gomock_test.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/gomock_test.go
@@ -26,6 +26,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/thriftrw/ptr"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/readonlystoretest"
 	"go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storetest"
@@ -33,10 +36,6 @@ import (
 	"go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/emptyservicetest"
 	"go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendemptytest"
 	"go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendonlytest"
-
-	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/thriftrw/ptr"
 )
 
 func TestMockClients(t *testing.T) {

--- a/encoding/thrift/thriftrw-plugin-yarpc/roundtrip_test.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/roundtrip_test.go
@@ -28,6 +28,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/thriftrw/ptr"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/thrift"
@@ -46,10 +49,6 @@ import (
 	"go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendonlyserver"
 	"go.uber.org/yarpc/internal/testtime"
 	"go.uber.org/yarpc/transport/http"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/thriftrw/ptr"
 )
 
 func TestRoundTrip(t *testing.T) {

--- a/encoding/x/protobuf/inbound.go
+++ b/encoding/x/protobuf/inbound.go
@@ -26,14 +26,13 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/proto"
 	apiencoding "go.uber.org/yarpc/api/encoding"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/x/protobuf/internal/wirepb"
 	"go.uber.org/yarpc/internal/buffer"
 	"go.uber.org/yarpc/internal/encoding"
-
-	"github.com/gogo/protobuf/jsonpb"
-	"github.com/gogo/protobuf/proto"
 )
 
 var (

--- a/encoding/x/protobuf/outbound.go
+++ b/encoding/x/protobuf/outbound.go
@@ -26,14 +26,13 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/gogo/protobuf/proto"
 	"go.uber.org/yarpc"
 	apiencoding "go.uber.org/yarpc/api/encoding"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/x/protobuf/internal/wirepb"
 	"go.uber.org/yarpc/internal/encoding"
 	"go.uber.org/yarpc/internal/procedure"
-
-	"github.com/gogo/protobuf/proto"
 )
 
 type client struct {

--- a/encoding/x/protobuf/protoc-gen-yarpc-go/internal/testing/testing.pb.yarpc.go.golden
+++ b/encoding/x/protobuf/protoc-gen-yarpc-go/internal/testing/testing.pb.yarpc.go.golden
@@ -7,7 +7,6 @@ package testing
 import (
 	"context"
 	"reflect"
-
 	"github.com/gogo/protobuf/proto"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"

--- a/encoding/x/protobuf/protoc-gen-yarpc-go/internal/testing/testing_test.go
+++ b/encoding/x/protobuf/protoc-gen-yarpc-go/internal/testing/testing_test.go
@@ -26,13 +26,12 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"go.uber.org/yarpc/encoding/x/protobuf/protoc-gen-yarpc-go/internal/lib"
-	_ "go.uber.org/yarpc/yarpcproto" // needed for proto.RegisterFile for Oneway type
-
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/protoc-gen-gogo/descriptor"
 	"github.com/gogo/protobuf/protoc-gen-gogo/plugin"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/encoding/x/protobuf/protoc-gen-yarpc-go/internal/lib"
+	_ "go.uber.org/yarpc/yarpcproto" // needed for proto.RegisterFile for Oneway type
 )
 
 func TestGolden(t *testing.T) {

--- a/encoding/x/protobuf/testing/testing_test.go
+++ b/encoding/x/protobuf/testing/testing_test.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/internal/examples/protobuf/example"
 	"go.uber.org/yarpc/internal/examples/protobuf/examplepb"
@@ -31,8 +32,6 @@ import (
 	"go.uber.org/yarpc/internal/testtime"
 	"go.uber.org/yarpc/internal/testutils"
 	"go.uber.org/yarpc/transport/x/grpc/grpcheader"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestIntegration(t *testing.T) {

--- a/encoding/x/protobuf/types.go
+++ b/encoding/x/protobuf/types.go
@@ -26,11 +26,10 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/gogo/protobuf/proto"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/procedure"
-
-	"github.com/gogo/protobuf/proto"
 )
 
 const (

--- a/inject_test.go
+++ b/inject_test.go
@@ -25,16 +25,15 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/api/transport/transporttest"
 	"go.uber.org/yarpc/encoding/json"
 	"go.uber.org/yarpc/encoding/raw"
 	"go.uber.org/yarpc/internal/clientconfig"
-
-	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestRegisterClientBuilderPanics(t *testing.T) {

--- a/internal/backoff/exponential.go
+++ b/internal/backoff/exponential.go
@@ -25,9 +25,8 @@ import (
 	"math/rand"
 	"time"
 
-	"go.uber.org/yarpc/api/backoff"
-
 	"go.uber.org/multierr"
+	"go.uber.org/yarpc/api/backoff"
 )
 
 var (

--- a/internal/clientconfig/multioutbound_test.go
+++ b/internal/clientconfig/multioutbound_test.go
@@ -23,9 +23,8 @@ package clientconfig
 import (
 	"testing"
 
-	"go.uber.org/yarpc/api/transport"
-
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/yarpc/api/transport"
 )
 
 const (

--- a/internal/crossdock/client/apachethrift/behavior.go
+++ b/internal/crossdock/client/apachethrift/behavior.go
@@ -23,12 +23,11 @@ package apachethrift
 import (
 	"fmt"
 
+	"github.com/crossdock/crossdock-go"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/encoding/thrift"
 	"go.uber.org/yarpc/internal/crossdock/client/gauntlet"
 	"go.uber.org/yarpc/transport/http"
-
-	"github.com/crossdock/crossdock-go"
 )
 
 const (

--- a/internal/crossdock/client/ctxpropagation/behavior.go
+++ b/internal/crossdock/client/ctxpropagation/behavior.go
@@ -27,6 +27,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/crossdock/crossdock-go"
+	"github.com/opentracing/opentracing-go"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/json"
@@ -34,9 +36,6 @@ import (
 	server "go.uber.org/yarpc/internal/crossdock/server/yarpc"
 	"go.uber.org/yarpc/transport/http"
 	tch "go.uber.org/yarpc/transport/tchannel"
-
-	"github.com/crossdock/crossdock-go"
-	"github.com/opentracing/opentracing-go"
 )
 
 // Run verifies that opentracing context is propagated across multiple hops.

--- a/internal/crossdock/client/dispatcher/dispatcher.go
+++ b/internal/crossdock/client/dispatcher/dispatcher.go
@@ -24,6 +24,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/crossdock/crossdock-go"
+	cherami_client "github.com/uber/cherami-client-go/client/cherami"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/raw"
@@ -33,9 +35,6 @@ import (
 	"go.uber.org/yarpc/transport/x/cherami"
 	"go.uber.org/yarpc/transport/x/grpc"
 	"go.uber.org/yarpc/transport/x/redis"
-
-	"github.com/crossdock/crossdock-go"
-	cherami_client "github.com/uber/cherami-client-go/client/cherami"
 )
 
 // Create creates an RPC from the given parameters or fails the whole behavior.

--- a/internal/crossdock/client/echo/behavior.go
+++ b/internal/crossdock/client/echo/behavior.go
@@ -21,9 +21,8 @@
 package echo
 
 import (
-	"go.uber.org/yarpc/internal/crossdock/client/params"
-
 	"github.com/crossdock/crossdock-go"
+	"go.uber.org/yarpc/internal/crossdock/client/params"
 )
 
 // createEchoT tags the given T with the transport, encoding and server.

--- a/internal/crossdock/client/echo/json.go
+++ b/internal/crossdock/client/echo/json.go
@@ -24,11 +24,10 @@ import (
 	"context"
 	"time"
 
+	"github.com/crossdock/crossdock-go"
 	"go.uber.org/yarpc/encoding/json"
 	disp "go.uber.org/yarpc/internal/crossdock/client/dispatcher"
 	"go.uber.org/yarpc/internal/crossdock/client/random"
-
-	"github.com/crossdock/crossdock-go"
 )
 
 // jsonEcho contains an echo request or response for the JSON echo endpoint.

--- a/internal/crossdock/client/echo/protobuf.go
+++ b/internal/crossdock/client/echo/protobuf.go
@@ -24,11 +24,10 @@ import (
 	"context"
 	"time"
 
+	"github.com/crossdock/crossdock-go"
 	disp "go.uber.org/yarpc/internal/crossdock/client/dispatcher"
 	"go.uber.org/yarpc/internal/crossdock/client/random"
 	"go.uber.org/yarpc/internal/crossdock/crossdockpb"
-
-	"github.com/crossdock/crossdock-go"
 )
 
 // Protobuf implements the 'protobuf' behavior.

--- a/internal/crossdock/client/echo/raw.go
+++ b/internal/crossdock/client/echo/raw.go
@@ -25,11 +25,10 @@ import (
 	"context"
 	"time"
 
+	"github.com/crossdock/crossdock-go"
 	"go.uber.org/yarpc/encoding/raw"
 	disp "go.uber.org/yarpc/internal/crossdock/client/dispatcher"
 	"go.uber.org/yarpc/internal/crossdock/client/random"
-
-	"github.com/crossdock/crossdock-go"
 )
 
 // Raw implements the 'raw' behavior.

--- a/internal/crossdock/client/echo/thrift.go
+++ b/internal/crossdock/client/echo/thrift.go
@@ -24,12 +24,11 @@ import (
 	"context"
 	"time"
 
+	"github.com/crossdock/crossdock-go"
 	disp "go.uber.org/yarpc/internal/crossdock/client/dispatcher"
 	"go.uber.org/yarpc/internal/crossdock/client/random"
 	"go.uber.org/yarpc/internal/crossdock/thrift/echo"
 	"go.uber.org/yarpc/internal/crossdock/thrift/echo/echoclient"
-
-	"github.com/crossdock/crossdock-go"
 )
 
 // Thrift implements the 'thrift' behavior.

--- a/internal/crossdock/client/errorshttpclient/behavior.go
+++ b/internal/crossdock/client/errorshttpclient/behavior.go
@@ -27,9 +27,8 @@ import (
 	"net/url"
 	"strings"
 
-	"go.uber.org/yarpc/internal/crossdock/client/params"
-
 	"github.com/crossdock/crossdock-go"
+	"go.uber.org/yarpc/internal/crossdock/client/params"
 )
 
 type httpClient struct {

--- a/internal/crossdock/client/errorstchclient/behavior.go
+++ b/internal/crossdock/client/errorstchclient/behavior.go
@@ -24,12 +24,10 @@ import (
 	"fmt"
 	"time"
 
-	"go.uber.org/yarpc/internal/crossdock/client/params"
-
+	"github.com/crossdock/crossdock-go"
 	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/json"
-
-	"github.com/crossdock/crossdock-go"
+	"go.uber.org/yarpc/internal/crossdock/client/params"
 )
 
 const (

--- a/internal/crossdock/client/gauntlet/behavior.go
+++ b/internal/crossdock/client/gauntlet/behavior.go
@@ -26,6 +26,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/crossdock/crossdock-go"
+	"go.uber.org/thriftrw/ptr"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/thrift"
@@ -35,9 +37,6 @@ import (
 	"go.uber.org/yarpc/internal/crossdock/thrift/gauntlet"
 	"go.uber.org/yarpc/internal/crossdock/thrift/gauntlet/secondserviceclient"
 	"go.uber.org/yarpc/internal/crossdock/thrift/gauntlet/thrifttestclient"
-
-	"github.com/crossdock/crossdock-go"
-	"go.uber.org/thriftrw/ptr"
 )
 
 const serverName = "yarpc-test"

--- a/internal/crossdock/client/googlegrpcclient/googlegrpcclient.go
+++ b/internal/crossdock/client/googlegrpcclient/googlegrpcclient.go
@@ -25,12 +25,11 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/crossdock/crossdock-go"
 	"go.uber.org/yarpc/internal/crossdock/client/params"
 	"go.uber.org/yarpc/internal/crossdock/client/random"
 	"go.uber.org/yarpc/internal/crossdock/crossdockpb"
 	"go.uber.org/yarpc/transport/x/grpc/grpcheader"
-
-	"github.com/crossdock/crossdock-go"
 	"google.golang.org/grpc"
 )
 

--- a/internal/crossdock/client/googlegrpcserver/googlegrpcserver.go
+++ b/internal/crossdock/client/googlegrpcserver/googlegrpcserver.go
@@ -25,13 +25,12 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/crossdock/crossdock-go"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/internal/crossdock/client/params"
 	"go.uber.org/yarpc/internal/crossdock/client/random"
 	"go.uber.org/yarpc/internal/crossdock/crossdockpb"
 	"go.uber.org/yarpc/transport/x/grpc"
-
-	"github.com/crossdock/crossdock-go"
 )
 
 // Run tests a yarpc call to the grpc-go server.

--- a/internal/crossdock/client/grpc/grpc.go
+++ b/internal/crossdock/client/grpc/grpc.go
@@ -21,10 +21,9 @@
 package grpc
 
 import (
+	"github.com/crossdock/crossdock-go"
 	"go.uber.org/yarpc/internal/crossdock/client/echo"
 	"go.uber.org/yarpc/internal/crossdock/client/params"
-
-	"github.com/crossdock/crossdock-go"
 )
 
 var encodingToRunFunc = map[string]func(crossdock.T, string){

--- a/internal/crossdock/client/headers/behavior.go
+++ b/internal/crossdock/client/headers/behavior.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/crossdock/crossdock-go"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/encoding/json"
 	"go.uber.org/yarpc/encoding/raw"
@@ -33,8 +34,6 @@ import (
 	"go.uber.org/yarpc/internal/crossdock/internal"
 	"go.uber.org/yarpc/internal/crossdock/thrift/echo"
 	"go.uber.org/yarpc/internal/crossdock/thrift/echo/echoclient"
-
-	"github.com/crossdock/crossdock-go"
 )
 
 func createHeadersT(t crossdock.T) crossdock.T {

--- a/internal/crossdock/client/httpserver/behavior.go
+++ b/internal/crossdock/client/httpserver/behavior.go
@@ -26,13 +26,12 @@ import (
 	"strings"
 	"time"
 
+	crossdock "github.com/crossdock/crossdock-go"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/raw"
 	"go.uber.org/yarpc/internal/crossdock/client/params"
 	"go.uber.org/yarpc/transport/http"
-
-	crossdock "github.com/crossdock/crossdock-go"
 )
 
 // Run exercise a yarpc client against a rigged httpserver.

--- a/internal/crossdock/client/oneway/json.go
+++ b/internal/crossdock/client/oneway/json.go
@@ -23,10 +23,9 @@ package oneway
 import (
 	"context"
 
+	"github.com/crossdock/crossdock-go"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/encoding/json"
-
-	"github.com/crossdock/crossdock-go"
 )
 
 type jsonToken struct {

--- a/internal/crossdock/client/oneway/oneway.go
+++ b/internal/crossdock/client/oneway/oneway.go
@@ -23,12 +23,11 @@ package oneway
 import (
 	"context"
 
+	"github.com/crossdock/crossdock-go"
 	"go.uber.org/yarpc/encoding/raw"
 	"go.uber.org/yarpc/internal/crossdock/client/dispatcher"
 	"go.uber.org/yarpc/internal/crossdock/client/params"
 	"go.uber.org/yarpc/internal/crossdock/client/random"
-
-	"github.com/crossdock/crossdock-go"
 )
 
 // Run starts the oneway behavior, testing a combination of encodings and transports

--- a/internal/crossdock/client/oneway/protobuf.go
+++ b/internal/crossdock/client/oneway/protobuf.go
@@ -23,10 +23,9 @@ package oneway
 import (
 	"context"
 
+	"github.com/crossdock/crossdock-go"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/internal/crossdock/crossdockpb"
-
-	"github.com/crossdock/crossdock-go"
 )
 
 // Protobuf starts an http oneway run using Protobuf encoding

--- a/internal/crossdock/client/oneway/raw.go
+++ b/internal/crossdock/client/oneway/raw.go
@@ -23,10 +23,9 @@ package oneway
 import (
 	"context"
 
+	"github.com/crossdock/crossdock-go"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/encoding/raw"
-
-	"github.com/crossdock/crossdock-go"
 )
 
 // Raw starts an http run using raw encoding

--- a/internal/crossdock/client/oneway/thrift.go
+++ b/internal/crossdock/client/oneway/thrift.go
@@ -23,10 +23,9 @@ package oneway
 import (
 	"context"
 
+	"github.com/crossdock/crossdock-go"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/internal/crossdock/thrift/oneway/onewayclient"
-
-	"github.com/crossdock/crossdock-go"
 )
 
 // Thrift starts an http oneway run using Thrift encoding

--- a/internal/crossdock/client/onewayctxpropagation/behavior.go
+++ b/internal/crossdock/client/onewayctxpropagation/behavior.go
@@ -23,12 +23,11 @@ package onewayctxpropagation
 import (
 	"context"
 
+	"github.com/crossdock/crossdock-go"
+	opentracing "github.com/opentracing/opentracing-go"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/encoding/raw"
 	"go.uber.org/yarpc/internal/crossdock/client/dispatcher"
-
-	"github.com/crossdock/crossdock-go"
-	opentracing "github.com/opentracing/opentracing-go"
 )
 
 // Run starts the behavior, testing oneway context propagation

--- a/internal/crossdock/client/start.go
+++ b/internal/crossdock/client/start.go
@@ -21,6 +21,7 @@
 package client
 
 import (
+	"github.com/crossdock/crossdock-go"
 	"go.uber.org/yarpc/internal/crossdock/client/apachethrift"
 	"go.uber.org/yarpc/internal/crossdock/client/ctxpropagation"
 	"go.uber.org/yarpc/internal/crossdock/client/echo"
@@ -37,8 +38,6 @@ import (
 	"go.uber.org/yarpc/internal/crossdock/client/tchclient"
 	"go.uber.org/yarpc/internal/crossdock/client/tchserver"
 	"go.uber.org/yarpc/internal/crossdock/client/timeout"
-
-	"github.com/crossdock/crossdock-go"
 )
 
 var behaviors = crossdock.Behaviors{

--- a/internal/crossdock/client/tchclient/behavior.go
+++ b/internal/crossdock/client/tchclient/behavior.go
@@ -23,10 +23,9 @@ package tchclient
 import (
 	"fmt"
 
-	"go.uber.org/yarpc/internal/crossdock/client/params"
-
 	"github.com/crossdock/crossdock-go"
 	"github.com/uber/tchannel-go"
+	"go.uber.org/yarpc/internal/crossdock/client/params"
 )
 
 const (

--- a/internal/crossdock/client/tchclient/json.go
+++ b/internal/crossdock/client/tchclient/json.go
@@ -23,11 +23,10 @@ package tchclient
 import (
 	"time"
 
-	"go.uber.org/yarpc/internal/crossdock/client/random"
-	"go.uber.org/yarpc/internal/crossdock/internal"
-
 	"github.com/crossdock/crossdock-go"
 	"github.com/uber/tchannel-go/json"
+	"go.uber.org/yarpc/internal/crossdock/client/random"
+	"go.uber.org/yarpc/internal/crossdock/internal"
 )
 
 func runJSON(t crossdock.T, call call) {

--- a/internal/crossdock/client/tchclient/raw.go
+++ b/internal/crossdock/client/tchclient/raw.go
@@ -24,10 +24,9 @@ import (
 	"context"
 	"time"
 
-	"go.uber.org/yarpc/internal/crossdock/client/random"
-
 	"github.com/crossdock/crossdock-go"
 	"github.com/uber/tchannel-go/raw"
+	"go.uber.org/yarpc/internal/crossdock/client/random"
 )
 
 func runRaw(t crossdock.T, call call) {

--- a/internal/crossdock/client/tchclient/thrift.go
+++ b/internal/crossdock/client/tchclient/thrift.go
@@ -25,15 +25,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/crossdock/crossdock-go"
+	"github.com/uber/tchannel-go/thrift"
+	"go.uber.org/thriftrw/ptr"
 	"go.uber.org/yarpc/internal/crossdock/client/gauntlet"
 	"go.uber.org/yarpc/internal/crossdock/client/random"
 	"go.uber.org/yarpc/internal/crossdock/internal"
 	"go.uber.org/yarpc/internal/crossdock/thrift/gen-go/echo"
 	"go.uber.org/yarpc/internal/crossdock/thrift/gen-go/gauntlet_tchannel"
-
-	"github.com/crossdock/crossdock-go"
-	"github.com/uber/tchannel-go/thrift"
-	"go.uber.org/thriftrw/ptr"
 )
 
 func runThrift(t crossdock.T, call call) {

--- a/internal/crossdock/client/tchserver/behavior.go
+++ b/internal/crossdock/client/tchserver/behavior.go
@@ -23,11 +23,10 @@ package tchserver
 import (
 	"fmt"
 
+	"github.com/crossdock/crossdock-go"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/internal/crossdock/client/params"
 	"go.uber.org/yarpc/transport/tchannel"
-
-	"github.com/crossdock/crossdock-go"
 )
 
 const (

--- a/internal/crossdock/client/tchserver/json.go
+++ b/internal/crossdock/client/tchserver/json.go
@@ -24,12 +24,11 @@ import (
 	"context"
 	"time"
 
+	"github.com/crossdock/crossdock-go"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/encoding/json"
 	"go.uber.org/yarpc/internal/crossdock/client/random"
 	"go.uber.org/yarpc/internal/crossdock/internal"
-
-	"github.com/crossdock/crossdock-go"
 )
 
 func runJSON(t crossdock.T, dispatcher *yarpc.Dispatcher) {

--- a/internal/crossdock/client/tchserver/raw.go
+++ b/internal/crossdock/client/tchserver/raw.go
@@ -25,13 +25,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/crossdock/crossdock-go"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/raw"
 	"go.uber.org/yarpc/internal/crossdock/client/random"
 	"go.uber.org/yarpc/internal/crossdock/internal"
-
-	"github.com/crossdock/crossdock-go"
 )
 
 func runRaw(t crossdock.T, dispatcher *yarpc.Dispatcher) {

--- a/internal/crossdock/client/tchserver/thrift.go
+++ b/internal/crossdock/client/tchserver/thrift.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/crossdock/crossdock-go"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/internal/crossdock/client/gauntlet"
 	"go.uber.org/yarpc/internal/crossdock/client/params"
@@ -31,8 +32,6 @@ import (
 	"go.uber.org/yarpc/internal/crossdock/internal"
 	"go.uber.org/yarpc/internal/crossdock/thrift/echo"
 	"go.uber.org/yarpc/internal/crossdock/thrift/echo/echoclient"
-
-	"github.com/crossdock/crossdock-go"
 )
 
 func runThrift(t crossdock.T, dispatcher *yarpc.Dispatcher) {

--- a/internal/crossdock/client/timeout/behavior.go
+++ b/internal/crossdock/client/timeout/behavior.go
@@ -25,12 +25,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/crossdock/crossdock-go"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/raw"
 	disp "go.uber.org/yarpc/internal/crossdock/client/dispatcher"
 	"go.uber.org/yarpc/internal/crossdock/client/params"
-
-	"github.com/crossdock/crossdock-go"
 )
 
 // Run tests if a yarpc client returns correctly a client timeout error behind

--- a/internal/crossdock/main_test.go
+++ b/internal/crossdock/main_test.go
@@ -24,12 +24,11 @@ import (
 	"net/url"
 	"testing"
 
-	"go.uber.org/yarpc/internal/crossdock/client"
-	"go.uber.org/yarpc/internal/crossdock/server"
-
 	"github.com/crossdock/crossdock-go"
 	"github.com/opentracing/opentracing-go"
 	jaeger "github.com/uber/jaeger-client-go"
+	"go.uber.org/yarpc/internal/crossdock/client"
+	"go.uber.org/yarpc/internal/crossdock/server"
 )
 
 const clientURL = "http://127.0.0.1:8080"

--- a/internal/crossdock/server/apachethrift/server.go
+++ b/internal/crossdock/server/apachethrift/server.go
@@ -25,10 +25,9 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/apache/thrift/lib/go/thrift"
 	"go.uber.org/yarpc/internal/crossdock/thrift/gen-go/gauntlet_apache"
 	"go.uber.org/yarpc/internal/net"
-
-	"github.com/apache/thrift/lib/go/thrift"
 )
 
 const addr = ":8088"

--- a/internal/crossdock/server/googlegrpc/echo.go
+++ b/internal/crossdock/server/googlegrpc/echo.go
@@ -22,7 +22,6 @@ package googlegrpc
 
 import (
 	"go.uber.org/yarpc/internal/crossdock/crossdockpb"
-
 	"golang.org/x/net/context"
 )
 

--- a/internal/crossdock/server/googlegrpc/server.go
+++ b/internal/crossdock/server/googlegrpc/server.go
@@ -25,7 +25,6 @@ import (
 	"net"
 
 	"go.uber.org/yarpc/internal/crossdock/crossdockpb"
-
 	"google.golang.org/grpc"
 )
 

--- a/internal/crossdock/server/oneway/server.go
+++ b/internal/crossdock/server/oneway/server.go
@@ -26,6 +26,8 @@ import (
 	"strings"
 	"time"
 
+	cherami_client "github.com/uber/cherami-client-go/client/cherami"
+	cherami_type "github.com/uber/cherami-thrift/.generated/go/cherami"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/json"
@@ -35,9 +37,6 @@ import (
 	"go.uber.org/yarpc/transport/http"
 	"go.uber.org/yarpc/transport/x/cherami"
 	"go.uber.org/yarpc/transport/x/redis"
-
-	cherami_client "github.com/uber/cherami-client-go/client/cherami"
-	cherami_type "github.com/uber/cherami-thrift/.generated/go/cherami"
 )
 
 var dispatcher *yarpc.Dispatcher

--- a/internal/crossdock/server/tch/echo.go
+++ b/internal/crossdock/server/tch/echo.go
@@ -21,11 +21,10 @@
 package tch
 
 import (
-	"go.uber.org/yarpc/internal/crossdock/thrift/gen-go/echo"
-
 	"github.com/uber/tchannel-go/json"
 	"github.com/uber/tchannel-go/raw"
 	"github.com/uber/tchannel-go/thrift"
+	"go.uber.org/yarpc/internal/crossdock/thrift/gen-go/echo"
 	"golang.org/x/net/context"
 )
 

--- a/internal/examples/protobuf/main.go
+++ b/internal/examples/protobuf/main.go
@@ -36,7 +36,6 @@ import (
 	"go.uber.org/yarpc/internal/examples/protobuf/examplepb"
 	"go.uber.org/yarpc/internal/examples/protobuf/exampleutil"
 	"go.uber.org/yarpc/internal/testutils"
-
 	"google.golang.org/grpc"
 )
 

--- a/internal/examples/protobuf/main_test.go
+++ b/internal/examples/protobuf/main_test.go
@@ -25,9 +25,8 @@ import (
 	"strings"
 	"testing"
 
-	"go.uber.org/yarpc/internal/testutils"
-
 	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/internal/testutils"
 )
 
 const (

--- a/internal/examples/thrift-hello/hello/main.go
+++ b/internal/examples/thrift-hello/hello/main.go
@@ -30,11 +30,10 @@ import (
 	"syscall"
 	"time"
 
+	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/internal/examples/thrift-hello/hello/echo"
 	"go.uber.org/yarpc/internal/examples/thrift-hello/hello/echo/helloclient"
 	"go.uber.org/yarpc/internal/examples/thrift-hello/hello/echo/helloserver"
-
-	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/transport/http"
 )
 

--- a/internal/examples/thrift-keyvalue/keyvalue/client/main.go
+++ b/internal/examples/thrift-keyvalue/keyvalue/client/main.go
@@ -30,10 +30,9 @@ import (
 	"strings"
 	"time"
 
-	"go.uber.org/yarpc/internal/examples/thrift-keyvalue/keyvalue/kv/keyvalueclient"
-
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/examples/thrift-keyvalue/keyvalue/kv/keyvalueclient"
 	"go.uber.org/yarpc/transport/http"
 	"go.uber.org/yarpc/transport/tchannel"
 	"go.uber.org/yarpc/transport/x/grpc"

--- a/internal/examples/thrift-keyvalue/keyvalue/server/main.go
+++ b/internal/examples/thrift-keyvalue/keyvalue/server/main.go
@@ -30,15 +30,14 @@ import (
 	"strings"
 	"sync"
 
+	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/examples/thrift-keyvalue/keyvalue/kv"
 	"go.uber.org/yarpc/internal/examples/thrift-keyvalue/keyvalue/kv/keyvalueserver"
-	"go.uber.org/yarpc/x/yarpcmeta"
-
-	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/transport/http"
 	"go.uber.org/yarpc/transport/tchannel"
 	"go.uber.org/yarpc/transport/x/grpc"
+	"go.uber.org/yarpc/x/yarpcmeta"
 )
 
 var flagInbound = flag.String("inbound", "", "name of the inbound to use (http/tchannel/grpc)")

--- a/internal/examples/thrift-oneway/main.go
+++ b/internal/examples/thrift-oneway/main.go
@@ -25,11 +25,10 @@ import (
 	"log"
 	"time"
 
+	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/internal/examples/thrift-oneway/sink"
 	"go.uber.org/yarpc/internal/examples/thrift-oneway/sink/helloclient"
 	"go.uber.org/yarpc/internal/examples/thrift-oneway/sink/helloserver"
-
-	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/transport/http"
 	"go.uber.org/yarpc/transport/x/redis"
 )

--- a/internal/inboundmiddleware/chain_test.go
+++ b/internal/inboundmiddleware/chain_test.go
@@ -26,13 +26,12 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/yarpc/api/middleware"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/api/transport/transporttest"
 	"go.uber.org/yarpc/internal/testtime"
-
-	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
 )
 
 type countInboundMiddleware struct{ Count int }

--- a/internal/integrationtest/util.go
+++ b/internal/integrationtest/util.go
@@ -28,6 +28,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
@@ -35,9 +37,6 @@ import (
 	"go.uber.org/yarpc/internal/testtime"
 	peerbind "go.uber.org/yarpc/peer"
 	"go.uber.org/yarpc/peer/roundrobin"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/internal/integrationtest/util_test.go
+++ b/internal/integrationtest/util_test.go
@@ -23,6 +23,7 @@ package integrationtest_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/backoff"
@@ -30,8 +31,6 @@ import (
 	"go.uber.org/yarpc/internal/testtime"
 	"go.uber.org/yarpc/peer/hostport"
 	"go.uber.org/yarpc/transport/tchannel"
-
-	"github.com/stretchr/testify/require"
 )
 
 var spec = integrationtest.TransportSpec{

--- a/internal/ioutil/rereader.go
+++ b/internal/ioutil/rereader.go
@@ -25,9 +25,8 @@ import (
 	"errors"
 	"io"
 
-	"go.uber.org/yarpc/internal/buffer"
-
 	"go.uber.org/atomic"
+	"go.uber.org/yarpc/internal/buffer"
 )
 
 // TODO Optimizations:

--- a/internal/net/httpserver_test.go
+++ b/internal/net/httpserver_test.go
@@ -28,10 +28,9 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/yarpc/internal/testtime"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/internal/testtime"
 )
 
 func TestStartAndStop(t *testing.T) {

--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"go.uber.org/yarpc/api/transport"
-
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )

--- a/internal/observability/graph.go
+++ b/internal/observability/graph.go
@@ -27,7 +27,6 @@ import (
 
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/pally"
-
 	"go.uber.org/zap"
 )
 

--- a/internal/observability/graph_test.go
+++ b/internal/observability/graph_test.go
@@ -24,10 +24,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/pally"
-
-	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 )
 

--- a/internal/observability/middleware.go
+++ b/internal/observability/middleware.go
@@ -26,7 +26,6 @@ import (
 
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/pally"
-
 	"go.uber.org/zap"
 )
 

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -29,13 +29,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/api/transport/transporttest"
 	"go.uber.org/yarpc/internal/pally"
 	"go.uber.org/yarpc/internal/pally/pallytest"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"

--- a/internal/outboundmiddleware/chain_test.go
+++ b/internal/outboundmiddleware/chain_test.go
@@ -27,13 +27,12 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/yarpc/api/middleware"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/api/transport/transporttest"
 	"go.uber.org/yarpc/internal/testtime"
-
-	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
 )
 
 type countOutboundMiddleware struct{ Count int }

--- a/internal/pally/counter_test.go
+++ b/internal/pally/counter_test.go
@@ -23,11 +23,10 @@ package pally
 import (
 	"testing"
 
-	"go.uber.org/yarpc/internal/pally/pallytest"
-	"go.uber.org/yarpc/internal/testtime"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/internal/pally/pallytest"
+	"go.uber.org/yarpc/internal/testtime"
 )
 
 func TestCounter(t *testing.T) {

--- a/internal/pally/gauge_test.go
+++ b/internal/pally/gauge_test.go
@@ -23,11 +23,10 @@ package pally
 import (
 	"testing"
 
-	"go.uber.org/yarpc/internal/pally/pallytest"
-	"go.uber.org/yarpc/internal/testtime"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/internal/pally/pallytest"
+	"go.uber.org/yarpc/internal/testtime"
 )
 
 func TestGauge(t *testing.T) {

--- a/internal/pally/global_test.go
+++ b/internal/pally/global_test.go
@@ -21,9 +21,8 @@
 package pally_test
 
 import (
-	"go.uber.org/yarpc/internal/pally"
-
 	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/yarpc/internal/pally"
 )
 
 // For expvar-style usage (where all metrics are package-global), create a

--- a/internal/pally/histogram_test.go
+++ b/internal/pally/histogram_test.go
@@ -25,9 +25,8 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/yarpc/internal/pally/pallytest"
-
 	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/internal/pally/pallytest"
 )
 
 func TestLatencies(t *testing.T) {

--- a/internal/pally/registry_test.go
+++ b/internal/pally/registry_test.go
@@ -27,8 +27,6 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/yarpc/internal/pally/pallytest"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/stretchr/testify/assert"
@@ -36,6 +34,7 @@ import (
 	"github.com/uber-go/tally"
 	"github.com/uber-go/tally/m3"
 	"go.uber.org/atomic"
+	"go.uber.org/yarpc/internal/pally/pallytest"
 )
 
 func TestSimpleMetricDuplicates(t *testing.T) {

--- a/internal/pally/scoped_test.go
+++ b/internal/pally/scoped_test.go
@@ -25,9 +25,8 @@ import (
 	"net/http"
 	"time"
 
-	"go.uber.org/yarpc/internal/pally"
-
 	"github.com/uber-go/tally"
+	"go.uber.org/yarpc/internal/pally"
 )
 
 // If you'd prefer to use pure dependency injection and scope your metrics

--- a/internal/pally/vector_test.go
+++ b/internal/pally/vector_test.go
@@ -24,10 +24,9 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/yarpc/internal/pally/pallytest"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/internal/pally/pallytest"
 )
 
 func TestSimpleVectors(t *testing.T) {

--- a/internal/retry/retry_action_test.go
+++ b/internal/retry/retry_action_test.go
@@ -28,14 +28,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc/api/middleware"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/testtime"
 	. "go.uber.org/yarpc/internal/yarpctest/outboundtest"
 	"go.uber.org/yarpc/yarpctest"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // MiddlewareAction is an action applied to a middleware.

--- a/internal/sync/lifecycle_action_test.go
+++ b/internal/sync/lifecycle_action_test.go
@@ -26,10 +26,9 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/yarpc/internal/testtime"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/uber-go/atomic"
+	"go.uber.org/yarpc/internal/testtime"
 )
 
 type wrappedLifecycleOnce struct {

--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -26,6 +26,7 @@ import (
 	"net"
 	"strconv"
 
+	"go.uber.org/multierr"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/x/protobuf"
@@ -33,8 +34,6 @@ import (
 	"go.uber.org/yarpc/transport/tchannel"
 	"go.uber.org/yarpc/transport/x/grpc"
 	"go.uber.org/yarpc/transport/x/grpc/grpcheader"
-
-	"go.uber.org/multierr"
 	ggrpc "google.golang.org/grpc"
 )
 

--- a/internal/yarpctest/outboundtest/outbound_event.go
+++ b/internal/yarpctest/outboundtest/outbound_event.go
@@ -25,11 +25,10 @@ import (
 	"context"
 	"io/ioutil"
 
-	"go.uber.org/yarpc/api/transport"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
+	"go.uber.org/yarpc/api/transport"
 )
 
 // OutboundEventCallable is an object that can be used in conjunction with a

--- a/internal/yarpctest/outboundtest/outbound_event_test.go
+++ b/internal/yarpctest/outboundtest/outbound_event_test.go
@@ -28,13 +28,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/testtime"
 	iyarpctest "go.uber.org/yarpc/internal/yarpctest"
 	"go.uber.org/yarpc/yarpctest"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestOutboundEvent(t *testing.T) {

--- a/peer/bind.go
+++ b/peer/bind.go
@@ -23,12 +23,11 @@ package peer
 import (
 	"context"
 
+	"go.uber.org/multierr"
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/introspection"
 	intsync "go.uber.org/yarpc/internal/sync"
-
-	"go.uber.org/multierr"
 )
 
 // Bind couples a peer list with a peer list updater.

--- a/peer/bind_test.go
+++ b/peer/bind_test.go
@@ -23,15 +23,14 @@ package peer_test
 import (
 	"testing"
 
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/peer/peertest"
 	. "go.uber.org/yarpc/peer"
 	"go.uber.org/yarpc/peer/hostport"
 	"go.uber.org/yarpc/peer/x/peerheap"
 	"go.uber.org/yarpc/yarpctest"
-
-	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestBind(t *testing.T) {

--- a/peer/hostport/hostport.go
+++ b/peer/hostport/hostport.go
@@ -23,9 +23,8 @@ package hostport
 import (
 	"sync"
 
-	"go.uber.org/yarpc/api/peer"
-
 	"go.uber.org/atomic"
+	"go.uber.org/yarpc/api/peer"
 )
 
 // PeerIdentifier uniquely references a host:port combination using a common interface

--- a/peer/hostport/hostport_test.go
+++ b/peer/hostport/hostport_test.go
@@ -24,11 +24,10 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/yarpc/api/peer"
-	. "go.uber.org/yarpc/api/peer/peertest"
-
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/yarpc/api/peer"
+	. "go.uber.org/yarpc/api/peer/peertest"
 )
 
 func TestPeerIdentifier(t *testing.T) {

--- a/peer/hostport/peeraction_test.go
+++ b/peer/hostport/peeraction_test.go
@@ -26,10 +26,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/internal/testtime"
-
-	"github.com/stretchr/testify/assert"
 )
 
 // There are no actual tests in this file, it contains a series of helper methods

--- a/peer/roundrobin/list.go
+++ b/peer/roundrobin/list.go
@@ -25,13 +25,12 @@ import (
 	"fmt"
 	"sync"
 
+	"go.uber.org/atomic"
+	"go.uber.org/multierr"
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/introspection"
 	ysync "go.uber.org/yarpc/internal/sync"
-
-	"go.uber.org/atomic"
-	"go.uber.org/multierr"
 )
 
 type listConfig struct {

--- a/peer/roundrobin/list_test.go
+++ b/peer/roundrobin/list_test.go
@@ -26,12 +26,11 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/yarpc/api/peer"
-	. "go.uber.org/yarpc/api/peer/peertest"
-
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/multierr"
+	"go.uber.org/yarpc/api/peer"
+	. "go.uber.org/yarpc/api/peer/peertest"
 )
 
 func TestRoundRobinList(t *testing.T) {

--- a/peer/x/peerheap/list.go
+++ b/peer/x/peerheap/list.go
@@ -26,11 +26,10 @@ import (
 	"sync"
 	"time"
 
+	"go.uber.org/multierr"
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
 	ysync "go.uber.org/yarpc/internal/sync"
-
-	"go.uber.org/multierr"
 )
 
 const unavailablePenalty = math.MaxInt32

--- a/peer/x/peerheap/list_test.go
+++ b/peer/x/peerheap/list_test.go
@@ -26,12 +26,11 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/yarpc/api/peer"
-	. "go.uber.org/yarpc/api/peer/peertest"
-
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/multierr"
+	"go.uber.org/yarpc/api/peer"
+	. "go.uber.org/yarpc/api/peer/peertest"
 )
 
 func TestPeerHeapList(t *testing.T) {

--- a/peer/x/roundrobin/deprecated_test.go
+++ b/peer/x/roundrobin/deprecated_test.go
@@ -23,11 +23,10 @@ package roundrobin
 import (
 	"testing"
 
-	"go.uber.org/yarpc/api/peer/peertest"
-	newrr "go.uber.org/yarpc/peer/roundrobin"
-
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/yarpc/api/peer/peertest"
+	newrr "go.uber.org/yarpc/peer/roundrobin"
 )
 
 func TestCreate(t *testing.T) {

--- a/router_test.go
+++ b/router_test.go
@@ -26,13 +26,12 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/yarpc/api/middleware"
 	"go.uber.org/yarpc/api/middleware/middlewaretest"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/api/transport/transporttest"
-
-	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestMapRouter(t *testing.T) {

--- a/serialize/serialize.go
+++ b/serialize/serialize.go
@@ -26,12 +26,11 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/serialize/internal"
-
 	"github.com/opentracing/opentracing-go"
 	"go.uber.org/thriftrw/protocol"
 	"go.uber.org/thriftrw/wire"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/serialize/internal"
 )
 
 // version indicates which underlying serialization method will be used

--- a/serialize/serialize_test.go
+++ b/serialize/serialize_test.go
@@ -26,13 +26,12 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/api/transport/transporttest"
-
 	"github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	jaeger "github.com/uber/jaeger-client-go"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/api/transport/transporttest"
 )
 
 func TestSerialization(t *testing.T) {

--- a/transport/http/config_test.go
+++ b/transport/http/config_test.go
@@ -26,10 +26,9 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/yarpc/x/config"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/x/config"
 )
 
 func TestTransportSpec(t *testing.T) {

--- a/transport/http/handler.go
+++ b/transport/http/handler.go
@@ -26,13 +26,12 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/errors"
 	"go.uber.org/yarpc/internal/iopool"
 	"go.uber.org/yarpc/internal/request"
-
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/ext"
 )
 
 func popHeader(h http.Header, n string) string {

--- a/transport/http/handler_test.go
+++ b/transport/http/handler_test.go
@@ -30,16 +30,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/mock/gomock"
+	"github.com/opentracing/opentracing-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	yarpc "go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/api/transport/transporttest"
 	"go.uber.org/yarpc/encoding/raw"
 	"go.uber.org/yarpc/internal/routertest"
-
-	"github.com/golang/mock/gomock"
-	"github.com/opentracing/opentracing-go"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestHandlerSuccess(t *testing.T) {

--- a/transport/http/header_test.go
+++ b/transport/http/header_test.go
@@ -24,9 +24,8 @@ import (
 	"net/http"
 	"testing"
 
-	"go.uber.org/yarpc/api/transport"
-
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/yarpc/api/transport"
 )
 
 func TestHeaders(t *testing.T) {

--- a/transport/http/inbound.go
+++ b/transport/http/inbound.go
@@ -24,13 +24,12 @@ import (
 	"net"
 	"net/http"
 
+	"github.com/opentracing/opentracing-go"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/errors"
 	"go.uber.org/yarpc/internal/introspection"
 	intnet "go.uber.org/yarpc/internal/net"
 	"go.uber.org/yarpc/internal/sync"
-
-	"github.com/opentracing/opentracing-go"
 )
 
 // InboundOption customizes the behavior of an HTTP Inbound constructed with

--- a/transport/http/inbound_test.go
+++ b/transport/http/inbound_test.go
@@ -31,15 +31,14 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/api/transport/transporttest"
 	"go.uber.org/yarpc/encoding/raw"
 	"go.uber.org/yarpc/internal/routertest"
 	"go.uber.org/yarpc/internal/testtime"
-
-	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestStartAddrInUse(t *testing.T) {

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -30,6 +30,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/errors"
@@ -37,9 +39,6 @@ import (
 	"go.uber.org/yarpc/internal/sync"
 	peerchooser "go.uber.org/yarpc/peer"
 	"go.uber.org/yarpc/peer/hostport"
-
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/ext"
 )
 
 // this ensures the HTTP outbound implements both transport.Outbound interfaces

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -30,12 +30,11 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/raw"
 	"go.uber.org/yarpc/internal/testtime"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestCallSuccess(t *testing.T) {

--- a/transport/http/peer_test.go
+++ b/transport/http/peer_test.go
@@ -25,14 +25,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/opentracing/opentracing-go"
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/backoff"
 	"go.uber.org/yarpc/internal/integrationtest"
 	"go.uber.org/yarpc/peer/hostport"
 	"go.uber.org/yarpc/transport/http"
-
-	"github.com/opentracing/opentracing-go"
 )
 
 func newTransport() peer.Transport {

--- a/transport/http/transport.go
+++ b/transport/http/transport.go
@@ -26,14 +26,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/opentracing/opentracing-go"
 	backoffapi "go.uber.org/yarpc/api/backoff"
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/backoff"
 	intsync "go.uber.org/yarpc/internal/sync"
 	"go.uber.org/yarpc/peer/hostport"
-
-	"github.com/opentracing/opentracing-go"
 )
 
 type transportOptions struct {

--- a/transport/http/transport_test.go
+++ b/transport/http/transport_test.go
@@ -23,13 +23,12 @@ package http
 import (
 	"testing"
 
+	"github.com/crossdock/crossdock-go/assert"
+	"github.com/golang/mock/gomock"
 	"go.uber.org/yarpc/api/peer"
 	. "go.uber.org/yarpc/api/peer/peertest"
 	"go.uber.org/yarpc/internal/testtime"
 	"go.uber.org/yarpc/peer/hostport"
-
-	"github.com/crossdock/crossdock-go/assert"
-	"github.com/golang/mock/gomock"
 )
 
 type peerExpectation struct {

--- a/transport/http/ttl_test.go
+++ b/transport/http/ttl_test.go
@@ -24,9 +24,8 @@ import (
 	"context"
 	"testing"
 
-	"go.uber.org/yarpc/api/transport"
-
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/yarpc/api/transport"
 )
 
 func TestParseTTL(t *testing.T) {

--- a/transport/roundtrip_test.go
+++ b/transport/roundtrip_test.go
@@ -28,6 +28,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber/tchannel-go"
+	"github.com/uber/tchannel-go/testutils"
 	"go.uber.org/yarpc/api/transport"
 	trans "go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/api/transport/transporttest"
@@ -36,11 +40,6 @@ import (
 	"go.uber.org/yarpc/internal/testtime"
 	"go.uber.org/yarpc/transport/http"
 	tch "go.uber.org/yarpc/transport/tchannel"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/uber/tchannel-go"
-	"github.com/uber/tchannel-go/testutils"
 )
 
 // all tests in this file should use these names for callers and services.

--- a/transport/tchannel/channel_inbound_test.go
+++ b/transport/tchannel/channel_inbound_test.go
@@ -27,17 +27,16 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"go.uber.org/yarpc"
-	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/encoding/json"
-	"go.uber.org/yarpc/encoding/raw"
-	"go.uber.org/yarpc/internal/testtime"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go"
 	tjson "github.com/uber/tchannel-go/json"
 	"github.com/uber/tchannel-go/testutils"
+	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/encoding/json"
+	"go.uber.org/yarpc/encoding/raw"
+	"go.uber.org/yarpc/internal/testtime"
 )
 
 func TestChannelInboundStartNew(t *testing.T) {

--- a/transport/tchannel/channel_outbound.go
+++ b/transport/tchannel/channel_outbound.go
@@ -24,14 +24,13 @@ import (
 	"context"
 	"io"
 
+	"github.com/uber/tchannel-go"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/encoding"
 	"go.uber.org/yarpc/internal/errors"
 	"go.uber.org/yarpc/internal/introspection"
 	"go.uber.org/yarpc/internal/iopool"
 	"go.uber.org/yarpc/internal/sync"
-
-	"github.com/uber/tchannel-go"
 )
 
 var (

--- a/transport/tchannel/channel_outbound_test.go
+++ b/transport/tchannel/channel_outbound_test.go
@@ -27,14 +27,13 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/encoding/raw"
-	"go.uber.org/yarpc/internal/testtime"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/testutils"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/encoding/raw"
+	"go.uber.org/yarpc/internal/testtime"
 	"golang.org/x/net/context"
 )
 

--- a/transport/tchannel/channel_transport.go
+++ b/transport/tchannel/channel_transport.go
@@ -23,11 +23,10 @@ package tchannel
 import (
 	"errors"
 
-	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/internal/sync"
-
 	"github.com/opentracing/opentracing-go"
 	"github.com/uber/tchannel-go"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/sync"
 )
 
 var errChannelOrServiceNameIsRequired = errors.New(

--- a/transport/tchannel/codes.go
+++ b/transport/tchannel/codes.go
@@ -21,9 +21,8 @@
 package tchannel
 
 import (
-	"go.uber.org/yarpc/api/yarpcerrors"
-
 	"github.com/uber/tchannel-go"
+	"go.uber.org/yarpc/api/yarpcerrors"
 )
 
 var (

--- a/transport/tchannel/config_test.go
+++ b/transport/tchannel/config_test.go
@@ -24,12 +24,11 @@ import (
 	"fmt"
 	"testing"
 
-	"go.uber.org/yarpc"
-	"go.uber.org/yarpc/x/config"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	tchanneltest "github.com/uber/tchannel-go/testutils"
+	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/x/config"
 )
 
 type badOption struct{}

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -25,14 +25,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/opentracing/opentracing-go"
+	"github.com/uber/tchannel-go"
+	"go.uber.org/multierr"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/encoding"
 	"go.uber.org/yarpc/internal/errors"
 	"go.uber.org/yarpc/internal/request"
-
-	"github.com/opentracing/opentracing-go"
-	"github.com/uber/tchannel-go"
-	"go.uber.org/multierr"
 	ncontext "golang.org/x/net/context"
 )
 

--- a/transport/tchannel/handler_test.go
+++ b/transport/tchannel/handler_test.go
@@ -27,6 +27,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber/tchannel-go"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/api/transport/transporttest"
 	"go.uber.org/yarpc/encoding/json"
@@ -34,11 +38,6 @@ import (
 	"go.uber.org/yarpc/internal/encoding"
 	"go.uber.org/yarpc/internal/routertest"
 	"go.uber.org/yarpc/internal/testtime"
-
-	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/uber/tchannel-go"
 )
 
 func TestHandlerErrors(t *testing.T) {

--- a/transport/tchannel/header.go
+++ b/transport/tchannel/header.go
@@ -25,10 +25,9 @@ import (
 	"encoding/binary"
 	"io"
 
+	"github.com/uber/tchannel-go"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/transport/tchannel/internal"
-
-	"github.com/uber/tchannel-go"
 )
 
 // readRequestHeaders reads headers and baggage from an incoming request.

--- a/transport/tchannel/header_test.go
+++ b/transport/tchannel/header_test.go
@@ -26,11 +26,10 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"go.uber.org/yarpc/api/transport"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go"
+	"go.uber.org/yarpc/api/transport"
 )
 
 func TestEncodeAndDecodeHeaders(t *testing.T) {

--- a/transport/tchannel/inbound_test.go
+++ b/transport/tchannel/inbound_test.go
@@ -26,14 +26,13 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/api/transport/transporttest"
 	"go.uber.org/yarpc/encoding/raw"
 	"go.uber.org/yarpc/internal/testtime"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestInboundStartNew(t *testing.T) {

--- a/transport/tchannel/options.go
+++ b/transport/tchannel/options.go
@@ -23,10 +23,9 @@ package tchannel
 import (
 	"time"
 
+	"github.com/opentracing/opentracing-go"
 	backoffapi "go.uber.org/yarpc/api/backoff"
 	"go.uber.org/yarpc/internal/backoff"
-
-	"github.com/opentracing/opentracing-go"
 )
 
 // Option allows customizing the YARPC TChannel transport.

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -23,6 +23,7 @@ package tchannel
 import (
 	"context"
 
+	"github.com/uber/tchannel-go"
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/encoding"
@@ -30,8 +31,6 @@ import (
 	intsync "go.uber.org/yarpc/internal/sync"
 	peerchooser "go.uber.org/yarpc/peer"
 	"go.uber.org/yarpc/peer/hostport"
-
-	"github.com/uber/tchannel-go"
 )
 
 var (

--- a/transport/tchannel/outbound_test.go
+++ b/transport/tchannel/outbound_test.go
@@ -27,14 +27,13 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/encoding/raw"
-	"go.uber.org/yarpc/internal/testtime"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go"
 	"github.com/uber/tchannel-go/testutils"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/encoding/raw"
+	"go.uber.org/yarpc/internal/testtime"
 	"golang.org/x/net/context"
 )
 

--- a/transport/tchannel/peer_test.go
+++ b/transport/tchannel/peer_test.go
@@ -25,6 +25,7 @@ import (
 	"net"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/backoff"
@@ -32,8 +33,6 @@ import (
 	"go.uber.org/yarpc/internal/testtime"
 	"go.uber.org/yarpc/peer/hostport"
 	"go.uber.org/yarpc/transport/tchannel"
-
-	"github.com/stretchr/testify/require"
 )
 
 var spec = integrationtest.TransportSpec{

--- a/transport/tchannel/transport.go
+++ b/transport/tchannel/transport.go
@@ -25,14 +25,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/opentracing/opentracing-go"
+	"github.com/uber/tchannel-go"
 	backoffapi "go.uber.org/yarpc/api/backoff"
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
 	intsync "go.uber.org/yarpc/internal/sync"
 	"go.uber.org/yarpc/peer/hostport"
-
-	"github.com/opentracing/opentracing-go"
-	"github.com/uber/tchannel-go"
 )
 
 // Transport is a TChannel transport suitable for use with YARPC's peer

--- a/transport/tracer_test.go
+++ b/transport/tracer_test.go
@@ -24,6 +24,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/mocktracer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc"
@@ -31,9 +33,6 @@ import (
 	"go.uber.org/yarpc/internal/testtime"
 	"go.uber.org/yarpc/transport/http"
 	ytchannel "go.uber.org/yarpc/transport/tchannel"
-
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/mocktracer"
 )
 
 type echoReqBody struct{}

--- a/transport/x/cherami/config.go
+++ b/transport/x/cherami/config.go
@@ -27,10 +27,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/uber/cherami-client-go/client/cherami"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/x/config"
-
-	"github.com/uber/cherami-client-go/client/cherami"
 )
 
 const (

--- a/transport/x/cherami/example/client.go
+++ b/transport/x/cherami/example/client.go
@@ -25,12 +25,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	cherami_client "github.com/uber/cherami-client-go/client/cherami"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/transport/x/cherami"
 	"go.uber.org/yarpc/transport/x/cherami/example/thrift/example/exampleserviceclient"
-
-	"github.com/stretchr/testify/assert"
-	cherami_client "github.com/uber/cherami-client-go/client/cherami"
 )
 
 // TestCheramiYARPC will create a yarpc client (using cherami transport), and issue an one way rpc call to the server

--- a/transport/x/cherami/example/server.go
+++ b/transport/x/cherami/example/server.go
@@ -24,11 +24,10 @@ import (
 	"context"
 	"fmt"
 
+	cherami_client "github.com/uber/cherami-client-go/client/cherami"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/transport/x/cherami"
 	"go.uber.org/yarpc/transport/x/cherami/example/thrift/example/exampleserviceserver"
-
-	cherami_client "github.com/uber/cherami-client-go/client/cherami"
 )
 
 // ServerConfig is the configuration needed to create a ExampleService

--- a/transport/x/cherami/inbound.go
+++ b/transport/x/cherami/inbound.go
@@ -25,15 +25,14 @@ import (
 	"log"
 	"time"
 
+	"github.com/opentracing/opentracing-go"
+	"github.com/uber/cherami-client-go/client/cherami"
+	"go.uber.org/multierr"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/errors"
 	"go.uber.org/yarpc/internal/sync"
 	"go.uber.org/yarpc/serialize"
 	"go.uber.org/yarpc/transport/x/cherami/internal"
-
-	"github.com/opentracing/opentracing-go"
-	"github.com/uber/cherami-client-go/client/cherami"
-	"go.uber.org/multierr"
 )
 
 const (

--- a/transport/x/cherami/inbound_test.go
+++ b/transport/x/cherami/inbound_test.go
@@ -23,11 +23,10 @@ package cherami
 import (
 	"testing"
 
-	"go.uber.org/yarpc/api/transport/transporttest"
-	"go.uber.org/yarpc/transport/x/cherami/mocks"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"go.uber.org/yarpc/api/transport/transporttest"
+	"go.uber.org/yarpc/transport/x/cherami/mocks"
 )
 
 func TestInbound(t *testing.T) {

--- a/transport/x/cherami/outbound.go
+++ b/transport/x/cherami/outbound.go
@@ -24,13 +24,12 @@ import (
 	"context"
 	"time"
 
+	"github.com/opentracing/opentracing-go"
+	"github.com/uber/cherami-client-go/client/cherami"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/sync"
 	"go.uber.org/yarpc/serialize"
 	"go.uber.org/yarpc/transport/x/cherami/internal"
-
-	"github.com/opentracing/opentracing-go"
-	"github.com/uber/cherami-client-go/client/cherami"
 )
 
 // OutboundOptions specifies a Cherami outbound.

--- a/transport/x/cherami/outbound_test.go
+++ b/transport/x/cherami/outbound_test.go
@@ -23,10 +23,9 @@ package cherami
 import (
 	"testing"
 
-	"go.uber.org/yarpc/transport/x/cherami/mocks"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"go.uber.org/yarpc/transport/x/cherami/mocks"
 )
 
 func TestOutbound(t *testing.T) {

--- a/transport/x/cherami/transport.go
+++ b/transport/x/cherami/transport.go
@@ -21,12 +21,11 @@
 package cherami
 
 import (
+	"github.com/opentracing/opentracing-go"
+	"github.com/uber/cherami-client-go/client/cherami"
 	"go.uber.org/yarpc/api/transport"
 	intsync "go.uber.org/yarpc/internal/sync"
 	"go.uber.org/yarpc/transport/x/cherami/internal"
-
-	"github.com/opentracing/opentracing-go"
-	"github.com/uber/cherami-client-go/client/cherami"
 )
 
 // NewTransport creates a new cherami transport for shared objects between inbound and outbound.

--- a/transport/x/grpc/codes.go
+++ b/transport/x/grpc/codes.go
@@ -22,7 +22,6 @@ package grpc
 
 import (
 	"go.uber.org/yarpc/api/yarpcerrors"
-
 	"google.golang.org/grpc/codes"
 )
 

--- a/transport/x/grpc/config_test.go
+++ b/transport/x/grpc/config_test.go
@@ -23,10 +23,9 @@ package grpc
 import (
 	"testing"
 
-	"go.uber.org/yarpc/x/config"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/x/config"
 )
 
 func TestNewTransportSpecOptions(t *testing.T) {

--- a/transport/x/grpc/handler.go
+++ b/transport/x/grpc/handler.go
@@ -30,7 +30,6 @@ import (
 	"go.uber.org/yarpc/encoding/x/protobuf"
 	"go.uber.org/yarpc/internal/errors"
 	"go.uber.org/yarpc/internal/request"
-
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"

--- a/transport/x/grpc/headers.go
+++ b/transport/x/grpc/headers.go
@@ -24,10 +24,9 @@ import (
 	"fmt"
 	"strings"
 
+	"go.uber.org/multierr"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/transport/x/grpc/grpcheader"
-
-	"go.uber.org/multierr"
 	"google.golang.org/grpc/metadata"
 )
 

--- a/transport/x/grpc/headers_test.go
+++ b/transport/x/grpc/headers_test.go
@@ -24,11 +24,10 @@ import (
 	"fmt"
 	"testing"
 
-	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/transport/x/grpc/grpcheader"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/transport/x/grpc/grpcheader"
 	"google.golang.org/grpc/metadata"
 )
 

--- a/transport/x/grpc/inbound.go
+++ b/transport/x/grpc/inbound.go
@@ -27,7 +27,6 @@ import (
 
 	"go.uber.org/yarpc/api/transport"
 	internalsync "go.uber.org/yarpc/internal/sync"
-
 	"google.golang.org/grpc"
 )
 

--- a/transport/x/grpc/inbound_test.go
+++ b/transport/x/grpc/inbound_test.go
@@ -26,9 +26,8 @@ import (
 	"fmt"
 	"testing"
 
-	"go.uber.org/yarpc/api/transport"
-
 	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/api/transport"
 	"google.golang.org/grpc"
 )
 

--- a/transport/x/grpc/integration_test.go
+++ b/transport/x/grpc/integration_test.go
@@ -27,6 +27,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/multierr"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/x/protobuf"
 	"go.uber.org/yarpc/internal/clientconfig"
@@ -34,10 +37,6 @@ import (
 	"go.uber.org/yarpc/internal/examples/protobuf/examplepb"
 	"go.uber.org/yarpc/internal/testtime"
 	"go.uber.org/yarpc/transport/x/grpc/grpcheader"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/multierr"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )

--- a/transport/x/grpc/outbound.go
+++ b/transport/x/grpc/outbound.go
@@ -31,7 +31,6 @@ import (
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/errors"
 	internalsync "go.uber.org/yarpc/internal/sync"
-
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"

--- a/transport/x/grpc/response_writer.go
+++ b/transport/x/grpc/response_writer.go
@@ -24,7 +24,6 @@ import (
 	"bytes"
 
 	"go.uber.org/yarpc/api/transport"
-
 	"google.golang.org/grpc/metadata"
 )
 

--- a/transport/x/redis/inbound.go
+++ b/transport/x/redis/inbound.go
@@ -25,14 +25,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/opentracing/opentracing-go"
+	"go.uber.org/multierr"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/errors"
 	"go.uber.org/yarpc/internal/introspection"
 	"go.uber.org/yarpc/internal/sync"
 	"go.uber.org/yarpc/serialize"
-
-	"github.com/opentracing/opentracing-go"
-	"go.uber.org/multierr"
 )
 
 const transportName = "redis"

--- a/transport/x/redis/inbound_test.go
+++ b/transport/x/redis/inbound_test.go
@@ -23,12 +23,11 @@ package redis
 import (
 	"testing"
 
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/yarpc/api/transport/transporttest"
 	"go.uber.org/yarpc/internal/testtime"
 	"go.uber.org/yarpc/transport/x/redis/redistest"
-
-	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestOperationOrder(t *testing.T) {

--- a/transport/x/redis/outbound.go
+++ b/transport/x/redis/outbound.go
@@ -25,12 +25,11 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/opentracing/opentracing-go"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/introspection"
 	"go.uber.org/yarpc/internal/sync"
 	"go.uber.org/yarpc/serialize"
-
-	"github.com/opentracing/opentracing-go"
 )
 
 var (

--- a/transport/x/redis/outbound_test.go
+++ b/transport/x/redis/outbound_test.go
@@ -26,14 +26,13 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/raw"
 	"go.uber.org/yarpc/internal/testtime"
 	"go.uber.org/yarpc/transport/x/redis/redistest"
-
-	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestCall(t *testing.T) {

--- a/x/config/backoff_test.go
+++ b/x/config/backoff_test.go
@@ -24,10 +24,9 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/yarpc/internal/whitespace"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/internal/whitespace"
 	"gopkg.in/yaml.v2"
 )
 

--- a/x/config/builder.go
+++ b/x/config/builder.go
@@ -23,10 +23,9 @@ package config
 import (
 	"fmt"
 
+	"go.uber.org/multierr"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
-
-	"go.uber.org/multierr"
 )
 
 type buildableOutbounds struct {

--- a/x/config/chooser_test.go
+++ b/x/config/chooser_test.go
@@ -26,6 +26,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/golang/mock/gomock"
+	"github.com/opentracing/opentracing-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc"
 	peerapi "go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/peer/peertest"
@@ -42,11 +46,6 @@ import (
 	"go.uber.org/yarpc/transport/tchannel"
 	"go.uber.org/yarpc/x/config"
 	"go.uber.org/yarpc/yarpctest"
-
-	"github.com/golang/mock/gomock"
-	"github.com/opentracing/opentracing-go"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestChooserConfigurator(t *testing.T) {

--- a/x/config/configurator.go
+++ b/x/config/configurator.go
@@ -27,10 +27,9 @@ import (
 	"io/ioutil"
 	"os"
 
+	"go.uber.org/multierr"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/internal/interpolate"
-
-	"go.uber.org/multierr"
 	"gopkg.in/yaml.v2"
 )
 

--- a/x/config/configurator_test.go
+++ b/x/config/configurator_test.go
@@ -26,13 +26,12 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/yarpc"
-	"go.uber.org/yarpc/api/transport/transporttest"
-	"go.uber.org/yarpc/internal/whitespace"
-
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/api/transport/transporttest"
+	"go.uber.org/yarpc/internal/whitespace"
 	"gopkg.in/yaml.v2"
 )
 

--- a/x/config/mapdecode.go
+++ b/x/config/mapdecode.go
@@ -25,9 +25,8 @@ import (
 	"reflect"
 	"strings"
 
-	"go.uber.org/yarpc/internal/interpolate"
-
 	"github.com/uber-go/mapdecode"
+	"go.uber.org/yarpc/internal/interpolate"
 )
 
 const (

--- a/x/config/mapdecode_test.go
+++ b/x/config/mapdecode_test.go
@@ -24,10 +24,9 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/yarpc/internal/interpolate"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/internal/interpolate"
 )
 
 func TestInterpolateHook(t *testing.T) {

--- a/x/config/mock_transport_spec_test.go
+++ b/x/config/mock_transport_spec_test.go
@@ -24,9 +24,8 @@ import (
 	"fmt"
 	"reflect"
 
-	"go.uber.org/yarpc/api/transport"
-
 	"github.com/golang/mock/gomock"
+	"go.uber.org/yarpc/api/transport"
 )
 
 // Builds mockTransportSpec objects.

--- a/x/config/spec.go
+++ b/x/config/spec.go
@@ -26,11 +26,10 @@ import (
 	"reflect"
 	"strings"
 
-	"go.uber.org/yarpc/api/peer"
-	"go.uber.org/yarpc/api/transport"
-
 	"github.com/uber-go/mapdecode"
 	"go.uber.org/multierr"
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/api/transport"
 )
 
 // TransportSpec specifies the configuration parameters for a transport. These

--- a/x/config/spec_test.go
+++ b/x/config/spec_test.go
@@ -26,11 +26,10 @@ import (
 	"reflect"
 	"testing"
 
-	"go.uber.org/yarpc/api/peer"
-	"go.uber.org/yarpc/api/transport"
-
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/api/transport"
 )
 
 var _typeOfEmptyStruct = reflect.TypeOf(struct{}{})

--- a/x/yarpcmeta/service_test.go
+++ b/x/yarpcmeta/service_test.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/encoding/json"
 )

--- a/yarpctest/recorder/recorder.go
+++ b/yarpctest/recorder/recorder.go
@@ -69,7 +69,6 @@ import (
 	"unicode"
 
 	"go.uber.org/yarpc/api/transport"
-
 	"gopkg.in/yaml.v2"
 )
 

--- a/yarpctest/recorder/recorder_test.go
+++ b/yarpctest/recorder/recorder_test.go
@@ -31,13 +31,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/raw"
 	"go.uber.org/yarpc/transport/http"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestSanitizeFilename(t *testing.T) {


### PR DESCRIPTION
Restore sanity to the universe. We never again be bothered to manually separate
import groups.