### PR TITLE
Stream1: Add x/yarpctest folder for integration test infrastructure.

### DIFF
--- a/x/yarpctest/api/core.go
+++ b/x/yarpctest/api/core.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package api
+
+// Lifecycle defines test infra that needs to be started before the actions
+// and stopped afterwards.
+type Lifecycle interface {
+	Start(TestingT) error
+	Stop(TestingT) error
+}
+
+// Action defines an object that can be "Run" to assert things against the
+// world through action.
+type Action interface {
+	Run(t TestingT)
+}
+
+// ActionFunc is a helper to convert a function to implement the Action
+// interface
+type ActionFunc func(TestingT)
+
+// Run implement Action.
+func (f ActionFunc) Run(t TestingT) { f(t) }

--- a/x/yarpctest/api/doc.go
+++ b/x/yarpctest/api/doc.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package api is for all interfaces and patterns that need to be implemented to
+// interact with the yarpctest api, but not the explicit types we'll use to make
+// requests, or the types that we'll use directly in tests.
+//
+// The purpose of this sub-package is to reduce the information that needs to be
+// provided at the top-level yarpctest package.
+package api

--- a/x/yarpctest/api/handler_unary.go
+++ b/x/yarpctest/api/handler_unary.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package api
+
+import (
+	"context"
+
+	"go.uber.org/yarpc/api/middleware"
+	"go.uber.org/yarpc/api/transport"
+)
+
+// UnaryHandler is a wrapper around the transport.UnaryInbound and Lifecycle
+// interfaces.
+type UnaryHandler interface {
+	Lifecycle
+
+	transport.UnaryHandler
+}
+
+// UnaryHandlerFunc converts a function into a transport.UnaryHandler.
+type UnaryHandlerFunc func(context.Context, *transport.Request, transport.ResponseWriter) error
+
+// Handle implements yarpc/api/transport#UnaryHandler.
+func (f UnaryHandlerFunc) Handle(ctx context.Context, req *transport.Request, resw transport.ResponseWriter) error {
+	return f(ctx, req, resw)
+}
+
+// Start is a noop for wrapped functions.
+func (f UnaryHandlerFunc) Start(TestingT) error { return nil }
+
+// Stop is a noop for wrapped functions.
+func (f UnaryHandlerFunc) Stop(TestingT) error { return nil }
+
+// UnaryInboundMiddleware is a wrapper around the middleware.UnaryInbound and
+// Lifecycle interfaces.
+type UnaryInboundMiddleware interface {
+	Lifecycle
+
+	middleware.UnaryInbound
+}
+
+// UnaryInboundMiddlewareFunc converts a function into a transport.UnaryInboundMiddleware.
+type UnaryInboundMiddlewareFunc func(context.Context, *transport.Request, transport.ResponseWriter, transport.UnaryHandler) error
+
+// Handle implements yarpc/api/transport#UnaryInboundMiddleware.
+func (f UnaryInboundMiddlewareFunc) Handle(ctx context.Context, req *transport.Request, resw transport.ResponseWriter, h transport.UnaryHandler) error {
+	return f(ctx, req, resw, h)
+}
+
+// Start is a noop for wrapped functions.
+func (f UnaryInboundMiddlewareFunc) Start(TestingT) error { return nil }
+
+// Stop is a noop for wrapped functions.
+func (f UnaryInboundMiddlewareFunc) Stop(TestingT) error { return nil }
+
+// HandlerOpts are configuration options for a series of handlers.
+type HandlerOpts struct {
+	Handlers []UnaryHandler
+}
+
+// HandlerOption defines options that can be passed into a handler.
+type HandlerOption interface {
+	Lifecycle
+
+	ApplyHandler(opts *HandlerOpts)
+}
+
+// HandlerOptionFunc converts a function into a HandlerOption.
+type HandlerOptionFunc func(opts *HandlerOpts)
+
+// ApplyHandler implements HandlerOption.
+func (f HandlerOptionFunc) ApplyHandler(opts *HandlerOpts) { f(opts) }

--- a/x/yarpctest/api/procedure.go
+++ b/x/yarpctest/api/procedure.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package api
+
+import "go.uber.org/yarpc/api/transport"
+
+// ProcOpts are configuration options for a procedure.
+type ProcOpts struct {
+	Name        string
+	HandlerSpec transport.HandlerSpec
+}
+
+// ProcOption defines the options that can be applied to a procedure.
+type ProcOption interface {
+	Lifecycle
+
+	ApplyProc(*ProcOpts)
+}

--- a/x/yarpctest/api/request_unary.go
+++ b/x/yarpctest/api/request_unary.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package api
+
+import (
+	"bytes"
+
+	"go.uber.org/yarpc/api/transport"
+)
+
+// RequestOpts are configuration options for a yarpc Request and assertions
+// to make on the response.
+type RequestOpts struct {
+	Port             int
+	GiveRequest      *transport.Request
+	ExpectedResponse *transport.Response
+	ExpectedError    error
+}
+
+// NewRequestOpts initializes a RequestOpts struct.
+func NewRequestOpts() RequestOpts {
+	return RequestOpts{
+		GiveRequest: &transport.Request{
+			Caller:   "unknown",
+			Encoding: transport.Encoding("raw"),
+			Headers:  transport.NewHeaders(),
+			Body:     bytes.NewBufferString(""),
+		},
+		ExpectedResponse: &transport.Response{
+			Headers: transport.NewHeaders(),
+		},
+	}
+}
+
+// RequestOption can be used to configure a request.
+type RequestOption interface {
+	ApplyRequest(*RequestOpts)
+}
+
+// RequestOptionFunc converts a function into a RequestOption.
+type RequestOptionFunc func(*RequestOpts)
+
+// ApplyRequest implements RequestOption.
+func (f RequestOptionFunc) ApplyRequest(opts *RequestOpts) { f(opts) }

