### PR TITLE
Test that peer Single Introspect does not panic

### DIFF
--- a/peer/single_test.go
+++ b/peer/single_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package peer_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/yarpc/internal/introspection"
+	"go.uber.org/yarpc/peer"
+	"go.uber.org/yarpc/peer/hostport"
+	"go.uber.org/yarpc/yarpctest"
+)
+
+func TestSingleIntrospect(t *testing.T) {
+	single := peer.NewSingle(hostport.PeerIdentifier("x"), yarpctest.NewFakeTransport())
+	assert.Equal(t, introspection.ChooserStatus{
+		Name:  "Single",
+		Peers: []introspection.PeerStatus{{Identifier: "x", State: "uninitialized"}},
+	}, single.Introspect())
+}


### PR DESCRIPTION
I thought I had fixed https://github.com/yarpc/yarpc-go/issues/1009 before so I wrote a test to verify it is fixed.