### PR TITLE
Implement isApplicationError logic on grpc transport

### DIFF
--- a/transport/x/grpc/headers.go
+++ b/transport/x/grpc/headers.go
@@ -60,6 +60,9 @@ const (
 	EncodingHeader = "rpc-encoding"
 	// ErrorNameHeader is the header key for the error name.
 	ErrorNameHeader = "rpc-error-name"
+	// ApplicationErrorHeader is the header key that will contain a non-empty value
+	// if there was an application error.
+	ApplicationErrorHeader = "rpc-application-error"
 
 	baseContentType   = "application/grpc"
 	contentTypeHeader = "content-type"
@@ -67,13 +70,14 @@ const (
 
 var (
 	_reservedHeaders = map[string]bool{
-		CallerHeader:          true,
-		ServiceHeader:         true,
-		ShardKeyHeader:        true,
-		RoutingKeyHeader:      true,
-		RoutingDelegateHeader: true,
-		EncodingHeader:        true,
-		ErrorNameHeader:       true,
+		CallerHeader:           true,
+		ServiceHeader:          true,
+		ShardKeyHeader:         true,
+		RoutingKeyHeader:       true,
+		RoutingDelegateHeader:  true,
+		EncodingHeader:         true,
+		ErrorNameHeader:        true,
+		ApplicationErrorHeader: true,
 	}
 )
 

--- a/transport/x/grpc/headers.go
+++ b/transport/x/grpc/headers.go
@@ -64,6 +64,13 @@ const (
 	// if there was an application error.
 	ApplicationErrorHeader = "rpc-application-error"
 
+	// ApplicationErrorHeaderValue is the value that will be set for
+	// ApplicationErrorHeader is there was an application error.
+	//
+	// The definition says any non-empty value is valid, however this is
+	// the specific value that will be used for now.
+	ApplicationErrorHeaderValue = "error"
+
 	baseContentType   = "application/grpc"
 	contentTypeHeader = "content-type"
 )

--- a/transport/x/grpc/integration_test.go
+++ b/transport/x/grpc/integration_test.go
@@ -144,7 +144,7 @@ func TestYARPCMaxMsgSize(t *testing.T) {
 	})
 }
 
