### PR TITLE
Add Chooser function to grpc Outbound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Releases
 v1.20.0-dev (unreleased)
 --------------------
 
-- No changes yet.
+-   transport/grpc: Add Chooser function to Outbound for testing.
 
 
 v1.19.0 (2017-10-10)

--- a/transport/grpc/outbound.go
+++ b/transport/grpc/outbound.go
@@ -90,6 +90,11 @@ func (o *Outbound) Transports() []transport.Transport {
 	return []transport.Transport{o.t}
 }
 
+// Chooser returns the peer.Chooser associated with this Outbound.
+func (o *Outbound) Chooser() peer.Chooser {
+	return o.peerChooser
+}
+
 // Call implements transport.UnaryOutbound#Call.
 func (o *Outbound) Call(ctx context.Context, request *transport.Request) (*transport.Response, error) {
 	if err := o.once.WaitUntilRunning(ctx); err != nil {


### PR DESCRIPTION
This is needed for internal testing.

This is going to be a hotfix with a micro release.

This was actually here for a long time, but in #1330 we said we would remove it until we needed it in the future, even though all other transports had it. I found where it's needed, so need to add this back quickly.