### PR TITLE
Stream4: Add streaming support to yarpcconfig

### DIFF
--- a/yarpcconfig/chooser_test.go
+++ b/yarpcconfig/chooser_test.go
@@ -806,6 +806,36 @@ func TestChooserConfigurator(t *testing.T) {
 			},
 		},
 		{
+			desc: "invalid stream peer list config",
+			given: whitespace.Expand(`
+				outbounds:
+					their-service:
+						oneway:
+							fake-transport:
+								fake-list:
+									invalid-updater: {}
+			`),
+			wantErr: []string{
+				`failed to configure oneway outbound for "their-service": `,
+				`could not create invalid-updater`,
+			},
+		},
+		{
+			desc: "invalid stream peer list config",
+			given: whitespace.Expand(`
+				outbounds:
+					their-service:
+						oneway:
+							fake-transport:
+								fake-list:
+									invalid-updater: {}
+			`),
+			wantErr: []string{
+				`failed to configure oneway outbound for "their-service": `,
+				`could not create invalid-updater`,
+			},
+		},
+		{
 			desc: "interpolation fallback",
 			given: whitespace.Expand(`
 				transports:

--- a/yarpcconfig/chooser_test.go
+++ b/yarpcconfig/chooser_test.go
@@ -806,7 +806,7 @@ func TestChooserConfigurator(t *testing.T) {
 			},
 		},
 		{
-			desc: "invalid stream peer list config",
+			desc: "invalid oneway peer list config",
 			given: whitespace.Expand(`
 				outbounds:
 					their-service:
@@ -825,13 +825,13 @@ func TestChooserConfigurator(t *testing.T) {
 			given: whitespace.Expand(`
 				outbounds:
 					their-service:
-						oneway:
+						stream:
 							fake-transport:
 								fake-list:
 									invalid-updater: {}
 			`),
 			wantErr: []string{
-				`failed to configure oneway outbound for "their-service": `,
+				`failed to configure stream outbound for "their-service": `,
 				`could not create invalid-updater`,
 			},
 		},

--- a/yarpcconfig/configurator.go
+++ b/yarpcconfig/configurator.go
@@ -298,7 +298,7 @@ func (c *Configurator) loadInboundInto(b *builder, i inbound) error {
 
 func (c *Configurator) loadOutboundInto(b *builder, name string, cfg outbounds) error {
 	// This matches the signature of builder.AddImplicitOutbound,
-	// AddUnaryOutbound and AddOnewayOutbound
+	// AddUnaryOutbound, AddOnewayOutbound and AddStreamOutbound
 	type adder func(*compiledTransportSpec, string, string, config.AttributeMap) error
 
 	loadUsing := func(o *outbound, adder adder) error {
@@ -326,6 +326,12 @@ func (c *Configurator) loadOutboundInto(b *builder, name string, cfg outbounds) 
 
 	if oneway := cfg.Oneway; oneway != nil {
 		if err := loadUsing(oneway, b.AddOnewayOutbound); err != nil {
+			return err
+		}
+	}
+
+	if stream := cfg.Stream; stream != nil {
+		if err := loadUsing(stream, b.AddStreamOutbound); err != nil {
 			return err
 		}
 	}

--- a/yarpcconfig/configurator_test.go
+++ b/yarpcconfig/configurator_test.go
@@ -528,15 +528,15 @@ func TestConfigurator(t *testing.T) {
 				tt.give = whitespace.Expand(`
 					outbounds:
 						bar:
-							redis:
+							fake-stream-transport:
 								queue: requests
 					transports:
-						redis:
+						fake-stream-transport:
 							address: localhost:6379
 				`)
 
 				redis := mockTransportSpecBuilder{
-					Name:                 "redis",
+					Name:                 "fake-stream-transport",
 					TransportConfig:      reflect.TypeOf(transportConfig{}),
 					StreamOutboundConfig: reflect.TypeOf(&outboundConfig{}),
 				}.Build(mockCtrl)

--- a/yarpcconfig/configurator_test.go
+++ b/yarpcconfig/configurator_test.go
@@ -646,6 +646,7 @@ func TestConfigurator(t *testing.T) {
 					TransportConfig:      _typeOfEmptyStruct,
 					OnewayOutboundConfig: reflect.TypeOf(&outboundConfig{}),
 					UnaryOutboundConfig:  reflect.TypeOf(&outboundConfig{}),
+					StreamOutboundConfig: reflect.TypeOf(&outboundConfig{}),
 				}.Build(mockCtrl)
 
 				tt.specs = []TransportSpec{http.Spec()}
@@ -653,6 +654,7 @@ func TestConfigurator(t *testing.T) {
 					`failed to add outbound "qux"`,
 					"failed to decode oneway outbound configuration",
 					"failed to decode unary outbound configuration",
+					"failed to decode stream outbound configuration",
 					"invalid keys: uri",
 				}
 

--- a/yarpcconfig/decode.go
+++ b/yarpcconfig/decode.go
@@ -101,6 +101,7 @@ type outbounds struct {
 	// transport supports.
 	Unary    *outbound
 	Oneway   *outbound
+	Stream   *outbound
 	Implicit *outbound
 }
 
@@ -126,7 +127,12 @@ func (o *outbounds) Decode(into mapdecode.Into) error {
 		return fmt.Errorf("failed to oneway outbound configuration: %v", err)
 	}
 
-	if hasUnary || hasOneway {
+	hasStream, err := attrs.Pop("stream", &o.Stream)
+	if err != nil {
+		return fmt.Errorf("failed to stream outbound configuration: %v", err)
+	}
+
+	if hasUnary || hasOneway || hasStream {
 		// No more attributes should be remaining
 		var empty struct{}
 		if err := attrs.Decode(&empty); err != nil {

--- a/yarpcconfig/mock_transport_spec_test.go
+++ b/yarpcconfig/mock_transport_spec_test.go
@@ -47,6 +47,7 @@ type mockTransportSpecBuilder struct {
 	InboundConfig        reflect.Type
 	UnaryOutboundConfig  reflect.Type
 	OnewayOutboundConfig reflect.Type
+	StreamOutboundConfig reflect.Type
 }
 
 // build the mockTransportSpec.
@@ -68,6 +69,9 @@ func (b mockTransportSpecBuilder) Build(ctrl *gomock.Controller) *mockTransportS
 	}
 	if b.OnewayOutboundConfig != nil {
 		s.BuildOnewayOutbound = builderFunc(ctrl, &m, "BuildOnewayOutbound", []reflect.Type{b.OnewayOutboundConfig, _typeOfTransport, _typeOfKit}, _typeOfOnewayOutbound)
+	}
+	if b.StreamOutboundConfig != nil {
+		s.BuildStreamOutbound = builderFunc(ctrl, &m, "BuildStreamOutbound", []reflect.Type{b.StreamOutboundConfig, _typeOfTransport, _typeOfKit}, _typeOfStreamOutbound)
 	}
 
 	return &m
@@ -96,6 +100,10 @@ func (m *mockTransportSpec) BuildUnaryOutbound(interface{}, transport.Transport,
 }
 
 func (m *mockTransportSpec) BuildOnewayOutbound(interface{}, transport.Transport, gomock.Matcher) (transport.OnewayOutbound, error) {
+	panic("This function should never be called")
+}
+
+func (m *mockTransportSpec) BuildStreamOutbound(interface{}, transport.Transport, gomock.Matcher) (transport.StreamOutbound, error) {
 	panic("This function should never be called")
 }
 
@@ -130,6 +138,10 @@ func (r *_transportSpecRecorder) BuildUnaryOutbound(cfg interface{}, t transport
 
 func (r *_transportSpecRecorder) BuildOnewayOutbound(cfg interface{}, t transport.Transport, kit gomock.Matcher) *gomock.Call {
 	return r.ctrl.RecordCall(r.m, "BuildOnewayOutbound", cfg, t, kit)
+}
+
+func (r *_transportSpecRecorder) BuildStreamOutbound(cfg interface{}, t transport.Transport, kit gomock.Matcher) *gomock.Call {
+	return r.ctrl.RecordCall(r.m, "BuildStreamOutbound", cfg, t, kit)
 }
 
 // anyKitMatcher verifies that an instance is a *Kit.

--- a/yarpcconfig/spec.go
+++ b/yarpcconfig/spec.go
@@ -112,6 +112,7 @@ type TransportSpec struct {
 	// outbounds for this transport.
 	BuildUnaryOutbound  interface{}
 	BuildOnewayOutbound interface{}
+	BuildStreamOutbound interface{}
 
 	// Named presets.
 	//
@@ -249,6 +250,7 @@ var (
 	_typeOfInbound         = reflect.TypeOf((*transport.Inbound)(nil)).Elem()
 	_typeOfUnaryOutbound   = reflect.TypeOf((*transport.UnaryOutbound)(nil)).Elem()
 	_typeOfOnewayOutbound  = reflect.TypeOf((*transport.OnewayOutbound)(nil)).Elem()
+	_typeOfStreamOutbound  = reflect.TypeOf((*transport.StreamOutbound)(nil)).Elem()
 	_typeOfPeerTransport   = reflect.TypeOf((*peer.Transport)(nil)).Elem()
 	_typeOfPeerChooserList = reflect.TypeOf((*peer.ChooserList)(nil)).Elem()
 	_typeOfPeerChooser     = reflect.TypeOf((*peer.Chooser)(nil)).Elem()
@@ -268,6 +270,7 @@ type compiledTransportSpec struct {
 	Inbound        *configSpec
 	UnaryOutbound  *configSpec
 	OnewayOutbound *configSpec
+	StreamOutbound *configSpec
 
 	PeerChooserPresets map[string]*compiledPeerChooserPreset
 }
@@ -280,6 +283,10 @@ func (s *compiledTransportSpec) SupportsOnewayOutbound() bool {
 	return s.OnewayOutbound != nil
 }
 
+func (s *compiledTransportSpec) SupportsStreamOutbound() bool {
+	return s.StreamOutbound != nil
+}
+
 func compileTransportSpec(spec *TransportSpec) (*compiledTransportSpec, error) {
 	out := compiledTransportSpec{Name: spec.Name}
 
@@ -288,7 +295,7 @@ func compileTransportSpec(spec *TransportSpec) (*compiledTransportSpec, error) {
 	}
 
 	switch strings.ToLower(spec.Name) {
-	case "unary", "oneway":
+	case "unary", "oneway", "stream":
 		return nil, fmt.Errorf("transport name cannot be %q: %q is a reserved name", spec.Name, spec.Name)
 	}
 
@@ -313,6 +320,9 @@ func compileTransportSpec(spec *TransportSpec) (*compiledTransportSpec, error) {
 	}
 	if spec.BuildOnewayOutbound != nil {
 		out.OnewayOutbound = appendError(compileOnewayOutboundConfig(spec.BuildOnewayOutbound))
+	}
+	if spec.BuildStreamOutbound != nil {
+		out.StreamOutbound = appendError(compileStreamOutboundConfig(spec.BuildStreamOutbound))
 	}
 
 	if len(spec.PeerChooserPresets) == 0 {
@@ -410,6 +420,17 @@ func compileOnewayOutboundConfig(build interface{}) (*configSpec, error) {
 
 	if err := validateConfigFunc(t, _typeOfOnewayOutbound); err != nil {
 		return nil, fmt.Errorf("invalid BuildOnewayOutbound: %v", err)
+	}
+
+	return &configSpec{inputType: t.In(0), factory: v}, nil
+}
+
+func compileStreamOutboundConfig(build interface{}) (*configSpec, error) {
+	v := reflect.ValueOf(build)
+	t := v.Type()
+
+	if err := validateConfigFunc(t, _typeOfStreamOutbound); err != nil {
+		return nil, fmt.Errorf("invalid BuildStreamOutbound: %v", err)
 	}
 
 	return &configSpec{inputType: t.In(0), factory: v}, nil

--- a/yarpctest/fake_config.go
+++ b/yarpctest/fake_config.go
@@ -44,7 +44,19 @@ type FakeOutboundConfig struct {
 	Nop string `config:"nop,interpolate"`
 }
 
-func buildFakeOutbound(c *FakeOutboundConfig, t transport.Transport, kit *yarpcconfig.Kit) (transport.UnaryOutbound, error) {
+func buildFakeUnaryOutbound(c *FakeOutboundConfig, t transport.Transport, kit *yarpcconfig.Kit) (transport.UnaryOutbound, error) {
+	return buildFakeOutbound(c, t, kit)
+}
+
+func buildFakeOnewayOutbound(c *FakeOutboundConfig, t transport.Transport, kit *yarpcconfig.Kit) (transport.OnewayOutbound, error) {
+	return buildFakeOutbound(c, t, kit)
+}
+
+func buildFakeStreamOutbound(c *FakeOutboundConfig, t transport.Transport, kit *yarpcconfig.Kit) (transport.StreamOutbound, error) {
+	return buildFakeOutbound(c, t, kit)
+}
+
+func buildFakeOutbound(c *FakeOutboundConfig, t transport.Transport, kit *yarpcconfig.Kit) (*FakeOutbound, error) {
 	x := t.(*FakeTransport)
 	chooser, err := c.BuildPeerChooser(x, hostport.Identify, kit)
 	if err != nil {
@@ -57,9 +69,11 @@ func buildFakeOutbound(c *FakeOutboundConfig, t transport.Transport, kit *yarpcc
 // transport type, suitable for passing to Configurator.MustRegisterTransport.
 func FakeTransportSpec() yarpcconfig.TransportSpec {
 	return yarpcconfig.TransportSpec{
-		Name:               "fake-transport",
-		BuildTransport:     buildFakeTransport,
-		BuildUnaryOutbound: buildFakeOutbound,
+		Name:                "fake-transport",
+		BuildTransport:      buildFakeTransport,
+		BuildUnaryOutbound:  buildFakeUnaryOutbound,
+		BuildOnewayOutbound: buildFakeOnewayOutbound,
+		BuildStreamOutbound: buildFakeStreamOutbound,
 		PeerChooserPresets: []yarpcconfig.PeerChooserPreset{
 			FakePeerChooserPreset(),
 		},

--- a/yarpctest/fake_outbound.go
+++ b/yarpctest/fake_outbound.go
@@ -122,6 +122,6 @@ func (o *FakeOutbound) CallOneway(ctx context.Context, req *transport.Request) (
 }
 
 // CallStream pretends to send a Stream RPC, but actually just returns an error.
-func (o *FakeOutbound) CallStream(ctx context.Context, req *transport.StreamRequest) (transport.ClientStream, error) {
+func (o *FakeOutbound) CallStream(ctx context.Context, req *transport.StreamRequest) (*transport.ClientStream, error) {
 	return nil, fmt.Errorf(`call stream outbound is unsupported`)
 }

--- a/yarpctest/fake_outbound.go
+++ b/yarpctest/fake_outbound.go
@@ -71,11 +71,11 @@ func (t *FakeTransport) NewOutbound(c peer.Chooser, opts ...FakeOutboundOption) 
 
 // FakeOutbound is a unary outbound for the FakeTransport. It is fake.
 type FakeOutbound struct {
-	once               *lifecycle.Once
-	transport          *FakeTransport
-	chooser            peer.Chooser
-	nopOption          string
-	callOverride       OutboundCallable
+	once         *lifecycle.Once
+	transport    *FakeTransport
+	chooser      peer.Chooser
+	nopOption    string
+	callOverride OutboundCallable
 }
 
 // Chooser returns theis FakeOutbound's peer chooser.
@@ -118,10 +118,10 @@ func (o *FakeOutbound) Call(ctx context.Context, req *transport.Request) (*trans
 
 // CallOneway pretends to send a oneway RPC, but actually just returns an error.
 func (o *FakeOutbound) CallOneway(ctx context.Context, req *transport.Request) (transport.Ack, error) {
-	return nil, fmt.Errorf(`call oneway outbound is unsupported.`)
+	return nil, fmt.Errorf(`call oneway outbound is unsupported`)
 }
 
 // CallStream pretends to send a Stream RPC, but actually just returns an error.
 func (o *FakeOutbound) CallStream(ctx context.Context, req *transport.StreamRequest) (transport.ClientStream, error) {
-	return nil, fmt.Errorf(`call stream outbound is unsupported.`)
+	return nil, fmt.Errorf(`call stream outbound is unsupported`)
 }

--- a/yarpctest/fake_outbound.go
+++ b/yarpctest/fake_outbound.go
@@ -71,11 +71,11 @@ func (t *FakeTransport) NewOutbound(c peer.Chooser, opts ...FakeOutboundOption) 
 
 // FakeOutbound is a unary outbound for the FakeTransport. It is fake.
 type FakeOutbound struct {
-	once         *lifecycle.Once
-	transport    *FakeTransport
-	chooser      peer.Chooser
-	nopOption    string
-	callOverride OutboundCallable
+	once               *lifecycle.Once
+	transport          *FakeTransport
+	chooser            peer.Chooser
+	nopOption          string
+	callOverride       OutboundCallable
 }
 
 // Chooser returns theis FakeOutbound's peer chooser.
@@ -113,5 +113,15 @@ func (o *FakeOutbound) Call(ctx context.Context, req *transport.Request) (*trans
 	if o.callOverride != nil {
 		return o.callOverride(ctx, req)
 	}
-	return nil, fmt.Errorf(`No Outbound callable specified on the outbound`)
+	return nil, fmt.Errorf(`no outbound callable specified on the outbound`)
+}
+
+// CallOneway pretends to send a oneway RPC, but actually just returns an error.
+func (o *FakeOutbound) CallOneway(ctx context.Context, req *transport.Request) (transport.Ack, error) {
+	return nil, fmt.Errorf(`call oneway outbound is unsupported.`)
+}
+
+// CallStream pretends to send a Stream RPC, but actually just returns an error.
+func (o *FakeOutbound) CallStream(ctx context.Context, req *transport.StreamRequest) (transport.ClientStream, error) {
+	return nil, fmt.Errorf(`call stream outbound is unsupported.`)
 }


### PR DESCRIPTION
Summary: This PR adds support for creating stream outbounds in the
yarpcconfig.