### PR TITLE
[Retry Middleware][Part 10.5] Prepare everything to be in an /x/ package

### DIFF
--- a/internal/retry/policy.go
+++ b/internal/retry/policy.go
@@ -49,12 +49,12 @@ var defaultPolicyOpts = policyOptions{
 }
 
 type policyOptions struct {
-	// retries is the number of attempts we will retry (after the initial
-	// attempt).
+	// retries is the number of times we will retry the request (after the
+	// initial attempt).
 	retries uint
 
-	// maxRequestTimeout is the Timeout we will enforce per request (if this is
-	// more than the context deadline, we'll use the context deadline instead).
+	// maxRequestTimeout is the timeout we will enforce for each outgoing
+	// request.  This will be clamped down to the context deadline.
 	maxRequestTimeout time.Duration
 
 	// backoffStrategy is a backoff strategy that will be called after every
@@ -71,7 +71,8 @@ type policyOptionFunc func(*policyOptions)
 
 func (f policyOptionFunc) apply(opts *policyOptions) { f(opts) }
 
-// Retries is the number of attempts we will retry (after the initial attempt).
+// Retries is the number of times we will retry the request (after the initial
+// attempt).
 //
 // Defaults to 1.
 func Retries(retries uint) PolicyOption {

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -30,34 +30,38 @@ import (
 )
 
 // MiddlewareOption customizes the behavior of a retry middleware.
-type MiddlewareOption func(*middlewareOptions)
+type MiddlewareOption interface {
+	apply(*middlewareOptions)
+}
+
+type retryOptionFunc func(*middlewareOptions)
+
+func (f retryOptionFunc) apply(opts *middlewareOptions) { f(opts) }
 
 // middlewareOptions enumerates the options for retry middleware.
 type middlewareOptions struct {
-	// policyProvider is a function that will provide a Retry policy
-	// for a context and request.
+	// policyProvider is a function that will provide a Retry policy for a
+	// context and request.
 	policyProvider PolicyProvider
 }
 
 var defaultMiddlewareOptions = middlewareOptions{
-	policyProvider: func(context.Context, *transport.Request) *Policy {
-		return &defaultPolicy
-	},
+	policyProvider: nil,
 }
 
 // WithPolicyProvider allows a custom retry policy to be used in the retry
 // middleware.
 func WithPolicyProvider(provider PolicyProvider) MiddlewareOption {
-	return func(opts *middlewareOptions) {
+	return retryOptionFunc(func(opts *middlewareOptions) {
 		opts.policyProvider = provider
-	}
+	})
 }
 
 // NewUnaryMiddleware creates a new Retry Middleware
 func NewUnaryMiddleware(opts ...MiddlewareOption) *OutboundMiddleware {
 	options := defaultMiddlewareOptions
 	for _, opt := range opts {
-		opt(&options)
+		opt.apply(&options)
 	}
 	return &OutboundMiddleware{options}
 }
@@ -80,10 +84,10 @@ func (r *OutboundMiddleware) Call(ctx context.Context, request *transport.Reques
 	rereader, finish := ioutil.NewRereader(request.Body)
 	defer finish()
 	request.Body = rereader
-	boff := policy.backoffStrategy.Backoff()
+	boff := policy.opts.backoffStrategy.Backoff()
 
-	for i := uint(0); i < policy.retries+1; i++ {
-		timeout, _ := getTimeLeft(ctx, policy.maxRequestTimeout)
+	for i := uint(0); i < policy.opts.retries+1; i++ {
+		timeout, _ := getTimeLeft(ctx, policy.opts.maxRequestTimeout)
 		subCtx, cancel := context.WithTimeout(ctx, timeout)
 		resp, err = out.Call(subCtx, request)
 		cancel() // Clear the new ctx immdediately after the call
@@ -112,12 +116,12 @@ func (r *OutboundMiddleware) getPolicy(ctx context.Context, request *transport.R
 	if r.opts.policyProvider == nil {
 		return nil
 	}
-	return r.opts.policyProvider(ctx, request)
+	return r.opts.policyProvider.Policy(ctx, request)
 }
 
-// getTimeLeft will return the amount of time left in the context or the
-// "max" duration passed in.  It will also return a boolean indicating
-// whether the context will timeout.
+// getTimeLeft will return the amount of time left in the context or the "max"
+// duration passed in.  It will also return a boolean indicating whether the
+// context will timeout.
 func getTimeLeft(ctx context.Context, max time.Duration) (timeleft time.Duration, ctxWillTimeout bool) {
 	ctxDeadline, ok := ctx.Deadline()
 	if !ok {

--- a/internal/retry/retry_action_test.go
+++ b/internal/retry/retry_action_test.go
@@ -42,8 +42,8 @@ type MiddlewareAction interface {
 	Apply(*testing.T, middleware.UnaryOutbound)
 }
 
-// RequestAction is an Action for sending a request to a
-// unary outbound middleware and asserting on the result.
+// RequestAction is an Action for sending a request to a unary outbound
+// middleware and asserting on the result.
 type RequestAction struct {
 	msg string
 
@@ -107,8 +107,8 @@ type ConcurrentAction struct {
 	Wait    time.Duration
 }
 
-// Apply runs all the ConcurrentAction's actions in goroutines with a delay of `Wait`
-// between each action. Returns when all actions have finished executing
+// Apply runs all the ConcurrentAction's actions in goroutines with a delay of
+// `Wait` between each action. Returns when all actions have finished executing.
 func (a ConcurrentAction) Apply(t *testing.T, mw middleware.UnaryOutbound) {
 	var wg sync.WaitGroup
 
@@ -127,7 +127,8 @@ func (a ConcurrentAction) Apply(t *testing.T, mw middleware.UnaryOutbound) {
 	wg.Wait()
 }
 
-// ApplyMiddlewareActions runs all the MiddlewareActions on the Unary outbound Middleware
+// ApplyMiddlewareActions runs all the MiddlewareActions on the Unary outbound
+// Middleware.
 func ApplyMiddlewareActions(t *testing.T, mw middleware.UnaryOutbound, actions []MiddlewareAction) {
 	for i, action := range actions {
 		t.Run(fmt.Sprintf("action #%d: %T", i, action), func(t *testing.T) {

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -37,7 +37,7 @@ func TestMiddleware(t *testing.T) {
 	type testStruct struct {
 		msg string
 
-		policyProvider *procedurePolicyProvider
+		policyProvider *ProcedurePolicyProvider
 
 		actions []MiddlewareAction
 	}
@@ -780,7 +780,7 @@ func TestMiddleware(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.msg, func(t *testing.T) {
 			retry := NewUnaryMiddleware(
-				WithPolicyProvider(tt.policyProvider.GetPolicy),
+				WithPolicyProvider(tt.policyProvider),
 			)
 
 			ApplyMiddlewareActions(t, retry, tt.actions)
@@ -852,26 +852,26 @@ func (f *fixedBackoff) Duration(_ uint) time.Duration {
 }
 
 type policyProviderBuilder struct {
-	provider *procedurePolicyProvider
+	provider *ProcedurePolicyProvider
 }
 
 func newPolicyProviderBuilder() *policyProviderBuilder {
 	return &policyProviderBuilder{
-		provider: newProcedurePolicyProvider(),
+		provider: NewProcedurePolicyProvider(),
 	}
 }
 
 func (pb *policyProviderBuilder) registerServiceProcedure(service, procedure string, pol *Policy) *policyProviderBuilder {
-	pb.provider.registerServiceProcedure(service, procedure, pol)
+	pb.provider.RegisterServiceProcedure(service, procedure, pol)
 	return pb
 }
 
 func (pb *policyProviderBuilder) registerService(service string, pol *Policy) *policyProviderBuilder {
-	pb.provider.registerService(service, pol)
+	pb.provider.RegisterService(service, pol)
 	return pb
 }
 
 func (pb *policyProviderBuilder) registerDefault(pol *Policy) *policyProviderBuilder {
-	pb.provider.registerDefault(pol)
+	pb.provider.RegisterDefault(pol)
 	return pb
 }


### PR DESCRIPTION
Summary: With some of the subsequent PRs on the Retry Middleware stack,
it was found to be constricting that we could only create middleware
directly from config.  In order to expose completely customizable retry
middleware, we will be moving basically all this code into an
experimental folder.  This PR in particular goes through all the
existing code and cleans up anything that will get exposed.  In
particular:

- Expose the "ProcedurePolicyProvider" so that it can be constructed
externally.
- Cleanup comments.
- Enforce a solid Options pattern like akshay described in #1164
- Some other minor twinges.

I'm making another easy PR just for the switch to the x folder, happy to
put that in this PR if people protest.