### PR TITLE
Increase granularity of observability metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Releases
 v1.14.0 (unreleased)
 --------------------
 
--   No changes yet.
+-   Increased granularity of error observability metrics to expose yarpc
+    error types.
 
 v1.13.1 (2017-08-03)
 --------------------

--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -98,7 +98,10 @@ func (c call) endStats(elapsed time.Duration, err error, isApplicationError bool
 		yarpcerrors.CodeNotFound,
 		yarpcerrors.CodeAlreadyExists,
 		yarpcerrors.CodePermissionDenied,
+		yarpcerrors.CodeFailedPrecondition,
+		yarpcerrors.CodeAborted,
 		yarpcerrors.CodeOutOfRange,
+		yarpcerrors.CodeUnimplemented,
 		yarpcerrors.CodeUnauthenticated:
 		c.edge.callerErrLatencies.Observe(elapsed)
 		if counter, err := c.edge.callerFailures.Get(errCode.String()); err == nil {
@@ -109,9 +112,6 @@ func (c call) endStats(elapsed time.Duration, err error, isApplicationError bool
 		yarpcerrors.CodeUnknown,
 		yarpcerrors.CodeDeadlineExceeded,
 		yarpcerrors.CodeResourceExhausted,
-		yarpcerrors.CodeFailedPrecondition,
-		yarpcerrors.CodeAborted,
-		yarpcerrors.CodeUnimplemented,
 		yarpcerrors.CodeInternal,
 		yarpcerrors.CodeUnavailable,
 		yarpcerrors.CodeDataLoss:

--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -94,7 +94,8 @@ func (c call) endStats(elapsed time.Duration, err error, isApplicationError bool
 
 	errCode := yarpcerrors.ErrorCode(err)
 	switch errCode {
-	case yarpcerrors.CodeInvalidArgument,
+	case yarpcerrors.CodeCancelled,
+		yarpcerrors.CodeInvalidArgument,
 		yarpcerrors.CodeNotFound,
 		yarpcerrors.CodeAlreadyExists,
 		yarpcerrors.CodePermissionDenied,
@@ -108,8 +109,7 @@ func (c call) endStats(elapsed time.Duration, err error, isApplicationError bool
 			counter.Inc()
 		}
 		return
-	case yarpcerrors.CodeCancelled,
-		yarpcerrors.CodeUnknown,
+	case yarpcerrors.CodeUnknown,
 		yarpcerrors.CodeDeadlineExceeded,
 		yarpcerrors.CodeResourceExhausted,
 		yarpcerrors.CodeInternal,
@@ -124,7 +124,7 @@ func (c call) endStats(elapsed time.Duration, err error, isApplicationError bool
 		// If we got "CodeOK" it really means that this is not a yarpcError, in
 		// which case this is another level of "unknown" error.
 		c.edge.serverErrLatencies.Observe(elapsed)
-		if counter, err := c.edge.serverFailures.Get("unknown_strange"); err == nil {
+		if counter, err := c.edge.serverFailures.Get("unknown_internal_yarpc"); err == nil {
 			counter.Inc()
 		}
 		return

--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -91,24 +91,48 @@ func (c call) endStats(elapsed time.Duration, err error, isApplicationError bool
 		}
 		return
 	}
-	// Bad request errors are the caller's fault.
-	if yarpcerrors.IsInvalidArgument(err) {
+
+	errCode := yarpcerrors.ErrorCode(err)
+	switch errCode {
+	case yarpcerrors.CodeInvalidArgument,
+		yarpcerrors.CodeNotFound,
+		yarpcerrors.CodeAlreadyExists,
+		yarpcerrors.CodePermissionDenied,
+		yarpcerrors.CodeOutOfRange,
+		yarpcerrors.CodeUnauthenticated:
 		c.edge.callerErrLatencies.Observe(elapsed)
-		if counter, err := c.edge.callerFailures.Get("bad_request"); err == nil {
+		if counter, err := c.edge.callerFailures.Get(errCode.String()); err == nil {
+			counter.Inc()
+		}
+		return
+	case yarpcerrors.CodeCancelled,
+		yarpcerrors.CodeUnknown,
+		yarpcerrors.CodeDeadlineExceeded,
+		yarpcerrors.CodeResourceExhausted,
+		yarpcerrors.CodeFailedPrecondition,
+		yarpcerrors.CodeAborted,
+		yarpcerrors.CodeUnimplemented,
+		yarpcerrors.CodeInternal,
+		yarpcerrors.CodeUnavailable,
+		yarpcerrors.CodeDataLoss:
+		c.edge.serverErrLatencies.Observe(elapsed)
+		if counter, err := c.edge.serverFailures.Get(errCode.String()); err == nil {
+			counter.Inc()
+		}
+		return
+	case yarpcerrors.CodeOK:
+		// If we got "CodeOK" it really means that this is not a yarpcError, in
+		// which case this is another level of "unknown" error.
+		c.edge.serverErrLatencies.Observe(elapsed)
+		if counter, err := c.edge.serverFailures.Get("unknown_strange"); err == nil {
 			counter.Inc()
 		}
 		return
 	}
-	// For now, assume that all other errors are the server's fault.
+	// If this code is executed we've hit an error code outside the usual error
+	// code range, so we'll just log the string representation of that code.
 	c.edge.serverErrLatencies.Observe(elapsed)
-	if yarpcerrors.IsInternal(err) {
-		if counter, err := c.edge.serverFailures.Get("unexpected"); err == nil {
-			counter.Inc()
-		}
-		return
-	}
-	// We've encountered an error that isn't otherwise categorized.
-	if counter, err := c.edge.serverFailures.Get("unknown"); err == nil {
+	if counter, err := c.edge.serverFailures.Get(errCode.String()); err == nil {
 		counter.Inc()
 	}
 }

--- a/internal/observability/graph.go
+++ b/internal/observability/graph.go
@@ -152,9 +152,15 @@ func newGraph(reg *pally.Registry, logger *zap.Logger, extract ContextExtractor)
 func (g *graph) begin(ctx context.Context, rpcType transport.Type, isInbound bool, req *transport.Request) call {
 	now := _timeNow()
 
-	key, free := getKey(req)
-	e := g.getOrCreateEdge(key, req)
-	free()
+	d := newDigester()
+	d.add(req.Caller)
+	d.add(req.Service)
+	d.add(string(req.Encoding))
+	d.add(req.Procedure)
+	d.add(req.RoutingKey)
+	d.add(req.RoutingDelegate)
+	e := g.getOrCreateEdge(d.digest(), req)
+	d.free()
 
 	return call{
 		edge:    e,
@@ -165,17 +171,6 @@ func (g *graph) begin(ctx context.Context, rpcType transport.Type, isInbound boo
 		rpcType: rpcType,
 		inbound: isInbound,
 	}
-}
-
-func getKey(req *transport.Request) (key []byte, free func()) {
-	d := newDigester()
-	d.add(req.Caller)
-	d.add(req.Service)
-	d.add(string(req.Encoding))
-	d.add(req.Procedure)
-	d.add(req.RoutingKey)
-	d.add(req.RoutingDelegate)
-	return d.digest(), d.free
 }
 
 func (g *graph) getOrCreateEdge(key []byte, req *transport.Request) *edge {

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -267,7 +267,7 @@ func TestMiddlewareMetrics(t *testing.T) {
 			wantCalls:     1,
 			wantSuccesses: 0,
 			wantServerFailures: map[string]int{
-				"unknown_strange": 1,
+				"unknown_internal_yarpc": 1,
 			},
 		},
 		{

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -313,6 +313,20 @@ func TestMiddlewareMetrics(t *testing.T) {
 	}
 }
 
+// getKey gets the "key" that we will use to get an edge in the graph.  We use
+// a separate function to recreate the logic because extracting it out in the
+// main code could have performance implications.
+func getKey(req *transport.Request) (key []byte, free func()) {
+	d := newDigester()
+	d.add(req.Caller)
+	d.add(req.Service)
+	d.add(string(req.Encoding))
+	d.add(req.Procedure)
+	d.add(req.RoutingKey)
+	d.add(req.RoutingDelegate)
+	return d.digest(), d.free
+}
+
 func TestUnaryInboundApplicationErrors(t *testing.T) {
 	defer stubTime()()
 	req := &transport.Request{

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -35,6 +35,7 @@ import (
 	"go.uber.org/yarpc/api/transport/transporttest"
 	"go.uber.org/yarpc/internal/pally"
 	"go.uber.org/yarpc/internal/pally/pallytest"
+	"go.uber.org/yarpc/yarpcerrors"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
@@ -214,6 +215,100 @@ func TestMiddlewareLogging(t *testing.T) {
 				Context: logContext,
 			}
 			assert.Equal(t, expected, getLog(), "Unexpected log entry written.")
+		})
+	}
+}
+
+func TestMiddlewareMetrics(t *testing.T) {
+	defer stubTime()()
+	req := &transport.Request{
+		Caller:    "caller",
+		Service:   "service",
+		Encoding:  "raw",
+		Procedure: "procedure",
+		Body:      strings.NewReader("body"),
+	}
+
+	tests := []struct {
+		desc               string
+		err                error // downstream error
+		applicationErr     bool  // downstream application error
+		wantCalls          int
+		wantSuccesses      int
+		wantCallerFailures map[string]int
+		wantServerFailures map[string]int
+	}{
+		{
+			desc:          "no downstream errors",
+			wantCalls:     1,
+			wantSuccesses: 1,
+		},
+		{
+			desc:          "invalid argument error",
+			err:           yarpcerrors.InvalidArgumentErrorf("test"),
+			wantCalls:     1,
+			wantSuccesses: 0,
+			wantCallerFailures: map[string]int{
+				yarpcerrors.CodeInvalidArgument.String(): 1,
+			},
+		},
+		{
+			desc:          "invalid argument error",
+			err:           yarpcerrors.InternalErrorf("test"),
+			wantCalls:     1,
+			wantSuccesses: 0,
+			wantServerFailures: map[string]int{
+				yarpcerrors.CodeInternal.String(): 1,
+			},
+		},
+		{
+			desc:          "unknown (unwrapped) error",
+			err:           errors.New("test"),
+			wantCalls:     1,
+			wantSuccesses: 0,
+			wantServerFailures: map[string]int{
+				"unknown_strange": 1,
+			},
+		},
+		{
+			desc:          "custom error code error",
+			err:           yarpcerrors.FromHeaders(yarpcerrors.Code(1000), "", "test"),
+			wantCalls:     1,
+			wantSuccesses: 0,
+			wantServerFailures: map[string]int{
+				"1000": 1,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		validate := func(mw *Middleware) {
+			key, free := getKey(req)
+			edge := mw.graph.getEdge(key)
+			free()
+			assert.Equal(t, int64(tt.wantCalls), edge.calls.Load())
+			assert.Equal(t, int64(tt.wantSuccesses), edge.successes.Load())
+			for tagName, val := range tt.wantCallerFailures {
+				assert.Equal(t, int64(val), edge.callerFailures.MustGet(tagName).Load())
+			}
+			for tagName, val := range tt.wantServerFailures {
+				assert.Equal(t, int64(val), edge.serverFailures.MustGet(tagName).Load())
+			}
+		}
+		t.Run(tt.desc+", unary inbound", func(t *testing.T) {
+			mw := NewMiddleware(zap.NewNop(), pally.NewRegistry(), NewNopContextExtractor())
+			mw.Handle(
+				context.Background(),
+				req,
+				&transporttest.FakeResponseWriter{},
+				fakeHandler{tt.err, tt.applicationErr},
+			)
+			validate(mw)
+		})
+		t.Run(tt.desc+", unary outbound", func(t *testing.T) {
+			mw := NewMiddleware(zap.NewNop(), pally.NewRegistry(), NewNopContextExtractor())
+			mw.Call(context.Background(), req, fakeOutbound{err: tt.err})
+			validate(mw)
 		})
 	}
 }


### PR DESCRIPTION
Summary: Currently we only enumerate "bad_request", "internal" and
"unknown" errors.  This PR uses the yarpcerrors api to enumerate all
error codes, as well as creating a "unknown_strange" bucket for any
error that is not a yarpcerror.

Test Plan: added tests.