--- a/x/yarpctest/api/service.go
+++ b/x/yarpctest/api/service.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package api
+
+import (
+	"net"
+
+	"go.uber.org/yarpc/api/transport"
+)
+
+// ServiceOpts are the configuration options for a yarpc service.
+type ServiceOpts struct {
+	Name       string
+	Listener   net.Listener
+	Port       int
+	Procedures []transport.Procedure
+}
+
+// ServiceOption is an option when creating a Service.
+type ServiceOption interface {
+	Lifecycle
+
+	ApplyService(*ServiceOpts)
+}
+
+// ServiceOptionFunc converts a function into a ServiceOption.
+type ServiceOptionFunc func(*ServiceOpts)
+
+// ApplyService implements ServiceOption.
+func (f ServiceOptionFunc) ApplyService(opts *ServiceOpts) { f(opts) }
+
+// Start is a noop for wrapped functions
+func (f ServiceOptionFunc) Start(TestingT) error { return nil }
+
+// Stop is a noop for wrapped functions
+func (f ServiceOptionFunc) Stop(TestingT) error { return nil }

--- a/x/yarpctest/api/testing.go
+++ b/x/yarpctest/api/testing.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package api
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestingT is an interface wrapper around *testing.T and *testing.B
+type TestingT interface {
+	testing.TB
+}
+
+// Run will cast the TestingT to it's sub and call the appropriate Run func.
+func Run(name string, t TestingT, f func(TestingT)) {
+	if tt, ok := t.(*testing.T); ok {
+		tt.Run(name, func(ttt *testing.T) { f(ttt) })
+		return
+	}
+	if tb, ok := t.(*testing.B); ok {
+		tb.Run(name, func(ttb *testing.B) { f(ttb) })
+		return
+	}
+	t.Error("invalid test harness")
+	t.FailNow()
+}
+
+// SafeTestingT is a struct that wraps a TestingT in a mutex for safe concurrent
+// usage.
+type SafeTestingT struct {
+	sync.Mutex
+	t TestingT
+}
+
+// SetTestingT safely sets the TestingT.
+func (s *SafeTestingT) SetTestingT(t TestingT) {
+	s.Lock()
+	s.t = t
+	s.Unlock()
+}
+
+// GetTestingT safely gets the TestingT for the testable.
+func (s *SafeTestingT) GetTestingT() TestingT {
+	s.Lock()
+	t := s.t
+	s.Unlock()
+	return t
+}
+
+// SafeTestingTOnStart is an embeddable struct that automatically grabs TestingT
+// objects on "Start" for lifecycles.
+type SafeTestingTOnStart struct {
+	SafeTestingT
+}
+
+// Start safely sets the TestingT for the testable.
+func (s *SafeTestingTOnStart) Start(t TestingT) error {
+	s.SetTestingT(t)
+	return nil
+}
+
+// NoopLifecycle is a convenience struct that can be embedded to make a struct
+// implement the Start and Stop methods of Lifecycle.
+type NoopLifecycle struct{}
+
+// Start is a Noop.
+func (b *NoopLifecycle) Start(t TestingT) error {
+	return nil
+}
+
+// Stop is a Noop.
+func (b *NoopLifecycle) Stop(t TestingT) error {
+	return nil
+}
+
+// NoopStop is a convenience struct that can be embedded to make a struct
+// implement the Stop method of Lifecycle.
+type NoopStop struct{}
+
+// Stop is a Noop.
+func (b *NoopStop) Stop(t TestingT) error {
+	return nil
+}

--- a/x/yarpctest/core.go
+++ b/x/yarpctest/core.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpctest
+
+import (
+	"fmt"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/multierr"
+	"go.uber.org/yarpc/x/yarpctest/api"
+)
+
+// Action is the interface for applying actions (Requests) in tests.
+type Action api.Action
+
+// Lifecycle is the interface for creating/starting/stopping lifecycles
+// (Services) in tests.
+type Lifecycle api.Lifecycle
+
+// Lifecycles is a wrapper around a list of Lifecycle definitions.
+func Lifecycles(l ...api.Lifecycle) api.Lifecycle {
+	return lifecycles(l)
+}
+
+type lifecycles []api.Lifecycle
+
+// Start the lifecycles. If there are any errors, stop any started lifecycles
+// and fail the test.
+func (ls lifecycles) Start(t api.TestingT) error {
+	startedLifecycles := make(lifecycles, 0, len(ls))
+	for _, l := range ls {
+		err := l.Start(t)
+		if !assert.NoError(t, err) {
+			// Cleanup started lifecycles (this could fail)
+			return multierr.Append(err, startedLifecycles.Stop(t))
+		}
+		startedLifecycles = append(startedLifecycles, l)
+	}
+	return nil
+}
+
+// Stop the lifecycles. Record all errors. If any lifecycle failed to stop
+// fail the test.
+func (ls lifecycles) Stop(t api.TestingT) error {
+	var err error
+	for _, l := range ls {
+		err = multierr.Append(err, l.Stop(t))
+	}
+	assert.NoError(t, err)
+	return err
+}
+
+// Actions will wrap a list of actions in a sequential executor.
+func Actions(actions ...api.Action) api.Action {
+	return multi(actions)
+}
+
+type multi []api.Action
+
+func (m multi) Run(t api.TestingT) {
+	for i, req := range m {
+		api.Run(fmt.Sprintf("Action #%d", i), t, req.Run)
+	}
+}

