### PR TITLE
[AppErr][Part 4] AppErr Passthrough support in observability middleware

### DIFF
--- a/api/transport/transporttest/reqres.go
+++ b/api/transport/transporttest/reqres.go
@@ -224,3 +224,33 @@ func (fw *FakeResponseWriter) AddHeaders(h transport.Headers) {
 func (fw *FakeResponseWriter) Write(s []byte) (int, error) {
 	return fw.Body.Write(s)
 }
+
+// FakeResponseWriterWithResponse is a ResponseWriterWithResponse that
+// records the headers and the body written to it.
+type FakeResponseWriterWithResponse struct {
+	Resp transport.Response
+	Body bytes.Buffer
+}
+
+// SetApplicationError for FakeResponseWriterWithResponse.
+func (fw *FakeResponseWriterWithResponse) SetApplicationError() {
+	fw.Resp.ApplicationError = true
+}
+
+// AddHeaders for FakeResponseWriterWithResponse.
+func (fw *FakeResponseWriterWithResponse) AddHeaders(h transport.Headers) {
+	for k, v := range h.Items() {
+		fw.Resp.Headers = fw.Resp.Headers.With(k, v)
+	}
+}
+
+// Write for FakeResponseWriterWithResponse.
+func (fw *FakeResponseWriterWithResponse) Write(s []byte) (int, error) {
+	return fw.Body.Write(s)
+}
+
+// Response for FakeResponseWriterWithResponse.
+func (fw *FakeResponseWriterWithResponse) Response() *transport.Response {
+	fw.Resp.Body = ioutil.NopCloser(&fw.Body)
+	return &fw.Resp
+}


### PR DESCRIPTION
Summary: The ResponseWriter changes we made in part 1 mean that if a
middleware is wrapping the ResponseWriter (like the observability
middleware does) the subsequent Callees will not see the "full"
interface anymore (because of the wrapping).  This PR shows how the
observability middleware can attempt to upcast the ResponseWriter into
the ResponseWriterWithResponse, and, if it can, it can choose to not
wrap the responseWriter and instead use the "Response" function to
determine whether an application error occurred.

Note, this does not add any advanced logging for App Errors yet, that
can come later, this PR just makes sure we can pass through safely.

Another option we have is that the Observability middleware can convert
basic ResponseWriters into the more advanced version in order to get
more granular metrics (thought this can get a bit more wonky).

Test Plan: Added tests.