### PR TITLE
Make the deprectation of the Config.Tracer field more explicit

### DIFF
--- a/config.go
+++ b/config.go
@@ -123,7 +123,10 @@ type Config struct {
 	InboundMiddleware  InboundMiddleware
 	OutboundMiddleware OutboundMiddleware
 
-	// Tracer is deprecated. The dispatcher does nothing with this property.
+	// Tracer is meant to add/record tracing information to a request.
+	//
+	// Deprecated: The dispatcher does nothing with this property.  Set the
+	// tracer directly on the transports used to build inbounds and outbounds.
 	Tracer opentracing.Tracer
 
 	// RouterMiddleware is middleware to control how requests are routed.

--- a/transport/tracer_test.go
+++ b/transport/tracer_test.go
@@ -102,7 +102,6 @@ func createGRPCDispatcher(t *testing.T, tracer opentracing.Tracer) *yarpc.Dispat
 				Unary: grpcTransport.NewSingleOutbound(listener.Addr().String()),
 			},
 		},
-		Tracer: tracer,
 	})
 }
 
@@ -121,7 +120,6 @@ func createHTTPDispatcher(tracer opentracing.Tracer) *yarpc.Dispatcher {
 				Unary: httpTransport.NewSingleOutbound("http://127.0.0.1:18080"),
 			},
 		},
-		Tracer: tracer,
 	})
 
 	return dispatcher
@@ -147,7 +145,6 @@ func createTChannelDispatcher(t *testing.T, tracer opentracing.Tracer) *yarpc.Di
 				Unary: tchannelTransport.NewSingleOutbound(hp),
 			},
 		},
-		Tracer: tracer,
 	})
 
 	return dispatcher


### PR DESCRIPTION
Summary: This caused some confusion.  This adds the proper godoc
deprecation style to the Tracer field.
https://blog.golang.org/godoc-documenting-go-code