### PR TITLE
Stream2: Add OutboundConfig to replace ClientConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ v1.23.0-dev (unreleased)
 -   Introduces `api/peer.ListImplementation` with `peer/peerlist.List`, a
     building block that provides peer availability management for peer lists
     like round-robin, hash-ring.
--   Add /x/yarpctest infrastructure to create fake services and requests for
+-   Adds /x/yarpctest infrastructure to create fake services and requests for
     tests.
 -   Adds a `peer/pendingheap` implementation that performs peer selection,
     sending requests to the available peer with the fewest pending requests.
+-   Adds `OutboundConfig` and `MustOutboundConfig` functions to the dispatcher
+    to replace the ClientConfig function.
 
 v1.22.0 (2017-11-14)
 --------------------

--- a/api/transport/outboundconfig.go
+++ b/api/transport/outboundconfig.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package transport
+
+import "fmt"
+
+// OutboundConfig is a configuration for how to call into another service.  It
+// is used in conjunction with an encoding to send a request through one of the
+// outbounds.
+type OutboundConfig struct {
+	CallerName string
+	Outbounds  Outbounds
+}
+
+var _ ClientConfig = (*OutboundConfig)(nil)
+
+// Caller is the name of the service making the request.
+//
+// Implements ClientConfig#Caller (for backwards compatibility).
+func (o *OutboundConfig) Caller() string {
+	// TODO: This function should be deprecated, it's for legacy support.
+	// Use CallerName instead.
+	return o.CallerName
+}
+
+// Service is the name of the service to which the request is being made.
+//
+// Implements ClientConfig#Service (for backwards compatibility).
+func (o *OutboundConfig) Service() string {
+	// TODO: This function should be deprecated, it's for legacy support.
+	// Use Outbounds.ServiceName instead.
+	return o.Outbounds.ServiceName
+}
+
+// GetUnaryOutbound returns an outbound to send the request through or panics
+// if there is no unary outbound for this service.
+//
+// Implements ClientConfig#GetUnaryOutbound.
+func (o *OutboundConfig) GetUnaryOutbound() UnaryOutbound {
+	// TODO: This function should be deprecated, it's for legacy support.
+	// Use Outbounds.Unary instead (and panic if you want).
+	if o.Outbounds.Unary == nil {
+		panic(fmt.Sprintf("service %q does not have a unary outbound", o.Outbounds.ServiceName))
+	}
+	return o.Outbounds.Unary
+}
+
+// GetOnewayOutbound returns an outbound to send the request through or panics
+// if there is no oneway outbound for this service.
+//
+// Implements ClientConfig#GetOnewayOutbound.
+func (o *OutboundConfig) GetOnewayOutbound() OnewayOutbound {
+	// TODO: This function should be deprecated, it's for legacy support.
+	// Use o.Outbounds.Oneway instead (and panic if you want).
+	if o.Outbounds.Oneway == nil {
+		panic(fmt.Sprintf("service %q does not have a oneway outbound", o.Outbounds.ServiceName))
+	}
+	return o.Outbounds.Oneway
+}

--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -349,6 +349,50 @@ func TestClientConfig(t *testing.T) {
 	assert.Equal(t, "my-test-service", cc.Service())
 }
 
