### PR TITLE
Remove version from testify in glide.yaml and fix lint

### DIFF
--- a/api/peer/connectionstatus_string.go
+++ b/api/peer/connectionstatus_string.go
@@ -22,7 +22,7 @@
 
 package peer
 
-import "fmt"
+import "strconv"
 
 const _ConnectionStatus_name = "UnavailableConnectingAvailable"
 
@@ -30,7 +30,7 @@ var _ConnectionStatus_index = [...]uint8{0, 11, 21, 30}
 
 func (i ConnectionStatus) String() string {
 	if i < 0 || i >= ConnectionStatus(len(_ConnectionStatus_index)-1) {
-		return fmt.Sprintf("ConnectionStatus(%d)", i)
+		return "ConnectionStatus(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return _ConnectionStatus_name[_ConnectionStatus_index[i]:_ConnectionStatus_index[i+1]]
 }

--- a/api/transport/propagation.go
+++ b/api/transport/propagation.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
+	opentracinglog "github.com/opentracing/opentracing-go/log"
 )
 
 // CreateOpenTracingSpan creates a new context with a started span
@@ -104,7 +105,7 @@ func (e *ExtractOpenTracingSpan) Do(
 func UpdateSpanWithErr(span opentracing.Span, err error) error {
 	if err != nil {
 		span.SetTag("error", true)
-		span.LogEvent(err.Error())
+		span.LogFields(opentracinglog.String("event", err.Error()))
 	}
 	return err
 }

--- a/api/transport/type_string.go
+++ b/api/transport/type_string.go
@@ -22,7 +22,7 @@
 
 package transport
 
-import "fmt"
+import "strconv"
 
 const _Type_name = "UnaryOneway"
 
@@ -31,7 +31,7 @@ var _Type_index = [...]uint8{0, 5, 11}
 func (i Type) String() string {
 	i -= 1
 	if i < 0 || i >= Type(len(_Type_index)-1) {
-		return fmt.Sprintf("Type(%d)", i+1)
+		return "Type(" + strconv.FormatInt(int64(i+1), 10) + ")"
 	}
 	return _Type_name[_Type_index[i]:_Type_index[i+1]]
 }

--- a/encoding/protobuf/testing/testing_test.go
+++ b/encoding/protobuf/testing/testing_test.go
@@ -35,6 +35,7 @@ import (
 	"go.uber.org/yarpc/internal/grpcctx"
 	"go.uber.org/yarpc/internal/testtime"
 	"go.uber.org/yarpc/internal/testutils"
+	intyarpcerrors "go.uber.org/yarpc/internal/yarpcerrors"
 	"go.uber.org/yarpc/yarpcerrors"
 )
 
@@ -69,10 +70,10 @@ func testIntegration(
 	keyValueYARPCServer *example.KeyValueYARPCServer,
 	sinkYARPCServer *example.SinkYARPCServer,
 ) {
-	keyValueYARPCServer.SetNextError(yarpcerrors.Newf(yarpcerrors.CodeUnknown, "baz").WithName("foo-bar"))
+	keyValueYARPCServer.SetNextError(intyarpcerrors.NewWithNamef(yarpcerrors.CodeUnknown, "foo-bar", "baz"))
 	err := setValue(clients.KeyValueYARPCClient, "foo", "bar")
-	assert.Equal(t, yarpcerrors.Newf(yarpcerrors.CodeUnknown, "baz").WithName("foo-bar"), err)
-	keyValueYARPCServer.SetNextError(yarpcerrors.Newf(yarpcerrors.CodeUnknown, "baz").WithName("foo-bar"))
+	assert.Equal(t, intyarpcerrors.NewWithNamef(yarpcerrors.CodeUnknown, "foo-bar", "baz"), err)
+	keyValueYARPCServer.SetNextError(intyarpcerrors.NewWithNamef(yarpcerrors.CodeUnknown, "foo-bar", "baz"))
 	err = setValueGRPC(clients.KeyValueGRPCClient, clients.ContextWrapper, "foo", "bar")
 	assert.Equal(t, status.Error(codes.Unknown, "foo-bar: baz"), err)
 

--- a/encoding/thrift/thriftrw-plugin-yarpc/fx_test.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/fx_test.go
@@ -130,7 +130,7 @@ func TestFxServer(t *testing.T) {
 		assert.Error(t, err, "request failed")
 
 		exc, ok := err.(*atomic.KeyDoesNotExist)
-		require.True(t, ok, "error must be a *KeyDoesNotExist, not %T", err)
+		require.True(t, ok, "error '%+v' must be a *KeyDoesNotExist, not %T", err, err)
 		assert.Equal(t, "baz", *exc.Key, "exception key did not match")
 	})
 }

