### PR TITLE
[AppErr][Part 3] HTTP Response+Error negotiation

### DIFF
--- a/transport/http/constants.go
+++ b/transport/http/constants.go
@@ -68,6 +68,16 @@ const (
 
 	// ErrorNameHeader contains the name of a user-defined error.
 	ErrorNameHeader = "Rpc-Error-Name"
+
+	// AcceptsBothResponseErrorHeader says that the AcceptsBothResponseError
+	// feature is supported on the client. If any non-empty value is set,
+	// this indicates true.
+	AcceptsBothResponseErrorHeader = "Rpc-Accepts-Both-Response-Error"
+
+	// BothResponseErrorHeader says that the BothResponseError
+	// feature is supported on the server. If any non-empty value is set,
+	// this indicates true.
+	BothResponseErrorHeader = "Rpc-Both-Response-Error"
 )
 
 // Valid values for the Rpc-Status header.
@@ -77,8 +87,35 @@ const (
 
 	// An error occurred. The response body contains an application header.
 	ApplicationErrorStatus = "error"
+
+	// AcceptTrue is the true value used for accept headers. Note that any
+	// non-empty value indicates true, but we end up sending this specific
+	// value.
+	AcceptTrue = "true"
 )
 
 // ApplicationHeaderPrefix is the prefix added to application header keys to
 // send them in requests or responses.
 const ApplicationHeaderPrefix = "Rpc-Header-"
+
+func toApplicationStatusValue(isApplicationError bool) string {
+	if isApplicationError {
+		return ApplicationErrorStatus
+	}
+	return ApplicationSuccessStatus
+}
+
+func isApplicationError(applicationStatusValue string) bool {
+	return applicationStatusValue == ApplicationErrorStatus
+}
+
+func acceptValue(accept bool) string {
+	if accept {
+		return AcceptTrue
+	}
+	return ""
+}
+
+func isAcceptTrue(acceptValue string) bool {
+	return len(acceptValue) > 0
+}


### PR DESCRIPTION
Summary: Now that we've added the new FullAppErr entry points and
refactored the http handler, this PR adds header negotiation for whether
an http response will encode the AppError's error code on the wire (this
includes setting an appropriate http status code).

This is a bit of a scary change, so please lay in the feedback. One
glaring issue is that we aren't propagating the error messages.  Might
be nice to add another header that writes the error message into a
response header (as mentioned in one of peter's comments).

Test Plan: Added tests for both the inbound and outbound case that would
perform the negotiation with and without the proper headers.