--- a/x/yarpctest/handler_unary.go
+++ b/x/yarpctest/handler_unary.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpctest
+
+import (
+	"context"
+	"io"
+	"io/ioutil"
+
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/x/yarpctest/api"
+	"go.uber.org/yarpc/x/yarpctest/types"
+)
+
+// EchoHandler is a Unary Handler that will echo the body of the request
+// into the response.
+func EchoHandler(mw ...api.UnaryInboundMiddleware) *types.UnaryHandler {
+	return &types.UnaryHandler{H: newEchoHandler(), MW: mw}
+}
+
+func newEchoHandler() api.UnaryHandler {
+	return api.UnaryHandlerFunc(
+		func(_ context.Context, req *transport.Request, resw transport.ResponseWriter) error {
+			_, err := io.Copy(resw, req.Body)
+			return err
+		},
+	)
+}
+
+// StaticHandler will always return the same response.
+func StaticHandler(msg string, mw ...api.UnaryInboundMiddleware) *types.UnaryHandler {
+	return &types.UnaryHandler{H: newStaticHandler(msg), MW: mw}
+}
+
+func newStaticHandler(msg string) api.UnaryHandler {
+	return api.UnaryHandlerFunc(
+		func(_ context.Context, _ *transport.Request, resw transport.ResponseWriter) error {
+			_, err := io.WriteString(resw, msg)
+			return err
+		},
+	)
+}
+
+// ErrorHandler will always return an Error.
+func ErrorHandler(err error, mw ...api.UnaryInboundMiddleware) *types.UnaryHandler {
+	return &types.UnaryHandler{H: newErrorHandler(err), MW: mw}
+}
+
+func newErrorHandler(err error) api.UnaryHandler {
+	return api.UnaryHandlerFunc(
+		func(context.Context, *transport.Request, transport.ResponseWriter) error {
+			return err
+		},
+	)
+}
+
+// EchoHandlerWithPrefix will echo the request it receives into the
+// response, but, it will insert a prefix in front of the message.
+func EchoHandlerWithPrefix(prefix string, mw ...api.UnaryInboundMiddleware) *types.UnaryHandler {
+	return &types.UnaryHandler{H: newEchoHandlerWithPrefix(prefix), MW: mw}
+}
+
+func newEchoHandlerWithPrefix(prefix string) api.UnaryHandler {
+	return api.UnaryHandlerFunc(
+		func(_ context.Context, req *transport.Request, resw transport.ResponseWriter) error {
+			body, err := ioutil.ReadAll(req.Body)
+			if err != nil {
+				return err
+			}
+			newMsg := prefix + string(body)
+			_, err = io.WriteString(resw, newMsg)
+			return err
+		},
+	)
+}
+
+// OrderedRequestHandler will execute a series of Handlers in the order they
+// are passed in.  If the number of requests does not match, it will return an
+// unknown error.
+func OrderedRequestHandler(options ...api.HandlerOption) *types.OrderedHandler {
+	opts := api.HandlerOpts{}
+	for _, option := range options {
+		option.ApplyHandler(&opts)
+	}
+	return &types.OrderedHandler{
+		Handlers: opts.Handlers,
+	}
+}

--- a/x/yarpctest/headers.go
+++ b/x/yarpctest/headers.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpctest
+
+import "go.uber.org/yarpc/x/yarpctest/types"
+
+// WithHeader will send headers for requests and responses.
+func WithHeader(key, value string) *types.GiveHeader {
+	return &types.GiveHeader{Key: key, Value: value}
+}
+
+// ExpectHeader will set up a header assertion for request/response headers.
+func ExpectHeader(key, value string) *types.ExpectHeader {
+	return &types.ExpectHeader{Key: key, Value: value}
+}

--- a/x/yarpctest/helpers/port.go
+++ b/x/yarpctest/helpers/port.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package helpers
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/x/yarpctest/api"
+)
+
+// NewPortProvider creates an object that can be used to synchronize ports in
+// yarpctest infrastructure.  Ports can be acquired through the "Port" function
+// which will create new ports for the test based on the id passed into the
+// function.
+func NewPortProvider(t api.TestingT) *PortProvider {
+	return &PortProvider{
+		idToPort: make(map[string]*Port),
+		t:        t,
+	}
+}
+
+// PortProvider maintains a list of IDs to Ports.
+type PortProvider struct {
+	idToPort map[string]*Port
+	t        api.TestingT
+}
+
+// Port will return a *Port object that exists for the passed in 'id', or it
+// will create a *Port object if one does not already exist.
+func (p *PortProvider) Port(id string) *Port {
+	port, ok := p.idToPort[id]
+	if !ok {
+		port = newPort(p.t)
+		p.idToPort[id] = port
+	}
+	return port
+}
+
+func newPort(t api.TestingT) *Port {
+	listener, err := net.Listen("tcp", fmt.Sprintf(":0"))
+	require.NoError(t, err)
+	pieces := strings.Split(listener.Addr().String(), ":")
+	port, err := strconv.ParseInt(pieces[len(pieces)-1], 10, 0)
+	require.NoError(t, err)
+	return &Port{
+		listener: listener,
+		port:     int(port),
+	}
+}
+
+// Port is an option injectable primitive for synchronizing port numbers between
+// requests and services.
+type Port struct {
+	api.NoopLifecycle
+	listener net.Listener
+	port     int
+}
+
+// ApplyService implements api.ServiceOption.
+func (n *Port) ApplyService(opts *api.ServiceOpts) {
+	opts.Listener = n.listener
+	opts.Port = n.port
+}
+
+// ApplyRequest implements RequestOption
+func (n *Port) ApplyRequest(opts *api.RequestOpts) {
+	opts.Port = n.port
+}

--- a/x/yarpctest/name.go
+++ b/x/yarpctest/name.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpctest
+
+import "go.uber.org/yarpc/x/yarpctest/types"
+
+// Name is a shared option across services and procedures. It can be used as
+// input in the constructor of both types.
+func Name(name string) *types.Name {
+	return &types.Name{Name: name}
+}