+func TestClientConfigError(t *testing.T) {
+	dispatcher := NewDispatcher(Config{
+		Name: "test",
+		Outbounds: Outbounds{
+			"my-test-service": {
+				Unary: http.NewTransport().NewSingleOutbound("http://127.0.0.1:1234"),
+			},
+		},
+	})
+
+	assert.Panics(t, func() { dispatcher.ClientConfig("wrong test name") })
+}
+
+func TestOutboundConfig(t *testing.T) {
+	dispatcher := NewDispatcher(Config{
+		Name: "test",
+		Outbounds: Outbounds{
+			"my-test-service": {
+				Unary: http.NewTransport().NewSingleOutbound("http://127.0.0.1:1234"),
+			},
+		},
+	})
+
+	cc := dispatcher.MustOutboundConfig("my-test-service")
+	assert.Equal(t, "test", cc.CallerName)
+	assert.Equal(t, "my-test-service", cc.Outbounds.ServiceName)
+}
+
+func TestOutboundConfigError(t *testing.T) {
+	dispatcher := NewDispatcher(Config{
+		Name: "test",
+		Outbounds: Outbounds{
+			"my-test-service": {
+				Unary: http.NewTransport().NewSingleOutbound("http://127.0.0.1:1234"),
+			},
+		},
+	})
+
+	assert.Panics(t, func() { dispatcher.MustOutboundConfig("wrong test name") })
+	oc, ok := dispatcher.OutboundConfig("wrong test name")
+	assert.False(t, ok, "getting outbound config should not have succeeded")
+	assert.Nil(t, oc, "getting outbound config should not have succeeded")
+}
+
 func TestInboundMiddleware(t *testing.T) {
 	dispatcher := NewDispatcher(Config{
 		Name: "test",

--- a/internal/clientconfig/multioutbound.go
+++ b/internal/clientconfig/multioutbound.go
@@ -21,37 +21,17 @@
 package clientconfig
 
 import (
-	"fmt"
-
 	"go.uber.org/yarpc/api/transport"
 )
 
-type multiOutbound struct {
-	caller    string
-	service   string
-	Outbounds transport.Outbounds
-}
-
 // MultiOutbound constructs a ClientConfig backed by multiple outbound types
-func MultiOutbound(caller, service string, Outbounds transport.Outbounds) transport.ClientConfig {
-	return multiOutbound{caller: caller, service: service, Outbounds: Outbounds}
-}
-
-func (c multiOutbound) Caller() string  { return c.caller }
-func (c multiOutbound) Service() string { return c.service }
-
-func (c multiOutbound) GetUnaryOutbound() transport.UnaryOutbound {
-	if c.Outbounds.Unary == nil {
-		panic(fmt.Sprintf("Service %q does not have a unary outbound", c.service))
+func MultiOutbound(caller, service string, outbounds transport.Outbounds) transport.ClientConfig {
+	return &transport.OutboundConfig{
+		CallerName: caller,
+		Outbounds: transport.Outbounds{
+			ServiceName: service,
+			Unary:       outbounds.Unary,
+			Oneway:      outbounds.Oneway,
+		},
 	}
-
-	return c.Outbounds.Unary
-}
-
-func (c multiOutbound) GetOnewayOutbound() transport.OnewayOutbound {
-	if c.Outbounds.Oneway == nil {
-		panic(fmt.Sprintf("Service %q does not have a oneway outbound", c.service))
-	}
-
-	return c.Outbounds.Oneway
 }


### PR DESCRIPTION
Summary: This is a re-release of #1317 with another change where we remove 
the clientconfig.MultiOutbound.  I landed #1317 into a branch to unblock the 
stream code we write after this.  The original commit remains unchanged, with
an extra commit to remove some code.

To Reiterate #1317: 

The ClientConfig interface we've been working with has some
drawbacks.  Primarily, it panics EVERYWHERE (*mostly everywhere). So as we
start thinking about dynamic config for things using YARPC, we start to get
into a dangerous zone where all our functions are incredibly panic-prone.
So if we wanted to check if an outbound key existed, the ClientConfig apis
would probably panic.

Additionally, the fact that both Unary and Oneway are hardcoded into the
ClientConfig interface means that we cannot iterate with new Outbound types
(*cough* streaming *cough*).

This PR provides an alternative to ClientConfig, "OutboundConfig".  The
OutboundConfig implements the ClientConfig interface (and functionality)
for backwards compatibility, but, it exposes all of the struct properties
externally, so if we want to add more types to the Outbounds struct, we
can. It also provides two functions for forcibly getting
(panic) and optionally getting an OutboundConfig.