### PR TITLE
Refresh README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ High-level features are implemented *above the wire*, enabling:
 
 * Exposing a server over multiple transports simultaneously.
 * Migrating outbound calls between transports with no code changes using config.
-* Middleware that work even as encodings and transports vary.
+* Middleware that work even as the encoding and transport vary.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,39 +1,16 @@
-# yarpc-go [![GoDoc][doc-img]][doc] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov]
+# `go.uber.org/yarpc`[![GoDoc][doc-img]][doc] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov]
 
-With hundreds to thousands of services communicating with RPC, transport
-protocols (like HTTP and [TChannel][]), encoding protocols (like JSON or
-Thrift), and peer choosers are the concepts that vary year over year.
-Separating these concerns allows services to change transports and wire
-protocols without changing call sites or request handlers, build proxies and
-wire protocol bridges, or experiment with load balancing strategies.
-YARPC is a toolkit for services and proxies.
+YARPC is a message passing platform for Go that:
 
-[TChannel]: https://github.com/uber/tchannel
+* Supports multiple binary encodings like Thrift & Protocol Buffers.
+* Enables multi-transport services with support for HTTP/1.1, HTTP/2(application/grpc), and TChannel.
+* Allows messages to be sent directly and through queues like Redis & Cherami.
 
-YARPC breaks RPC into interchangeable encodings, transports, and peer
-choosers.
-YARPC for Go provides reference implementations for HTTP/1.1 and TChannel
-transports, and also raw, JSON, and Thrift encodings.
-YARPC for Go provides experimental implementations for a Redis transport, a
-gRPC transport, a Protobuf encoding, and a round robin peer chooser.
-YARPC for Go plans to provide a load balancer that uses
-a least-pending-requests strategy.
-Peer choosers can implement any strategy, including load balancing or sharding,
-in turn bound to any peer list updater, like an address file watcher.
+High-level features are implemented *above the wire*, enabling:
 
-Regardless of transport, every RPC has some common properties: caller name,
-service name, procedure name, encoding name, deadline or TTL, headers, baggage
-(multi-hop headers), and tracing.
-Each RPC can also have an optional shard key, routing key, or routing delegate
-for advanced routing.
-YARPC transports use a shared API for capturing RPC metadata, so middleware can
-apply to requests over any transport.
-
-Each YARPC transport protocol can implement inbound handlers and outbound
-callers. Each of these can support different RPC types, like unary (request and
-response) or oneway (request and receipt) RPC. A future release of YARPC will
-add support for other RPC types including variations on streaming and pubsub.
-
+* Exposing a server over multiple transports simultaneously
+* Migrating outbound calls between transports with no code changes using config
+* Shipping a set of middleware that work regardless of encoding or transport
 
 ## Installation
 
