### PR TITLE
Add hashring32 peer list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ v1.23.0-dev (unreleased)
     tests.
 -   Adds a `peer/pendingheap` implementation that performs peer selection,
     sending requests to the available peer with the fewest pending requests.
+-   Adds a `peer/hashring32` implementation that can perform peer selection
+    based on the `req.ShardKey` and a consistent hash function over all
+    *available* peers.
 
 v1.22.0 (2017-11-14)
 --------------------

--- a/peer/hashring32/doc.go
+++ b/peer/hashring32/doc.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package hashring32 provides a peer list that chooses a peer based on each
+// request's ShardKey and a given 32 bit consistent hash function.
+package hashring32

--- a/peer/hashring32/list.go
+++ b/peer/hashring32/list.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package hashring32
+
+import (
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/peer/peerlist"
+)
+
+type listConfig struct {
+	capacity    int
+	numReplicas int
+}
+
+var defaultListConfig = listConfig{
+	capacity:    10,
+	numReplicas: 100,
+}
+
+// ListOption customizes the behavior of a roundrobin list.
+type ListOption func(*listConfig)
+
+// Capacity specifies the default capacity of the underlying
+// data structures for this list
+//
+// Defaults to 10.
+func Capacity(capacity int) ListOption {
+	return func(c *listConfig) {
+		c.capacity = capacity
+	}
+}
+
+// NumReplicas specifies the number of replicas for each peer in the ring.
+//
+// Defaults to 100.
+func NumReplicas(n int) ListOption {
+	return func(c *listConfig) {
+		c.numReplicas = n
+	}
+}
+
+// New creates a new hash ring peer list.
+func New(transport peer.Transport, name string, hashFunc HashFunc, opts ...ListOption) *List {
+	cfg := defaultListConfig
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	ring := newPeerRing(name, hashFunc, cfg.numReplicas)
+
+	return &List{
+		List: peerlist.New(
+			"hashring32",
+			transport,
+			ring,
+			peerlist.Capacity(cfg.capacity),
+		),
+		ring: ring,
+	}
+}
+
+// Len returns the number of members of the ring.
+func (l *List) Len() int {
+	return l.ring.Len()
+}
+
+// List is a PeerList which rotates which peers are to be selected in a circle
+type List struct {
+	*peerlist.List
+
+	ring *ring
+}

--- a/peer/hashring32/list_test.go
+++ b/peer/hashring32/list_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package hashring32
+
+import (
+	"context"
+	"hash/fnv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/testtime"
+	"go.uber.org/yarpc/peer/hostport"
+	"go.uber.org/yarpc/yarpctest"
+)
+
+const (
+	ringID1 = hostport.PeerIdentifier("127.0.0.1:10000")
+	ringID2 = hostport.PeerIdentifier("127.0.0.1:10001")
+	ringID3 = hostport.PeerIdentifier("127.0.0.1:10002")
+	ringID4 = hostport.PeerIdentifier("127.0.0.1:10004")
+	ringID5 = hostport.PeerIdentifier("127.0.0.1:10005")
+
+	key1 = "123"
+)
+
+func testHash(key []byte) uint32 {
+	digest := fnv.New32()
+	digest.Write(key)
+	return digest.Sum32()
+}
+
+func newTestList() *List {
+	t := yarpctest.NewFakeTransport()
+	return New(t, "fnvring", testHash)
+}
+
+func TestRingAddRemove(t *testing.T) {
+	r := newTestList()
+	r.Start()
+	defer r.Stop()
+
+	b := r.Update(peer.ListUpdates{Additions: []peer.Identifier{ringID1}})
+	b2 := r.Update(peer.ListUpdates{Additions: []peer.Identifier{ringID1}})
+
+	p, _, err := r.Choose(context.Background(), &transport.Request{ShardKey: key1})
+	assert.NoError(t, err, "Choose failed to select peer")
+	assert.Nil(t, b, "Choose returned false but element did not exist.")
+	assert.Error(t, b2, "Choose returned true but element already exists.")
+	assert.Equal(t, ringID1.Identifier(), p.Identifier(), "aaa")
+	assert.Equal(t, 1, r.Len(), "Size of members should be 1")
+
+	r.Update(peer.ListUpdates{Removals: []peer.Identifier{ringID1}})
+	r.Update(peer.ListUpdates{Removals: []peer.Identifier{ringID1, ringID1}})
+	r.Update(peer.ListUpdates{Removals: []peer.Identifier{ringID1}})
+	ctx, cancel := context.WithTimeout(context.Background(), 1*testtime.Millisecond)
+	defer cancel()
+	p, _, err = r.Choose(ctx, &transport.Request{ShardKey: key1})
+	assert.Error(t, err, "Expected not to find any peer")
+	assert.Equal(t, nil, p, "Expected to find nil peer")
+	assert.Equal(t, 0, r.Len(), "Size of members should be 1")
+}

