### PR TITLE
Stickers should reflect master.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ the containing `x` package and their APIs will be locked.
 [mit-img]: http://img.shields.io/badge/License-MIT-blue.svg
 [mit]: https://github.com/yarpc/yarpc-go/blob/dev/LICENSE
 
-[ci-img]: https://img.shields.io/travis/yarpc/yarpc-go.svg
+[ci-img]: https://img.shields.io/travis/yarpc/yarpc-go/master.svg
 [ci]: https://travis-ci.org/yarpc/yarpc-go/branches
 
 [cov-img]: https://codecov.io/gh/yarpc/yarpc-go/branch/dev/graph/badge.svg

--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ the containing `x` package and their APIs will be locked.
 [release]: https://github.com/yarpc/yarpc-go/releases
 
 [mit-img]: http://img.shields.io/badge/License-MIT-blue.svg
-[mit]: https://github.com/yarpc/yarpc-go/blob/dev/LICENSE
+[mit]: https://github.com/yarpc/yarpc-go/blob/master/LICENSE
 
 [ci-img]: https://img.shields.io/travis/yarpc/yarpc-go/master.svg
 [ci]: https://travis-ci.org/yarpc/yarpc-go/branches
 
-[cov-img]: https://codecov.io/gh/yarpc/yarpc-go/branch/dev/graph/badge.svg
-[cov]: https://codecov.io/gh/yarpc/yarpc-go/branch/dev
+[cov-img]: https://codecov.io/gh/yarpc/yarpc-go/branch/master/graph/badge.svg
+[cov]: https://codecov.io/gh/yarpc/yarpc-go/branch/master
 
 [report-card-img]: https://goreportcard.com/badge/go.uber.org/yarpc
 [report-card]: https://goreportcard.com/report/go.uber.org/yarpc

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,7 +5,7 @@ import:
 - package: github.com/apache/thrift
   repo: git://git.apache.org/thrift.git
   vcs: git
-  version: ^0.9.3
+  version: 0.9.3 # TODO switch back to ^0.9.3 once Apache Thrift fixes https://issues.apache.org/jira/browse/THRIFT-4261
 - package: github.com/crossdock/crossdock-go
   version: master
 - package: github.com/gogo/protobuf


### PR DESCRIPTION
Stickers aren't for us, they're for our end-users.

These users expect to see what is in the latest release, e.g. the master branch.