### PR TITLE
Bypass "ClientConfig" with new hotness "OutboundConfig"

### DIFF
--- a/api/transport/outboundconfig.go
+++ b/api/transport/outboundconfig.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package transport
+
+import "fmt"
+
+// OutboundConfig is a configuration for how to call into another service.  It
+// is used in conjunction with an encoding to send a request through one of the
+// outbounds.
+type OutboundConfig struct {
+	CallerName  string
+	Outbounds   Outbounds
+}
+
+// Caller is the name of the service making the request.
+// implements ClientConfig#Caller (for backwards compatibility)
+// TODO: This function should be deprecated, it's for legacy support.
+// Use oc.CallerName instead
+func (oc *OutboundConfig) Caller() string {
+	return oc.CallerName
+}
+
+// Caller is the name of the service to which the request is being made.
+// implements ClientConfig#Service (for backwards compatibility)
+// TODO: This function should be deprecated, it's for legacy support.
+// Use oc.Outbounds.ServiceName instead
+func (oc *OutboundConfig) Service() string {
+	return oc.Outbounds.ServiceName
+}
+
+// GetUnaryOutbound returns an outbound to send the request through or panics
+// if there is no unary outbound for this service
+// Implements ClientConfig#GetUnaryOutbound
+// TODO: This function should be deprecated, it's for legacy support.
+// Use oc.Outbounds.Unary instead (and panic if you want)
+func (oc *OutboundConfig) GetUnaryOutbound() UnaryOutbound {
+	if oc.Outbounds.Unary == nil {
+		panic(fmt.Sprintf("Service %q does not have a unary outbound", oc.Outbounds.ServiceName))
+	}
+	return oc.Outbounds.Unary
+}
+
+// GetOnewayOutbound returns an outbound to send the request through or panics
+// if there is no oneway outbound for this service
+// Implements ClientConfig#GetOnewayOutbound
+// TODO: This function should be deprecated, it's for legacy support.
+// Use oc.Outbounds.Oneway instead (and panic if you want)
+func (oc *OutboundConfig) GetOnewayOutbound() OnewayOutbound {
+	if oc.Outbounds.Oneway == nil {
+		panic(fmt.Sprintf("Service %q does not have a oneway outbound", oc.Outbounds.ServiceName))
+	}
+
+	return oc.Outbounds.Oneway
+}

--- a/api/transport/outboundconfig.go
+++ b/api/transport/outboundconfig.go
@@ -26,47 +26,52 @@ import "fmt"
 // is used in conjunction with an encoding to send a request through one of the
 // outbounds.
 type OutboundConfig struct {
-	CallerName  string
-	Outbounds   Outbounds
+	CallerName string
+	Outbounds  Outbounds
 }
+
+var _ ClientConfig = (*OutboundConfig)(nil)
 
 // Caller is the name of the service making the request.
