### PR TITLE
thriftrw-plugin: Test coverage

### DIFF
--- a/Dockerfile.1.8
+++ b/Dockerfile.1.8
@@ -2,7 +2,7 @@ FROM golang:1.8.3
 
 ENV SUPPRESS_DOCKER 1
 WORKDIR /go/src/go.uber.org/yarpc
-RUN apt-get update -yq && apt-get install -yq jq unzip
+RUN apt-get update -yq && apt-get install -yq jq unzip netcat
 ADD dockerdeps.mk /go/src/go.uber.org/yarpc/
 ADD etc/make/base.mk etc/make/deps.mk /go/src/go.uber.org/yarpc/etc/make/
 RUN make -f dockerdeps.mk predeps

--- a/Dockerfile.1.9
+++ b/Dockerfile.1.9
@@ -2,7 +2,7 @@ FROM golang:1.9beta2
 
 ENV SUPPRESS_DOCKER 1
 WORKDIR /go/src/go.uber.org/yarpc
-RUN apt-get update -yq && apt-get install -yq jq unzip
+RUN apt-get update -yq && apt-get install -yq jq unzip netcat
 ADD dockerdeps.mk /go/src/go.uber.org/yarpc/
 ADD etc/make/base.mk etc/make/deps.mk /go/src/go.uber.org/yarpc/etc/make/
 RUN make -f dockerdeps.mk predeps


### PR DESCRIPTION
This is built on some work Prashant and I did a couple months ago.

---

We were already testing the ThriftRW plugin but not counting it as
covered because of how it is executed. The test runs an external
process (`thriftrw`) which then runs the plugin process
(`thriftrw-plugin-yarpc`), which contains the code being tested.
Unfortunately, that makes it impossible to track coverage.

This changes execution so that `thriftrw` is actually calling a script which
*pretends* to be the ThriftRW plugin but really just forwards input and output
back to our test. The test acts as the plugin (calling into the actual
plugin), giving us a better view of code coverage.