### PR TITLE
Read entire resp body into buffer for retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ v1.16.0-dev (unreleased)
 -   x/retry: Fix bug where large TChannel responses would cause errors in retries.
 
 
+
 v1.15.0 (2017-09-15)
 --------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ v1.16.0-dev (unreleased)
 
 -   ThriftRW Plugin: Added an option to strip TChannel-specific
     information from Contexts before making outgoing requests.
+-   x/retry: Fix bug where large TChannel responses would cause errors in retries.
 
 
 v1.15.0 (2017-09-15)

--- a/internal/ioutil/buffercloser.go
+++ b/internal/ioutil/buffercloser.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ioutil
+
+import (
+	"bytes"
+	"io"
+	"sync"
+)
+
+var _pool = sync.Pool{
+	New: func() interface{} {
+		return &BufferCloser{
+			b: &bytes.Buffer{},
+		}
+	},
+}
+
+// BufferCloser is a light wrapping around the bytes.Buffer that implements
+// a "Close" method to return the buffer to a sync.Pool of buffers.
+type BufferCloser struct {
+	b *bytes.Buffer
+}
+
+// NewBufferCloser returns a new BufferCloser from the Buffer pool that has been
+// reset.
+func NewBufferCloser() *BufferCloser {
+	buf := _pool.Get().(*BufferCloser)
+	buf.b.Reset()
+	return buf
+}
+
+// ReadFrom implements io.ReaderFrom
+func (b *BufferCloser) ReadFrom(r io.Reader) (n int64, err error) {
+	return b.b.ReadFrom(r)
+}
+
+// WriteTo implements io.WriterTo
+func (b *BufferCloser) WriteTo(w io.Writer) (n int64, err error) {
+	return b.b.WriteTo(w)
+}
+
+// Read implements io.Reader
+func (b *BufferCloser) Read(p []byte) (n int, err error) {
+	return b.b.Read(p)
+}
+
+// Close implements io.Closer.  This will return the buffer to the buffer pool.
+func (b *BufferCloser) Close() error {
+	_pool.Put(b)
+	return nil
+}

--- a/internal/ioutil/buffercloser_test.go
+++ b/internal/ioutil/buffercloser_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ioutil
+
+import (
+	"bytes"
+	"io"
+	"math/rand"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuffers(t *testing.T) {
+	var wg sync.WaitGroup
+	for g := 0; g < 10; g++ {
+		wg.Add(1)
+		go func() {
+			for i := 0; i < 100; i++ {
+				buf := NewBufferCloser()
+				b := make([]byte, 1)
+				n, readErr := buf.Read(b)
+				assert.Equal(t, 0, n, "expected empty buffer")
+				assert.Equal(t, io.EOF, readErr, "expected empty buffer")
+
+				bytesOfNoise := make([]byte, rand.Intn(5000))
+				_, err := rand.Read(bytesOfNoise)
+				assert.NoError(t, err, "Unexpected error from rand.Read")
+				_, err = buf.ReadFrom(bytes.NewReader(bytesOfNoise))
+				assert.NoError(t, err, "Unexpected error from buf.ReadFrom")
+
+				if i%2 == 0 {
+					actualBytes := make([]byte, len(bytesOfNoise))
+					num, err := buf.Read(actualBytes)
+					assert.NoError(t, err, "unexpected error reading from buffer")
+					assert.Equal(t, len(bytesOfNoise), num, "wrong number of bytes read")
+					assert.Equal(t, string(bytesOfNoise), string(actualBytes), "bytes read did not match")
+				} else {
+					actualBuf := &bytes.Buffer{}
+					num, err := buf.WriteTo(actualBuf)
+					assert.NoError(t, err, "unexpected error writing to other buffer")
+					assert.Equal(t, len(bytesOfNoise), int(num), "wrong number of bytes written")
+					assert.Equal(t, string(bytesOfNoise), string(actualBuf.Bytes()), "bytes written did not match")
+				}
+
+				buf.Close()
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/ioutil/buffercloser_test.go
+++ b/internal/ioutil/buffercloser_test.go
@@ -38,12 +38,12 @@ func TestBuffers(t *testing.T) {
 			for i := 0; i < 100; i++ {
 				buf := NewBufferCloser()
 				b := make([]byte, 1)
-				n, readErr := buf.Read(b)
+				n, err := buf.Read(b)
 				assert.Equal(t, 0, n, "expected empty buffer")
-				assert.Equal(t, io.EOF, readErr, "expected empty buffer")
+				assert.Equal(t, io.EOF, err, "expected empty buffer")
 
 				bytesOfNoise := make([]byte, rand.Intn(5000))
-				_, err := rand.Read(bytesOfNoise)
+				_, err = rand.Read(bytesOfNoise)
 				assert.NoError(t, err, "Unexpected error from rand.Read")
 				_, err = buf.ReadFrom(bytes.NewReader(bytesOfNoise))
 				assert.NoError(t, err, "Unexpected error from buf.ReadFrom")

--- a/x/retry/observer.go
+++ b/x/retry/observer.go
@@ -45,6 +45,8 @@ const (
 	_yarpcInternal = "yarpc_internal"
 	_noTime        = "no_time"
 	_maxAttempts   = "max_attempts"
+
+	_unknownErrorName = "unknown_internal_yarpc"
 )
 
 type observerGraph struct {
@@ -243,7 +245,7 @@ func (c call) maxAttemptsError(err error) {
 
 func getErrorName(err error) string {
 	if !yarpcerrors.IsYARPCError(err) {
-		return "unknown_internal_yarpc"
+		return _unknownErrorName
 	}
 	return yarpcerrors.ErrorCode(err).String()
 }

--- a/x/retry/observer_test.go
+++ b/x/retry/observer_test.go
@@ -95,7 +95,7 @@ func TestErrorName(t *testing.T) {
 		{
 			msg:      "yarpc unknown",
 			giveErr:  errors.New("unknown"),
-			wantName: "unknown_internal_yarpc",
+			wantName: _unknownErrorName,
 		},
 	}
 

--- a/x/retry/retry.go
+++ b/x/retry/retry.go
@@ -209,11 +209,11 @@ func isIdempotentProcedureRetryable(err error) bool {
 func readBody(src io.ReadCloser) (io.ReadCloser, error) {
 	buffer := ioutil.NewBufferCloser()
 	if _, err := buffer.ReadFrom(src); err != nil {
-		buffer.Close() // Make sure we cleanup the buffer.
+		buffer.Close() // Make sure we clean up the buffer.
 		return nil, err
 	}
 	if err := src.Close(); err != nil {
-		buffer.Close() // Make sure we cleanup the buffer.
+		buffer.Close() // Make sure we clean up the buffer.
 		return nil, err
 	}
 	return buffer, nil


### PR DESCRIPTION
Summary: Depending on the transport, we might have cases where
the "success" of a request is not determined until the io.ReadCloser
body of the Response has been fully read (example being tchannel
requests that have more than 1 frame (1<<16 bytes)).  If we pass
back the body to the handler and reading the body fails, we no longer
have the ability to retry the request.

This PR reads the response body into a "buffercloser" type that is
a pooled buffer that will return itself to the sync pool when the
"Close" method is called. It also supports "ReadFrom" for wrapping
the incoming io.Reader, and io.WriteTo to allow io.Copy without
allocations.

Test Plan: added tests, have tested this in the frontcar repo with
its megasuite integration tests.