### PR TITLE
Add yarpctest.ZeroAddrToHostPort functions for backwards compatible tests with Golang 1.8

### DIFF
--- a/encoding/thrift/thriftrw-plugin-yarpc/roundtrip_test.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/roundtrip_test.go
@@ -48,6 +48,7 @@ import (
 	"go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendonlyclient"
 	"go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendonlyserver"
 	"go.uber.org/yarpc/internal/testtime"
+	"go.uber.org/yarpc/internal/yarpctest"
 	"go.uber.org/yarpc/transport/http"
 )
 
@@ -274,7 +275,7 @@ func testRoundTrip(t *testing.T, enveloped, multiplexed bool) {
 			defer server.Stop()
 
 			outbound := http.NewTransport().NewSingleOutbound(
-				fmt.Sprintf("http://%v/", httpInbound.Addr().String()))
+				fmt.Sprintf("http://%v", yarpctest.ZeroAddrToHostPort(httpInbound.Addr())))
 
 			dispatcher := yarpc.NewDispatcher(yarpc.Config{
 				Name: "roundtrip-client",

--- a/internal/crossdock/client/dispatcher/dispatcher.go
+++ b/internal/crossdock/client/dispatcher/dispatcher.go
@@ -110,5 +110,5 @@ func CreateOnewayDispatcher(t crossdock.T, handler raw.OnewayHandler) (*yarpc.Di
 	dispatcher.Register(raw.OnewayProcedure("call-back", raw.OnewayHandler(handler)))
 	fatals.NoError(dispatcher.Start(), "could not start oneway Dispatcher")
 
-	return dispatcher, yarpctest.ZeroAddrToHostPort(callBackInbound.Addr())
+	return dispatcher, client + ":" + yarpctest.ZeroAddrToPort(callBackInbound.Addr())
 }

--- a/internal/crossdock/client/dispatcher/dispatcher.go
+++ b/internal/crossdock/client/dispatcher/dispatcher.go
@@ -28,6 +28,7 @@ import (
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/raw"
 	"go.uber.org/yarpc/internal/crossdock/client/params"
+	"go.uber.org/yarpc/internal/yarpctest"
 	"go.uber.org/yarpc/transport/http"
 	"go.uber.org/yarpc/transport/tchannel"
 	"go.uber.org/yarpc/transport/x/grpc"
@@ -109,5 +110,5 @@ func CreateOnewayDispatcher(t crossdock.T, handler raw.OnewayHandler) (*yarpc.Di
 	dispatcher.Register(raw.OnewayProcedure("call-back", raw.OnewayHandler(handler)))
 	fatals.NoError(dispatcher.Start(), "could not start oneway Dispatcher")
 
-	return dispatcher, callBackInbound.Addr().String()
+	return dispatcher, yarpctest.ZeroAddrToHostPort(callBackInbound.Addr())
 }

--- a/internal/integrationtest/util_test.go
+++ b/internal/integrationtest/util_test.go
@@ -29,6 +29,7 @@ import (
 	"go.uber.org/yarpc/internal/backoff"
 	"go.uber.org/yarpc/internal/integrationtest"
 	"go.uber.org/yarpc/internal/testtime"
+	"go.uber.org/yarpc/internal/yarpctest"
 	"go.uber.org/yarpc/peer/hostport"
 	"go.uber.org/yarpc/transport/tchannel"
 )
@@ -59,7 +60,7 @@ var spec = integrationtest.TransportSpec{
 		return x.(*tchannel.Transport).NewOutbound(pc)
 	},
 	Addr: func(x peer.Transport, ib transport.Inbound) string {
-		return x.(*tchannel.Transport).ListenAddr()
+		return yarpctest.ZeroAddrStringToHostPort(x.(*tchannel.Transport).ListenAddr())
 	},
 }
 

--- a/internal/net/httpserver_test.go
+++ b/internal/net/httpserver_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc/internal/testtime"
+	"go.uber.org/yarpc/internal/yarpctest"
 )
 
 func TestStartAndStop(t *testing.T) {
@@ -38,7 +39,7 @@ func TestStartAndStop(t *testing.T) {
 	require.NoError(t, server.ListenAndServe())
 
 	require.NotNil(t, server.Listener())
-	addr := server.Listener().Addr().String()
+	addr := yarpctest.ZeroAddrToHostPort(server.Listener().Addr())
 
 	conn, err := net.Dial("tcp", addr)
 	require.NoError(t, err)
@@ -54,7 +55,8 @@ func TestStartAddrInUse(t *testing.T) {
 	require.NoError(t, s1.ListenAndServe())
 	defer s1.Stop()
 
-	s2 := NewHTTPServer(&http.Server{Addr: s1.Listener().Addr().String()})
+	addr := yarpctest.ZeroAddrToHostPort(s1.Listener().Addr())
+	s2 := NewHTTPServer(&http.Server{Addr: addr})
 	err := s2.ListenAndServe()
 
 	require.Error(t, err)

--- a/internal/yarpctest/hostport.go
+++ b/internal/yarpctest/hostport.go
@@ -43,6 +43,25 @@ func ZeroAddrToHostPort(addr net.Addr) string {
 // See the "net" section in https://golang.org/doc/go1.9#minor_library_changes
 // for more details.
 func ZeroAddrStringToHostPort(addrString string) string {
+	return localhostString + ":" + ZeroAddrStringToPort(addrString)
+}
+
+// ZeroAddrToPort converts a net.Addr created with net.Listen("tcp", ":0")
+// to a port string valid to use for Golang versions <= 1.8
+//
+// See the "net" section in https://golang.org/doc/go1.9#minor_library_changes
+// for more details.
+func ZeroAddrToPort(addr net.Addr) string {
+	return ZeroAddrStringToPort(addr.String())
+}
+
+// ZeroAddrStringToPort converts a string from net.Addr.String() created
+// with net.Listen("tcp", ":0") to a port string valid to use for Golang
+// versions <= 1.8
+//
+// See the "net" section in https://golang.org/doc/go1.9#minor_library_changes
+// for more details.
+func ZeroAddrStringToPort(addrString string) string {
 	split := strings.Split(addrString, ":")
-	return localhostString + ":" + split[len(split)-1]
+	return split[len(split)-1]
 }

--- a/internal/yarpctest/hostport.go
+++ b/internal/yarpctest/hostport.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpctest
+
+import (
+	"net"
+	"strings"
+)
+
+const localhostString = "127.0.0.1"
+
+// ZeroAddrToHostPort converts a net.Addr created with net.Listen("tcp", ":0")
+// to a hostPort string valid to use for Golang versions <= 1.8
+//
+// See the "net" section in https://golang.org/doc/go1.9#minor_library_changes
+// for more details.
+func ZeroAddrToHostPort(addr net.Addr) string {
+	return ZeroAddrStringToHostPort(addr.String())
+}
+
+// ZeroAddrStringToHostPort converts a string from net.Addr.String() created
+// with net.Listen("tcp", ":0") to a hostPort string valid to use for Golang
+// versions <= 1.8
+//
+// See the "net" section in https://golang.org/doc/go1.9#minor_library_changes
+// for more details.
+func ZeroAddrStringToHostPort(addrString string) string {
+	split := strings.Split(addrString, ":")
+	return localhostString + ":" + split[len(split)-1]
+}

--- a/internal/yarpctest/hostport_test.go
+++ b/internal/yarpctest/hostport_test.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpctest
+
+import (
+	"net"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var regex = regexp.MustCompile(`127\.0\.0\.1:[0-9]+`)
+
+func TestZeroAddrToHostPort(t *testing.T) {
+	for i := 0; i < 10; i++ {
+		listener, err := net.Listen("tcp", ":0")
+		require.NoError(t, err)
+		require.True(t, regex.MatchString(ZeroAddrToHostPort(listener.Addr())))
+		require.NoError(t, listener.Close())
+	}
+}

--- a/transport/http/inbound_test.go
+++ b/transport/http/inbound_test.go
@@ -39,6 +39,7 @@ import (
 	"go.uber.org/yarpc/encoding/raw"
 	"go.uber.org/yarpc/internal/routertest"
 	"go.uber.org/yarpc/internal/testtime"
+	"go.uber.org/yarpc/internal/yarpctest"
 	"go.uber.org/yarpc/yarpcerrors"
 )
 
@@ -124,7 +125,7 @@ func TestInboundMux(t *testing.T) {
 
 	defer i.Stop()
 
-	addr := fmt.Sprintf("http://%v/", i.Addr().String())
+	addr := fmt.Sprintf("http://%v/", yarpctest.ZeroAddrToHostPort(i.Addr()))
 	resp, err := http.Get(addr + "health")
 	if assert.NoError(t, err, "/health failed") {
 		defer resp.Body.Close()

--- a/transport/http/peer_test.go
+++ b/transport/http/peer_test.go
@@ -30,6 +30,7 @@ import (
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/backoff"
 	"go.uber.org/yarpc/internal/integrationtest"
+	"go.uber.org/yarpc/internal/yarpctest"
 	"go.uber.org/yarpc/peer/hostport"
 	"go.uber.org/yarpc/transport/http"
 )
@@ -58,7 +59,7 @@ var spec = integrationtest.TransportSpec{
 		return x.(*http.Transport).NewInbound(addr)
 	},
 	Addr: func(x peer.Transport, ib transport.Inbound) string {
-		return ib.(*http.Inbound).Addr().String()
+		return yarpctest.ZeroAddrToHostPort(ib.(*http.Inbound).Addr())
 	},
 }
 

--- a/transport/tchannel/peer_test.go
+++ b/transport/tchannel/peer_test.go
@@ -31,6 +31,7 @@ import (
 	"go.uber.org/yarpc/internal/backoff"
 	"go.uber.org/yarpc/internal/integrationtest"
 	"go.uber.org/yarpc/internal/testtime"
+	"go.uber.org/yarpc/internal/yarpctest"
 	"go.uber.org/yarpc/peer/hostport"
 	"go.uber.org/yarpc/transport/tchannel"
 )
@@ -61,7 +62,7 @@ var spec = integrationtest.TransportSpec{
 		return x.(*tchannel.Transport).NewOutbound(pc)
 	},
 	Addr: func(x peer.Transport, ib transport.Inbound) string {
-		return x.(*tchannel.Transport).ListenAddr()
+		return yarpctest.ZeroAddrStringToHostPort(x.(*tchannel.Transport).ListenAddr())
 	},
 }
 

--- a/transport/tracer_test.go
+++ b/transport/tracer_test.go
@@ -32,6 +32,7 @@ import (
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/encoding/json"
 	"go.uber.org/yarpc/internal/testtime"
+	"go.uber.org/yarpc/internal/yarpctest"
 	"go.uber.org/yarpc/transport/http"
 	ytchannel "go.uber.org/yarpc/transport/tchannel"
 	"go.uber.org/yarpc/transport/x/grpc"
@@ -99,7 +100,7 @@ func createGRPCDispatcher(t *testing.T, tracer opentracing.Tracer) *yarpc.Dispat
 		},
 		Outbounds: yarpc.Outbounds{
 			"yarpc-test": {
-				Unary: grpcTransport.NewSingleOutbound(listener.Addr().String()),
+				Unary: grpcTransport.NewSingleOutbound(yarpctest.ZeroAddrToHostPort(listener.Addr())),
 			},
 		},
 	})

--- a/transport/x/grpc/peer_test.go
+++ b/transport/x/grpc/peer_test.go
@@ -30,6 +30,7 @@ import (
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/backoff"
 	"go.uber.org/yarpc/internal/integrationtest"
+	"go.uber.org/yarpc/internal/yarpctest"
 	"go.uber.org/yarpc/peer/hostport"
 )
 
@@ -52,7 +53,7 @@ var spec = integrationtest.TransportSpec{
 		return t.(*Transport).NewInbound(listener)
 	},
 	Addr: func(_ peer.Transport, inbound transport.Inbound) string {
-		return inbound.(*Inbound).listener.Addr().String()
+		return yarpctest.ZeroAddrToHostPort(inbound.(*Inbound).listener.Addr())
 	},
 }
 

--- a/yarpctest/recorder/recorder_test.go
+++ b/yarpctest/recorder/recorder_test.go
@@ -36,6 +36,7 @@ import (
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/raw"
+	"go.uber.org/yarpc/internal/yarpctest"
 	"go.uber.org/yarpc/transport/http"
 )
 
@@ -219,7 +220,7 @@ func withConnectedClient(t *testing.T, recorder *Recorder, f func(raw.Client)) {
 		Name: "client",
 		Outbounds: yarpc.Outbounds{
 			"server": {
-				Unary: httpTransport.NewSingleOutbound(fmt.Sprintf("http://%s", serverHTTP.Addr())),
+				Unary: httpTransport.NewSingleOutbound(fmt.Sprintf("http://%s", yarpctest.ZeroAddrToHostPort(serverHTTP.Addr()))),
 			},
 		},
 		OutboundMiddleware: yarpc.OutboundMiddleware{


### PR DESCRIPTION
See "net" in https://golang.org/doc/go1.9#minor_library_changes