--- a/encoding/thrift/thriftrw-plugin-yarpc/fx_test.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/fx_test.go
@@ -33,6 +33,7 @@ import (
 	"go.uber.org/thriftrw/ptr"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/encoding/raw"
 	"go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic"
 	"go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/readonlystorefx"
 	"go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/readonlystoreserver"
@@ -63,22 +64,52 @@ func TestFxClient(t *testing.T) {
 	}, "expected panic")
 }
 
+func extractProcedures(procs *[]transport.Procedure) fx.Option {
+	type params struct {
+		fx.In
+
+		// We need to handle both cases: A single transport.Procedure provided
+		// to the "yarpcfx" group and a []transport.Procedure provided to the
+		// "yarpcfx" group.
+		SingleProcedures []transport.Procedure   `group:"yarpcfx"`
+		ProcedureLists   [][]transport.Procedure `group:"yarpcfx"`
+	}
+
+	return fx.Invoke(func(p params) {
+		for _, proc := range p.SingleProcedures {
+			*procs = append(*procs, proc)
+		}
+		for _, procList := range p.ProcedureLists {
+			*procs = append(*procs, procList...)
+		}
+	})
+}
+
+func echoRaw(ctx context.Context, req []byte) ([]byte, error) { return req, nil }
+
 func TestFxServer(t *testing.T) {
+	type rawProcedures struct {
+		fx.Out
+
+		Procedures []transport.Procedure `group:"yarpcfx"`
+	}
+
 	handler := readOnlyStoreHandler{
 		"foo":    1,
 		"bar":    2,
 		"answer": 42,
 	}
 
-	var out struct {
-		Procedures []transport.Procedure `group:"yarpcfx"`
-	}
+	var procedures []transport.Procedure
 	serverApp := fxtest.New(t,
 		fx.Provide(
 			func() readonlystoreserver.Interface { return handler },
 			readonlystorefx.Server(),
+			func() rawProcedures {
+				return rawProcedures{Procedures: raw.Procedure("echoRaw", echoRaw)}
+			},
 		),
-		fx.Extract(&out),
+		extractProcedures(&procedures),
 	)
 	defer serverApp.RequireStart().RequireStop()
 
@@ -87,7 +118,7 @@ func TestFxServer(t *testing.T) {
 		Name:     "myserver",
 		Inbounds: yarpc.Inbounds{inbound},
 	})
-	serverD.Register(out.Procedures)
+	serverD.Register(procedures)
 	require.NoError(t, serverD.Start(), "failed to start server")
 	defer func() {
 		assert.NoError(t, serverD.Stop(), "failed to stop server")
@@ -132,6 +163,17 @@ func TestFxServer(t *testing.T) {
 		exc, ok := err.(*atomic.KeyDoesNotExist)
 		require.True(t, ok, "error '%+v' must be a *KeyDoesNotExist, not %T", err, err)
 		assert.Equal(t, "baz", *exc.Key, "exception key did not match")
+	})
+
+	rawClient := raw.New(clientD.ClientConfig("myserver"))
+
+	t.Run("raw", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(ctx, time.Second)
+		defer cancel()
+
+		res, err := rawClient.Call(ctx, "echoRaw", []byte("hello"))
+		require.NoError(t, err, "request failed")
+		assert.Equal(t, "hello", string(res), "response body did not match")
 	})
 }
 

