### PR TITLE
Modify Travis CI to use Trusty for sudo jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,16 +17,22 @@ matrix:
         - secure: Vg1mnR5Eu98dQ30rNb2fFblehh71a6goJz/Crhh+kae1z1Ec6NuQ6b0mNrzZMIXg6QktZ9gK0bJHjg1t90QpDfWHtSqAhQ0Z5yI4xH7Dt7jEMSYhGQ+YSmG6qo4c6Rh7CrIYXFRenS+qzhA8h7m48O8j1Z5G24qfen3y9cs7TNWKi43kGY8kSue3+xMi8hVErFLhfyhLNkOMJzWes+22apwEWIYwZWALYLpkmpYmgK8+nw+cZrI/r1WX5f6tdyZ/CRD/BAMgCwJYo7SNMuqTzsKTdqlHr7p2j7vcZtBSk5SJwzeChNJQwy94k+HF79R0WX8T8wuvxZKGtRqo7kf5bHAg2NRNDEL1KjBjV8tCJoh7FHLmQenQKfAt7x/eQu9r/+3do9Wvyan5MV3zYpDlCFZrRua9BL+cuSQaDAvGDAfqbzuDdlqUJLmn+t2+yyrxJS1NX5fLi6MX8cyh/11JkcIXifM9HqD1yM9S99MA8M3/O2g71oEbvcktkRCMOGga68sap+GzavVElyuutzHDGrPSvSqFw42yBAEKbnEJDbsMYL/6xxN/Xd3ez3YuwRs4R1m2NRN4Nq53ERozW8k7uVxmaEBioGfO+e5n0MfDQXY6uvdCx/R32ub4QDYOAovvoxhg042pYMbxWJkO73RMWTQzJvY8dbrxdMkw4xyq3Ic=
         - secure: dhvshW7GvphJ6xvS8MxEtJGN+4C4d64hqOcaCKXXXVqyeunJ1gH/Cb6v1RcETgtRxOIHyyHo218j0cs0hNtIWCZq5YVbXMAJ5Sret+cKA3aZNMCbgwPNS48WdVZsCHurW22abq41ejfKuuFqSI+ooMprrsGeRjHMbJZM86k7UuEqxdvqGjotYugGcfiCjxnNtMHd1M6AQ9fPFzhg8TUeqPy7eDIdKTcqwa/h7ZsYn/WJp1LkUtwyHsfpweIv6JBQ9/xUDzjcoz5MA6Nj75/Mk4bJzzLEem3EKs1TTZOqV1NVt7VJ887NPe4fLIxP1/jQLzsh6kShTcctLszc70NgrowdwhdIqN/3TUmxkVbGP2JzbQ4yR6LVKCDDeWpKGiPsIKy75kEiW4ZlEZhnwCOKaR94FyBy1HEnhyoD9OJD6Gq/u4UdEw/QuNfE89gbr47LA4z487AzYGzH+1J3MlEbTNgTCmWduC0ghTx33vItrYMXXabGDe7XwfdJKTnMjfXVv+CVBdMAZVtDL27sEmbbAzIrRjP+JOFm7ZRYfzvxu5vCWlB/3wMMt7DzcutjxR4tyYs71Ec5zdUH/16wSvjQR1laJZCujlNSA/3FZUizCzW3qFVsBkaWRF+/C/cksi6cR83xIrc4y4WRLttAcbfqmsXaigL5Iz4GbLg62vmFP88=
       sudo: required
+      dist: trusty
+      group: edge
       services:
         - docker
     - env: CI_TYPES='deps examples codecov' SUPPRESS_DOCKER=1 SUPPRESS_CROSSDOCK=1
       go: 1.7
     - env: CI_TYPES='deps examples lint test' SUPPRESS_CROSSDOCK=1 DOCKER_GO_VERSION=1.8
       sudo: required
+      dist: trusty
+      group: edge
       services:
         - docker
     - env: CI_TYPES='deps examples lint test' SUPPRESS_CROSSDOCK=1 DOCKER_GO_VERSION=1.9
       sudo: required
+      dist: trusty
+      group: edge
       services:
         - docker
 before_install:


### PR DESCRIPTION
We're getting warning messages about updating this by today. I've verified this passes testing.