### PR TITLE
Stream 8: Add stream observability middleware

### DIFF
--- a/dispatcher.go
+++ b/dispatcher.go
@@ -102,9 +102,11 @@ func addObservingMiddleware(cfg Config, registry *pally.Registry, logger *zap.Lo
 
 	cfg.InboundMiddleware.Unary = inboundmiddleware.UnaryChain(observer, cfg.InboundMiddleware.Unary)
 	cfg.InboundMiddleware.Oneway = inboundmiddleware.OnewayChain(observer, cfg.InboundMiddleware.Oneway)
+	cfg.InboundMiddleware.Stream = inboundmiddleware.StreamChain(observer, cfg.InboundMiddleware.Stream)
 
 	cfg.OutboundMiddleware.Unary = outboundmiddleware.UnaryChain(cfg.OutboundMiddleware.Unary, observer)
 	cfg.OutboundMiddleware.Oneway = outboundmiddleware.OnewayChain(cfg.OutboundMiddleware.Oneway, observer)
+	cfg.OutboundMiddleware.Stream = outboundmiddleware.StreamChain(cfg.OutboundMiddleware.Stream, observer)
 
 	return cfg
 }

--- a/internal/observability/common_test.go
+++ b/internal/observability/common_test.go
@@ -48,7 +48,7 @@ func (h fakeHandler) HandleOneway(context.Context, *transport.Request) error {
 	return h.err
 }
 
