### PR TITLE
Fewest pending requests peer heap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ v1.23.0-dev (unreleased)
     like round-robin, hash-ring.
 -   Add /x/yarpctest infrastructure to create fake services and requests for
     tests.
+-   Adds a `peer/pendingheap` implementation that performs peer selection,
+    sending requests to the available peer with the fewest pending requests.
 
 v1.22.0 (2017-11-14)
 --------------------

--- a/peer/peerlist/list.go
+++ b/peer/peerlist/list.go
@@ -92,8 +92,7 @@ func New(name string, transport peer.Transport, availableChooser peer.ListImplem
 // The peer list will not choose an unavailable peer, prefering to block until
 // one becomes available.
 //
-// The list is a suitable basis for concrete implementations like round-robin
-// and join-shortest-queue.
+// The list is a suitable basis for concrete implementations like round-robin.
 type List struct {
 	lock sync.RWMutex
 

--- a/peer/pendingheap/config.go
+++ b/peer/pendingheap/config.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package pendingheap
+
+import (
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/yarpcconfig"
+)
+
+// Spec returns a configuration specification for the round-robin peer list
+// implementation, making it possible to select the least recently chosen peer
+// with transports that use outbound peer list configuration (like HTTP).
+//
+//  cfg := yarpcconfig.New()
+//  cfg.MustRegisterPeerList(pendingheap.Spec())
+//
+// This enables the round-robin peer list:
+//
+//  outbounds:
+//    otherservice:
+//      unary:
+//        http:
+//          url: https://host:port/rpc
+//          fewest-pending-requests:
+//            peers:
+//              - 127.0.0.1:8080
+//              - 127.0.0.1:8081
+func Spec() yarpcconfig.PeerListSpec {
+	return yarpcconfig.PeerListSpec{
+		Name: "fewest-pending-requests",
+		BuildPeerList: func(c struct{}, t peer.Transport, k *yarpcconfig.Kit) (peer.ChooserList, error) {
+			return New(t), nil
+		},
+	}
+}

--- a/peer/pendingheap/config_test.go
+++ b/peer/pendingheap/config_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package pendingheap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/peer/hostport"
+	"go.uber.org/yarpc/yarpcconfig"
+	"go.uber.org/yarpc/yarpctest"
+)
+
+func TestPendingHeapConfig(t *testing.T) {
+	s := Spec()
+	build := s.BuildPeerList.(func(struct{}, peer.Transport, *yarpcconfig.Kit) (peer.ChooserList, error))
+	pl, err := build(struct{}{}, yarpctest.NewFakeTransport(), nil)
+	assert.NoError(t, err, "must construct a peer list")
+	pl.Update(peer.ListUpdates{Additions: []peer.Identifier{hostport.PeerIdentifier("127.0.0.1:8080")}})
+}

--- a/peer/pendingheap/doc.go
+++ b/peer/pendingheap/doc.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package pendingheap provides an implementation of a peer list that sends
+// traffic to the peer with the fewest pending requests, but degenerates to
+// round robin when all peers have equal pending requests, using a heap.
+package pendingheap

--- a/peer/pendingheap/heap.go
+++ b/peer/pendingheap/heap.go
@@ -1,0 +1,191 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package pendingheap
+
+import (
+	"container/heap"
+	"context"
+	"sync"
+
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/api/transport"
+)
+
+type pendingHeap struct {
+	sync.Mutex
+
+	peers []*peerScore
+
+	// next is an incrementing counter for every push, which is compared when
+	// scores are equal. This ends up implementing round-robin when scores are
+	// equal.
+	next int
+}
+
+func (ph *pendingHeap) Choose(ctx context.Context, req *transport.Request) peer.StatusPeer {
+	ph.Lock()
+	ps, ok := ph.popPeer()
+	if !ok {
+		ph.Unlock()
+		return nil
+	}
+
+	// Note: We push the peer back to reset the "next" counter.
+	// This gives us round-robin behavior.
+	ph.pushPeer(ps)
+
+	ph.Unlock()
+	return ps.peer
+}
+
+func (ph *pendingHeap) Add(p peer.StatusPeer) peer.Subscriber {
+	if p == nil {
+		return nil
+	}
+
+	ps := &peerScore{peer: p, heap: ph}
+	ps.score = scorePeer(p)
+
+	ph.Lock()
+	ph.pushPeer(ps)
+	ph.Unlock()
+	return ps
+}
+
+func (ph *pendingHeap) Remove(p peer.StatusPeer, sub peer.Subscriber) {
+	ps, ok := sub.(*peerScore)
+	if !ok {
+		return
+	}
+
+	ph.Lock()
+	ph.delete(ps.index)
+	ph.Unlock()
+}
+
+func (ph *pendingHeap) notifyStatusChanged(ps *peerScore) {
+	status := ps.peer.Status()
+	ph.Lock()
+	ps.status = status
+	ps.score = scorePeer(ps.peer)
+	ph.update(ps.index)
+	ph.Unlock()
+}
+
+// Len must be called in the context of a lock, as it is indirectly called
+// through heap.Push and heap.Pop.
+func (ph *pendingHeap) Len() int {
+	return len(ph.peers)
+}
+
+// Less returns whether the left peer has a lower score. If the scores are
+// equal, it returns the older peer (where "last" is lower.)
+// Less must be called in the context of a lock, as it is indirectly called
+// through heap.Push and heap.Pop.
+func (ph *pendingHeap) Less(i, j int) bool {
+	p1 := ph.peers[i]
+	p2 := ph.peers[j]
+	if p1.score == p2.score {
+		return p1.last < p2.last
+	}
+	return p1.score < p2.score
+}
+
+// Swap implements the heap.Interface. Do NOT use this method directly.
+// Swap must be called in the context of a lock, as it is indirectly called
+// through heap.Push and heap.Pop.
+func (ph *pendingHeap) Swap(i, j int) {
+	p1 := ph.peers[i]
+	p2 := ph.peers[j]
+
+	ph.peers[i], ph.peers[j] = ph.peers[j], ph.peers[i]
+	p1.index = j
+	p2.index = i
+}
+
+// Push implements the heap.Interface. Do NOT use this method directly.
+// Use pushPeer instead.
+// Push must be called in the context of a lock, as it is indirectly called
+// through heap.Push.
+func (ph *pendingHeap) Push(x interface{}) {
+	ps := x.(*peerScore)
+	ps.index = len(ph.peers)
+	ph.peers = append(ph.peers, ps)
+}
+
+// Pop implements the heap.Interface. Do NOT use this method directly.
+// Use popPeer instead.
+// Pop must be called in the context of a lock, as it is indirectly called
+// through heap.Pop.
+func (ph *pendingHeap) Pop() interface{} {
+	lastIndex := len(ph.peers) - 1
+	last := ph.peers[lastIndex]
+	ph.peers = ph.peers[:lastIndex]
+	return last
+}
+
+// delete removes the score at the given index.
+// delete must be called in a lock.
+func (ph *pendingHeap) delete(index int) {
+	// Swap the element we want to delete with the last element, then pop it off.
+	ph.Swap(index, ph.Len()-1)
+	ph.Pop()
+
+	// If the original index still exists in the list, it contains a different
+	// element so update the heap.
+	if index < ph.Len() {
+		ph.update(index)
+	}
+}
+
+// pushPeer must be called in the context of a lock.
+func (ph *pendingHeap) pushPeer(ps *peerScore) {
+	ph.next++
+	ps.last = ph.next
+	heap.Push(ph, ps)
+}
+
+// popPeer must be called in the context of a lock.
+func (ph *pendingHeap) popPeer() (*peerScore, bool) {
+	if ph.Len() == 0 {
+		return nil, false
+	}
+
+	peer := heap.Pop(ph).(*peerScore)
+	return peer, true
+}
+
+// update must be called in the context of a lock.
+func (ph *pendingHeap) update(i int) {
+	heap.Fix(ph, i)
+}
+
+func (ph *pendingHeap) Start() error {
+	return nil
+}
+
+func (ph *pendingHeap) Stop() error {
+	return nil
+}
+
+func (ph *pendingHeap) IsRunning() bool {
+	return true
+}

--- a/peer/pendingheap/heap_test.go
+++ b/peer/pendingheap/heap_test.go
@@ -1,0 +1,169 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package pendingheap
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPeerHeapRunning(t *testing.T) {
+	var ph pendingHeap
+	assert.True(t, (&ph).IsRunning(), "Always running. Nothing stops the peer heap.")
+}
+
+func TestPeerHeapEmpty(t *testing.T) {
+	var ph pendingHeap
+	assert.Zero(t, ph.Len(), "New peer heap should be empty")
+	popAndVerifyHeap(t, &ph)
+}
+
+func TestPeerHeapOrdering(t *testing.T) {
+	p1 := &peerScore{score: 1}
+	p2 := &peerScore{score: 2}
+	p3 := &peerScore{score: 3}
+
+	// same score as p3, but always pushed after p3, so it will be returned last.
+	p4 := &peerScore{score: 3}
+
+	want := []*peerScore{p1, p2, p3, p4}
+	tests := [][]*peerScore{
+		{p1, p2, p3, p4},
+		{p3, p4, p2, p1},
+		{p3, p1, p2, p4},
+	}
+
+	for _, tt := range tests {
+		var h pendingHeap
+		for _, ps := range tt {
+			h.pushPeer(ps)
+		}
+
+		popped := popAndVerifyHeap(t, &h)
+		assert.Equal(t, want, popped, "Unexpected ordering of peers")
+	}
+}
+
+func TestPeerHeapUpdate(t *testing.T) {
+	var h pendingHeap
+	p1 := &peerScore{score: 1}
+	p2 := &peerScore{score: 2}
+	p3 := &peerScore{score: 3}
+
+	h.pushPeer(p3)
+	h.pushPeer(p1)
+	h.pushPeer(p2)
+
+	ps, ok := h.popPeer()
+	require.True(t, ok, "pop with non-empty heap should succeed")
+	assert.Equal(t, p1, ps, "Wrong peer")
+
+	// Now update p2's score to be higher than p3.
+	p2.score = 10
+	h.update(p2.index)
+
+	popped := popAndVerifyHeap(t, &h)
+	assert.Equal(t, []*peerScore{p3, p2}, popped, "Unexpected order after p2 update")
+}
+
+func TestPeerHeapDelete(t *testing.T) {
+	const numPeers = 10
+
+	var h pendingHeap
+	peers := make([]*peerScore, numPeers)
+	for i := range peers {
+		peers[i] = &peerScore{score: int64(i)}
+		h.pushPeer(peers[i])
+	}
+
+	// The first peer is the lowest, remove it so it swaps with the last peer.
+	h.delete(0)
+
+	// Now when we pop peers, we expect peers 1 to N.
+	want := peers[1:]
+	popped := popAndVerifyHeap(t, &h)
+	assert.Equal(t, want, popped, "Unexpected peers after delete peer 0")
+}
+
+func (ph *pendingHeap) validate(ps *peerScore) error {
+	if ps.index < 0 || ps.index >= ph.Len() || ph.peers[ps.index] != ps {
+		return fmt.Errorf("pendingHeap bug: %+v has bad index %v (len %v)", ps, ps.index, ph.Len())
+	}
+	return nil
+}
+
+func TestPeerHeapValidate(t *testing.T) {
+	var h pendingHeap
+	ps := &peerScore{score: 1}
+	h.pushPeer(ps)
+	assert.Nil(t, h.validate(ps), "peer %v should validate", ps)
+
+	for _, i := range []int{0, -1, 5} {
+		ps := &peerScore{index: i}
+		assert.Error(t, h.validate(ps), "peer %v should not validate", ps)
+	}
+}
+
+func popAndVerifyHeap(t *testing.T, h *pendingHeap) []*peerScore {
+	var popped []*peerScore
+
+	lastScore := int64(-1)
+	for h.Len() > 0 {
+		verifyIndexes(t, h)
+
+		ps, ok := h.popPeer()
+		require.True(t, ok, "pop with non-empty heap should succeed")
+		popped = append(popped, ps)
+
+		if lastScore == -1 {
+			lastScore = ps.score
+			continue
+		}
+
+		if ps.score < lastScore {
+			t.Fatalf("heap returned peer %v with lower score than %v", ps, lastScore)
+		}
+		lastScore = ps.score
+	}
+
+	_, ok := h.popPeer()
+	require.False(t, ok, "Expected no peers to be returned with empty list")
+	return popped
+}
+
+func verifyIndexes(t *testing.T, h *pendingHeap) {
+	for i := range h.peers {
+		assert.Equal(t, i, h.peers[i].index, "wrong index for peer %v", h.peers[i])
+	}
+}
+
+func TestPeerHeapInvalidAdd(t *testing.T) {
+	var ph pendingHeap
+	assert.Nil(t, (&ph).Add(nil), "heap does not panic when adding nil")
+}
+
+func TestPeerHeapInvalidRemoval(t *testing.T) {
+	var ph pendingHeap
+	(&ph).Remove(nil, nil)
+}

--- a/peer/pendingheap/list.go
+++ b/peer/pendingheap/list.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package pendingheap
+
+import (
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/peer/peerlist"
+)
+
+type listConfig struct {
+	capacity int
+}
+
+var defaultListConfig = listConfig{
+	capacity: 10,
+}
+
+// ListOption customizes the behavior of a pending requests peer heap.
+type ListOption func(*listConfig)
+
+// Capacity specifies the default capacity of the underlying
+// data structures for this list.
+//
+// Defaults to 10.
+func Capacity(capacity int) ListOption {
+	return func(c *listConfig) {
+		c.capacity = capacity
+	}
+}
+
+// New creates a new pending heap.
+func New(transport peer.Transport, opts ...ListOption) *List {
+	cfg := defaultListConfig
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	return &List{
+		List: peerlist.New(
+			"fewest-pending-requests",
+			transport,
+			&pendingHeap{},
+			peerlist.Capacity(cfg.capacity),
+		),
+	}
+}
+
+// List is a PeerList which rotates which peers are to be selected in a circle
+type List struct {
+	*peerlist.List
+}

--- a/peer/pendingheap/list_test.go
+++ b/peer/pendingheap/list_test.go
@@ -1,0 +1,613 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package pendingheap
+
+import (
+	"context"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/multierr"
+	"go.uber.org/yarpc/api/peer"
+	. "go.uber.org/yarpc/api/peer/peertest"
+	"go.uber.org/yarpc/yarpcerrors"
+)
+
+var (
+	_noContextDeadlineError = yarpcerrors.Newf(yarpcerrors.CodeInvalidArgument, "can't wait for peer without a context deadline for a fewest-pending-requests peer list")
+)
+
+func newNotRunningError(err error) error {
+	return yarpcerrors.FailedPreconditionErrorf("fewest-pending-requests peer list is not running: %s", err.Error())
+}
+
+func newUnavailableError(err error) error {
+	return yarpcerrors.UnavailableErrorf("fewest-pending-requests peer list timed out waiting for peer: %s", err.Error())
+}
+
+func TestPeerHeapList(t *testing.T) {
+	type testStruct struct {
+		msg string
+
+		// PeerIDs that will be returned from the transport's OnRetain with "Available" status
+		retainedAvailablePeerIDs []string
+
+		// PeerIDs that will be returned from the transport's OnRetain with "Unavailable" status
+		retainedUnavailablePeerIDs []string
+
+		// PeerIDs that will be released from the transport
+		releasedPeerIDs []string
+
+		// PeerIDs that will return "retainErr" from the transport's OnRetain function
+		errRetainedPeerIDs []string
+		retainErr          error
+
+		// PeerIDs that will return "releaseErr" from the transport's OnRelease function
+		errReleasedPeerIDs []string
+		releaseErr         error
+
+		// A list of actions that will be applied on the PeerList
+		peerListActions []PeerListAction
+
+		// PeerIDs expected to be in the PeerList's "Available" list after the actions have been applied
+		expectedAvailablePeers []string
+
+		// PeerIDs expected to be in the PeerList's "Unavailable" list after the actions have been applied
+		expectedUnavailablePeers []string
+
+		// Boolean indicating whether the PeerList is "running" after the actions have been applied
+		expectedRunning bool
+	}
+	tests := []testStruct{
+		{
+			msg: "setup",
+			retainedAvailablePeerIDs: []string{"1"},
+			expectedAvailablePeers:   []string{"1"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "setup with disconnected",
+			retainedAvailablePeerIDs:   []string{"1"},
+			retainedUnavailablePeerIDs: []string{"2"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1", "2"}},
+			},
+			expectedAvailablePeers:   []string{"1"},
+			expectedUnavailablePeers: []string{"2"},
+			expectedRunning:          true,
+		},
+		{
+			msg: "start",
+			retainedAvailablePeerIDs: []string{"1"},
+			expectedAvailablePeers:   []string{"1"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
+				ChooseAction{
+					ExpectedPeer: "1",
+				},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "start stop",
+			retainedAvailablePeerIDs:   []string{"1", "2", "3", "4", "5", "6"},
+			retainedUnavailablePeerIDs: []string{"7", "8", "9"},
+			releasedPeerIDs:            []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"}},
+				StopAction{},
+				ChooseAction{
+					ExpectedErr:         newNotRunningError(context.DeadlineExceeded),
+					InputContextTimeout: 10 * time.Millisecond,
+				},
+			},
+			expectedRunning: false,
+		},
+		{
+			msg: "update, start, and choose",
+			retainedAvailablePeerIDs: []string{"1"},
+			expectedAvailablePeers:   []string{"1"},
+			peerListActions: []PeerListAction{
+				UpdateAction{AddedPeerIDs: []string{"1"}},
+				StartAction{},
+				ChooseAction{ExpectedPeer: "1"},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "start many and choose",
+			retainedAvailablePeerIDs: []string{"1", "2", "3", "4", "5", "6"},
+			expectedAvailablePeers:   []string{"1", "2", "3", "4", "5", "6"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1", "2", "3", "4", "5", "6"}},
+				ChooseAction{ExpectedPeer: "1"},
+				ChooseAction{ExpectedPeer: "2"},
+				ChooseAction{ExpectedPeer: "3"},
+				ChooseAction{ExpectedPeer: "4"},
+				ChooseAction{ExpectedPeer: "5"},
+				ChooseAction{ExpectedPeer: "6"},
+				ChooseAction{ExpectedPeer: "1"},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "assure start is idempotent",
+			retainedAvailablePeerIDs: []string{"1"},
+			expectedAvailablePeers:   []string{"1"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
+				StartAction{},
+				StartAction{},
+				ChooseAction{
+					ExpectedPeer: "1",
+				},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "stop no start",
+			retainedAvailablePeerIDs: []string{},
+			releasedPeerIDs:          []string{},
+			peerListActions: []PeerListAction{
+				StopAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
+			},
+			expectedRunning: false,
+		},
+		{
+			msg:                "update retain error",
+			errRetainedPeerIDs: []string{"1"},
+			retainErr:          peer.ErrInvalidPeerType{},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}, ExpectedErr: peer.ErrInvalidPeerType{}},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "update retain multiple errors",
+			retainedAvailablePeerIDs: []string{"2"},
+			errRetainedPeerIDs:       []string{"1", "3"},
+			retainErr:                peer.ErrInvalidPeerType{},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{
+					AddedPeerIDs: []string{"1", "2", "3"},
+					ExpectedErr:  multierr.Combine(peer.ErrInvalidPeerType{}, peer.ErrInvalidPeerType{}),
+				},
+			},
+			expectedAvailablePeers: []string{"2"},
+			expectedRunning:        true,
+		},
+		{
+			msg: "start stop release error",
+			retainedAvailablePeerIDs: []string{"1"},
+			errReleasedPeerIDs:       []string{"1"},
+			releaseErr:               peer.ErrTransportHasNoReferenceToPeer{},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
+				StopAction{
+					ExpectedErr: peer.ErrTransportHasNoReferenceToPeer{},
+				},
+			},
+			expectedRunning: false,
+		},
+		{
+			msg: "assure stop is idempotent",
+			retainedAvailablePeerIDs: []string{"1"},
+			errReleasedPeerIDs:       []string{"1"},
+			releaseErr:               peer.ErrTransportHasNoReferenceToPeer{},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
+				ConcurrentAction{
+					Actions: []PeerListAction{
+						StopAction{
+							ExpectedErr: peer.ErrTransportHasNoReferenceToPeer{},
+						},
+						StopAction{
+							ExpectedErr: peer.ErrTransportHasNoReferenceToPeer{},
+						},
+						StopAction{
+							ExpectedErr: peer.ErrTransportHasNoReferenceToPeer{},
+						},
+					},
+				},
+			},
+			expectedRunning: false,
+		},
+		{
+			msg: "start stop release multiple errors",
+			retainedAvailablePeerIDs: []string{"1", "2", "3"},
+			releasedPeerIDs:          []string{"2"},
+			errReleasedPeerIDs:       []string{"1", "3"},
+			releaseErr:               peer.ErrTransportHasNoReferenceToPeer{},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1", "2", "3"}},
+				StopAction{
+					ExpectedErr: multierr.Combine(
+						peer.ErrTransportHasNoReferenceToPeer{},
+						peer.ErrTransportHasNoReferenceToPeer{},
+					),
+				},
+			},
+			expectedRunning: false,
+		},
+		{
+			msg: "choose before start",
+			peerListActions: []PeerListAction{
+				ChooseAction{
+					ExpectedErr:         newNotRunningError(context.DeadlineExceeded),
+					InputContextTimeout: 10 * time.Millisecond,
+				},
+				ChooseAction{
+					ExpectedErr:         newNotRunningError(context.DeadlineExceeded),
+					InputContextTimeout: 10 * time.Millisecond,
+				},
+			},
+			expectedRunning: false,
+		},
+		{
+			msg: "update before start",
+			retainedAvailablePeerIDs: []string{"1"},
+			expectedAvailablePeers:   []string{"1"},
+			peerListActions: []PeerListAction{
+				ConcurrentAction{
+					Actions: []PeerListAction{
+						UpdateAction{AddedPeerIDs: []string{"1"}},
+						StartAction{},
+					},
+					Wait: 20 * time.Millisecond,
+				},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "start choose no peers",
+			peerListActions: []PeerListAction{
+				StartAction{},
+				ChooseAction{
+					InputContextTimeout: 20 * time.Millisecond,
+					ExpectedErr:         newUnavailableError(context.DeadlineExceeded),
+				},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "start then add",
+			retainedAvailablePeerIDs: []string{"1", "2"},
+			expectedAvailablePeers:   []string{"1", "2"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
+				UpdateAction{AddedPeerIDs: []string{"2"}},
+				ChooseAction{ExpectedPeer: "1"},
+				ChooseAction{ExpectedPeer: "2"},
+				ChooseAction{ExpectedPeer: "1"},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "start remove",
+			retainedAvailablePeerIDs: []string{"1", "2"},
+			expectedAvailablePeers:   []string{"2"},
+			releasedPeerIDs:          []string{"1"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1", "2"}},
+				UpdateAction{RemovedPeerIDs: []string{"1"}},
+				ChooseAction{ExpectedPeer: "2"},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "start add many and remove many",
+			retainedAvailablePeerIDs: []string{"1", "2", "3-r", "4-r", "5-a-r", "6-a-r", "7-a", "8-a"},
+			releasedPeerIDs:          []string{"3-r", "4-r", "5-a-r", "6-a-r"},
+			expectedAvailablePeers:   []string{"1", "2", "7-a", "8-a"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1", "2", "3-r", "4-r"}},
+				UpdateAction{
+					AddedPeerIDs: []string{"5-a-r", "6-a-r", "7-a", "8-a"},
+				},
+				UpdateAction{
+					RemovedPeerIDs: []string{"5-a-r", "6-a-r", "3-r", "4-r"},
+				},
+				ChooseAction{ExpectedPeer: "1"},
+				ChooseAction{ExpectedPeer: "2"},
+				ChooseAction{ExpectedPeer: "7-a"},
+				ChooseAction{ExpectedPeer: "8-a"},
+				ChooseAction{ExpectedPeer: "1"},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "add retain error",
+			retainedAvailablePeerIDs: []string{"1", "2"},
+			expectedAvailablePeers:   []string{"1", "2"},
+			errRetainedPeerIDs:       []string{"3"},
+			retainErr:                peer.ErrInvalidPeerType{},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1", "2"}},
+				UpdateAction{
+					AddedPeerIDs: []string{"3"},
+					ExpectedErr:  peer.ErrInvalidPeerType{},
+				},
+				ChooseAction{ExpectedPeer: "1"},
+				ChooseAction{ExpectedPeer: "2"},
+				ChooseAction{ExpectedPeer: "1"},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "add duplicate peer",
+			retainedAvailablePeerIDs: []string{"1", "2"},
+			expectedAvailablePeers:   []string{"1", "2"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1", "2"}},
+				UpdateAction{
+					AddedPeerIDs: []string{"2"},
+					ExpectedErr:  peer.ErrPeerAddAlreadyInList("2"),
+				},
+				ChooseAction{ExpectedPeer: "1"},
+				ChooseAction{ExpectedPeer: "2"},
+				ChooseAction{ExpectedPeer: "1"},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "remove peer not in list",
+			retainedAvailablePeerIDs: []string{"1", "2"},
+			expectedAvailablePeers:   []string{"1", "2"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1", "2"}},
+				UpdateAction{
+					RemovedPeerIDs: []string{"3"},
+					ExpectedErr:    peer.ErrPeerRemoveNotInList("3"),
+				},
+				ChooseAction{ExpectedPeer: "1"},
+				ChooseAction{ExpectedPeer: "2"},
+				ChooseAction{ExpectedPeer: "1"},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "remove release error",
+			retainedAvailablePeerIDs: []string{"1", "2"},
+			errReleasedPeerIDs:       []string{"2"},
+			releaseErr:               peer.ErrTransportHasNoReferenceToPeer{},
+			expectedAvailablePeers:   []string{"1"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1", "2"}},
+				UpdateAction{
+					RemovedPeerIDs: []string{"2"},
+					ExpectedErr:    peer.ErrTransportHasNoReferenceToPeer{},
+				},
+				ChooseAction{ExpectedPeer: "1"},
+				ChooseAction{ExpectedPeer: "1"},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "block but added too late",
+			retainedAvailablePeerIDs: []string{"1"},
+			expectedAvailablePeers:   []string{"1"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				ConcurrentAction{
+					Actions: []PeerListAction{
+						ChooseAction{
+							InputContextTimeout: 10 * time.Millisecond,
+							ExpectedErr:         newUnavailableError(context.DeadlineExceeded),
+						},
+						UpdateAction{AddedPeerIDs: []string{"1"}},
+					},
+					Wait: 20 * time.Millisecond,
+				},
+				ChooseAction{ExpectedPeer: "1"},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "no blocking with no context deadline",
+			peerListActions: []PeerListAction{
+				StartAction{},
+				ChooseAction{
+					InputContext: context.Background(),
+					ExpectedErr:  _noContextDeadlineError,
+				},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "add unavailable peer",
+			retainedAvailablePeerIDs:   []string{"1"},
+			retainedUnavailablePeerIDs: []string{"2"},
+			expectedAvailablePeers:     []string{"1"},
+			expectedUnavailablePeers:   []string{"2"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
+				UpdateAction{AddedPeerIDs: []string{"2"}},
+				ChooseAction{
+					ExpectedPeer:        "1",
+					InputContextTimeout: 20 * time.Millisecond,
+				},
+				ChooseAction{
+					ExpectedPeer:        "1",
+					InputContextTimeout: 20 * time.Millisecond,
+				},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "remove unavailable peer",
+			retainedUnavailablePeerIDs: []string{"1"},
+			releasedPeerIDs:            []string{"1"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
+				UpdateAction{RemovedPeerIDs: []string{"1"}},
+				ChooseAction{
+					InputContextTimeout: 10 * time.Millisecond,
+					ExpectedErr:         newUnavailableError(context.DeadlineExceeded),
+				},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "notify peer is now available",
+			retainedUnavailablePeerIDs: []string{"1"},
+			expectedAvailablePeers:     []string{"1"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
+				ChooseAction{
+					InputContextTimeout: 10 * time.Millisecond,
+					ExpectedErr:         newUnavailableError(context.DeadlineExceeded),
+				},
+				NotifyStatusChangeAction{PeerID: "1", NewConnectionStatus: peer.Available},
+				ChooseAction{ExpectedPeer: "1"},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "notify peer is still available",
+			retainedAvailablePeerIDs: []string{"1"},
+			expectedAvailablePeers:   []string{"1"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
+				ChooseAction{ExpectedPeer: "1"},
+				NotifyStatusChangeAction{PeerID: "1", NewConnectionStatus: peer.Available},
+				ChooseAction{ExpectedPeer: "1"},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "notify peer is now unavailable",
+			retainedAvailablePeerIDs: []string{"1"},
+			expectedUnavailablePeers: []string{"1"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
+				ChooseAction{ExpectedPeer: "1"},
+				NotifyStatusChangeAction{PeerID: "1", NewConnectionStatus: peer.Unavailable},
+				ChooseAction{
+					InputContextTimeout: 10 * time.Millisecond,
+					ExpectedErr:         newUnavailableError(context.DeadlineExceeded),
+				},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "notify peer is still unavailable",
+			retainedUnavailablePeerIDs: []string{"1"},
+			expectedUnavailablePeers:   []string{"1"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
+				NotifyStatusChangeAction{PeerID: "1", NewConnectionStatus: peer.Unavailable},
+				ChooseAction{
+					InputContextTimeout: 10 * time.Millisecond,
+					ExpectedErr:         newUnavailableError(context.DeadlineExceeded),
+				},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "notify invalid peer",
+			retainedAvailablePeerIDs: []string{"1"},
+			releasedPeerIDs:          []string{"1"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
+				UpdateAction{RemovedPeerIDs: []string{"1"}},
+				NotifyStatusChangeAction{PeerID: "1", NewConnectionStatus: peer.Available},
+			},
+			expectedRunning: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			transport := NewMockTransport(mockCtrl)
+
+			// Healthy Transport Retain/Release
+			peerMap := ExpectPeerRetains(
+				transport,
+				tt.retainedAvailablePeerIDs,
+				tt.retainedUnavailablePeerIDs,
+			)
+			ExpectPeerReleases(transport, tt.releasedPeerIDs, nil)
+
+			// Unhealthy Transport Retain/Release
+			ExpectPeerRetainsWithError(transport, tt.errRetainedPeerIDs, tt.retainErr)
+			ExpectPeerReleases(transport, tt.errReleasedPeerIDs, tt.releaseErr)
+
+			pl := New(transport, Capacity(0))
+
+			deps := ListActionDeps{
+				Peers: peerMap,
+			}
+			ApplyPeerListActions(t, pl, tt.peerListActions, deps)
+
+			var availablePeers []string
+			var unavailablePeers []string
+			for _, p := range pl.Peers() {
+				ps := p.Status()
+				if ps.ConnectionStatus == peer.Available {
+					availablePeers = append(availablePeers, p.Identifier())
+				} else if ps.ConnectionStatus == peer.Unavailable {
+					unavailablePeers = append(unavailablePeers, p.Identifier())
+				}
+			}
+			sort.Strings(availablePeers)
+			sort.Strings(unavailablePeers)
+
+			assert.Equal(t, availablePeers, tt.expectedAvailablePeers, "incorrect available peers")
+			assert.Equal(t, unavailablePeers, tt.expectedUnavailablePeers, "incorrect unavailable peers")
+			assert.Equal(t, tt.expectedRunning, pl.IsRunning(), "Peer list should match expected final running state")
+		})
+	}
+}

--- a/peer/pendingheap/score.go
+++ b/peer/pendingheap/score.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package pendingheap
+
+import (
+	"go.uber.org/yarpc/api/peer"
+)
+
+// peerScore is a book-keeping object for each retained peer
+type peerScore struct {
+	// immutable after creation
+	peer peer.StatusPeer
+	heap *pendingHeap
+	// mutable
+	status peer.Status
+	score  int64
+	index  int // index in the peer list.
+	last   int // snapshot of the heap's incrementing counter.
+}
+
+func (ps *peerScore) NotifyStatusChanged(_ peer.Identifier) {
+	ps.heap.notifyStatusChanged(ps)
+}
+
+func scorePeer(p peer.StatusPeer) int64 {
+	status := p.Status()
+	score := int64(status.PendingRequestCount)
+	return score
+}


### PR DESCRIPTION
Having refactored round robin’s peer availability management into a utility, this gives us an opportunity to have parity with the fewest pending requests peer heap. This change brings peer/x/peerheap out of the shadows.

Next steps: Create PeerListSpec for configuration.

- [x] Docs (package doc)
- [x] Entry in CHANGELOG.md