### PR TITLE
Fix type collision in structured logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Releases
 v1.14.0-dev (unreleased)
 ------------------------
 
--   No changes yet.
+-   Rename structured logging field to avoid a type collision.
 
 v1.13.0 (2017-08-01)
 --------------------

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -246,7 +246,7 @@ func (d *Dispatcher) Register(rs []transport.Procedure) {
 		}
 
 		procedures = append(procedures, r)
-		d.log.Info("Registration succeeded.", zap.Object("procedure", r))
+		d.log.Info("Registration succeeded.", zap.Object("registeredProcedure", r))
 	}
 
 	d.table.Register(procedures)


### PR DESCRIPTION
We're using `yarpc.procedure` as both a string and an object, which
breaks ElasticSearch indexing.

We'll need to cut a patch release with this fix today.