### PR TITLE
Allow Procedure-Based retry PolicyProviders

### DIFF
--- a/x/retry/config.go
+++ b/x/retry/config.go
@@ -150,6 +150,11 @@ func (cfg MiddlewareConfig) getPolicyProvider(nameToPolicy map[string]*Policy) (
 			continue
 		}
 
+		if override.Procedure != "" {
+			policyProvider.RegisterProcedure(override.Procedure, pol)
+			continue
+		}
+
 		errs = multierr.Append(errs, fmt.Errorf("did not specify a service or procedure for retry policy override: %q", override.WithPolicy))
 	}
 

--- a/x/retry/doc.go
+++ b/x/retry/doc.go
@@ -111,6 +111,8 @@
 //    - service: fastservice
 //      procedure: slowprocedure
 //      with: slowretry
+//    - procedure: fastprocedure
+//      with: fastretry
 //
 // Each override specifies which policy will be used based on the `with`
 // attribute, which must point to one of the 'policies' we've defined in the
@@ -118,11 +120,13 @@
 // We can specify policies with varying levels of granularity. We can specify
 // both, 'service' and 'procedure' to apply the policy to requests made to that
 // procedure of that service, or we can specify just 'service' to apply the
-// given policy to all requests made to that service.
+// given policy to all requests made to that service, or we can specify a
+// 'procedure' that will get applied to all requests made to a procedure name.
 //
 // In terms of preference, the order of importance for policies will be:
 //
 //   1) "service" and "procedure" overrides
 //   2) "service" overrides
-//   3) default policy
+//   3) "procedure" overrides
+//   4) default policy
 package retry

--- a/x/retry/policyprovider.go
+++ b/x/retry/policyprovider.go
@@ -70,6 +70,12 @@ func (ppp *ProcedurePolicyProvider) RegisterService(service string, pol *Policy)
 	ppp.serviceProcedureToPolicy[serviceProcedure{Service: service}] = pol
 }
 