-func TestApplicationErrorPropogation(t *testing.T) {
+func TestApplicationErrorPropagation(t *testing.T) {
 	t.Parallel()
 	doWithTestEnv(t, nil, nil, nil, func(t *testing.T, e *testEnv) {
 		response, err := e.Call(

--- a/transport/x/grpc/integration_test.go
+++ b/transport/x/grpc/integration_test.go
@@ -21,6 +21,7 @@
 package grpc
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"math"
@@ -28,6 +29,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/multierr"
@@ -38,6 +40,7 @@ import (
 	"go.uber.org/yarpc/internal/examples/protobuf/examplepb"
 	"go.uber.org/yarpc/internal/grpcctx"
 	"go.uber.org/yarpc/internal/testtime"
+	"go.uber.org/yarpc/pkg/procedure"
 	"go.uber.org/yarpc/yarpcerrors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -141,6 +144,27 @@ func TestYARPCMaxMsgSize(t *testing.T) {
 	})
 }
 
+func TestApplicationErrorPropogation(t *testing.T) {
+	t.Parallel()
+	doWithTestEnv(t, nil, nil, nil, func(t *testing.T, e *testEnv) {
+		response, err := e.Call(
+			context.Background(),
+			"GetValue",
+			&examplepb.GetValueRequest{Key: "foo"},
+		)
+		require.Error(t, err)
+		require.True(t, response.ApplicationError)
+
+		response, err = e.Call(
+			context.Background(),
+			"SetValue",
+			&examplepb.SetValueRequest{Key: "foo", Value: "hello"},
+		)
+		require.NoError(t, err)
+		require.False(t, response.ApplicationError)
+	})
+}
+
 func doWithTestEnv(t *testing.T, transportOptions []TransportOption, inboundOptions []InboundOption, outboundOptions []OutboundOption, f func(*testing.T, *testEnv)) {
 	testEnv, err := newTestEnv(transportOptions, inboundOptions, outboundOptions)
 	require.NoError(t, err)
@@ -151,6 +175,8 @@ func doWithTestEnv(t *testing.T, transportOptions []TransportOption, inboundOpti
 }
 
 type testEnv struct {
+	Caller              string
+	Service             string
 	Inbound             *Inbound
 	Outbound            *Outbound
 	ClientConn          *grpc.ClientConn
@@ -213,11 +239,14 @@ func newTestEnv(transportOptions []TransportOption, inboundOptions []InboundOpti
 			err = multierr.Append(err, outbound.Stop())
 		}
 	}()
+
+	caller := "example-client"
+	service := "example"
 	clientConfig := clientconfig.MultiOutbound(
-		"example-client",
-		"example",
+		caller,
+		service,
 		transport.Outbounds{
-			ServiceName: "example-client",
+			ServiceName: caller,
 			Unary:       outbound,
 		},
 	)
@@ -229,6 +258,8 @@ func newTestEnv(transportOptions []TransportOption, inboundOptions []InboundOpti
 		WithEncoding(string(protobuf.Encoding))
 
 	return &testEnv{
+		caller,
+		service,
 		inbound,
 		outbound,
 		clientConn,
@@ -239,6 +270,28 @@ func newTestEnv(transportOptions []TransportOption, inboundOptions []InboundOpti
 		keyValueYARPCClient,
 		keyValueYARPCServer,
 	}, nil
+}
+
+func (e *testEnv) Call(ctx context.Context, methodName string, message proto.Message) (*transport.Response, error) {
+	data, err := proto.Marshal(message)
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(ctx, testtime.Second)
+	defer cancel()
+	return e.Outbound.Call(
+		ctx,
+		&transport.Request{
+			Caller:   e.Caller,
+			Service:  e.Service,
+			Encoding: protobuf.Encoding,
+			Procedure: procedure.ToName(
+				"uber.yarpc.internal.examples.protobuf.example.KeyValue",
+				methodName,
+			),
+			Body: bytes.NewReader(data),
+		},
+	)
 }
 
 func (e *testEnv) GetValueYARPC(ctx context.Context, key string) (string, error) {

--- a/transport/x/grpc/response_writer.go
+++ b/transport/x/grpc/response_writer.go
@@ -29,9 +29,8 @@ import (
 )
 
 type responseWriter struct {
-	buffer             *bytes.Buffer
-	md                 metadata.MD
-	isApplicationError bool
+	buffer *bytes.Buffer
+	md     metadata.MD
 }
 
 func newResponseWriter() *responseWriter {
@@ -54,7 +53,7 @@ func (r *responseWriter) AddHeaders(headers transport.Headers) {
 }
 
 func (r *responseWriter) SetApplicationError() {
-	r.isApplicationError = true
+	r.AddSystemHeader(ApplicationErrorHeader, "1")
 }
 
 func (r *responseWriter) AddSystemHeader(key string, value string) {

--- a/transport/x/grpc/response_writer.go
+++ b/transport/x/grpc/response_writer.go
@@ -53,7 +53,7 @@ func (r *responseWriter) AddHeaders(headers transport.Headers) {
 }
 
 func (r *responseWriter) SetApplicationError() {
-	r.AddSystemHeader(ApplicationErrorHeader, "1")
+	r.AddSystemHeader(ApplicationErrorHeader, ApplicationErrorHeaderValue)
 }
 
 func (r *responseWriter) AddSystemHeader(key string, value string) {


### PR DESCRIPTION
When I originally implemented gRPC, I didn't think this was necessary as this was not a grpc concept. However, having worked more in yarpc-go, I see that that's an oversight - encodings may rely on isApplicationError logic, and for users to switch between transports transparently, all transports need to implement this.

I do this slightly differently than the http transport by instead checking for a non-empty string on the response header, which I think is safer.