--- a/etc/make/local.mk
+++ b/etc/make/local.mk
@@ -10,6 +10,9 @@ ERRCHECK_FLAGS := -ignoretests
 ERRCHECK_EXCLUDES := \.Close\(\) \.Stop\(\)
 FILTER_ERRCHECK := grep -v $(patsubst %,-e %, $(ERRCHECK_EXCLUDES))
 
+STATICCHECK_FLAGS := \
+	-ignore go.uber.org/yarpc/internal/yarpcerrors/yarpcerrors.go:SA1019
+
 # The number of jobs allocated to run examples tests in parallel
 # The goal is to have all examples tests run in parallel, and
 # this is currently greater than the number of examples tests
@@ -81,7 +84,7 @@ golint: $(GOLINT) __eval_packages __eval_go_files ## check golint
 .PHONY: staticcheck
 staticcheck: $(STATICCHECK) __eval_packages __eval_go_files ## check staticcheck
 	$(eval STATICCHECK_LOG := $(shell mktemp -t staticcheck.XXXXX))
-	@PATH=$(BIN):$$PATH staticcheck $(PACKAGES) 2>&1 | $(FILTER_LINT) > $(STATICCHECK_LOG) || true
+	@PATH=$(BIN):$$PATH staticcheck $(STATICCHECK_FLAGS) $(PACKAGES) 2>&1 | $(FILTER_LINT) > $(STATICCHECK_LOG) || true
 	@[ ! -s "$(STATICCHECK_LOG)" ] || (echo "staticcheck failed:" | cat - $(STATICCHECK_LOG) && false)
 
 .PHONY: errcheck

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 2ae2256c1070f8aaa397564451e9bc13affcd87e33ee50b94d95fbff4c4dcb9a
-updated: 2017-11-27T16:12:15.117513014-05:00
+updated: 2017-11-27T16:51:06.196113099-05:00
 imports:
 - name: github.com/apache/thrift
   version: 53dd39833a08ce33582e5ff31fa18bb4735d6731
@@ -165,7 +165,7 @@ imports:
   - zapcore
   - zaptest/observer
 - name: golang.org/x/net
-  version: c7086645de248775cbf2373cf5ca4d2fa664b8c1
+  version: 80e70a3f7765a5661a179fd8399b4db2c72646fb
   repo: https://github.com/golang/net
   subpackages:
   - bpf

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 03e53a22016b7b24bcc33371ea1fdb68f68345986902271fc20aaed8dd98b7b8
-updated: 2017-10-25T17:02:44.199257+02:00
+hash: 2ae2256c1070f8aaa397564451e9bc13affcd87e33ee50b94d95fbff4c4dcb9a
+updated: 2017-11-27T16:12:15.117513014-05:00
 imports:
 - name: github.com/apache/thrift
   version: 53dd39833a08ce33582e5ff31fa18bb4735d6731
@@ -11,8 +11,6 @@ imports:
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
   subpackages:
   - quantile
-- name: github.com/codahale/hdrhistogram
-  version: 3a0bb77429bd3a61596f5e8a3172445844342120
 - name: github.com/crossdock/crossdock-go
   version: 049aabb0122b03bc9bd30cab8f3f91fb60166361
   subpackages:
@@ -38,7 +36,7 @@ imports:
   subpackages:
   - gomock
 - name: github.com/golang/protobuf
-  version: 18c9bb3261723cd5401db4d0c9fbc5c3b6c70fe8
+  version: 1e59b77b52bf8e4b449a57e6f79f21226d571845
   subpackages:
   - proto
   - ptypes
@@ -58,7 +56,7 @@ imports:
   - log
   - mocktracer
 - name: github.com/pmezard/go-difflib
-  version: 792786c7400a136282c1664665ae0a8db921c6c2
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
 - name: github.com/prometheus/client_golang
@@ -67,11 +65,11 @@ imports:
   - prometheus
   - prometheus/promhttp
 - name: github.com/prometheus/client_model
-  version: 6f3806018612930941127f2a7c6c453ba2c527d2
+  version: 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 1bab55dd05dbff384524a6a1c99006d9eb5f139b
+  version: 2e54d0b93cba2fd133edc32211dcc32c06ef72ca
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
@@ -84,7 +82,6 @@ imports:
   version: 2aa2c176b9dab406a6970f6a55f513e8a8c8b18f
   subpackages:
   - assert
