### PR TITLE
README - tighten up pitch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A message passing platform for Go that lets you:
 
-* Write servers and clients with various encodings, including [JSON](http://www.json.org/), [Thrift](https://thrift.apache.org/), and [Protobufs](https://developers.google.com/protocol-buffers/).
+* Write servers and clients with various encodings, including [JSON](http://www.json.org/), [Thrift](https://thrift.apache.org/), and [Protobuf](https://developers.google.com/protocol-buffers/).
 * Expose servers over many transports simultaneously, including [HTTP/1.1](https://www.w3.org/Protocols/rfc2616/rfc2616.html), [gRPC](https://grpc.io/), and [TChannel](https://github.com/uber/tchannel).
 * Migrate outbound calls between transports without any code changes using config.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ A message passing platform for Go that lets you:
 * Write servers and clients in multiple encodings, including [JSON](http://www.json.org/), [Thrift](https://thrift.apache.org/), and [Protocol Buffers](https://developers.google.com/protocol-buffers/).
 * Expose servers over many transports simultaneously, including [HTTP/1.1](https://www.w3.org/Protocols/rfc2616/rfc2616.html), [gRPC](https://grpc.io/), and [TChannel](https://github.com/uber/tchannel).
 * Migrate outbound calls between transports without any code changes using config.
-* Author uniform middleware that work even as the encoding and transport varies.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A message passing platform for Go that lets you:
 
-* Write servers and clients in multiple encodings, including [JSON](http://www.json.org/), [Thrift](https://thrift.apache.org/), and [Protocol Buffers](https://developers.google.com/protocol-buffers/).
+* Write servers and clients with various encodings, including [JSON](http://www.json.org/), [Thrift](https://thrift.apache.org/), and [Protocol Buffers](https://developers.google.com/protocol-buffers/).
 * Expose servers over many transports simultaneously, including [HTTP/1.1](https://www.w3.org/Protocols/rfc2616/rfc2616.html), [gRPC](https://grpc.io/), and [TChannel](https://github.com/uber/tchannel).
 * Migrate outbound calls between transports without any code changes using config.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A message passing platform for Go that lets you:
 
-* Write servers and clients with various encodings, including [JSON](http://www.json.org/), [Thrift](https://thrift.apache.org/), and [Protocol Buffers](https://developers.google.com/protocol-buffers/).
+* Write servers and clients with various encodings, including [JSON](http://www.json.org/), [Thrift](https://thrift.apache.org/), and [Protobufs](https://developers.google.com/protocol-buffers/).
 * Expose servers over many transports simultaneously, including [HTTP/1.1](https://www.w3.org/Protocols/rfc2616/rfc2616.html), [gRPC](https://grpc.io/), and [TChannel](https://github.com/uber/tchannel).
 * Migrate outbound calls between transports without any code changes using config.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A message passing platform for Go that lets you:
 * Write servers and clients in multiple encodings, including [JSON](http://www.json.org/), [Thrift](https://thrift.apache.org/), and [Protocol Buffers](https://developers.google.com/protocol-buffers/).
 * Expose servers over many transports simultaneously, including [HTTP/1.1](https://www.w3.org/Protocols/rfc2616/rfc2616.html), [gRPC](https://grpc.io/), and [TChannel](https://github.com/uber/tchannel).
 * Migrate outbound calls between transports without any code changes using config.
-* Author uniform middleware that work even as encodings and transports vary.
+* Author uniform middleware that work even as the encoding and transport varies.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,11 @@
 # yarpc [![GoDoc][doc-img]][doc] [![GitHub release][release-img]][release] [![Mit License][mit-img]][mit] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov] [![Go Report Card][report-card-img]][report-card]
 
-A message passing platform for Go that:
+A message passing platform for Go that lets you:
 
-* Supports multiple encodings like [JSON](http://www.json.org/), [Thrift](https://thrift.apache.org/), and [Protocol Buffers](https://developers.google.com/protocol-buffers/).
-* Supports multiple transports like [HTTP/1.1](https://www.w3.org/Protocols/rfc2616/rfc2616.html), [gRPC](https://grpc.io/), and [TChannel](https://github.com/uber/tchannel).
-* Allows messages to be sent directly and through queues like [Redis](https://redis.io/) and [Cherami](https://eng.uber.com/cherami/).
-
-High-level features are implemented *above the wire*, enabling:
-
-* Exposing a server over multiple transports simultaneously.
-* Migrating outbound calls between transports with just config changes.
-* Middlewares that work even as the encoding and transport vary.
+* Write servers and clients in multiple encodings, including [JSON](http://www.json.org/), [Thrift](https://thrift.apache.org/), and [Protocol Buffers](https://developers.google.com/protocol-buffers/).
+* Expose servers over many transports simultaneously, including [HTTP/1.1](https://www.w3.org/Protocols/rfc2616/rfc2616.html), [gRPC](https://grpc.io/), and [TChannel](https://github.com/uber/tchannel).
+* Migrate outbound calls between transports without any code changes using config.
+* Author uniform middleware that work even as encodings and transports vary.
 
 ## Installation
 


### PR DESCRIPTION
We should shoot for a single list of key-points with each of our products. This gets YARPC down to 3 bullet-points, instead of 2 paragraphs.

Next I'll be looking to add a Getting Started section which will point off to md/godocs that elaborate on how to use YARPC.