### PR TITLE
Cleanup Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,18 +15,15 @@ cache:
     - $HOME/.glide
 matrix:
   include:
-    - env: CI_TYPES='compose-codecov'
+    - env: CI_TYPES='compose-codecov' SUPPRESS_CROSSDOCK=1
     - env:
         - CI_TYPES='crossdock'
         - secure: rZOVU0zQTkPvaG43IIt/guPoq3EAE6/So/+elGcmHF14PsfPcPQ6MyexqdwRkVPd/fAuNwiXXwTXHkjI8ECYz5LF+m+g2VwvrhE9H1wfLuGbtgXSSXqB+dqylHGUz4ksm4q1gwiet8fpVHlNfbSfu+lhTpbl4+SUfFK+s9LqnAKbm+Hi8vKzyhGhvlTngi0Y2O4Z2FLUgU2fkUm5fesdUyW0H2/Bn5KRqJRtcyTmmj4eD/qMq5WDe8n5Sy9J+kuCpweC8vBZQzAGuPpGdj8jvbPCO+N2xM26Y7DNKMsgj6IU49D6sbmLvyVMbI1pBeAQ54TCJx5LySuZpLAzyaaqHEDwOs4+cRolZSQwpd7Q8/wOxZ13KqMhYOokBIcDlLs0yB9J3KOTS1lxU8YC6A3j+Wenw9/JjL0sXSSeOAvNkAeVtEu3dqXg326HJjzXgIQbci83TTtWv4MsQKIXMADOgMnQdgd4JRaGyfxM2hswsE2/Y5OlyXqrqtFHvgKy6MpLTB26r3aRA22VY6p5hFhuEGLClbHidyeHgkNI2iHOXZqoEdmno33Eq7WicH64bezmq+Z4nwyjBOLTblcG7V79s9hI296zGdAN+KLXezlS00qhWH3UVmsi/hYTyXbWXay3S0Hc5jB+YUrHZ1y+OM6fm442qzz+M5q+MdtCfRad7ZM=
         - secure: Vg1mnR5Eu98dQ30rNb2fFblehh71a6goJz/Crhh+kae1z1Ec6NuQ6b0mNrzZMIXg6QktZ9gK0bJHjg1t90QpDfWHtSqAhQ0Z5yI4xH7Dt7jEMSYhGQ+YSmG6qo4c6Rh7CrIYXFRenS+qzhA8h7m48O8j1Z5G24qfen3y9cs7TNWKi43kGY8kSue3+xMi8hVErFLhfyhLNkOMJzWes+22apwEWIYwZWALYLpkmpYmgK8+nw+cZrI/r1WX5f6tdyZ/CRD/BAMgCwJYo7SNMuqTzsKTdqlHr7p2j7vcZtBSk5SJwzeChNJQwy94k+HF79R0WX8T8wuvxZKGtRqo7kf5bHAg2NRNDEL1KjBjV8tCJoh7FHLmQenQKfAt7x/eQu9r/+3do9Wvyan5MV3zYpDlCFZrRua9BL+cuSQaDAvGDAfqbzuDdlqUJLmn+t2+yyrxJS1NX5fLi6MX8cyh/11JkcIXifM9HqD1yM9S99MA8M3/O2g71oEbvcktkRCMOGga68sap+GzavVElyuutzHDGrPSvSqFw42yBAEKbnEJDbsMYL/6xxN/Xd3ez3YuwRs4R1m2NRN4Nq53ERozW8k7uVxmaEBioGfO+e5n0MfDQXY6uvdCx/R32ub4QDYOAovvoxhg042pYMbxWJkO73RMWTQzJvY8dbrxdMkw4xyq3Ic=
         - secure: dhvshW7GvphJ6xvS8MxEtJGN+4C4d64hqOcaCKXXXVqyeunJ1gH/Cb6v1RcETgtRxOIHyyHo218j0cs0hNtIWCZq5YVbXMAJ5Sret+cKA3aZNMCbgwPNS48WdVZsCHurW22abq41ejfKuuFqSI+ooMprrsGeRjHMbJZM86k7UuEqxdvqGjotYugGcfiCjxnNtMHd1M6AQ9fPFzhg8TUeqPy7eDIdKTcqwa/h7ZsYn/WJp1LkUtwyHsfpweIv6JBQ9/xUDzjcoz5MA6Nj75/Mk4bJzzLEem3EKs1TTZOqV1NVt7VJ887NPe4fLIxP1/jQLzsh6kShTcctLszc70NgrowdwhdIqN/3TUmxkVbGP2JzbQ4yR6LVKCDDeWpKGiPsIKy75kEiW4ZlEZhnwCOKaR94FyBy1HEnhyoD9OJD6Gq/u4UdEw/QuNfE89gbr47LA4z487AzYGzH+1J3MlEbTNgTCmWduC0ghTx33vItrYMXXabGDe7XwfdJKTnMjfXVv+CVBdMAZVtDL27sEmbbAzIrRjP+JOFm7ZRYfzvxu5vCWlB/3wMMt7DzcutjxR4tyYs71Ec5zdUH/16wSvjQR1laJZCujlNSA/3FZUizCzW3qFVsBkaWRF+/C/cksi6cR83xIrc4y4WRLttAcbfqmsXaigL5Iz4GbLg62vmFP88=
