### PR TITLE
Add internal fake clock

### DIFF
--- a/internal/clock/doc.go
+++ b/internal/clock/doc.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package clock provides swappable real and fake clocks.
+// The real clock is a stateless wrapper around the "time" module.
+// The fake clock provides manual control over progress.
+// They share a common Clock and Timer interface.
+package clock

--- a/internal/clock/fake.go
+++ b/internal/clock/fake.go
@@ -1,0 +1,218 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package clock
+
+// Forked from github.com/andres-erbsen/clock to isolate a missing nap.
+
+import (
+	"container/heap"
+	"runtime"
+	"sync"
+	"time"
+)
+
+// FakeClock represents a fake clock that only moves forward programmically.
+// It can be preferable to a real-time clock when testing time-based functionality.
+type FakeClock struct {
+	sync.Mutex
+
+	addLock sync.Mutex
+	now     time.Time
+	timers  timers
+}
+
+var _ Clock = (*FakeClock)(nil)
+
+// NewFake returns an instance of a fake clock.
+// The current time of the fake clock on initialization is the Unix epoch.
+func NewFake() *FakeClock {
+	// Note: Unix(0, 0) is not the zero value for time, and we need the zero
+	// value to distinguish rate limiters that have not started.
+	return &FakeClock{now: time.Unix(0, 0)}
+}
+
+// Add moves the current time of the fake clock forward by the duration.
+// This should only be called from a single goroutine at a time.
+func (fc *FakeClock) Add(d time.Duration) {
+	fc.Lock()
+	// Calculate the final time.
+	end := fc.now.Add(d)
+	fc.flush(end)
+
+	if fc.now.Before(end) {
+		fc.now = end
+	}
+	fc.Unlock()
+	nap()
+}
+
+// Set advances the current time of the fake clock to the given absolute time.
+func (fc *FakeClock) Set(end time.Time) {
+	fc.Lock()
+	fc.flush(end)
+
+	if fc.now.Before(end) {
+		fc.now = end
+	}
+	fc.Unlock()
+	nap()
+}
+
+// flush runs all timers before the given end time and is used to run newly
+// added timers as well as expired timers in Add().
+func (fc *FakeClock) flush(end time.Time) {
+	for len(fc.timers) > 0 && !fc.timers[0].time.After(end) {
+		t := fc.timers[0]
+		heap.Pop(&fc.timers)
+		if fc.now.Before(t.time) {
+			fc.now = t.time
+		}
+		fc.Unlock()
+		t.tick()
+		fc.Lock()
+	}
+}
+
+// FakeTimer produces a timer that will emit a time some duration after now,
+// exposing the fake timer internals and type.
+func (fc *FakeClock) FakeTimer(d time.Duration) *FakeTimer {
+	fc.Lock()
+	defer fc.Unlock()
+
+	c := make(chan time.Time, 1)
+	t := &FakeTimer{
+		c:     c,
+		clock: fc,
+		time:  fc.now.Add(d),
+	}
+	fc.addTimer(t)
+	return t
+}
+
+// Timer produces a timer that will emit a time some duration after now.
+func (fc *FakeClock) Timer(d time.Duration) Timer {
+	return fc.FakeTimer(d)
+}
+
+func (fc *FakeClock) addTimer(t *FakeTimer) {
+	heap.Push(&fc.timers, t)
+	fc.flush(fc.now)
+}
+
+// After produces a channel that will emit the time after a duration passes.
+func (fc *FakeClock) After(d time.Duration) <-chan time.Time {
+	return fc.Timer(d).C()
+}
+
+// FakeAfterFunc waits for the duration to elapse and then executes a function.
+// A Timer is returned that can be stopped.
+func (fc *FakeClock) FakeAfterFunc(d time.Duration, f func()) *FakeTimer {
+	t := fc.FakeTimer(d)
+	go func() {
+		<-t.c
+		f()
+	}()
+	nap()
+	return t
+}
+
+// AfterFunc waits for the duration to elapse and then executes a function.
+// A Timer is returned that can be stopped.
+func (fc *FakeClock) AfterFunc(d time.Duration, f func()) Timer {
+	return fc.FakeAfterFunc(d, f)
+}
+
+// Now returns the current time on the fake clock.
+func (fc *FakeClock) Now() time.Time {
+	fc.Lock()
+	defer fc.Unlock()
+	return fc.now
+}
+
+// Sleep pauses the goroutine for the given duration on the fake clock.
+// The clock must be moved forward in a separate goroutine.
+func (fc *FakeClock) Sleep(d time.Duration) {
+	<-fc.After(d)
+}
+
+// FakeTimer represents a single event.
+type FakeTimer struct {
+	c     chan time.Time
+	time  time.Time
+	clock *FakeClock
+	index int
+}
+
+// C returns a channel that will send the time when it fires.
+func (t *FakeTimer) C() <-chan time.Time {
+	return t.c
+}
+
+// tick advances the clock to this timer.
+func (t *FakeTimer) tick() {
+	select {
+	case t.c <- t.time:
+	default:
+	}
+	nap()
+}
+
+// Reset adjusts the timer's scheduled time forward from now, unless it has
+// already fired.
+func (t *FakeTimer) Reset(d time.Duration) bool {
+	t.time = t.clock.now.Add(d)
+
+	// Empty the channel if already filled.
+	select {
+	case <-t.c:
+	default:
+	}
+
+	if t.index >= 0 {
+		heap.Fix(&t.clock.timers, t.index)
+		return true
+	}
+	heap.Push(&t.clock.timers, t)
+	return false
+}
+
+// Stop removes a timer from the scheduled timers.
+func (t *FakeTimer) Stop() bool {
+	if t.index < 0 {
+		return false
+	}
+
+	// Empty the channel if already filled.
+	select {
+	case <-t.c:
+	default:
+	}
+
+	t.clock.timers.Swap(t.index, len(t.clock.timers)-1)
+	t.clock.timers.Pop()
+	heap.Fix(&t.clock.timers, t.index)
+	return true
+}
+
+func nap() {
+	// time.Sleep(time.Millisecond)
+	runtime.Gosched()
+}

