### PR TITLE
Test against Go 1.9

### DIFF
--- a/Dockerfile.1.9
+++ b/Dockerfile.1.9
@@ -1,4 +1,4 @@
-FROM golang:1.9rc1
+FROM golang:1.9
 
 ENV SUPPRESS_DOCKER 1
 WORKDIR /go/src/go.uber.org/yarpc


### PR DESCRIPTION
Upgrades from `1.9rc1` to `1.9`.