### PR TITLE
Test to make sure an valid JSON string but invalid error code results in an Unmarshal error

### DIFF
--- a/yarpcerrors/codes_test.go
+++ b/yarpcerrors/codes_test.go
@@ -69,4 +69,5 @@ func TestCodesFailures(t *testing.T) {
 	assert.Error(t, err)
 	assert.Error(t, badCode.UnmarshalText([]byte("200")))
 	assert.Error(t, badCode.UnmarshalJSON([]byte("200")))
+	assert.Error(t, badCode.UnmarshalJSON([]byte(`"200"`)))
 }


### PR DESCRIPTION
This also gets `yarpcerrors` to 100% code coverage.