--- a/internal/clock/fake_test.go
+++ b/internal/clock/fake_test.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package clock
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFakeClockAdd(t *testing.T) {
+	clock := NewFake()
+	start := clock.Now()
+	clock.Add(time.Second)
+	assert.Equal(t, time.Second, clock.Now().Sub(start))
+}
+
+func TestFakeClockAfter(t *testing.T) {
+	clock := NewFake()
+	start := clock.Now()
+	done := make(chan struct{})
+	then := clock.After(time.Second)
+
+	go func() {
+		assert.Equal(t, start.Add(time.Second), <-then)
+		close(done)
+	}()
+
+	clock.Add(time.Second)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		assert.Fail(t, "test timed out")
+	}
+}
+
+func TestFakeClockSleep(t *testing.T) {
+	clock := NewFake()
+
+	go func() {
+		clock.Add(2 * time.Second)
+	}()
+
+	clock.Sleep(time.Second)
+}
+
+func TestFakeAfterFunc(t *testing.T) {
+	clock := NewFake()
+	start := clock.Now()
+	done := make(chan struct{})
+	clock.AfterFunc(time.Second, func() {
+		assert.False(t, clock.Now().Before(start.Add(time.Second)), "should be called after one second")
+		close(done)
+	})
+	clock.Add(time.Second)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		assert.Fail(t, "test timed out")
+	}
+}
+
+func TestFakeTimerStop(t *testing.T) {
+	clock := NewFake()
+	timer := clock.Timer(60 * time.Second)
+	assert.True(t, timer.Stop())
+	assert.False(t, timer.Stop())
+}
+
+func TestFakeTimerReset(t *testing.T) {
+	clock := NewFake()
+	timer := clock.Timer(60 * time.Second)
+	assert.True(t, timer.Stop())
+	assert.False(t, timer.Stop())
+	assert.False(t, timer.Reset(time.Second))
+
+	go func() {
+		clock.Add(time.Second)
+	}()
+
+	select {
+	case <-timer.C():
+	case <-time.After(time.Second):
+		assert.Fail(t, "test timed out")
+	}
+}
+
+func TestFakeTimerResetWithoutStop(t *testing.T) {
+	clock := NewFake()
+	timer := clock.Timer(60 * time.Second)
+	assert.True(t, timer.Reset(time.Second))
+
+	go func() {
+		clock.Add(time.Second)
+	}()
+
+	select {
+	case <-timer.C():
+	case <-time.After(time.Second):
+		assert.Fail(t, "test timed out")
+	}
+}

--- a/internal/clock/interface.go
+++ b/internal/clock/interface.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package clock
+
+import "time"
+
+// Clock represents an interface to the functions in the standard library time
+// package. Two implementations are available in the clock package. The first
+// is a real-time clock which simply wraps the time package's functions. The
+// second is a mock clock which will only make forward progress when
+// programmatically adjusted.
+type Clock interface {
+	AfterFunc(d time.Duration, f func()) Timer
+	After(d time.Duration) <-chan time.Time
+	Now() time.Time
+	Sleep(d time.Duration)
+}
+
+// Timer represents an individual timer in a clock, either real or fake.
+// Unlike time.Timer, this is an interface instead of a struct to abstract the
+// implementation. Consequently, the C property is instead a C() method.
+type Timer interface {
+	C() <-chan time.Time
+	Reset(d time.Duration) bool
+	Stop() bool
+}

