### PR TITLE
Undeprecate ClientConfig function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Releases
 v1.25.0-dev (unreleased)
 --------------------
 
--   No changes yet.
+-   Undeprecate ClientConfig function.
 
 
 v1.24.0 (2017-11-22)

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -209,8 +209,6 @@ func (d *Dispatcher) Inbounds() Inbounds {
 // 	keyvalueClient := json.New(dispatcher.ClientConfig("keyvalue"))
 //
 // This function panics if the outboundKey is not known.
-//
-// Deprecated: Use MustOutboundConfig instead.
 func (d *Dispatcher) ClientConfig(outboundKey string) transport.ClientConfig {
 	return d.MustOutboundConfig(outboundKey)
 }


### PR DESCRIPTION
Summary: Didn't mean to deprecate the Dispatcher's ClientConfig function
yet.  This was meant to be deprecated some time in the future after
we've migrated most of the users off the function.  Currently, any use
of this function will cause lint errors internally, which is a lot of
churn for users.