--- a/x/yarpctest/port.go
+++ b/x/yarpctest/port.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpctest
+
+import (
+	"go.uber.org/yarpc/x/yarpctest/api"
+	"go.uber.org/yarpc/x/yarpctest/helpers"
+	"go.uber.org/yarpc/x/yarpctest/types"
+)
+
+// Port is a shared option across services and requests. It can be embedded
+// in the constructor of both types.
+func Port(port int) *types.Port {
+	return &types.Port{Port: port}
+}
+
+// NewPortProvider creates an object that can be used to synchronize ports in
+// yarpctest infrastructure.  Ports can be acquired through the "Port" function
+// which will create new ports for the test based on the id passed into the
+// function.
+func NewPortProvider(t api.TestingT) *helpers.PortProvider {
+	return helpers.NewPortProvider(t)
+}

--- a/x/yarpctest/procedure.go
+++ b/x/yarpctest/procedure.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpctest
+
+import (
+	"go.uber.org/multierr"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/x/yarpctest/api"
+)
+
+// Proc will create a new Procedure that can be included in a Service.
+func Proc(options ...api.ProcOption) api.ServiceOption {
+	return newProc(options...)
+}
+
+func newProc(options ...api.ProcOption) *proc {
+	opts := api.ProcOpts{Name: "proc"}
+	for _, option := range options {
+		option.ApplyProc(&opts)
+	}
+	return &proc{
+		procedure: transport.Procedure{
+			Name:        opts.Name,
+			HandlerSpec: opts.HandlerSpec,
+		},
+		options: options,
+	}
+}
+
+type proc struct {
+	procedure transport.Procedure
+	options   []api.ProcOption
+}
+
+// ApplyService implements ServiceOption.
+func (p *proc) ApplyService(opts *api.ServiceOpts) {
+	opts.Procedures = append(opts.Procedures, p.procedure)
+}
+
+// Start implements Lifecycle.
+func (p *proc) Start(t api.TestingT) error {
+	var err error
+	for _, option := range p.options {
+		err = multierr.Append(err, option.Start(t))
+	}
+	return err
+}
+
+// Stop implements Lifecycle.
+func (p *proc) Stop(t api.TestingT) error {
+	var err error
+	for _, option := range p.options {
+		err = multierr.Append(err, option.Stop(t))
+	}
+	return err
+}

--- a/x/yarpctest/request.go
+++ b/x/yarpctest/request.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpctest
+
+import "go.uber.org/yarpc/x/yarpctest/types"
+
+// Service specifies the "service" header for a request. It is a shared
+// option across different requests.
+func Service(service string) *types.Service {
+	return &types.Service{Service: service}
+}
+
+// Procedure specifies the "procedure" header for a request. It is a shared
+// option across different requests.
+func Procedure(procedure string) *types.Procedure {
+	return &types.Procedure{Procedure: procedure}
+}
+
+// ShardKey specifies that "shard key" header for a request. It is a shared
+// option across different requests.
+func ShardKey(key string) *types.ShardKey {
+	return &types.ShardKey{ShardKey: key}
+}

