### PR TITLE
 x/debug: Add debug introspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ Releases
 v1.12.0-dev (unreleased)
 -------------------
 
--   No changes yet.
+Experimental:
+
+-   x/debug: Added support for debug pages for introspection.
 
 
 v1.11.0 (2017-07-18)

--- a/x/debug/debug.go
+++ b/x/debug/debug.go
@@ -30,6 +30,8 @@ import (
 	"go.uber.org/yarpc/internal/introspection"
 )
 
+// NewHandler returns a func to expose dispatcher status and package
+// versions.
 func NewHandler(d *yarpc.Dispatcher) func(w http.ResponseWriter, req *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")

--- a/x/debug/debug.go
+++ b/x/debug/debug.go
@@ -199,7 +199,7 @@ func WithTemplate(tmpl Template) HandlerOption {
 //
 // If set to nil, no logging will be performed.
 //
-// By default, log.Printf is ued.
+// By default, log.Printf is used.
 func WithLogFunc(logFunc func(string, ...interface{})) HandlerOption {
 	return func(handler *handler) {
 		handler.logFunc = logFunc
@@ -233,6 +233,8 @@ func (h *handler) handle(responseWriter http.ResponseWriter, _ *http.Request) {
 	responseWriter.Header().Set("Content-Type", "text/html; charset=utf-8")
 	if err := h.tmpl.Execute(responseWriter, newTmplData(h.dispatcher.Introspect())); err != nil {
 		if h.logFunc != nil {
+			// TODO: does this work, since we already tried a write?
+			responseWriter.WriteHeader(http.StatusInternalServerError)
 			h.logFunc("yarpc/debug: failed executing template: %v", err)
 		}
 	}

--- a/x/debug/debug.go
+++ b/x/debug/debug.go
@@ -27,6 +27,7 @@ import (
 	"runtime/debug"
 
 	"go.uber.org/yarpc"
+
 	"go.uber.org/yarpc/internal/introspection"
 	"go.uber.org/zap"
 )

--- a/x/debug/debug.go
+++ b/x/debug/debug.go
@@ -21,7 +21,6 @@
 package debug
 
 import (
-	"fmt"
 	"html/template"
 	"io"
 	"net/http"
@@ -200,7 +199,7 @@ func (h *handler) handle(responseWriter http.ResponseWriter, _ *http.Request) {
 	defer func() {
 		if r := recover(); r != nil {
 			responseWriter.WriteHeader(http.StatusInternalServerError)
-			h.logger.Error(fmt.Sprintf("Unary handler panicked: %v\n%s", r, debug.Stack()))
+			h.logger.Error("Unary handler panicked:", zap.Any("recover", r), zap.ByteString("stacktrace", debug.Stack()))
 		}
 	}()
 	responseWriter.Header().Set("Content-Type", "text/html; charset=utf-8")

--- a/x/debug/debug.go
+++ b/x/debug/debug.go
@@ -232,9 +232,9 @@ func newHandler(dispatcher *yarpc.Dispatcher, opts ...HandlerOption) *handler {
 func (h *handler) handle(responseWriter http.ResponseWriter, _ *http.Request) {
 	responseWriter.Header().Set("Content-Type", "text/html; charset=utf-8")
 	if err := h.tmpl.Execute(responseWriter, newTmplData(h.dispatcher.Introspect())); err != nil {
+		// TODO: does this work, since we already tried a write?
+		responseWriter.WriteHeader(http.StatusInternalServerError)
 		if h.logFunc != nil {
-			// TODO: does this work, since we already tried a write?
-			responseWriter.WriteHeader(http.StatusInternalServerError)
 			h.logFunc("yarpc/debug: failed executing template: %v", err)
 		}
 	}

--- a/x/debug/debug.go
+++ b/x/debug/debug.go
@@ -1,0 +1,197 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package debug
+
+import (
+	"html/template"
+	"io"
+	"log"
+	"net/http"
+
+	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/internal/introspection"
+)
+
+func NewHandler(d *yarpc.Dispatcher) func(w http.ResponseWriter, req *http.Request) {
+	return func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		render(w, req, d)
+	}
+}
+
+func render(w io.Writer, req *http.Request, dispatcher *yarpc.Dispatcher) {
+	data := struct {
+		Dispatchers     []introspection.DispatcherStatus
+		PackageVersions []introspection.PackageVersion
+	}{
+		Dispatchers: []introspection.DispatcherStatus{
+			dispatcher.Introspect(),
+		},
+		PackageVersions: yarpc.PackageVersions,
+	}
+
+	if err := pageTmpl.ExecuteTemplate(w, "Page", data); err != nil {
+		log.Printf("yarpc/debug: Failed executing template: %v", err)
+	}
+}
+
+var pageTmpl = template.Must(template.New("Page").Funcs(template.FuncMap{}).Parse(pageHTML))
+
+const pageHTML = `
+<html>
+	<head>
+	<title>/debug/yarpc</title>
+	<style type="text/css">
+		body {
+			font-family: "Courier New", Courier, monospace;
+		}
+		table {
+			color:#333333;
+			border-width: 1px;
+			border-color: #3A3A3A;
+			border-collapse: collapse;
+		}
+		table th {
+			border-width: 1px;
+			padding: 8px;
+			border-style: solid;
+			border-color: #3A3A3A;
+			background-color: #B3B3B3;
+		}
+		table td {
+			border-width: 1px;
+			padding: 8px;
+			border-style: solid;
+			border-color: #3A3A3A;
+			background-color: #ffffff;
+		}
+		header::after {
+			content: "";
+			clear: both;
+			display: table;
+		}
+		h1 {
+			width: 40%;
+			float: left;
+			margin: 0;
+		}
+		div.dependencies {
+			width: 60%;
+			float: left;
+			font-size: small;
+			text-align: right;
+		}
+	</style>
+	</head>
+	<body>
+
+<header>
+<h1>/debug/yarpc</h1>
+<div class="dependencies">
+	{{range .PackageVersions}}
+	<span>{{.Name}}={{.Version}}</span>
+	{{end}}
+</div>
+</header>
+
+{{range .Dispatchers}}
+	<hr />
+	<h2>Dispatcher "{{.Name}}" <small>({{.ID}})</small></h2>
+	<table>
+		<tr>
+			<th>Procedure</th>
+			<th>Encoding</th>
+			<th>Signature</th>
+			<th>RPC Type</th>
+		</tr>
+		{{range .Procedures}}
+		<tr>
+			<td>{{.Name}}</td>
+			<td>{{.Encoding}}</td>
+			<td>{{.Signature}}</td>
+			<td>{{.RPCType}}</td>
+		</tr>
+		{{end}}
+	</table>
+	<h3>Inbounds</h3>
+	<table>
+		<tr>
+			<th>Transport</th>
+			<th>Endpoint</th>
+			<th>State</th>
+		</tr>
+		{{range .Inbounds}}
+		<tr>
+			<td>{{.Transport}}</td>
+			<td>{{.Endpoint}}</td>
+			<td>{{.State}}</td>
+		</tr>
+		{{end}}
+	</table>
+	<h3>Outbounds</h3>
+	<table>
+		<thead>
+		<tr>
+			<th>Outbound Key</th>
+			<th>Service</th>
+			<th>Transport</th>
+			<th>RPC Type</th>
+			<th>Endpoint</th>
+			<th>State</th>
+			<th colspan="3">Chooser</th>
+		</tr>
+		<tr>
+			<th></th>
+			<th></th>
+			<th></th>
+			<th></th>
+			<th></th>
+			<th>Name</th>
+			<th>State</th>
+			<th>Peers</th>
+		</tr>
+		</thead>
+		<tbody>
+		{{range .Outbounds}}
+		<tr>
+			<td>{{.OutboundKey}}</td>
+			<td>{{.Service}}</td>
+			<td>{{.Transport}}</td>
+			<td>{{.RPCType}}</td>
+			<td>{{.Endpoint}}</td>
+			<td>{{.State}}</td>
+			<td>{{.Chooser.Name}}</td>
+			<td>{{.Chooser.State}}</td>
+			<td>
+				<ul>
+				{{range .Chooser.Peers}}
+					<li>{{.Identifier}} ({{.State}})</li>
+				{{end}}
+				</ul>
+			</td>
+		</tr>
+		</tbody>
+		{{end}}
+	</table>
+{{end}}
+	</body>
+</html>
+`

--- a/x/debug/debug_test.go
+++ b/x/debug/debug_test.go
@@ -30,7 +30,6 @@ import (
 	"text/template"
 
 	"github.com/stretchr/testify/require"
-
 	"go.uber.org/yarpc"
 	yarpchttp "go.uber.org/yarpc/transport/http"
 )

--- a/x/debug/debug_test.go
+++ b/x/debug/debug_test.go
@@ -36,7 +36,7 @@ import (
 )
 
 var (
-	jsonTestTmpl = template.Must(template.New("tmpl").Funcs(template.FuncMap{
+	_jsonTestTmpl = template.Must(template.New("tmpl").Funcs(template.FuncMap{
 		"jsonMarshal": func(v interface{}) (string, error) {
 			data, err := json.Marshal(v)
 			if err != nil {
@@ -46,7 +46,7 @@ var (
 		},
 	}).Parse(`{{jsonMarshal .}}`))
 
-	errorTestTmpl = template.Must(template.New("tmpl").Funcs(template.FuncMap{
+	_errorTestTmpl = template.Must(template.New("tmpl").Funcs(template.FuncMap{
 		"returnError": func(_ interface{}) (string, error) {
 			return "", errors.New("error")
 		},
@@ -60,7 +60,7 @@ func TestHandler(t *testing.T) {
 	require.NoError(t, err)
 
 	responseRecorder := httptest.NewRecorder()
-	NewHandler(dispatcher, WithTemplate(jsonTestTmpl), WithLogFunc(nil))(responseRecorder, nil)
+	NewHandler(dispatcher, withTemplate(_jsonTestTmpl), WithLogFunc(nil))(responseRecorder, nil)
 
 	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	data, err := ioutil.ReadAll(responseRecorder.Body)
@@ -73,7 +73,7 @@ func TestHandlerError(t *testing.T) {
 	logged := false
 
 	responseRecorder := httptest.NewRecorder()
-	NewHandler(dispatcher, WithTemplate(errorTestTmpl), WithLogFunc(func(string, ...interface{}) { logged = true }))(responseRecorder, nil)
+	NewHandler(dispatcher, withTemplate(_errorTestTmpl), WithLogFunc(func(string, ...interface{}) { logged = true }))(responseRecorder, nil)
 	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 	require.True(t, logged)
 }

--- a/x/debug/debug_test.go
+++ b/x/debug/debug_test.go
@@ -60,7 +60,7 @@ func TestHandler(t *testing.T) {
 	require.NoError(t, err)
 
 	responseRecorder := httptest.NewRecorder()
-	NewHandler(dispatcher, withTemplate(_jsonTestTmpl), WithLogFunc(nil))(responseRecorder, nil)
+	NewHandler(dispatcher, Template(_jsonTestTmpl), Logger(nil))(responseRecorder, nil)
 
 	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	data, err := ioutil.ReadAll(responseRecorder.Body)
@@ -70,12 +70,10 @@ func TestHandler(t *testing.T) {
 
 func TestHandlerError(t *testing.T) {
 	dispatcher := newTestDispatcher()
-	logged := false
 
 	responseRecorder := httptest.NewRecorder()
-	NewHandler(dispatcher, withTemplate(_errorTestTmpl), WithLogFunc(func(string, ...interface{}) { logged = true }))(responseRecorder, nil)
+	NewHandler(dispatcher, Template(_errorTestTmpl))(responseRecorder, nil)
 	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
-	require.True(t, logged)
 }
 
 func newTestDispatcher() *yarpc.Dispatcher {

--- a/x/debug/debug_test.go
+++ b/x/debug/debug_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package debug
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/require"
+
+	"go.uber.org/yarpc"
+	yarpchttp "go.uber.org/yarpc/transport/http"
+)
+
+var testTmpl = template.Must(template.New("tmpl").Funcs(template.FuncMap{
+	"jsonMarshal": func(v interface{}) (string, error) {
+		data, err := json.Marshal(v)
+		if err != nil {
+			return "", err
+		}
+		return string(data), nil
+	},
+}).Parse(`{{jsonMarshal .}}`))
+
+func TestHandler(t *testing.T) {
+	httpTransport := yarpchttp.NewTransport()
+	dispatcher := yarpc.NewDispatcher(yarpc.Config{
+		Name: "test",
+		Inbounds: yarpc.Inbounds{
+			httpTransport.NewInbound(":0"),
+		},
+		Outbounds: yarpc.Outbounds{
+			"test-client": {
+				Unary:  httpTransport.NewSingleOutbound("http://127.0.0.1:1234"),
+				Oneway: httpTransport.NewSingleOutbound("http://127.0.0.1:1234"),
+			},
+		},
+	})
+
+	expectedData, err := json.Marshal(newTmplData(dispatcher.Introspect()))
+	require.NoError(t, err)
+
+	responseRecorder := httptest.NewRecorder()
+	NewHandler(dispatcher, WithTemplate(testTmpl), WithLogFunc(nil))(responseRecorder, nil)
+
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
+	data, err := ioutil.ReadAll(responseRecorder.Body)
+	require.NoError(t, err)
+	require.Equal(t, string(expectedData), string(data))
+}

--- a/x/debug/debug_test.go
+++ b/x/debug/debug_test.go
@@ -29,8 +29,9 @@ import (
 	"testing"
 	"text/template"
 
-	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc"
+
+	"github.com/stretchr/testify/require"
 	yarpchttp "go.uber.org/yarpc/transport/http"
 )
 

--- a/x/debug/debug_test.go
+++ b/x/debug/debug_test.go
@@ -60,7 +60,7 @@ func TestHandler(t *testing.T) {
 	require.NoError(t, err)
 
 	responseRecorder := httptest.NewRecorder()
-	NewHandler(dispatcher, Template(_jsonTestTmpl), Logger(nil))(responseRecorder, nil)
+	NewHandler(dispatcher, tmpl(_jsonTestTmpl))(responseRecorder, nil)
 
 	require.Equal(t, http.StatusOK, responseRecorder.Code)
 	data, err := ioutil.ReadAll(responseRecorder.Body)
@@ -72,7 +72,7 @@ func TestHandlerError(t *testing.T) {
 	dispatcher := newTestDispatcher()
 
 	responseRecorder := httptest.NewRecorder()
-	NewHandler(dispatcher, Template(_errorTestTmpl))(responseRecorder, nil)
+	NewHandler(dispatcher, tmpl(_errorTestTmpl))(responseRecorder, nil)
 	require.Equal(t, http.StatusInternalServerError, responseRecorder.Code)
 }
 

--- a/x/debug/options.go
+++ b/x/debug/options.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package debug
 
 import "go.uber.org/zap"
@@ -23,6 +43,8 @@ func Logger(logger *zap.Logger) Option {
 	})
 }
 
+// tmpl specifies the template to use.
+// It is only used for testing.
 func tmpl(tmpl templateIface) Option {
 	return optionFunc(func(opts *options) {
 		opts.tmpl = tmpl

--- a/x/debug/options.go
+++ b/x/debug/options.go
@@ -1,0 +1,44 @@
+package debug
+
+import "go.uber.org/zap"
+
+// Option describes a func that can modify options.
+type Option interface {
+	apply(*options)
+}
+
+type optionFunc func(*options)
+
+// opts represents the combined options supplied by the user.
+type options struct {
+	logger   *zap.Logger
+	template templateIface
+}
+
+// Logger specifies the logger that should be used to log.
+func Logger(logger *zap.Logger) Option {
+	return optionFunc(func(opts *options) {
+		opts.logger = logger
+	})
+}
+
+// Template specifies the template to be used for debug pages.
+func Template(template templateIface) Option {
+	return optionFunc(func(opts *options) {
+		opts.template = template
+	})
+}
+
+func (f optionFunc) apply(options *options) { f(options) }
+
+// applyOptions creates new opts based on the given options.
+func applyOptions(opts ...Option) options {
+	options := options{
+		logger:   zap.NewNop(),
+		template: _defaultTmpl,
+	}
+	for _, opt := range opts {
+		opt.apply(&options)
+	}
+	return options
+}

--- a/x/debug/options.go
+++ b/x/debug/options.go
@@ -2,7 +2,7 @@ package debug
 
 import "go.uber.org/zap"
 
-// Option describes a func that can modify options.
+// Option is an interface for customizing debug handlers.
 type Option interface {
 	apply(*options)
 }
@@ -11,31 +11,30 @@ type optionFunc func(*options)
 
 // opts represents the combined options supplied by the user.
 type options struct {
-	logger   *zap.Logger
-	template templateIface
+	logger *zap.Logger
+	tmpl   templateIface
 }
 
 // Logger specifies the logger that should be used to log.
+// Default value is noop zap logger.
 func Logger(logger *zap.Logger) Option {
 	return optionFunc(func(opts *options) {
 		opts.logger = logger
 	})
 }
 
-// Template specifies the template to be used for debug pages.
-func Template(template templateIface) Option {
+func tmpl(tmpl templateIface) Option {
 	return optionFunc(func(opts *options) {
-		opts.template = template
+		opts.tmpl = tmpl
 	})
 }
-
 func (f optionFunc) apply(options *options) { f(options) }
 
 // applyOptions creates new opts based on the given options.
 func applyOptions(opts ...Option) options {
 	options := options{
-		logger:   zap.NewNop(),
-		template: _defaultTmpl,
+		logger: zap.NewNop(),
+		tmpl:   _defaultTmpl,
 	}
 	for _, opt := range opts {
 		opt.apply(&options)

--- a/x/debug/options_test.go
+++ b/x/debug/options_test.go
@@ -1,0 +1,23 @@
+package debug
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoggerOption(t *testing.T) {
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+	option := Logger(logger)
+	opts := applyOptions(option)
+	assert.Equal(t, logger, opts.logger)
+}
+
+func TestNilLoggerOption(t *testing.T) {
+	opts := applyOptions()
+	assert.NotNil(t, opts.logger)
+}

--- a/x/debug/options_test.go
+++ b/x/debug/options_test.go
@@ -1,12 +1,31 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package debug
 
 import (
 	"testing"
 
-	"go.uber.org/zap"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func TestLoggerOption(t *testing.T) {


### PR DESCRIPTION
- Adds the debug pages to yarpc/x/debug to expose Introspect so that users can call have some 
insights into dispatcher. Panics wraps the call to ensure caller doesn't panic while performing
introspection.
