### PR TITLE
Add Github PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,3 @@
+- [ ] Description and context for reviewers: one partner, one stranger
+- [ ] Docs (package doc)
+- [ ] Entry in CHANGELOG.md


### PR DESCRIPTION
This change adds a Github Pull Request template with a checklist for commonly
forgotten criteria to land.