### PR TITLE
Factor peerlist out of roundrobin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ Releases
 v1.22.0-dev (unreleased)
 --------------------
 
--   No changes yet.
+-   Introduces `api/peer.ListImplementation` with `peer/peerlist.List`, a
+    building block that provides peer availability management for peer lists
+    like round-robin, hash-ring.
 
 v1.21.0 (2017-10-26)
 --------------------

--- a/api/peer/peer.go
+++ b/api/peer/peer.go
@@ -48,14 +48,27 @@ type Identifier interface {
 	Identifier() string
 }
 
-// Peer is a level on top of Identifier.  It should be created by a Transport so we
-// can maintain multiple references to the same downstream peer (e.g. hostport).  This is
-// useful for load balancing requests to downstream services.
-type Peer interface {
+// StatusPeer captures a concrete peer implementation for a particular
+// transport, exposing its Identifier and Status.
+// StatusPeer provides observability without mutability.
+type StatusPeer interface {
 	Identifier
 
 	// Get the status of the Peer
 	Status() Status
+}
+
+// Peer captures a concrete peer implementation for a particular transport,
+// providing both observability (Identifier and Status), along with load change
+// notifications (StartRequest) (EndRequest).
+// Transports reveal peers to peer lists, which in turn offer them to outbounds
+// when they choose a peer.
+// Having Start/End request messages allows the outbound to broadcast load
+// changes to all subscribed load balancers.
+// The peer should be created by a transport so we can maintain multiple
+// references to the same peer (e.g., hostport).
+type Peer interface {
+	StatusPeer
 
 	// Tell the peer that a request is starting
 	StartRequest()

--- a/peer/peerlist/doc.go
+++ b/peer/peerlist/doc.go
@@ -18,52 +18,28 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package roundrobin
-
-import (
-	"go.uber.org/yarpc/api/peer"
-	"go.uber.org/yarpc/peer/peerlist"
-)
-
-type listConfig struct {
-	capacity int
-}
-
-var defaultListConfig = listConfig{
-	capacity: 10,
-}
-
-// ListOption customizes the behavior of a roundrobin list.
-type ListOption func(*listConfig)
-
-// Capacity specifies the default capacity of the underlying
-// data structures for this list.
+// Package peerlist provides a utility for managing peer availability with a
+// separate implementation of peer selection from just among available peers.
+// The peer list implements the peer.ChooserList interface and accepts a
+// peer.ListImplementation to provide the implementation-specific concern of,
+// for example, a *roundrobin.List.
 //
-// Defaults to 10.
-func Capacity(capacity int) ListOption {
-	return func(c *listConfig) {
-		c.capacity = capacity
-	}
-}
-
-// New creates a new round robin peer list.
-func New(transport peer.Transport, opts ...ListOption) *List {
-	cfg := defaultListConfig
-	for _, o := range opts {
-		o(&cfg)
-	}
-
-	return &List{
-		List: peerlist.New(
-			"roundrobin",
-			transport,
-			newPeerRing(),
-			peerlist.Capacity(cfg.capacity),
-		),
-	}
-}
-
-// List is a PeerList which rotates which peers are to be selected in a circle
-type List struct {
-	*peerlist.List
-}
+// The example is an implementation of peer.ChooserList using a random peer selection
+// strategy, returned by newRandomListImplementation(), implementing
+// peer.ListImplementation.
+//
+//   type List struct {
+//   	*peerlist.List
+//   }
+//
+//   func New(transport peer.Transport) *List {
+//   	return &List{
+//   		List: peerlist.New(
+//   			"random",
+//   			transport,
+//   			newRandomListImplementation(),
+//   		),
+//   	}
+//   }
+//
+package peerlist

--- a/peer/peerlist/list.go
+++ b/peer/peerlist/list.go
@@ -1,0 +1,574 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package peerlist
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"go.uber.org/atomic"
+	"go.uber.org/multierr"
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/introspection"
+	"go.uber.org/yarpc/pkg/lifecycle"
+	"go.uber.org/yarpc/yarpcerrors"
+)
+
+var (
+	_noContextDeadlineError = "can't wait for peer without a context deadline for a %s peer list"
+)
+
+type listOptions struct {
+	capacity int
+}
+
+var defaultListOptions = listOptions{
+	capacity: 10,
+}
+
+// ListOption customizes the behavior of a list.
+type ListOption interface {
+	apply(*listOptions)
+}
+
+type listOptionFunc func(*listOptions)
+
+func (f listOptionFunc) apply(options *listOptions) { f(options) }
+
+// Capacity specifies the default capacity of the underlying
+// data structures for this list
+//
+// Defaults to 10.
+func Capacity(capacity int) ListOption {
+	return listOptionFunc(func(options *listOptions) {
+		options.capacity = capacity
+	})
+}
+
+// New creates a new peer list with an identifier chooser for available peers.
+func New(name string, transport peer.Transport, availableChooser peer.ListImplementation, opts ...ListOption) *List {
+	options := defaultListOptions
+	for _, o := range opts {
+		o.apply(&options)
+	}
+
+	return &List{
+		once:               lifecycle.NewOnce(),
+		name:               name,
+		uninitializedPeers: make(map[string]peer.Identifier, options.capacity),
+		unavailablePeers:   make(map[string]*peerThunk, options.capacity),
+		availablePeers:     make(map[string]*peerThunk, options.capacity),
+		availableChooser:   availableChooser,
+		transport:          transport,
+		peerAvailableEvent: make(chan struct{}, 1),
+	}
+}
+
+// List is an abstract peer list, backed by a peer.ListImplementation to
+// determine which peer to choose among available peers.
+// The abstract list manages available versus unavailable peers, intercepting
+// these notifications from the transport's concrete implementation of
+// peer.Peer with the peer.Subscriber API.
+// The peer list will not choose an unavailable peer, prefering to block until
+// one becomes available.
+//
+// The list is a suitable basis for concrete implementations like round-robin
+// and join-shortest-queue.
+type List struct {
+	lock sync.RWMutex
+
+	name string
+
+	shouldRetainPeers  atomic.Bool
+	uninitializedPeers map[string]peer.Identifier
+
+	unavailablePeers   map[string]*peerThunk
+	availablePeers     map[string]*peerThunk
+	availableChooser   peer.ListImplementation
+	peerAvailableEvent chan struct{}
+	transport          peer.Transport
+
+	once *lifecycle.Once
+}
+
+// Update applies the additions and removals of peer Identifiers to the list
+// it returns a multi-error result of every failure that happened without
+// circuit breaking due to failures.
+func (pl *List) Update(updates peer.ListUpdates) error {
+	if len(updates.Additions) == 0 && len(updates.Removals) == 0 {
+		return nil
+	}
+
+	pl.lock.Lock()
+	defer pl.lock.Unlock()
+
+	if pl.shouldRetainPeers.Load() {
+		return pl.updateInitialized(updates)
+	}
+	return pl.updateUninitialized(updates)
+}
+
+// updateInitialized applies peer list updates when the peer list
+// is able to retain peers, putting the updates into the available
+// or unavailable containers.
+//
+// Must be run inside a mutex.Lock()
+func (pl *List) updateInitialized(updates peer.ListUpdates) error {
+	var errs error
+	for _, peerID := range updates.Removals {
+		errs = multierr.Append(errs, pl.removePeerIdentifier(peerID))
+	}
+
+	for _, peerID := range updates.Additions {
+		errs = multierr.Append(errs, pl.addPeerIdentifier(peerID))
+	}
+	return errs
+}
+
+// updateUninitialized applies peer list updates when the peer list
+// is **not** able to retain peers, putting the updates into a single
+// uninitialized peer list.
+//
+// Must be run inside a mutex.Lock()
+func (pl *List) updateUninitialized(updates peer.ListUpdates) error {
+	var errs error
+	for _, peerID := range updates.Removals {
+		if _, ok := pl.uninitializedPeers[peerID.Identifier()]; ok {
+			delete(pl.uninitializedPeers, peerID.Identifier())
+		} else {
+			errs = multierr.Append(errs, peer.ErrPeerRemoveNotInList(peerID.Identifier()))
+		}
+	}
+	for _, peerID := range updates.Additions {
+		pl.uninitializedPeers[peerID.Identifier()] = peerID
+	}
+
+	return errs
+}
+
+// Must be run inside a mutex.Lock()
+func (pl *List) addPeerIdentifier(pid peer.Identifier) error {
+	if t := pl.getThunk(pid); t != nil {
+		return peer.ErrPeerAddAlreadyInList(pid.Identifier())
+	}
+
+	t := &peerThunk{list: pl, id: pid}
+	t.boundOnFinish = t.onFinish
+	p, err := pl.transport.RetainPeer(pid, t)
+	if err != nil {
+		return err
+	}
+	t.peer = p
+	return pl.addPeer(t)
+}
+
+// Must be run in a mutex.Lock()
+func (pl *List) addPeer(t *peerThunk) error {
+	if t.peer.Status().ConnectionStatus != peer.Available {
+		return pl.addToUnavailablePeers(t)
+	}
+
+	return pl.addToAvailablePeers(t)
+}
+
+// Must be run in a mutex.Lock()
+func (pl *List) addToUnavailablePeers(t *peerThunk) error {
+	pl.unavailablePeers[t.peer.Identifier()] = t
+	return nil
+}
+
+// Must be run in a mutex.Lock()
+func (pl *List) addToAvailablePeers(t *peerThunk) error {
+	if pl.availablePeers[t.peer.Identifier()] != nil {
+		return peer.ErrPeerAddAlreadyInList(t.peer.Identifier())
+	}
+	sub := pl.availableChooser.Add(t)
+	t.SetSubscriber(sub)
+	pl.availablePeers[t.Identifier()] = t
+	pl.notifyPeerAvailable()
+	return nil
+}
+
+// Start notifies the List that requests will start coming
+func (pl *List) Start() error {
+	return pl.once.Start(pl.start)
+}
+
+func (pl *List) start() error {
+	pl.lock.Lock()
+	defer pl.lock.Unlock()
+
+	if err := pl.availableChooser.Start(); err != nil {
+		return err
+	}
+
+	var errs error
+	for k, pid := range pl.uninitializedPeers {
+		errs = multierr.Append(errs, pl.addPeerIdentifier(pid))
+		delete(pl.uninitializedPeers, k)
+	}
+
+	pl.shouldRetainPeers.Store(true)
+
+	return errs
+}
+
+// Stop notifies the List that requests will stop coming
+func (pl *List) Stop() error {
+	return pl.once.Stop(pl.stop)
+}
+
+// stop will release all the peers from the list
+func (pl *List) stop() error {
+	pl.lock.Lock()
+	defer pl.lock.Unlock()
+
+	var errs error
+
+	if err := pl.availableChooser.Stop(); err != nil {
+		errs = multierr.Append(errs, err)
+	}
+
+	availablePeers := pl.removeAllAvailablePeers(pl.availablePeers)
+	errs = pl.releaseAll(errs, availablePeers)
+	pl.addToUninitialized(availablePeers)
+
+	unavailablePeers := pl.removeAllUnavailablePeers(pl.unavailablePeers)
+	errs = pl.releaseAll(errs, unavailablePeers)
+	pl.addToUninitialized(unavailablePeers)
+
+	pl.shouldRetainPeers.Store(false)
+
+	return errs
+}
+
+func (pl *List) addToUninitialized(thunks []*peerThunk) {
+	for _, t := range thunks {
+		pl.uninitializedPeers[t.id.Identifier()] = t.id
+	}
+}
+
+// removeAllAvailablePeers will clear the availablePeers list and return all
+// the Peers in the list in a slice
+// Must be run in a mutex.Lock()
+func (pl *List) removeAllAvailablePeers(toRemove map[string]*peerThunk) []*peerThunk {
+	thunks := make([]*peerThunk, 0, len(toRemove))
+	for id, t := range toRemove {
+		thunks = append(thunks, t)
+		delete(pl.availablePeers, id)
+		pl.availableChooser.Remove(t, t.Subscriber())
+	}
+	return thunks
+}
+
+// removeAllUnavailablePeers will clear the unavailablePeers list and
+// return all the Peers in the list in a slice
+// Must be run in a mutex.Lock()
+func (pl *List) removeAllUnavailablePeers(toRemove map[string]*peerThunk) []*peerThunk {
+	thunks := make([]*peerThunk, 0, len(toRemove))
+	for id, t := range toRemove {
+		thunks = append(thunks, t)
+		delete(toRemove, id)
+	}
+	return thunks
+}
+
+// releaseAll will iterate through a list of peers and call release
+// on the transport
+func (pl *List) releaseAll(errs error, peers []*peerThunk) error {
+	for _, t := range peers {
+		if err := pl.transport.ReleasePeer(t.peer, t); err != nil {
+			errs = multierr.Append(errs, err)
+		}
+	}
+	return errs
+}
+
+// removePeerIdentifier will go remove references to the peer identifier and release
+// it from the transport
+// Must be run in a mutex.Lock()
+func (pl *List) removePeerIdentifier(pid peer.Identifier) error {
+	t, err := pl.removePeerIdentifierReferences(pid)
+	if err != nil {
+		// The peer has already been removed
+		return err
+	}
+
+	return pl.transport.ReleasePeer(pid, t)
+}
+
+// removePeerIdentifierReferences will search through the Available and Unavailable Peers
+// for the PeerID and remove it
+// Must be run in a mutex.Lock()
+func (pl *List) removePeerIdentifierReferences(pid peer.Identifier) (*peerThunk, error) {
+	if t := pl.availablePeers[pid.Identifier()]; t != nil {
+		return t, pl.removeFromAvailablePeers(t)
+	}
+
+	if t, ok := pl.unavailablePeers[pid.Identifier()]; ok && t != nil {
+		pl.removeFromUnavailablePeers(t)
+		return t, nil
+	}
+
+	return nil, peer.ErrPeerRemoveNotInList(pid.Identifier())
+}
+
+// removeFromAvailablePeers remove a peer from the Available Peers list the
+// Peer should already be validated as non-nil and in the Available list.
+// Must be run in a mutex.Lock()
+func (pl *List) removeFromAvailablePeers(t *peerThunk) error {
+	delete(pl.availablePeers, t.peer.Identifier())
+	pl.availableChooser.Remove(t, t.Subscriber())
+	t.SetSubscriber(nil)
+	return nil
+}
+
+// removeFromUnavailablePeers remove a peer from the Unavailable Peers list the
+// Peer should already be validated as non-nil and in the Unavailable list.
+// Must be run in a mutex.Lock()
+func (pl *List) removeFromUnavailablePeers(t *peerThunk) {
+	delete(pl.unavailablePeers, t.peer.Identifier())
+}
+
+// Choose selects the next available peer in the peer list
+func (pl *List) Choose(ctx context.Context, req *transport.Request) (peer.Peer, func(error), error) {
+	if err := pl.once.WaitUntilRunning(ctx); err != nil {
+		return nil, nil, pl.newNotRunningError(err)
+	}
+
+	for {
+		pl.lock.RLock()
+		p := pl.availableChooser.Choose(ctx, req)
+		pl.lock.RUnlock()
+
+		if p != nil {
+			t := p.(*peerThunk)
+			pl.notifyPeerAvailable()
+			t.onStart()
+			return t.peer, t.boundOnFinish, nil
+		}
+		if err := pl.waitForPeerAddedEvent(ctx); err != nil {
+			return nil, nil, err
+		}
+	}
+}
+
+func (pl *List) newNotRunningError(err error) error {
+	return yarpcerrors.Newf(yarpcerrors.CodeFailedPrecondition, "%s peer list is not running: %s", pl.name, err.Error())
+}
+
+// IsRunning returns whether the peer list is running.
+func (pl *List) IsRunning() bool {
+	return pl.once.IsRunning()
+}
+
+// notifyPeerAvailable writes to a channel indicating that a Peer is currently
+// available for requests
+func (pl *List) notifyPeerAvailable() {
+	select {
+	case pl.peerAvailableEvent <- struct{}{}:
+	default:
+	}
+}
+
+// waitForPeerAddedEvent waits until a peer is added to the peer list or the
+// given context finishes.
+// Must NOT be run in a mutex.Lock()
+func (pl *List) waitForPeerAddedEvent(ctx context.Context) error {
+	if _, ok := ctx.Deadline(); !ok {
+		return pl.newNoContextDeadlineError()
+	}
+
+	select {
+	case <-pl.peerAvailableEvent:
+		return nil
+	case <-ctx.Done():
+		return pl.newUnavailableError(ctx.Err())
+	}
+}
+
+func (pl *List) newNoContextDeadlineError() error {
+	return yarpcerrors.Newf(yarpcerrors.CodeInvalidArgument, _noContextDeadlineError, pl.name)
+}
+
+func (pl *List) newUnavailableError(err error) error {
+	return yarpcerrors.Newf(yarpcerrors.CodeUnavailable, "%s peer list timed out waiting for peer: %s", pl.name, err.Error())
+}
+
+// NotifyStatusChanged receives status change notifications for peers in the
+// list.
+func (pl *List) NotifyStatusChanged(pid peer.Identifier) {
+	pl.lock.RLock()
+	t := pl.getThunk(pid)
+	pl.lock.RUnlock()
+
+	if t != nil {
+		t.NotifyStatusChanged(pid)
+	}
+}
+
+// getThunk returns either the available or unavailable peer thunk.
+// Must be called under a lock.
+func (pl *List) getThunk(pid peer.Identifier) *peerThunk {
+	if t := pl.availablePeers[pid.Identifier()]; t != nil {
+		return t
+	}
+	return pl.unavailablePeers[pid.Identifier()]
+}
+
+// notifyStatusChanged gets called by peer thunks
+func (pl *List) notifyStatusChanged(pid peer.Identifier) {
+	pl.lock.Lock()
+	defer pl.lock.Unlock()
+
+	if t := pl.availablePeers[pid.Identifier()]; t != nil {
+		// TODO: log error
+		_ = pl.handleAvailablePeerStatusChange(t)
+		return
+	}
+
+	if t := pl.unavailablePeers[pid.Identifier()]; t != nil {
+		// TODO: log error
+		_ = pl.handleUnavailablePeerStatusChange(t)
+	}
+	// No action required
+}
+
+// handleAvailablePeerStatusChange checks the connection status of a connected peer to potentially
+// move that Peer from the PeerRing to the unavailable peer map
+// Must be run in a mutex.Lock()
+func (pl *List) handleAvailablePeerStatusChange(t *peerThunk) error {
+	if t.peer.Status().ConnectionStatus == peer.Available {
+		// Peer is in the proper pool, ignore
+		return nil
+	}
+
+	pl.availableChooser.Remove(t, t.Subscriber())
+	t.SetSubscriber(nil)
+	delete(pl.availablePeers, t.peer.Identifier())
+
+	return pl.addToUnavailablePeers(t)
+
+}
+
+// handleUnavailablePeerStatusChange checks the connection status of an unavailable peer to potentially
+// move that Peer from the unavailablePeerMap into the available Peer Ring
+// Must be run in a mutex.Lock()
+func (pl *List) handleUnavailablePeerStatusChange(t *peerThunk) error {
+	if t.peer.Status().ConnectionStatus != peer.Available {
+		// Peer is in the proper pool, ignore
+		return nil
+	}
+
+	pl.removeFromUnavailablePeers(t)
+	return pl.addToAvailablePeers(t)
+}
+
+// Available returns whether the identifier peer is available for traffic.
+func (pl *List) Available(p peer.Identifier) bool {
+	_, ok := pl.availablePeers[p.Identifier()]
+	return ok
+}
+
+// Uninitialized returns whether a peer is waiting for the peer list to start.
+func (pl *List) Uninitialized(p peer.Identifier) bool {
+	_, ok := pl.uninitializedPeers[p.Identifier()]
+	return ok
+}
+
+// Peers returns a snapshot of all retained (available and
+// unavailable) peers.
+func (pl *List) Peers() []peer.Peer {
+	pl.lock.RLock()
+	defer pl.lock.RUnlock()
+	peers := make([]peer.Peer, 0)
+	for _, t := range pl.availablePeers {
+		peers = append(peers, t.peer)
+	}
+	for _, t := range pl.unavailablePeers {
+		peers = append(peers, t.peer)
+	}
+	return peers
+}
+
+// NumAvailable returns how many peers are available.
+func (pl *List) NumAvailable() int {
+	return len(pl.availablePeers)
+}
+
+// NumUnavailable returns how many peers are unavailable.
+func (pl *List) NumUnavailable() int {
+	return len(pl.unavailablePeers)
+}
+
+// NumUninitialized returns how many peers are unavailable.
+func (pl *List) NumUninitialized() int {
+	return len(pl.uninitializedPeers)
+}
+
+// Introspect returns a ChooserStatus with a summary of the Peers.
+func (pl *List) Introspect() introspection.ChooserStatus {
+	state := "Stopped"
+	if pl.IsRunning() {
+		state = "Running"
+	}
+
+	pl.lock.Lock()
+	availables := make([]peer.Peer, 0, len(pl.availablePeers))
+	for _, t := range pl.availablePeers {
+		availables = append(availables, t.peer)
+	}
+	unavailables := make([]peer.Peer, 0, len(pl.unavailablePeers))
+	for _, t := range pl.unavailablePeers {
+		unavailables = append(unavailables, t.peer)
+	}
+	pl.lock.Unlock()
+
+	peersStatus := make([]introspection.PeerStatus, 0,
+		len(availables)+len(unavailables))
+
+	buildPeerStatus := func(peer peer.Peer) introspection.PeerStatus {
+		ps := peer.Status()
+		return introspection.PeerStatus{
+			Identifier: peer.Identifier(),
+			State: fmt.Sprintf("%s, %d pending request(s)",
+				ps.ConnectionStatus.String(),
+				ps.PendingRequestCount),
+		}
+	}
+
+	for _, peer := range availables {
+		peersStatus = append(peersStatus, buildPeerStatus(peer))
+	}
+
+	for _, peer := range unavailables {
+		peersStatus = append(peersStatus, buildPeerStatus(peer))
+	}
+
+	return introspection.ChooserStatus{
+		Name: "Single",
+		State: fmt.Sprintf("%s (%d/%d available)", state, len(availables),
+			len(availables)+len(unavailables)),
+		Peers: peersStatus,
+	}
+}

--- a/peer/peerlist/peer.go
+++ b/peer/peerlist/peer.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package peerlist
+
+import (
+	"sync"
+
+	"go.uber.org/yarpc/api/peer"
+)
+
+// peerThunk captures a peer and its corresponding subscriber,
+// and serves as a subscriber by proxy.
+type peerThunk struct {
+	lock          sync.RWMutex
+	list          *List
+	id            peer.Identifier
+	peer          peer.Peer
+	subscriber    peer.Subscriber
+	boundOnFinish func(error)
+}
+
+func (t *peerThunk) onStart() {
+	t.peer.StartRequest()
+}
+
+func (t *peerThunk) onFinish(error) {
+	t.peer.EndRequest()
+}
+
+func (t *peerThunk) Identifier() string {
+	return t.peer.Identifier()
+}
+
+func (t *peerThunk) Status() peer.Status {
+	return t.peer.Status()
+}
+
+func (t *peerThunk) StartRequest() {
+	t.peer.StartRequest()
+}
+
+func (t *peerThunk) EndRequest() {
+	t.peer.EndRequest()
+}
+
+// NotifyStatusChanged forwards a status notification to the peer list and to
+// the underlying identifier chooser list.
+func (t *peerThunk) NotifyStatusChanged(pid peer.Identifier) {
+	t.list.notifyStatusChanged(pid)
+
+	s := t.Subscriber()
+	if s != nil {
+		s.NotifyStatusChanged(pid)
+	}
+}
+
+// SetSubscriber assigns a subscriber to the subscriber thunk.
+func (t *peerThunk) SetSubscriber(s peer.Subscriber) {
+	t.lock.Lock()
+	t.subscriber = s
+	t.lock.Unlock()
+}
+
+// Subscriber returns the subscriber.
+func (t *peerThunk) Subscriber() peer.Subscriber {
+	t.lock.RLock()
+	s := t.subscriber
+	t.lock.RUnlock()
+	return s
+}

--- a/peer/roundrobin/list_test.go
+++ b/peer/roundrobin/list_test.go
@@ -32,7 +32,21 @@ import (
 	"go.uber.org/yarpc/api/peer"
 	. "go.uber.org/yarpc/api/peer/peertest"
 	"go.uber.org/yarpc/internal/introspection"
+	"go.uber.org/yarpc/peer/hostport"
+	"go.uber.org/yarpc/yarpcerrors"
 )
+
+var (
+	_noContextDeadlineError = yarpcerrors.Newf(yarpcerrors.CodeInvalidArgument, "can't wait for peer without a context deadline for a roundrobin peer list")
+)
+
+func newNotRunningError(err error) error {
+	return yarpcerrors.FailedPreconditionErrorf("roundrobin peer list is not running: %s", err.Error())
+}
+
+func newUnavailableError(err error) error {
+	return yarpcerrors.UnavailableErrorf("roundrobin peer list timed out waiting for peer: %s", err.Error())
+}
 
 func TestRoundRobinList(t *testing.T) {
 	type testStruct struct {
@@ -353,7 +367,7 @@ func TestRoundRobinList(t *testing.T) {
 		},
 		{
 			msg: "add duplicate peer",
-			retainedAvailablePeerIDs: []string{"1", "2", "2"},
+			retainedAvailablePeerIDs: []string{"1", "2"},
 			expectedAvailablePeers:   []string{"1", "2"},
 			peerListActions: []PeerListAction{
 				StartAction{},
@@ -856,32 +870,22 @@ func TestRoundRobinList(t *testing.T) {
 			}
 			ApplyPeerListActions(t, pl, tt.peerListActions, deps)
 
-			assert.Len(t, pl.availablePeerRing.peerToNode, len(tt.expectedAvailablePeers), "invalid available peerlist size")
+			assert.Equal(t, pl.NumAvailable(), len(tt.expectedAvailablePeers), "invalid available peerlist size")
 			for _, expectedRingPeer := range tt.expectedAvailablePeers {
-				node, ok := pl.availablePeerRing.peerToNode[expectedRingPeer]
+				ok := pl.Available(hostport.PeerIdentifier(expectedRingPeer))
 				assert.True(t, ok, fmt.Sprintf("expected peer: %s was not in available peerlist", expectedRingPeer))
-				if ok {
-					actualPeer := getPeerForRingNode(node)
-					assert.Equal(t, expectedRingPeer, actualPeer.Identifier())
-				}
 			}
 
-			assert.Len(t, pl.unavailablePeers, len(tt.expectedUnavailablePeers), "invalid unavailable peerlist size")
+			assert.Equal(t, pl.NumUnavailable(), len(tt.expectedUnavailablePeers), "invalid unavailable peerlist size")
 			for _, expectedUnavailablePeer := range tt.expectedUnavailablePeers {
-				p, ok := pl.unavailablePeers[expectedUnavailablePeer]
+				ok := !pl.Available(hostport.PeerIdentifier(expectedUnavailablePeer))
 				assert.True(t, ok, fmt.Sprintf("expected peer: %s was not in unavailable peerlist", expectedUnavailablePeer))
-				if ok {
-					assert.Equal(t, expectedUnavailablePeer, p.Identifier())
-				}
 			}
 
-			assert.Len(t, pl.uninitializedPeers, len(tt.expectedUninitializedPeers), "invalid uninitialized peerlist size")
+			assert.Equal(t, pl.NumUninitialized(), len(tt.expectedUninitializedPeers), "invalid uninitialized peerlist size")
 			for _, expectedUninitializedPeer := range tt.expectedUninitializedPeers {
-				p, ok := pl.uninitializedPeers[expectedUninitializedPeer]
+				ok := pl.Uninitialized(hostport.PeerIdentifier(expectedUninitializedPeer))
 				assert.True(t, ok, fmt.Sprintf("expected peer: %s was not in uninitialized peerlist", expectedUninitializedPeer))
-				if ok {
-					assert.Equal(t, expectedUninitializedPeer, p.Identifier())
-				}
 			}
 
 			assert.Equal(t, tt.expectedRunning, pl.IsRunning(), "List was not in the expected state")


### PR DESCRIPTION
These changes separate common logic for peer availability management out of
roundrobin and into a common peerlist implementation, which in turn uses a new
RetainedChooserList interface.

This puts us in a better position to create new peer lists based on just the
logic for peer selection among available peers. I follow this change with a stack that vets the peer list with implementations for:

* round robin
* hash ring
* join shortest queue