### PR TITLE
Revert #1231

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,6 @@ services:
   - docker
 language: go
 go_import_path: go.uber.org/yarpc
-branches:
-  only:
-    - master
-    - dev
 env:
   global:
     - TEST_TIME_SCALE=5


### PR DESCRIPTION
Summary: #1231 accidentally stopped running builds on stacked diffs,
so we're reverting it so that tests will be run in those cases again.