### PR TITLE
Add Logger TransportOption to all transports

### DIFF
--- a/transport/grpc/inbound.go
+++ b/transport/grpc/inbound.go
@@ -27,6 +27,7 @@ import (
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/pkg/lifecycle"
 	"go.uber.org/yarpc/yarpcerrors"
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 )
 
@@ -101,6 +102,9 @@ func (i *Inbound) start() error {
 	)
 
 	go func() {
+		if i.t.options.logger != nil {
+			i.t.options.logger.Info("grpc inbound started", zap.String("address", i.listener.Addr().String()))
+		}
 		// TODO there should be some mechanism to block here
 		// there is a race because the listener gets set in the grpc
 		// Server implementation and we should be able to block

--- a/transport/grpc/inbound.go
+++ b/transport/grpc/inbound.go
@@ -102,11 +102,9 @@ func (i *Inbound) start() error {
 	)
 
 	go func() {
-		if i.t.options.logger != nil {
-			i.t.options.logger.Info("grpc inbound started", zap.String("address", i.listener.Addr().String()))
-			if len(i.router.Procedures()) == 0 {
-				i.t.options.logger.Warn("no procedures specified for grpc inbound")
-			}
+		i.t.options.logger.Info("started GRPC inbound", zap.Stringer("address", i.listener.Addr()))
+		if len(i.router.Procedures()) == 0 {
+			i.t.options.logger.Warn("no procedures specified for GRPC inbound")
 		}
 		// TODO there should be some mechanism to block here
 		// there is a race because the listener gets set in the grpc

--- a/transport/grpc/inbound.go
+++ b/transport/grpc/inbound.go
@@ -104,6 +104,9 @@ func (i *Inbound) start() error {
 	go func() {
 		if i.t.options.logger != nil {
 			i.t.options.logger.Info("grpc inbound started", zap.String("address", i.listener.Addr().String()))
+			if len(i.router.Procedures()) == 0 {
+				i.t.options.logger.Warn("no procedures specified for grpc inbound")
+			}
 		}
 		// TODO there should be some mechanism to block here
 		// there is a race because the listener gets set in the grpc

--- a/transport/grpc/integration_test.go
+++ b/transport/grpc/integration_test.go
@@ -42,7 +42,6 @@ import (
 	"go.uber.org/yarpc/internal/testtime"
 	"go.uber.org/yarpc/pkg/procedure"
 	"go.uber.org/yarpc/yarpcerrors"
-	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -233,7 +232,7 @@ func newTestEnv(transportOptions []TransportOption, inboundOptions []InboundOpti
 	procedures := examplepb.BuildKeyValueYARPCProcedures(keyValueYARPCServer)
 	testRouter := newTestRouter(procedures)
 
-	t := NewTransport(append(transportOptions, Logger(zap.NewExample()))...)
+	t := NewTransport(transportOptions...)
 	if err := t.Start(); err != nil {
 		return nil, err
 	}

--- a/transport/grpc/integration_test.go
+++ b/transport/grpc/integration_test.go
@@ -42,6 +42,7 @@ import (
 	"go.uber.org/yarpc/internal/testtime"
 	"go.uber.org/yarpc/pkg/procedure"
 	"go.uber.org/yarpc/yarpcerrors"
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -232,7 +233,7 @@ func newTestEnv(transportOptions []TransportOption, inboundOptions []InboundOpti
 	procedures := examplepb.BuildKeyValueYARPCProcedures(keyValueYARPCServer)
 	testRouter := newTestRouter(procedures)
 
-	t := NewTransport(transportOptions...)
+	t := NewTransport(append(transportOptions, Logger(zap.NewExample()))...)
 	if err := t.Start(); err != nil {
 		return nil, err
 	}

--- a/transport/grpc/options.go
+++ b/transport/grpc/options.go
@@ -26,6 +26,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"go.uber.org/yarpc/api/backoff"
 	intbackoff "go.uber.org/yarpc/internal/backoff"
+	"go.uber.org/zap"
 )
 
 const (
@@ -70,6 +71,15 @@ func BackoffStrategy(backoffStrategy backoff.Strategy) TransportOption {
 func Tracer(tracer opentracing.Tracer) TransportOption {
 	return func(transportOptions *transportOptions) {
 		transportOptions.tracer = tracer
+	}
+}
+
+// Logger sets a logger to use for internal logging.
+//
+// The default is to not write any logs.
+func Logger(logger *zap.Logger) TransportOption {
+	return func(transportOptions *transportOptions) {
+		transportOptions.logger = logger
 	}
 }
 
@@ -122,6 +132,7 @@ func (OutboundOption) grpcOption() {}
 type transportOptions struct {
 	backoffStrategy      backoff.Strategy
 	tracer               opentracing.Tracer
+	logger               *zap.Logger
 	serverMaxRecvMsgSize int
 	serverMaxSendMsgSize int
 	clientMaxRecvMsgSize int

--- a/transport/grpc/options.go
+++ b/transport/grpc/options.go
@@ -150,6 +150,9 @@ func newTransportOptions(options []TransportOption) *transportOptions {
 	for _, option := range options {
 		option(transportOptions)
 	}
+	if transportOptions.logger == nil {
+		transportOptions.logger = zap.NewNop()
+	}
 	return transportOptions
 }
 

--- a/transport/http/inbound.go
+++ b/transport/http/inbound.go
@@ -174,11 +174,9 @@ func (i *Inbound) start() error {
 	}
 
 	i.addr = i.server.Listener().Addr().String() // in case it changed
-	if i.logger != nil {
-		i.logger.Info("http inbound started", zap.String("address", i.addr))
-		if len(i.router.Procedures()) == 0 {
-			i.logger.Warn("no procedures specified for http inbound")
-		}
+	i.logger.Info("started HTTP inbound", zap.String("address", i.addr))
+	if len(i.router.Procedures()) == 0 {
+		i.logger.Warn("no procedures specified for HTTP inbound")
 	}
 	return nil
 }

--- a/transport/http/inbound.go
+++ b/transport/http/inbound.go
@@ -31,6 +31,7 @@ import (
 	intnet "go.uber.org/yarpc/internal/net"
 	"go.uber.org/yarpc/pkg/lifecycle"
 	"go.uber.org/yarpc/yarpcerrors"
+	"go.uber.org/zap"
 )
 
 // InboundOption customizes the behavior of an HTTP Inbound constructed with
@@ -85,6 +86,7 @@ func (t *Transport) NewInbound(addr string, opts ...InboundOption) *Inbound {
 		once:              lifecycle.NewOnce(),
 		addr:              addr,
 		tracer:            t.tracer,
+		logger:            t.logger,
 		transport:         t,
 		grabHeaders:       make(map[string]struct{}),
 		bothResponseError: true,
@@ -104,6 +106,7 @@ type Inbound struct {
 	server      *intnet.HTTPServer
 	router      transport.Router
 	tracer      opentracing.Tracer
+	logger      *zap.Logger
 	transport   *Transport
 	grabHeaders map[string]struct{}
 	interceptor func(http.Handler) http.Handler
@@ -171,6 +174,9 @@ func (i *Inbound) start() error {
 	}
 
 	i.addr = i.server.Listener().Addr().String() // in case it changed
+	if i.logger != nil {
+		i.logger.Info("http inbound started", zap.String("address", i.addr))
+	}
 	return nil
 }
 

--- a/transport/http/inbound.go
+++ b/transport/http/inbound.go
@@ -176,6 +176,9 @@ func (i *Inbound) start() error {
 	i.addr = i.server.Listener().Addr().String() // in case it changed
 	if i.logger != nil {
 		i.logger.Info("http inbound started", zap.String("address", i.addr))
+		if len(i.router.Procedures()) == 0 {
+			i.logger.Warn("no procedures specified for http inbound")
+		}
 	}
 	return nil
 }

--- a/transport/http/inbound_test.go
+++ b/transport/http/inbound_test.go
@@ -54,11 +54,11 @@ func TestStartAddrInUse(t *testing.T) {
 	// comparison
 	assert.True(t, t1 == i1.Transports()[0], "transports must match")
 
-	i1.SetRouter(new(transporttest.MockRouter))
+	i1.SetRouter(newTestRouter(nil))
 	require.NoError(t, i1.Start(), "inbound 1 must start without an error")
 	t2 := NewTransport()
 	i2 := t2.NewInbound(i1.Addr().String())
-	i2.SetRouter(new(transporttest.MockRouter))
+	i2.SetRouter(newTestRouter(nil))
 	err := i2.Start()
 
 	require.Error(t, err)
@@ -75,7 +75,7 @@ func TestStartAddrInUse(t *testing.T) {
 func TestNilAddrAfterStop(t *testing.T) {
 	x := NewTransport()
 	i := x.NewInbound(":0")
-	i.SetRouter(new(transporttest.MockRouter))
+	i.SetRouter(newTestRouter(nil))
 	require.NoError(t, i.Start())
 	assert.NotEqual(t, ":0", i.Addr().String())
 	assert.NotNil(t, i.Addr())
@@ -86,7 +86,7 @@ func TestNilAddrAfterStop(t *testing.T) {
 func TestInboundStartAndStop(t *testing.T) {
 	x := NewTransport()
 	i := x.NewInbound(":0")
-	i.SetRouter(new(transporttest.MockRouter))
+	i.SetRouter(newTestRouter(nil))
 	require.NoError(t, i.Start())
 	assert.NotEqual(t, ":0", i.Addr().String())
 	assert.NoError(t, i.Stop())
@@ -129,6 +129,7 @@ func TestInboundMux(t *testing.T) {
 	i := httpTransport.NewInbound(":0", Mux("/rpc/v1", mux))
 	h := transporttest.NewMockUnaryHandler(mockCtrl)
 	reg := transporttest.NewMockRouter(mockCtrl)
+	reg.EXPECT().Procedures()
 	i.SetRouter(reg)
 	require.NoError(t, i.Start())
 
@@ -220,7 +221,7 @@ func TestMuxWithInterceptor(t *testing.T) {
 
 	transport := NewTransport()
 	inbound := transport.NewInbound("127.0.0.1:0", Mux("/", mux), Interceptor(intercept))
-	inbound.SetRouter(new(transporttest.MockRouter))
+	inbound.SetRouter(newTestRouter(nil))
 	require.NoError(t, inbound.Start(), "Failed to start inbound")
 	defer inbound.Stop()
 

--- a/transport/http/transport.go
+++ b/transport/http/transport.go
@@ -144,6 +144,10 @@ func NewTransport(opts ...TransportOption) *Transport {
 }
 
 func (o *transportOptions) newTransport() *Transport {
+	logger := o.logger
+	if logger == nil {
+		logger = zap.NewNop()
+	}
 	return &Transport{
 		once:                lifecycle.NewOnce(),
 		client:              o.buildClient(o),
@@ -151,7 +155,7 @@ func (o *transportOptions) newTransport() *Transport {
 		connBackoffStrategy: o.connBackoffStrategy,
 		peers:               make(map[string]*httpPeer),
 		tracer:              o.tracer,
-		logger:              o.logger,
+		logger:              logger,
 	}
 }
 

--- a/transport/http/transport.go
+++ b/transport/http/transport.go
@@ -33,6 +33,7 @@ import (
 	"go.uber.org/yarpc/internal/backoff"
 	"go.uber.org/yarpc/peer/hostport"
 	"go.uber.org/yarpc/pkg/lifecycle"
+	"go.uber.org/zap"
 )
 
 type transportOptions struct {
@@ -42,6 +43,7 @@ type transportOptions struct {
 	connBackoffStrategy backoffapi.Strategy
 	tracer              opentracing.Tracer
 	buildClient         func(*transportOptions) *http.Client
+	logger              *zap.Logger
 }
 
 var defaultTransportOptions = transportOptions{
@@ -115,6 +117,15 @@ func Tracer(tracer opentracing.Tracer) TransportOption {
 	}
 }
 
+// Logger sets a logger to use for internal logging.
+//
+// The default is to not write any logs.
+func Logger(logger *zap.Logger) TransportOption {
+	return func(options *transportOptions) {
+		options.logger = logger
+	}
+}
+
 // Hidden option to override the buildHTTPClient function. This is used only
 // for testing.
 func buildClient(f func(*transportOptions) *http.Client) TransportOption {
@@ -140,6 +151,7 @@ func (o *transportOptions) newTransport() *Transport {
 		connBackoffStrategy: o.connBackoffStrategy,
 		peers:               make(map[string]*httpPeer),
 		tracer:              o.tracer,
+		logger:              o.logger,
 	}
 }
 
@@ -174,6 +186,7 @@ type Transport struct {
 	connectorsGroup     sync.WaitGroup
 
 	tracer opentracing.Tracer
+	logger *zap.Logger
 }
 
 var _ transport.Transport = (*Transport)(nil)

--- a/transport/tchannel/channel_inbound.go
+++ b/transport/tchannel/channel_inbound.go
@@ -24,6 +24,7 @@ import (
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/introspection"
 	"go.uber.org/yarpc/pkg/lifecycle"
+	"go.uber.org/zap"
 )
 
 // ChannelInbound receives YARPC requests over TChannel.
@@ -73,7 +74,12 @@ func (i *ChannelInbound) Channel() Channel {
 // connections; that occurs when you start the underlying ChannelTransport is
 // started.
 func (i *ChannelInbound) Start() error {
-	return i.once.Start(nil)
+	return i.once.Start(func() error {
+		if i.transport.logger != nil {
+			i.transport.logger.Info("tchannel inbound started", zap.String("address", i.transport.ListenAddr()))
+		}
+		return nil
+	})
 }
 
 // Stop stops the TChannel outbound. This currently does nothing.

--- a/transport/tchannel/channel_inbound.go
+++ b/transport/tchannel/channel_inbound.go
@@ -77,6 +77,9 @@ func (i *ChannelInbound) Start() error {
 	return i.once.Start(func() error {
 		if i.transport.logger != nil {
 			i.transport.logger.Info("tchannel inbound started", zap.String("address", i.transport.ListenAddr()))
+			if i.transport.router == nil || len(i.transport.router.Procedures()) == 0 {
+				i.transport.logger.Warn("no procedures specified for tchannel inbound")
+			}
 		}
 		return nil
 	})

--- a/transport/tchannel/channel_inbound.go
+++ b/transport/tchannel/channel_inbound.go
@@ -75,11 +75,9 @@ func (i *ChannelInbound) Channel() Channel {
 // started.
 func (i *ChannelInbound) Start() error {
 	return i.once.Start(func() error {
-		if i.transport.logger != nil {
-			i.transport.logger.Info("tchannel inbound started", zap.String("address", i.transport.ListenAddr()))
-			if i.transport.router == nil || len(i.transport.router.Procedures()) == 0 {
-				i.transport.logger.Warn("no procedures specified for tchannel inbound")
-			}
+		i.transport.logger.Info("started TChannel inbound", zap.String("address", i.transport.ListenAddr()))
+		if i.transport.router == nil || len(i.transport.router.Procedures()) == 0 {
+			i.transport.logger.Warn("no procedures specified for tchannel inbound")
 		}
 		return nil
 	})

--- a/transport/tchannel/channel_transport.go
+++ b/transport/tchannel/channel_transport.go
@@ -27,6 +27,7 @@ import (
 	"github.com/uber/tchannel-go"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/pkg/lifecycle"
+	"go.uber.org/zap"
 )
 
 var errChannelOrServiceNameIsRequired = errors.New(
@@ -81,6 +82,7 @@ func (options transportOptions) newChannelTransport() *ChannelTransport {
 		ch:     options.ch,
 		addr:   options.addr,
 		tracer: options.tracer,
+		logger: options.logger,
 	}
 }
 
@@ -93,6 +95,7 @@ type ChannelTransport struct {
 	name   string
 	addr   string
 	tracer opentracing.Tracer
+	logger *zap.Logger
 	router transport.Router
 
 	once *lifecycle.Once

--- a/transport/tchannel/channel_transport.go
+++ b/transport/tchannel/channel_transport.go
@@ -77,12 +77,16 @@ func NewChannelTransport(opts ...TransportOption) (*ChannelTransport, error) {
 }
 
 func (options transportOptions) newChannelTransport() *ChannelTransport {
+	logger := options.logger
+	if logger == nil {
+		logger = zap.NewNop()
+	}
 	return &ChannelTransport{
 		once:   lifecycle.NewOnce(),
 		ch:     options.ch,
 		addr:   options.addr,
 		tracer: options.tracer,
-		logger: options.logger,
+		logger: logger,
 	}
 }
 

--- a/transport/tchannel/inbound.go
+++ b/transport/tchannel/inbound.go
@@ -24,6 +24,7 @@ import (
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/introspection"
 	"go.uber.org/yarpc/pkg/lifecycle"
+	"go.uber.org/zap"
 )
 
 // Inbound receives YARPC requests over TChannel. It may be constructed using
@@ -62,7 +63,12 @@ func (i *Inbound) Transports() []transport.Transport {
 // connections; that occurs when you start the underlying ChannelTransport is
 // started.
 func (i *Inbound) Start() error {
-	return i.once.Start(nil)
+	return i.once.Start(func() error {
+		if i.transport.logger != nil {
+			i.transport.logger.Info("tchannel inbound started", zap.String("address", i.transport.addr))
+		}
+		return nil
+	})
 }
 
 // Stop stops the TChannel outbound. This currently does nothing.

--- a/transport/tchannel/inbound.go
+++ b/transport/tchannel/inbound.go
@@ -66,6 +66,9 @@ func (i *Inbound) Start() error {
 	return i.once.Start(func() error {
 		if i.transport.logger != nil {
 			i.transport.logger.Info("tchannel inbound started", zap.String("address", i.transport.addr))
+			if i.transport.router == nil || len(i.transport.router.Procedures()) == 0 {
+				i.transport.logger.Warn("no procedures specified for tchannel inbound")
+			}
 		}
 		return nil
 	})

--- a/transport/tchannel/inbound.go
+++ b/transport/tchannel/inbound.go
@@ -64,11 +64,9 @@ func (i *Inbound) Transports() []transport.Transport {
 // started.
 func (i *Inbound) Start() error {
 	return i.once.Start(func() error {
-		if i.transport.logger != nil {
-			i.transport.logger.Info("tchannel inbound started", zap.String("address", i.transport.addr))
-			if i.transport.router == nil || len(i.transport.router.Procedures()) == 0 {
-				i.transport.logger.Warn("no procedures specified for tchannel inbound")
-			}
+		i.transport.logger.Info("started TChannel inbound", zap.String("address", i.transport.addr))
+		if i.transport.router == nil || len(i.transport.router.Procedures()) == 0 {
+			i.transport.logger.Warn("no procedures specified for tchannel inbound")
 		}
 		return nil
 	})

--- a/transport/tchannel/options.go
+++ b/transport/tchannel/options.go
@@ -26,6 +26,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	backoffapi "go.uber.org/yarpc/api/backoff"
 	"go.uber.org/yarpc/internal/backoff"
+	"go.uber.org/zap"
 )
 
 // Option allows customizing the YARPC TChannel transport.
@@ -48,6 +49,7 @@ var _ Option = (TransportOption)(nil)
 type transportOptions struct {
 	ch                  Channel
 	tracer              opentracing.Tracer
+	logger              *zap.Logger
 	addr                string
 	name                string
 	connTimeout         time.Duration
@@ -75,6 +77,15 @@ func (TransportOption) tchannelOption() {}
 func Tracer(tracer opentracing.Tracer) TransportOption {
 	return func(t *transportOptions) {
 		t.tracer = tracer
+	}
+}
+
+// Logger sets a logger to use for internal logging.
+//
+// The default is to not write any logs.
+func Logger(logger *zap.Logger) TransportOption {
+	return func(t *transportOptions) {
+		t.logger = logger
 	}
 }
 

--- a/transport/tchannel/transport.go
+++ b/transport/tchannel/transport.go
@@ -32,6 +32,7 @@ import (
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/peer/hostport"
 	"go.uber.org/yarpc/pkg/lifecycle"
+	"go.uber.org/zap"
 )
 
 // Transport is a TChannel transport suitable for use with YARPC's peer
@@ -47,6 +48,7 @@ type Transport struct {
 	ch     Channel
 	router transport.Router
 	tracer opentracing.Tracer
+	logger *zap.Logger
 	name   string
 	addr   string
 
@@ -89,6 +91,7 @@ func (o transportOptions) newTransport() *Transport {
 		connBackoffStrategy: o.connBackoffStrategy,
 		peers:               make(map[string]*tchannelPeer),
 		tracer:              o.tracer,
+		logger:              o.logger,
 	}
 }
 

--- a/transport/tchannel/transport.go
+++ b/transport/tchannel/transport.go
@@ -83,6 +83,10 @@ func NewTransport(opts ...TransportOption) (*Transport, error) {
 }
 
 func (o transportOptions) newTransport() *Transport {
+	logger := o.logger
+	if logger == nil {
+		logger = zap.NewNop()
+	}
 	return &Transport{
 		once:                lifecycle.NewOnce(),
 		name:                o.name,
@@ -91,7 +95,7 @@ func (o transportOptions) newTransport() *Transport {
 		connBackoffStrategy: o.connBackoffStrategy,
 		peers:               make(map[string]*tchannelPeer),
 		tracer:              o.tracer,
-		logger:              o.logger,
+		logger:              logger,
 	}
 }
 


### PR DESCRIPTION
This adds a `func Logger(*zap.Logger) TransportOption` to all transports, as well as logging when their respective inbounds start, and if there are no procedures specified.