--- a/x/yarpctest/request_unary.go
+++ b/x/yarpctest/request_unary.go
@@ -1,0 +1,184 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpctest
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/transport/grpc"
+	"go.uber.org/yarpc/transport/http"
+	"go.uber.org/yarpc/transport/tchannel"
+	"go.uber.org/yarpc/x/yarpctest/api"
+)
+
+// HTTPRequest creates a new YARPC http request.
+func HTTPRequest(options ...api.RequestOption) api.Action {
+	opts := api.NewRequestOpts()
+	for _, option := range options {
+		option.ApplyRequest(&opts)
+	}
+	return api.ActionFunc(func(t api.TestingT) {
+		trans := http.NewTransport()
+		out := trans.NewSingleOutbound(fmt.Sprintf("http://127.0.0.1:%d/", opts.Port))
+
+		require.NoError(t, trans.Start())
+		defer func() { assert.NoError(t, trans.Stop()) }()
+
+		require.NoError(t, out.Start())
+		defer func() { assert.NoError(t, out.Stop()) }()
+
+		resp, cancel, err := sendRequest(out, opts.GiveRequest)
+		defer cancel()
+		validateError(t, err, opts.ExpectedError)
+		if opts.ExpectedError == nil {
+			validateResponse(t, resp, opts.ExpectedResponse)
+		}
+	})
+}
+
+// TChannelRequest creates a new tchannel request.
+func TChannelRequest(options ...api.RequestOption) api.Action {
+	opts := api.NewRequestOpts()
+	for _, option := range options {
+		option.ApplyRequest(&opts)
+	}
+	return api.ActionFunc(func(t api.TestingT) {
+		trans, err := tchannel.NewTransport(tchannel.ServiceName(opts.GiveRequest.Caller))
+		require.NoError(t, err)
+		out := trans.NewSingleOutbound(fmt.Sprintf("127.0.0.1:%d", opts.Port))
+
+		require.NoError(t, trans.Start())
+		defer func() { assert.NoError(t, trans.Stop()) }()
+
+		require.NoError(t, out.Start())
+		defer func() { assert.NoError(t, out.Stop()) }()
+
+		resp, cancel, err := sendRequest(out, opts.GiveRequest)
+		defer cancel()
+		validateError(t, err, opts.ExpectedError)
+		if opts.ExpectedError == nil {
+			validateResponse(t, resp, opts.ExpectedResponse)
+		}
+	})
+}
+
+// GRPCRequest creates a new grpc unary request.
+func GRPCRequest(options ...api.RequestOption) api.Action {
+	opts := api.NewRequestOpts()
+	for _, option := range options {
+		option.ApplyRequest(&opts)
+	}
+	return api.ActionFunc(func(t api.TestingT) {
+		trans := grpc.NewTransport()
+		out := trans.NewSingleOutbound(fmt.Sprintf("127.0.0.1:%d", opts.Port))
+
+		require.NoError(t, trans.Start())
+		defer func() { assert.NoError(t, trans.Stop()) }()
+
+		require.NoError(t, out.Start())
+		defer func() { assert.NoError(t, out.Stop()) }()
+
+		resp, cancel, err := sendRequest(out, opts.GiveRequest)
+		defer cancel()
+		validateError(t, err, opts.ExpectedError)
+		if opts.ExpectedError == nil {
+			validateResponse(t, resp, opts.ExpectedResponse)
+		}
+	})
+}
+
+func sendRequest(out transport.UnaryOutbound, request *transport.Request) (*transport.Response, context.CancelFunc, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	resp, err := out.Call(ctx, request)
+	return resp, cancel, err
+}
+
+func validateError(t api.TestingT, actualErr error, wantError error) {
+	if wantError != nil {
+		require.Error(t, actualErr)
+		require.Contains(t, actualErr.Error(), wantError.Error())
+		return
+	}
+	require.NoError(t, actualErr)
+}
+
+func validateResponse(t api.TestingT, actualResp *transport.Response, expectedResp *transport.Response) {
+	var actualBody []byte
+	var expectedBody []byte
+	var err error
+	if actualResp.Body != nil {
+		actualBody, err = ioutil.ReadAll(actualResp.Body)
+		require.NoError(t, err)
+	}
+	if expectedResp.Body != nil {
+		expectedBody, err = ioutil.ReadAll(expectedResp.Body)
+		require.NoError(t, err)
+	}
+	assert.Equal(t, string(actualBody), string(expectedBody))
+	for k, v := range expectedResp.Headers.Items() {
+		actualValue, ok := actualResp.Headers.Get(k)
+		require.True(t, ok, "header %q was not set on the response", k)
+		require.Equal(t, actualValue, v, "headers did not match for %q", k)
+	}
+}
+
+// UNARY-SPECIFIC REQUEST OPTIONS
+
+// Body sets the body on a request to the raw representation of the msg field.
+func Body(msg string) api.RequestOption {
+	return api.RequestOptionFunc(func(opts *api.RequestOpts) {
+		opts.GiveRequest.Body = bytes.NewBufferString(msg)
+	})
+}
+
+// ExpectError creates an assertion on the request response to validate the
+// error.
+func ExpectError(errMsg string) api.RequestOption {
+	return api.RequestOptionFunc(func(opts *api.RequestOpts) {
+		opts.ExpectedError = errors.New(errMsg)
+	})
+}
+
+// ExpectRespBody will assert that the response body matches at the end of the
+// request.
+func ExpectRespBody(body string) api.RequestOption {
+	return api.RequestOptionFunc(func(opts *api.RequestOpts) {
+		opts.ExpectedResponse.Body = ioutil.NopCloser(bytes.NewBufferString(body))
+	})
+}
+
+// GiveAndExpectLargeBodyIsEchoed creates an extremely large random byte buffer
+// and validates that the body is echoed back to the response.
+func GiveAndExpectLargeBodyIsEchoed(numOfBytes int) api.RequestOption {
+	return api.RequestOptionFunc(func(opts *api.RequestOpts) {
+		body := bytes.Repeat([]byte("t"), numOfBytes)
+		opts.GiveRequest.Body = bytes.NewReader(body)
+		opts.ExpectedResponse.Body = ioutil.NopCloser(bytes.NewReader(body))
+	})
+}

