### PR TITLE
Fix typos in messages

### DIFF
--- a/api/transport/router.go
+++ b/api/transport/router.go
@@ -37,7 +37,7 @@ type Procedure struct {
 	// Service or empty to use the default service name.
 	Service string
 
-	// HandlerSpec specifiying which handler and rpc type.
+	// HandlerSpec specifying which handler and rpc type.
 	HandlerSpec HandlerSpec
 
 	// Encoding of the handler (optional) used for introspection and routing

--- a/internal/backoff/exponential.go
+++ b/internal/backoff/exponential.go
@@ -35,7 +35,7 @@ var (
 )
 
 // ExponentialOption defines options that can be applied to an
-// exponential backoff stragety
+// exponential backoff strategy
 type ExponentialOption func(*exponentialOptions)
 
 // exponentialOptions are the configuration options for an exponential backoff

--- a/internal/iopool/copy.go
+++ b/internal/iopool/copy.go
@@ -39,7 +39,7 @@ var _pool = sync.Pool{
 
 // Copy copies bytes from the Reader to the Writer until the Reader is exhausted.
 func Copy(dst io.Writer, src io.Reader) (int64, error) {
-	// To avoid unecessary memory allocations we maintain our own pool of
+	// To avoid unnecessary memory allocations we maintain our own pool of
 	// buffers.
 	buf := _pool.Get().(*buffer)
 	written, err := io.CopyBuffer(dst, src, buf.b)

--- a/internal/pally/doc.go
+++ b/internal/pally/doc.go
@@ -44,7 +44,7 @@
 // In many real-world situations, it's impossible to know all the labels for a
 // metric ahead of time. For example, you may want to track the number of
 // requests your server receives by caller; in most cases, you can't list all
-// the possible callers ahead of time. To accomodate these situations, Pally
+// the possible callers ahead of time. To accommadate these situations, Pally
 // offers vectors.
 //
 // Vectors represent a collection of metrics that have some constant labels,

--- a/internal/protoplugin/protoplugin.go
+++ b/internal/protoplugin/protoplugin.go
@@ -26,7 +26,7 @@ not guaranteed to stay here.
 
 This was HEAVILY adapted from github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway.
 
-Eventually, a rewrite of this to be simplier for what we need would be nice, but this was
+Eventually, a rewrite of this to be simpler for what we need would be nice, but this was
 available to get us here, especially with handling go imports.
 
 Note that "FQMN", "FQSN", etc stand for "Fully Qualified Message Name",

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -36,7 +36,7 @@ import (
 	ncontext "golang.org/x/net/context"
 )
 
-// inboundCall provides an interface similiar tchannel.InboundCall.
+// inboundCall provides an interface similar tchannel.InboundCall.
 //
 // We use it instead of *tchannel.InboundCall because tchannel.InboundCall is
 // not an interface, so we have little control over its behavior in tests.

--- a/x/ratelimit/ratelimit.go
+++ b/x/ratelimit/ratelimit.go
@@ -149,7 +149,7 @@ func (t *Throttle) Throttle() bool {
 		// Next time through the loop, the time will be farther into the future
 		// and our chance to allow a request may have expired.
 		// We do not advance `now` to reduce the probability of spinning in
-		// this loop, prefering to throttle if we repeatedly lose the race.
+		// this loop, preferring to throttle if we repeatedly lose the race.
 
 		// Coverage over the next line reveals that tests exercise contention.
 		_ = struct{}{}

--- a/x/retry/config.go
+++ b/x/retry/config.go
@@ -129,14 +129,14 @@ func (cfg MiddlewareConfig) getPolicyProvider(nameToPolicy map[string]*Policy) (
 		if defaultPol, ok := nameToPolicy[cfg.Default]; ok {
 			policyProvider.SetDefault(defaultPol)
 		} else {
-			errs = multierr.Append(errs, fmt.Errorf("invalid default retry policy: %q, possiblities are: %v", cfg.Default, policyNames(nameToPolicy)))
+			errs = multierr.Append(errs, fmt.Errorf("invalid default retry policy: %q, possibilities are: %v", cfg.Default, policyNames(nameToPolicy)))
 		}
 	}
 
 	for _, override := range cfg.PolicyOverrides {
 		pol, ok := nameToPolicy[override.WithPolicy]
 		if !ok {
-			errs = multierr.Append(errs, fmt.Errorf("invalid retry policy: %q, possiblities are: %v", override.WithPolicy, policyNames(nameToPolicy)))
+			errs = multierr.Append(errs, fmt.Errorf("invalid retry policy: %q, possibilities are: %v", override.WithPolicy, policyNames(nameToPolicy)))
 			continue
 		}
 

--- a/x/retry/config_test.go
+++ b/x/retry/config_test.go
@@ -282,7 +282,7 @@ func TestConfig(t *testing.T) {
 				default: fakepolicy
 			`,
 			wantError: []string{
-				`invalid default retry policy: "fakepolicy", possiblities are:`,
+				`invalid default retry policy: "fakepolicy", possibilities are:`,
 				`realpolicy`,
 			},
 		},
@@ -303,7 +303,7 @@ func TestConfig(t *testing.T) {
 					  with: fakepolicy
 			`,
 			wantError: []string{
-				`invalid retry policy: "fakepolicy", possiblities are:`,
+				`invalid retry policy: "fakepolicy", possibilities are:`,
 				`realpolicy`,
 			},
 		},
@@ -323,7 +323,7 @@ func TestConfig(t *testing.T) {
 					- service: myservice
 			`,
 			wantError: []string{
-				`invalid retry policy: "", possiblities are:`,
+				`invalid retry policy: "", possibilities are:`,
 				`realpolicy`,
 			},
 		},


### PR DESCRIPTION
Fixes all of https://goreportcard.com/report/go.uber.org/yarpc#misspell