### PR TITLE
Readd crossdock testing for a yarpc-go client talking to a grpc-go server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,9 +52,8 @@ services:
             - SKIP_GRPC=client:node,client:python,client:python-sync,server:java,server:node,server:python
             - BEHAVIOR_GOOGLE_GRPC_CLIENT=client,server
             - SKIP_GOOGLE_GRPC_CLIENT=client:java,client:node,client:python,client:python-sync,server:java,server:node,server:python
-              # TODO: uncomment when transport errors are implemented and we no longer wrap protobuf responses
-              #- BEHAVIOR_GOOGLE_GRPC_SERVER=client,server
-              #- SKIP_GOOGLE_GRPC_SERVER=client:java,client:node,client:python,client:python-sync,server:java,server:node,server:python
+            - BEHAVIOR_GOOGLE_GRPC_SERVER=client,server
+            - SKIP_GOOGLE_GRPC_SERVER=client:java,client:node,client:python,client:python-sync,server:java,server:node,server:python
             - BEHAVIOR_HEADERS=client,server,transport,encoding
             - SKIP_HEADERS=client:java+transport:tchannel,server:java+transport:tchannel,encoding:protobuf
             - BEHAVIOR_ERRORS_HTTPCLIENT=errors_httpclient,server

--- a/internal/crossdock/main_test.go
+++ b/internal/crossdock/main_test.go
@@ -78,6 +78,9 @@ func TestCrossdock(t *testing.T) {
 			name: "google_grpc_client",
 		},
 		{
+			name: "google_grpc_server",
+		},
+		{
 			name: "headers",
 			axes: axes{
 				"transport": []string{"http", "tchannel"},


### PR DESCRIPTION
This was commented out until we got rid of non-raw protobuf responses, which happened with #1098.