### PR TITLE
Skip encoding/thrift/thriftrw-plugin-yarpc#TestRoundTrip/enveloped(true)/multiplexed(false) until fixed

### DIFF
--- a/encoding/thrift/thriftrw-plugin-yarpc/roundtrip_test.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/roundtrip_test.go
@@ -54,7 +54,10 @@ import (
 func TestRoundTrip(t *testing.T) {
 	tests := []struct{ enveloped, multiplexed bool }{
 		{true, true},
-		{true, false},
+		// Skipping for now until flaky test fixed.
+		// Uncomment this when fixed.
+		// https://github.com/yarpc/yarpc-go/issues/1171
+		//{true, false},
 		{false, true},
 		{false, false},
 	}


### PR DESCRIPTION
See https://github.com/yarpc/yarpc-go/issues/1171

Per our new policy, will merge if this passes.