### PR TITLE
Remove unnecessary allocation of metadata in grpc outbound call

### DIFF
--- a/transport/x/grpc/headers.go
+++ b/transport/x/grpc/headers.go
@@ -162,6 +162,9 @@ func addApplicationHeaders(md metadata.MD, headers transport.Headers) error {
 
 // getApplicationHeaders returns the headers from md without any reserved headers.
 func getApplicationHeaders(md metadata.MD) (transport.Headers, error) {
+	if md == nil {
+		return transport.Headers{}, nil
+	}
 	headers := transport.NewHeadersWithCapacity(md.Len())
 	for header, values := range md {
 		header = transport.CanonicalizeHeaderKey(header)

--- a/transport/x/grpc/headers.go
+++ b/transport/x/grpc/headers.go
@@ -162,7 +162,7 @@ func addApplicationHeaders(md metadata.MD, headers transport.Headers) error {
 
 // getApplicationHeaders returns the headers from md without any reserved headers.
 func getApplicationHeaders(md metadata.MD) (transport.Headers, error) {
-	if md == nil {
+	if len(md) == 0 {
 		return transport.Headers{}, nil
 	}
 	headers := transport.NewHeadersWithCapacity(md.Len())

--- a/transport/x/grpc/outbound.go
+++ b/transport/x/grpc/outbound.go
@@ -103,7 +103,7 @@ func (o *Outbound) Call(ctx context.Context, request *transport.Request) (*trans
 	start := time.Now()
 
 	var responseBody []byte
-	responseMD := metadata.New(nil)
+	var responseMD metadata.MD
 	invokeErr := o.invoke(ctx, request, &responseBody, &responseMD, start)
 	responseHeaders, err := getApplicationHeaders(responseMD)
 	if err != nil {


### PR DESCRIPTION
The value `responseMD` is used for the `grpc.Trailer` `CallOption`, which just sets `*responseMD = trailerValues`, so whatever the existing value is of `responseMD` is overwritten, therefore setting `responseMD := metadata.New(nil)` is unnecessary.

This is already tested by doing end-to-end tests for named errors, which rely on response metadata.

This results in one less allocation for outbound requests.