### PR TITLE
Add make basiclint

### DIFF
--- a/build/docker.mk
+++ b/build/docker.mk
@@ -64,6 +64,10 @@ verifycodecovignores: deps ## check verifycodecovignores
 verifyversion: deps ## verify the version in the changelog is the same as in version.go
 	PATH=$$PATH:$(BIN) docker run $(DOCKER_RUN_FLAGS) $(DOCKER_IMAGE) make verifyversion
 
+.PHONY: basiclint
+basiclint: deps ## run gofmt govet golint staticcheck errcheck
+	PATH=$$PATH:$(BIN) docker run $(DOCKER_RUN_FLAGS) $(DOCKER_IMAGE) make basiclint
+
 .PHONY: lint
 lint: deps ## run all linters
 	PATH=$$PATH:$(BIN) docker run $(DOCKER_RUN_FLAGS) $(DOCKER_IMAGE) make lint

--- a/build/local.mk
+++ b/build/local.mk
@@ -117,8 +117,11 @@ verifycodecovignores: ## verify that .codecov.yml contains all .nocover packages
 			fi \
 		done
 
+.PHONY: basiclint
+basiclint: gofmt govet golint staticcheck errcheck # run gofmt govet golint staticcheck errcheck
+
 .PHONY: lint
-lint: generatenodiff nogogenerate gofmt govet golint staticcheck errcheck verifyversion verifycodecovignores ## run all linters
+lint: basiclint generatenodiff nogogenerate verifyversion verifycodecovignores ## run all linters
 
 .PHONY: test
 test: $(THRIFTRW) __eval_packages ## run all tests


### PR DESCRIPTION
`make lint` does a bunch of stuff that in general we don't care about, and Travis CI should catch. The biggest thing it does that is annoying is it effectively calls `make generate`, which takes a while. This adds `make basiclint` that runs the actual linters, so you can run them quickly locally before pushing a PR to GitHub and kicking off Travis CI. On my computer, `make -j lint` takes about 49 seconds, and `make -j basiclint` takes about 23 seconds.