### PR TITLE
More testing for encoding/json registration

### DIFF
--- a/encoding/json/register.go
+++ b/encoding/json/register.go
@@ -132,14 +132,6 @@ func verifyUnarySignature(n string, t reflect.Type) reflect.Type {
 
 	resBodyType := t.Out(0)
 
-	if !isValidReqResType(reqBodyType) {
-		panic(fmt.Sprintf(
-			"the second argument of the handler for %q must be "+
-				"a struct pointer, a map[string]interface{}, or interface{}, and not: %v",
-			n, reqBodyType,
-		))
-	}
-
 	if !isValidReqResType(resBodyType) {
 		panic(fmt.Sprintf(
 			"the first result of the handler for %q must be "+

--- a/encoding/json/register_test.go
+++ b/encoding/json/register_test.go
@@ -76,6 +76,12 @@ func TestWrapUnaryHandlerInvalid(t *testing.T) {
 				return nil, nil
 			},
 		},
+		{
+			"second-return-value-not-error",
+			func(context.Context, *struct{}) (*struct{}, *struct{}) {
+				return nil, nil
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This adds a test to make sure that a second return value that is not an error will result in a panic, and removes a redundant check of the request body type that is done in a helper function and will never be called.