-  - mock
   - require
 - name: github.com/uber-go/atomic
   version: e682c1008ac17bf26d2e4b5ad6cdd08520ed0b22
@@ -100,8 +97,9 @@ imports:
   - m3/thrift
   - m3/thriftudp
 - name: github.com/uber/jaeger-client-go
-  version: 3e3870040def0ebdaf65a003863fa64f5cb26139
+  version: ff3efa227b65e419701a4f48985379ca106a89e7
   subpackages:
+  - internal/baggage
   - internal/spanlog
   - log
   - thrift-gen/agent
@@ -109,12 +107,8 @@ imports:
   - thrift-gen/sampling
   - thrift-gen/zipkincore
   - utils
-- name: github.com/uber/jaeger-lib
-  version: bc381f836083a0f7d5778d4216022388c4aeaf46
-  subpackages:
-  - metrics
 - name: github.com/uber/tchannel-go
-  version: a7ad9ecb640b5f10a0395b38d6319175172b3ab2
+  version: 7bcb33f4bb908c21374f8bfdc9d4b1ebcbb8dab0
   subpackages:
   - internal/argreader
   - json
@@ -131,12 +125,13 @@ imports:
   - trand
   - typed
 - name: go.uber.org/atomic
-  version: 4e336646b2ef9fc6e47be8e21594178f98e5ebcf
+  version: 8474b86a5a6f79c443ce4b2992817ff32cf208b8
 - name: go.uber.org/dig
-  version: f57771ac8fdc4c484fcd111a700659c6282e1509
+  version: a752dd97d0e0718ba977eaaca94a23a4d28b7a08
 - name: go.uber.org/fx
   version: a47f1657ce04f3d82db1ef230ffbb292b15af0ee
   subpackages:
+  - fxtest
   - internal/fxlog
   - internal/fxreflect
   - internal/lifecycle
@@ -170,7 +165,7 @@ imports:
   - zapcore
   - zaptest/observer
 - name: golang.org/x/net
-  version: 4b14673ba32bee7f5ac0f990a48f033919fd418b
+  version: c7086645de248775cbf2373cf5ca4d2fa664b8c1
   repo: https://github.com/golang/net
   subpackages:
   - bpf
@@ -187,32 +182,34 @@ imports:
   - lex/httplex
   - trace
 - name: golang.org/x/sys
-  version: f0d39a4bd5f1a0a15ef46503d12cffc780be4b9b
+  version: a204229cd828a74741ee7b5da9bf4794497f85ed
   repo: https://github.com/golang/sys
 - name: golang.org/x/text
-  version: 6eab0e8f74e86c598ec3b6fad4888e0c11482d48
+  version: 88f656faf3f37f690df1a32515b479415e1a6769
   subpackages:
   - secure/bidirule
   - transform
   - unicode/bidi
   - unicode/norm
 - name: golang.org/x/tools
-  version: 9b61fcc4c548d69663d915801fc4b42a43b6cd9c
+  version: 6d70fb2e85323e81c89374331d3d2b93304faa36
   repo: https://github.com/golang/tools
   subpackages:
   - go/ast/astutil
 - name: google.golang.org/genproto
-  version: f676e0f3ac6395ff1a529ae59a6670878a8371a6
+  version: 7f0da29060c682909f650ad8ed4e515bd74fa12a
   subpackages:
   - googleapis/rpc/status
 - name: google.golang.org/grpc
-  version: f7bf885db0b7479a537ec317c6e48ce53145f3db
+  version: 5a9f7b402fe85096d2e1d0383435ee1876e863d0
   repo: https://github.com/grpc/grpc-go
   subpackages:
   - balancer
+  - balancer/roundrobin
   - codes
   - connectivity
   - credentials
+  - encoding
   - grpclb/grpc_lb_v1/messages
   - grpclog
   - internal
@@ -221,21 +218,29 @@ imports:
   - naming
   - peer
   - resolver
+  - resolver/dns
+  - resolver/passthrough
   - stats
   - status
   - tap
   - transport
 - name: gopkg.in/yaml.v2