@@ -51,243 +28,17 @@ glide version 0.12.3
 $ glide get 'go.uber.org/yarpc#^1'
 ```
 
-To use Thrift code generation, you will need to install plugins.
-These cannot be vendored since go depends on the binaries being available on
-the path.
+## Stability: Stable
 
-```
-$ go get 'go.uber.org/thriftrw'
-$ go get 'go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc'
-```
+This library follows [semver](http://semver.org/) strictly.
 
+No breaking changes will be made to exported APIs before `v2.0.0` with the
+exception of expiremental packages.
 
-## Examples
-
-This [example][hello] illustrates a simple service that implements a handler
-for a `Hello::echo` Thrift procedure.
-
-```thrift
-service Hello {
-    EchoResponse echo(1:EchoRequest echo)
-}
-
-struct EchoRequest {
-    1: required string message;
-    2: required i16 count;
-}
-
-struct EchoResponse {
-    1: required string message;
-    2: required i16 count;
-}
-```
-
-A go:generate directive informs `go generate` how to produce the Thrift models
-and YARPC bindings for the echo service.
-
-```go
-//go:generate thriftrw --plugin=yarpc echo.thrift
-```
-
-```
-$ go generate echo.thrift
-```
-
-Setting up a YARPC dispatcher configures inbounds and outbounds for supported
-transport protocols and RPC types.
-This sets a service up to receive HTTP requests on port 8080 and send requests
-to itself.
-YARPC funnels requests from all inbound transports into its routing table, and
-organizes outbounds by name.
-
-```go
-httpTransport := http.NewTransport()
-dispatcher := yarpc.NewDispatcher(yarpc.Config{
-    Name: "hello",
-    Inbounds: yarpc.Inbounds{
-        httpTransport.NewInbound(":8080"),
-    },
-    Outbounds: yarpc.Outbounds{
-        "hello": {
-            Unary: httpTransport.NewSingleOutbound("http://127.0.0.1:8080"),
-        },
-    },
-})
-```
-
-The dispatcher governs the lifecycle of every inbound, outbound, and the
-singleton for each transport protocol.
-The singleton can manage the lifecycle of shared peers and connections.
-
-```go
-if err := dispatcher.Start(); err != nil {
-    log.Fatal(err)
-}
-defer dispatcher.Stop()
-```
-
-At the end of `main`, we block until we receive a signal to exit, then unravel
-anything deferred like `dispatcher.Stop()`, shutting down gracefully.
-
-```
-signals := make(chan os.Signal, 1)
-signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
-<-signals
-```
-
-### Handle
-
-To receive requests from any inbound, we register a handler object using the
-Thrift generated server.
-
-```go
-dispatcher.Register(helloserver.New(&helloHandler{}))
-```
-
-The handler must implement the Hello service from the Thrift IDL.
-The generated code requires a handler that implements `helloserver.Interface`.
-
-```go
-type helloHandler struct{}
-
-func (h *helloHandler) Echo(ctx context.Context, e *echo.EchoRequest) (*echo.EchoResponse, error) {
-	return &echo.EchoResponse{Message: e.Message, Count: e.Count + 1}, nil
-}
-```
-
-#### JSON handler
-
-To create a handler which supports JSON encoding rather than Thrift, you can use the `json.Procedure` function:
-
-```go
-type fooInput struct {
-	Input string `json:"input"`
-}
-type fooOutput struct {
-	Output string `json:"output"`
-}
-dispatcher.Register(json.Procedure("Foo::bar", func(_ context.Context, data *fooInput) (*fooOutput, error) {
-	return &fooOutput{
-		Output: data.Input,
-	}, nil
-}))
-```
-
-### Call
-
-To send a request on an outbound, we construct a client using the corresponding
-named outbound from the dispatcher.
-The client will use that name for the outbound request service name.
-
-```go
-client := helloclient.New(dispatcher.ClientConfig("hello"))
-```
-
-To call a remote procedure, the context *must* have a deadline.
-We create a context with a one second deadline and call a method of the client.
-The client will use the dispatcher name for the caller name, Thrift for the
-encoding, and infer the procedure names from the `Echo` method (`Hello::echo`).
-
-```go
-ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-defer cancel()
-
-res, err := client.Echo(ctx, &echo.EchoRequest{Message: "Hello world", Count: 1})
-if err != nil {
-    log.Fatal(err)
-}
-fmt.Println(res)
-```
-
-#### Calling from the commmand line
-
-It is often useful to call a remote procedure from the command line for development and debugging purposes. For procedures which use a TChannel or HTTP inbound and Thrift encoding, [yab][yab] is the simplest tool for the job. For services with an HTTP inbound and JSON encoding you can use `cURL` to achieve this:
-
-```sh
-curl -v http://${host}:${port} \
-  -H 'Rpc-Caller: test-client' \
-  -H 'Rpc-Encoding: json' \
-  -H 'Context-TTL-MS: 2000' \
-  -H 'Rpc-Service: ${service}' \
-  -H 'Rpc-Procedure: Foo::bar' -d '{"input": "test"}'
-```
-
-#### Introspection handlers (experimental)
-
-YARPC ships with an experimental `yarpcmeta` package which contains some introspective functions which might be useful. Note that this package may change in the future and should not be relied on. To enable the meta procedures, register them with your dispatcher:
-
-```go
-yarpcmeta.Register(dispatcher)
-```
-
-You can then either use `yab` or `curl` to list available procedures:
-
-```bash
-$ yab -e json -p "http://${host}:${port}" ${service} yarpc::procedures
-```
-
-### Other Examples
-
-YARPC also provides examples for the [oneway][] RPC type and a key value
-service using both the [Thrift][thrift-keyvalue] and [JSON][json-keyvalue]
-encodings.
-
-[hello]: https://github.com/yarpc/yarpc-go/tree/master/internal/examples/thrift-hello
-[oneway]: https://github.com/yarpc/yarpc-go/tree/master/internal/examples/thrift-oneway
-[thrift-keyvalue]: https://github.com/yarpc/yarpc-go/tree/master/internal/examples/thrift-keyvalue
-[json-keyvalue]: https://github.com/yarpc/yarpc-go/tree/master/internal/examples/json-keyvalue
-[yab]: https://github.com/yarpc/yab
-
-<!--
-TODO
-- headers
-- tracing
-- baggage
-- middleware
-- oneway
-- custom encoding
-- custom transport
-- routing key
-- routing delegate (route by tenancy baggage)
-- handle-or-forward (route by shard key)
-- transport bridge (http to tchannel)
-- custom peer chooser-list (sharding)
-- custom peer chooser-list (round robin for example)
-- custom peer list updater (dns srv records)
--->
-
-## Development Status: Stable
-
-Ready for most users. No breaking changes to stable APIs will be made before
-2.0.
-
-Stable:
-- handler and call sites for unary and oneway
-- dispatcher constructor and config type
-- transport constructors (including the `tchannel.NewTransportChannel(...)`
-  although YARPC will eventually also have `tchannel.NewTransport(chooser,
-  ...)`)
-- interfaces for "go.uber.org/yarpc/api/transport" Transport (for lifecycle
-  management), Inbound, Outbound, Request, Response, ResponseWriter, Router,
-  RouteTable, Procedure, and Lifecycle
-- interfaces for "go.uber.org/yarpc/api/peer" Transport (for peer management),
-  Chooser, List
-- the middleware API
-- wire representation of RPC for HTTP and TChannel, including all required
-  headers: Rpc-Caller, Rpc-Service, Rpc-Procedure, and Context-TTL-MS.
-
-Unstable:
-- Any package in an `x` directory, including the experimental Redis transport,
-  the gRPC transport, the Protobuf encoding, and the round-robin peer chooser.
-- debug and introspection APIs (these are internal to prevent external
-  implementations of transports, inbounds, and outbounds from making use of
-  them, but we further do not guarantee the content of debug pages)
-
-Upcoming:
-- peer choosers for TChannel
-- handle-or-forward request handlers, possibly using per-procedure middleware
-- streaming RPC type for some transports (gRPC, WebSocket)
-- pubsub RPC type for some transports (Redis)
+Experimental packages reside within packages named `x`, and are *not stable*. This means their
+APIs can break at any time. The purpose of these packages is to incubate new features.
+These packages are vetted with internal customers, and are moved out of
+the `x` package when stable, at which point their public APIs will be locked.
 
 [doc-img]: https://godoc.org/go.uber.org/yarpc?status.svg
 [doc]: https://godoc.org/go.uber.org/yarpc

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 A message passing platform for Go that:
 
 * Supports multiple encodings like JSON, [Thrift](https://thrift.apache.org/), and [Protocol Buffers](https://developers.google.com/protocol-buffers/).
-* Enables multiple transports like [HTTP/1.1](https://www.w3.org/Protocols/rfc2616/rfc2616.html), [gRPC](https://grpc.io/docs/guides/wire.html), and [TChannel](https://github.com/uber/tchannel).
-* Allows messages to be sent directly and through queues like Redis and Cherami.
+* Enables multiple transports like [HTTP/1.1](https://www.w3.org/Protocols/rfc2616/rfc2616.html), [gRPC](https://grpc.io/), and [TChannel](https://github.com/uber/tchannel).
+* Allows messages to be sent directly and through queues like [Redis](https://redis.io/) and [Cherami](https://eng.uber.com/cherami/).
 
 High-level features are implemented *above the wire*, enabling:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# yarpc [![GoDoc][doc-img]][doc] [![GitHub release][release-img]][release] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov] [![Go Report Card][report-card-img]][report-card]
+# yarpc [![GoDoc][doc-img]][doc] [![GitHub release][release-img]][release] [![Mit License][mit-img]][mit] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov] [![Go Report Card][report-card-img]][report-card]
 
 A message passing platform for Go that:
 
@@ -37,6 +37,9 @@ the containing `x` package and their APIs will be locked.
 
 [release-img]: https://img.shields.io/github/release/yarpc/yarpc-go.svg
 [release]: https://github.com/yarpc/yarpc-go/releases
+
+[mit-img]: http://img.shields.io/badge/License-MIT-blue.svg
+[mit]: https://github.com/yarpc/yarpc-go/blob/dev/LICENSE
 
 [ci-img]: https://img.shields.io/travis/yarpc/yarpc-go.svg
 [ci]: https://travis-ci.org/yarpc/yarpc-go/branches

--- a/README.md
+++ b/README.md
@@ -22,10 +22,8 @@ glide get 'go.uber.org/yarpc#^1'
 
 ## Stability: Stable
 
-This library follows [SemVer](http://semver.org/) strictly.
-
-No breaking changes will be made to exported APIs before `v2.0.0` with the
-exception of expiremental packages.
+This library follows [SemVer](http://semver.org/) strictly. No breaking changes will be made to exported APIs before `v2.0.0` with the
+**exception of expiremental packages**.
 
 Experimental packages reside within packages named `x`, and are *not stable*. This means their
 APIs can break at any time. The purpose of these packages is to incubate new features.

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ the containing `x` package and their APIs will be locked.
 
 [doc-img]: https://godoc.org/go.uber.org/yarpc?status.svg
 [doc]: https://godoc.org/go.uber.org/yarpc
-[ci-img]: https://travis-ci.org/yarpc/yarpc-go.svg?branch=dev
+[ci-img]: https://travis-ci.org/yarpc/yarpc-go.svg?branch=master
 [cov-img]: https://codecov.io/gh/yarpc/yarpc-go/branch/dev/graph/badge.svg
 [ci]: https://travis-ci.org/yarpc/yarpc-go
-[cov]: https://codecov.io/gh/yarpc/yarpc-go/branch/dev
+[cov]: https://codecov.io/gh/yarpc/yarpc-go/branch/master
 [report-card]: https://goreportcard.com/badge/go.uber.org/yarpc

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 A message passing platform for Go that:
 
-* Supports multiple binary encodings like Thrift and Protocol Buffers.
+* Supports multiple encodings like JSON, Thrift, and Protocol Buffers.
 * Enables multi-transport services with support for HTTP/1.1, gRPC, and TChannel.
 * Allows messages to be sent directly and through queues like Redis and Cherami.
 
 High-level features are implemented *above the wire*, enabling:
 
-* Exposing a server over multiple transports simultaneously
-* Migrating outbound calls between transports with no code changes using config
-* Shipping a set of middleware that work regardless of encoding or transport
+* Exposing a server over multiple transports simultaneously.
+* Migrating outbound calls between transports with no code changes using config.
+* Shipping a set of middleware that work regardless of encoding or transport.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# `go.uber.org/yarpc`[![GoDoc][doc-img]][doc] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov]
+# yarpc[![GoDoc][doc-img]][doc] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov]
 
 YARPC is a message passing platform for Go that:
 
 * Supports multiple binary encodings like Thrift & Protocol Buffers.
-* Enables multi-transport services with support for HTTP/1.1, HTTP/2(application/grpc), and TChannel.
+* Enables multi-transport services with support for HTTP/1.1, gRPC, and TChannel.
 * Allows messages to be sent directly and through queues like Redis & Cherami.
 
 High-level features are implemented *above the wire*, enabling:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ glide get 'go.uber.org/yarpc#^1'
 This library is `v1` and follows [SemVer](http://semver.org/) strictly.
 
 No breaking changes will be made to exported APIs before `v2.0.0` with the
-**exception of expiremental packages**.
+**exception of experimental packages**.
 
 Experimental packages reside within packages named `x`, and are *not stable*. This means their
 APIs can break at any time. The purpose of these packages is to incubate new features.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# yarpc [![GoDoc][doc-img]][doc] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov]
+# yarpc [![GoDoc][doc-img]][doc] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov] [![Go Report Card][report-card][report-card]
 
 A message passing platform for Go that:
 
@@ -38,3 +38,4 @@ the containing `x` package and their APIs will be locked.
 [cov-img]: https://codecov.io/gh/yarpc/yarpc-go/branch/dev/graph/badge.svg
 [ci]: https://travis-ci.org/yarpc/yarpc-go
 [cov]: https://codecov.io/gh/yarpc/yarpc-go/branch/dev
+[report-card]: https://goreportcard.com/badge/go.uber.org/yarpc

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# yarpc [![GoDoc][doc-img]][doc] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov] [![Go Report Card][report-card-img]][report-card]
+# yarpc [![GoDoc][doc-img]][doc] [![GitHub release][release-img][release]] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov] [![Go Report Card][report-card-img]][report-card]
 
 A message passing platform for Go that:
 
@@ -34,6 +34,9 @@ the containing `x` package and their APIs will be locked.
 
 [doc-img]: http://img.shields.io/badge/GoDoc-Reference-blue.svg
 [doc]: https://godoc.org/go.uber.org/yarpc
+
+[release-img]: https://img.shields.io/github/release/yarpc/yarpc-go.svg
+[release]: https://github.com/yarpc/yarpc-go/releases
 
 [ci-img]: https://img.shields.io/travis/yarpc/yarpc-go.svg
 [ci]: https://travis-ci.org/yarpc/yarpc-go/branches

--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@ We recommend locking to [SemVer](http://semver.org/) range `^1` using [Glide](ht
 glide get 'go.uber.org/yarpc#^1'
 ```
 
