### PR TITLE
Remove breaking change from retry middleware

### DIFF
--- a/x/retry/config.go
+++ b/x/retry/config.go
@@ -21,7 +21,6 @@
 package retry
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -88,25 +87,25 @@ type MiddlewareConfig struct {
 
 // NewUnaryMiddlewareFromConfig creates a new policy provider that can be used
 // in retry middleware.
-func NewUnaryMiddlewareFromConfig(src interface{}, opts ...MiddlewareOption) (*OutboundMiddleware, context.CancelFunc, error) {
+func NewUnaryMiddlewareFromConfig(src interface{}, opts ...MiddlewareOption) (*OutboundMiddleware, error) {
 	var cfg MiddlewareConfig
 	if err := iconfig.DecodeInto(&cfg, src); err != nil {
-		return nil, func() {}, err
+		return nil, err
 	}
 
 	nameToPolicy, err := cfg.getPolicies()
 	if err != nil {
-		return nil, func() {}, err
+		return nil, err
 	}
 
 	policyProvider, err := cfg.getPolicyProvider(nameToPolicy)
 	if err != nil {
-		return nil, func() {}, err
+		return nil, err
 	}
 
 	opts = append(opts, WithPolicyProvider(policyProvider))
-	mw, stopFunc := NewUnaryMiddleware(opts...)
-	return mw, stopFunc, nil
+	mw := NewUnaryMiddleware(opts...)
+	return mw, nil
 }
 
 func (cfg MiddlewareConfig) getPolicies() (map[string]*Policy, error) {

--- a/x/retry/config_test.go
+++ b/x/retry/config_test.go
@@ -410,8 +410,8 @@ func TestConfig(t *testing.T) {
 			err := yaml.Unmarshal([]byte(whitespace.Expand(tt.retryConfig)), &data)
 			require.NoError(t, err, "error unmarshalling")
 
-			middleware, stopFunc, err := NewUnaryMiddlewareFromConfig(data)
-			defer stopFunc()
+			middleware, err := NewUnaryMiddlewareFromConfig(data)
+			defer middleware.Stop()
 			if len(tt.wantError) > 0 {
 				require.Error(t, err, "expected error, got none")
 				for _, wantErr := range tt.wantError {

--- a/x/retry/retry_test.go
+++ b/x/retry/retry_test.go
@@ -1018,12 +1018,12 @@ func TestMiddleware(t *testing.T) {
 		t.Run(tt.msg, func(t *testing.T) {
 			testScope := tally.NewTestScope("", map[string]string{})
 
-			retry, stopFunc := NewUnaryMiddleware(
+			retry := NewUnaryMiddleware(
 				WithPolicyProvider(tt.policyProvider),
 				WithTally(testScope),
 				WithLogger(zap.NewNop()),
 			)
-			defer stopFunc()
+			defer retry.Stop()
 
 			ApplyMiddlewareActions(t, retry, tt.actions)
 


### PR DESCRIPTION
Summary: This PR removes the change that added a breaking change to the
retry middleware.  Instead of another parameter being returned, we will
add a function to the retry middleware object to "Stop"