### PR TITLE
Make thrift arguments lowercase

### DIFF
--- a/encoding/thrift/thriftrw-plugin-yarpc/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/client.go
@@ -50,7 +50,7 @@ type Interface interface {
 		<$context := import "context">
 		<.Name>(
 			ctx <$context>.Context, <range .Arguments>
-			<.Name> <formatType .Type>,<end>
+			<lower .Name> <formatType .Type>,<end>
 			opts ...<$yarpc>.CallOption,
 		)<if .OneWay> (<$yarpc>.Ack, error)
 		<else if .ReturnType> (<formatType .ReturnType>, error)
@@ -97,15 +97,15 @@ type client struct {
 
 func (c client) <.Name>(
 	ctx <$context>.Context, <range .Arguments>
-	_<.Name> <formatType .Type>,<end>
+	<lower .Name>Arg <formatType .Type>,<end>
 	opts ...<$yarpc>.CallOption,
 <if .OneWay>) (<$yarpc>.Ack, error) {
-	args := <$prefix>Helper.Args(<range .Arguments>_<.Name>, <end>)
+	args := <$prefix>Helper.Args(<range .Arguments><lower .Name>Arg, <end>)
 	return c.c.CallOneway(ctx, args, opts...)
 }
 <else>) (<if .ReturnType>success <formatType .ReturnType>,<end> err error) {
 	<$wire := import "go.uber.org/thriftrw/wire">
-	args := <$prefix>Helper.Args(<range .Arguments>_<.Name>, <end>)
+	args := <$prefix>Helper.Args(<range .Arguments><lower .Name>Arg, <end>)
 
 	<if $sanitize>ctx = <import "github.com/uber/tchannel-go">.WithoutHeaders(ctx)<end>
 	var body <$wire>.Value

--- a/encoding/thrift/thriftrw-plugin-yarpc/gomock.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/gomock.go
@@ -78,12 +78,12 @@ func (m *MockClient) EXPECT() *_MockClientRecorder {
 // 	... := client.<.Name>(...)
 func (m *MockClient) <.Name>(
 	ctx <$context>.Context, <range .Arguments>
-	_<.Name> <formatType .Type>,<end>
+	<lower .Name>Arg <formatType .Type>,<end>
 	opts ...<$yarpc>.CallOption,
 ) <if .OneWay> (ack <$yarpc>.Ack, err error) {
   <else>       (<if .ReturnType>success <formatType .ReturnType>,<end> err error) {
   <end>
-	args := []interface{}{ctx,<range .Arguments> _<.Name>,<end>}
+	args := []interface{}{ctx,<range .Arguments> <lower .Name>Arg,<end>}
 	for _, o := range opts {
 		args = append(args, o)
 	}
@@ -97,10 +97,10 @@ func (m *MockClient) <.Name>(
 
 func (mr *_MockClientRecorder) <.Name>(
 	ctx interface{}, <range .Arguments>
-	_<.Name> interface{},<end>
+	<lower .Name>Arg interface{},<end>
 	opts ...interface{},
 ) *gomock.Call {
-	args := append([]interface{}{ctx,<range .Arguments> _<.Name>,<end>}, opts...)
+	args := append([]interface{}{ctx,<range .Arguments> <lower .Name>Arg,<end>}, opts...)
 	return mr.mock.ctrl.RecordCall(mr.mock, "<.Name>", args...)
 }
 <end>

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/readonlystoreclient/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/readonlystoreclient/client.go
@@ -20,7 +20,7 @@ type Interface interface {
 
 	Integer(
 		ctx context.Context,
-		Key *string,
+		key *string,
 		opts ...yarpc.CallOption,
 	) (int64, error)
 }
@@ -54,11 +54,11 @@ type client struct {
 
 func (c client) Integer(
 	ctx context.Context,
-	_Key *string,
+	keyArg *string,
 	opts ...yarpc.CallOption,
 ) (success int64, err error) {
 
-	args := atomic.ReadOnlyStore_Integer_Helper.Args(_Key)
+	args := atomic.ReadOnlyStore_Integer_Helper.Args(keyArg)
 
 	var body wire.Value
 	body, err = c.c.Call(ctx, args, opts...)

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/readonlystoreserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/readonlystoreserver/server.go
@@ -18,7 +18,7 @@ type Interface interface {
 
 	Integer(
 		ctx context.Context,
-		Key *string,
+		key *string,
 	) (int64, error)
 }
 
@@ -40,7 +40,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					Type:  transport.Unary,
 					Unary: thrift.UnaryHandler(h.Integer),
 				},
-				Signature:    "Integer(Key *string) (int64)",
+				Signature:    "Integer(key *string) (int64)",
 				ThriftModule: atomic.ThriftModule,
 			},
 		},

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/readonlystoretest/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/readonlystoretest/client.go
@@ -49,11 +49,11 @@ func (m *MockClient) EXPECT() *_MockClientRecorder {
 // 	... := client.Integer(...)
 func (m *MockClient) Integer(
 	ctx context.Context,
-	_Key *string,
+	keyArg *string,
 	opts ...yarpc.CallOption,
 ) (success int64, err error) {
 
-	args := []interface{}{ctx, _Key}
+	args := []interface{}{ctx, keyArg}
 	for _, o := range opts {
 		args = append(args, o)
 	}
@@ -67,10 +67,10 @@ func (m *MockClient) Integer(
 
 func (mr *_MockClientRecorder) Integer(
 	ctx interface{},
-	_Key interface{},
+	keyArg interface{},
 	opts ...interface{},
 ) *gomock.Call {
-	args := append([]interface{}{ctx, _Key}, opts...)
+	args := append([]interface{}{ctx, keyArg}, opts...)
 	return mr.mock.ctrl.RecordCall(mr.mock, "Integer", args...)
 }
 

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storeclient/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storeclient/client.go
@@ -20,20 +20,20 @@ type Interface interface {
 
 	CompareAndSwap(
 		ctx context.Context,
-		Request *atomic.CompareAndSwap,
+		request *atomic.CompareAndSwap,
 		opts ...yarpc.CallOption,
 	) error
 
 	Forget(
 		ctx context.Context,
-		Key *string,
+		key *string,
 		opts ...yarpc.CallOption,
 	) (yarpc.Ack, error)
 
 	Increment(
 		ctx context.Context,
-		Key *string,
-		Value *int64,
+		key *string,
+		value *int64,
 		opts ...yarpc.CallOption,
 	) error
 }
@@ -67,11 +67,11 @@ type client struct {
 
 func (c client) CompareAndSwap(
 	ctx context.Context,
-	_Request *atomic.CompareAndSwap,
+	requestArg *atomic.CompareAndSwap,
 	opts ...yarpc.CallOption,
 ) (err error) {
 
-	args := atomic.Store_CompareAndSwap_Helper.Args(_Request)
+	args := atomic.Store_CompareAndSwap_Helper.Args(requestArg)
 
 	var body wire.Value
 	body, err = c.c.Call(ctx, args, opts...)
@@ -90,21 +90,21 @@ func (c client) CompareAndSwap(
 
 func (c client) Forget(
 	ctx context.Context,
-	_Key *string,
+	keyArg *string,
 	opts ...yarpc.CallOption,
 ) (yarpc.Ack, error) {
-	args := atomic.Store_Forget_Helper.Args(_Key)
+	args := atomic.Store_Forget_Helper.Args(keyArg)
 	return c.c.CallOneway(ctx, args, opts...)
 }
 
 func (c client) Increment(
 	ctx context.Context,
-	_Key *string,
-	_Value *int64,
+	keyArg *string,
+	valueArg *int64,
 	opts ...yarpc.CallOption,
 ) (err error) {
 
-	args := atomic.Store_Increment_Helper.Args(_Key, _Value)
+	args := atomic.Store_Increment_Helper.Args(keyArg, valueArg)
 
 	var body wire.Value
 	body, err = c.c.Call(ctx, args, opts...)

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storeserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storeserver/server.go
@@ -18,18 +18,18 @@ type Interface interface {
 
 	CompareAndSwap(
 		ctx context.Context,
-		Request *atomic.CompareAndSwap,
+		request *atomic.CompareAndSwap,
 	) error
 
 	Forget(
 		ctx context.Context,
-		Key *string,
+		key *string,
 	) error
 
 	Increment(
 		ctx context.Context,
-		Key *string,
-		Value *int64,
+		key *string,
+		value *int64,
 	) error
 }
 
@@ -51,7 +51,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					Type:  transport.Unary,
 					Unary: thrift.UnaryHandler(h.CompareAndSwap),
 				},
-				Signature:    "CompareAndSwap(Request *atomic.CompareAndSwap)",
+				Signature:    "CompareAndSwap(request *atomic.CompareAndSwap)",
 				ThriftModule: atomic.ThriftModule,
 			},
 
@@ -62,7 +62,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					Type:   transport.Oneway,
 					Oneway: thrift.OnewayHandler(h.Forget),
 				},
-				Signature:    "Forget(Key *string)",
+				Signature:    "Forget(key *string)",
 				ThriftModule: atomic.ThriftModule,
 			},
 
@@ -73,7 +73,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					Type:  transport.Unary,
 					Unary: thrift.UnaryHandler(h.Increment),
 				},
-				Signature:    "Increment(Key *string, Value *int64)",
+				Signature:    "Increment(key *string, value *int64)",
 				ThriftModule: atomic.ThriftModule,
 			},
 		},

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storetest/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storetest/client.go
@@ -50,11 +50,11 @@ func (m *MockClient) EXPECT() *_MockClientRecorder {
 // 	... := client.CompareAndSwap(...)
 func (m *MockClient) CompareAndSwap(
 	ctx context.Context,
-	_Request *atomic.CompareAndSwap,
+	requestArg *atomic.CompareAndSwap,
 	opts ...yarpc.CallOption,
 ) (err error) {
 
-	args := []interface{}{ctx, _Request}
+	args := []interface{}{ctx, requestArg}
 	for _, o := range opts {
 		args = append(args, o)
 	}
@@ -66,10 +66,10 @@ func (m *MockClient) CompareAndSwap(
 
 func (mr *_MockClientRecorder) CompareAndSwap(
 	ctx interface{},
-	_Request interface{},
+	requestArg interface{},
 	opts ...interface{},
 ) *gomock.Call {
-	args := append([]interface{}{ctx, _Request}, opts...)
+	args := append([]interface{}{ctx, requestArg}, opts...)
 	return mr.mock.ctrl.RecordCall(mr.mock, "CompareAndSwap", args...)
 }
 
@@ -81,11 +81,11 @@ func (mr *_MockClientRecorder) CompareAndSwap(
 // 	... := client.Forget(...)
 func (m *MockClient) Forget(
 	ctx context.Context,
-	_Key *string,
+	keyArg *string,
 	opts ...yarpc.CallOption,
 ) (ack yarpc.Ack, err error) {
 
-	args := []interface{}{ctx, _Key}
+	args := []interface{}{ctx, keyArg}
 	for _, o := range opts {
 		args = append(args, o)
 	}
@@ -99,10 +99,10 @@ func (m *MockClient) Forget(
 
 func (mr *_MockClientRecorder) Forget(
 	ctx interface{},
-	_Key interface{},
+	keyArg interface{},
 	opts ...interface{},
 ) *gomock.Call {
-	args := append([]interface{}{ctx, _Key}, opts...)
+	args := append([]interface{}{ctx, keyArg}, opts...)
 	return mr.mock.ctrl.RecordCall(mr.mock, "Forget", args...)
 }
 
@@ -114,12 +114,12 @@ func (mr *_MockClientRecorder) Forget(
 // 	... := client.Increment(...)
 func (m *MockClient) Increment(
 	ctx context.Context,
-	_Key *string,
-	_Value *int64,
+	keyArg *string,
+	valueArg *int64,
 	opts ...yarpc.CallOption,
 ) (err error) {
 
-	args := []interface{}{ctx, _Key, _Value}
+	args := []interface{}{ctx, keyArg, valueArg}
 	for _, o := range opts {
 		args = append(args, o)
 	}
@@ -131,11 +131,11 @@ func (m *MockClient) Increment(
 
 func (mr *_MockClientRecorder) Increment(
 	ctx interface{},
-	_Key interface{},
-	_Value interface{},
+	keyArg interface{},
+	valueArg interface{},
 	opts ...interface{},
 ) *gomock.Call {
-	args := append([]interface{}{ctx, _Key, _Value}, opts...)
+	args := append([]interface{}{ctx, keyArg, valueArg}, opts...)
 	return mr.mock.ctrl.RecordCall(mr.mock, "Increment", args...)
 }
 
@@ -147,11 +147,11 @@ func (mr *_MockClientRecorder) Increment(
 // 	... := client.Integer(...)
 func (m *MockClient) Integer(
 	ctx context.Context,
-	_Key *string,
+	keyArg *string,
 	opts ...yarpc.CallOption,
 ) (success int64, err error) {
 
-	args := []interface{}{ctx, _Key}
+	args := []interface{}{ctx, keyArg}
 	for _, o := range opts {
 		args = append(args, o)
 	}
@@ -165,10 +165,10 @@ func (m *MockClient) Integer(
 
 func (mr *_MockClientRecorder) Integer(
 	ctx interface{},
-	_Key interface{},
+	keyArg interface{},
 	opts ...interface{},
 ) *gomock.Call {
-	args := append([]interface{}{ctx, _Key}, opts...)
+	args := append([]interface{}{ctx, keyArg}, opts...)
 	return mr.mock.ctrl.RecordCall(mr.mock, "Integer", args...)
 }
 

--- a/encoding/thrift/thriftrw-plugin-yarpc/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/server.go
@@ -55,7 +55,7 @@ type Interface interface {
 		<$context := import $contextImportPath>
 		<.Name>(
 			ctx <$context>.Context, <range .Arguments>
-			<.Name> <formatType .Type>,<end>
+			<lower .Name> <formatType .Type>,<end>
 		)<if .OneWay> error
 		<else if .ReturnType> (<formatType .ReturnType>, error)
 		<else> error
@@ -87,7 +87,7 @@ func New(impl Interface, opts ...<$thrift>.RegisterOption) []<$transport>.Proced
 					Unary: <import $unaryWrapperImport>.<$unaryWrapperFunc>(h.<.Name>),
 				<end>
 				},
-				Signature: "<.Name>(<range $i, $v := .Arguments><if ne $i 0>, <end><.Name> <formatType .Type><end>)<if not .OneWay | and .ReturnType> (<formatType .ReturnType>)<end>",
+				Signature: "<.Name>(<range $i, $v := .Arguments><if ne $i 0>, <end><lower .Name> <formatType .Type><end>)<if not .OneWay | and .ReturnType> (<formatType .ReturnType>)<end>",
 				ThriftModule: <import $module.ImportPath>.ThriftModule,
 				},
 		<end>},

--- a/internal/crossdock/thrift/echo/echoclient/client.go
+++ b/internal/crossdock/thrift/echo/echoclient/client.go
@@ -37,7 +37,7 @@ import (
 type Interface interface {
 	Echo(
 		ctx context.Context,
-		Ping *echo.Ping,
+		ping *echo.Ping,
 		opts ...yarpc.CallOption,
 	) (*echo.Pong, error)
 }
@@ -68,11 +68,11 @@ type client struct {
 
 func (c client) Echo(
 	ctx context.Context,
-	_Ping *echo.Ping,
+	pingArg *echo.Ping,
 	opts ...yarpc.CallOption,
 ) (success *echo.Pong, err error) {
 
-	args := echo.Echo_Echo_Helper.Args(_Ping)
+	args := echo.Echo_Echo_Helper.Args(pingArg)
 
 	var body wire.Value
 	body, err = c.c.Call(ctx, args, opts...)

--- a/internal/crossdock/thrift/echo/echoserver/server.go
+++ b/internal/crossdock/thrift/echo/echoserver/server.go
@@ -35,7 +35,7 @@ import (
 type Interface interface {
 	Echo(
 		ctx context.Context,
-		Ping *echo.Ping,
+		ping *echo.Ping,
 	) (*echo.Pong, error)
 }
 
@@ -57,7 +57,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					Type:  transport.Unary,
 					Unary: thrift.UnaryHandler(h.Echo),
 				},
-				Signature:    "Echo(Ping *echo.Ping) (*echo.Pong)",
+				Signature:    "Echo(ping *echo.Ping) (*echo.Pong)",
 				ThriftModule: echo.ThriftModule,
 			},
 		},

--- a/internal/crossdock/thrift/echo/echotest/client.go
+++ b/internal/crossdock/thrift/echo/echotest/client.go
@@ -70,11 +70,11 @@ func (m *MockClient) EXPECT() *_MockClientRecorder {
 // 	... := client.Echo(...)
 func (m *MockClient) Echo(
 	ctx context.Context,
-	_Ping *echo.Ping,
+	pingArg *echo.Ping,
 	opts ...yarpc.CallOption,
 ) (success *echo.Pong, err error) {
 
-	args := []interface{}{ctx, _Ping}
+	args := []interface{}{ctx, pingArg}
 	for _, o := range opts {
 		args = append(args, o)
 	}
@@ -88,9 +88,9 @@ func (m *MockClient) Echo(
 
 func (mr *_MockClientRecorder) Echo(
 	ctx interface{},
-	_Ping interface{},
+	pingArg interface{},
 	opts ...interface{},
 ) *gomock.Call {
-	args := append([]interface{}{ctx, _Ping}, opts...)
+	args := append([]interface{}{ctx, pingArg}, opts...)
 	return mr.mock.ctrl.RecordCall(mr.mock, "Echo", args...)
 }

--- a/internal/crossdock/thrift/gauntlet/secondserviceclient/client.go
+++ b/internal/crossdock/thrift/gauntlet/secondserviceclient/client.go
@@ -42,7 +42,7 @@ type Interface interface {
 
 	SecondtestString(
 		ctx context.Context,
-		Thing *string,
+		thing *string,
 		opts ...yarpc.CallOption,
 	) (string, error)
 }
@@ -95,11 +95,11 @@ func (c client) BlahBlah(
 
 func (c client) SecondtestString(
 	ctx context.Context,
-	_Thing *string,
+	thingArg *string,
 	opts ...yarpc.CallOption,
 ) (success string, err error) {
 
-	args := gauntlet.SecondService_SecondtestString_Helper.Args(_Thing)
+	args := gauntlet.SecondService_SecondtestString_Helper.Args(thingArg)
 
 	var body wire.Value
 	body, err = c.c.Call(ctx, args, opts...)

--- a/internal/crossdock/thrift/gauntlet/secondserviceserver/server.go
+++ b/internal/crossdock/thrift/gauntlet/secondserviceserver/server.go
@@ -39,7 +39,7 @@ type Interface interface {
 
 	SecondtestString(
 		ctx context.Context,
-		Thing *string,
+		thing *string,
 	) (string, error)
 }
 
@@ -72,7 +72,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					Type:  transport.Unary,
 					Unary: thrift.UnaryHandler(h.SecondtestString),
 				},
-				Signature:    "SecondtestString(Thing *string) (string)",
+				Signature:    "SecondtestString(thing *string) (string)",
 				ThriftModule: gauntlet.ThriftModule,
 			},
 		},

--- a/internal/crossdock/thrift/gauntlet/secondservicetest/client.go
+++ b/internal/crossdock/thrift/gauntlet/secondservicetest/client.go
@@ -98,11 +98,11 @@ func (mr *_MockClientRecorder) BlahBlah(
 // 	... := client.SecondtestString(...)
 func (m *MockClient) SecondtestString(
 	ctx context.Context,
-	_Thing *string,
+	thingArg *string,
 	opts ...yarpc.CallOption,
 ) (success string, err error) {
 
-	args := []interface{}{ctx, _Thing}
+	args := []interface{}{ctx, thingArg}
 	for _, o := range opts {
 		args = append(args, o)
 	}
@@ -116,9 +116,9 @@ func (m *MockClient) SecondtestString(
 
 func (mr *_MockClientRecorder) SecondtestString(
 	ctx interface{},
-	_Thing interface{},
+	thingArg interface{},
 	opts ...interface{},
 ) *gomock.Call {
-	args := append([]interface{}{ctx, _Thing}, opts...)
+	args := append([]interface{}{ctx, thingArg}, opts...)
 	return mr.mock.ctrl.RecordCall(mr.mock, "SecondtestString", args...)
 }

--- a/internal/crossdock/thrift/gauntlet/thrifttestclient/client.go
+++ b/internal/crossdock/thrift/gauntlet/thrifttestclient/client.go
@@ -37,127 +37,127 @@ import (
 type Interface interface {
 	TestBinary(
 		ctx context.Context,
-		Thing []byte,
+		thing []byte,
 		opts ...yarpc.CallOption,
 	) ([]byte, error)
 
 	TestByte(
 		ctx context.Context,
-		Thing *int8,
+		thing *int8,
 		opts ...yarpc.CallOption,
 	) (int8, error)
 
 	TestDouble(
 		ctx context.Context,
-		Thing *float64,
+		thing *float64,
 		opts ...yarpc.CallOption,
 	) (float64, error)
 
 	TestEnum(
 		ctx context.Context,
-		Thing *gauntlet.Numberz,
+		thing *gauntlet.Numberz,
 		opts ...yarpc.CallOption,
 	) (gauntlet.Numberz, error)
 
 	TestException(
 		ctx context.Context,
-		Arg *string,
+		arg *string,
 		opts ...yarpc.CallOption,
 	) error
 
 	TestI32(
 		ctx context.Context,
-		Thing *int32,
+		thing *int32,
 		opts ...yarpc.CallOption,
 	) (int32, error)
 
 	TestI64(
 		ctx context.Context,
-		Thing *int64,
+		thing *int64,
 		opts ...yarpc.CallOption,
 	) (int64, error)
 
 	TestInsanity(
 		ctx context.Context,
-		Argument *gauntlet.Insanity,
+		argument *gauntlet.Insanity,
 		opts ...yarpc.CallOption,
 	) (map[gauntlet.UserId]map[gauntlet.Numberz]*gauntlet.Insanity, error)
 
 	TestList(
 		ctx context.Context,
-		Thing []int32,
+		thing []int32,
 		opts ...yarpc.CallOption,
 	) ([]int32, error)
 
 	TestMap(
 		ctx context.Context,
-		Thing map[int32]int32,
+		thing map[int32]int32,
 		opts ...yarpc.CallOption,
 	) (map[int32]int32, error)
 
 	TestMapMap(
 		ctx context.Context,
-		Hello *int32,
+		hello *int32,
 		opts ...yarpc.CallOption,
 	) (map[int32]map[int32]int32, error)
 
 	TestMulti(
 		ctx context.Context,
-		Arg0 *int8,
-		Arg1 *int32,
-		Arg2 *int64,
-		Arg3 map[int16]string,
-		Arg4 *gauntlet.Numberz,
-		Arg5 *gauntlet.UserId,
+		arg0 *int8,
+		arg1 *int32,
+		arg2 *int64,
+		arg3 map[int16]string,
+		arg4 *gauntlet.Numberz,
+		arg5 *gauntlet.UserId,
 		opts ...yarpc.CallOption,
 	) (*gauntlet.Xtruct, error)
 
 	TestMultiException(
 		ctx context.Context,
-		Arg0 *string,
-		Arg1 *string,
+		arg0 *string,
+		arg1 *string,
 		opts ...yarpc.CallOption,
 	) (*gauntlet.Xtruct, error)
 
 	TestNest(
 		ctx context.Context,
-		Thing *gauntlet.Xtruct2,
+		thing *gauntlet.Xtruct2,
 		opts ...yarpc.CallOption,
 	) (*gauntlet.Xtruct2, error)
 
 	TestOneway(
 		ctx context.Context,
-		SecondsToSleep *int32,
+		secondstosleep *int32,
 		opts ...yarpc.CallOption,
 	) (yarpc.Ack, error)
 
 	TestSet(
 		ctx context.Context,
-		Thing map[int32]struct{},
+		thing map[int32]struct{},
 		opts ...yarpc.CallOption,
 	) (map[int32]struct{}, error)
 
 	TestString(
 		ctx context.Context,
-		Thing *string,
+		thing *string,
 		opts ...yarpc.CallOption,
 	) (string, error)
 
 	TestStringMap(
 		ctx context.Context,
-		Thing map[string]string,
+		thing map[string]string,
 		opts ...yarpc.CallOption,
 	) (map[string]string, error)
 
 	TestStruct(
 		ctx context.Context,
-		Thing *gauntlet.Xtruct,
+		thing *gauntlet.Xtruct,
 		opts ...yarpc.CallOption,
 	) (*gauntlet.Xtruct, error)
 
 	TestTypedef(
 		ctx context.Context,
-		Thing *gauntlet.UserId,
+		thing *gauntlet.UserId,
 		opts ...yarpc.CallOption,
 	) (gauntlet.UserId, error)
 
@@ -193,11 +193,11 @@ type client struct {
 
 func (c client) TestBinary(
 	ctx context.Context,
-	_Thing []byte,
+	thingArg []byte,
 	opts ...yarpc.CallOption,
 ) (success []byte, err error) {
 
-	args := gauntlet.ThriftTest_TestBinary_Helper.Args(_Thing)
+	args := gauntlet.ThriftTest_TestBinary_Helper.Args(thingArg)
 
 	var body wire.Value
 	body, err = c.c.Call(ctx, args, opts...)
@@ -216,11 +216,11 @@ func (c client) TestBinary(
 
 func (c client) TestByte(
 	ctx context.Context,
-	_Thing *int8,
+	thingArg *int8,
 	opts ...yarpc.CallOption,
 ) (success int8, err error) {
 
-	args := gauntlet.ThriftTest_TestByte_Helper.Args(_Thing)
+	args := gauntlet.ThriftTest_TestByte_Helper.Args(thingArg)
 
 	var body wire.Value
 	body, err = c.c.Call(ctx, args, opts...)
@@ -239,11 +239,11 @@ func (c client) TestByte(
 
 func (c client) TestDouble(
 	ctx context.Context,
-	_Thing *float64,
+	thingArg *float64,
 	opts ...yarpc.CallOption,
 ) (success float64, err error) {
 
-	args := gauntlet.ThriftTest_TestDouble_Helper.Args(_Thing)
+	args := gauntlet.ThriftTest_TestDouble_Helper.Args(thingArg)
 
 	var body wire.Value
 	body, err = c.c.Call(ctx, args, opts...)
@@ -262,11 +262,11 @@ func (c client) TestDouble(
 
 func (c client) TestEnum(
 	ctx context.Context,
-	_Thing *gauntlet.Numberz,
+	thingArg *gauntlet.Numberz,
 	opts ...yarpc.CallOption,
 ) (success gauntlet.Numberz, err error) {
 
-	args := gauntlet.ThriftTest_TestEnum_Helper.Args(_Thing)
+	args := gauntlet.ThriftTest_TestEnum_Helper.Args(thingArg)
 
 	var body wire.Value
 	body, err = c.c.Call(ctx, args, opts...)
@@ -285,11 +285,11 @@ func (c client) TestEnum(
 
 func (c client) TestException(
 	ctx context.Context,
-	_Arg *string,
+	argArg *string,
 	opts ...yarpc.CallOption,
 ) (err error) {
 
-	args := gauntlet.ThriftTest_TestException_Helper.Args(_Arg)
+	args := gauntlet.ThriftTest_TestException_Helper.Args(argArg)
 
 	var body wire.Value
 	body, err = c.c.Call(ctx, args, opts...)
@@ -308,11 +308,11 @@ func (c client) TestException(
 
 func (c client) TestI32(
 	ctx context.Context,
-	_Thing *int32,
+	thingArg *int32,
 	opts ...yarpc.CallOption,
 ) (success int32, err error) {
 
-	args := gauntlet.ThriftTest_TestI32_Helper.Args(_Thing)
+	args := gauntlet.ThriftTest_TestI32_Helper.Args(thingArg)
 
 	var body wire.Value
 	body, err = c.c.Call(ctx, args, opts...)
@@ -331,11 +331,11 @@ func (c client) TestI32(
 
 func (c client) TestI64(
 	ctx context.Context,
-	_Thing *int64,
+	thingArg *int64,
 	opts ...yarpc.CallOption,
 ) (success int64, err error) {
 
-	args := gauntlet.ThriftTest_TestI64_Helper.Args(_Thing)
+	args := gauntlet.ThriftTest_TestI64_Helper.Args(thingArg)
 
 	var body wire.Value
 	body, err = c.c.Call(ctx, args, opts...)
@@ -354,11 +354,11 @@ func (c client) TestI64(
 
 func (c client) TestInsanity(
 	ctx context.Context,
-	_Argument *gauntlet.Insanity,
+	argumentArg *gauntlet.Insanity,
 	opts ...yarpc.CallOption,
 ) (success map[gauntlet.UserId]map[gauntlet.Numberz]*gauntlet.Insanity, err error) {
 
-	args := gauntlet.ThriftTest_TestInsanity_Helper.Args(_Argument)
+	args := gauntlet.ThriftTest_TestInsanity_Helper.Args(argumentArg)
 
 	var body wire.Value
 	body, err = c.c.Call(ctx, args, opts...)
@@ -377,11 +377,11 @@ func (c client) TestInsanity(
 
 func (c client) TestList(
 	ctx context.Context,
-	_Thing []int32,
+	thingArg []int32,
 	opts ...yarpc.CallOption,
 ) (success []int32, err error) {
 
-	args := gauntlet.ThriftTest_TestList_Helper.Args(_Thing)
+	args := gauntlet.ThriftTest_TestList_Helper.Args(thingArg)
 
 	var body wire.Value
 	body, err = c.c.Call(ctx, args, opts...)
@@ -400,11 +400,11 @@ func (c client) TestList(
 
 func (c client) TestMap(
 	ctx context.Context,
-	_Thing map[int32]int32,
+	thingArg map[int32]int32,
 	opts ...yarpc.CallOption,
 ) (success map[int32]int32, err error) {
 
-	args := gauntlet.ThriftTest_TestMap_Helper.Args(_Thing)
+	args := gauntlet.ThriftTest_TestMap_Helper.Args(thingArg)
 
 	var body wire.Value
 	body, err = c.c.Call(ctx, args, opts...)
@@ -423,11 +423,11 @@ func (c client) TestMap(
 
 func (c client) TestMapMap(
 	ctx context.Context,
-	_Hello *int32,
+	helloArg *int32,
 	opts ...yarpc.CallOption,
 ) (success map[int32]map[int32]int32, err error) {
 
-	args := gauntlet.ThriftTest_TestMapMap_Helper.Args(_Hello)
+	args := gauntlet.ThriftTest_TestMapMap_Helper.Args(helloArg)
 
 	var body wire.Value
 	body, err = c.c.Call(ctx, args, opts...)
@@ -446,16 +446,16 @@ func (c client) TestMapMap(
 
 func (c client) TestMulti(
 	ctx context.Context,
-	_Arg0 *int8,
-	_Arg1 *int32,
-	_Arg2 *int64,
-	_Arg3 map[int16]string,
-	_Arg4 *gauntlet.Numberz,
-	_Arg5 *gauntlet.UserId,
+	arg0Arg *int8,
+	arg1Arg *int32,
+	arg2Arg *int64,
+	arg3Arg map[int16]string,
+	arg4Arg *gauntlet.Numberz,
+	arg5Arg *gauntlet.UserId,
 	opts ...yarpc.CallOption,
 ) (success *gauntlet.Xtruct, err error) {
 
-	args := gauntlet.ThriftTest_TestMulti_Helper.Args(_Arg0, _Arg1, _Arg2, _Arg3, _Arg4, _Arg5)
+	args := gauntlet.ThriftTest_TestMulti_Helper.Args(arg0Arg, arg1Arg, arg2Arg, arg3Arg, arg4Arg, arg5Arg)
 
 	var body wire.Value
 	body, err = c.c.Call(ctx, args, opts...)
@@ -474,12 +474,12 @@ func (c client) TestMulti(
 
 func (c client) TestMultiException(
 	ctx context.Context,
-	_Arg0 *string,
-	_Arg1 *string,
+	arg0Arg *string,
+	arg1Arg *string,
 	opts ...yarpc.CallOption,
 ) (success *gauntlet.Xtruct, err error) {
 
-	args := gauntlet.ThriftTest_TestMultiException_Helper.Args(_Arg0, _Arg1)
+	args := gauntlet.ThriftTest_TestMultiException_Helper.Args(arg0Arg, arg1Arg)
 
 	var body wire.Value
 	body, err = c.c.Call(ctx, args, opts...)
@@ -498,11 +498,11 @@ func (c client) TestMultiException(
 
 func (c client) TestNest(
 	ctx context.Context,
-	_Thing *gauntlet.Xtruct2,
+	thingArg *gauntlet.Xtruct2,
 	opts ...yarpc.CallOption,
 ) (success *gauntlet.Xtruct2, err error) {
 
-	args := gauntlet.ThriftTest_TestNest_Helper.Args(_Thing)
+	args := gauntlet.ThriftTest_TestNest_Helper.Args(thingArg)
 
 	var body wire.Value
 	body, err = c.c.Call(ctx, args, opts...)
@@ -521,20 +521,20 @@ func (c client) TestNest(
 
 func (c client) TestOneway(
 	ctx context.Context,
-	_SecondsToSleep *int32,
+	secondstosleepArg *int32,
 	opts ...yarpc.CallOption,
 ) (yarpc.Ack, error) {
-	args := gauntlet.ThriftTest_TestOneway_Helper.Args(_SecondsToSleep)
+	args := gauntlet.ThriftTest_TestOneway_Helper.Args(secondstosleepArg)
 	return c.c.CallOneway(ctx, args, opts...)
 }
 
 func (c client) TestSet(
 	ctx context.Context,
-	_Thing map[int32]struct{},
+	thingArg map[int32]struct{},
 	opts ...yarpc.CallOption,
 ) (success map[int32]struct{}, err error) {
 
-	args := gauntlet.ThriftTest_TestSet_Helper.Args(_Thing)
+	args := gauntlet.ThriftTest_TestSet_Helper.Args(thingArg)
 
 	var body wire.Value
 	body, err = c.c.Call(ctx, args, opts...)
@@ -553,11 +553,11 @@ func (c client) TestSet(
 
 func (c client) TestString(
 	ctx context.Context,
-	_Thing *string,
+	thingArg *string,
 	opts ...yarpc.CallOption,
 ) (success string, err error) {
 
-	args := gauntlet.ThriftTest_TestString_Helper.Args(_Thing)
+	args := gauntlet.ThriftTest_TestString_Helper.Args(thingArg)
 
 	var body wire.Value
 	body, err = c.c.Call(ctx, args, opts...)
@@ -576,11 +576,11 @@ func (c client) TestString(
 
 func (c client) TestStringMap(
 	ctx context.Context,
-	_Thing map[string]string,
+	thingArg map[string]string,
 	opts ...yarpc.CallOption,
 ) (success map[string]string, err error) {
 
-	args := gauntlet.ThriftTest_TestStringMap_Helper.Args(_Thing)
+	args := gauntlet.ThriftTest_TestStringMap_Helper.Args(thingArg)
 
 	var body wire.Value
 	body, err = c.c.Call(ctx, args, opts...)
@@ -599,11 +599,11 @@ func (c client) TestStringMap(
 
 func (c client) TestStruct(
 	ctx context.Context,
-	_Thing *gauntlet.Xtruct,
+	thingArg *gauntlet.Xtruct,
 	opts ...yarpc.CallOption,
 ) (success *gauntlet.Xtruct, err error) {
 
-	args := gauntlet.ThriftTest_TestStruct_Helper.Args(_Thing)
+	args := gauntlet.ThriftTest_TestStruct_Helper.Args(thingArg)
 
 	var body wire.Value
 	body, err = c.c.Call(ctx, args, opts...)
@@ -622,11 +622,11 @@ func (c client) TestStruct(
 
 func (c client) TestTypedef(
 	ctx context.Context,
-	_Thing *gauntlet.UserId,
+	thingArg *gauntlet.UserId,
 	opts ...yarpc.CallOption,
 ) (success gauntlet.UserId, err error) {
 
-	args := gauntlet.ThriftTest_TestTypedef_Helper.Args(_Thing)
+	args := gauntlet.ThriftTest_TestTypedef_Helper.Args(thingArg)
 
 	var body wire.Value
 	body, err = c.c.Call(ctx, args, opts...)

--- a/internal/crossdock/thrift/gauntlet/thrifttestserver/server.go
+++ b/internal/crossdock/thrift/gauntlet/thrifttestserver/server.go
@@ -35,108 +35,108 @@ import (
 type Interface interface {
 	TestBinary(
 		ctx context.Context,
-		Thing []byte,
+		thing []byte,
 	) ([]byte, error)
 
 	TestByte(
 		ctx context.Context,
-		Thing *int8,
+		thing *int8,
 	) (int8, error)
 
 	TestDouble(
 		ctx context.Context,
-		Thing *float64,
+		thing *float64,
 	) (float64, error)
 
 	TestEnum(
 		ctx context.Context,
-		Thing *gauntlet.Numberz,
+		thing *gauntlet.Numberz,
 	) (gauntlet.Numberz, error)
 
 	TestException(
 		ctx context.Context,
-		Arg *string,
+		arg *string,
 	) error
 
 	TestI32(
 		ctx context.Context,
-		Thing *int32,
+		thing *int32,
 	) (int32, error)
 
 	TestI64(
 		ctx context.Context,
-		Thing *int64,
+		thing *int64,
 	) (int64, error)
 
 	TestInsanity(
 		ctx context.Context,
-		Argument *gauntlet.Insanity,
+		argument *gauntlet.Insanity,
 	) (map[gauntlet.UserId]map[gauntlet.Numberz]*gauntlet.Insanity, error)
 
 	TestList(
 		ctx context.Context,
-		Thing []int32,
+		thing []int32,
 	) ([]int32, error)
 
 	TestMap(
 		ctx context.Context,
-		Thing map[int32]int32,
+		thing map[int32]int32,
 	) (map[int32]int32, error)
 
 	TestMapMap(
 		ctx context.Context,
-		Hello *int32,
+		hello *int32,
 	) (map[int32]map[int32]int32, error)
 
 	TestMulti(
 		ctx context.Context,
-		Arg0 *int8,
-		Arg1 *int32,
-		Arg2 *int64,
-		Arg3 map[int16]string,
-		Arg4 *gauntlet.Numberz,
-		Arg5 *gauntlet.UserId,
+		arg0 *int8,
+		arg1 *int32,
+		arg2 *int64,
+		arg3 map[int16]string,
+		arg4 *gauntlet.Numberz,
+		arg5 *gauntlet.UserId,
 	) (*gauntlet.Xtruct, error)
 
 	TestMultiException(
 		ctx context.Context,
-		Arg0 *string,
-		Arg1 *string,
+		arg0 *string,
+		arg1 *string,
 	) (*gauntlet.Xtruct, error)
 
 	TestNest(
 		ctx context.Context,
-		Thing *gauntlet.Xtruct2,
+		thing *gauntlet.Xtruct2,
 	) (*gauntlet.Xtruct2, error)
 
 	TestOneway(
 		ctx context.Context,
-		SecondsToSleep *int32,
+		secondstosleep *int32,
 	) error
 
 	TestSet(
 		ctx context.Context,
-		Thing map[int32]struct{},
+		thing map[int32]struct{},
 	) (map[int32]struct{}, error)
 
 	TestString(
 		ctx context.Context,
-		Thing *string,
+		thing *string,
 	) (string, error)
 
 	TestStringMap(
 		ctx context.Context,
-		Thing map[string]string,
+		thing map[string]string,
 	) (map[string]string, error)
 
 	TestStruct(
 		ctx context.Context,
-		Thing *gauntlet.Xtruct,
+		thing *gauntlet.Xtruct,
 	) (*gauntlet.Xtruct, error)
 
 	TestTypedef(
 		ctx context.Context,
-		Thing *gauntlet.UserId,
+		thing *gauntlet.UserId,
 	) (gauntlet.UserId, error)
 
 	TestVoid(
@@ -162,7 +162,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					Type:  transport.Unary,
 					Unary: thrift.UnaryHandler(h.TestBinary),
 				},
-				Signature:    "TestBinary(Thing []byte) ([]byte)",
+				Signature:    "TestBinary(thing []byte) ([]byte)",
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -173,7 +173,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					Type:  transport.Unary,
 					Unary: thrift.UnaryHandler(h.TestByte),
 				},
-				Signature:    "TestByte(Thing *int8) (int8)",
+				Signature:    "TestByte(thing *int8) (int8)",
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -184,7 +184,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					Type:  transport.Unary,
 					Unary: thrift.UnaryHandler(h.TestDouble),
 				},
-				Signature:    "TestDouble(Thing *float64) (float64)",
+				Signature:    "TestDouble(thing *float64) (float64)",
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -195,7 +195,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					Type:  transport.Unary,
 					Unary: thrift.UnaryHandler(h.TestEnum),
 				},
-				Signature:    "TestEnum(Thing *gauntlet.Numberz) (gauntlet.Numberz)",
+				Signature:    "TestEnum(thing *gauntlet.Numberz) (gauntlet.Numberz)",
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -206,7 +206,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					Type:  transport.Unary,
 					Unary: thrift.UnaryHandler(h.TestException),
 				},
-				Signature:    "TestException(Arg *string)",
+				Signature:    "TestException(arg *string)",
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -217,7 +217,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					Type:  transport.Unary,
 					Unary: thrift.UnaryHandler(h.TestI32),
 				},
-				Signature:    "TestI32(Thing *int32) (int32)",
+				Signature:    "TestI32(thing *int32) (int32)",
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -228,7 +228,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					Type:  transport.Unary,
 					Unary: thrift.UnaryHandler(h.TestI64),
 				},
-				Signature:    "TestI64(Thing *int64) (int64)",
+				Signature:    "TestI64(thing *int64) (int64)",
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -239,7 +239,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					Type:  transport.Unary,
 					Unary: thrift.UnaryHandler(h.TestInsanity),
 				},
-				Signature:    "TestInsanity(Argument *gauntlet.Insanity) (map[gauntlet.UserId]map[gauntlet.Numberz]*gauntlet.Insanity)",
+				Signature:    "TestInsanity(argument *gauntlet.Insanity) (map[gauntlet.UserId]map[gauntlet.Numberz]*gauntlet.Insanity)",
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -250,7 +250,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					Type:  transport.Unary,
 					Unary: thrift.UnaryHandler(h.TestList),
 				},
-				Signature:    "TestList(Thing []int32) ([]int32)",
+				Signature:    "TestList(thing []int32) ([]int32)",
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -261,7 +261,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					Type:  transport.Unary,
 					Unary: thrift.UnaryHandler(h.TestMap),
 				},
-				Signature:    "TestMap(Thing map[int32]int32) (map[int32]int32)",
+				Signature:    "TestMap(thing map[int32]int32) (map[int32]int32)",
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -272,7 +272,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					Type:  transport.Unary,
 					Unary: thrift.UnaryHandler(h.TestMapMap),
 				},
-				Signature:    "TestMapMap(Hello *int32) (map[int32]map[int32]int32)",
+				Signature:    "TestMapMap(hello *int32) (map[int32]map[int32]int32)",
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -283,7 +283,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					Type:  transport.Unary,
 					Unary: thrift.UnaryHandler(h.TestMulti),
 				},
-				Signature:    "TestMulti(Arg0 *int8, Arg1 *int32, Arg2 *int64, Arg3 map[int16]string, Arg4 *gauntlet.Numberz, Arg5 *gauntlet.UserId) (*gauntlet.Xtruct)",
+				Signature:    "TestMulti(arg0 *int8, arg1 *int32, arg2 *int64, arg3 map[int16]string, arg4 *gauntlet.Numberz, arg5 *gauntlet.UserId) (*gauntlet.Xtruct)",
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -294,7 +294,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					Type:  transport.Unary,
 					Unary: thrift.UnaryHandler(h.TestMultiException),
 				},
-				Signature:    "TestMultiException(Arg0 *string, Arg1 *string) (*gauntlet.Xtruct)",
+				Signature:    "TestMultiException(arg0 *string, arg1 *string) (*gauntlet.Xtruct)",
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -305,7 +305,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					Type:  transport.Unary,
 					Unary: thrift.UnaryHandler(h.TestNest),
 				},
-				Signature:    "TestNest(Thing *gauntlet.Xtruct2) (*gauntlet.Xtruct2)",
+				Signature:    "TestNest(thing *gauntlet.Xtruct2) (*gauntlet.Xtruct2)",
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -316,7 +316,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					Type:   transport.Oneway,
 					Oneway: thrift.OnewayHandler(h.TestOneway),
 				},
-				Signature:    "TestOneway(SecondsToSleep *int32)",
+				Signature:    "TestOneway(secondstosleep *int32)",
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -327,7 +327,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					Type:  transport.Unary,
 					Unary: thrift.UnaryHandler(h.TestSet),
 				},
-				Signature:    "TestSet(Thing map[int32]struct{}) (map[int32]struct{})",
+				Signature:    "TestSet(thing map[int32]struct{}) (map[int32]struct{})",
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -338,7 +338,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					Type:  transport.Unary,
 					Unary: thrift.UnaryHandler(h.TestString),
 				},
-				Signature:    "TestString(Thing *string) (string)",
+				Signature:    "TestString(thing *string) (string)",
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -349,7 +349,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					Type:  transport.Unary,
 					Unary: thrift.UnaryHandler(h.TestStringMap),
 				},
-				Signature:    "TestStringMap(Thing map[string]string) (map[string]string)",
+				Signature:    "TestStringMap(thing map[string]string) (map[string]string)",
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -360,7 +360,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					Type:  transport.Unary,
 					Unary: thrift.UnaryHandler(h.TestStruct),
 				},
-				Signature:    "TestStruct(Thing *gauntlet.Xtruct) (*gauntlet.Xtruct)",
+				Signature:    "TestStruct(thing *gauntlet.Xtruct) (*gauntlet.Xtruct)",
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -371,7 +371,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					Type:  transport.Unary,
 					Unary: thrift.UnaryHandler(h.TestTypedef),
 				},
-				Signature:    "TestTypedef(Thing *gauntlet.UserId) (gauntlet.UserId)",
+				Signature:    "TestTypedef(thing *gauntlet.UserId) (gauntlet.UserId)",
 				ThriftModule: gauntlet.ThriftModule,
 			},
 

--- a/internal/crossdock/thrift/gauntlet/thrifttesttest/client.go
+++ b/internal/crossdock/thrift/gauntlet/thrifttesttest/client.go
@@ -70,11 +70,11 @@ func (m *MockClient) EXPECT() *_MockClientRecorder {
 // 	... := client.TestBinary(...)
 func (m *MockClient) TestBinary(
 	ctx context.Context,
-	_Thing []byte,
+	thingArg []byte,
 	opts ...yarpc.CallOption,
 ) (success []byte, err error) {
 
-	args := []interface{}{ctx, _Thing}
+	args := []interface{}{ctx, thingArg}
 	for _, o := range opts {
 		args = append(args, o)
 	}
@@ -88,10 +88,10 @@ func (m *MockClient) TestBinary(
 
 func (mr *_MockClientRecorder) TestBinary(
 	ctx interface{},
-	_Thing interface{},
+	thingArg interface{},
 	opts ...interface{},
 ) *gomock.Call {
-	args := append([]interface{}{ctx, _Thing}, opts...)
+	args := append([]interface{}{ctx, thingArg}, opts...)
 	return mr.mock.ctrl.RecordCall(mr.mock, "TestBinary", args...)
 }
 
@@ -103,11 +103,11 @@ func (mr *_MockClientRecorder) TestBinary(
 // 	... := client.TestByte(...)
 func (m *MockClient) TestByte(
 	ctx context.Context,
-	_Thing *int8,
+	thingArg *int8,
 	opts ...yarpc.CallOption,
 ) (success int8, err error) {
 
-	args := []interface{}{ctx, _Thing}
+	args := []interface{}{ctx, thingArg}
 	for _, o := range opts {
 		args = append(args, o)
 	}
@@ -121,10 +121,10 @@ func (m *MockClient) TestByte(
 
 func (mr *_MockClientRecorder) TestByte(
 	ctx interface{},
-	_Thing interface{},
+	thingArg interface{},
 	opts ...interface{},
 ) *gomock.Call {
-	args := append([]interface{}{ctx, _Thing}, opts...)
+	args := append([]interface{}{ctx, thingArg}, opts...)
 	return mr.mock.ctrl.RecordCall(mr.mock, "TestByte", args...)
 }
 
@@ -136,11 +136,11 @@ func (mr *_MockClientRecorder) TestByte(
 // 	... := client.TestDouble(...)
 func (m *MockClient) TestDouble(
 	ctx context.Context,
-	_Thing *float64,
+	thingArg *float64,
 	opts ...yarpc.CallOption,
 ) (success float64, err error) {
 
-	args := []interface{}{ctx, _Thing}
+	args := []interface{}{ctx, thingArg}
 	for _, o := range opts {
 		args = append(args, o)
 	}
@@ -154,10 +154,10 @@ func (m *MockClient) TestDouble(
 
 func (mr *_MockClientRecorder) TestDouble(
 	ctx interface{},
-	_Thing interface{},
+	thingArg interface{},
 	opts ...interface{},
 ) *gomock.Call {
-	args := append([]interface{}{ctx, _Thing}, opts...)
+	args := append([]interface{}{ctx, thingArg}, opts...)
 	return mr.mock.ctrl.RecordCall(mr.mock, "TestDouble", args...)
 }
 
@@ -169,11 +169,11 @@ func (mr *_MockClientRecorder) TestDouble(
 // 	... := client.TestEnum(...)
 func (m *MockClient) TestEnum(
 	ctx context.Context,
-	_Thing *gauntlet.Numberz,
+	thingArg *gauntlet.Numberz,
 	opts ...yarpc.CallOption,
 ) (success gauntlet.Numberz, err error) {
 
-	args := []interface{}{ctx, _Thing}
+	args := []interface{}{ctx, thingArg}
 	for _, o := range opts {
 		args = append(args, o)
 	}
@@ -187,10 +187,10 @@ func (m *MockClient) TestEnum(
 
 func (mr *_MockClientRecorder) TestEnum(
 	ctx interface{},
-	_Thing interface{},
+	thingArg interface{},
 	opts ...interface{},
 ) *gomock.Call {
-	args := append([]interface{}{ctx, _Thing}, opts...)
+	args := append([]interface{}{ctx, thingArg}, opts...)
 	return mr.mock.ctrl.RecordCall(mr.mock, "TestEnum", args...)
 }
 
@@ -202,11 +202,11 @@ func (mr *_MockClientRecorder) TestEnum(
 // 	... := client.TestException(...)
 func (m *MockClient) TestException(
 	ctx context.Context,
-	_Arg *string,
+	argArg *string,
 	opts ...yarpc.CallOption,
 ) (err error) {
 
-	args := []interface{}{ctx, _Arg}
+	args := []interface{}{ctx, argArg}
 	for _, o := range opts {
 		args = append(args, o)
 	}
@@ -218,10 +218,10 @@ func (m *MockClient) TestException(
 
 func (mr *_MockClientRecorder) TestException(
 	ctx interface{},
-	_Arg interface{},
+	argArg interface{},
 	opts ...interface{},
 ) *gomock.Call {
-	args := append([]interface{}{ctx, _Arg}, opts...)
+	args := append([]interface{}{ctx, argArg}, opts...)
 	return mr.mock.ctrl.RecordCall(mr.mock, "TestException", args...)
 }
 
@@ -233,11 +233,11 @@ func (mr *_MockClientRecorder) TestException(
 // 	... := client.TestI32(...)
 func (m *MockClient) TestI32(
 	ctx context.Context,
-	_Thing *int32,
+	thingArg *int32,
 	opts ...yarpc.CallOption,
 ) (success int32, err error) {
 
-	args := []interface{}{ctx, _Thing}
+	args := []interface{}{ctx, thingArg}
 	for _, o := range opts {
 		args = append(args, o)
 	}
@@ -251,10 +251,10 @@ func (m *MockClient) TestI32(
 
 func (mr *_MockClientRecorder) TestI32(
 	ctx interface{},
-	_Thing interface{},
+	thingArg interface{},
 	opts ...interface{},
 ) *gomock.Call {
-	args := append([]interface{}{ctx, _Thing}, opts...)
+	args := append([]interface{}{ctx, thingArg}, opts...)
 	return mr.mock.ctrl.RecordCall(mr.mock, "TestI32", args...)
 }
 
@@ -266,11 +266,11 @@ func (mr *_MockClientRecorder) TestI32(
 // 	... := client.TestI64(...)
 func (m *MockClient) TestI64(
 	ctx context.Context,
-	_Thing *int64,
+	thingArg *int64,
 	opts ...yarpc.CallOption,
 ) (success int64, err error) {
 
-	args := []interface{}{ctx, _Thing}
+	args := []interface{}{ctx, thingArg}
 	for _, o := range opts {
 		args = append(args, o)
 	}
@@ -284,10 +284,10 @@ func (m *MockClient) TestI64(
 
 func (mr *_MockClientRecorder) TestI64(
 	ctx interface{},
-	_Thing interface{},
+	thingArg interface{},
 	opts ...interface{},
 ) *gomock.Call {
-	args := append([]interface{}{ctx, _Thing}, opts...)
+	args := append([]interface{}{ctx, thingArg}, opts...)
 	return mr.mock.ctrl.RecordCall(mr.mock, "TestI64", args...)
 }
 
@@ -299,11 +299,11 @@ func (mr *_MockClientRecorder) TestI64(
 // 	... := client.TestInsanity(...)
 func (m *MockClient) TestInsanity(
 	ctx context.Context,
-	_Argument *gauntlet.Insanity,
+	argumentArg *gauntlet.Insanity,
 	opts ...yarpc.CallOption,
 ) (success map[gauntlet.UserId]map[gauntlet.Numberz]*gauntlet.Insanity, err error) {
 
-	args := []interface{}{ctx, _Argument}
+	args := []interface{}{ctx, argumentArg}
 	for _, o := range opts {
 		args = append(args, o)
 	}
@@ -317,10 +317,10 @@ func (m *MockClient) TestInsanity(
 
 func (mr *_MockClientRecorder) TestInsanity(
 	ctx interface{},
-	_Argument interface{},
+	argumentArg interface{},
 	opts ...interface{},
 ) *gomock.Call {
-	args := append([]interface{}{ctx, _Argument}, opts...)
+	args := append([]interface{}{ctx, argumentArg}, opts...)
 	return mr.mock.ctrl.RecordCall(mr.mock, "TestInsanity", args...)
 }
 
@@ -332,11 +332,11 @@ func (mr *_MockClientRecorder) TestInsanity(
 // 	... := client.TestList(...)
 func (m *MockClient) TestList(
 	ctx context.Context,
-	_Thing []int32,
+	thingArg []int32,
 	opts ...yarpc.CallOption,
 ) (success []int32, err error) {
 
-	args := []interface{}{ctx, _Thing}
+	args := []interface{}{ctx, thingArg}
 	for _, o := range opts {
 		args = append(args, o)
 	}
@@ -350,10 +350,10 @@ func (m *MockClient) TestList(
 
 func (mr *_MockClientRecorder) TestList(
 	ctx interface{},
-	_Thing interface{},
+	thingArg interface{},
 	opts ...interface{},
 ) *gomock.Call {
-	args := append([]interface{}{ctx, _Thing}, opts...)
+	args := append([]interface{}{ctx, thingArg}, opts...)
 	return mr.mock.ctrl.RecordCall(mr.mock, "TestList", args...)
 }
 
@@ -365,11 +365,11 @@ func (mr *_MockClientRecorder) TestList(
 // 	... := client.TestMap(...)
 func (m *MockClient) TestMap(
 	ctx context.Context,
-	_Thing map[int32]int32,
+	thingArg map[int32]int32,
 	opts ...yarpc.CallOption,
 ) (success map[int32]int32, err error) {
 
-	args := []interface{}{ctx, _Thing}
+	args := []interface{}{ctx, thingArg}
 	for _, o := range opts {
 		args = append(args, o)
 	}
@@ -383,10 +383,10 @@ func (m *MockClient) TestMap(
 
 func (mr *_MockClientRecorder) TestMap(
 	ctx interface{},
-	_Thing interface{},
+	thingArg interface{},
 	opts ...interface{},
 ) *gomock.Call {
-	args := append([]interface{}{ctx, _Thing}, opts...)
+	args := append([]interface{}{ctx, thingArg}, opts...)
 	return mr.mock.ctrl.RecordCall(mr.mock, "TestMap", args...)
 }
 
@@ -398,11 +398,11 @@ func (mr *_MockClientRecorder) TestMap(
 // 	... := client.TestMapMap(...)
 func (m *MockClient) TestMapMap(
 	ctx context.Context,
-	_Hello *int32,
+	helloArg *int32,
 	opts ...yarpc.CallOption,
 ) (success map[int32]map[int32]int32, err error) {
 
-	args := []interface{}{ctx, _Hello}
+	args := []interface{}{ctx, helloArg}
 	for _, o := range opts {
 		args = append(args, o)
 	}
@@ -416,10 +416,10 @@ func (m *MockClient) TestMapMap(
 
 func (mr *_MockClientRecorder) TestMapMap(
 	ctx interface{},
-	_Hello interface{},
+	helloArg interface{},
 	opts ...interface{},
 ) *gomock.Call {
-	args := append([]interface{}{ctx, _Hello}, opts...)
+	args := append([]interface{}{ctx, helloArg}, opts...)
 	return mr.mock.ctrl.RecordCall(mr.mock, "TestMapMap", args...)
 }
 
@@ -431,16 +431,16 @@ func (mr *_MockClientRecorder) TestMapMap(
 // 	... := client.TestMulti(...)
 func (m *MockClient) TestMulti(
 	ctx context.Context,
-	_Arg0 *int8,
-	_Arg1 *int32,
-	_Arg2 *int64,
-	_Arg3 map[int16]string,
-	_Arg4 *gauntlet.Numberz,
-	_Arg5 *gauntlet.UserId,
+	arg0Arg *int8,
+	arg1Arg *int32,
+	arg2Arg *int64,
+	arg3Arg map[int16]string,
+	arg4Arg *gauntlet.Numberz,
+	arg5Arg *gauntlet.UserId,
 	opts ...yarpc.CallOption,
 ) (success *gauntlet.Xtruct, err error) {
 
-	args := []interface{}{ctx, _Arg0, _Arg1, _Arg2, _Arg3, _Arg4, _Arg5}
+	args := []interface{}{ctx, arg0Arg, arg1Arg, arg2Arg, arg3Arg, arg4Arg, arg5Arg}
 	for _, o := range opts {
 		args = append(args, o)
 	}
@@ -454,15 +454,15 @@ func (m *MockClient) TestMulti(
 
 func (mr *_MockClientRecorder) TestMulti(
 	ctx interface{},
-	_Arg0 interface{},
-	_Arg1 interface{},
-	_Arg2 interface{},
-	_Arg3 interface{},
-	_Arg4 interface{},
-	_Arg5 interface{},
+	arg0Arg interface{},
+	arg1Arg interface{},
+	arg2Arg interface{},
+	arg3Arg interface{},
+	arg4Arg interface{},
+	arg5Arg interface{},
 	opts ...interface{},
 ) *gomock.Call {
-	args := append([]interface{}{ctx, _Arg0, _Arg1, _Arg2, _Arg3, _Arg4, _Arg5}, opts...)
+	args := append([]interface{}{ctx, arg0Arg, arg1Arg, arg2Arg, arg3Arg, arg4Arg, arg5Arg}, opts...)
 	return mr.mock.ctrl.RecordCall(mr.mock, "TestMulti", args...)
 }
 
@@ -474,12 +474,12 @@ func (mr *_MockClientRecorder) TestMulti(
 // 	... := client.TestMultiException(...)
 func (m *MockClient) TestMultiException(
 	ctx context.Context,
-	_Arg0 *string,
-	_Arg1 *string,
+	arg0Arg *string,
+	arg1Arg *string,
 	opts ...yarpc.CallOption,
 ) (success *gauntlet.Xtruct, err error) {
 
-	args := []interface{}{ctx, _Arg0, _Arg1}
+	args := []interface{}{ctx, arg0Arg, arg1Arg}
 	for _, o := range opts {
 		args = append(args, o)
 	}
@@ -493,11 +493,11 @@ func (m *MockClient) TestMultiException(
 
 func (mr *_MockClientRecorder) TestMultiException(
 	ctx interface{},
-	_Arg0 interface{},
-	_Arg1 interface{},
+	arg0Arg interface{},
+	arg1Arg interface{},
 	opts ...interface{},
 ) *gomock.Call {
-	args := append([]interface{}{ctx, _Arg0, _Arg1}, opts...)
+	args := append([]interface{}{ctx, arg0Arg, arg1Arg}, opts...)
 	return mr.mock.ctrl.RecordCall(mr.mock, "TestMultiException", args...)
 }
 
@@ -509,11 +509,11 @@ func (mr *_MockClientRecorder) TestMultiException(
 // 	... := client.TestNest(...)
 func (m *MockClient) TestNest(
 	ctx context.Context,
-	_Thing *gauntlet.Xtruct2,
+	thingArg *gauntlet.Xtruct2,
 	opts ...yarpc.CallOption,
 ) (success *gauntlet.Xtruct2, err error) {
 
-	args := []interface{}{ctx, _Thing}
+	args := []interface{}{ctx, thingArg}
 	for _, o := range opts {
 		args = append(args, o)
 	}
@@ -527,10 +527,10 @@ func (m *MockClient) TestNest(
 
 func (mr *_MockClientRecorder) TestNest(
 	ctx interface{},
-	_Thing interface{},
+	thingArg interface{},
 	opts ...interface{},
 ) *gomock.Call {
-	args := append([]interface{}{ctx, _Thing}, opts...)
+	args := append([]interface{}{ctx, thingArg}, opts...)
 	return mr.mock.ctrl.RecordCall(mr.mock, "TestNest", args...)
 }
 
@@ -542,11 +542,11 @@ func (mr *_MockClientRecorder) TestNest(
 // 	... := client.TestOneway(...)
 func (m *MockClient) TestOneway(
 	ctx context.Context,
-	_SecondsToSleep *int32,
+	secondstosleepArg *int32,
 	opts ...yarpc.CallOption,
 ) (ack yarpc.Ack, err error) {
 
-	args := []interface{}{ctx, _SecondsToSleep}
+	args := []interface{}{ctx, secondstosleepArg}
 	for _, o := range opts {
 		args = append(args, o)
 	}
@@ -560,10 +560,10 @@ func (m *MockClient) TestOneway(
 
 func (mr *_MockClientRecorder) TestOneway(
 	ctx interface{},
-	_SecondsToSleep interface{},
+	secondstosleepArg interface{},
 	opts ...interface{},
 ) *gomock.Call {
-	args := append([]interface{}{ctx, _SecondsToSleep}, opts...)
+	args := append([]interface{}{ctx, secondstosleepArg}, opts...)
 	return mr.mock.ctrl.RecordCall(mr.mock, "TestOneway", args...)
 }
 
@@ -575,11 +575,11 @@ func (mr *_MockClientRecorder) TestOneway(
 // 	... := client.TestSet(...)
 func (m *MockClient) TestSet(
 	ctx context.Context,
-	_Thing map[int32]struct{},
+	thingArg map[int32]struct{},
 	opts ...yarpc.CallOption,
 ) (success map[int32]struct{}, err error) {
 
-	args := []interface{}{ctx, _Thing}
+	args := []interface{}{ctx, thingArg}
 	for _, o := range opts {
 		args = append(args, o)
 	}
@@ -593,10 +593,10 @@ func (m *MockClient) TestSet(
 
 func (mr *_MockClientRecorder) TestSet(
 	ctx interface{},
-	_Thing interface{},
+	thingArg interface{},
 	opts ...interface{},
 ) *gomock.Call {
-	args := append([]interface{}{ctx, _Thing}, opts...)
+	args := append([]interface{}{ctx, thingArg}, opts...)
 	return mr.mock.ctrl.RecordCall(mr.mock, "TestSet", args...)
 }
 
@@ -608,11 +608,11 @@ func (mr *_MockClientRecorder) TestSet(
 // 	... := client.TestString(...)
 func (m *MockClient) TestString(
 	ctx context.Context,
-	_Thing *string,
+	thingArg *string,
 	opts ...yarpc.CallOption,
 ) (success string, err error) {
 
-	args := []interface{}{ctx, _Thing}
+	args := []interface{}{ctx, thingArg}
 	for _, o := range opts {
 		args = append(args, o)
 	}
@@ -626,10 +626,10 @@ func (m *MockClient) TestString(
 
 func (mr *_MockClientRecorder) TestString(
 	ctx interface{},
-	_Thing interface{},
+	thingArg interface{},
 	opts ...interface{},
 ) *gomock.Call {
-	args := append([]interface{}{ctx, _Thing}, opts...)
+	args := append([]interface{}{ctx, thingArg}, opts...)
 	return mr.mock.ctrl.RecordCall(mr.mock, "TestString", args...)
 }
 
@@ -641,11 +641,11 @@ func (mr *_MockClientRecorder) TestString(
 // 	... := client.TestStringMap(...)
 func (m *MockClient) TestStringMap(
 	ctx context.Context,
-	_Thing map[string]string,
+	thingArg map[string]string,
 	opts ...yarpc.CallOption,
 ) (success map[string]string, err error) {
 
-	args := []interface{}{ctx, _Thing}
+	args := []interface{}{ctx, thingArg}
 	for _, o := range opts {
 		args = append(args, o)
 	}
@@ -659,10 +659,10 @@ func (m *MockClient) TestStringMap(
 
 func (mr *_MockClientRecorder) TestStringMap(
 	ctx interface{},
-	_Thing interface{},
+	thingArg interface{},
 	opts ...interface{},
 ) *gomock.Call {
-	args := append([]interface{}{ctx, _Thing}, opts...)
+	args := append([]interface{}{ctx, thingArg}, opts...)
 	return mr.mock.ctrl.RecordCall(mr.mock, "TestStringMap", args...)
 }
 
@@ -674,11 +674,11 @@ func (mr *_MockClientRecorder) TestStringMap(
 // 	... := client.TestStruct(...)
 func (m *MockClient) TestStruct(
 	ctx context.Context,
-	_Thing *gauntlet.Xtruct,
+	thingArg *gauntlet.Xtruct,
 	opts ...yarpc.CallOption,
 ) (success *gauntlet.Xtruct, err error) {
 
-	args := []interface{}{ctx, _Thing}
+	args := []interface{}{ctx, thingArg}
 	for _, o := range opts {
 		args = append(args, o)
 	}
@@ -692,10 +692,10 @@ func (m *MockClient) TestStruct(
 
 func (mr *_MockClientRecorder) TestStruct(
 	ctx interface{},
-	_Thing interface{},
+	thingArg interface{},
 	opts ...interface{},
 ) *gomock.Call {
-	args := append([]interface{}{ctx, _Thing}, opts...)
+	args := append([]interface{}{ctx, thingArg}, opts...)
 	return mr.mock.ctrl.RecordCall(mr.mock, "TestStruct", args...)
 }
 
@@ -707,11 +707,11 @@ func (mr *_MockClientRecorder) TestStruct(
 // 	... := client.TestTypedef(...)
 func (m *MockClient) TestTypedef(
 	ctx context.Context,
-	_Thing *gauntlet.UserId,
+	thingArg *gauntlet.UserId,
 	opts ...yarpc.CallOption,
 ) (success gauntlet.UserId, err error) {
 
-	args := []interface{}{ctx, _Thing}
+	args := []interface{}{ctx, thingArg}
 	for _, o := range opts {
 		args = append(args, o)
 	}
@@ -725,10 +725,10 @@ func (m *MockClient) TestTypedef(
 
 func (mr *_MockClientRecorder) TestTypedef(
 	ctx interface{},
-	_Thing interface{},
+	thingArg interface{},
 	opts ...interface{},
 ) *gomock.Call {
-	args := append([]interface{}{ctx, _Thing}, opts...)
+	args := append([]interface{}{ctx, thingArg}, opts...)
 	return mr.mock.ctrl.RecordCall(mr.mock, "TestTypedef", args...)
 }
 

--- a/internal/crossdock/thrift/oneway/onewayclient/client.go
+++ b/internal/crossdock/thrift/oneway/onewayclient/client.go
@@ -36,7 +36,7 @@ import (
 type Interface interface {
 	Echo(
 		ctx context.Context,
-		Token *string,
+		token *string,
 		opts ...yarpc.CallOption,
 	) (yarpc.Ack, error)
 }
@@ -67,9 +67,9 @@ type client struct {
 
 func (c client) Echo(
 	ctx context.Context,
-	_Token *string,
+	tokenArg *string,
 	opts ...yarpc.CallOption,
 ) (yarpc.Ack, error) {
-	args := oneway.Oneway_Echo_Helper.Args(_Token)
+	args := oneway.Oneway_Echo_Helper.Args(tokenArg)
 	return c.c.CallOneway(ctx, args, opts...)
 }

--- a/internal/crossdock/thrift/oneway/onewayserver/server.go
+++ b/internal/crossdock/thrift/oneway/onewayserver/server.go
@@ -35,7 +35,7 @@ import (
 type Interface interface {
 	Echo(
 		ctx context.Context,
-		Token *string,
+		token *string,
 	) error
 }
 
@@ -57,7 +57,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					Type:   transport.Oneway,
 					Oneway: thrift.OnewayHandler(h.Echo),
 				},
-				Signature:    "Echo(Token *string)",
+				Signature:    "Echo(token *string)",
 				ThriftModule: oneway.ThriftModule,
 			},
 		},

--- a/internal/crossdock/thrift/oneway/onewaytest/client.go
+++ b/internal/crossdock/thrift/oneway/onewaytest/client.go
@@ -69,11 +69,11 @@ func (m *MockClient) EXPECT() *_MockClientRecorder {
 // 	... := client.Echo(...)
 func (m *MockClient) Echo(
 	ctx context.Context,
-	_Token *string,
+	tokenArg *string,
 	opts ...yarpc.CallOption,
 ) (ack yarpc.Ack, err error) {
 
-	args := []interface{}{ctx, _Token}
+	args := []interface{}{ctx, tokenArg}
 	for _, o := range opts {
 		args = append(args, o)
 	}
@@ -87,9 +87,9 @@ func (m *MockClient) Echo(
 
 func (mr *_MockClientRecorder) Echo(
 	ctx interface{},
-	_Token interface{},
+	tokenArg interface{},
 	opts ...interface{},
 ) *gomock.Call {
-	args := append([]interface{}{ctx, _Token}, opts...)
+	args := append([]interface{}{ctx, tokenArg}, opts...)
 	return mr.mock.ctrl.RecordCall(mr.mock, "Echo", args...)
 }

--- a/internal/examples/thrift-hello/hello/echo/helloclient/client.go
+++ b/internal/examples/thrift-hello/hello/echo/helloclient/client.go
@@ -37,7 +37,7 @@ import (
 type Interface interface {
 	Echo(
 		ctx context.Context,
-		Echo *echo.EchoRequest,
+		echo *echo.EchoRequest,
 		opts ...yarpc.CallOption,
 	) (*echo.EchoResponse, error)
 }
@@ -68,11 +68,11 @@ type client struct {
 
 func (c client) Echo(
 	ctx context.Context,
-	_Echo *echo.EchoRequest,
+	echoArg *echo.EchoRequest,
 	opts ...yarpc.CallOption,
 ) (success *echo.EchoResponse, err error) {
 
-	args := echo.Hello_Echo_Helper.Args(_Echo)
+	args := echo.Hello_Echo_Helper.Args(echoArg)
 
 	var body wire.Value
 	body, err = c.c.Call(ctx, args, opts...)

--- a/internal/examples/thrift-hello/hello/echo/helloserver/server.go
+++ b/internal/examples/thrift-hello/hello/echo/helloserver/server.go
@@ -35,7 +35,7 @@ import (
 type Interface interface {
 	Echo(
 		ctx context.Context,
-		Echo *echo.EchoRequest,
+		echo *echo.EchoRequest,
 	) (*echo.EchoResponse, error)
 }
 
@@ -57,7 +57,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					Type:  transport.Unary,
 					Unary: thrift.UnaryHandler(h.Echo),
 				},
-				Signature:    "Echo(Echo *echo.EchoRequest) (*echo.EchoResponse)",
+				Signature:    "Echo(echo *echo.EchoRequest) (*echo.EchoResponse)",
 				ThriftModule: echo.ThriftModule,
 			},
 		},

--- a/internal/examples/thrift-hello/hello/echo/hellotest/client.go
+++ b/internal/examples/thrift-hello/hello/echo/hellotest/client.go
@@ -70,11 +70,11 @@ func (m *MockClient) EXPECT() *_MockClientRecorder {
 // 	... := client.Echo(...)
 func (m *MockClient) Echo(
 	ctx context.Context,
-	_Echo *echo.EchoRequest,
+	echoArg *echo.EchoRequest,
 	opts ...yarpc.CallOption,
 ) (success *echo.EchoResponse, err error) {
 
-	args := []interface{}{ctx, _Echo}
+	args := []interface{}{ctx, echoArg}
 	for _, o := range opts {
 		args = append(args, o)
 	}
@@ -88,9 +88,9 @@ func (m *MockClient) Echo(
 
 func (mr *_MockClientRecorder) Echo(
 	ctx interface{},
-	_Echo interface{},
+	echoArg interface{},
 	opts ...interface{},
 ) *gomock.Call {
-	args := append([]interface{}{ctx, _Echo}, opts...)
+	args := append([]interface{}{ctx, echoArg}, opts...)
 	return mr.mock.ctrl.RecordCall(mr.mock, "Echo", args...)
 }

--- a/internal/examples/thrift-keyvalue/keyvalue/kv/keyvalueclient/client.go
+++ b/internal/examples/thrift-keyvalue/keyvalue/kv/keyvalueclient/client.go
@@ -37,14 +37,14 @@ import (
 type Interface interface {
 	GetValue(
 		ctx context.Context,
-		Key *string,
+		key *string,
 		opts ...yarpc.CallOption,
 	) (string, error)
 
 	SetValue(
 		ctx context.Context,
-		Key *string,
-		Value *string,
+		key *string,
+		value *string,
 		opts ...yarpc.CallOption,
 	) error
 }
@@ -75,11 +75,11 @@ type client struct {
 
 func (c client) GetValue(
 	ctx context.Context,
-	_Key *string,
+	keyArg *string,
 	opts ...yarpc.CallOption,
 ) (success string, err error) {
 
-	args := kv.KeyValue_GetValue_Helper.Args(_Key)
+	args := kv.KeyValue_GetValue_Helper.Args(keyArg)
 
 	var body wire.Value
 	body, err = c.c.Call(ctx, args, opts...)
@@ -98,12 +98,12 @@ func (c client) GetValue(
 
 func (c client) SetValue(
 	ctx context.Context,
-	_Key *string,
-	_Value *string,
+	keyArg *string,
+	valueArg *string,
 	opts ...yarpc.CallOption,
 ) (err error) {
 
-	args := kv.KeyValue_SetValue_Helper.Args(_Key, _Value)
+	args := kv.KeyValue_SetValue_Helper.Args(keyArg, valueArg)
 
 	var body wire.Value
 	body, err = c.c.Call(ctx, args, opts...)

--- a/internal/examples/thrift-keyvalue/keyvalue/kv/keyvalueserver/server.go
+++ b/internal/examples/thrift-keyvalue/keyvalue/kv/keyvalueserver/server.go
@@ -35,13 +35,13 @@ import (
 type Interface interface {
 	GetValue(
 		ctx context.Context,
-		Key *string,
+		key *string,
 	) (string, error)
 
 	SetValue(
 		ctx context.Context,
-		Key *string,
-		Value *string,
+		key *string,
+		value *string,
 	) error
 }
 
@@ -63,7 +63,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					Type:  transport.Unary,
 					Unary: thrift.UnaryHandler(h.GetValue),
 				},
-				Signature:    "GetValue(Key *string) (string)",
+				Signature:    "GetValue(key *string) (string)",
 				ThriftModule: kv.ThriftModule,
 			},
 
@@ -74,7 +74,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					Type:  transport.Unary,
 					Unary: thrift.UnaryHandler(h.SetValue),
 				},
-				Signature:    "SetValue(Key *string, Value *string)",
+				Signature:    "SetValue(key *string, value *string)",
 				ThriftModule: kv.ThriftModule,
 			},
 		},

--- a/internal/examples/thrift-keyvalue/keyvalue/kv/keyvaluetest/client.go
+++ b/internal/examples/thrift-keyvalue/keyvalue/kv/keyvaluetest/client.go
@@ -69,11 +69,11 @@ func (m *MockClient) EXPECT() *_MockClientRecorder {
 // 	... := client.GetValue(...)
 func (m *MockClient) GetValue(
 	ctx context.Context,
-	_Key *string,
+	keyArg *string,
 	opts ...yarpc.CallOption,
 ) (success string, err error) {
 
-	args := []interface{}{ctx, _Key}
+	args := []interface{}{ctx, keyArg}
 	for _, o := range opts {
 		args = append(args, o)
 	}
@@ -87,10 +87,10 @@ func (m *MockClient) GetValue(
 
 func (mr *_MockClientRecorder) GetValue(
 	ctx interface{},
-	_Key interface{},
+	keyArg interface{},
 	opts ...interface{},
 ) *gomock.Call {
-	args := append([]interface{}{ctx, _Key}, opts...)
+	args := append([]interface{}{ctx, keyArg}, opts...)
 	return mr.mock.ctrl.RecordCall(mr.mock, "GetValue", args...)
 }
 
@@ -102,12 +102,12 @@ func (mr *_MockClientRecorder) GetValue(
 // 	... := client.SetValue(...)
 func (m *MockClient) SetValue(
 	ctx context.Context,
-	_Key *string,
-	_Value *string,
+	keyArg *string,
+	valueArg *string,
 	opts ...yarpc.CallOption,
 ) (err error) {
 
-	args := []interface{}{ctx, _Key, _Value}
+	args := []interface{}{ctx, keyArg, valueArg}
 	for _, o := range opts {
 		args = append(args, o)
 	}
@@ -119,10 +119,10 @@ func (m *MockClient) SetValue(
 
 func (mr *_MockClientRecorder) SetValue(
 	ctx interface{},
-	_Key interface{},
-	_Value interface{},
+	keyArg interface{},
+	valueArg interface{},
 	opts ...interface{},
 ) *gomock.Call {
-	args := append([]interface{}{ctx, _Key, _Value}, opts...)
+	args := append([]interface{}{ctx, keyArg, valueArg}, opts...)
 	return mr.mock.ctrl.RecordCall(mr.mock, "SetValue", args...)
 }

--- a/internal/examples/thrift-oneway/sink/helloclient/client.go
+++ b/internal/examples/thrift-oneway/sink/helloclient/client.go
@@ -36,7 +36,7 @@ import (
 type Interface interface {
 	Sink(
 		ctx context.Context,
-		Snk *sink.SinkRequest,
+		snk *sink.SinkRequest,
 		opts ...yarpc.CallOption,
 	) (yarpc.Ack, error)
 }
@@ -67,9 +67,9 @@ type client struct {
 
 func (c client) Sink(
 	ctx context.Context,
-	_Snk *sink.SinkRequest,
+	snkArg *sink.SinkRequest,
 	opts ...yarpc.CallOption,
 ) (yarpc.Ack, error) {
-	args := sink.Hello_Sink_Helper.Args(_Snk)
+	args := sink.Hello_Sink_Helper.Args(snkArg)
 	return c.c.CallOneway(ctx, args, opts...)
 }

--- a/internal/examples/thrift-oneway/sink/helloserver/server.go
+++ b/internal/examples/thrift-oneway/sink/helloserver/server.go
@@ -35,7 +35,7 @@ import (
 type Interface interface {
 	Sink(
 		ctx context.Context,
-		Snk *sink.SinkRequest,
+		snk *sink.SinkRequest,
 	) error
 }
 
@@ -57,7 +57,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					Type:   transport.Oneway,
 					Oneway: thrift.OnewayHandler(h.Sink),
 				},
-				Signature:    "Sink(Snk *sink.SinkRequest)",
+				Signature:    "Sink(snk *sink.SinkRequest)",
 				ThriftModule: sink.ThriftModule,
 			},
 		},

--- a/internal/examples/thrift-oneway/sink/hellotest/client.go
+++ b/internal/examples/thrift-oneway/sink/hellotest/client.go
@@ -70,11 +70,11 @@ func (m *MockClient) EXPECT() *_MockClientRecorder {
 // 	... := client.Sink(...)
 func (m *MockClient) Sink(
 	ctx context.Context,
-	_Snk *sink.SinkRequest,
+	snkArg *sink.SinkRequest,
 	opts ...yarpc.CallOption,
 ) (ack yarpc.Ack, err error) {
 
-	args := []interface{}{ctx, _Snk}
+	args := []interface{}{ctx, snkArg}
 	for _, o := range opts {
 		args = append(args, o)
 	}
@@ -88,9 +88,9 @@ func (m *MockClient) Sink(
 
 func (mr *_MockClientRecorder) Sink(
 	ctx interface{},
-	_Snk interface{},
+	snkArg interface{},
 	opts ...interface{},
 ) *gomock.Call {
-	args := append([]interface{}{ctx, _Snk}, opts...)
+	args := append([]interface{}{ctx, snkArg}, opts...)
 	return mr.mock.ctrl.RecordCall(mr.mock, "Sink", args...)
 }


### PR DESCRIPTION
https://github.com/yarpc/yarpc-go/issues/590

@abhinav make sure this is right, the implementations needed `fooArg` instead of `foo` to make sure there was no overlap with the package name.