### PR TITLE
Add yarpc error code information to peer lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ v1.14.0 (unreleased)
 
 -   Increased granularity of error observability metrics to expose yarpc
     error types.
+-   Wrapped peer list `Choose` errors in yarpc error codes.
 
 v1.13.1 (2017-08-03)
 --------------------

--- a/api/peer/errors.go
+++ b/api/peer/errors.go
@@ -108,6 +108,7 @@ func (e ErrPeerRemoveNotInList) Error() string {
 }
 
 // ErrChooseContextHasNoDeadline is returned when a context is sent to a peerlist with no deadline
+// DEPRECATED use yarpcerrors api instead.
 type ErrChooseContextHasNoDeadline string
 
 func (e ErrChooseContextHasNoDeadline) Error() string {

--- a/peer/roundrobin/list.go
+++ b/peer/roundrobin/list.go
@@ -31,6 +31,11 @@ import (
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/introspection"
 	"go.uber.org/yarpc/pkg/lifecycle"
+	"go.uber.org/yarpc/yarpcerrors"
+)
+
+var (
+	_noContextDeadlineError = yarpcerrors.InvalidArgumentErrorf("can't wait for peer without a context deadline for roundrobin list")
 )
 
 type listConfig struct {
@@ -289,7 +294,7 @@ func (pl *List) removeFromUnavailablePeers(p peer.Peer) {
 // Choose selects the next available peer in the round robin
 func (pl *List) Choose(ctx context.Context, req *transport.Request) (peer.Peer, func(error), error) {
 	if err := pl.once.WaitUntilRunning(ctx); err != nil {
-		return nil, nil, err
+		return nil, nil, newNotRunningError(err)
 	}
 
 	for {
@@ -303,6 +308,10 @@ func (pl *List) Choose(ctx context.Context, req *transport.Request) (peer.Peer, 
 			return nil, nil, err
 		}
 	}
+}
+
+func newNotRunningError(err error) error {
+	return yarpcerrors.FailedPreconditionErrorf("round robin peer list is not running: %s", err.Error())
 }
 
 // IsRunning returns whether the peer list is running.
@@ -340,15 +349,19 @@ func (pl *List) getOnFinishFunc(p peer.Peer) func(error) {
 // Must NOT be run in a mutex.Lock()
 func (pl *List) waitForPeerAddedEvent(ctx context.Context) error {
 	if _, ok := ctx.Deadline(); !ok {
-		return peer.ErrChooseContextHasNoDeadline("RoundRobinList")
+		return _noContextDeadlineError
 	}
 
 	select {
 	case <-pl.peerAvailableEvent:
 		return nil
 	case <-ctx.Done():
-		return ctx.Err()
+		return newUnavailableError(ctx.Err())
 	}
+}
+
+func newUnavailableError(err error) error {
+	return yarpcerrors.UnavailableErrorf("round robin peer list timed out waiting for peer: %s", err.Error())
 }
 
 // NotifyStatusChanged when the peer's status changes

--- a/peer/roundrobin/list_test.go
+++ b/peer/roundrobin/list_test.go
@@ -116,7 +116,7 @@ func TestRoundRobinList(t *testing.T) {
 				UpdateAction{AddedPeerIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"}},
 				StopAction{},
 				ChooseAction{
-					ExpectedErr:         context.DeadlineExceeded,
+					ExpectedErr:         newNotRunningError(context.DeadlineExceeded),
 					InputContextTimeout: 10 * time.Millisecond,
 				},
 			},
@@ -252,11 +252,11 @@ func TestRoundRobinList(t *testing.T) {
 			msg: "choose before start",
 			peerListActions: []PeerListAction{
 				ChooseAction{
-					ExpectedErr:         context.DeadlineExceeded,
+					ExpectedErr:         newNotRunningError(context.DeadlineExceeded),
 					InputContextTimeout: 10 * time.Millisecond,
 				},
 				ChooseAction{
-					ExpectedErr:         context.DeadlineExceeded,
+					ExpectedErr:         newNotRunningError(context.DeadlineExceeded),
 					InputContextTimeout: 10 * time.Millisecond,
 				},
 			},
@@ -278,7 +278,7 @@ func TestRoundRobinList(t *testing.T) {
 				StartAction{},
 				ChooseAction{
 					InputContextTimeout: 20 * time.Millisecond,
-					ExpectedErr:         context.DeadlineExceeded,
+					ExpectedErr:         newUnavailableError(context.DeadlineExceeded),
 				},
 			},
 			expectedRunning: true,
@@ -462,7 +462,7 @@ func TestRoundRobinList(t *testing.T) {
 					Actions: []PeerListAction{
 						ChooseAction{
 							InputContextTimeout: 10 * time.Millisecond,
-							ExpectedErr:         context.DeadlineExceeded,
+							ExpectedErr:         newUnavailableError(context.DeadlineExceeded),
 						},
 						UpdateAction{AddedPeerIDs: []string{"1"}},
 					},
@@ -502,7 +502,7 @@ func TestRoundRobinList(t *testing.T) {
 				StartAction{},
 				ChooseAction{
 					InputContext: context.Background(),
-					ExpectedErr:  peer.ErrChooseContextHasNoDeadline("RoundRobinList"),
+					ExpectedErr:  _noContextDeadlineError,
 				},
 			},
 			expectedRunning: true,
@@ -532,7 +532,7 @@ func TestRoundRobinList(t *testing.T) {
 				UpdateAction{RemovedPeerIDs: []string{"1"}},
 				ChooseAction{
 					InputContextTimeout: 10 * time.Millisecond,
-					ExpectedErr:         context.DeadlineExceeded,
+					ExpectedErr:         newUnavailableError(context.DeadlineExceeded),
 				},
 			},
 			expectedRunning: true,
@@ -546,7 +546,7 @@ func TestRoundRobinList(t *testing.T) {
 				UpdateAction{AddedPeerIDs: []string{"1"}},
 				ChooseAction{
 					InputContextTimeout: 10 * time.Millisecond,
-					ExpectedErr:         context.DeadlineExceeded,
+					ExpectedErr:         newUnavailableError(context.DeadlineExceeded),
 				},
 				NotifyStatusChangeAction{PeerID: "1", NewConnectionStatus: peer.Available},
 				ChooseAction{ExpectedPeer: "1"},
@@ -577,7 +577,7 @@ func TestRoundRobinList(t *testing.T) {
 				NotifyStatusChangeAction{PeerID: "1", NewConnectionStatus: peer.Unavailable},
 				ChooseAction{
 					InputContextTimeout: 10 * time.Millisecond,
-					ExpectedErr:         context.DeadlineExceeded,
+					ExpectedErr:         newUnavailableError(context.DeadlineExceeded),
 				},
 			},
 			expectedRunning: true,
@@ -592,7 +592,7 @@ func TestRoundRobinList(t *testing.T) {
 				NotifyStatusChangeAction{PeerID: "1", NewConnectionStatus: peer.Unavailable},
 				ChooseAction{
 					InputContextTimeout: 10 * time.Millisecond,
-					ExpectedErr:         context.DeadlineExceeded,
+					ExpectedErr:         newUnavailableError(context.DeadlineExceeded),
 				},
 			},
 			expectedRunning: true,

--- a/peer/x/peerheap/list_test.go
+++ b/peer/x/peerheap/list_test.go
@@ -115,7 +115,7 @@ func TestPeerHeapList(t *testing.T) {
 				UpdateAction{AddedPeerIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"}},
 				StopAction{},
 				ChooseAction{
-					ExpectedErr:         context.DeadlineExceeded,
+					ExpectedErr:         newNotRunningError(context.DeadlineExceeded),
 					InputContextTimeout: 10 * time.Millisecond,
 				},
 			},
@@ -248,11 +248,11 @@ func TestPeerHeapList(t *testing.T) {
 			msg: "choose before start",
 			peerListActions: []PeerListAction{
 				ChooseAction{
-					ExpectedErr:         context.DeadlineExceeded,
+					ExpectedErr:         newNotRunningError(context.DeadlineExceeded),
 					InputContextTimeout: 10 * time.Millisecond,
 				},
 				ChooseAction{
-					ExpectedErr:         context.DeadlineExceeded,
+					ExpectedErr:         newNotRunningError(context.DeadlineExceeded),
 					InputContextTimeout: 10 * time.Millisecond,
 				},
 			},
@@ -294,7 +294,7 @@ func TestPeerHeapList(t *testing.T) {
 				StartAction{},
 				ChooseAction{
 					InputContextTimeout: 20 * time.Millisecond,
-					ExpectedErr:         context.DeadlineExceeded,
+					ExpectedErr:         newUnavailableError(context.DeadlineExceeded),
 				},
 			},
 			expectedRunning: true,
@@ -478,7 +478,7 @@ func TestPeerHeapList(t *testing.T) {
 					Actions: []PeerListAction{
 						ChooseAction{
 							InputContextTimeout: 10 * time.Millisecond,
-							ExpectedErr:         context.DeadlineExceeded,
+							ExpectedErr:         newUnavailableError(context.DeadlineExceeded),
 						},
 						UpdateAction{AddedPeerIDs: []string{"1"}},
 					},
@@ -518,7 +518,7 @@ func TestPeerHeapList(t *testing.T) {
 				StartAction{},
 				ChooseAction{
 					InputContext: context.Background(),
-					ExpectedErr:  peer.ErrChooseContextHasNoDeadline("PeerHeap"),
+					ExpectedErr:  _noContextDeadlineError,
 				},
 			},
 			expectedRunning: true,
@@ -554,7 +554,7 @@ func TestPeerHeapList(t *testing.T) {
 				UpdateAction{RemovedPeerIDs: []string{"1"}},
 				ChooseAction{
 					InputContextTimeout: 10 * time.Millisecond,
-					ExpectedErr:         context.DeadlineExceeded,
+					ExpectedErr:         newUnavailableError(context.DeadlineExceeded),
 				},
 			},
 			expectedRunning: true,
@@ -568,7 +568,7 @@ func TestPeerHeapList(t *testing.T) {
 				UpdateAction{AddedPeerIDs: []string{"1"}},
 				ChooseAction{
 					InputContextTimeout: 10 * time.Millisecond,
-					ExpectedErr:         context.DeadlineExceeded,
+					ExpectedErr:         newUnavailableError(context.DeadlineExceeded),
 				},
 				NotifyStatusChangeAction{PeerID: "1", NewConnectionStatus: peer.Available},
 				ChooseAction{ExpectedPeer: "1"},
@@ -599,7 +599,7 @@ func TestPeerHeapList(t *testing.T) {
 				NotifyStatusChangeAction{PeerID: "1", NewConnectionStatus: peer.Unavailable},
 				ChooseAction{
 					InputContextTimeout: 10 * time.Millisecond,
-					ExpectedErr:         context.DeadlineExceeded,
+					ExpectedErr:         newUnavailableError(context.DeadlineExceeded),
 				},
 			},
 			expectedRunning: true,
@@ -614,7 +614,7 @@ func TestPeerHeapList(t *testing.T) {
 				NotifyStatusChangeAction{PeerID: "1", NewConnectionStatus: peer.Unavailable},
 				ChooseAction{
 					InputContextTimeout: 10 * time.Millisecond,
-					ExpectedErr:         context.DeadlineExceeded,
+					ExpectedErr:         newUnavailableError(context.DeadlineExceeded),
 				},
 			},
 			expectedRunning: true,

--- a/pkg/lifecycle/once.go
+++ b/pkg/lifecycle/once.go
@@ -28,7 +28,7 @@ import (
 	"go.uber.org/atomic"
 )
 
-var errDeadlineRequired = errors.New("deadline required")
+var errDeadlineRequired = errors.New("deadline required on request context")
 
 // State represents `states` that a lifecycle object can be in.
 type State int


### PR DESCRIPTION
Summary: Currently if a yarpc peer list (round robin or peer heap) has
an error when choosing a peer, we return a "raw" error.  The rest of the
yarpc stack should not have to worry about the errors returned from the
peer chooser, the chooser should wrap the errors it returns in yarpc
error codes for the different possible issues it could experience.  This
PR wraps the roundrobin and peer heap implementations in yarpc errors
for the "Choose" call stack.

Test Plan: Updated tests, they pass.