### PR TITLE
Amend FX plugin to provide client as a named type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Releases
 v1.11.0 (unreleased)
 -------------------
 
--    No changes yet.
+-   Thrift: UberFX-compatible module modified to output named type
 
 
 v1.10.0 (2017-17-11)

--- a/encoding/thrift/thriftrw-plugin-yarpc/fx_test.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/fx_test.go
@@ -21,11 +21,11 @@
 package main
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/yarpc"
-	"go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storeclient"
 	"go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storefx"
 	"go.uber.org/yarpc/transport/http"
 )
@@ -39,12 +39,15 @@ func TestFxClient(t *testing.T) {
 	})
 
 	assert.NotPanics(t, func() {
-		f := storefx.Client("store").(func(*yarpc.Dispatcher) storeclient.Interface)
-		f(d)
+		f := storefx.Client("store").(func(*yarpc.Dispatcher) interface{})
+		s := f(d)
+		clientfield, ok := reflect.TypeOf(s).Elem().FieldByName("Client")
+		assert.True(t, ok)
+		assert.Equal(t, "store", clientfield.Tag)
 	}, "failed to build client")
 
 	assert.Panics(t, func() {
-		f := storefx.Client("not-store").(func(*yarpc.Dispatcher) storeclient.Interface)
+		f := storefx.Client("not-store").(func(*yarpc.Dispatcher) interface{})
 		f(d)
 	}, "expected panic")
 }


### PR DESCRIPTION
- [x] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [x] Entry in CHANGELOG.md

Currently, the FX modules generated by the yarpc plugin have no naming on them which means that only one per thrift shape can be in a graph. Several services at uber rely on having multiple services with the same shape. Fixing this now means we can give users a consistent experience and not have to modify their code too much when we get to our ideal of auto-provided clients.

Dev note: I had trouble getting the tests to run locally and even to get the thriftrw-plugin to run again so I have no idea if this actually passes the build.