### PR TITLE
Rewrite release instructions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,48 +3,109 @@ Release process
 
 This document outlines how to create a release of yarpc-go
 
-1.  `git checkout master`
+1.  Set up some environment variables for use later.
 
-2.  `git pull`
+    ```
+    # This is the version being released.
+    $ VERSION=1.21.0
 
-3.  `git merge <branch>` where `<branch>` is the branch we want to cut the
-    release on (most likely `dev`)
+    # This is the branch from which $VERSION will be released.
+    # This is almost always dev.
+    $ BRANCH=dev
+    ```
 
-4.  Alter CHANGELOG.md from `v<version>-dev (unreleased)` to
-    `v<version_to_release> (YYYY-MM-DD)`
+2.  Make sure you have the latest master.
 
-5.  Alter `version.go` to have the same version as `version_to_release`
+    ```
+    $ git checkout master
+    $ git pull
+    ```
 
-6.  Run `make verifyversion`
+3.  Merge the branch being released into master.
 
-7.  Create a commit with the title `Preparing for release <version_to_release>`
+    ```
+    $ git merge $BRANCH
+    ```
 
-8.  Create a git tag for the version using
-    `git tag -a v<version_to_release> -m v<version_to_release` (e.g.
-    `git tag -a v1.0.0 -m v1.0.0`)
+4.  Alter the release date in CHANGELOG.md for `$VERSION` using the format
+    `YYYY-MM-DD`.
 
-9.  Push the release `git push origin v<version_to_release> master`
+    ```diff
+    -v1.21.0-dev (unreleased)
+    +v1.21.0-dev (2017-10-23)
+    ```
 
-10. Go to https://travis-ci.org/yarpc/yarpc-go/builds and cancel the build for
-    v<version_to_release>. If the Codecov build for v<version_to_release>
-    completes before the Codecov build for master, the code coverage for master
-    will not get updated, only one branch gets updated per commit, this is
-    verified with Codecov support. This will get tested by the build for master
-    anyways.
+5.  Update the version number in version.go and verify that it matches what is
+    in the changelog.
 
-11. Go to https://github.com/yarpc/yarpc-go/tags and edit the release notes of
-    the new tag (copy the changelog into the release notes and make the release
-    name the version number)
+    ```
+    $ sed -i '' -e "s/^const Version =.*/const Version = \"$VERSION\"/" version.go
+    $ make verifyversion
+    ```
 
-12. `git checkout dev`
+6.  Create a commit for the release.
 
-13. `git merge master`
+    ```
+    $ git add version.go CHANGELOG.md
+    $ git commit -m "Preparing release v$VERSION"
+    ```
 
-14. Update `CHANGELOG.md` and `version.go` to have a new
-    `v<version>-dev (unreleased)`
+7.  Tag and push the release.
 
-15. Run `make verifyversion`
+    ```
+    $ git tag -a "v$VERSION" -m "v$VERSION"
+    $ git push origin master "v$VERSION"
+    ```
 
-16. Create a commit with the title `Back to development`
+8.  Go to <https://travis-ci.org/yarpc/yarpc-go/builds> and cancel the build
+    for `v$VERSION`.  If that Codecov build completes before the Codecov build
+    for master, the code coverage for master will not get updated because only
+    one branch gets updated per commit; this was verified with Codecov support.
+    This will get tested by the build for master anyways.
 
-17. `git push origin dev`
+9.  Go to <https://github.com/yarpc/yarpc-go/tags> and edit the release notes
+    of the new tag.  Copy the changelog entries for this release int the
+    release notes and set the name of the release to the version number
+    (`v$VERSION`).
+
+10. Switch back to development.
+
+    ```
+    $ git checkout $BRANCH
+    $ git merge master
+    ```
+
+11. Add a placeholder for the next version to CHANGELOG.md.  This is typically
+    one minor version above the version just released.
+
+    ```diff
+    +v1.22.0-dev (unreleased)
+    +------------------------
+    +
+    +-   No changes yet.
+    +
+    +
+     v1.21.0 (2017-10-23)
+     --------------------
+    ```
+
+12. Update the version number in version.go to the same version.
+
+    ```diff
+    -const Version = "1.21.0"
+    +const Version = "1.22.0-dev"
+    ```
+
+13. Verify the version number matches.
+
+    ```
+    $ make verifyversion
+    ```
+
+14. Commit and push your changes.
+
+    ```
+    $ git add CHANGELOG.md version.go
+    $ git commit -m 'Back to development'
+    $ git push origin $BRANCH
+    ```


### PR DESCRIPTION
This changes the release instructions to be more copy-paste friendly.
Otherwise it's easy to miss parts of commands. For example, in,

    $ git push origin v<version_to_release> master

It's easy to miss the `master` at the end.

