### PR TITLE
Pin Thrift to avoid their backwards breaking patch

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -5,7 +5,7 @@ import:
 - package: github.com/apache/thrift
   repo: git://git.apache.org/thrift.git
   vcs: git
-  version: ^0.9.3
+  version: 0.9.3 # TODO switch back to ^0.9.3 once Apache Thrift fixes https://issues.apache.org/jira/browse/THRIFT-4261
 - package: github.com/crossdock/crossdock-go
   version: master
 - package: github.com/gogo/protobuf


### PR DESCRIPTION
This fixes the build, which is busted due to https://issues.apache.org/jira/browse/THRIFT-4261