--- a/x/yarpctest/roundtrip_test.go
+++ b/x/yarpctest/roundtrip_test.go
@@ -1,0 +1,240 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpctest
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/yarpcerrors"
+)
+
+func TestServiceRouting(t *testing.T) {
+	p := NewPortProvider(t)
+	tests := []struct {
+		name     string
+		services Lifecycle
+		requests Action
+	}{
+		{
+			name: "http to http request",
+			services: Lifecycles(
+				HTTPService(
+					Name("myservice"),
+					p.Port("1"),
+					Proc(Name("echo"), EchoHandler()),
+				),
+			),
+			requests: Actions(
+				HTTPRequest(
+					p.Port("1"),
+					Body("test body"),
+					Service("myservice"),
+					Procedure("echo"),
+					ExpectRespBody("test body"),
+				),
+			),
+		},
+		{
+			name: "tchannel to tchannel request",
+			services: Lifecycles(
+				TChannelService(
+					Name("myservice"),
+					p.Port("2"),
+					Proc(Name("echo"), EchoHandler()),
+				),
+			),
+			requests: Actions(
+				TChannelRequest(
+					p.Port("2"),
+					Body("test body"),
+					Service("myservice"),
+					Procedure("echo"),
+					ExpectRespBody("test body"),
+				),
+			),
+		},
+		{
+			name: "grpc to grpc request",
+			services: Lifecycles(
+				GRPCService(
+					Name("myservice"),
+					p.Port("3"),
+					Proc(Name("echo"), EchoHandler()),
+				),
+			),
+			requests: Actions(
+				GRPCRequest(
+					p.Port("3"),
+					Body("test body"),
+					Service("myservice"),
+					Procedure("echo"),
+					ExpectRespBody("test body"),
+				),
+			),
+		},
+		{
+			name: "response errors",
+			services: Lifecycles(
+				HTTPService(
+					Name("myservice"),
+					p.Port("4-http"),
+					Proc(
+						Name("error"),
+						ErrorHandler(
+							errors.New("error from myservice"),
+						),
+					),
+				),
+				TChannelService(
+					Name("myotherservice"),
+					p.Port("4-tch"),
+					Proc(Name("error"), ErrorHandler(errors.New("error from myotherservice"))),
+				),
+				GRPCService(
+					Name("myotherservice2"),
+					p.Port("4-grpc"),
+					Proc(Name("error"), ErrorHandler(errors.New("error from myotherservice2"))),
+				),
+			),
+			requests: Actions(
+				HTTPRequest(
+					p.Port("4-http"),
+					Service("myservice"),
+					Procedure("error"),
+					ExpectError("error from myservice"),
+				),
+				TChannelRequest(
+					p.Port("4-tch"),
+					Service("myotherservice"),
+					Procedure("error"),
+					ExpectError("error from myotherservice"),
+				),
+				GRPCRequest(
+					p.Port("4-grpc"),
+					Service("myotherservice2"),
+					Procedure("error"),
+					ExpectError("error from myotherservice2"),
+				),
+			),
+		},
+		{
+			name: "ordered requests",
+			services: Lifecycles(
+				HTTPService(
+					Name("myservice"),
+					p.Port("5"),
+					Proc(
+						Name("proc"),
+						OrderedRequestHandler(
+							ErrorHandler(yarpcerrors.InternalErrorf("internal error")),
+							StaticHandler("success"),
+							EchoHandlerWithPrefix("echo: "),
+							EchoHandler(),
+						),
+					),
+				),
+			),
+			requests: Actions(
+				HTTPRequest(
+					p.Port("5"),
+					Service("myservice"),
+					Procedure("proc"),
+					ShardKey("ignoreme"),
+					ExpectError(yarpcerrors.InternalErrorf("internal error").Error()),
+				),
+				HTTPRequest(
+					p.Port("5"),
+					Service("myservice"),
+					Procedure("proc"),
+					ExpectRespBody("success"),
+				),
+				HTTPRequest(
+					p.Port("5"),
+					Service("myservice"),
+					Procedure("proc"),
+					Body("hello"),
+					ExpectRespBody("echo: hello"),
+				),
+				HTTPRequest(
+					p.Port("5"),
+					Service("myservice"),
+					Procedure("proc"),
+					GiveAndExpectLargeBodyIsEchoed(1<<17),
+				),
+			),
+		},
+		{
+			name: "ordered request headers",
+			services: Lifecycles(
+				HTTPService(
+					Name("myservice"),
+					p.Port("6"),
+					Proc(
+						Name("proc"),
+						OrderedRequestHandler(
+							ErrorHandler(
+								yarpcerrors.InternalErrorf("internal error"),
+								ExpectHeader("key1", "val1"),
+								ExpectHeader("key2", "val2"),
+								WithHeader("resp_key1", "resp_val1"),
+								WithHeader("resp_key2", "resp_val2"),
+							),
+							StaticHandler(
+								"success",
+								ExpectHeader("successKey", "successValue"),
+								WithHeader("responseKey", "responseValue"),
+							),
+						),
+					),
+				),
+			),
+			requests: Actions(
+				HTTPRequest(
+					p.Port("6"),
+					Service("myservice"),
+					Procedure("proc"),
+					ShardKey("ignoreme"),
+					WithHeader("key1", "val1"),
+					WithHeader("key2", "val2"),
+					ExpectError(yarpcerrors.InternalErrorf("internal error").Error()),
+				),
+				HTTPRequest(
+					p.Port("6"),
+					Service("myservice"),
+					Procedure("proc"),
+					WithHeader("successKey", "successValue"),
+					ExpectRespBody("success"),
+					ExpectHeader("responseKey", "responseValue"),
+				),
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, tt.services.Start(t))
+			defer func() { require.NoError(t, tt.services.Stop(t)) }()
+			tt.requests.Run(t)
+		})
+	}
+}

--- a/x/yarpctest/service.go
+++ b/x/yarpctest/service.go
@@ -1,0 +1,167 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpctest
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uber-go/tally"
+	"go.uber.org/multierr"
+	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/transport/grpc"
+	"go.uber.org/yarpc/transport/http"
+	"go.uber.org/yarpc/transport/tchannel"
+	"go.uber.org/yarpc/x/yarpctest/api"
+)
+
+// HTTPService will create a runnable HTTP service.
+func HTTPService(options ...api.ServiceOption) api.Lifecycle {
+	opts := api.ServiceOpts{}
+	for _, option := range options {
+		option.ApplyService(&opts)
+	}
+	if opts.Listener != nil {
+		err := opts.Listener.Close()
+		if err != nil {
+			panic(err)
+		}
+	}
+	inbound := http.NewTransport().NewInbound(fmt.Sprintf(":%d", opts.Port))
+	return createService(opts.Name, inbound, opts.Procedures, options)
+}
+
+// TChannelService will create a runnable TChannel service.
+func TChannelService(options ...api.ServiceOption) api.Lifecycle {
+	opts := api.ServiceOpts{}
+	for _, option := range options {
+		option.ApplyService(&opts)
+	}
+	if opts.Listener != nil {
+		err := opts.Listener.Close()
+		if err != nil {
+			panic(err)
+		}
+	}
+	trans, err := tchannel.NewTransport(
+		tchannel.ListenAddr(fmt.Sprintf(":%d", opts.Port)),
+		tchannel.ServiceName(opts.Name),
+	)
+	if err != nil {
+		panic(err)
+	}
+	inbound := trans.NewInbound()
+	return createService(opts.Name, inbound, opts.Procedures, options)
+}
+
+// GRPCService will create a runnable GRPC service.
+func GRPCService(options ...api.ServiceOption) api.Lifecycle {
+	opts := api.ServiceOpts{}
+	for _, option := range options {
+		option.ApplyService(&opts)
+	}
+	trans := grpc.NewTransport()
+	listener := opts.Listener
+	var err error
+	if listener == nil {
+		listener, err = net.Listen("tcp", fmt.Sprintf(":%d", opts.Port))
+		if err != nil {
+			panic(err)
+		}
+	}
+	inbound := trans.NewInbound(listener)
+	return createService(opts.Name, inbound, opts.Procedures, options)
+}
+
+func createService(
+	name string,
+	inbound transport.Inbound,
+	procedures []transport.Procedure,
+	options []api.ServiceOption,
+) *wrappedDispatcher {
+	d := yarpc.NewDispatcher(
+		yarpc.Config{
+			Name:     name,
+			Inbounds: yarpc.Inbounds{inbound},
+			Metrics: yarpc.MetricsConfig{
+				Tally: tally.NoopScope,
+			},
+		},
+	)
+	d.Register(procedures)
+	return &wrappedDispatcher{
+		Dispatcher: d,
+		options:    options,
+		procedures: procedures,
+	}
+}
+
+type wrappedDispatcher struct {
+	*yarpc.Dispatcher
+	options    []api.ServiceOption
+	procedures []transport.Procedure
+}
+
+func (w *wrappedDispatcher) Start(t api.TestingT) error {
+	var err error
+	for _, option := range w.options {
+		err = multierr.Append(err, option.Start(t))
+	}
+	for _, procedure := range w.procedures {
+		if unary := procedure.HandlerSpec.Unary(); unary != nil {
+			if lc, ok := unary.(api.Lifecycle); ok {
+				err = multierr.Append(err, lc.Start(t))
+			}
+		}
+		if oneway := procedure.HandlerSpec.Oneway(); oneway != nil {
+			if lc, ok := oneway.(api.Lifecycle); ok {
+				err = multierr.Append(err, lc.Start(t))
+			}
+		}
+	}
+	err = multierr.Append(err, w.Dispatcher.Start())
+	assert.NoError(t, err, "error starting dispatcher: %s", w.Name())
+	return err
+}
+
+func (w *wrappedDispatcher) Stop(t api.TestingT) error {
+	var err error
+	for _, option := range w.options {
+		err = multierr.Append(err, option.Stop(t))
+	}
+	for _, procedure := range w.procedures {
+		if unary := procedure.HandlerSpec.Unary(); unary != nil {
+			if lc, ok := unary.(api.Lifecycle); ok {
+				err = multierr.Append(err, lc.Stop(t))
+			}
+		}
+		if oneway := procedure.HandlerSpec.Oneway(); oneway != nil {
+			if lc, ok := oneway.(api.Lifecycle); ok {
+				err = multierr.Append(err, lc.Stop(t))
+			}
+		}
+	}
+	err = multierr.Append(err, w.Dispatcher.Stop())
+	assert.NoError(t, err, "error stopping dispatcher: %s", w.Name())
+	return err
+}