+// RegisterProcedure specifies the retry policy for requests that match the given
+// procedure name.
+func (ppp *ProcedurePolicyProvider) RegisterProcedure(procedure string, pol *Policy) {
+	ppp.serviceProcedureToPolicy[serviceProcedure{Procedure: procedure}] = pol
+}
+
 // SetDefault specifies the default retry Policy that will be used if there are
 // no matches for any other policy (based on Service or Procedure).
 func (ppp *ProcedurePolicyProvider) SetDefault(pol *Policy) {
@@ -82,6 +88,9 @@ func (ppp *ProcedurePolicyProvider) Policy(_ context.Context, req *transport.Req
 		return pol
 	}
 	if pol, ok := ppp.serviceProcedureToPolicy[serviceProcedure{Service: req.Service}]; ok {
+		return pol
+	}
+	if pol, ok := ppp.serviceProcedureToPolicy[serviceProcedure{Procedure: req.Procedure}]; ok {
 		return pol
 	}
 	return ppp.defaultPolicy

--- a/x/retry/retry_test.go
+++ b/x/retry/retry_test.go
@@ -713,6 +713,7 @@ func TestMiddleware(t *testing.T) {
 			// Policies:
 			//   default: 	   retries=2   timeout=20ms  backoff=25ms
 			//   s="s": 	   retries=1   timeout=50ms  backoff=50ms
+			//   p="pr": 	   retries=3   timeout=75ms  backoff=10ms
 			//   s="s",p="p":  retries=0   timeout=100ms backoff=None
 			//   s="s",p="fp": retries=100 timeout=10s   backoff=None // Fake policy
 			// Request 1: "Default retry policy"
@@ -733,6 +734,16 @@ func TestMiddleware(t *testing.T) {
 			// ms :  service:"s" proc:"p" timeout:200ms expectedPolicy:"s="s",p="p""
 			// 000:  initial request
 			// 100:  final error: Timeout
+			// Request 3: "Procedure-only Retry Policy"
+			// ms :  service:"ss" proc:"pr" timeout:400ms expectedPolicy:"p="pr""
+			// 000:  initial request
+			// 075:  error: Timeout
+			// 085:  retry #1
+			// 160:  error: Timeout
+			// 170:  retry #2
+			// 245:  error: Timeout
+			// 255:  retry #3
+			// 330:  final error: Timeout
 			policyProvider: newPolicyProviderBuilder().setDefault(
 				NewPolicy(
 					Retries(2),
@@ -745,6 +756,13 @@ func TestMiddleware(t *testing.T) {
 					Retries(1),
 					MaxRequestTimeout(testtime.Millisecond*50),
 					BackoffStrategy(newFixedBackoff(testtime.Millisecond*50)),
+				),
+			).registerProcedure(
+				"pr",
+				NewPolicy(
+					Retries(3),
+					MaxRequestTimeout(testtime.Millisecond*70),
+					BackoffStrategy(newFixedBackoff(testtime.Millisecond*10)),
 				),
 			).registerServiceProcedure(
 				"s",
@@ -842,13 +860,56 @@ func TestMiddleware(t *testing.T) {
 							},
 							wantError: yarpcerrors.DeadlineExceededErrorf("service:serv procedure:proc ttl:%v", testtime.Millisecond*100).Error(),
 						},
+						RequestAction{
+							request: &transport.Request{
+								Service:   "ss",
+								Procedure: "pr",
+								Body:      bytes.NewBufferString("body4"),
+							},
+							reqTimeout: testtime.Millisecond * 400,
+							events: []*OutboundEvent{
+								{
+									WantTimeout:    testtime.Millisecond * 75,
+									WantService:    "ss",
+									WantProcedure:  "pr",
+									WantBody:       "body4",
+									WaitForTimeout: true,
+									GiveError:      yarpcerrors.DeadlineExceededErrorf("service:serv procedure:proc ttl:%v", testtime.Millisecond*75),
+								},
+								{
+									WantTimeout:    testtime.Millisecond * 75,
+									WantService:    "ss",
+									WantProcedure:  "pr",
+									WantBody:       "body4",
+									WaitForTimeout: true,
+									GiveError:      yarpcerrors.DeadlineExceededErrorf("service:serv procedure:proc ttl:%v", testtime.Millisecond*75),
+								},
+								{
+									WantTimeout:    testtime.Millisecond * 75,
+									WantService:    "ss",
+									WantProcedure:  "pr",
+									WantBody:       "body4",
+									WaitForTimeout: true,
+									GiveError:      yarpcerrors.DeadlineExceededErrorf("service:serv procedure:proc ttl:%v", testtime.Millisecond*75),
+								},
+								{
+									WantTimeout:    testtime.Millisecond * 75,
+									WantService:    "ss",
+									WantProcedure:  "pr",
+									WantBody:       "body4",
+									WaitForTimeout: true,
+									GiveError:      yarpcerrors.DeadlineExceededErrorf("service:serv procedure:proc ttl:%v", testtime.Millisecond*75),
+								},
+							},
+							wantError: yarpcerrors.DeadlineExceededErrorf("service:serv procedure:proc ttl:%v", testtime.Millisecond*75).Error(),
+						},
 					},
 				},
 			},
 			wantCounters: map[string]int{
-				"retry_calls+":                      6,
+				"retry_calls+":                      10,
 				"retry_successes+":                  0,
-				"retry_failures+error=max_attempts": 3,
+				"retry_failures+error=max_attempts": 4,
 			},
 		},
 	}
@@ -953,6 +1014,11 @@ func (pb *policyProviderBuilder) registerServiceProcedure(service, procedure str
 
 func (pb *policyProviderBuilder) registerService(service string, pol *Policy) *policyProviderBuilder {
 	pb.provider.RegisterService(service, pol)
+	return pb
+}
+
+func (pb *policyProviderBuilder) registerProcedure(procedure string, pol *Policy) *policyProviderBuilder {
+	pb.provider.RegisterProcedure(procedure, pol)
 	return pb
 }
 


### PR DESCRIPTION
Summary: Sometimes services will shard between multiple "services" that
have the same procedure set, but different service names.  In order to
remove duplication at the Retry Middleware Layer, this PR allows retry
policies to be defined for Procedures without a service.  This allows
services that make calls to similar services to define a single retry
policy without having to repeat it multiple times.

Test Plan: added tests.