### PR TITLE
Add tests for yarpc.CallOption, yarpc.Call, and yarpc.CanonicalizeHeaderKey

### DIFF
--- a/call_test.go
+++ b/call_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpc_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/api/encoding"
+	"go.uber.org/yarpc/api/transport"
+	pkgencoding "go.uber.org/yarpc/pkg/encoding"
+)
+
+func TestCallOptionsWriteToRequest(t *testing.T) {
+	outboundCall := encoding.NewOutboundCall(
+		pkgencoding.FromOptions(
+			[]yarpc.CallOption{
+				yarpc.WithShardKey("foo"),
+				yarpc.WithRoutingKey("bar"),
+				yarpc.WithRoutingDelegate("baz`"),
+			},
+		)...,
+	)
+	request := &transport.Request{}
+	_, err := outboundCall.WriteToRequest(context.Background(), request)
+	assert.NoError(t, err)
+	assert.Equal(t, "foo", request.ShardKey)
+}
+
+func TestCallFromContext(t *testing.T) {
+	ctx, inboundCall := encoding.NewInboundCall(context.Background())
+	err := inboundCall.ReadFromRequest(
+		&transport.Request{
+			Caller:          "foo",
+			Service:         "bar",
+			Encoding:        transport.Encoding("baz"),
+			Procedure:       "hello",
+			Headers:         transport.NewHeaders().With("foo", "bar"),
+			ShardKey:        "one",
+			RoutingKey:      "two",
+			RoutingDelegate: "three",
+		},
+	)
+	assert.NoError(t, err)
+	call := yarpc.CallFromContext(ctx)
+	assert.Equal(t, "foo", call.Caller())
+	assert.Equal(t, "bar", call.Service())
+	assert.Equal(t, transport.Encoding("baz"), call.Encoding())
+	assert.Equal(t, "hello", call.Procedure())
+	assert.Equal(t, "bar", call.Header("foo"))
+	assert.Equal(t, []string{"foo"}, call.HeaderNames())
+	assert.Equal(t, "one", call.ShardKey())
+	assert.Equal(t, "two", call.RoutingKey())
+	assert.Equal(t, "three", call.RoutingDelegate())
+}

--- a/call_test.go
+++ b/call_test.go
@@ -37,7 +37,7 @@ func TestCallOptionsWriteToRequest(t *testing.T) {
 			[]yarpc.CallOption{
 				yarpc.WithShardKey("foo"),
 				yarpc.WithRoutingKey("bar"),
-				yarpc.WithRoutingDelegate("baz`"),
+				yarpc.WithRoutingDelegate("baz"),
 			},
 		)...,
 	)
@@ -45,6 +45,8 @@ func TestCallOptionsWriteToRequest(t *testing.T) {
 	_, err := outboundCall.WriteToRequest(context.Background(), request)
 	assert.NoError(t, err)
 	assert.Equal(t, "foo", request.ShardKey)
+	assert.Equal(t, "bar", request.RoutingKey)
+	assert.Equal(t, "baz", request.RoutingDelegate)
 }
 
 func TestCallFromContext(t *testing.T) {

--- a/header_test.go
+++ b/header_test.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCanonicalizeHeaderKey(t *testing.T) {
+	assert.Equal(t, "foo", CanonicalizeHeaderKey("foo"))
+	assert.Equal(t, "foo", CanonicalizeHeaderKey("Foo"))
+	assert.Equal(t, "foo", CanonicalizeHeaderKey("FOO"))
+	assert.Equal(t, "foo", CanonicalizeHeaderKey("fOo"))
+}


### PR DESCRIPTION
This takes care of two things that bother me on the front page of https://codecov.io/gh/yarpc/yarpc-go. Along with https://github.com/yarpc/yarpc-go/pull/1303 and https://github.com/yarpc/yarpc-go/pull/1295, this gets us right to the edge of 88% code coverage.