### PR TITLE
interpolate: Add test for $$ behavior

### DIFF
--- a/internal/interpolate/parse_test.go
+++ b/internal/interpolate/parse_test.go
@@ -103,6 +103,10 @@ func TestParseSuccess(t *testing.T) {
 				literal(" c"),
 			},
 		},
+		{
+			give: "foo $${bar}",
+			want: String{literal("foo "), literal("$$"), literal("{bar}")},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
We already support the behavior where using two consecutive `$` signs
allows you to escape `$` signs. This adds a test for that behavior.