### PR TITLE
http: Fix http.Interceptor ignoring http.Mux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
 Releases
 ========
 
-v1.21.0-dev (unreleased)
+v1.20.1 (2017-10-20)
 --------------------
 
-- No changes yet.
-
+-   http: Fix `http.Interceptor` ignoreing `http.Mux`.
 
 v1.20.0 (2017-10-16)
 --------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 Releases
 ========
 
-v1.20.1 (2017-10-20)
+v1.20.1 (2017-10-23)
 --------------------
 
--   http: Fix `http.Interceptor` ignoreing `http.Mux`.
+-   http: Fix `http.Interceptor` ignoring `http.Mux`.
 
 v1.20.0 (2017-10-16)
 --------------------

--- a/transport/http/inbound.go
+++ b/transport/http/inbound.go
@@ -149,13 +149,12 @@ func (i *Inbound) start() error {
 		tracer:      i.tracer,
 		grabHeaders: i.grabHeaders,
 	}
+	if i.interceptor != nil {
+		httpHandler = i.interceptor(httpHandler)
+	}
 	if i.mux != nil {
 		i.mux.Handle(i.muxPattern, httpHandler)
 		httpHandler = i.mux
-	}
-
-	if i.interceptor != nil {
-		httpHandler = i.interceptor(httpHandler)
 	}
 
 	i.server = intnet.NewHTTPServer(&http.Server{

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package yarpc // import "go.uber.org/yarpc"
 
 // Version is the current version of YARPC.
-const Version = "1.21.0-dev"
+const Version = "1.20.1"


### PR DESCRIPTION
When using the interceptor, the mux ends up being ignored since YARPC
either handles the request, or relegates it to the handler. However, we
should use the mux first, and only call the interceptor for requests
that the mux did not have registered.

Since this is a bug fix, I thought we could cut a `1.20.1` with this fix.

(References T1250945)