-  version: eb3733d160e74a9c7e442f435eb3bea458e1d19f
+  version: 287cf08546ab5e7e37d55a84f7ed3fd1db036de5
 testImports:
+- name: github.com/codahale/hdrhistogram
+  version: 3a0bb77429bd3a61596f5e8a3172445844342120
 - name: github.com/golang/lint
-  version: e5d664eb928e9d79eea4a648ca451da7208d5789
+  version: 6aaf7c34af0f4c36a57e0c429bace4d706d8e931
   subpackages:
   - golint
 - name: github.com/kisielk/errcheck
-  version: db0ca22445717d1b2c51ac1034440e0a2a2de645
+  version: b1445a9dd8285a50c6d1661d16f0a9ceb08125f7
 - name: github.com/kisielk/gotool
   version: d6ce6262d87e3a4e153e86023ff56ae771554a41
+- name: github.com/uber/jaeger-lib
+  version: c48167d9cae5887393dd5e61efd06a4a48b7fbb3
+  subpackages:
+  - metrics
 - name: github.com/wadey/gocovmerge
   version: b5bfa59ec0adc420475f97f89b58045c721d761c
 - name: go.uber.org/tools
@@ -244,6 +249,6 @@ testImports:
   - parallel-exec
   - update-license
 - name: honnef.co/go/tools
-  version: f3398275e64e1167d1b8b9951663163e3a01c861
+  version: 376b3b58b9e4def403181ee2fd3d4cc7de8375ae
   subpackages:
   - cmd/staticcheck

--- a/glide.yaml
+++ b/glide.yaml
@@ -77,4 +77,3 @@ testImport:
   subpackages:
   - cmd/staticcheck
 - package: github.com/stretchr/testify
-  version: master

--- a/internal/yarpcerrors/yarpcerrors.go
+++ b/internal/yarpcerrors/yarpcerrors.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpcerrors
+
+import "go.uber.org/yarpc/yarpcerrors"
+
+// NewWithNamef calls yarpcerrors.Newf and WithName on the resulting Status.
+//
+// This is put in a separate package so that we can ignore this specific file
+// with staticcheck and existing transports can still use this logic, as
+// WithName is deprecated but we still want to handle name behavior for
+// backwards compatibility.
+func NewWithNamef(code yarpcerrors.Code, name string, format string, args ...interface{}) *yarpcerrors.Status {
+	return yarpcerrors.Newf(code, format, args...).WithName(name)
+}

--- a/pkg/lifecycle/state_string.go
+++ b/pkg/lifecycle/state_string.go
@@ -22,7 +22,7 @@
 
 package lifecycle
 
-import "fmt"
+import "strconv"
 
 const _State_name = "IdleStartingRunningStoppingStoppedErrored"
 
