### PR TITLE
Inbound ratelimit middleware

### DIFF
--- a/internal/integrationtest/util.go
+++ b/internal/integrationtest/util.go
@@ -97,12 +97,8 @@ func (s TransportSpec) NewServer(t *testing.T, addr string) (*yarpc.Dispatcher, 
 		Name:     "service",
 		Inbounds: yarpc.Inbounds{inbound},
 	})
+	Register(dispatcher)
 
-	handle := func(ctx context.Context, req []byte) ([]byte, error) {
-		return req, nil
-	}
-
-	dispatcher.Register(raw.Procedure("echo", handle))
 	require.NoError(t, dispatcher.Start(), "start server dispatcher")
 
 	return dispatcher, s.Addr(xport, inbound)
@@ -221,4 +217,12 @@ func Call(ctx context.Context, rawClient raw.Client) error {
 		return fmt.Errorf("unexpected response %+v", res)
 	}
 	return nil
+}
+
+// Register registers an echo procedure handler on a dispatcher.
+func Register(dispatcher *yarpc.Dispatcher) {
+	handle := func(ctx context.Context, req []byte) ([]byte, error) {
+		return req, nil
+	}
+	dispatcher.Register(raw.Procedure("echo", handle))
 }

--- a/internal/ratelimit/inbound_middleware.go
+++ b/internal/ratelimit/inbound_middleware.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ratelimit
+
+import (
+	"context"
+
+	"go.uber.org/yarpc/api/middleware"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/yarpcerrors"
+)
+
+var errRateLimitExceeded = yarpcerrors.ResourceExhaustedErrorf("rate limit exceeded")
+
+// NewUnaryInboundMiddleware creates a unary inbound middleware that
+// introduces a throttle, shedding inbound requests if they arrive more often
+// than the configured rate limit.
+func NewUnaryInboundMiddleware(rps int, opts ...Option) (*UnaryInboundMiddleware, error) {
+	throttle, err := NewThrottle(rps, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &UnaryInboundMiddleware{
+		throttle: throttle,
+	}, nil
+}
+
+// UnaryInboundMiddleware is a unary inbound middleware that sheds inbound
+// requests above a rate limit, with some slack for bursts.
+type UnaryInboundMiddleware struct {
+	throttle *Throttle
+}
+
+var _ middleware.UnaryInbound = (*UnaryInboundMiddleware)(nil)
+
+// Handle drops inbound requests with a ResourceExhaustedError if the arrive
+// more frequently than the configured rate limit.
+func (m *UnaryInboundMiddleware) Handle(ctx context.Context, req *transport.Request, resw transport.ResponseWriter, next transport.UnaryHandler) error {
+	if m.throttle.Throttle() {
+		return errRateLimitExceeded
+	}
+	return next.Handle(ctx, req, resw)
+}

--- a/internal/ratelimit/inbound_middleware_test.go
+++ b/internal/ratelimit/inbound_middleware_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ratelimit_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/encoding/raw"
+	"go.uber.org/yarpc/internal/integrationtest"
+	"go.uber.org/yarpc/internal/ratelimit"
+	"go.uber.org/yarpc/transport/http"
+)
+
+func TestRateLimiterMiddleware(t *testing.T) {
+	middleware, err := ratelimit.NewUnaryInboundMiddleware(1, ratelimit.WithoutSlack)
+	require.NoError(t, err)
+	serverTransport := http.NewTransport()
+	serverInbound := serverTransport.NewInbound("127.0.0.1:0")
+	serverDispatcher := yarpc.NewDispatcher(yarpc.Config{
+		Name:     "service",
+		Inbounds: yarpc.Inbounds{serverInbound},
+		InboundMiddleware: yarpc.InboundMiddleware{
+			Unary: middleware,
+		},
+	})
+	integrationtest.Register(serverDispatcher)
+	require.NoError(t, serverDispatcher.Start())
+	defer serverDispatcher.Stop()
+	inboundAddr := serverInbound.Addr()
+
+	outboundAddr := fmt.Sprintf("http://%s/", inboundAddr)
+	clientTransport := http.NewTransport()
+	clientOutbound := clientTransport.NewSingleOutbound(outboundAddr)
+	clientDispatcher := yarpc.NewDispatcher(yarpc.Config{
+		Name: "client",
+		Outbounds: yarpc.Outbounds{
+			"service": transport.Outbounds{
+				Unary: clientOutbound,
+			},
+		},
+	})
+	require.NoError(t, clientDispatcher.Start())
+	defer clientDispatcher.Stop()
+	rawClient := raw.New(clientDispatcher.ClientConfig("service"))
+
+	assert.NoError(t, integrationtest.Call(context.Background(), rawClient))
+	err = integrationtest.Call(context.Background(), rawClient)
+	assert.Error(t, err, "rate limit exceeded")
+	assert.Contains(t, err.Error(), "rate limit exceeded")
+}
+
+func TestInvalidRateLimiterMiddleware(t *testing.T) {
+	_, err := ratelimit.NewUnaryInboundMiddleware(-1)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
This change introduces an inbound rate limiter middleware. This applies a rate limit closing over all inbound requests. The intention is for this feature to become public API. The next change in this stack will introduce a config shape.