### PR TITLE
[RetryStats][Part 1] Move observability.digester into reusable package

### DIFF
--- a/internal/digester/digester.go
+++ b/internal/digester/digester.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package digester
+
+import "sync"
+
+var _digesterPool = sync.Pool{New: func() interface{} {
+	return &Digester{make([]byte, 0, 128)}
+}}
+
+// Digester creates a null-delimited byte slice from a series of strings. It's
+// an efficient way to create map keys.
+//
+// This helps because (1) appending to a string allocates and (2) converting a
+// byte slice to a string allocates, but (3) the Go compiler optimizes away
+// byte-to-string conversions in map lookups. Using this type to build up a key
+// and doing map lookups with myMap[string(d.digest())] is fast and
+// zero-allocation.
+type Digester struct {
+	bs []byte
+}
+
+// New creates a new Digester.
+// For optimal performance, be sure to call "Free" on each digester.
+func New() *Digester {
+	d := _digesterPool.Get().(*Digester)
+	d.bs = d.bs[:0]
+	return d
+}
+
+// Add adds a string to the digester slice.
+func (d *Digester) Add(s string) {
+	if len(d.bs) > 0 {
+		// separate labels with a null byte
+		d.bs = append(d.bs, '\x00')
+	}
+	d.bs = append(d.bs, s...)
+}
+
+// Digest returns a map key for the digester.
+func (d *Digester) Digest() []byte {
+	return d.bs
+}
+
+// Free is called to indicate that the digester can be returned to the pool to
+// be used in another context.
+func (d *Digester) Free() {
+	_digesterPool.Put(d)
+}

--- a/internal/digester/digester_test.go
+++ b/internal/digester/digester_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package digester
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDigester(t *testing.T) {
+	const (
+		goroutines = 10
+		iterations = 100
+	)
+
+	expected := []byte{'f', 'o', 'o', 0, 'b', 'a', 'r'}
+
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				d := New()
+				defer d.Free()
+
+				assert.Equal(t, 0, len(d.Digest()), "Expected fresh digester to have no internal state.")
+				assert.True(t, cap(d.Digest()) > 0, "Expected fresh digester to have available capacity.")
+
+				d.Add("foo")
+				d.Add("bar")
+				assert.Equal(
+					t,
+					string(expected),
+					string(d.Digest()),
+					"Expected digest to be null-separated concatenation of inputs.",
+				)
+			}
+		}()
+	}
+
+	wg.Wait()
+}

--- a/internal/observability/graph.go
+++ b/internal/observability/graph.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/digester"
 	"go.uber.org/yarpc/internal/pally"
 	"go.uber.org/zap"
 )
@@ -33,9 +34,6 @@ import (
 var (
 	_timeNow          = time.Now // for tests
 	_defaultGraphSize = 128
-	_digesterPool     = sync.Pool{New: func() interface{} {
-		return &digester{make([]byte, 0, 128)}
-	}}
 	// Latency buckets for histograms. At some point, we may want to make these
 	// configurable.
 	_ms      = time.Millisecond
@@ -93,41 +91,6 @@ var (
 	}
 )
 
-// A digester creates a null-delimited byte slice from a series of strings. It's
-// an efficient way to create map keys.
-//
-// This helps because (1) appending to a string allocates and (2) converting a
-// byte slice to a string allocates, but (3) the Go compiler optimizes away
-// byte-to-string conversions in map lookups. Using this type to build up a key
-// and doing map lookups with myMap[string(d.digest())] is fast and
-// zero-allocation.
-type digester struct {
-	bs []byte
-}
-
-// For optimal performance, be sure to free each digester.
-func newDigester() *digester {
-	d := _digesterPool.Get().(*digester)
-	d.bs = d.bs[:0]
-	return d
-}
-
-func (d *digester) add(s string) {
-	if len(d.bs) > 0 {
-		// separate labels with a null byte
-		d.bs = append(d.bs, '\x00')
-	}
-	d.bs = append(d.bs, s...)
-}
-
-func (d *digester) digest() []byte {
-	return d.bs
-}
-
-func (d *digester) free() {
-	_digesterPool.Put(d)
-}
-
 // A graph represents a collection of services: each service is a node, and we
 // collect stats for each caller-callee-encoding-procedure-rk-sk-rd edge.
 type graph struct {
@@ -152,15 +115,15 @@ func newGraph(reg *pally.Registry, logger *zap.Logger, extract ContextExtractor)
 func (g *graph) begin(ctx context.Context, rpcType transport.Type, isInbound bool, req *transport.Request) call {
 	now := _timeNow()
 
-	d := newDigester()
-	d.add(req.Caller)
-	d.add(req.Service)
-	d.add(string(req.Encoding))
-	d.add(req.Procedure)
-	d.add(req.RoutingKey)
-	d.add(req.RoutingDelegate)
-	e := g.getOrCreateEdge(d.digest(), req)
-	d.free()
+	d := digester.New()
+	d.Add(req.Caller)
+	d.Add(req.Service)
+	d.Add(string(req.Encoding))
+	d.Add(req.Procedure)
+	d.Add(req.RoutingKey)
+	d.Add(req.RoutingDelegate)
+	e := g.getOrCreateEdge(d.Digest(), req)
+	d.Free()
 
 	return call{
 		edge:    e,


### PR DESCRIPTION
Summary: I'm going through and adding better metrics to the retry
middleware stack. This involves taking as much as possible from the
current observability middleware and using it for other purposes.

This PR takes the digester out of the observability folder so it can be
reused in the retry metrics (and beyond).

Test Plan: tests pass