### PR TITLE
Reserve prefix rpc- for gRPC headers

### DIFF
--- a/transport/grpc/handler.go
+++ b/transport/grpc/handler.go
@@ -83,6 +83,9 @@ func (h *handler) handle(srv interface{}, serverStream grpc.ServerStream) error 
 	if responseWriter.md != nil {
 		serverStream.SetTrailer(responseWriter.md)
 	}
+	if responseWriter.headerErr != nil {
+		err = handlerErrorToGRPCError(responseWriter.headerErr, responseWriter)
+	}
 	return err
 }
 

--- a/transport/grpc/headers.go
+++ b/transport/grpc/headers.go
@@ -75,26 +75,16 @@ const (
 	contentTypeHeader = "content-type"
 )
 
-var (
-	_reservedHeaders = map[string]bool{
-		CallerHeader:           true,
-		ServiceHeader:          true,
-		ShardKeyHeader:         true,
-		RoutingKeyHeader:       true,
-		RoutingDelegateHeader:  true,
-		EncodingHeader:         true,
-		ErrorNameHeader:        true,
-		ApplicationErrorHeader: true,
-	}
-)
-
 // TODO: there are way too many repeat calls to strings.ToLower
 // Note that these calls are done indirectly, primarily through
 // transport.CanonicalizeHeaderKey
 
 func isReserved(header string) bool {
-	_, ok := _reservedHeaders[strings.ToLower(header)]
-	return ok
+	lower := strings.ToLower(header)
+	// We reserve rpc- for future headers
+	// gRPC reserved grpc- for future gRPC headers
+	// https://grpc.io/docs/guides/wire.html
+	return strings.HasPrefix(lower, "rpc-") || strings.HasPrefix(lower, "grpc-")
 }
 
 // transportRequestToMetadata will populate all reserved and application headers

--- a/transport/grpc/headers.go
+++ b/transport/grpc/headers.go
@@ -80,11 +80,7 @@ const (
 // transport.CanonicalizeHeaderKey
 
 func isReserved(header string) bool {
-	lower := strings.ToLower(header)
-	// We reserve rpc- for future headers
-	// gRPC reserved grpc- for future gRPC headers
-	// https://grpc.io/docs/guides/wire.html
-	return strings.HasPrefix(lower, "rpc-") || strings.HasPrefix(lower, "grpc-")
+	return strings.HasPrefix(strings.ToLower(header), "rpc-")
 }
 
 // transportRequestToMetadata will populate all reserved and application headers

--- a/transport/grpc/headers_test.go
+++ b/transport/grpc/headers_test.go
@@ -198,4 +198,6 @@ func TestIsReserved(t *testing.T) {
 	assert.True(t, isReserved(RoutingKeyHeader))
 	assert.True(t, isReserved(RoutingDelegateHeader))
 	assert.True(t, isReserved(EncodingHeader))
+	assert.True(t, isReserved("rpc-foo"))
+	assert.True(t, isReserved("grpc-foo"))
 }

--- a/transport/grpc/headers_test.go
+++ b/transport/grpc/headers_test.go
@@ -199,5 +199,4 @@ func TestIsReserved(t *testing.T) {
 	assert.True(t, isReserved(RoutingDelegateHeader))
 	assert.True(t, isReserved(EncodingHeader))
 	assert.True(t, isReserved("rpc-foo"))
-	assert.True(t, isReserved("grpc-foo"))
 }


### PR DESCRIPTION
We want to reserve `rpc-` for future use. Originally `grpc-` was checked too, but it turns out other grpc libraries use this for things grpc-go does not, which means they come across as application headers here, which causes an error.