--- a/peer/hashring32/ring.go
+++ b/peer/hashring32/ring.go
@@ -1,0 +1,369 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package hashring32
+
+import (
+	"context"
+	"math"
+	"math/rand"
+	"sort"
+	"strconv"
+	"sync"
+
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/yarpcerrors"
+)
+
+// HashFunc is the hash function used in ringpop hash ring.
+type HashFunc func([]byte) uint32
+
+// ring maintains the same ring topology as downstream,
+// and apply a best effort selection to relay to the correct peer.
+// When shard key not provided, a random peer would be returned.
+type ring struct {
+	serversByHash  map[uint32][]peer.StatusPeer
+	servers        map[string]peer.StatusPeer
+	hashRing       []uint32
+	hashFunc       HashFunc
+	replica        int
+	m              sync.RWMutex
+	errUnavailable error
+}
+
+type ringSubscriber struct{}
+
+func (r ringSubscriber) NotifyStatusChanged(peer.Identifier) {}
+
+var nopSubscriber = ringSubscriber{}
+
+const (
+	// Estimated number of hosts in a single downstream
+	// This value is used to pre-allocate memory
+	estimatedMaxNumHosts = 1500
+
+	// Radix sort constants
+	radix     = 16
+	radixSize = 65536
+	radixMask = 0xFFFF
+	// for arrays shorter than min length, use regular sort
+	radixMinLength = 128
+
+	maxUINT32 = uint32(math.MaxUint32)
+)
+
+// newPeerRing a new consistent-hashing peer ring.
+func newPeerRing(name string, hashFunc HashFunc, replica int) *ring {
+	capacity := estimatedMaxNumHosts * replica
+	return &ring{
+		serversByHash:  make(map[uint32][]peer.StatusPeer, capacity),
+		hashRing:       make([]uint32, 0, capacity),
+		servers:        make(map[string]peer.StatusPeer, estimatedMaxNumHosts),
+		hashFunc:       hashFunc,
+		replica:        replica,
+		errUnavailable: yarpcerrors.Newf(yarpcerrors.CodeUnavailable, "%s peer list fails to find a peer", name),
+	}
+}
+
+// Choose a peer based on the hash of the shard key. Choose first peer in the
+// ring that owns a replica to the right of the hash.
+//
+// A Choose on an empty population returns nil.
+func (r *ring) Choose(ctx context.Context, req *transport.Request) peer.StatusPeer {
+	return r.choose(req.ShardKey)
+}
+
+func (r *ring) choose(shardKey string) peer.StatusPeer {
+	r.m.RLock()
+	defer r.m.RUnlock()
+
+	if len(r.servers) == 0 {
+		return nil
+	}
+
+	var ix int
+	if shardKey == "" {
+		// Random index to get hash value
+		ix = rand.Intn(len(r.hashRing))
+	} else {
+		// Binary search to find hash value
+		key := r.hashFunc([]byte(shardKey))
+		ix = indexOf(r.hashRing, key)
+	}
+
+	hash := r.hashRing[ix]
+	servers := r.serversByHash[hash]
+
+	return servers[0]
+}
+
+// Add an individual to the population.
+// Returns a subscriber if the individual was absent, nil otherwise.
+func (r *ring) Add(p peer.StatusPeer) peer.Subscriber {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	individual := p.Identifier()
+
+	if _, ok := r.servers[individual]; ok {
+		return nil
+	}
+	r.addToServersMapAndHashRing(p)
+	r.radixSortHashRing()
+	return nopSubscriber
+}
+
+// Remove removes an individual from the population.
+// Returns early if the individual is absent.
+func (r *ring) Remove(p peer.StatusPeer, sub peer.Subscriber) {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	individual := p.Identifier()
+
+	if _, ok := r.servers[individual]; !ok {
+		return
+	}
+	toBeRemovedIndexSet := make(map[int]struct{}, r.replica)
+	r.removeFromServersMap(p, toBeRemovedIndexSet)
+	r.removeFromHashRing(toBeRemovedIndexSet)
+}
+
+// Include extends the ring's population with new members. Think
+// set union.
+// The implementations can mutate the input.
+func (r *ring) Include(pids []peer.StatusPeer) {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	r.includeNoLock(pids)
+}
+
+func (r *ring) includeNoLock(pids []peer.StatusPeer) {
+	for _, p := range pids {
+		individual := p.Identifier()
+		if _, ok := r.servers[individual]; ok {
+			continue
+		}
+		r.addToServersMapAndHashRing(p)
+	}
+	r.radixSortHashRing()
+}
+
+// Exclude shrinks the ring's population by removing members. Think
+// set difference.
+// The implementations can mutate the input.
+func (r *ring) Exclude(pids []peer.StatusPeer) {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	r.excludeNoLock(pids)
+}
+
+func (r *ring) excludeNoLock(pids []peer.StatusPeer) {
+	toBeRemovedIndexSet := make(map[int]struct{})
+
+	for _, p := range pids {
+		individual := p.Identifier()
+		if _, ok := r.servers[individual]; !ok {
+			continue
+		}
+		r.removeFromServersMap(p, toBeRemovedIndexSet)
+	}
+	r.removeFromHashRing(toBeRemovedIndexSet)
+}
+
+// Set replaces the ring's population with the new one.
+// The implementations can mutate the input.
+func (r *ring) Set(pids []peer.StatusPeer) {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	// Create string set for population, to ensure it is addressable.
+	population := make(map[string]peer.StatusPeer)
+	for _, p := range pids {
+		population[p.Identifier()] = p
+	}
+
+	// peers in old set but not in new set
+	toBeRemoved := make([]peer.StatusPeer, 0, len(pids))
+	for k, p := range r.servers {
+		if _, ok := population[k]; !ok {
+			toBeRemoved = append(toBeRemoved, p)
+		}
+	}
+	r.excludeNoLock(toBeRemoved)
+
+	// peers in new set but not in old set
+	toBeAdded := make([]peer.StatusPeer, 0, len(pids))
+	for k, p := range population {
+		if _, ok := r.servers[k]; !ok {
+			toBeAdded = append(toBeRemoved, p)
+		}
+	}
+	r.includeNoLock(toBeAdded)
+}
+
+// Len returns the size of the ring population.
+func (r *ring) Len() int {
+	r.m.RLock()
+	defer r.m.RUnlock()
+
+	return len(r.servers)
+}
+
+// addToHashRing adds individual into both servers map and hash ring array,
+// the array requires sort later.
+func (r *ring) addToServersMapAndHashRing(p peer.StatusPeer) {
+	individual := p.Identifier()
+
+	r.servers[individual] = p
+	hashes := hashes(individual, r.replica, r.hashFunc)
+	r.hashRing = append(r.hashRing, hashes...)
+
+	for _, hash := range hashes {
+		r.serversByHash[hash] = append(r.serversByHash[hash], p)
+	}
+}
+
+// removeFromServersMap removes server from map and
+// adds it's hash ring array index to the to-be-removed set.
+func (r *ring) removeFromServersMap(p peer.StatusPeer, toBeRemoved map[int]struct{}) {
+	individual := p.Identifier()
+
+	delete(r.servers, individual)
+
+	hashes := hashes(individual, r.replica, r.hashFunc)
+
+	for _, hash := range hashes {
+		servers := r.serversByHash[hash]
+		// Remove servers that have this ID
+		var newServers []peer.StatusPeer
+		for _, server := range servers {
+			if server.Identifier() == individual {
+				continue
+			}
+			newServers = append(newServers, server)
+		}
+		// When a hash value has no servers, mark as 'to be removed'
+		// Cannot remove now because it is needed for binary search
+		if len(newServers) == 0 {
+			delete(r.serversByHash, hash)
+			index := indexOf(r.hashRing, hash)
+			// Remove hash from ring slice and also its duplicates (collisions)
+			for i := index; i < len(r.hashRing); i++ {
+				if r.hashRing[i] != hash {
+					break
+				}
+				toBeRemoved[i] = struct{}{}
+			}
+		} else {
+			r.serversByHash[hash] = newServers
+		}
+	}
+}
+
+// removeFromHashRing removes all peers in the given set from the ring.
+func (r *ring) removeFromHashRing(toBeRemoved map[int]struct{}) {
+	// Remove by setting values to max, sorting, and returning sub-array
+	// Remove the tails instead of heads to avoid unnecessary memory allocations
+	for index := range toBeRemoved {
+		r.hashRing[index] = maxUINT32
+	}
+	r.radixSortHashRing()
+	r.hashRing = r.hashRing[:len(r.hashRing)-len(toBeRemoved)]
+}
+
+// sortHashRing sorts the hash ring array.
+func (r *ring) radixSortHashRing() {
+	if len(r.hashRing) <= radixMinLength {
+		sort.Slice(r.hashRing, func(i, j int) bool {
+			return r.hashRing[i] < r.hashRing[j]
+		})
+		return
+	}
+
+	origin := r.hashRing
+	swap := make([]uint32, len(r.hashRing))
+	var key uint16
+	var offset [radixSize]int
+
+	for i := uint(0); i < 2; i++ {
+		keyOffset := i * radix
+		keyMask := uint32(radixMask << keyOffset)
+		var counts [radixSize]int
+
+		for _, h := range origin {
+			key = uint16((h & keyMask) >> keyOffset)
+			counts[key]++
+		}
+
+		offset[0] = 0
+		for j := 1; j < radixSize; j++ {
+			offset[j] = offset[j-1] + counts[j-1]
+		}
+
+		for _, h := range origin {
+			key = uint16((h & keyMask) >> keyOffset)
+			swap[offset[key]] = h
+			offset[key]++
+		}
+		swap, origin = origin, swap
+	}
+}
+
+// hashes creates replicas and their hash values.
+func hashes(s string, replicas int, hashFunc HashFunc) []uint32 {
+	r := make([]uint32, replicas)
+	for i := 0; i < replicas; i++ {
+		// This older replicaStr format will cause replica point collisions when there are
+		// multiple instances running on the same host (e.g. on port 2100 and 21001).
+		r[i] = hashFunc([]byte(s + strconv.Itoa(i)))
+	}
+	return r
+}
+
+// indexOf applies binary search to get the value in an array.
+func indexOf(slice []uint32, v uint32) int {
+	if len(slice) == 0 {
+		return -1
+	}
+	// binary search
+	index := sort.Search(len(slice),
+		func(i int) bool { return slice[i] >= v })
+	// greater than all elements, returns the first
+	if index >= len(slice) {
+		return 0
+	}
+	return index
+}
+
+func (r *ring) Start() error {
+	return nil
+}
+
+func (r *ring) Stop() error {
+	return nil
+}
+
+func (r *ring) IsRunning() bool {
+	return true
+}