@@ -30,7 +30,7 @@ var _State_index = [...]uint8{0, 4, 12, 19, 27, 34, 41}
 
 func (i State) String() string {
 	if i < 0 || i >= State(len(_State_index)-1) {
-		return fmt.Sprintf("State(%d)", i)
+		return "State(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return _State_name[_State_index[i]:_State_index[i+1]]
 }

--- a/transport/grpc/integration_test.go
+++ b/transport/grpc/integration_test.go
@@ -40,6 +40,7 @@ import (
 	"go.uber.org/yarpc/internal/examples/protobuf/examplepb"
 	"go.uber.org/yarpc/internal/grpcctx"
 	"go.uber.org/yarpc/internal/testtime"
+	intyarpcerrors "go.uber.org/yarpc/internal/yarpcerrors"
 	"go.uber.org/yarpc/pkg/procedure"
 	"go.uber.org/yarpc/yarpcerrors"
 	"google.golang.org/grpc"
@@ -83,18 +84,18 @@ func TestYARPCWellKnownError(t *testing.T) {
 func TestYARPCNamedError(t *testing.T) {
 	t.Parallel()
 	doWithTestEnv(t, nil, nil, nil, func(t *testing.T, e *testEnv) {
-		e.KeyValueYARPCServer.SetNextError(yarpcerrors.Newf(yarpcerrors.CodeUnknown, "baz 1").WithName("bar"))
+		e.KeyValueYARPCServer.SetNextError(intyarpcerrors.NewWithNamef(yarpcerrors.CodeUnknown, "bar", "baz 1"))
 		err := e.SetValueYARPC(context.Background(), "foo", "bar")
-		assert.Equal(t, yarpcerrors.Newf(yarpcerrors.CodeUnknown, "baz 1").WithName("bar"), err)
+		assert.Equal(t, intyarpcerrors.NewWithNamef(yarpcerrors.CodeUnknown, "bar", "baz 1"), err)
 	})
 }
 
 func TestYARPCNamedErrorNoMessage(t *testing.T) {
 	t.Parallel()
 	doWithTestEnv(t, nil, nil, nil, func(t *testing.T, e *testEnv) {
-		e.KeyValueYARPCServer.SetNextError(yarpcerrors.Newf(yarpcerrors.CodeUnknown, "").WithName("bar"))
+		e.KeyValueYARPCServer.SetNextError(intyarpcerrors.NewWithNamef(yarpcerrors.CodeUnknown, "bar", ""))
 		err := e.SetValueYARPC(context.Background(), "foo", "bar")
-		assert.Equal(t, yarpcerrors.Newf(yarpcerrors.CodeUnknown, "").WithName("bar"), err)
+		assert.Equal(t, intyarpcerrors.NewWithNamef(yarpcerrors.CodeUnknown, "bar", ""), err)
 	})
 }
 
@@ -110,7 +111,7 @@ func TestGRPCWellKnownError(t *testing.T) {
 func TestGRPCNamedError(t *testing.T) {
 	t.Parallel()
 	doWithTestEnv(t, nil, nil, nil, func(t *testing.T, e *testEnv) {
-		e.KeyValueYARPCServer.SetNextError(yarpcerrors.Newf(yarpcerrors.CodeUnknown, "baz 1").WithName("bar"))
+		e.KeyValueYARPCServer.SetNextError(intyarpcerrors.NewWithNamef(yarpcerrors.CodeUnknown, "bar", "baz 1"))
 		err := e.SetValueGRPC(context.Background(), "foo", "bar")
 		assert.Equal(t, status.Error(codes.Unknown, "bar: baz 1"), err)
 	})
@@ -119,7 +120,7 @@ func TestGRPCNamedError(t *testing.T) {
 func TestGRPCNamedErrorNoMessage(t *testing.T) {
 	t.Parallel()
 	doWithTestEnv(t, nil, nil, nil, func(t *testing.T, e *testEnv) {
-		e.KeyValueYARPCServer.SetNextError(yarpcerrors.Newf(yarpcerrors.CodeUnknown, "").WithName("bar"))
+		e.KeyValueYARPCServer.SetNextError(intyarpcerrors.NewWithNamef(yarpcerrors.CodeUnknown, "bar", ""))
 		err := e.SetValueGRPC(context.Background(), "foo", "bar")
 		assert.Equal(t, status.Error(codes.Unknown, "bar"), err)
 	})

--- a/transport/grpc/outbound.go
+++ b/transport/grpc/outbound.go
@@ -33,6 +33,7 @@ import (
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/bufferpool"
+	intyarpcerrors "go.uber.org/yarpc/internal/yarpcerrors"
 	peerchooser "go.uber.org/yarpc/peer"
 	"go.uber.org/yarpc/peer/hostport"
 	"go.uber.org/yarpc/pkg/lifecycle"
@@ -227,5 +228,5 @@ func invokeErrorToYARPCError(err error, responseMD metadata.MD) error {
 	} else if name != "" && message == name {
 		message = ""
 	}
-	return yarpcerrors.Newf(code, message).WithName(name)
+	return intyarpcerrors.NewWithNamef(code, name, message)
 }

--- a/transport/http/handler.go
+++ b/transport/http/handler.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
+	opentracinglog "github.com/opentracing/opentracing-go/log"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/bufferpool"
 	"go.uber.org/yarpc/internal/iopool"
@@ -182,7 +183,7 @@ func handleOnewayRequest(
 func updateSpanWithErr(span opentracing.Span, err error) {
 	if err != nil {
 		span.SetTag("error", true)
-		span.LogEvent(err.Error())
+		span.LogFields(opentracinglog.String("event", err.Error()))
 	}
 }
 

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
+	opentracinglog "github.com/opentracing/opentracing-go/log"
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/introspection"
@@ -274,7 +275,7 @@ func (o *Outbound) callWithPeer(
 		}
 
 		span.SetTag("error", true)
-		span.LogEvent(err.Error())
+		span.LogFields(opentracinglog.String("event", err.Error()))
 		if err == context.DeadlineExceeded {
 			end := time.Now()
 			return nil, yarpcerrors.Newf(

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -36,6 +36,7 @@ import (
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/introspection"
+	intyarpcerrors "go.uber.org/yarpc/internal/yarpcerrors"
 	peerchooser "go.uber.org/yarpc/peer"
 	"go.uber.org/yarpc/peer/hostport"
 	"go.uber.org/yarpc/pkg/lifecycle"
@@ -425,10 +426,11 @@ func getYARPCErrorFromResponse(response *http.Response, bothResponseError bool) 
 			code = errorCode
 		}
 	}
-	return yarpcerrors.Newf(
+	return intyarpcerrors.NewWithNamef(
 		code,
+		response.Header.Get(ErrorNameHeader),
 		strings.TrimSuffix(contents, "\n"),
-	).WithName(response.Header.Get(ErrorNameHeader))
+	)
 }
 
 // Introspect returns basic status about this outbound.

--- a/transport/tchannel/channel_outbound.go
+++ b/transport/tchannel/channel_outbound.go
@@ -28,6 +28,7 @@ import (
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/introspection"
 	"go.uber.org/yarpc/internal/iopool"
+	intyarpcerrors "go.uber.org/yarpc/internal/yarpcerrors"
 	"go.uber.org/yarpc/pkg/errors"
 	"go.uber.org/yarpc/pkg/lifecycle"
 	"go.uber.org/yarpc/yarpcerrors"
@@ -244,5 +245,5 @@ func getResponseErrorAndDeleteHeaderKeys(headers transport.Headers) error {
 	}
 	errorName, _ := headers.Get(ErrorNameHeaderKey)
 	errorMessage, _ := headers.Get(ErrorMessageHeaderKey)
-	return yarpcerrors.Newf(errorCode, errorMessage).WithName(errorName)
+	return intyarpcerrors.NewWithNamef(errorCode, errorName, errorMessage)
 }


### PR DESCRIPTION
Right now there's an issue with `glide update` where it comes back with:

```
[ERROR]    Failed to generate lock file: Generating lock produced conflicting versions of github.com/stretchr/testify. import (), testImport (master)
```

This usually means someone imported testify in `import` instead of `testImport`, but I can't figure out who after a long search. Moving testify to `import` in yarpc-go fixes it, but that is not desirable. This also fixes it.

This also does:

- `glide update`
- `make generate` after `glide update`
- Fixes `make staticcheck` issues by no longer calling the deprecated `span.LogEvent` and doing the equivalent call with `span.LogFields` (the logic is the same per my reading of jaeger-client-go), and by only calling `yarpcerrors.Status#WithName` from an internal package.
- Adds `STATICCHECK_FLAGS` to `etc/make/local.mk` to ignore the call to `WithName` in `internal/yarpcerrors/yarpcerrors.go`

Also fixes a fx testing bug:

For the Fx generated code tests, we were doing,

    var out struct {
        Procedures []transport.Procedure `group:"yarpcfx"`
    }
    fx.Extract(&out)

This isn't quite right because `myservicefx.Server()` feeds a
`[]transport.Procedure` into `group:"yarpcfx"`. That is accessible only
via a field similar to,

    Procedures [][]transport.Procedure `group:"yarpcfx"`

These tests broke with a `glide up` becasue previously, they were
running against a version of Dig which simply ignored the value group
tag.

This change fixes this procedure extraction bug and modifies the test to
ensure that procedures provided from multiple sources are consumed.