### PR TITLE
WIP: Enable protobuf to propagate both responses and errors

### DIFF
--- a/encoding/protobuf/testing/testing_test.go
+++ b/encoding/protobuf/testing/testing_test.go
@@ -96,13 +96,12 @@ func testIntegration(
 	assert.NoError(t, err)
 	assert.Equal(t, "baz", value)
 
-	keyValueYARPCServer.SetNextError(yarpcerrors.Newf(yarpcerrors.CodeFailedPrecondition, "baz"))
-	value, err = getValue(clients.KeyValueYARPCClient, "foo")
 	switch transportType {
 	case testutils.TransportTypeGRPC, testutils.TransportTypeTChannel:
+		keyValueYARPCServer.SetNextError(yarpcerrors.Newf(yarpcerrors.CodeFailedPrecondition, "baz"))
+		value, err = getValue(clients.KeyValueYARPCClient, "foo")
+		assert.Equal(t, yarpcerrors.Newf(yarpcerrors.CodeFailedPrecondition, "baz"), err)
 		assert.Equal(t, "baz", value)
-	default:
-		assert.Equal(t, "", value)
 	}
 
 	assert.NoError(t, setValueGRPC(clients.KeyValueGRPCClient, clients.ContextWrapper, "foo", "barGRPC"))

--- a/encoding/protobuf/testing/testing_test.go
+++ b/encoding/protobuf/testing/testing_test.go
@@ -70,11 +70,13 @@ func testIntegration(
 	sinkYARPCServer *example.SinkYARPCServer,
 ) {
 	keyValueYARPCServer.SetNextError(yarpcerrors.Newf(yarpcerrors.CodeUnknown, "baz").WithName("foo-bar"))
-	_, err := getValue(clients.KeyValueYARPCClient, "foo")
+	err := setValue(clients.KeyValueYARPCClient, "foo", "bar")
 	assert.Equal(t, yarpcerrors.Newf(yarpcerrors.CodeUnknown, "baz").WithName("foo-bar"), err)
 	keyValueYARPCServer.SetNextError(yarpcerrors.Newf(yarpcerrors.CodeUnknown, "baz").WithName("foo-bar"))
-	_, err = getValueGRPC(clients.KeyValueGRPCClient, clients.ContextWrapper, "foo")
+	err = setValueGRPC(clients.KeyValueGRPCClient, clients.ContextWrapper, "foo", "bar")
 	assert.Equal(t, status.Error(codes.Unknown, "foo-bar: baz"), err)
+
+	assert.NoError(t, setValue(clients.KeyValueYARPCClient, "foo", ""))
 
 	_, err = getValue(clients.KeyValueYARPCClient, "foo")
 	assert.Equal(t, yarpcerrors.Newf(yarpcerrors.CodeNotFound, "foo"), err)

--- a/transport/x/grpc/integration_test.go
+++ b/transport/x/grpc/integration_test.go
@@ -72,7 +72,7 @@ func TestYARPCWellKnownError(t *testing.T) {
 	t.Parallel()
 	doWithTestEnv(t, nil, nil, nil, func(t *testing.T, e *testEnv) {
 		e.KeyValueYARPCServer.SetNextError(status.Error(codes.FailedPrecondition, "bar 1"))
-		_, err := e.GetValueYARPC(context.Background(), "foo")
+		err := e.SetValueYARPC(context.Background(), "foo", "bar")
 		assert.Equal(t, yarpcerrors.Newf(yarpcerrors.CodeFailedPrecondition, "bar 1"), err)
 	})
 }
@@ -81,7 +81,7 @@ func TestYARPCNamedError(t *testing.T) {
 	t.Parallel()
 	doWithTestEnv(t, nil, nil, nil, func(t *testing.T, e *testEnv) {
 		e.KeyValueYARPCServer.SetNextError(yarpcerrors.Newf(yarpcerrors.CodeUnknown, "baz 1").WithName("bar"))
-		_, err := e.GetValueYARPC(context.Background(), "foo")
+		err := e.SetValueYARPC(context.Background(), "foo", "bar")
 		assert.Equal(t, yarpcerrors.Newf(yarpcerrors.CodeUnknown, "baz 1").WithName("bar"), err)
 	})
 }
@@ -90,7 +90,7 @@ func TestYARPCNamedErrorNoMessage(t *testing.T) {
 	t.Parallel()
 	doWithTestEnv(t, nil, nil, nil, func(t *testing.T, e *testEnv) {
 		e.KeyValueYARPCServer.SetNextError(yarpcerrors.Newf(yarpcerrors.CodeUnknown, "").WithName("bar"))
-		_, err := e.GetValueYARPC(context.Background(), "foo")
+		err := e.SetValueYARPC(context.Background(), "foo", "bar")
 		assert.Equal(t, yarpcerrors.Newf(yarpcerrors.CodeUnknown, "").WithName("bar"), err)
 	})
 }
@@ -99,7 +99,7 @@ func TestGRPCWellKnownError(t *testing.T) {
 	t.Parallel()
 	doWithTestEnv(t, nil, nil, nil, func(t *testing.T, e *testEnv) {
 		e.KeyValueYARPCServer.SetNextError(status.Error(codes.FailedPrecondition, "bar 1"))
-		_, err := e.GetValueGRPC(context.Background(), "foo")
+		err := e.SetValueGRPC(context.Background(), "foo", "bar")
 		assert.Equal(t, status.Error(codes.FailedPrecondition, "bar 1"), err)
 	})
 }
@@ -108,7 +108,7 @@ func TestGRPCNamedError(t *testing.T) {
 	t.Parallel()
 	doWithTestEnv(t, nil, nil, nil, func(t *testing.T, e *testEnv) {
 		e.KeyValueYARPCServer.SetNextError(yarpcerrors.Newf(yarpcerrors.CodeUnknown, "baz 1").WithName("bar"))
-		_, err := e.GetValueGRPC(context.Background(), "foo")
+		err := e.SetValueGRPC(context.Background(), "foo", "bar")
 		assert.Equal(t, status.Error(codes.Unknown, "bar: baz 1"), err)
 	})
 }
@@ -117,7 +117,7 @@ func TestGRPCNamedErrorNoMessage(t *testing.T) {
 	t.Parallel()
 	doWithTestEnv(t, nil, nil, nil, func(t *testing.T, e *testEnv) {
 		e.KeyValueYARPCServer.SetNextError(yarpcerrors.Newf(yarpcerrors.CodeUnknown, "").WithName("bar"))
-		_, err := e.GetValueGRPC(context.Background(), "foo")
+		err := e.SetValueGRPC(context.Background(), "foo", "bar")
 		assert.Equal(t, status.Error(codes.Unknown, "bar"), err)
 	})
 }


### PR DESCRIPTION
Do not merge yet: does not work on HTTP.

This enables protobuf to propagate both responses and errors back to the user by always reading the transport response body if it is not nil, regardless of if there was an error from the handler. The grpc (and apparently tchannel) transports handle responses and errors, so this also adds testing for this. The majority of this change is updating the `SetNextError` function in the protobuf example to return a response and error, and some changes around doing this in helper test functions.

Note this isn't working with a grpc-go client, which is very weird, it's either that grpc-go doesn't actually support this (which would be weird), or there's a pre-existing issue that I can't think of. Regardless, nothing on this diff affects the interaction with grpc-go, and all existing tests pass.