### PR TITLE
[AppErr][part 1] Add "Full" Application Error to transport.Response

### DIFF
--- a/api/transport/response.go
+++ b/api/transport/response.go
@@ -24,9 +24,10 @@ import "io"
 
 // Response is the low level response representation.
 type Response struct {
-	Headers          Headers
-	Body             io.ReadCloser
-	ApplicationError bool
+	Headers              Headers
+	Body                 io.ReadCloser
+	ApplicationError     bool
+	FullApplicationError error
 }
 
 // ResponseWriter allows Handlers to write responses in a streaming fashion.
@@ -46,4 +47,18 @@ type ResponseWriter interface {
 	// application error. If called, this MUST be called before any invocation
 	// of Write().
 	SetApplicationError()
+}
+
+// ResponseWriterWithResponse is an advanced representation of a ResponseWriter
+// that has all of it's attributes stored in a *Response. From the middleware
+// stack, the contract is that the Response will be filled after the "Call" has
+// finished.
+// This allows us to alter the ResponseWriter interface once and have a
+// backwards compatible way for adding new attributes in the future (we just add
+// them to the Response).
+// Altering the "Response" is not thread-safe.
+type ResponseWriterWithResponse interface {
+	ResponseWriter
+
+	Response() *Response
 }


### PR DESCRIPTION
Summary: We want to have the ability in middleware to introspect
application error codes, this PR adds a full application error
to the transport.Response in order to introspect that info (though
encodings/middleware/transports need to read/write to it).

It also adds a new "ResponseWriterWithResponse" which is a bit of a
round-about step 1 to potentially deprecate the ResponseWriter API.
Essentially, in fear of having to make more API changes here (if we want
to pass more information in the ResponseWriter),  we introduce a struct that
can be extended with more response information, but, basically, the
transport.Response already has all the attributes we might ever need, so
we just create a *Response with the ResponseWriter and allow alteration
of these Response attributes directly through this new API.

This is flexible/we can change this, feel free to add your thoughts.

The next PR does a refactor of the http handler to facilitate the new
ResponseWriterWithResponse interface, it might be easier to get an idea
about the changes involved there.