-    - env: CI_TYPES='deps examples lint test' DOCKER_GO_VERSION=1.8
-    - env: CI_TYPES='deps examples lint test' DOCKER_GO_VERSION=1.9
-before_install:
-  - make travis-docker-load
+    - env: CI_TYPES='deps examples lint test' DOCKER_GO_VERSION=1.8 SUPPRESS_CROSSDOCK=1
+    - env: CI_TYPES='deps examples lint test' DOCKER_GO_VERSION=1.9 SUPPRESS_CROSSDOCK=1
 script:
   - make ci
-  - make travis-docker-save
 after_success:
   - make travis-docker-push

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,7 @@ language: go
 go_import_path: go.uber.org/yarpc
 env:
   global:
-    - XDG_CACHE_HOME=$HOME/.cache
     - TEST_TIME_SCALE=5
-cache:
-  directories:
-    - $XDG_CACHE_HOME/yarpc-go
-    - $HOME/.glide
 matrix:
   include:
     - env: CI_TYPES='compose-codecov' SUPPRESS_CROSSDOCK=1

--- a/etc/make/travis.mk
+++ b/etc/make/travis.mk
@@ -1,35 +1,6 @@
 CROSSDOCK_DOCKER_IMAGE := yarpc_go
 
-DOCKER_CACHE_DIR := $(CACHE)/docker
-CROSSDOCK_DOCKER_CACHE_FILE := $(DOCKER_CACHE_DIR)/$(CROSSDOCK_DOCKER_IMAGE)
-#ifndef SUPPRESS_DOCKER
-#DOCKER_CACHE_FILE := $(DOCKER_CACHE_DIR)/$(shell echo $(DOCKER_IMAGE) | sed 's/\//-/g')
-#endif
-
 DOCKER_RUN_FLAGS += -e TRAVIS_JOB_ID -e TRAVIS_PULL_REQUEST
-
-.PHONY: travis-docker-load
-travis-docker-load: ## load docker images from travis cache
-ifndef SUPPRESS_CROSSDOCK
-	if [ -f $(CROSSDOCK_DOCKER_CACHE_FILE) ]; then gunzip -c $(CROSSDOCK_DOCKER_CACHE_FILE) | docker load; fi
-endif
-#ifndef SUPPRESS_DOCKER
-	#if [ -f $(DOCKER_CACHE_FILE) ]; then gunzip -c $(DOCKER_CACHE_FILE) | docker load; fi
-#endif
-
-.PHONY: travis-docker-save
-travis-docker-save: ## save docker images to travis cache
-ifeq ($(TRAVIS_BRANCH),dev)
-ifeq ($(TRAVIS_PULL_REQUEST),false)
-	mkdir -p $(DOCKER_CACHE_DIR)
-ifndef SUPPRESS_CROSSDOCK
-	PATH=$$PATH:$(BIN) docker save $(shell docker history -q $(CROSSDOCK_DOCKER_IMAGE) | grep -v '<missing>') | gzip > $(CROSSDOCK_DOCKER_CACHE_FILE)
-endif
-#ifndef SUPPRESS_DOCKER
-	#PATH=$$PATH:$(BIN) docker save $(shell docker history -q $(DOCKER_IMAGE) | grep -v '<missing>') | gzip > $(DOCKER_CACHE_FILE)
-#endif
-endif
-endif
 
 .PHONY: travis-docker-push
 travis-docker-push: ## push crossdock docker image from travis


### PR DESCRIPTION
This PR does a few things:

- Stop using the cache. We do everything in Docker now, and the only thing cached is the Docker binary, which is almost quicker to download than loading and saving the cache.
- Set `SUPPRESS_CROSSDOCK` on all tests except crossdock, so that the `travis-docker-push.sh` script isn't even invoked.
- Stop caching Docker images. Travis actually recommends not doing this, there was barely any speedup (it might actually be slower) and the images were getting rebuilt anyways, and there were caching errors on builds.