### PR TITLE
Allow both a response and error to be returned over HTTP transport and Protobuf, Raw, JSON encodings

### DIFF
--- a/encoding/json/outbound.go
+++ b/encoding/json/outbound.go
@@ -78,21 +78,22 @@ func (c jsonClient) Call(ctx context.Context, procedure string, reqBody interfac
 
 	treq.Body = bytes.NewReader(encoded)
 	tres, appErr := c.cc.GetUnaryOutbound().Call(ctx, &treq)
+	if tres == nil {
+		return appErr
+	}
 
 	// we want to return the appErr if it exists as this is what
 	// the previous behavior was so we deprioritize this error
 	var decodeErr error
-	if tres != nil {
-		if _, err = call.ReadFromResponse(ctx, tres); err != nil {
-			decodeErr = err
+	if _, err = call.ReadFromResponse(ctx, tres); err != nil {
+		decodeErr = err
+	}
+	if tres.Body != nil {
+		if err := json.NewDecoder(tres.Body).Decode(resBodyOut); err != nil && decodeErr == nil {
+			decodeErr = errors.ResponseBodyDecodeError(&treq, err)
 		}
-		if tres.Body != nil {
-			if err := json.NewDecoder(tres.Body).Decode(resBodyOut); err != nil && decodeErr == nil {
-				decodeErr = errors.ResponseBodyDecodeError(&treq, err)
-			}
-			if err := tres.Body.Close(); err != nil && decodeErr == nil {
-				decodeErr = err
-			}
+		if err := tres.Body.Close(); err != nil && decodeErr == nil {
+			decodeErr = err
 		}
 	}
 

--- a/encoding/raw/inbound.go
+++ b/encoding/raw/inbound.go
@@ -54,16 +54,18 @@ func (r rawUnaryHandler) Handle(ctx context.Context, treq *transport.Request, rw
 	if err := call.WriteToResponse(rw); err != nil {
 		return err
 	}
+
+	// we want to return the appErr if it exists as this is what
+	// the previous behavior was so we deprioritize this error
+	var writeErr error
+	if len(resBody) > 0 {
+		_, writeErr = rw.Write(resBody)
+	}
 	if appErr != nil {
 		rw.SetApplicationError()
 		return appErr
 	}
-
-	if _, err := rw.Write(resBody); err != nil {
-		return err
-	}
-
-	return nil
+	return writeErr
 }
 
 func (r rawOnewayHandler) HandleOneway(ctx context.Context, treq *transport.Request) error {

--- a/transport/grpc/integration_test.go
+++ b/transport/grpc/integration_test.go
@@ -75,7 +75,7 @@ func TestYARPCWellKnownError(t *testing.T) {
 	t.Parallel()
 	doWithTestEnv(t, nil, nil, nil, func(t *testing.T, e *testEnv) {
 		e.KeyValueYARPCServer.SetNextError(status.Error(codes.FailedPrecondition, "bar 1"))
-		_, err := e.GetValueYARPC(context.Background(), "foo")
+		err := e.SetValueYARPC(context.Background(), "foo", "bar")
 		assert.Equal(t, yarpcerrors.Newf(yarpcerrors.CodeFailedPrecondition, "bar 1"), err)
 	})
 }
@@ -84,7 +84,7 @@ func TestYARPCNamedError(t *testing.T) {
 	t.Parallel()
 	doWithTestEnv(t, nil, nil, nil, func(t *testing.T, e *testEnv) {
 		e.KeyValueYARPCServer.SetNextError(yarpcerrors.Newf(yarpcerrors.CodeUnknown, "baz 1").WithName("bar"))
-		_, err := e.GetValueYARPC(context.Background(), "foo")
+		err := e.SetValueYARPC(context.Background(), "foo", "bar")
 		assert.Equal(t, yarpcerrors.Newf(yarpcerrors.CodeUnknown, "baz 1").WithName("bar"), err)
 	})
 }
@@ -93,7 +93,7 @@ func TestYARPCNamedErrorNoMessage(t *testing.T) {
 	t.Parallel()
 	doWithTestEnv(t, nil, nil, nil, func(t *testing.T, e *testEnv) {
 		e.KeyValueYARPCServer.SetNextError(yarpcerrors.Newf(yarpcerrors.CodeUnknown, "").WithName("bar"))
-		_, err := e.GetValueYARPC(context.Background(), "foo")
+		err := e.SetValueYARPC(context.Background(), "foo", "bar")
 		assert.Equal(t, yarpcerrors.Newf(yarpcerrors.CodeUnknown, "").WithName("bar"), err)
 	})
 }
@@ -102,7 +102,7 @@ func TestGRPCWellKnownError(t *testing.T) {
 	t.Parallel()
 	doWithTestEnv(t, nil, nil, nil, func(t *testing.T, e *testEnv) {
 		e.KeyValueYARPCServer.SetNextError(status.Error(codes.FailedPrecondition, "bar 1"))
-		_, err := e.GetValueGRPC(context.Background(), "foo")
+		err := e.SetValueGRPC(context.Background(), "foo", "bar")
 		assert.Equal(t, status.Error(codes.FailedPrecondition, "bar 1"), err)
 	})
 }
@@ -111,7 +111,7 @@ func TestGRPCNamedError(t *testing.T) {
 	t.Parallel()
 	doWithTestEnv(t, nil, nil, nil, func(t *testing.T, e *testEnv) {
 		e.KeyValueYARPCServer.SetNextError(yarpcerrors.Newf(yarpcerrors.CodeUnknown, "baz 1").WithName("bar"))
-		_, err := e.GetValueGRPC(context.Background(), "foo")
+		err := e.SetValueGRPC(context.Background(), "foo", "bar")
 		assert.Equal(t, status.Error(codes.Unknown, "bar: baz 1"), err)
 	})
 }
@@ -120,8 +120,33 @@ func TestGRPCNamedErrorNoMessage(t *testing.T) {
 	t.Parallel()
 	doWithTestEnv(t, nil, nil, nil, func(t *testing.T, e *testEnv) {
 		e.KeyValueYARPCServer.SetNextError(yarpcerrors.Newf(yarpcerrors.CodeUnknown, "").WithName("bar"))
-		_, err := e.GetValueGRPC(context.Background(), "foo")
+		err := e.SetValueGRPC(context.Background(), "foo", "bar")
 		assert.Equal(t, status.Error(codes.Unknown, "bar"), err)
+	})
+}
+
+func TestYARPCResponseAndError(t *testing.T) {
+	t.Parallel()
+	doWithTestEnv(t, nil, nil, nil, func(t *testing.T, e *testEnv) {
+		err := e.SetValueYARPC(context.Background(), "foo", "bar")
+		assert.NoError(t, err)
+		e.KeyValueYARPCServer.SetNextError(status.Error(codes.FailedPrecondition, "bar 1"))
+		value, err := e.GetValueYARPC(context.Background(), "foo")
+		assert.Equal(t, "bar", value)
+		assert.Equal(t, yarpcerrors.Newf(yarpcerrors.CodeFailedPrecondition, "bar 1"), err)
+	})
+}
+
+func TestGRPCResponseAndError(t *testing.T) {
+	t.Skip()
+	t.Parallel()
+	doWithTestEnv(t, nil, nil, nil, func(t *testing.T, e *testEnv) {
+		err := e.SetValueGRPC(context.Background(), "foo", "bar")
+		assert.NoError(t, err)
+		e.KeyValueYARPCServer.SetNextError(status.Error(codes.FailedPrecondition, "bar 1"))
+		value, err := e.GetValueGRPC(context.Background(), "foo")
+		assert.Equal(t, "bar", value)
+		assert.Equal(t, status.Error(codes.FailedPrecondition, "bar 1"), err)
 	})
 }
 
@@ -319,10 +344,10 @@ func (e *testEnv) GetValueYARPC(ctx context.Context, key string) (string, error)
 	ctx, cancel := context.WithTimeout(ctx, testtime.Second)
 	defer cancel()
 	response, err := e.KeyValueYARPCClient.GetValue(ctx, &examplepb.GetValueRequest{key})
-	if err != nil {
-		return "", err
+	if response != nil {
+		return response.Value, err
 	}
-	return response.Value, nil
+	return "", err
 }
 
 func (e *testEnv) SetValueYARPC(ctx context.Context, key string, value string) error {
@@ -336,10 +361,10 @@ func (e *testEnv) GetValueGRPC(ctx context.Context, key string) (string, error) 
 	ctx, cancel := context.WithTimeout(ctx, testtime.Second)
 	defer cancel()
 	response, err := e.KeyValueGRPCClient.GetValue(e.ContextWrapper.Wrap(ctx), &examplepb.GetValueRequest{key})
-	if err != nil {
-		return "", err
+	if response != nil {
+		return response.Value, err
 	}
-	return response.Value, nil
+	return "", err
 }
 
 func (e *testEnv) SetValueGRPC(ctx context.Context, key string, value string) error {

--- a/transport/grpc/integration_test.go
+++ b/transport/grpc/integration_test.go
@@ -138,7 +138,7 @@ func TestYARPCResponseAndError(t *testing.T) {
 }
 
 func TestGRPCResponseAndError(t *testing.T) {
-	t.Skip()
+	t.Skip("grpc-go clients do not support returning both a response and error as of now")
 	t.Parallel()
 	doWithTestEnv(t, nil, nil, nil, func(t *testing.T, e *testEnv) {
 		err := e.SetValueGRPC(context.Background(), "foo", "bar")

--- a/transport/http/constants.go
+++ b/transport/http/constants.go
@@ -102,22 +102,8 @@ const (
 // send them in requests or responses.
 const ApplicationHeaderPrefix = "Rpc-Header-"
 
-func applicationStatusValue(isApplicationError bool) string {
-	if isApplicationError {
-		return ApplicationErrorStatus
-	}
-	return ApplicationSuccessStatus
-}
-
 func fromApplicationStatusValue(applicationStatusValue string) bool {
 	return applicationStatusValue == ApplicationErrorStatus
-}
-
-func acceptValue(accept bool) string {
-	if accept {
-		return AcceptTrue
-	}
-	return ""
 }
 
 func fromAcceptValue(acceptValue string) bool {

--- a/transport/http/constants.go
+++ b/transport/http/constants.go
@@ -68,6 +68,20 @@ const (
 
 	// ErrorNameHeader contains the name of a user-defined error.
 	ErrorNameHeader = "Rpc-Error-Name"
+
+	// ErrorMessageHeader contains the message of an error, if the
+	// BothResponseError feature is enabled.
+	ErrorMessageHeader = "Rpc-Error-Message"
+
+	// AcceptsBothResponseErrorHeader says that the BothResponseError
+	// feature is supported on the client. If any non-empty value is set,
+	// this indicates true.
+	AcceptsBothResponseErrorHeader = "Rpc-Accepts-Both-Response-Error"
+
+	// BothResponseErrorHeader says that the BothResponseError
+	// feature is supported on the server. If any non-empty value is set,
+	// this indicates true.
+	BothResponseErrorHeader = "Rpc-Both-Response-Error"
 )
 
 // Valid values for the Rpc-Status header.
@@ -77,8 +91,35 @@ const (
 
 	// An error occurred. The response body contains an application header.
 	ApplicationErrorStatus = "error"
+
+	// AcceptTrue is the true value used for accept headers. Note that any
+	// non-empty value indicates true, but we end up sending this specific
+	// value.
+	AcceptTrue = "true"
 )
 
 // ApplicationHeaderPrefix is the prefix added to application header keys to
 // send them in requests or responses.
 const ApplicationHeaderPrefix = "Rpc-Header-"
+
+func applicationStatusValue(isApplicationError bool) string {
+	if isApplicationError {
+		return ApplicationErrorStatus
+	}
+	return ApplicationSuccessStatus
+}
+
+func fromApplicationStatusValue(applicationStatusValue string) bool {
+	return applicationStatusValue == ApplicationErrorStatus
+}
+
+func acceptValue(accept bool) string {
+	if accept {
+		return AcceptTrue
+	}
+	return ""
+}
+
+func fromAcceptValue(acceptValue string) bool {
+	return len(acceptValue) > 0
+}

--- a/transport/http/constants.go
+++ b/transport/http/constants.go
@@ -74,7 +74,7 @@ const (
 	ErrorMessageHeader = "Rpc-Error-Message"
 
 	// AcceptsBothResponseErrorHeader says that the BothResponseError
-	// feature is supported on the client. If any non-empty value is set,
+	// feature is supported on the client. If the value is "true",
 	// this indicates true.
 	AcceptsBothResponseErrorHeader = "Rpc-Accepts-Both-Response-Error"
 
@@ -92,16 +92,10 @@ const (
 	// An error occurred. The response body contains an application header.
 	ApplicationErrorStatus = "error"
 
-	// AcceptTrue is the true value used for accept headers. Note that any
-	// non-empty value indicates true, but we end up sending this specific
-	// value.
+	// AcceptTrue is the true value used for accept headers.
 	AcceptTrue = "true"
 )
 
 // ApplicationHeaderPrefix is the prefix added to application header keys to
 // send them in requests or responses.
 const ApplicationHeaderPrefix = "Rpc-Header-"
-
-func fromAcceptValue(acceptValue string) bool {
-	return len(acceptValue) > 0
-}

--- a/transport/http/constants.go
+++ b/transport/http/constants.go
@@ -102,10 +102,6 @@ const (
 // send them in requests or responses.
 const ApplicationHeaderPrefix = "Rpc-Header-"
 
-func fromApplicationStatusValue(applicationStatusValue string) bool {
-	return applicationStatusValue == ApplicationErrorStatus
-}
-
 func fromAcceptValue(acceptValue string) bool {
 	return len(acceptValue) > 0
 }

--- a/transport/http/handler.go
+++ b/transport/http/handler.go
@@ -54,7 +54,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	responseWriter := newResponseWriter(w)
 	service := popHeader(req.Header, ServiceHeader)
 	procedure := popHeader(req.Header, ProcedureHeader)
-	bothResponseError := fromAcceptValue(popHeader(req.Header, AcceptsBothResponseErrorHeader))
+	bothResponseError := popHeader(req.Header, AcceptsBothResponseErrorHeader) == AcceptTrue
 	status := yarpcerrors.FromError(errors.WrapHandlerError(h.callHandler(responseWriter, req, service, procedure), service, procedure))
 	if status == nil {
 		responseWriter.Close(http.StatusOK)

--- a/transport/http/handler.go
+++ b/transport/http/handler.go
@@ -44,9 +44,10 @@ func popHeader(h http.Header, n string) string {
 
 // handler adapts a transport.Handler into a handler for net/http.
 type handler struct {
-	router      transport.Router
-	tracer      opentracing.Tracer
-	grabHeaders map[string]struct{}
+	router            transport.Router
+	tracer            opentracing.Tracer
+	grabHeaders       map[string]struct{}
+	bothResponseError bool
 }
 
 func (h handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
@@ -68,7 +69,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if status.Name() != "" {
 		responseWriter.AddSystemHeader(ErrorNameHeader, status.Name())
 	}
-	if bothResponseError {
+	if bothResponseError && h.bothResponseError {
 		responseWriter.AddSystemHeader(BothResponseErrorHeader, AcceptTrue)
 		responseWriter.AddSystemHeader(ErrorMessageHeader, status.Message())
 	} else {

--- a/transport/http/handler.go
+++ b/transport/http/handler.go
@@ -216,6 +216,7 @@ type responseWriter struct {
 }
 
 func newResponseWriter(w http.ResponseWriter) *responseWriter {
+	w.Header().Set(ApplicationStatusHeader, ApplicationSuccessStatus)
 	return &responseWriter{w: w}
 }
 

--- a/transport/http/handler_test.go
+++ b/transport/http/handler_test.go
@@ -84,7 +84,7 @@ func TestHandlerSuccess(t *testing.T) {
 		gomock.Any(),
 	).Return(nil)
 
-	httpHandler := handler{router: router, tracer: &opentracing.NoopTracer{}}
+	httpHandler := handler{router: router, tracer: &opentracing.NoopTracer{}, bothResponseError: true}
 	req := &http.Request{
 		Method: "POST",
 		Header: headers,
@@ -160,7 +160,7 @@ func TestHandlerHeaders(t *testing.T) {
 			WithProcedure("hello"),
 		).Return(spec, nil)
 
-		httpHandler := handler{router: router, tracer: &opentracing.NoopTracer{}, grabHeaders: tt.grabHeaders}
+		httpHandler := handler{router: router, tracer: &opentracing.NoopTracer{}, grabHeaders: tt.grabHeaders, bothResponseError: true}
 
 		rpcHandler.EXPECT().Handle(
 			transporttest.NewContextMatcher(t,
@@ -291,7 +291,7 @@ func TestHandlerFailures(t *testing.T) {
 			).Return(spec, nil)
 		}
 
-		h := handler{router: reg, tracer: &opentracing.NoopTracer{}}
+		h := handler{router: reg, tracer: &opentracing.NoopTracer{}, bothResponseError: true}
 
 		rw := httptest.NewRecorder()
 		h.ServeHTTP(rw, tt.req)
@@ -344,7 +344,7 @@ func TestHandlerInternalFailure(t *testing.T) {
 		WithProcedure("hello"),
 	).Return(spec, nil)
 
-	httpHandler := handler{router: router, tracer: &opentracing.NoopTracer{}}
+	httpHandler := handler{router: router, tracer: &opentracing.NoopTracer{}, bothResponseError: true}
 	httpResponse := httptest.NewRecorder()
 	httpHandler.ServeHTTP(httpResponse, &request)
 

--- a/transport/http/integration_test.go
+++ b/transport/http/integration_test.go
@@ -1,0 +1,139 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package http
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/multierr"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/clientconfig"
+)
+
+func TestBothResponseError(t *testing.T) {
+	doWithTestEnv(t, testEnvOptions{}, func(t *testing.T, testEnv *testEnv) {
+
+	})
+}
+
+func doWithTestEnv(t *testing.T, options testEnvOptions, f func(*testing.T, *testEnv)) {
+	testEnv, err := newTestEnv(options)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, testEnv.Close())
+	}()
+	f(t, testEnv)
+}
+
+type testEnv struct {
+	Inbound      *Inbound
+	Outbound     *Outbound
+	ClientConfig transport.ClientConfig
+}
+
+type testEnvOptions struct {
+	Procedures       []transport.Procedure
+	TransportOptions []TransportOption
+	InboundOptions   []InboundOption
+	OutboundOptions  []OutboundOption
+}
+
+func newTestEnv(options testEnvOptions) (_ *testEnv, err error) {
+	t := NewTransport(options.TransportOptions...)
+	if err := t.Start(); err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err != nil {
+			err = multierr.Append(err, t.Stop())
+		}
+	}()
+
+	inbound := t.NewInbound("127.0.0.1:0", options.InboundOptions...)
+	inbound.SetRouter(newTestRouter(options.Procedures))
+	if err := inbound.Start(); err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err != nil {
+			err = multierr.Append(err, inbound.Stop())
+		}
+	}()
+
+	outbound := t.NewSingleOutbound(fmt.Sprintf("http://%s", inbound.Addr().String()), options.OutboundOptions...)
+	if err := outbound.Start(); err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err != nil {
+			err = multierr.Append(err, outbound.Stop())
+		}
+	}()
+
+	caller := "example-client"
+	service := "example"
+	clientConfig := clientconfig.MultiOutbound(
+		caller,
+		service,
+		transport.Outbounds{
+			ServiceName: caller,
+			Unary:       outbound,
+		},
+	)
+
+	return &testEnv{
+		inbound,
+		outbound,
+		clientConfig,
+	}, nil
+}
+
+func (e *testEnv) Close() error {
+	return multierr.Combine(
+		e.Outbound.Stop(),
+		e.Inbound.Stop(),
+	)
+}
+
+type testRouter struct {
+	procedures []transport.Procedure
+}
+
+func newTestRouter(procedures []transport.Procedure) *testRouter {
+	return &testRouter{procedures}
+}
+
+func (r *testRouter) Procedures() []transport.Procedure {
+	return r.procedures
+}
+
+func (r *testRouter) Choose(_ context.Context, request *transport.Request) (transport.HandlerSpec, error) {
+	for _, procedure := range r.procedures {
+		if procedure.Name == request.Procedure {
+			return procedure.HandlerSpec, nil
+		}
+	}
+	return transport.HandlerSpec{}, fmt.Errorf("no procedure for name %s", request.Procedure)
+}

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -297,7 +297,7 @@ func (o *Outbound) callWithPeer(
 		Body:             response.Body,
 		ApplicationError: response.Header.Get(ApplicationStatusHeader) == ApplicationErrorStatus,
 	}
-	bothResponseError := fromAcceptValue(response.Header.Get(BothResponseErrorHeader))
+	bothResponseError := response.Header.Get(BothResponseErrorHeader) == AcceptTrue
 	if bothResponseError && o.bothResponseError {
 		if response.StatusCode >= 300 {
 			return tres, getYARPCErrorFromResponse(response, true)

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -295,7 +295,7 @@ func (o *Outbound) callWithPeer(
 	tres := &transport.Response{
 		Headers:          applicationHeaders.FromHTTPHeaders(response.Header, transport.NewHeaders()),
 		Body:             response.Body,
-		ApplicationError: fromApplicationStatusValue(response.Header.Get(ApplicationStatusHeader)),
+		ApplicationError: response.Header.Get(ApplicationStatusHeader) == ApplicationErrorStatus,
 	}
 	bothResponseError := fromAcceptValue(response.Header.Get(BothResponseErrorHeader))
 	if bothResponseError && o.bothResponseError {

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -288,18 +288,22 @@ func (o *Outbound) callWithPeer(
 
 	span.SetTag("http.status_code", response.StatusCode)
 
-	if response.StatusCode >= 200 && response.StatusCode < 300 {
-		appHeaders := applicationHeaders.FromHTTPHeaders(
-			response.Header, transport.NewHeaders())
-		appError := response.Header.Get(ApplicationStatusHeader) == ApplicationErrorStatus
-		return &transport.Response{
-			Headers:          appHeaders,
-			Body:             response.Body,
-			ApplicationError: appError,
-		}, nil
+	bothResponseError := fromAcceptValue(response.Header.Get(BothResponseErrorHeader))
+	tres := &transport.Response{
+		Headers:          applicationHeaders.FromHTTPHeaders(response.Header, transport.NewHeaders()),
+		Body:             response.Body,
+		ApplicationError: fromApplicationStatusValue(response.Header.Get(ApplicationStatusHeader)),
 	}
-
-	return nil, getYARPCErrorFromResponse(response)
+	if bothResponseError {
+		if response.StatusCode >= 300 {
+			return tres, getYARPCErrorFromResponse(response, true)
+		}
+		return tres, nil
+	}
+	if response.StatusCode >= 200 && response.StatusCode < 300 {
+		return tres, nil
+	}
+	return nil, getYARPCErrorFromResponse(response, false)
 }
 
 func (o *Outbound) getPeerForRequest(ctx context.Context, treq *transport.Request) (*httpPeer, func(error), error) {
@@ -386,16 +390,24 @@ func (o *Outbound) withCoreHeaders(req *http.Request, treq *transport.Request, t
 		req.Header.Set(EncodingHeader, encoding)
 	}
 
+	req.Header.Set(AcceptsBothResponseErrorHeader, AcceptTrue)
+
 	return req
 }
 
-func getYARPCErrorFromResponse(response *http.Response) error {
-	contents, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		return yarpcerrors.Newf(yarpcerrors.CodeInternal, err.Error())
-	}
-	if err := response.Body.Close(); err != nil {
-		return yarpcerrors.Newf(yarpcerrors.CodeInternal, err.Error())
+func getYARPCErrorFromResponse(response *http.Response, bothResponseError bool) error {
+	var contents string
+	if bothResponseError {
+		contents = response.Header.Get(ErrorMessageHeader)
+	} else {
+		contentsBytes, err := ioutil.ReadAll(response.Body)
+		if err != nil {
+			return yarpcerrors.Newf(yarpcerrors.CodeInternal, err.Error())
+		}
+		contents = string(contentsBytes)
+		if err := response.Body.Close(); err != nil {
+			return yarpcerrors.Newf(yarpcerrors.CodeInternal, err.Error())
+		}
 	}
 	// use the status code if we can't get a code from the headers
 	code := statusCodeToBestCode(response.StatusCode)
@@ -408,7 +420,7 @@ func getYARPCErrorFromResponse(response *http.Response) error {
 	}
 	return yarpcerrors.Newf(
 		code,
-		strings.TrimSuffix(string(contents), "\n"),
+		strings.TrimSuffix(contents, "\n"),
 	).WithName(response.Header.Get(ErrorNameHeader))
 }
 

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -288,12 +288,12 @@ func (o *Outbound) callWithPeer(
 
 	span.SetTag("http.status_code", response.StatusCode)
 
-	bothResponseError := fromAcceptValue(response.Header.Get(BothResponseErrorHeader))
 	tres := &transport.Response{
 		Headers:          applicationHeaders.FromHTTPHeaders(response.Header, transport.NewHeaders()),
 		Body:             response.Body,
 		ApplicationError: fromApplicationStatusValue(response.Header.Get(ApplicationStatusHeader)),
 	}
+	bothResponseError := fromAcceptValue(response.Header.Get(BothResponseErrorHeader))
 	if bothResponseError {
 		if response.StatusCode >= 300 {
 			return tres, getYARPCErrorFromResponse(response, true)


### PR DESCRIPTION
This implements the negotiation to see if we should send the error message for HTTP on a response header instead of in the body, as well as potentially returning both the response and error for Protobuf, JSON and Raw encodings.