-func (h fakeHandler) HandleStream(transport.ServerStream) error {
+func (h fakeHandler) HandleStream(*transport.ServerStream) error {
 	return h.err
 }
 
@@ -72,20 +72,19 @@ func (o fakeOutbound) CallOneway(context.Context, *transport.Request) (transport
 	return fakeAck{}, nil
 }
 
-func (o fakeOutbound) CallStream(ctx context.Context, request *transport.StreamRequest) (transport.ClientStream, error) {
+func (o fakeOutbound) CallStream(ctx context.Context, request *transport.StreamRequest) (*transport.ClientStream, error) {
 	if o.err != nil {
 		return nil, o.err
 	}
-	return &fakeStream{
+	return transport.NewClientStream(&fakeStream{
 		ctx:     ctx,
 		request: request,
-	}, nil
+	})
 }
 
 type fakeStream struct {
-	ctx      context.Context
-	request  *transport.StreamRequest
-	response *transport.StreamResponse
+	ctx     context.Context
+	request *transport.StreamRequest
 }
 
 func (s *fakeStream) Context() context.Context {
@@ -94,14 +93,6 @@ func (s *fakeStream) Context() context.Context {
 
 func (s *fakeStream) Request() *transport.StreamRequest {
 	return s.request
-}
-
-func (s *fakeStream) Response() *transport.StreamResponse {
-	return s.response
-}
-
-func (s *fakeStream) SetResponse(response *transport.StreamResponse) {
-	s.response = response
 }
 
 func (s *fakeStream) SendMessage(context.Context, *transport.StreamMessage) error {

--- a/internal/observability/common_test.go
+++ b/internal/observability/common_test.go
@@ -112,7 +112,7 @@ func (s *fakeStream) ReceiveMessage(context.Context) (*transport.StreamMessage, 
 	return nil, nil
 }
 
-func (s *fakeStream) Close() error {
+func (s *fakeStream) Close(context.Context) error {
 	return nil
 }
 

--- a/internal/observability/common_test.go
+++ b/internal/observability/common_test.go
@@ -72,43 +72,43 @@ func (o fakeOutbound) CallOneway(context.Context, *transport.Request) (transport
 	return fakeAck{}, nil
 }
 
-func (o fakeOutbound) CallStream(ctx context.Context, requestMeta *transport.RequestMeta) (transport.ClientStream, error) {
+func (o fakeOutbound) CallStream(ctx context.Context, request *transport.StreamRequest) (transport.ClientStream, error) {
 	if o.err != nil {
 		return nil, o.err
 	}
 	return &fakeStream{
-		ctx:         ctx,
-		requestMeta: requestMeta,
+		ctx:     ctx,
+		request: request,
 	}, nil
 }
 
 type fakeStream struct {
-	ctx          context.Context
-	requestMeta  *transport.RequestMeta
-	responseMeta *transport.ResponseMeta
+	ctx      context.Context
+	request  *transport.StreamRequest
+	response *transport.StreamResponse
 }
 
 func (s *fakeStream) Context() context.Context {
 	return s.ctx
 }
 
-func (s *fakeStream) RequestMeta() *transport.RequestMeta {
-	return s.requestMeta
+func (s *fakeStream) Request() *transport.StreamRequest {
+	return s.request
 }
 
-func (s *fakeStream) ResponseMeta() *transport.ResponseMeta {
-	return s.responseMeta
+func (s *fakeStream) Response() *transport.StreamResponse {
+	return s.response
 }
 
-func (s *fakeStream) SetResponseMeta(responseMeta *transport.ResponseMeta) {
-	s.responseMeta = responseMeta
+func (s *fakeStream) SetResponse(response *transport.StreamResponse) {
+	s.response = response
 }
 
-func (s *fakeStream) SendMsg(*transport.StreamMessage) error {
+func (s *fakeStream) SendMessage(context.Context, *transport.StreamMessage) error {
 	return nil
 }
 
-func (s *fakeStream) RecvMsg() (*transport.StreamMessage, error) {
+func (s *fakeStream) ReceiveMessage(context.Context) (*transport.StreamMessage, error) {
 	return nil, nil
 }
 

--- a/internal/observability/graph_test.go
+++ b/internal/observability/graph_test.go
@@ -45,10 +45,10 @@ func TestEdgeNopFallbacks(t *testing.T) {
 	}
 
 	// Should succeed, covered by middleware tests.
-	_ = newEdge(zap.NewNop(), reg, req, _directionOutbound)
+	_ = newEdge(zap.NewNop(), reg, req, string(_directionOutbound))
 
 	// Should fall back to no-op metrics.
-	e := newEdge(zap.NewNop(), reg, req, _directionOutbound)
+	e := newEdge(zap.NewNop(), reg, req, string(_directionOutbound))
 	assert.NotNil(t, e.calls, "Expected to fall back to no-op metrics.")
 	assert.NotNil(t, e.successes, "Expected to fall back to no-op metrics.")
 	assert.NotNil(t, e.callerFailures, "Expected to fall back to no-op metrics.")

--- a/internal/observability/graph_test.go
+++ b/internal/observability/graph_test.go
@@ -21,7 +21,6 @@
 package observability
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -43,7 +42,6 @@ func TestEdgeNopFallbacks(t *testing.T) {
 		ShardKey:        "sk",
 		RoutingKey:      "rk",
 		RoutingDelegate: "rd",
-		Body:            strings.NewReader("body"),
 	}
 
 	// Should succeed, covered by middleware tests.

--- a/internal/observability/middleware.go
+++ b/internal/observability/middleware.go
@@ -107,19 +107,19 @@ func (m *Middleware) CallOneway(ctx context.Context, req *transport.Request, out
 }
 
 // HandleStream implements middleware.StreamInbound.
-func (m *Middleware) HandleStream(serverStream transport.ServerStream, h transport.StreamHandler) error {
+func (m *Middleware) HandleStream(serverStream *transport.ServerStream, h transport.StreamHandler) error {
 	call := m.graph.begin(serverStream.Context(), transport.Streaming, _directionInbound, serverStream.Request().Meta.ToRequest())
 	err := h.HandleStream(serverStream)
-	// TODO(pedge): wrap the transport.ServerStream?
+	// TODO(pedge): wrap the *transport.ServerStream?
 	call.End(err)
 	return err
 }
 
 // CallStream implements middleware.StreamOutbound.
-func (m *Middleware) CallStream(ctx context.Context, request *transport.StreamRequest, out transport.StreamOutbound) (transport.ClientStream, error) {
+func (m *Middleware) CallStream(ctx context.Context, request *transport.StreamRequest, out transport.StreamOutbound) (*transport.ClientStream, error) {
 	call := m.graph.begin(ctx, transport.Streaming, _directionOutbound, request.Meta.ToRequest())
 	clientStream, err := out.CallStream(ctx, request)
-	// TODO(pedge): wrap the transport.ClientStream?
+	// TODO(pedge): wrap the *transport.ClientStream?
 	call.End(err)
 	return clientStream, err
 }

--- a/internal/observability/middleware.go
+++ b/internal/observability/middleware.go
@@ -105,3 +105,21 @@ func (m *Middleware) CallOneway(ctx context.Context, req *transport.Request, out
 	call.End(err, false /* isApplicationError */)
 	return ack, err
 }
+
+// HandleStream implements middleware.StreamInbound.
+func (m *Middleware) HandleStream(serverStream transport.ServerStream, h transport.StreamHandler) error {
+	call := m.graph.begin(serverStream.Context(), transport.Streaming, true /* isInbound */, serverStream.Request().Meta.ToRequest())
+	err := h.HandleStream(serverStream)
+	// TODO(pedge): wrap the transport.ServerStream?
+	call.End(err, false /* isApplicationError */)
+	return err
+}
+
+// CallStream implements middleware.StreamOutbound.
+func (m *Middleware) CallStream(ctx context.Context, request *transport.StreamRequest, out transport.StreamOutbound) (transport.ClientStream, error) {
+	call := m.graph.begin(ctx, transport.Streaming, false /* isInbound */, request.Meta.ToRequest())
+	clientStream, err := out.CallStream(ctx, request)
+	// TODO(pedge): wrap the transport.ClientStream?
+	call.End(err, false /* isApplicationError */)
+	return clientStream, err
+}

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -125,7 +125,7 @@ func TestMiddlewareLogging(t *testing.T) {
 			checkErr(err)
 			logContext := append(
 				baseFields(),
-				zap.String("direction", _directionInbound),
+				zap.String("direction", string(_directionInbound)),
 				zap.String("rpcType", "Unary"),
 			)
 			logContext = append(logContext, tt.wantFields...)
@@ -146,7 +146,7 @@ func TestMiddlewareLogging(t *testing.T) {
 			}
 			logContext := append(
 				baseFields(),
-				zap.String("direction", _directionOutbound),
+				zap.String("direction", string(_directionOutbound)),
 				zap.String("rpcType", "Unary"),
 			)
 			logContext = append(logContext, tt.wantFields...)
@@ -164,7 +164,7 @@ func TestMiddlewareLogging(t *testing.T) {
 			checkErr(err)
 			logContext := append(
 				baseFields(),
-				zap.String("direction", _directionInbound),
+				zap.String("direction", string(_directionInbound)),
 				zap.String("rpcType", "Oneway"),
 			)
 			logContext = append(logContext, tt.wantFields...)
@@ -182,7 +182,7 @@ func TestMiddlewareLogging(t *testing.T) {
 			checkErr(err)
 			logContext := append(
 				baseFields(),
-				zap.String("direction", _directionOutbound),
+				zap.String("direction", string(_directionOutbound)),
 				zap.String("rpcType", "Oneway"),
 			)
 			logContext = append(logContext, tt.wantFields...)
@@ -203,7 +203,7 @@ func TestMiddlewareLogging(t *testing.T) {
 			checkErr(err)
 			logContext := append(
 				baseFields(),
-				zap.String("direction", _directionInbound),
+				zap.String("direction", string(_directionInbound)),
 				zap.String("rpcType", "Streaming"),
 			)
 			logContext = append(logContext, tt.wantFields...)
@@ -221,7 +221,7 @@ func TestMiddlewareLogging(t *testing.T) {
 			checkErr(err)
 			logContext := append(
 				baseFields(),
-				zap.String("direction", _directionOutbound),
+				zap.String("direction", string(_directionOutbound)),
 				zap.String("rpcType", "Streaming"),
 			)
 			logContext = append(logContext, tt.wantFields...)
@@ -324,12 +324,12 @@ func TestMiddlewareMetrics(t *testing.T) {
 				&transporttest.FakeResponseWriter{},
 				fakeHandler{tt.err, tt.applicationErr},
 			)
-			validate(mw, _directionInbound)
+			validate(mw, string(_directionInbound))
 		})
 		t.Run(tt.desc+", unary outbound", func(t *testing.T) {
 			mw := NewMiddleware(zap.NewNop(), pally.NewRegistry(), NewNopContextExtractor())
 			mw.Call(context.Background(), req, fakeOutbound{err: tt.err})
-			validate(mw, _directionOutbound)
+			validate(mw, string(_directionOutbound))
 		})
 	}
 }
@@ -369,7 +369,7 @@ func TestUnaryInboundApplicationErrors(t *testing.T) {
 		zap.String("encoding", string(req.Encoding)),
 		zap.String("routingKey", req.RoutingKey),
 		zap.String("routingDelegate", req.RoutingDelegate),
-		zap.String("direction", _directionInbound),
+		zap.String("direction", string(_directionInbound)),
 		zap.String("rpcType", "Unary"),
 		zap.Duration("latency", 0),
 		zap.Bool("successful", false),

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -199,7 +199,9 @@ func TestMiddlewareLogging(t *testing.T) {
 			assert.Equal(t, expected, getLog(), "Unexpected log entry written.")
 		})
 		t.Run(tt.desc+", stream inbound", func(t *testing.T) {
-			err := mw.HandleStream(&fakeStream{ctx: context.Background(), request: sreq}, fakeHandler{tt.err, false})
+			stream, err := transport.NewServerStream(&fakeStream{ctx: context.Background(), request: sreq})
+			require.NoError(t, err)
+			err = mw.HandleStream(stream, fakeHandler{tt.err, false})
 			checkErr(err)
 			logContext := append(
 				baseFields(),


### PR DESCRIPTION
Summary: This PR adds middleware for recording metrics on stream
creation and end.  We haven't wrapped the streams, so we don't have
introspection on each passed message, but that's something we can add
later.