### PR TITLE
Add back staticchecks

### DIFF
--- a/etc/make/deps.mk
+++ b/etc/make/deps.mk
@@ -13,7 +13,8 @@ EXTRA_GO_BIN_DEPS = \
 	github.com/golang/lint/golint \
 	github.com/wadey/gocovmerge \
 	golang.org/x/tools/cmd/cover \
-	go.uber.org/tools/parallel-exec
+	go.uber.org/tools/parallel-exec \
+	honnef.co/go/tools/cmd/staticcheck
 
 # all we want is go get -u github.com/Masterminds/glide
 # but have to pin to 0.12.3 due to https://github.com/Masterminds/glide/issues/745
@@ -124,6 +125,7 @@ $(foreach i,$(EXTRA_GO_BIN_DEPS),$(eval $(call deprule,$(i))))
 THRIFTRW = $(BIN)/thriftrw
 GOLINT = $(BIN)/golint
 ERRCHECK = $(BIN)/errcheck
+STATICCHECK = $(BIN)/staticcheck
 COVER = $(BIN)/cover
 GOCOVMERGE = $(BIN)/gocovmerge
 PARALLEL_EXEC = $(BIN)/parallel-exec

--- a/etc/make/docker.mk
+++ b/etc/make/docker.mk
@@ -45,6 +45,10 @@ govet: deps ## check go vet
 golint: deps ## check golint
 	PATH=$$PATH:$(BIN) docker run $(DOCKER_RUN_FLAGS) $(DOCKER_IMAGE) make golint
 
+.PHONY: staticcheck
+staticcheck: deps ## check staticchck
+	PATH=$$PATH:$(BIN) docker run $(DOCKER_RUN_FLAGS) $(DOCKER_IMAGE) make staticcheck
+
 .PHONY: errcheck
 errcheck: deps ## check errcheck
 	PATH=$$PATH:$(BIN) docker run $(DOCKER_RUN_FLAGS) $(DOCKER_IMAGE) make errcheck
@@ -58,7 +62,7 @@ verifyversion: deps ## verify the version in the changelog is the same as in ver
 	PATH=$$PATH:$(BIN) docker run $(DOCKER_RUN_FLAGS) $(DOCKER_IMAGE) make verifyversion
 
 .PHONY: basiclint
-basiclint: deps ## run gofmt govet golint errcheck
+basiclint: deps ## run gofmt govet golint staticcheck errcheck
 	PATH=$$PATH:$(BIN) docker run $(DOCKER_RUN_FLAGS) $(DOCKER_IMAGE) make basiclint
 
 .PHONY: lint

--- a/etc/make/local.mk
+++ b/etc/make/local.mk
@@ -78,6 +78,12 @@ golint: $(GOLINT) __eval_packages __eval_go_files ## check golint
 	done
 	@[ ! -s "$(LINT_LOG)" ] || (echo "golint failed:" | cat - $(LINT_LOG) && false)
 
+.PHONY: staticcheck
+staticcheck: $(STATICCHECK) __eval_packages __eval_go_files ## check staticcheck
+	$(eval STATICCHECK_LOG := $(shell mktemp -t staticcheck.XXXXX))
+	@PATH=$(BIN):$$PATH staticcheck $(PACKAGES) 2>&1 | $(FILTER_LINT) > $(STATICCHECK_LOG) || true
+	@[ ! -s "$(STATICCHECK_LOG)" ] || (echo "staticcheck failed:" | cat - $(STATICCHECK_LOG) && false)
+
 .PHONY: errcheck
 errcheck: $(ERRCHECK) __eval_packages __eval_go_files ## check errcheck
 	$(eval ERRCHECK_LOG := $(shell mktemp -t errcheck.XXXXX))
@@ -111,7 +117,7 @@ verifycodecovignores: ## verify that .codecov.yml contains all .nocover packages
 		done
 
 .PHONY: basiclint
-basiclint: gofmt govet golint errcheck # run gofmt govet golint errcheck
+basiclint: gofmt govet golint staticcheck errcheck # run gofmt govet golint staticcheck errcheck
 
 .PHONY: lint
 lint: basiclint generatenodiff nogogenerate verifyversion verifycodecovignores ## run all linters

--- a/glide.lock
+++ b/glide.lock
@@ -241,3 +241,7 @@ testImports:
   subpackages:
   - parallel-exec
   - update-license
+- name: honnef.co/go/tools
+  version: 49f44f893d933fd08cd7d67d65ccefa5d7c23329
+  subpackages:
+  - cmd/staticcheck

--- a/glide.yaml
+++ b/glide.yaml
@@ -73,5 +73,8 @@ testImport:
   subpackages:
   - parallel-exec
   - update-license
+- package: honnef.co/go/tools
+  subpackages:
+  - cmd/staticcheck
 - package: github.com/stretchr/testify
   version: master


### PR DESCRIPTION
Summary: As a mitigation for an issue reaching honnef.co we removed
static checks from yarpc (#1324).  This pr adds them back (and it
should be safe to land as soon as
https://github.com/dominikh/go-tools/issues/197 is resolved).

Till then it won't work...