### PR TITLE
Add http.Interceptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,8 @@ Releases
 v1.20.0-dev (unreleased)
 --------------------
 
--   Added the `http.Interceptor` inbound option which allows the
-    behavior of incoming HTTP requests to be customized.
-
+-   http: Add `http.Interceptor` option to inbounds, which allows intercepting
+    incoming HTTP requests for that inbound.
 
 v1.19.2 (2017-10-10)
 --------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Releases
 v1.20.0-dev (unreleased)
 --------------------
 
-- No changes yet.
+-   Added the `http.Interceptor` inbound option which allows the
+    behavior of incoming HTTP requests to be customized.
 
 
 v1.19.2 (2017-10-10)

--- a/transport/http/inbound.go
+++ b/transport/http/inbound.go
@@ -51,10 +51,12 @@ func Mux(pattern string, mux *http.ServeMux) InboundOption {
 	}
 }
 
-// Interceptor specifies a func that takes the transport http.Handler and
-// produces an http.Handler. This can be used to create custom behavior
-// when inbound HTTP requests are recieved.
-func Interceptor(interceptor func(http.Handler) http.Handler) InboundOption {
+// Interceptor specifies a function which can wrap the YARPC handler. If
+// provided, this function will be called with an http.Handler which will
+// route requests through YARPC. The http.Handler returned by this function
+// may delegate requests to the provided YARPC handler to route them through
+// YARPC.
+func Interceptor(interceptor func(yarpcHandler http.Handler) http.Handler) InboundOption {
 	return func(i *Inbound) {
 		i.interceptor = interceptor
 	}

--- a/transport/http/inbound_example_test.go
+++ b/transport/http/inbound_example_test.go
@@ -102,7 +102,7 @@ func ExampleInterceptor() {
 		})
 	}
 
-	// This handler represents some existing http.Handler.
+	// This handler will be executed for non-YARPC HTTP requests.
 	handler := nethttp.HandlerFunc(func(w nethttp.ResponseWriter, req *nethttp.Request) {
 		io.WriteString(w, "hello, world!")
 	})

--- a/transport/http/inbound_example_test.go
+++ b/transport/http/inbound_example_test.go
@@ -22,6 +22,7 @@ package http_test
 
 import (
 	"fmt"
+	"io"
 	"log"
 	nethttp "net/http"
 	"os"
@@ -82,4 +83,53 @@ func ExampleMux() {
 		log.Fatal(err)
 	}
 	// Output: hello from /health
+}
+
+func ExampleInterceptor() {
+	// import nethttp "net/http"
+
+	// We create an interceptor which executes an override http.Handler if
+	// the HTTP request is not a well-formed YARPC request.
+	override := func(overrideHandler nethttp.Handler) http.InboundOption {
+		return http.Interceptor(func(transportHandler nethttp.Handler) nethttp.Handler {
+			return nethttp.HandlerFunc(func(w nethttp.ResponseWriter, r *nethttp.Request) {
+				if r.Header.Get("RPC-Encoding") == "" {
+					overrideHandler.ServeHTTP(w, r)
+				} else {
+					transportHandler.ServeHTTP(w, r)
+				}
+			})
+		})
+	}
+
+	// This handler represents some existing http.Handler.
+	handler := nethttp.HandlerFunc(func(w nethttp.ResponseWriter, req *nethttp.Request) {
+		io.WriteString(w, "hello, world!")
+	})
+
+	// We create the inbound, attaching the override interceptor.
+	transport := http.NewTransport()
+	inbound := transport.NewInbound(":8889", override(handler))
+
+	// Fire up a dispatcher with the new inbound.
+	dispatcher := yarpc.NewDispatcher(yarpc.Config{
+		Name:     "server",
+		Inbounds: yarpc.Inbounds{inbound},
+	})
+	if err := dispatcher.Start(); err != nil {
+		log.Fatal(err)
+	}
+	defer dispatcher.Stop()
+
+	// Make a non-YARPC request to the / endpoint.
+	res, err := nethttp.Get("http://127.0.0.1:8889/")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer res.Body.Close()
+
+	if _, err := iopool.Copy(os.Stdout, res.Body); err != nil {
+		log.Fatal(err)
+	}
+	// Output: hello, world!
 }


### PR DESCRIPTION
This replaces #1334 as a more flexible way to accomplish:

* Providing an overriding http.Handler when the request is not a YARPC HTTP request.
* Retrofitting existing HTTP Rest APIs to YARPC HTTP requests.
* And more!

The advantage here is that:

* The interceptor pattern is more powerful w/ fewer LOC.
* Less edits to the mainline HTTP transport, we can extend internally. 

- [x] Add `http.Interceptor`.
- [x] Add example test that illustrates how to use `http.Interceptor`.
- [x] Changelog.