### PR TITLE
[Retry Middleware][Part 14] Adding tally metrics to retry middleware.

### DIFF
--- a/x/retry/config_test.go
+++ b/x/retry/config_test.go
@@ -372,7 +372,7 @@ func TestConfig(t *testing.T) {
 			}
 			require.NoError(t, err, "error decoding")
 
-			policyProvider, ok := middleware.opts.policyProvider.(*ProcedurePolicyProvider)
+			policyProvider, ok := middleware.provider.(*ProcedurePolicyProvider)
 			require.True(t, ok, "PolicyProvider was not a ProcedurePolicyProvider")
 			assertPoliciesAreEqual(t, tt.wantPolicyProvider.defaultPolicy, policyProvider.defaultPolicy)
 

--- a/x/retry/observer.go
+++ b/x/retry/observer.go
@@ -1,14 +1,34 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package retry
 
 import "github.com/uber-go/tally"
 
 type observer struct {
 	unretryableErrorCounter tally.Counter
-	yarpcErrorCounter  tally.Counter
+	yarpcErrorCounter       tally.Counter
 	noTimeErrorCounter      tally.Counter
 	maxAttemptsErrorCounter tally.Counter
 	successCounter          tally.Counter
-	callCounter          tally.Counter
+	callCounter             tally.Counter
 }
 
 func newObserver(scope tally.Scope) *observer {
@@ -18,11 +38,11 @@ func newObserver(scope tally.Scope) *observer {
 	maxAttemptsErrScope := scope.Tagged(map[string]string{"error": "max_attempts"})
 	return &observer{
 		unretryableErrorCounter: unretryableErrScope.Counter("retry_failures"),
-		yarpcErrorCounter:  yarpcErrScope.Counter("retry_failures"),
+		yarpcErrorCounter:       yarpcErrScope.Counter("retry_failures"),
 		noTimeErrorCounter:      noTimeErrScope.Counter("retry_failures"),
 		maxAttemptsErrorCounter: maxAttemptsErrScope.Counter("retry_failures"),
 		successCounter:          scope.Counter("retry_successes"),
-		callCounter:          scope.Counter("retry_calls"),
+		callCounter:             scope.Counter("retry_calls"),
 	}
 }
 

--- a/x/retry/observer.go
+++ b/x/retry/observer.go
@@ -33,7 +33,7 @@ type observer struct {
 
 func newObserver(scope tally.Scope) *observer {
 	unretryableErrScope := scope.Tagged(map[string]string{"error": "unretryable"})
-	yarpcErrScope := scope.Tagged(map[string]string{"error": "yarpc"})
+	yarpcErrScope := scope.Tagged(map[string]string{"error": "yarpc_internal"})
 	noTimeErrScope := scope.Tagged(map[string]string{"error": "notime"})
 	maxAttemptsErrScope := scope.Tagged(map[string]string{"error": "max_attempts"})
 	return &observer{

--- a/x/retry/observer.go
+++ b/x/retry/observer.go
@@ -1,0 +1,51 @@
+package retry
+
+import "github.com/uber-go/tally"
+
+type observer struct {
+	unretryableErrorCounter tally.Counter
+	yarpcErrorCounter  tally.Counter
+	noTimeErrorCounter      tally.Counter
+	maxAttemptsErrorCounter tally.Counter
+	successCounter          tally.Counter
+	callCounter          tally.Counter
+}
+
+func newObserver(scope tally.Scope) *observer {
+	unretryableErrScope := scope.Tagged(map[string]string{"error": "unretryable"})
+	yarpcErrScope := scope.Tagged(map[string]string{"error": "yarpc"})
+	noTimeErrScope := scope.Tagged(map[string]string{"error": "notime"})
+	maxAttemptsErrScope := scope.Tagged(map[string]string{"error": "max_attempts"})
+	return &observer{
+		unretryableErrorCounter: unretryableErrScope.Counter("retry_failures"),
+		yarpcErrorCounter:  yarpcErrScope.Counter("retry_failures"),
+		noTimeErrorCounter:      noTimeErrScope.Counter("retry_failures"),
+		maxAttemptsErrorCounter: maxAttemptsErrScope.Counter("retry_failures"),
+		successCounter:          scope.Counter("retry_successes"),
+		callCounter:          scope.Counter("retry_calls"),
+	}
+}
+
+func (o *observer) unretryableError() {
+	o.unretryableErrorCounter.Inc(1)
+}
+
+func (o *observer) yarpcError() {
+	o.yarpcErrorCounter.Inc(1)
+}
+
+func (o *observer) noTimeError() {
+	o.noTimeErrorCounter.Inc(1)
+}
+
+func (o *observer) maxAttemptsError() {
+	o.maxAttemptsErrorCounter.Inc(1)
+}
+
+func (o *observer) success() {
+	o.successCounter.Inc(1)
+}
+
+func (o *observer) call() {
+	o.callCounter.Inc(1)
+}

--- a/x/retry/retry.go
+++ b/x/retry/retry.go
@@ -45,7 +45,7 @@ type middlewareOptions struct {
 	// context and request.
 	policyProvider PolicyProvider
 
-	// tallyScope is an interface for recording metrics.
+	// scope is an interface for recording metrics to tally.
 	scope tally.Scope
 }
 
@@ -62,8 +62,8 @@ func WithPolicyProvider(provider PolicyProvider) MiddlewareOption {
 	})
 }
 
-// TallyScope sets a Tally scope that will be used to record retry metrics.
-func TallyScope(scope tally.Scope) MiddlewareOption {
+// WithTally sets a Tally scope that will be used to record retry metrics.
+func WithTally(scope tally.Scope) MiddlewareOption {
 	return retryOptionFunc(func(opts *middlewareOptions) {
 		opts.scope = scope
 	})

--- a/x/retry/retry.go
+++ b/x/retry/retry.go
@@ -51,7 +51,7 @@ type middlewareOptions struct {
 
 var defaultMiddlewareOptions = middlewareOptions{
 	policyProvider: nil,
-	scope: tally.NoopScope,
+	scope:          tally.NoopScope,
 }
 
 // WithPolicyProvider allows a custom retry policy to be used in the retry

--- a/x/retry/retry.go
+++ b/x/retry/retry.go
@@ -64,9 +64,9 @@ func WithPolicyProvider(provider PolicyProvider) MiddlewareOption {
 
 // TallyScope sets a Tally scope that will be used to record retry metrics.
 func TallyScope(scope tally.Scope) MiddlewareOption {
-	return func(opts *middlewareOptions) {
+	return retryOptionFunc(func(opts *middlewareOptions) {
 		opts.scope = scope
-	}
+	})
 }
 
 // NewUnaryMiddleware creates a new Retry Middleware
@@ -109,7 +109,7 @@ func (r *OutboundMiddleware) Call(ctx context.Context, request *transport.Reques
 		resp, err = out.Call(subCtx, request)
 		cancel() // Clear the new ctx immdediately after the call
 
-		if err == nil || !isRetryable(err) {
+		if err == nil {
 			r.observer.success()
 			return resp, err
 		}

--- a/x/retry/retry_test.go
+++ b/x/retry/retry_test.go
@@ -25,13 +25,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/uber-go/tally"
 	"go.uber.org/yarpc/api/backoff"
 	"go.uber.org/yarpc/api/transport"
 	iioutil "go.uber.org/yarpc/internal/ioutil"
 	"go.uber.org/yarpc/internal/testtime"
 	. "go.uber.org/yarpc/internal/yarpctest/outboundtest"
 	"go.uber.org/yarpc/yarpcerrors"
-	"github.com/uber-go/tally"
 )
 
 func TestMiddleware(t *testing.T) {

--- a/x/retry/retry_test.go
+++ b/x/retry/retry_test.go
@@ -31,6 +31,7 @@ import (
 	"go.uber.org/yarpc/internal/testtime"
 	. "go.uber.org/yarpc/internal/yarpctest/outboundtest"
 	"go.uber.org/yarpc/yarpcerrors"
+	"github.com/uber-go/tally"
 )
 
 func TestMiddleware(t *testing.T) {
@@ -781,6 +782,7 @@ func TestMiddleware(t *testing.T) {
 		t.Run(tt.msg, func(t *testing.T) {
 			retry := NewUnaryMiddleware(
 				WithPolicyProvider(tt.policyProvider),
+				TallyScope(tally.NoopScope),
 			)
 
 			ApplyMiddlewareActions(t, retry, tt.actions)


### PR DESCRIPTION
Summary:  This PR adds basic metrics to the retry middleware.  We have
plans to make these metrics better once we've figured out how we want
pally to be integrated with things outside of core yarpc.

I've enumerated 6 different error types for the retry middleware:
1) Calls (number of times we've called the downstream)
2) Successes (number of times we've gotten a successful response)
3) Unretryable error (error that's type was not retryable)
4) Yarpc error (the yarpc middleware itself has screwed up)
5) No Time error (there wasn't enough time for another retry, so we fail)
6) Max attempts error (We exhausted all our retry attempts)