-// implements ClientConfig#Caller (for backwards compatibility)
-// TODO: This function should be deprecated, it's for legacy support.
-// Use oc.CallerName instead
-func (oc *OutboundConfig) Caller() string {
-	return oc.CallerName
+//
+// Implements ClientConfig#Caller (for backwards compatibility).
+func (o *OutboundConfig) Caller() string {
+	// TODO: This function should be deprecated, it's for legacy support.
+	// Use CallerName instead.
+	return o.CallerName
 }
 
-// Caller is the name of the service to which the request is being made.
-// implements ClientConfig#Service (for backwards compatibility)
-// TODO: This function should be deprecated, it's for legacy support.
-// Use oc.Outbounds.ServiceName instead
-func (oc *OutboundConfig) Service() string {
-	return oc.Outbounds.ServiceName
+// Service is the name of the service to which the request is being made.
+//
+// Implements ClientConfig#Service (for backwards compatibility).
+func (o *OutboundConfig) Service() string {
+	// TODO: This function should be deprecated, it's for legacy support.
+	// Use Outbounds.ServiceName instead.
+	return o.Outbounds.ServiceName
 }
 
 // GetUnaryOutbound returns an outbound to send the request through or panics
-// if there is no unary outbound for this service
-// Implements ClientConfig#GetUnaryOutbound
-// TODO: This function should be deprecated, it's for legacy support.
-// Use oc.Outbounds.Unary instead (and panic if you want)
-func (oc *OutboundConfig) GetUnaryOutbound() UnaryOutbound {
-	if oc.Outbounds.Unary == nil {
-		panic(fmt.Sprintf("Service %q does not have a unary outbound", oc.Outbounds.ServiceName))
+// if there is no unary outbound for this service.
+//
+// Implements ClientConfig#GetUnaryOutbound.
+func (o *OutboundConfig) GetUnaryOutbound() UnaryOutbound {
+	// TODO: This function should be deprecated, it's for legacy support.
+	// Use Outbounds.Unary instead (and panic if you want).
+	if o.Outbounds.Unary == nil {
+		panic(fmt.Sprintf("service %q does not have a unary outbound", o.Outbounds.ServiceName))
 	}
-	return oc.Outbounds.Unary
+	return o.Outbounds.Unary
 }
 
 // GetOnewayOutbound returns an outbound to send the request through or panics
-// if there is no oneway outbound for this service
-// Implements ClientConfig#GetOnewayOutbound
-// TODO: This function should be deprecated, it's for legacy support.
-// Use oc.Outbounds.Oneway instead (and panic if you want)
-func (oc *OutboundConfig) GetOnewayOutbound() OnewayOutbound {
-	if oc.Outbounds.Oneway == nil {
-		panic(fmt.Sprintf("Service %q does not have a oneway outbound", oc.Outbounds.ServiceName))
+// if there is no oneway outbound for this service.
+//
+// Implements ClientConfig#GetOnewayOutbound.
+func (o *OutboundConfig) GetOnewayOutbound() OnewayOutbound {
+	// TODO: This function should be deprecated, it's for legacy support.
+	// Use o.Outbounds.Oneway instead (and panic if you want).
+	if o.Outbounds.Oneway == nil {
+		panic(fmt.Sprintf("service %q does not have a oneway outbound", o.Outbounds.ServiceName))
 	}
-
-	return oc.Outbounds.Oneway
+	return o.Outbounds.Oneway
 }

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -229,7 +229,7 @@ func (d *Dispatcher) MustOutboundConfig(outboundKey string) *transport.OutboundC
 	panic(fmt.Sprintf("no configured outbound transport for outbound key %q", outboundKey))
 }
 
-// MustOutboundConfig provides the configuration needed to talk to the given
+// OutboundConfig provides the configuration needed to talk to the given
 // service through an outboundKey. This configuration may be directly
 // passed into encoding-specific RPC clients.
 //

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -209,10 +209,19 @@ func (d *Dispatcher) Inbounds() Inbounds {
 // 	keyvalueClient := json.New(dispatcher.ClientConfig("keyvalue"))
 //
 // This function panics if the outboundKey is not known.
+//
+// Deprecated: Use MustOutboundConfig instead.
 func (d *Dispatcher) ClientConfig(outboundKey string) transport.ClientConfig {
 	return d.MustOutboundConfig(outboundKey)
 }
 
+// MustOutboundConfig provides the configuration needed to talk to the given
+// service through an outboundKey. This configuration may be directly
+// passed into encoding-specific RPC clients.
+//
+// 	keyvalueClient := json.New(dispatcher.MustOutboundConfig("keyvalue"))
+//
+// This function panics if the outboundKey is not known.
 func (d *Dispatcher) MustOutboundConfig(outboundKey string) *transport.OutboundConfig {
 	if oc, ok := d.OutboundConfig(outboundKey); ok {
 		return oc
@@ -220,6 +229,15 @@ func (d *Dispatcher) MustOutboundConfig(outboundKey string) *transport.OutboundC
 	panic(fmt.Sprintf("no configured outbound transport for outbound key %q", outboundKey))
 }
 
+// MustOutboundConfig provides the configuration needed to talk to the given
+// service through an outboundKey. This configuration may be directly
+// passed into encoding-specific RPC clients.
+//
+//  outboundConfig, ok := dispatcher.OutboundConfig("keyvalue")
+//  if !ok {
+//    // do something
+//  }
+// 	keyvalueClient := json.New(outboundConfig)
 func (d *Dispatcher) OutboundConfig(outboundKey string) (oc *transport.OutboundConfig, ok bool) {
 	if out, ok := d.outbounds[outboundKey]; ok {
 		return &transport.OutboundConfig{

--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -349,6 +349,50 @@ func TestClientConfig(t *testing.T) {
 	assert.Equal(t, "my-test-service", cc.Service())
 }
 
+func TestClientConfigError(t *testing.T) {
+	dispatcher := NewDispatcher(Config{
+		Name: "test",
+		Outbounds: Outbounds{
+			"my-test-service": {
+				Unary: http.NewTransport().NewSingleOutbound("http://127.0.0.1:1234"),
+			},
+		},
+	})
+
+	assert.Panics(t, func() { dispatcher.ClientConfig("wrong test name") })
+}
+
+func TestOutboundConfig(t *testing.T) {
+	dispatcher := NewDispatcher(Config{
+		Name: "test",
+		Outbounds: Outbounds{
+			"my-test-service": {
+				Unary: http.NewTransport().NewSingleOutbound("http://127.0.0.1:1234"),
+			},
+		},
+	})
+
+	cc := dispatcher.MustOutboundConfig("my-test-service")
+	assert.Equal(t, "test", cc.CallerName)
+	assert.Equal(t, "my-test-service", cc.Outbounds.ServiceName)
+}
+
+func TestOutboundConfigError(t *testing.T) {
+	dispatcher := NewDispatcher(Config{
+		Name: "test",
+		Outbounds: Outbounds{
+			"my-test-service": {
+				Unary: http.NewTransport().NewSingleOutbound("http://127.0.0.1:1234"),
+			},
+		},
+	})
+
+	assert.Panics(t, func() { dispatcher.MustOutboundConfig("wrong test name") })
+	oc, ok := dispatcher.OutboundConfig("wrong test name")
+	assert.False(t, ok, "getting outbound config should not have succeeded")
+	assert.Nil(t, oc, "getting outbound config should not have succeeded")
+}
+
 func TestInboundMiddleware(t *testing.T) {
 	dispatcher := NewDispatcher(Config{
 		Name: "test",


### PR DESCRIPTION
Summary: The ClientConfig interface we've been working with has some
drawbacks.  Primarily, it panics EVERYWHERE (*mostly everywhere). So
as we start thinking about dynamic config for things using YARPC, we
start to get into a dangerous zone where all our functions are incredibly
panic-prone. So if we wanted to check if an outbound key existed, the
ClientConfig apis would probably panic.

Additionally, the fact that both Unary and Oneway are hardcoded into the
ClientConfig interface means that we cannot iterate with new Outbound
types (*cough* streaming *cough*).

This PR provides an alternative to ClientConfig, "OutboundConfig".  The
OutboundConfig implements the ClientConfig interface (and functionality)
for backwards compatibility, but, it exposes all of the struct
properties externally, so if we want to add more types to the Outbounds
struct, we can. It also provides two functions for forcibly getting
(panic) and optionally getting an OutboundConfig.