### PR TITLE
[retry] Add robust metrics to retry middleware.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ v1.14.0 (unreleased)
 -   Increased granularity of error observability metrics to expose yarpc
     error types.
 -   Wrapped peer list `Choose` errors in yarpc error codes.
+-   x/retry: Add granular metric counters for retry middleware.
 
 v1.13.1 (2017-08-03)
 --------------------

--- a/x/retry/config_test.go
+++ b/x/retry/config_test.go
@@ -410,7 +410,8 @@ func TestConfig(t *testing.T) {
 			err := yaml.Unmarshal([]byte(whitespace.Expand(tt.retryConfig)), &data)
 			require.NoError(t, err, "error unmarshalling")
 
-			middleware, err := NewUnaryMiddlewareFromConfig(data)
+			middleware, stopFunc, err := NewUnaryMiddlewareFromConfig(data)
+			defer stopFunc()
 			if len(tt.wantError) > 0 {
 				require.Error(t, err, "expected error, got none")
 				for _, wantErr := range tt.wantError {

--- a/x/retry/observer_test.go
+++ b/x/retry/observer_test.go
@@ -53,7 +53,7 @@ func TestNopEdge(t *testing.T) {
 
 	// Should fall back to no-op metrics.
 	e := newEdge(zap.NewNop(), reg, req)
-	assert.NotNil(t, e.calls, "Expected to fall back to no-op metrics.")
+	assert.NotNil(t, e.attempts, "Expected to fall back to no-op metrics.")
 	assert.NotNil(t, e.successes, "Expected to fall back to no-op metrics.")
 	assert.NotNil(t, e.retriesAfterError, "Expected to fall back to no-op metrics.")
 	assert.NotNil(t, e.failures, "Expected to fall back to no-op metrics.")

--- a/x/retry/observer_test.go
+++ b/x/retry/observer_test.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package retry
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uber-go/tally"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/yarpcerrors"
+	"go.uber.org/zap"
+)
+
+func TestNopEdge(t *testing.T) {
+	// If we fail to create any of the metrics required for the edge, we should
+	// fall back to no-op implementations. The easiest way to trigger failures
+	// is to re-use the same Registry.
+	reg, _ := newRegistry(zap.NewNop(), nil)
+	req := &transport.Request{
+		Caller:          "caller",
+		Service:         "service",
+		Encoding:        "raw",
+		Procedure:       "procedure",
+		ShardKey:        "sk",
+		RoutingKey:      "rk",
+		RoutingDelegate: "rd",
+		Body:            strings.NewReader("body"),
+	}
+
+	// Should succeed, covered by middleware tests.
+	_ = newEdge(zap.NewNop(), reg, req)
+
+	// Should fall back to no-op metrics.
+	e := newEdge(zap.NewNop(), reg, req)
+	assert.NotNil(t, e.calls, "Expected to fall back to no-op metrics.")
+	assert.NotNil(t, e.successes, "Expected to fall back to no-op metrics.")
+	assert.NotNil(t, e.retriesAfterError, "Expected to fall back to no-op metrics.")
+	assert.NotNil(t, e.failures, "Expected to fall back to no-op metrics.")
+}
+
+func TestYarpcInternalErrorCounter(t *testing.T) {
+	testScope := tally.NewTestScope("", map[string]string{})
+	graph, _ := newObserverGraph(zap.NewNop(), testScope)
+
+	call := graph.begin(&transport.Request{
+		Caller:    "caller",
+		Service:   "service",
+		Encoding:  "raw",
+		Procedure: "procedure",
+	})
+
+	call.yarpcInternalError(yarpcerrors.InternalErrorf("test"))
+
+	assert.Equal(t, int64(1), call.e.failures.MustGet(_yarpcInternal, yarpcerrors.CodeInternal.String()).Load())
+}
+
+func TestErrorName(t *testing.T) {
+	type testStruct struct {
+		msg      string
+		giveErr  error
+		wantName string
+	}
+	tests := []testStruct{
+		{
+			msg:      "internal",
+			giveErr:  yarpcerrors.InternalErrorf("test"),
+			wantName: yarpcerrors.CodeInternal.String(),
+		},
+		{
+			msg:      "invalid request",
+			giveErr:  yarpcerrors.InvalidArgumentErrorf("test"),
+			wantName: yarpcerrors.CodeInvalidArgument.String(),
+		},
+		{
+			msg:      "yarpc unknown",
+			giveErr:  errors.New("unknown"),
+			wantName: "unknown_internal_yarpc",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			assert.Equal(t, tt.wantName, getErrorName(tt.giveErr))
+		})
+	}
+}

--- a/x/retry/retry.go
+++ b/x/retry/retry.go
@@ -117,7 +117,7 @@ func (r *OutboundMiddleware) Call(ctx context.Context, request *transport.Reques
 	call := r.observerGraph.begin(request)
 
 	for i := uint(0); i < policy.opts.retries+1; i++ {
-		call.call()
+		call.attempt()
 		if i > 0 { // Only log retries if this isn't the first attempt
 			call.retryOnError(err)
 		}

--- a/x/retry/retry_test.go
+++ b/x/retry/retry_test.go
@@ -77,7 +77,7 @@ func TestMiddleware(t *testing.T) {
 				edgeAssertion(
 					service("serv"),
 					procedure("proc"),
-					wantCalls(1),
+					wantAttempts(1),
 					wantSuccesses(1),
 				),
 			},
@@ -144,7 +144,7 @@ func TestMiddleware(t *testing.T) {
 				edgeAssertion(
 					service("serv"),
 					procedure("proc"),
-					wantCalls(2),
+					wantAttempts(2),
 					wantSuccesses(1),
 					wantRetriesWithError(yarpcerrors.CodeInternal, 1),
 				),
@@ -205,7 +205,7 @@ func TestMiddleware(t *testing.T) {
 				edgeAssertion(
 					service("serv"),
 					procedure("proc"),
-					wantCalls(5),
+					wantAttempts(5),
 					wantSuccesses(1),
 					wantRetriesWithError(yarpcerrors.CodeInternal, 2),
 					wantRetriesWithError(yarpcerrors.CodeDeadlineExceeded, 2),
@@ -243,7 +243,7 @@ func TestMiddleware(t *testing.T) {
 				edgeAssertion(
 					service("serv"),
 					procedure("proc"),
-					wantCalls(1),
+					wantAttempts(1),
 					wantFailures(_unretryable, yarpcerrors.CodeInvalidArgument, 1),
 				),
 			},
@@ -285,7 +285,7 @@ func TestMiddleware(t *testing.T) {
 				edgeAssertion(
 					service("serv"),
 					procedure("proc"),
-					wantCalls(2),
+					wantAttempts(2),
 					wantRetriesWithError(yarpcerrors.CodeInternal, 1),
 					wantFailures(_unretryable, yarpcerrors.CodeInvalidArgument, 1),
 				),
@@ -323,7 +323,7 @@ func TestMiddleware(t *testing.T) {
 				edgeAssertion(
 					service("serv"),
 					procedure("proc"),
-					wantCalls(1),
+					wantAttempts(1),
 					wantSuccesses(1),
 				),
 			},
@@ -368,7 +368,7 @@ func TestMiddleware(t *testing.T) {
 				edgeAssertion(
 					service("serv"),
 					procedure("proc"),
-					wantCalls(2),
+					wantAttempts(2),
 					wantSuccesses(1),
 					wantRetriesWithError(yarpcerrors.CodeDeadlineExceeded, 1),
 				),
@@ -413,7 +413,7 @@ func TestMiddleware(t *testing.T) {
 				edgeAssertion(
 					service("serv"),
 					procedure("proc"),
-					wantCalls(2),
+					wantAttempts(2),
 					wantSuccesses(1),
 					wantRetriesWithError(yarpcerrors.CodeDeadlineExceeded, 1),
 				),
@@ -458,7 +458,7 @@ func TestMiddleware(t *testing.T) {
 				edgeAssertion(
 					service("serv"),
 					procedure("proc"),
-					wantCalls(2),
+					wantAttempts(2),
 					wantRetriesWithError(yarpcerrors.CodeInternal, 1),
 					wantFailures(_maxAttempts, yarpcerrors.CodeInternal, 1),
 				),
@@ -504,7 +504,7 @@ func TestMiddleware(t *testing.T) {
 				edgeAssertion(
 					service("serv"),
 					procedure("proc"),
-					wantCalls(2),
+					wantAttempts(2),
 					wantRetriesWithError(yarpcerrors.CodeInternal, 1),
 					wantFailures(_maxAttempts, yarpcerrors.CodeInternal, 1),
 				),
@@ -551,7 +551,7 @@ func TestMiddleware(t *testing.T) {
 				edgeAssertion(
 					service("serv"),
 					procedure("proc"),
-					wantCalls(2),
+					wantAttempts(2),
 					wantSuccesses(1),
 					wantRetriesWithError(yarpcerrors.CodeDeadlineExceeded, 1),
 				),
@@ -609,7 +609,7 @@ func TestMiddleware(t *testing.T) {
 				edgeAssertion(
 					service("serv"),
 					procedure("proc"),
-					wantCalls(3),
+					wantAttempts(3),
 					wantSuccesses(1),
 					wantRetriesWithError(yarpcerrors.CodeDeadlineExceeded, 2),
 				),
@@ -651,7 +651,7 @@ func TestMiddleware(t *testing.T) {
 				edgeAssertion(
 					service("serv"),
 					procedure("proc"),
-					wantCalls(1),
+					wantAttempts(1),
 					wantFailures(_noTime, yarpcerrors.CodeInternal, 1),
 				),
 			},
@@ -765,20 +765,20 @@ func TestMiddleware(t *testing.T) {
 				edgeAssertion(
 					service("serv"),
 					procedure("proc"),
-					wantCalls(2),
+					wantAttempts(2),
 					wantSuccesses(1),
 					wantRetriesWithError(yarpcerrors.CodeDeadlineExceeded, 1),
 				),
 				edgeAssertion(
 					service("serv2"),
 					procedure("proc2"),
-					wantCalls(1),
+					wantAttempts(1),
 					wantFailures(_unretryable, yarpcerrors.CodeInvalidArgument, 1),
 				),
 				edgeAssertion(
 					service("serv3"),
 					procedure("proc3"),
-					wantCalls(2),
+					wantAttempts(2),
 					wantRetriesWithError(yarpcerrors.CodeDeadlineExceeded, 1),
 					wantFailures(_noTime, yarpcerrors.CodeDeadlineExceeded, 1),
 				),
@@ -986,27 +986,27 @@ func TestMiddleware(t *testing.T) {
 				edgeAssertion(
 					service("ns"),
 					procedure("np"),
-					wantCalls(3),
+					wantAttempts(3),
 					wantRetriesWithError(yarpcerrors.CodeDeadlineExceeded, 2),
 					wantFailures(_maxAttempts, yarpcerrors.CodeDeadlineExceeded, 1),
 				),
 				edgeAssertion(
 					service("s"),
 					procedure("np"),
-					wantCalls(2),
+					wantAttempts(2),
 					wantRetriesWithError(yarpcerrors.CodeDeadlineExceeded, 1),
 					wantFailures(_maxAttempts, yarpcerrors.CodeDeadlineExceeded, 1),
 				),
 				edgeAssertion(
 					service("s"),
 					procedure("p"),
-					wantCalls(1),
+					wantAttempts(1),
 					wantFailures(_maxAttempts, yarpcerrors.CodeDeadlineExceeded, 1),
 				),
 				edgeAssertion(
 					service("ss"),
 					procedure("pr"),
-					wantCalls(4),
+					wantAttempts(4),
 					wantRetriesWithError(yarpcerrors.CodeDeadlineExceeded, 3),
 					wantFailures(_maxAttempts, yarpcerrors.CodeDeadlineExceeded, 1),
 				),
@@ -1139,7 +1139,7 @@ func edgeAssertion(options ...counterOption) counterAssertion {
 	}
 	return func(t *testing.T, graph *observerGraph) {
 		e := graph.getOrCreateEdge(opts.giveRequest)
-		assert.Equal(t, int64(opts.wantCalls), e.calls.Load(), "mismatched calls counter")
+		assert.Equal(t, int64(opts.wantAttempts), e.attempts.Load(), "mismatched attempts counter")
 		assert.Equal(t, int64(opts.wantSuccesses), e.successes.Load(), "mismatched successes counter")
 		for errName, count := range opts.wantRetryWithError {
 			counter := e.retriesAfterError.MustGet(errName)
@@ -1160,7 +1160,7 @@ type failureAssertion struct {
 
 type counterOpts struct {
 	giveRequest        *transport.Request
-	wantCalls          int
+	wantAttempts       int
 	wantSuccesses      int
 	wantRetryWithError map[string]int
 	wantFailures       []failureAssertion
@@ -1193,9 +1193,9 @@ func procedure(p string) counterOption {
 	})
 }
 
-func wantCalls(n int) counterOption {
+func wantAttempts(n int) counterOption {
 	return counterOptionFunc(func(opts *counterOpts) {
-		opts.wantCalls = n
+		opts.wantAttempts = n
 	})
 }
 

--- a/x/retry/retry_test.go
+++ b/x/retry/retry_test.go
@@ -32,6 +32,7 @@ import (
 	"go.uber.org/yarpc/internal/testtime"
 	. "go.uber.org/yarpc/internal/yarpctest/outboundtest"
 	"go.uber.org/yarpc/yarpcerrors"
+	"go.uber.org/zap"
 )
 
 func TestMiddleware(t *testing.T) {
@@ -1020,6 +1021,7 @@ func TestMiddleware(t *testing.T) {
 			retry, stopFunc := NewUnaryMiddleware(
 				WithPolicyProvider(tt.policyProvider),
 				WithTally(testScope),
+				WithLogger(zap.NewNop()),
 			)
 			defer stopFunc()
 


### PR DESCRIPTION
Summary: This PR modifies the retry middleware to add more robust
metrics that will be logged through pally.  Since this PR got quite
large, I've only include base metrics here (no logs or timers). I plan
to add those later as needs arise.

Much of this code is very similar to the code in
/internal/observability. Unfortunately I couldn't figure out a way to
share more code with that codebase withour resorting to interface{} and
casting, so a large amount of the code is quite similar.

Test Plan: Added test infrastructure to assert against the pally
counters for the different use cases.  I've added these assertions to
the retry middleware integration test.