-## Stability: Stable
+## Stability
 
-This library follows [SemVer](http://semver.org/) strictly. No breaking changes will be made to exported APIs before `v2.0.0` with the
+This library is `v1` and follows [SemVer](http://semver.org/) strictly.
+
+No breaking changes will be made to exported APIs before `v2.0.0` with the
 **exception of expiremental packages**.
 
 Experimental packages reside within packages named `x`, and are *not stable*. This means their

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# yarpc [![GoDoc][doc-img]][doc] [![GitHub release][release-img]][release]] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov] [![Go Report Card][report-card-img]][report-card]
+# yarpc [![GoDoc][doc-img]][doc] [![GitHub release][release-img]][release] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov] [![Go Report Card][report-card-img]][report-card]
 
 A message passing platform for Go that:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# yarpc [![GoDoc][doc-img]][doc] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov] [![Go Report Card][report-card][report-card]
+# yarpc [![GoDoc][doc-img]][doc] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov] [![Go Report Card][report-card]][report-card]
 
 A message passing platform for Go that:
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A message passing platform for Go that:
 
-* Supports multiple encodings like JSON, [Thrift](https://thrift.apache.org/), and [Protocol Buffers](https://developers.google.com/protocol-buffers/).
+* Supports multiple encodings like [JSON](http://www.json.org/), [Thrift](https://thrift.apache.org/), and [Protocol Buffers](https://developers.google.com/protocol-buffers/).
 * Enables multiple transports like [HTTP/1.1](https://www.w3.org/Protocols/rfc2616/rfc2616.html), [gRPC](https://grpc.io/), and [TChannel](https://github.com/uber/tchannel).
 * Allows messages to be sent directly and through queues like [Redis](https://redis.io/) and [Cherami](https://eng.uber.com/cherami/).
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,18 @@
-# YARPC [![GoDoc][doc-img]][doc] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov]
+# yarpc [![GoDoc][doc-img]][doc] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov]
 
 A message passing platform for Go that:
 
-* Supports multiple encodings like JSON, Thrift, and Protocol Buffers.
-* Enables multi-transport services with support for HTTP/1.1, gRPC, and TChannel.
+* Supports multiple encodings like JSON, [Thrift](https://thrift.apache.org/), and [Protocol Buffers](https://developers.google.com/protocol-buffers/).
+* Enables multi-transport services with support for [HTTP/1.1](https://www.w3.org/Protocols/rfc2616/rfc2616.html), [gRPC](https://grpc.io/docs/guides/wire.html), and [TChannel](https://github.com/uber/tchannel).
 * Allows messages to be sent directly and through queues like Redis and Cherami.
 
 High-level features are implemented *above the wire*, enabling:
 
 * Exposing a server over multiple transports simultaneously.
 * Migrating outbound calls between transports with no code changes using config.
-* Shipping a set of middleware that work regardless of encoding or transport.
+* Middleware that work even as encodings and transports vary.
 
 ## Installation
-
-```
-go get -u go.uber.org/yarpc
-```
 
 We recommend locking to [SemVer](http://semver.org/) range `^1` using [Glide](https://github.com/Masterminds/glide):
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ A message passing platform for Go that:
 High-level features are implemented *above the wire*, enabling:
 
 * Exposing a server over multiple transports simultaneously.
-* Migrating outbound calls between transports with no code changes using config.
-* Middleware that work even as the encoding and transport vary.
+* Migrating outbound calls between transports with just config changes.
+* Middlewares that work even as the encoding and transport vary.
 
 ## Installation
 
@@ -28,8 +28,8 @@ No breaking changes will be made to exported APIs before `v2.0.0` with the
 **exception of experimental packages**.
 
 Experimental packages reside within packages named `x`, and are *not stable*. This means their
-APIs can break at any time. The intention here is to iterate closely with internal
-customers validate and mature the contained APIs. Once stable, their contents will be moved out of
+APIs can break at any time. The intention here is to validate these APIs and iterate on them
+by working closely with internal customers. Once stable, their contents will be moved out of
 the containing `x` package and their APIs will be locked.
 
 [doc-img]: http://img.shields.io/badge/GoDoc-Reference-blue.svg

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ No breaking changes will be made to exported APIs before `v2.0.0` with the
 **exception of experimental packages**.
 
 Experimental packages reside within packages named `x`, and are *not stable*. This means their
-APIs can break at any time. The purpose of these packages is to incubate new features.
-These packages are vetted with internal customers, and are moved out of
-the `x` package when stable, at which point their public APIs will be locked.
+APIs can break at any time. The intention here is to iterate closely with internal
+customers validate and mature the contained APIs. Once stable, their contents will be moved out of
+the containing `x` package and their APIs will be locked.
 
 [doc-img]: https://godoc.org/go.uber.org/yarpc?status.svg
 [doc]: https://godoc.org/go.uber.org/yarpc

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# yarpc [![GoDoc][doc-img]][doc] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov] [![Go Report Card][report-card]][report-card]
+# yarpc [![GoDoc][doc-img]][doc] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov] [![Go Report Card][report-card-img]][report-card]
 
 A message passing platform for Go that:
 
@@ -32,10 +32,14 @@ APIs can break at any time. The intention here is to iterate closely with intern
 customers validate and mature the contained APIs. Once stable, their contents will be moved out of
 the containing `x` package and their APIs will be locked.
 
-[doc-img]: https://godoc.org/go.uber.org/yarpc?status.svg
+[doc-img]: http://img.shields.io/badge/GoDoc-Reference-blue.svg
 [doc]: https://godoc.org/go.uber.org/yarpc
-[ci-img]: https://travis-ci.org/yarpc/yarpc-go.svg?branch=master
+
+[ci-img]: https://img.shields.io/travis/yarpc/yarpc-go.svg
+[ci]: https://travis-ci.org/yarpc/yarpc-go/branches
+
 [cov-img]: https://codecov.io/gh/yarpc/yarpc-go/branch/dev/graph/badge.svg
-[ci]: https://travis-ci.org/yarpc/yarpc-go
-[cov]: https://codecov.io/gh/yarpc/yarpc-go/branch/master
-[report-card]: https://goreportcard.com/badge/go.uber.org/yarpc
+[cov]: https://codecov.io/gh/yarpc/yarpc-go/branch/dev
+
+[report-card-img]: https://goreportcard.com/badge/go.uber.org/yarpc
+[report-card]: https://goreportcard.com/report/go.uber.org/yarpc

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A message passing platform for Go that:
 
 * Supports multiple encodings like JSON, [Thrift](https://thrift.apache.org/), and [Protocol Buffers](https://developers.google.com/protocol-buffers/).
-* Enables multi-transport services with support for [HTTP/1.1](https://www.w3.org/Protocols/rfc2616/rfc2616.html), [gRPC](https://grpc.io/docs/guides/wire.html), and [TChannel](https://github.com/uber/tchannel).
+* Enables multiple transports like [HTTP/1.1](https://www.w3.org/Protocols/rfc2616/rfc2616.html), [gRPC](https://grpc.io/docs/guides/wire.html), and [TChannel](https://github.com/uber/tchannel).
 * Allows messages to be sent directly and through queues like Redis and Cherami.
 
 High-level features are implemented *above the wire*, enabling:

--- a/README.md
+++ b/README.md
@@ -18,14 +18,10 @@ High-level features are implemented *above the wire*, enabling:
 go get -u go.uber.org/yarpc
 ```
 
-If using [Glide](https://github.com/Masterminds/glide), *at least* `glide
-version 0.12.3` is required to install:
+We recommend locking to [SemVer](http://semver.org/) range `^1` using [Glide](https://github.com/Masterminds/glide):
 
 ```
-$ glide --version
-glide version 0.12.3
-
-$ glide get 'go.uber.org/yarpc#^1'
+glide get 'go.uber.org/yarpc#^1'
 ```
 
 ## Stability: Stable

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# yarpc [![GoDoc][doc-img]][doc] [![GitHub release][release-img][release]] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov] [![Go Report Card][report-card-img]][report-card]
+# yarpc [![GoDoc][doc-img]][doc] [![GitHub release][release-img]][release]] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov] [![Go Report Card][report-card-img]][report-card]
 
 A message passing platform for Go that:
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# yarpc[![GoDoc][doc-img]][doc] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov]
+# YARPC [![GoDoc][doc-img]][doc] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov]
 
-YARPC is a message passing platform for Go that:
+A message passing platform for Go that:
 
-* Supports multiple binary encodings like Thrift & Protocol Buffers.
+* Supports multiple binary encodings like Thrift and Protocol Buffers.
 * Enables multi-transport services with support for HTTP/1.1, gRPC, and TChannel.
-* Allows messages to be sent directly and through queues like Redis & Cherami.
+* Allows messages to be sent directly and through queues like Redis and Cherami.
 
 High-level features are implemented *above the wire*, enabling:
 
@@ -30,7 +30,7 @@ $ glide get 'go.uber.org/yarpc#^1'
 
 ## Stability: Stable
 
-This library follows [semver](http://semver.org/) strictly.
+This library follows [SemVer](http://semver.org/) strictly.
 
 No breaking changes will be made to exported APIs before `v2.0.0` with the
 exception of expiremental packages.


### PR DESCRIPTION
Updating with the idea that the README should:

* Only contain a pitch
* Be small (roughly less than a page)
* Make it easy to locate critical info like the Stability section
* Delegate detailed usage docs to Godocs
* Contain badges reflecting master (what customers use)

Resolves #1206

https://github.com/yarpc/yarpc-go/blob/readme-refresh/README.md