### PR TITLE
[Retry Middleware][Part 7.9] Add back timing tests with "testtime"

### DIFF
--- a/internal/retry/retry_action_test.go
+++ b/internal/retry/retry_action_test.go
@@ -72,7 +72,7 @@ func (r RequestAction) Apply(t *testing.T, mw middleware.UnaryOutbound) {
 			r.wantTimeLimit = r.reqTimeout + testtime.Millisecond*10
 		}
 
-		newCtx, cancel := context.WithTimeout(ctx, testtime.Scale(r.reqTimeout))
+		newCtx, cancel := context.WithTimeout(ctx, r.reqTimeout)
 		defer cancel()
 		ctx = newCtx
 	}

--- a/internal/retry/retry_action_test.go
+++ b/internal/retry/retry_action_test.go
@@ -52,6 +52,7 @@ type RequestAction struct {
 
 	events []*OutboundEvent
 
+	wantTimeLimit        time.Duration
 	wantError            string
 	wantApplicationError bool
 	wantBody             string
@@ -67,12 +68,22 @@ func (r RequestAction) Apply(t *testing.T, mw middleware.UnaryOutbound) {
 
 	ctx := context.Background()
 	if r.reqTimeout != 0 {
+		if r.wantTimeLimit == 0 {
+			r.wantTimeLimit = r.reqTimeout + testtime.Millisecond*10
+		}
+
 		newCtx, cancel := context.WithTimeout(ctx, testtime.Scale(r.reqTimeout))
 		defer cancel()
 		ctx = newCtx
 	}
 
+	start := time.Now()
 	resp, err := mw.Call(ctx, r.request, out)
+	elapsed := time.Now().Sub(start)
+
+	if r.wantTimeLimit > 0 {
+		assert.True(t, r.wantTimeLimit > elapsed, "execution took to long, wanted %s, took %s", r.wantTimeLimit, elapsed)
+	}
 
 	if r.wantError != "" {
 		assert.EqualError(t, err, r.wantError)

--- a/internal/retry/retry_action_test.go
+++ b/internal/retry/retry_action_test.go
@@ -82,7 +82,7 @@ func (r RequestAction) Apply(t *testing.T, mw middleware.UnaryOutbound) {
 	elapsed := time.Now().Sub(start)
 
 	if r.wantTimeLimit > 0 {
-		assert.True(t, r.wantTimeLimit > elapsed, "execution took to long, wanted %s, took %s", r.wantTimeLimit, elapsed)
+		assert.True(t, r.wantTimeLimit > elapsed, "execution took too long, wanted %s, took %s", r.wantTimeLimit, elapsed)
 	}
 
 	if r.wantError != "" {

--- a/internal/retry/retry_action_test.go
+++ b/internal/retry/retry_action_test.go
@@ -69,7 +69,7 @@ func (r RequestAction) Apply(t *testing.T, mw middleware.UnaryOutbound) {
 	ctx := context.Background()
 	if r.reqTimeout != 0 {
 		if r.wantTimeLimit == 0 {
-			r.wantTimeLimit = r.reqTimeout + testtime.Millisecond*10
+			r.wantTimeLimit = r.reqTimeout * 2
 		}
 
 		newCtx, cancel := context.WithTimeout(ctx, r.reqTimeout)

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -48,7 +48,7 @@ func TestMiddleware(t *testing.T) {
 		{
 			msg:          "no retry",
 			retries:      1,
-			retryTimeout: time.Millisecond * 500,
+			retryTimeout: testtime.Millisecond * 500,
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -56,7 +56,7 @@ func TestMiddleware(t *testing.T) {
 						Procedure: "proc",
 						Body:      bytes.NewBufferString("body"),
 					},
-					reqTimeout: time.Second,
+					reqTimeout: testtime.Second,
 					events: []*OutboundEvent{
 						{
 							WantService:   "serv",
@@ -72,7 +72,7 @@ func TestMiddleware(t *testing.T) {
 		{
 			msg:          "single retry",
 			retries:      1,
-			retryTimeout: time.Millisecond * 500,
+			retryTimeout: testtime.Millisecond * 500,
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -80,7 +80,7 @@ func TestMiddleware(t *testing.T) {
 						Procedure: "proc",
 						Body:      bytes.NewBufferString("body"),
 					},
-					reqTimeout: time.Second,
+					reqTimeout: testtime.Second,
 					events: []*OutboundEvent{
 						{
 							WantService:   "serv",
@@ -102,7 +102,7 @@ func TestMiddleware(t *testing.T) {
 		{
 			msg:          "multiple retries",
 			retries:      4,
-			retryTimeout: time.Millisecond * 500,
+			retryTimeout: testtime.Millisecond * 500,
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -110,7 +110,7 @@ func TestMiddleware(t *testing.T) {
 						Procedure: "proc",
 						Body:      bytes.NewBufferString("body"),
 					},
-					reqTimeout: time.Second,
+					reqTimeout: testtime.Second,
 					events: []*OutboundEvent{
 						{
 							WantService:   "serv",
@@ -122,7 +122,7 @@ func TestMiddleware(t *testing.T) {
 							WantService:   "serv",
 							WantProcedure: "proc",
 							WantBody:      "body",
-							GiveError:     errors.ClientTimeoutError("serv", "proc", time.Millisecond*300),
+							GiveError:     errors.ClientTimeoutError("serv", "proc", testtime.Millisecond*300),
 						},
 						{
 							WantService:   "serv",
@@ -150,7 +150,7 @@ func TestMiddleware(t *testing.T) {
 		{
 			msg:          "immediate hard failure",
 			retries:      1,
-			retryTimeout: time.Millisecond * 500,
+			retryTimeout: testtime.Millisecond * 500,
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -158,7 +158,7 @@ func TestMiddleware(t *testing.T) {
 						Procedure: "proc",
 						Body:      bytes.NewBufferString("body"),
 					},
-					reqTimeout: time.Second,
+					reqTimeout: testtime.Second,
 					events: []*OutboundEvent{
 						{
 							WantService:   "serv",
@@ -174,7 +174,7 @@ func TestMiddleware(t *testing.T) {
 		{
 			msg:          "retry once, then hard failure",
 			retries:      1,
-			retryTimeout: time.Millisecond * 500,
+			retryTimeout: testtime.Millisecond * 500,
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -182,7 +182,7 @@ func TestMiddleware(t *testing.T) {
 						Procedure: "proc",
 						Body:      bytes.NewBufferString("body"),
 					},
-					reqTimeout: time.Second,
+					reqTimeout: testtime.Second,
 					events: []*OutboundEvent{
 						{
 							WantService:   "serv",
@@ -204,7 +204,7 @@ func TestMiddleware(t *testing.T) {
 		{
 			msg:          "ctx timeout less than retry timeout",
 			retries:      1,
-			retryTimeout: time.Millisecond * 500,
+			retryTimeout: testtime.Millisecond * 500,
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -212,9 +212,10 @@ func TestMiddleware(t *testing.T) {
 						Procedure: "proc",
 						Body:      bytes.NewBufferString("body"),
 					},
-					reqTimeout: time.Millisecond * 300,
+					reqTimeout: testtime.Millisecond * 300,
 					events: []*OutboundEvent{
 						{
+							WantTimeout:   testtime.Millisecond * 300,
 							WantService:   "serv",
 							WantProcedure: "proc",
 							WantBody:      "body",
@@ -228,7 +229,7 @@ func TestMiddleware(t *testing.T) {
 		{
 			msg:          "ctx timeout less than retry timeout",
 			retries:      1,
-			retryTimeout: time.Millisecond * 50,
+			retryTimeout: testtime.Millisecond * 50,
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -236,16 +237,18 @@ func TestMiddleware(t *testing.T) {
 						Procedure: "proc",
 						Body:      bytes.NewBufferString("body"),
 					},
-					reqTimeout: time.Millisecond * 75,
+					reqTimeout: testtime.Millisecond * 75,
 					events: []*OutboundEvent{
 						{
+							WantTimeout:    testtime.Millisecond * 50,
 							WantService:    "serv",
 							WantProcedure:  "proc",
 							WantBody:       "body",
 							WaitForTimeout: true,
-							GiveError:      errors.ClientTimeoutError("serv", "proc", time.Millisecond*50),
+							GiveError:      errors.ClientTimeoutError("serv", "proc", testtime.Millisecond*50),
 						},
 						{
+							WantTimeout:   testtime.Millisecond * 25,
 							WantService:   "serv",
 							WantProcedure: "proc",
 							WantBody:      "body",
@@ -259,7 +262,7 @@ func TestMiddleware(t *testing.T) {
 		{
 			msg:          "no ctx timeout",
 			retries:      1,
-			retryTimeout: time.Millisecond * 50,
+			retryTimeout: testtime.Millisecond * 50,
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -269,13 +272,15 @@ func TestMiddleware(t *testing.T) {
 					},
 					events: []*OutboundEvent{
 						{
+							WantTimeout:    testtime.Millisecond * 50,
 							WantService:    "serv",
 							WantProcedure:  "proc",
 							WantBody:       "body",
 							WaitForTimeout: true,
-							GiveError:      errors.ClientTimeoutError("serv", "proc", time.Millisecond*50),
+							GiveError:      errors.ClientTimeoutError("serv", "proc", testtime.Millisecond*50),
 						},
 						{
+							WantTimeout:   testtime.Millisecond * 50,
 							WantService:   "serv",
 							WantProcedure: "proc",
 							WantBody:      "body",
@@ -289,7 +294,7 @@ func TestMiddleware(t *testing.T) {
 		{
 			msg:          "exhaust retries",
 			retries:      1,
-			retryTimeout: time.Millisecond * 50,
+			retryTimeout: testtime.Millisecond * 50,
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -297,15 +302,17 @@ func TestMiddleware(t *testing.T) {
 						Procedure: "proc",
 						Body:      bytes.NewBufferString("body"),
 					},
-					reqTimeout: time.Millisecond * 400,
+					reqTimeout: testtime.Millisecond * 400,
 					events: []*OutboundEvent{
 						{
+							WantTimeout:   testtime.Millisecond * 50,
 							WantService:   "serv",
 							WantProcedure: "proc",
 							WantBody:      "body",
 							GiveError:     errors.RemoteUnexpectedError("unexpected error 1"),
 						},
 						{
+							WantTimeout:   testtime.Millisecond * 50,
 							WantService:   "serv",
 							WantProcedure: "proc",
 							WantBody:      "body",
@@ -319,7 +326,7 @@ func TestMiddleware(t *testing.T) {
 		{
 			msg:          "Reset Error",
 			retries:      1,
-			retryTimeout: time.Millisecond * 50,
+			retryTimeout: testtime.Millisecond * 50,
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -327,9 +334,10 @@ func TestMiddleware(t *testing.T) {
 						Procedure: "proc",
 						Body:      bytes.NewBufferString("body"),
 					},
-					reqTimeout: time.Millisecond * 400,
+					reqTimeout: testtime.Millisecond * 400,
 					events: []*OutboundEvent{
 						{
+							WantTimeout:   testtime.Millisecond * 50,
 							WantService:   "serv",
 							WantProcedure: "proc",
 							// We have explicitly not read the body, which will not exhaust the
@@ -344,8 +352,8 @@ func TestMiddleware(t *testing.T) {
 		{
 			msg:          "backoff timeout",
 			retries:      1,
-			retryTimeout: time.Millisecond * 50,
-			retryBackoff: newFixedBackoff(time.Millisecond * 25),
+			retryTimeout: testtime.Millisecond * 50,
+			retryBackoff: newFixedBackoff(testtime.Millisecond * 25),
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -353,16 +361,18 @@ func TestMiddleware(t *testing.T) {
 						Procedure: "proc",
 						Body:      bytes.NewBufferString("body"),
 					},
-					reqTimeout: time.Millisecond * 100,
+					reqTimeout: testtime.Millisecond * 100,
 					events: []*OutboundEvent{
 						{
+							WantTimeout:    testtime.Millisecond * 50,
 							WantService:    "serv",
 							WantProcedure:  "proc",
 							WantBody:       "body",
 							WaitForTimeout: true,
-							GiveError:      errors.ClientTimeoutError("serv", "proc", time.Millisecond*50),
+							GiveError:      errors.ClientTimeoutError("serv", "proc", testtime.Millisecond*50),
 						},
 						{
+							WantTimeout:   testtime.Millisecond * 25,
 							WantService:   "serv",
 							WantProcedure: "proc",
 							WantBody:      "body",
@@ -376,8 +386,8 @@ func TestMiddleware(t *testing.T) {
 		{
 			msg:          "sequential backoff timeout",
 			retries:      2,
-			retryTimeout: time.Millisecond * 100,
-			retryBackoff: newSequentialBackoff(time.Millisecond * 50),
+			retryTimeout: testtime.Millisecond * 100,
+			retryBackoff: newSequentialBackoff(testtime.Millisecond * 50),
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -385,27 +395,33 @@ func TestMiddleware(t *testing.T) {
 						Procedure: "proc",
 						Body:      bytes.NewBufferString("body"),
 					},
-					reqTimeout: time.Millisecond * 400,
+					reqTimeout: testtime.Millisecond * 400,
 					events: []*OutboundEvent{
 						{
-							WantService:    "serv",
-							WantProcedure:  "proc",
-							WantBody:       "body",
-							WaitForTimeout: true,
-							GiveError:      errors.ClientTimeoutError("serv", "proc", time.Millisecond*50),
+							WantTimeout:       testtime.Millisecond * 100,
+							WantTimeoutBounds: testtime.Millisecond * 20,
+							WantService:       "serv",
+							WantProcedure:     "proc",
+							WantBody:          "body",
+							WaitForTimeout:    true,
+							GiveError:         errors.ClientTimeoutError("serv", "proc", testtime.Millisecond*50),
 						},
 						{
-							WantService:    "serv",
-							WantProcedure:  "proc",
-							WantBody:       "body",
-							WaitForTimeout: true,
-							GiveError:      errors.ClientTimeoutError("serv", "proc", time.Millisecond*50),
+							WantTimeout:       testtime.Millisecond * 100,
+							WantTimeoutBounds: testtime.Millisecond * 20,
+							WantService:       "serv",
+							WantProcedure:     "proc",
+							WantBody:          "body",
+							WaitForTimeout:    true,
+							GiveError:         errors.ClientTimeoutError("serv", "proc", testtime.Millisecond*50),
 						},
 						{
-							WantService:   "serv",
-							WantProcedure: "proc",
-							WantBody:      "body",
-							GiveRespBody:  "respbody",
+							WantTimeout:       testtime.Millisecond * 50,
+							WantTimeoutBounds: testtime.Millisecond * 20,
+							WantService:       "serv",
+							WantProcedure:     "proc",
+							WantBody:          "body",
+							GiveRespBody:      "respbody",
 						},
 					},
 					wantBody: "respbody",
@@ -415,8 +431,8 @@ func TestMiddleware(t *testing.T) {
 		{
 			msg:          "backoff context will timeout",
 			retries:      2,
-			retryTimeout: time.Millisecond * 30,
-			retryBackoff: newFixedBackoff(time.Millisecond * 5000),
+			retryTimeout: testtime.Millisecond * 30,
+			retryBackoff: newFixedBackoff(testtime.Millisecond * 5000),
 			actions: []MiddlewareAction{
 				RequestAction{
 					request: &transport.Request{
@@ -424,25 +440,28 @@ func TestMiddleware(t *testing.T) {
 						Procedure: "proc",
 						Body:      bytes.NewBufferString("body"),
 					},
-					reqTimeout: time.Millisecond * 60,
+					reqTimeout: testtime.Millisecond * 60,
 					events: []*OutboundEvent{
 						{
-							WantService:    "serv",
-							WantProcedure:  "proc",
-							WantBody:       "body",
-							WaitForTimeout: true,
-							GiveError:      errors.RemoteUnexpectedError("unexpected error 2"),
+							WantTimeout:       testtime.Millisecond * 30,
+							WantTimeoutBounds: testtime.Millisecond * 10,
+							WantService:       "serv",
+							WantProcedure:     "proc",
+							WantBody:          "body",
+							WaitForTimeout:    true,
+							GiveError:         errors.RemoteUnexpectedError("unexpected error 2"),
 						},
 					},
-					wantError: errors.RemoteUnexpectedError("unexpected error 2").Error(),
+					wantTimeLimit: testtime.Millisecond * 40,
+					wantError:     errors.RemoteUnexpectedError("unexpected error 2").Error(),
 				},
 			},
 		},
 		{
 			msg:          "concurrent retries",
 			retries:      2,
-			retryTimeout: time.Millisecond * 50,
-			retryBackoff: newFixedBackoff(time.Millisecond * 25),
+			retryTimeout: testtime.Millisecond * 50,
+			retryBackoff: newFixedBackoff(testtime.Millisecond * 25),
 			actions: []MiddlewareAction{
 				ConcurrentAction{
 					Actions: []MiddlewareAction{
@@ -452,16 +471,18 @@ func TestMiddleware(t *testing.T) {
 								Procedure: "proc",
 								Body:      bytes.NewBufferString("body"),
 							},
-							reqTimeout: time.Millisecond * 100,
+							reqTimeout: testtime.Millisecond * 100,
 							events: []*OutboundEvent{
 								{
+									WantTimeout:    testtime.Millisecond * 50,
 									WantService:    "serv",
 									WantProcedure:  "proc",
 									WantBody:       "body",
 									WaitForTimeout: true,
-									GiveError:      errors.ClientTimeoutError("serv", "proc", time.Millisecond*50),
+									GiveError:      errors.ClientTimeoutError("serv", "proc", testtime.Millisecond*50),
 								},
 								{
+									WantTimeout:   testtime.Millisecond * 25,
 									WantService:   "serv",
 									WantProcedure: "proc",
 									WantBody:      "body",
@@ -476,9 +497,10 @@ func TestMiddleware(t *testing.T) {
 								Procedure: "proc2",
 								Body:      bytes.NewBufferString("body2"),
 							},
-							reqTimeout: time.Second,
+							reqTimeout: testtime.Second,
 							events: []*OutboundEvent{
 								{
+									WantTimeout:   testtime.Millisecond * 50,
 									WantService:   "serv2",
 									WantProcedure: "proc2",
 									WantBody:      "body2",
@@ -493,25 +515,27 @@ func TestMiddleware(t *testing.T) {
 								Procedure: "proc3",
 								Body:      bytes.NewBufferString("body3"),
 							},
-							reqTimeout: time.Millisecond * 100,
+							reqTimeout: testtime.Millisecond * 100,
 							events: []*OutboundEvent{
 								{
+									WantTimeout:    testtime.Millisecond * 50,
 									WantService:    "serv3",
 									WantProcedure:  "proc3",
 									WantBody:       "body3",
 									WaitForTimeout: true,
-									GiveError:      errors.ClientTimeoutError("serv3", "proc3", time.Millisecond*50),
+									GiveError:      errors.ClientTimeoutError("serv3", "proc3", testtime.Millisecond*50),
 								},
 								{
+									WantTimeout:    testtime.Millisecond * 25,
 									WantService:    "serv3",
 									WantProcedure:  "proc3",
 									WantBody:       "body3",
 									GiveRespBody:   "respbody",
 									WaitForTimeout: true,
-									GiveError:      errors.ClientTimeoutError("serv3", "proc3", time.Millisecond*25),
+									GiveError:      errors.ClientTimeoutError("serv3", "proc3", testtime.Millisecond*25),
 								},
 							},
-							wantError: errors.ClientTimeoutError("serv3", "proc3", time.Millisecond*25).Error(),
+							wantError: errors.ClientTimeoutError("serv3", "proc3", testtime.Millisecond*25).Error(),
 						},
 					},
 				},

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -550,7 +550,7 @@ func TestMiddleware(t *testing.T) {
 					func(context.Context, *transport.Request) *Policy {
 						return NewPolicy(
 							Retries(tt.retries),
-							MaxRequestTimeout(testtime.Scale(tt.retryTimeout)),
+							MaxRequestTimeout(tt.retryTimeout),
 							BackoffStrategy(tt.retryBackoff),
 						)
 					},

--- a/internal/yarpctest/outboundtest/outbound_event.go
+++ b/internal/yarpctest/outboundtest/outbound_event.go
@@ -24,11 +24,13 @@ import (
 	"bytes"
 	"context"
 	"io/ioutil"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/testtime"
 )
 
 // OutboundEventCallable is an object that can be used in conjunction with a
@@ -76,6 +78,10 @@ func (c *OutboundEventCallable) Cleanup() {
 // It has explicit checks for all request and timeout attributes, and it
 // can return all the information needed from the request.
 type OutboundEvent struct {
+	// context.Deadline validation
+	WantTimeout       time.Duration
+	WantTimeoutBounds time.Duration
+
 	// transport.Request validation
 	WantCaller          string
 	WantService         string
@@ -105,6 +111,18 @@ type OutboundEvent struct {
 // Call will validate a single call to the outbound event based on
 // the OutboundEvent's parameters.
 func (e *OutboundEvent) Call(ctx context.Context, t require.TestingT, req *transport.Request) (*transport.Response, error) {
+	if e.WantTimeout != 0 {
+		timeoutBounds := e.WantTimeoutBounds
+		if timeoutBounds == 0 {
+			timeoutBounds = testtime.Millisecond * 20
+		}
+		deadline, ok := ctx.Deadline()
+		require.True(t, ok, "wanted context deadline, but there was no deadline")
+		deadlineDuration := deadline.Sub(time.Now())
+		assert.True(t, deadlineDuration > (e.WantTimeout-timeoutBounds), "deadline was less than expected, want %q (within %s), got %q", e.WantTimeout, timeoutBounds, deadlineDuration)
+		assert.True(t, deadlineDuration < (e.WantTimeout+timeoutBounds), "deadline was greater than expected, want %q (within %s), got %q", e.WantTimeout, timeoutBounds, deadlineDuration)
+	}
+
 	assertEqualIfSet(t, e.WantCaller, req.Caller, "invalid Caller")
 	assertEqualIfSet(t, e.WantService, req.Service, "invalid Service")
 	assertEqualIfSet(t, string(e.WantEncoding), string(req.Encoding), "invalid Encoding")

--- a/internal/yarpctest/outboundtest/outbound_event.go
+++ b/internal/yarpctest/outboundtest/outbound_event.go
@@ -114,7 +114,7 @@ func (e *OutboundEvent) Call(ctx context.Context, t require.TestingT, req *trans
 	if e.WantTimeout != 0 {
 		timeoutBounds := e.WantTimeoutBounds
 		if timeoutBounds == 0 {
-			timeoutBounds = testtime.Millisecond * 20
+			timeoutBounds = testtime.Millisecond * 30
 		}
 		deadline, ok := ctx.Deadline()
 		require.True(t, ok, "wanted context deadline, but there was no deadline")

--- a/internal/yarpctest/outboundtest/outbound_event_test.go
+++ b/internal/yarpctest/outboundtest/outbound_event_test.go
@@ -66,8 +66,10 @@ func TestOutboundEvent(t *testing.T) {
 				Headers:         transport.NewHeaders().With("key", "val"),
 				Body:            bytes.NewBufferString("body"),
 			},
-			reqTimeout: time.Second,
+			reqTimeout: testtime.Second,
 			event: &OutboundEvent{
+				WantTimeout:         testtime.Second,
+				WantTimeoutBounds:   testtime.Millisecond * 20,
 				WantCaller:          "caller",
 				WantService:         "service",
 				WantEncoding:        transport.Encoding("encoding"),
@@ -95,7 +97,7 @@ func TestOutboundEvent(t *testing.T) {
 				Headers:         transport.NewHeaders().With("key2", "val2"),
 				Body:            bytes.NewBufferString("body"),
 			},
-			reqTimeout: time.Second,
+			reqTimeout: testtime.Second,
 			event: &OutboundEvent{
 				WantCaller:          "caller",
 				WantService:         "service",
@@ -135,10 +137,12 @@ func TestOutboundEvent(t *testing.T) {
 				Headers:         transport.NewHeaders().With("key2", "val2"),
 				Body:            bytes.NewBufferString("body"),
 			},
-			reqTimeout: time.Second,
+			reqTimeout: testtime.Second,
 			event: &OutboundEvent{
-				WantBody:     "body",
-				GiveRespBody: "respbody",
+				WantTimeout:       testtime.Second,
+				WantTimeoutBounds: testtime.Millisecond * 20,
+				WantBody:          "body",
+				GiveRespBody:      "respbody",
 			},
 			wantBody:            "respbody",
 			wantExecutionStatus: iyarpctest.Finished,
@@ -148,8 +152,9 @@ func TestOutboundEvent(t *testing.T) {
 			request: &transport.Request{
 				Body: bytes.NewBufferString("body"),
 			},
-			reqTimeout: time.Second,
+			reqTimeout: testtime.Second,
 			event: &OutboundEvent{
+				WantTimeout:  testtime.Second,
 				WantBody:     "body",
 				GiveRespBody: "respbody",
 			},
@@ -157,12 +162,61 @@ func TestOutboundEvent(t *testing.T) {
 			wantExecutionStatus: iyarpctest.Finished,
 		},
 		{
+			msg: "timeout smaller than expected",
+			request: &transport.Request{
+				Body: bytes.NewBufferString("body"),
+			},
+			reqTimeout: testtime.Second,
+			event: &OutboundEvent{
+				WantTimeout:  testtime.Second * 2,
+				WantBody:     "body",
+				GiveRespBody: "respbody",
+			},
+			wantBody:            "respbody",
+			wantExecutionStatus: iyarpctest.Finished,
+			wantExecutionErrors: []string{
+				"deadline was less than expected",
+			},
+		},
+		{
+			msg: "timeout larger than expected",
+			request: &transport.Request{
+				Body: bytes.NewBufferString("body"),
+			},
+			reqTimeout: testtime.Second * 2,
+			event: &OutboundEvent{
+				WantTimeout:  testtime.Second,
+				WantBody:     "body",
+				GiveRespBody: "respbody",
+			},
+			wantBody:            "respbody",
+			wantExecutionStatus: iyarpctest.Finished,
+			wantExecutionErrors: []string{
+				"deadline was greater than expected",
+			},
+		},
+		{
+			msg: "wanttimeout with no deadline",
+			request: &transport.Request{
+				Body: bytes.NewBufferString("body"),
+			},
+			event: &OutboundEvent{
+				WantTimeout:  testtime.Second,
+				WantBody:     "body",
+				GiveRespBody: "respbody",
+			},
+			wantExecutionStatus: iyarpctest.Fatal,
+			wantExecutionErrors: []string{
+				"wanted context deadline, but there was no deadline",
+			},
+		},
+		{
 			msg: "invalid number of header keys",
 			request: &transport.Request{
 				Headers: transport.NewHeaders().With("key2", "val2").With("key3", "val3"),
 				Body:    bytes.NewBufferString("body"),
 			},
-			reqTimeout: time.Second,
+			reqTimeout: testtime.Second,
 			event: &OutboundEvent{
 				WantHeaders:  transport.NewHeaders().With("key", "val"),
 				WantBody:     "body",
@@ -181,7 +235,7 @@ func TestOutboundEvent(t *testing.T) {
 			request: &transport.Request{
 				Body: bytes.NewBufferString("body22"),
 			},
-			reqTimeout: time.Second,
+			reqTimeout: testtime.Second,
 			event: &OutboundEvent{
 				WantBody:     "body",
 				GiveRespBody: "respbody",
@@ -197,7 +251,7 @@ func TestOutboundEvent(t *testing.T) {
 			request: &transport.Request{
 				Body: bytes.NewBufferString("body"),
 			},
-			reqTimeout: time.Millisecond * 10,
+			reqTimeout: testtime.Millisecond * 10,
 			event: &OutboundEvent{
 				WaitForTimeout: true,
 				WantBody:       "body",

--- a/internal/yarpctest/outboundtest/outbound_event_test.go
+++ b/internal/yarpctest/outboundtest/outbound_event_test.go
@@ -299,7 +299,7 @@ func TestOutboundEvent(t *testing.T) {
 			testResult := iyarpctest.WithFakeTestingT(func(ft require.TestingT) {
 				ctx := context.Background()
 				if tt.reqTimeout != 0 {
-					newCtx, cancel := context.WithTimeout(ctx, testtime.Scale(tt.reqTimeout))
+					newCtx, cancel := context.WithTimeout(ctx, tt.reqTimeout)
 					defer cancel()
 					ctx = newCtx
 				}
@@ -434,7 +434,7 @@ func TestOutboundCallable(t *testing.T) {
 
 				ctx := context.Background()
 				if tt.reqTimeout != 0 {
-					newCtx, cancel := context.WithTimeout(ctx, testtime.Scale(tt.reqTimeout))
+					newCtx, cancel := context.WithTimeout(ctx, tt.reqTimeout)
 					defer cancel()
 					ctx = newCtx
 				}


### PR DESCRIPTION
Summary: We originally removed the timing tests because they were being
flaky in travis.  This PR adds the timing tests back (because they are
quite valuable) using the testtime time dilation to make the tests less
flaky.

Test Plan: Ran these tests using flakytest (#1144) with time dilation and they appear 
to be stable.