--- a/internal/clock/real.go
+++ b/internal/clock/real.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package clock
+
+import "time"
+
+// RealClock implements a real-time clock by simply wrapping the time package functions.
+type RealClock struct{}
+
+// NewReal returns an instance of a real clock (changing in the very real fourth dimension).
+func NewReal() RealClock {
+	return RealClock{}
+}
+
+var _ Clock = (*RealClock)(nil)
+
+// After produces a channel that will emit the time after a duration passes.
+func (RealClock) After(d time.Duration) <-chan time.Time { return time.After(d) }
+
+// AfterFunc waits for the duration to elapse and then executes a function.
+// A Timer is returned that can be stopped.
+func (RealClock) AfterFunc(d time.Duration, f func()) Timer {
+	return &realTimer{time.AfterFunc(d, f)}
+}
+
+// Now returns the current time on the real clock.
+func (RealClock) Now() time.Time { return time.Now() }
+
+// Sleep pauses the goroutine for the given duration on the fake clock.
+// The clock must be moved forward in a separate goroutine.
+func (RealClock) Sleep(d time.Duration) { time.Sleep(d) }
+
+// Timer produces a timer that will emit a time some duration after now.
+func (RealClock) Timer(d time.Duration) Timer {
+	return &realTimer{t: time.NewTimer(d)}
+}
+
+type realTimer struct {
+	t *time.Timer
+}
+
+func (t *realTimer) Stop() bool {
+	return t.t.Stop()
+}
+
+func (t *realTimer) Reset(d time.Duration) bool {
+	return t.t.Reset(d)
+}
+
+func (t *realTimer) C() <-chan time.Time {
+	return t.t.C
+}

--- a/internal/clock/real_test.go
+++ b/internal/clock/real_test.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package clock
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// These real clock tests at best exercise code coverage but, wanting not to
+// rely on precise timing or even spend wall-clock time testing these
+// interfaces.
+
+func TestRealClockNow(t *testing.T) {
+	clock := NewReal()
+	clock.Now()
+}
+
+func TestRealClockAfter(t *testing.T) {
+	clock := NewReal()
+	done := make(chan struct{})
+	then := clock.After(time.Millisecond)
+
+	go func() {
+		<-then
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		assert.Fail(t, "test timed out")
+	}
+}
+
+func TestRealClockSleep(t *testing.T) {
+	clock := NewReal()
+	clock.Sleep(time.Millisecond)
+}
+
+func TestRealAfterFunc(t *testing.T) {
+	clock := NewReal()
+	done := make(chan struct{})
+	clock.AfterFunc(time.Millisecond, func() {
+		close(done)
+	})
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		assert.Fail(t, "test timed out")
+	}
+}
+
+func TestTimerStop(t *testing.T) {
+	clock := NewReal()
+	timer := clock.Timer(60 * time.Second)
+	assert.True(t, timer.Stop())
+	assert.False(t, timer.Stop())
+}
+
+func TestRealTimerReset(t *testing.T) {
+	clock := NewReal()
+	timer := clock.Timer(60 * time.Millisecond)
+	assert.True(t, timer.Stop())
+	assert.False(t, timer.Stop())
+	assert.False(t, timer.Reset(time.Millisecond))
+
+	select {
+	case <-timer.C():
+	case <-time.After(time.Second):
+		assert.Fail(t, "test timed out")
+	}
+}
+
+func TestTimerResetWithoutStop(t *testing.T) {
+	clock := NewReal()
+	timer := clock.Timer(60 * time.Second)
+	assert.True(t, timer.Reset(time.Millisecond))
+
+	select {
+	case <-timer.C():
+	case <-time.After(time.Second):
+		assert.Fail(t, "test timed out")
+	}
+}

--- a/internal/clock/timers.go
+++ b/internal/clock/timers.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package clock
+
+// timers represents a list of sortable timers.
+type timers []*FakeTimer
+
+func (ts timers) Len() int { return len(ts) }
+
+func (ts timers) Swap(i, j int) {
+	a, b := ts[i], ts[j]
+	ts[i], ts[j] = b, a
+	a.index, b.index = j, i
+}
+
+func (ts timers) Less(i, j int) bool {
+	return ts[i].time.Before(ts[j].time)
+}
+
+func (ts *timers) Push(t interface{}) {
+	mt := t.(*FakeTimer)
+	mt.index = len(*ts)
+	*ts = append(*ts, mt)
+}
+
+func (ts *timers) Pop() interface{} {
+	t := (*ts)[len(*ts)-1]
+	*ts = (*ts)[:len(*ts)-1]
+	t.index = -1
+	return t
+}


### PR DESCRIPTION
This change introduces a fake clock (and real clock) with a shared interface, so we can use one for production and the other for testing, anywhere we need time.

The fake clock is not perfect, but improves on the prior work I did in go.uber.org/ratelimit, fixing one bug (did not set Now() if there were no timers), and exposes an interface free of structs that covers both fake and real Timers. Note that timer.C() is a method.