### PR TITLE
Test errors functions in base package

### DIFF
--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/yarpc/yarpcerrors"
+)
+
+func TestErrorCodes(t *testing.T) {
+	assert.True(t, IsBadRequestError(yarpcerrors.InvalidArgumentErrorf("")))
+	assert.True(t, IsUnexpectedError(yarpcerrors.InternalErrorf("")))
+	assert.True(t, IsTimeoutError(yarpcerrors.DeadlineExceededErrorf("")))
+}


### PR DESCRIPTION
This is mostly because code coverage is at 86.96% which is annoying me when I look at the badge and it says 86%.