--- a/peer/hashring32/ring_test.go
+++ b/peer/hashring32/ring_test.go
@@ -1,0 +1,276 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package hashring32
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/peer/hostport"
+	"go.uber.org/yarpc/yarpctest"
+)
+
+var (
+	t         = yarpctest.NewFakeTransport()
+	ringPeer1 = hostport.NewPeer("127.0.0.1:10000", t)
+	ringPeer2 = hostport.NewPeer("127.0.0.1:10001", t)
+	ringPeer3 = hostport.NewPeer("127.0.0.1:10002", t)
+	ringPeer4 = hostport.NewPeer("127.0.0.1:10004", t)
+	ringPeer5 = hostport.NewPeer("127.0.0.1:10005", t)
+)
+
+func newTestRing() *ring {
+	return newPeerRing("fnv-hashring", testHash, 100)
+}
+
+func TestAddRemove(t *testing.T) {
+	r := newTestRing()
+
+	s := r.Add(ringPeer1)
+	assert.NotNil(t, s, "Add returned a subscriber")
+	s2 := r.Add(ringPeer1)
+	assert.Nil(t, s2, "Add returned nil on redundant peer")
+
+	p := r.Choose(context.Background(), &transport.Request{ShardKey: key1})
+	assert.NotNil(t, p, "Choose failed to select peer")
+	assert.Equal(t, ringPeer1.Identifier(), p.Identifier(), "chose the single peer")
+	assert.Equal(t, 1, r.Len(), "Size of members should be 1")
+
+	r.Remove(ringPeer1, s)
+	assert.Equal(t, 0, r.Len(), "Size of members should be 0")
+}
+
+// TestMultipleChoose tests whether peer chooser
+// always selects the same peer when ring is at the same topology.
+func TestMultipleChoose(t *testing.T) {
+	r := newTestRing()
+	r.Add(ringPeer1)
+	r.Add(ringPeer2)
+	r.Add(ringPeer3)
+
+	assert.Equal(t, 3, r.Len(), "Size of members should be 3")
+	p := r.choose(key1)
+	assert.NotEqual(t, "", p, "Choose failed to select a peer")
+	p2 := r.choose(key1)
+	assert.NotEqual(t, "", p2, "Choose failed to select a peer")
+	assert.Equal(t, p, p2, "Choose selected a different peer")
+	p3 := r.choose(key1)
+	assert.NotEqual(t, "", p3, "Choose failed to select a peer")
+	assert.Equal(t, p, p3, "Choose selected a different peer")
+
+	s4 := r.Add(ringPeer4)
+	s5 := r.Add(ringPeer5)
+	r.Remove(ringPeer4, s4)
+	r.Remove(ringPeer5, s5)
+
+	p4 := r.choose(key1)
+	assert.NotEqual(t, "", p4, "Choose failed to select a peer")
+	p5 := r.choose(key1)
+	assert.Equal(t, p, p4, "Choose selected a different peer")
+	assert.NotEqual(t, "", p5, "Choose failed to select a peer")
+	assert.Equal(t, p, p5, "Choose selected a different peer")
+}
+
+func TestNoShardKey(t *testing.T) {
+	r := newTestRing()
+	r.Add(ringPeer1)
+	p := r.choose("")
+	assert.NotEqual(t, "", p, "Choose failed to select a peer")
+	assert.Equal(t, ringPeer1, p, "Should returns a random individual.")
+}
+
+func TestNoPeer(t *testing.T) {
+	r := newTestRing()
+	p := r.choose("")
+	assert.Nil(t, p, "Should return nil when no peer can be selected.")
+
+	p2 := r.choose(key1)
+	assert.Nil(t, p2, "Should return nil when no peer can be selected.")
+}
+
+func TestRingIncludeExclude(t *testing.T) {
+	r := newTestRing()
+	servers := []peer.StatusPeer{
+		ringPeer1,
+		ringPeer2,
+		ringPeer3,
+		ringPeer4,
+		ringPeer5,
+	}
+	r.Include(servers)
+	assert.Equal(t, 5, r.Len(), "Load balancer pool size should be 5.")
+	r.Include(servers)
+	assert.Equal(t, 5, r.Len(), "Load balancer pool size should be 5.")
+
+	toBeRemoved := []peer.StatusPeer{
+		ringPeer2,
+		ringPeer3,
+		ringPeer4,
+	}
+	r.Exclude(toBeRemoved)
+	assert.Equal(t, 2, r.Len(), "Load balancer pool size should be 2")
+	r.Exclude(toBeRemoved)
+	assert.Equal(t, 2, r.Len(), "Load balancer pool size should be 2")
+}
+
+// TODO TestHashCollision
+
+func TestIndexOf(t *testing.T) {
+	var empty = []uint32{}
+	assert.Equal(t, -1, indexOf(empty, uint32(0)), "Should return -1 for empty array")
+
+	var slice = []uint32{0, 1, 2, 3, 4}
+	assert.Equal(t, 0, indexOf(slice, uint32(0)), "Should return index 0")
+	assert.Equal(t, 3, indexOf(slice, uint32(3)), "Should return index 3")
+	assert.Equal(t, 4, indexOf(slice, uint32(4)), "Should return index 4")
+	assert.Equal(t, 0, indexOf(slice, uint32(5)), "Should return index 0")
+}
+
+// Benchmarks
+
+func BenchmarkRingAdd(b *testing.B) {
+	servers := generatePeers(b.N)
+
+	r := newTestRing()
+	b.ResetTimer()
+	for _, server := range servers {
+		r.Add(server)
+	}
+	b.ReportAllocs()
+}
+
+func BenchmarkRingRemove(b *testing.B) {
+	count := b.N
+	servers := generatePeers(count)
+
+	r := newTestRing()
+	r.Include(servers)
+
+	b.ResetTimer()
+	for _, server := range servers {
+		r.Remove(server, nopSubscriber)
+	}
+	b.ReportAllocs()
+}
+
+func BenchmarkRingInclude(b *testing.B) {
+	count := b.N
+	servers := generatePeers(count)
+
+	r := newTestRing()
+
+	b.ResetTimer()
+	r.Include(servers)
+	b.ReportAllocs()
+}
+
+func BenchmarkRingExclude(b *testing.B) {
+	count := b.N
+	servers := generatePeers(count)
+
+	r := newTestRing()
+	r.Include(servers)
+	b.ResetTimer()
+
+	r.Exclude(servers)
+	b.ReportAllocs()
+}
+
+func BenchmarkRingSet(b *testing.B) {
+	count := b.N
+	oldServers := generatePeers(count)
+	newServers := newPopulation(count/3, oldServers)
+
+	r := newTestRing()
+	r.Include(oldServers)
+	b.ResetTimer()
+	r.Set(newServers)
+	b.ReportAllocs()
+}
+
+// newPopulation updates numUpdates individuals in the oldPopulation,
+// and keeps the size unchanged.
+func newPopulation(numUpdates int, oldPopulation []peer.StatusPeer) []peer.StatusPeer {
+	count := len(oldPopulation)
+
+	sameHostPortsCount := count - numUpdates
+	newPopulation := make([]peer.StatusPeer, 0, count)
+	hostPorts := make(map[string]struct{})
+
+	for _, p := range oldPopulation {
+		if len(newPopulation) == sameHostPortsCount {
+			break
+		}
+		hostPorts[p.Identifier()] = struct{}{}
+		newPopulation = append(newPopulation, p)
+	}
+
+	// Generate new hostPorts so that size doesn't change
+	for {
+		if len(newPopulation) == count {
+			break
+		}
+		hostPort := generateRandomHostPort()
+		if _, ok := hostPorts[hostPort]; ok {
+			continue
+		}
+		newPopulation = append(newPopulation, hostport.NewPeer(hostport.PeerIdentifier(hostPort), t))
+		hostPorts[hostPort] = struct{}{}
+	}
+	return newPopulation
+}
+
+// Helpers
+
+const ipUpperBound = 256
+
+func generateRandomHostPort() string {
+	// Make port number exact 5 digits so no replica collisions
+	return fmt.Sprintf("%d.%d.%d.%d:%d",
+		rand.Intn(ipUpperBound),
+		rand.Intn(ipUpperBound),
+		rand.Intn(ipUpperBound),
+		rand.Intn(ipUpperBound),
+		rand.Intn(55536)+10000, // interval [10000, 65536)
+	)
+}
+
+func generatePeers(count int) []peer.StatusPeer {
+	peersSet := make(map[string]struct{}, count)
+	peers := make([]peer.StatusPeer, 0, count)
+	for i := 0; i < count; i++ {
+		for {
+			hostPort := generateRandomHostPort()
+			if _, ok := peersSet[hostPort]; ok {
+				continue
+			}
+			peersSet[hostPort] = struct{}{}
+			peers = append(peers, hostport.NewPeer(hostport.PeerIdentifier(hostPort), t))
+			break
+		}
+	}
+	return peers
+}


### PR DESCRIPTION
This change introduces a hashring32 peer chooser. The peer chooser accepts any 32 bit integer hash function. Provisionally, this can be any hash impl from the standard library, though this is intended to be integrated with a production hash impl like farmhash fingerprint32.

- [ ] Rebase on dev when #1346 lands.
- [x] Docs (package doc)
- [x] Entry in CHANGELOG.md