--- a/x/yarpctest/types/doc.go
+++ b/x/yarpctest/types/doc.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package types are for objects in the yarpctest API that implement
+// multiple interfaces.  So if we want to reuse a function like "Name" across
+// the Service and Procedure option patterns, we need to have specific structs
+// that implement both of those types.  These structs also need to be public.
+// By putting these structs into a single package, we can remove unusable
+// functions from the exposed yarpctest package and hide them in a sub package.
+package types

--- a/x/yarpctest/types/handler_unary.go
+++ b/x/yarpctest/types/handler_unary.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package types
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/atomic"
+	"go.uber.org/multierr"
+	"go.uber.org/yarpc/api/middleware"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/inboundmiddleware"
+	"go.uber.org/yarpc/x/yarpctest/api"
+)
+
+// UnaryHandler is a struct that implements the ProcOptions and HandlerOption
+// interfaces (so it can be used directly as a procedure, or as a single use
+// handler (depending on the use case)).
+type UnaryHandler struct {
+	H  api.UnaryHandler
+	MW []api.UnaryInboundMiddleware
+}
+
+// Start implements Lifecycle.
+func (h *UnaryHandler) Start(t api.TestingT) error {
+	var err error
+	err = multierr.Append(err, h.H.Start(t))
+	for _, mw := range h.MW {
+		err = multierr.Append(err, mw.Start(t))
+	}
+	return err
+}
+
+// Stop implements Lifecycle.
+func (h *UnaryHandler) Stop(t api.TestingT) error {
+	var err error
+	err = multierr.Append(err, h.H.Stop(t))
+	for _, mw := range h.MW {
+		err = multierr.Append(err, mw.Stop(t))
+	}
+	return err
+}
+
+// ApplyProc implements ProcOption.
+func (h *UnaryHandler) ApplyProc(opts *api.ProcOpts) {
+	opts.HandlerSpec = transport.NewUnaryHandlerSpec(h)
+}
+
+// ApplyHandler implements HandlerOption.
+func (h *UnaryHandler) ApplyHandler(opts *api.HandlerOpts) {
+	opts.Handlers = append(opts.Handlers, h)
+}
+
+// Handle implements transport.UnaryHandler.
+func (h *UnaryHandler) Handle(ctx context.Context, req *transport.Request, resw transport.ResponseWriter) error {
+	mws := make([]middleware.UnaryInbound, 0, len(h.MW))
+	for _, mw := range h.MW {
+		mws = append(mws, mw)
+	}
+	handler := middleware.ApplyUnaryInbound(h.H, inboundmiddleware.UnaryChain(mws...))
+	return handler.Handle(ctx, req, resw)
+}
+
+// OrderedHandler implements the transport.UnaryHandler and ProcOption
+// interfaces.
+type OrderedHandler struct {
+	attempt  atomic.Int32
+	Handlers []api.UnaryHandler
+}
+
+// Start implements Lifecycle.
+func (h *OrderedHandler) Start(t api.TestingT) error {
+	var err error
+	for _, handler := range h.Handlers {
+		err = multierr.Append(err, handler.Start(t))
+	}
+	return err
+}
+
+// Stop implements Lifecycle.
+func (h *OrderedHandler) Stop(t api.TestingT) error {
+	var err error
+	for _, handler := range h.Handlers {
+		err = multierr.Append(err, handler.Stop(t))
+	}
+	return err
+}
+
+// ApplyProc implements ProcOption.
+func (h *OrderedHandler) ApplyProc(opts *api.ProcOpts) {
+	opts.HandlerSpec = transport.NewUnaryHandlerSpec(h)
+}
+
+// Handle implements transport.UnaryHandler#Handle.
+func (h *OrderedHandler) Handle(ctx context.Context, req *transport.Request, resw transport.ResponseWriter) error {
+	if len(h.Handlers) <= 0 {
+		return fmt.Errorf("No handlers for the request")
+	}
+	n := h.attempt.Inc()
+	if int(n) > len(h.Handlers) {
+		return fmt.Errorf("too many requests, expected %d, got %d", len(h.Handlers), n)
+	}
+	return h.Handlers[n-1].Handle(ctx, req, resw)
+}

