### PR TITLE
Add more retryable codes

### DIFF
--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -282,7 +282,7 @@ func (o *Outbound) callWithPeer(
 		// maintenance loop resumes probing for availability.
 		p.OnDisconnected()
 
-		return nil, err
+		return nil, yarpcerrors.UnknownErrorf("unknown error from http client: %s", err.Error())
 	}
 
 	span.SetTag("http.status_code", response.StatusCode)

--- a/x/retry/retry.go
+++ b/x/retry/retry.go
@@ -114,7 +114,7 @@ func (r *OutboundMiddleware) Call(ctx context.Context, request *transport.Reques
 			return resp, err
 		}
 
-		if !isRetryable(err) {
+		if !isIdempotentProcedureRetryable(err) {
 			r.observer.unretryableError()
 			return resp, err
 		}
@@ -160,8 +160,7 @@ func getTimeLeft(ctx context.Context, max time.Duration) (timeleft time.Duration
 	return ctxDeadline.Sub(now), true
 }
 
-func isRetryable(err error) bool {
-	// TODO(#1080) Update Error assertions to be more granular.
+func isIdempotentProcedureRetryable(err error) bool {
 	switch yarpcerrors.ErrorCode(err) {
 	case yarpcerrors.CodeInternal, yarpcerrors.CodeDeadlineExceeded, yarpcerrors.CodeUnavailable, yarpcerrors.CodeUnknown:
 		return true

--- a/x/retry/retry.go
+++ b/x/retry/retry.go
@@ -163,7 +163,7 @@ func getTimeLeft(ctx context.Context, max time.Duration) (timeleft time.Duration
 func isRetryable(err error) bool {
 	// TODO(#1080) Update Error assertions to be more granular.
 	switch yarpcerrors.ErrorCode(err) {
-	case yarpcerrors.CodeInternal, yarpcerrors.CodeDeadlineExceeded:
+	case yarpcerrors.CodeInternal, yarpcerrors.CodeDeadlineExceeded, yarpcerrors.CodeUnavailable, yarpcerrors.CodeUnknown:
 		return true
 	default:
 		return false


### PR DESCRIPTION
Summary: Adds more codes of errors that can be retried with idempotent endpoints.  Unavailable is
pretty straightforward, and I'm including Unknown provisionally.
In the process of determining that I needed this, I also found that
http outbounds were not wrapping connection errors with a yarpc type, so
I'm going with "unknown" for now.

In the future, the outbounds should handle the unavailable errors retries internally (so that they can be applied to all endpoints (not just idempotent ones).