### PR TITLE
Fix grpc deadlock where Peers can never be stopped if their corresponding Transport was not started

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Releases
 v1.20.0-dev (unreleased)
 --------------------
 
-- No changes yet.
+-   transport/grpc: Fix deadlock where Peers can never be stopped if their
+    corresponding Transport was not started.
 
 
 v1.19.1 (2017-10-10)


### PR DESCRIPTION
This fixes a deadlock where peers could never be waited on if their corresponding Transports were not started.
