### PR TITLE
Simplify release instructions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -23,30 +23,28 @@ This document outlines how to create a release of yarpc-go
     `git tag -a v<version_to_release> -m v<version_to_release` (e.g.
     `git tag -a v1.0.0 -m v1.0.0`)
 
-9.  Push the tag to origin `git push --tags origin v<version_to_release>`
+9.  Push the release `git push origin v<version_to_release> master`
 
-10. `git push origin master`
-
-11. Go to https://travis-ci.org/yarpc/yarpc-go/builds and cancel the build for
+10. Go to https://travis-ci.org/yarpc/yarpc-go/builds and cancel the build for
     v<version_to_release>. If the Codecov build for v<version_to_release>
     completes before the Codecov build for master, the code coverage for master
     will not get updated, only one branch gets updated per commit, this is
     verified with Codecov support. This will get tested by the build for master
     anyways.
 
-12. Go to https://github.com/yarpc/yarpc-go/tags and edit the release notes of
+11. Go to https://github.com/yarpc/yarpc-go/tags and edit the release notes of
     the new tag (copy the changelog into the release notes and make the release
     name the version number)
 
-13. `git checkout dev`
+12. `git checkout dev`
 
-14. `git merge master`
+13. `git merge master`
 
-15. Update `CHANGELOG.md` and `version.go` to have a new
+14. Update `CHANGELOG.md` and `version.go` to have a new
     `v<version>-dev (unreleased)`
 
-16. Run `make verifyversion`
+15. Run `make verifyversion`
 
-17. Create a commit with the title `Back to development`
+16. Create a commit with the title `Back to development`
 
-18. `git push origin dev`
+17. `git push origin dev`


### PR DESCRIPTION
`git push --tags` is equivalent to "push all tags under refs/tags". We
can simplify this to,

    git push origin v<version> master

Which says, push both, master and the version tag.
