### PR TITLE
Skip transport/http TestIntegration test due to flakiness

### DIFF
--- a/transport/http/peer_test.go
+++ b/transport/http/peer_test.go
@@ -102,5 +102,6 @@ func TestHTTPWithRoundRobin(t *testing.T) {
 }
 
 func TestIntegration(t *testing.T) {
+	t.Skip("Skipping due to test flakiness")
 	spec.Test(t)
 }


### PR DESCRIPTION
Merging now so this doesn't affect testing.