### PR TITLE
make lifecycle test less flaky

### DIFF
--- a/internal/sync/lifecycle_test.go
+++ b/internal/sync/lifecycle_test.go
@@ -147,9 +147,8 @@ func TestLifecycleOnce(t *testing.T) {
 				StartAction{ExpectedState: Running},
 				ConcurrentAction{
 					Actions: []LifecycleAction{
-						StopAction{ExpectedState: Stopped, Wait: 20 * testtime.Millisecond},
+						StopAction{ExpectedState: Stopped, Wait: 50 * testtime.Millisecond},
 						GetStateAction{ExpectedState: Stopping},
-						GetStateAction{ExpectedState: Stopped},
 					},
 					Wait: 10 * testtime.Millisecond,
 				},


### PR DESCRIPTION
Summary: Makes test less flaky

Test Plan: `TEST_TIME_SCALE=3 DOCKER_CPUS=0.5 make test`