### PR TITLE
http: Allow override handler to be provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ Releases
 v1.20.0-dev (unreleased)
 --------------------
 
-- No changes yet.
+-  http: Override the HTTP transport's handler using the `http.Override`
+   option, which allows a provided `http.Handler` to be executed instead of
+   the transport's handler, when the supplied check function returns true.
 
 
 v1.19.2 (2017-10-10)

--- a/transport/http/handler.go
+++ b/transport/http/handler.go
@@ -47,15 +47,18 @@ type handler struct {
 	router      transport.Router
 	tracer      opentracing.Tracer
 	grabHeaders map[string]struct{}
+	override    *override
+}
 
-	accepts  func(req *http.Request) bool
-	fallback http.Handler
+type override struct {
+	check   func(req *http.Request) bool
+	handler http.Handler
 }
 
 func (h handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	// if accepts returns false, execute the fallback, if provided
-	if h.fallback != nil && h.accepts != nil && !h.accepts(req) {
-		h.fallback.ServeHTTP(w, req)
+	// if override is provided and check returns true, execute override handler
+	if h.override != nil && h.override.check(req) {
+		h.override.handler.ServeHTTP(w, req)
 		return
 	}
 

--- a/transport/http/inbound.go
+++ b/transport/http/inbound.go
@@ -149,6 +149,11 @@ func (i *Inbound) start() error {
 		}
 	}
 
+	// error if override option provided, but check or handler is nil
+	if i.override != nil && (i.override.check == nil || i.override.handler == nil) {
+		return yarpcerrors.Newf(yarpcerrors.CodeInvalidArgument, "http.Override check and handler must not be nil")
+	}
+
 	var httpHandler http.Handler = handler{
 		router:      i.router,
 		tracer:      i.tracer,

--- a/transport/http/inbound_example_test.go
+++ b/transport/http/inbound_example_test.go
@@ -90,9 +90,9 @@ func ExampleOverride() {
 	// If check returns true, then our override handler will be executed.
 	check := func(req *nethttp.Request) bool {
 		if req.Header.Get("RPC-Encoding") == "" {
-			return false
+			return true
 		}
-		return true
+		return false
 	}
 
 	// This handler would represent some existing HTTP handler.
@@ -103,7 +103,7 @@ func ExampleOverride() {
 	// This inbound will serve YARPC requests when the RPC-Encoding header is present,
 	// else it will execute the override handler.
 	transport := http.NewTransport()
-	inbound := transport.NewInbound(":8888", http.Override(check, handler))
+	inbound := transport.NewInbound(":8889", http.Override(check, handler))
 
 	// Fire up a dispatcher with the new inbound.
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
@@ -116,7 +116,7 @@ func ExampleOverride() {
 	defer dispatcher.Stop()
 
 	// Make a non-YARPC request to /
-	res, err := nethttp.Get("http://127.0.0.1:8888/")
+	res, err := nethttp.Get("http://127.0.0.1:8889/")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/transport/http/inbound_example_test.go
+++ b/transport/http/inbound_example_test.go
@@ -85,25 +85,25 @@ func ExampleMux() {
 	// Output: hello from /health
 }
 
-func ExampleFallbackHandler() {
+func ExampleOverride() {
 	// We test the HTTP request to determine if it's a YARPC request or not.
-	// If accepts returns false, then our fallback handler will be executed.
-	accepts := func(req *nethttp.Request) bool {
+	// If check returns true, then our override handler will be executed.
+	check := func(req *nethttp.Request) bool {
 		if req.Header.Get("RPC-Encoding") == "" {
 			return false
 		}
 		return true
 	}
 
-	// This handler would represent some existing HTTP handler
+	// This handler would represent some existing HTTP handler.
 	handler := nethttp.HandlerFunc(func(w nethttp.ResponseWriter, req *nethttp.Request) {
 		io.WriteString(w, "hello, world")
 	})
 
 	// This inbound will serve YARPC requests when the RPC-Encoding header is present,
-	// else it will fallback to the provided handler.
+	// else it will execute the override handler.
 	transport := http.NewTransport()
-	inbound := transport.NewInbound(":8888", http.FallbackHandler(accepts, handler))
+	inbound := transport.NewInbound(":8888", http.Override(check, handler))
 
 	// Fire up a dispatcher with the new inbound.
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{

--- a/transport/http/inbound_test.go
+++ b/transport/http/inbound_test.go
@@ -190,3 +190,15 @@ func TestInboundMux(t *testing.T) {
 		}
 	}
 }
+
+func TestInboundOverrideErr(t *testing.T) {
+	transport := NewTransport()
+
+	// use the override option with nil params
+	inbound := transport.NewInbound(":8888", Override(nil, nil))
+	inbound.SetRouter(new(transporttest.MockRouter))
+
+	err := inbound.start()
+	require.NotNil(t, err, "Expected error")
+	assert.Equal(t, "code:invalid-argument message:http.Override check and handler must not be nil", err.Error())
+}


### PR DESCRIPTION
Existing HTTP services have no way to introduce YARPC procedures over a shared port.

This allows an accepts function and a fallback handler to be injected, which allows the request to be forwarded to the fallback handler when accepts returns false.

- [x] Update `http.handler` to take a check and handler.
- [x] Add option to HTTP transport to provide the override handler.
- [x] Add example test that illustrates how to use the `http.Override` option.
- [x] Changelog entry.