### PR TITLE
Pull backoff.None out of the internal backoff package.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Releases
 v1.17.0-dev (unreleased)
 --------------------
 
--   Expose backoff.None in backoff api.
+-   Export no-op backoff strategy in api/backoff.
 
 
 v1.16.0 (2017-09-18)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Releases
 v1.17.0-dev (unreleased)
 --------------------
 
--   No changes yet.
+-   Expose backoff.None in backoff api.
 
 
 v1.16.0 (2017-09-18)

--- a/api/backoff/none.go
+++ b/api/backoff/none.go
@@ -29,12 +29,12 @@ var None Strategy = &none{}
 
 type none struct{}
 
-// Backoff implements Strategy
+// Backoff implements Strategy.
 func (n *none) Backoff() Backoff {
 	return n
 }
 
-// Duration implements Backoff
+// Duration implements Backoff.
 func (*none) Duration(attempts uint) time.Duration {
 	return time.Duration(0)
 }

--- a/api/backoff/none.go
+++ b/api/backoff/none.go
@@ -20,18 +20,21 @@
 
 package backoff
 
-import "go.uber.org/yarpc/api/backoff"
-
-// The None backoff strategy could be implemented as a trivial singleton, but
-// for brevity, is just a degenerate case of the exponential backoff.
-
-var noneOpts = exponentialOptions{
-	newRand: newRand,
-}
+import "time"
 
 // None is a shorted backoff strategy that will always produce a 0ms duration.
 // This strategy is intended to minimize arbitrary delays during tests or
 // maximize load on a benchmark.
-var None backoff.Strategy = &ExponentialStrategy{
-	opts: noneOpts,
+var None Strategy = &none{}
+
+type none struct{}
+
+// Backoff implements Strategy
+func (n *none) Backoff() Backoff {
+	return n
+}
+
+// Duration implements Backoff
+func (*none) Duration(attempts uint) time.Duration {
+	return time.Duration(0)
 }

--- a/api/backoff/none_test.go
+++ b/api/backoff/none_test.go
@@ -28,8 +28,8 @@ import (
 )
 
 func TestNone(t *testing.T) {
-	none := None.Backoff()
-	assert.Equal(t, time.Duration(0), none.Duration(0))
-	assert.Equal(t, time.Duration(0), none.Duration(1))
-	assert.Equal(t, time.Duration(0), none.Duration(2))
+	boff := None.Backoff()
+	assert.Equal(t, time.Duration(0), boff.Duration(0))
+	assert.Equal(t, time.Duration(0), boff.Duration(1))
+	assert.Equal(t, time.Duration(0), boff.Duration(2))
 }

--- a/internal/integrationtest/util_test.go
+++ b/internal/integrationtest/util_test.go
@@ -24,9 +24,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/api/backoff"
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/internal/backoff"
 	"go.uber.org/yarpc/internal/integrationtest"
 	"go.uber.org/yarpc/internal/testtime"
 	"go.uber.org/yarpc/internal/yarpctest"

--- a/transport/http/peer_test.go
+++ b/transport/http/peer_test.go
@@ -26,9 +26,9 @@ import (
 	"time"
 
 	"github.com/opentracing/opentracing-go"
+	"go.uber.org/yarpc/api/backoff"
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/internal/backoff"
 	"go.uber.org/yarpc/internal/integrationtest"
 	"go.uber.org/yarpc/internal/yarpctest"
 	"go.uber.org/yarpc/peer/hostport"

--- a/transport/tchannel/peer_test.go
+++ b/transport/tchannel/peer_test.go
@@ -26,9 +26,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/api/backoff"
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/internal/backoff"
 	"go.uber.org/yarpc/internal/integrationtest"
 	"go.uber.org/yarpc/internal/testtime"
 	"go.uber.org/yarpc/internal/yarpctest"

--- a/transport/x/grpc/peer_test.go
+++ b/transport/x/grpc/peer_test.go
@@ -26,9 +26,9 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/yarpc/api/backoff"
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/internal/backoff"
 	"go.uber.org/yarpc/internal/integrationtest"
 	"go.uber.org/yarpc/internal/yarpctest"
 	"go.uber.org/yarpc/peer/hostport"

--- a/x/retry/policy.go
+++ b/x/retry/policy.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"go.uber.org/yarpc/api/backoff"
-	ibackoff "go.uber.org/yarpc/internal/backoff"
 )
 
 // Policy defines how a retry will be applied.  It contains all the information
@@ -45,7 +44,7 @@ func NewPolicy(opts ...PolicyOption) *Policy {
 var defaultPolicyOpts = policyOptions{
 	retries:           0,
 	maxRequestTimeout: time.Second,
-	backoffStrategy:   ibackoff.None,
+	backoffStrategy:   backoff.None,
 }
 
 type policyOptions struct {


### PR DESCRIPTION
Summary: I'm going through the internal dependencies of the retry module
so I can pull retry middleware into it's own repo (Pinning to yarpc
versions is a bit painful when not much is changing (though we haven't
fully committed to the api.

This is a small dependency on the backoff interface, I could copy the
code if I wanted, but it's not going to be changing anytime soon since
it's already a part of the api.