### PR TITLE
Only build master and dev branches on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ services:
   - docker
 language: go
 go_import_path: go.uber.org/yarpc
+branches:
+  only:
+    - master
+    - dev
 env:
   global:
     - XDG_CACHE_HOME=$HOME/.cache


### PR DESCRIPTION
Travis CI does two builds for every push to a PR - a branch build, and a PR build. The branch build runs on the branch, the PR build merges the PR into dev and runs on the merge. In practice, this means we basically two two extremely (if not exactly the same) builds for every push to a PR, which wastes Travis CI resources and makes it harder to get CI results quickly.

With this change, PR builds will always be done, but pushes to branches will not, except to master and dev. This means if you want to run a Travis CI build, you have to create a PR, but this is basically what we want in general anyways.