--- a/x/yarpctest/types/header.go
+++ b/x/yarpctest/types/header.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package types
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/x/yarpctest/api"
+)
+
+// GiveHeader is an API for giving headers to a Request or a Response.
+type GiveHeader struct {
+	api.NoopLifecycle
+
+	Key   string
+	Value string
+}
+
+// ApplyRequest implements RequestOption.
+func (h *GiveHeader) ApplyRequest(opts *api.RequestOpts) {
+	opts.GiveRequest.Headers = opts.GiveRequest.Headers.With(h.Key, h.Value)
+}
+
+// Handle implements middleware.UnaryInbound.
+func (h *GiveHeader) Handle(ctx context.Context, req *transport.Request, resw transport.ResponseWriter, handler transport.UnaryHandler) error {
+	err := handler.Handle(ctx, req, resw)
+	resw.AddHeaders(transport.NewHeaders().With(h.Key, h.Value))
+	return err
+}
+
+// ExpectHeader is an API for asserting headers sent on a Request or a Response.
+type ExpectHeader struct {
+	api.SafeTestingTOnStart
+	api.NoopStop
+
+	Key   string
+	Value string
+}
+
+// ApplyRequest implements RequestOption.
+func (h *ExpectHeader) ApplyRequest(opts *api.RequestOpts) {
+	opts.ExpectedResponse.Headers = opts.ExpectedResponse.Headers.With(h.Key, h.Value)
+}
+
+// Handle implements middleware.UnaryInbound.
+func (h *ExpectHeader) Handle(ctx context.Context, req *transport.Request, resw transport.ResponseWriter, handler transport.UnaryHandler) error {
+	actualValue, ok := req.Headers.Get(h.Key)
+	require.True(h.GetTestingT(), ok, "header %q was not set on the request", h.Key)
+	require.Equal(h.GetTestingT(), actualValue, h.Value, "headers did not match for %q", h.Key)
+	return handler.Handle(ctx, req, resw)
+}

--- a/x/yarpctest/types/name.go
+++ b/x/yarpctest/types/name.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package types
+
+import "go.uber.org/yarpc/x/yarpctest/api"
+
+// Name is a concrete type that implements both ServiceOption and
+// ProcedureOption interfaces so it can be used interchangeably.
+type Name struct {
+	api.NoopLifecycle
+
+	Name string
+}
+
+// ApplyService implements ServiceOption.
+func (n *Name) ApplyService(opts *api.ServiceOpts) {
+	opts.Name = n.Name
+}
+
+// ApplyProc implements ProcOption.
+func (n *Name) ApplyProc(opts *api.ProcOpts) {
+	opts.Name = n.Name
+}

--- a/x/yarpctest/types/port.go
+++ b/x/yarpctest/types/port.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package types
+
+import "go.uber.org/yarpc/x/yarpctest/api"
+
+// Port is a concrete type that implements multiple interfaces as ease
+// of use for synchronizing ports.
+type Port struct {
+	api.NoopLifecycle
+
+	Port int
+}
+
+// ApplyService implements api.ServiceOption.
+func (n *Port) ApplyService(opts *api.ServiceOpts) {
+	opts.Port = n.Port
+}
+
+// ApplyRequest implements RequestOption
+func (n *Port) ApplyRequest(opts *api.RequestOpts) {
+	opts.Port = n.Port
+}

--- a/x/yarpctest/types/request.go
+++ b/x/yarpctest/types/request.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package types
+
+import "go.uber.org/yarpc/x/yarpctest/api"
+
+// Service is a concrete type that represents the "service" for a request.
+// It can be used in multiple interfaces.
+type Service struct {
+	Service string
+}
+
+// ApplyRequest implements api.RequestOption
+func (n *Service) ApplyRequest(opts *api.RequestOpts) {
+	opts.GiveRequest.Service = n.Service
+}
+
+// Procedure is a concrete type that represents the "procedure" for a request.
+// It can be used in multiple interfaces.
+type Procedure struct {
+	Procedure string
+}
+
+// ApplyRequest implements api.RequestOption
+func (n *Procedure) ApplyRequest(opts *api.RequestOpts) {
+	opts.GiveRequest.Procedure = n.Procedure
+}
+
+// ShardKey is a concrete type that represents the "shard key" for a request.
+// It can be used in multiple interfaces.
+type ShardKey struct {
+	ShardKey string
+}
+
+// ApplyRequest implements api.RequestOption
+func (n *ShardKey) ApplyRequest(opts *api.RequestOpts) {
+	opts.GiveRequest.ShardKey = n.ShardKey
+}


### PR DESCRIPTION
Summary: This is an adaptation of an internal test library we've been
using in the frontcar, the priority of the library being the legibility
of the tests that are written.
Before we add the GRPC streaming functionality in the next PRs, this PR
adds the basic test infrastructure in an /x/ package that can be used to
start up services (lifecycles) and apply requests (actions) against those
services.
So if we want to define a service like this:

```
HTTPService(
  Name("myservice"),
  Port(12345),
  Proc(Name("echo"), EchoHandler()),
)
```

We can make requests against it like this:

```
HTTPRequest(
  Port(12345),
  Body("test body"),
  Service("myservice"),
  Procedure("echo"),
  ExpectRespBody("test body"),
),
```

It's possible that the apis here might need to change based on new
functionality requirements, which is a reason to incubate this in an /x/
package. It may be used in non-x packages only for testing.