### PR TITLE
Use the buffer pool for gRPC Inbounds

### DIFF
--- a/transport/x/grpc/config_test.go
+++ b/transport/x/grpc/config_test.go
@@ -35,11 +35,10 @@ import (
 func TestNewTransportSpecOptions(t *testing.T) {
 	transportSpec, err := newTransportSpec(
 		BackoffStrategy(nil),
-		withInboundUnaryInterceptor(nil),
 	)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(transportSpec.TransportOptions))
-	require.Equal(t, 1, len(transportSpec.InboundOptions))
+	require.Equal(t, 0, len(transportSpec.InboundOptions))
 	require.Equal(t, 0, len(transportSpec.OutboundOptions))
 }
 

--- a/transport/x/grpc/handler.go
+++ b/transport/x/grpc/handler.go
@@ -103,24 +103,6 @@ func (h *handler) handleBeforeErrorConversion(
 	ctx, span := extractOpenTracingSpan.Do(ctx, transportRequest)
 	defer span.Finish()
 
-	if h.i.options.unaryInterceptor != nil {
-		return h.i.options.unaryInterceptor(
-			ctx,
-			transportRequest,
-			&grpc.UnaryServerInfo{
-				Server:     noopGrpcStruct{},
-				FullMethod: streamMethod,
-			},
-			func(ctx context.Context, request interface{}) (interface{}, error) {
-				transportRequest, ok := request.(*transport.Request)
-				if !ok {
-					return nil, yarpcerrors.InternalErrorf("expected *transport.Request, got %T", request)
-				}
-				response, err := h.call(ctx, transportRequest, responseMD)
-				return response, transport.UpdateSpanWithErr(span, err)
-			},
-		)
-	}
 	response, err := h.call(ctx, transportRequest, responseMD)
 	return response, transport.UpdateSpanWithErr(span, err)
 }

--- a/transport/x/grpc/integration_test.go
+++ b/transport/x/grpc/integration_test.go
@@ -40,7 +40,6 @@ import (
 	"go.uber.org/yarpc/yarpcerrors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
@@ -65,16 +64,6 @@ func TestGRPCBasic(t *testing.T) {
 		value, err := e.GetValueGRPC(context.Background(), "foo")
 		assert.NoError(t, err)
 		assert.Equal(t, "bar", value)
-	})
-}
-
-func TestYARPCMetadata(t *testing.T) {
-	t.Parallel()
-	var md metadata.MD
-	doWithTestEnv(t, nil, []InboundOption{withInboundUnaryInterceptor(newMetadataUnaryServerInterceptor(&md))}, nil, func(t *testing.T, e *testEnv) {
-		assert.NoError(t, e.SetValueYARPC(context.Background(), "foo", "bar"))
-		assert.Len(t, md["user-agent"], 1)
-		assert.True(t, strings.Contains(md["user-agent"][0], UserAgent))
 	})
 }
 

--- a/transport/x/grpc/options.go
+++ b/transport/x/grpc/options.go
@@ -1,5 +1,6 @@
 // Copyright (c) 2017 Uber Technologies, Inc.
 //
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
@@ -26,7 +27,6 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"go.uber.org/yarpc/api/backoff"
 	intbackoff "go.uber.org/yarpc/internal/backoff"
-	"google.golang.org/grpc"
 )
 
 const (
@@ -143,9 +143,7 @@ func newTransportOptions(options []TransportOption) *transportOptions {
 	return transportOptions
 }
 
-type inboundOptions struct {
-	unaryInterceptor grpc.UnaryServerInterceptor
-}
+type inboundOptions struct{}
 
 func newInboundOptions(options []InboundOption) *inboundOptions {
 	inboundOptions := &inboundOptions{}
@@ -163,12 +161,4 @@ func newOutboundOptions(options []OutboundOption) *outboundOptions {
 		option(outboundOptions)
 	}
 	return outboundOptions
-}
-
-// for testing only for now
-// grpc-go only allows one interceptor, so need to handle all cases
-func withInboundUnaryInterceptor(unaryInterceptor grpc.UnaryServerInterceptor) InboundOption {
-	return func(inboundOptions *inboundOptions) {
-		inboundOptions.unaryInterceptor = unaryInterceptor
-	}
 }

--- a/transport/x/grpc/options.go
+++ b/transport/x/grpc/options.go
@@ -1,6 +1,5 @@
 // Copyright (c) 2017 Uber Technologies, Inc.
 //
-//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights

--- a/transport/x/grpc/response_writer.go
+++ b/transport/x/grpc/response_writer.go
@@ -24,28 +24,57 @@ import (
 	"bytes"
 
 	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/bufferpool"
 	"google.golang.org/grpc/metadata"
 )
 
 type responseWriter struct {
-	*bytes.Buffer
+	buffer             *bytes.Buffer
 	md                 metadata.MD
 	isApplicationError bool
 }
 
-func newResponseWriter(md metadata.MD) *responseWriter {
-	return &responseWriter{
-		bytes.NewBuffer(nil),
-		md,
-		false,
+func newResponseWriter() *responseWriter {
+	return &responseWriter{}
+}
+
+func (r *responseWriter) Write(p []byte) (int, error) {
+	if r.buffer == nil {
+		r.buffer = bufferpool.Get()
 	}
+	return r.buffer.Write(p)
 }
 
 func (r *responseWriter) AddHeaders(headers transport.Headers) {
+	if r.md == nil {
+		r.md = metadata.New(nil)
+	}
 	// TODO: handle error
 	_ = addApplicationHeaders(r.md, headers)
 }
 
 func (r *responseWriter) SetApplicationError() {
 	r.isApplicationError = true
+}
+
+func (r *responseWriter) AddSystemHeader(key string, value string) {
+	if r.md == nil {
+		r.md = metadata.New(nil)
+	}
+	// TODO: handle error
+	_ = addToMetadata(r.md, key, value)
+}
+
+func (r *responseWriter) Bytes() []byte {
+	if r.buffer == nil {
+		return nil
+	}
+	return r.buffer.Bytes()
+}
+
+func (r *responseWriter) Close() {
+	if r.buffer != nil {
+		bufferpool.Put(r.buffer)
+	}
+	r.buffer = nil
 }


### PR DESCRIPTION
This reworks the code in `transport/x/grpc` to use the buffer pool for inbounds. This is possible because we control the necessary buffers end-to-end within the `transport/x/grpc` package, outbounds will take more work. This also has the effect of only calling `metadata.New(nil)` to allocate a `metadata.MD` when necessary for inbounds.

This reduces the number of allocations made for every call by 3 in testing.

This also deletes the `withInboundUnaryInterceptor` option as this would make this more difficult - deleting this is something @willhug wanted anyways, and it wasn't much use even in testing.