### PR TITLE
Fix content-type for http errors

### DIFF
--- a/transport/http/handler.go
+++ b/transport/http/handler.go
@@ -75,8 +75,8 @@ func (h handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	} else {
 		responseWriter.ResetBuffer()
 		_, _ = fmt.Fprintln(responseWriter, status.Message())
+		responseWriter.AddSystemHeader("Content-Type", "text/plain; charset=utf8")
 	}
-	responseWriter.AddSystemHeader("Content-Type", "text/plain; charset=utf8")
 	httpStatusCode, ok := _codeToStatusCode[status.Code()]
 	if !ok {
 		httpStatusCode = http.StatusInternalServerError


### PR DESCRIPTION
The setting of `Content-Type` to `text/plain; charset=utf8` should only happen if the error is written to the body. This is a fix to #1335.