### PR TITLE
Update WaitUntilRunning functions to return better error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Releases
 v1.26.0-dev (unreleased)
 --------------------
 
--   No changes yet.
+-   Wrap errors returned from lifecycle.Once functions in the yarpcerrors API.
 
 
 v1.25.1 (2017-12-05)

--- a/internal/yarpcerrors/yarpcerrors.go
+++ b/internal/yarpcerrors/yarpcerrors.go
@@ -38,9 +38,8 @@ func NewWithNamef(code yarpcerrors.Code, name string, format string, args ...int
 
 // AnnotateWithInfo will take an error and add info to it's error message while
 // keeping the same status code.
-func AnnotateWithInfo(err error, format string, args ...interface{}) *yarpcerrors.Status {
-	status := yarpcerrors.FromError(err)
-	return yarpcerrors.Newf(status.Code(), "%s: err: %s", sprintf(format, args...), status.Message())
+func AnnotateWithInfo(status *yarpcerrors.Status, format string, args ...interface{}) *yarpcerrors.Status {
+	return yarpcerrors.Newf(status.Code(), "%s: %s", sprintf(format, args...), status.Message())
 }
 
 func sprintf(format string, args ...interface{}) string {

--- a/internal/yarpcerrors/yarpcerrors.go
+++ b/internal/yarpcerrors/yarpcerrors.go
@@ -39,12 +39,5 @@ func NewWithNamef(code yarpcerrors.Code, name string, format string, args ...int
 // AnnotateWithInfo will take an error and add info to it's error message while
 // keeping the same status code.
 func AnnotateWithInfo(status *yarpcerrors.Status, format string, args ...interface{}) *yarpcerrors.Status {
-	return yarpcerrors.Newf(status.Code(), "%s: %s", sprintf(format, args...), status.Message())
-}
-
-func sprintf(format string, args ...interface{}) string {
-	if len(args) == 0 {
-		return format
-	}
-	return fmt.Sprintf(format, args...)
+	return yarpcerrors.Newf(status.Code(), "%s: %s", fmt.Sprintf(format, args...), status.Message())
 }

--- a/internal/yarpcerrors/yarpcerrors_test.go
+++ b/internal/yarpcerrors/yarpcerrors_test.go
@@ -40,7 +40,7 @@ func TestAnnotateWithError(t *testing.T) {
 			name:       "basic",
 			giveErr:    yarpcerrors.FailedPreconditionErrorf("test"),
 			giveFormat: "mytest",
-			wantErr:    yarpcerrors.FailedPreconditionErrorf("mytest: err: test"),
+			wantErr:    yarpcerrors.FailedPreconditionErrorf("mytest: test"),
 		},
 		{
 			name:       "basic with args",
@@ -49,18 +49,18 @@ func TestAnnotateWithError(t *testing.T) {
 			giveArgs: []interface{}{
 				"arg1",
 			},
-			wantErr: yarpcerrors.FailedPreconditionErrorf("mytest arg1: err: test"),
+			wantErr: yarpcerrors.FailedPreconditionErrorf("mytest arg1: test"),
 		},
 		{
 			name:       "unannotated",
 			giveErr:    errors.New("test"),
 			giveFormat: "mytest",
-			wantErr:    yarpcerrors.UnknownErrorf("mytest: err: test"),
+			wantErr:    yarpcerrors.UnknownErrorf("mytest: test"),
 		},
 	}
 	for _, n := range tests {
 		t.Run(n.name, func(t *testing.T) {
-			gotErr := AnnotateWithInfo(n.giveErr, n.giveFormat, n.giveArgs...)
+			gotErr := AnnotateWithInfo(yarpcerrors.FromError(n.giveErr), n.giveFormat, n.giveArgs...)
 			assert.Equal(t, n.wantErr, gotErr)
 		})
 	}

--- a/peer/peerlist/list.go
+++ b/peer/peerlist/list.go
@@ -30,6 +30,7 @@ import (
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/introspection"
+	intyarpcerrors "go.uber.org/yarpc/internal/yarpcerrors"
 	"go.uber.org/yarpc/pkg/lifecycle"
 	"go.uber.org/yarpc/yarpcerrors"
 )
@@ -373,7 +374,7 @@ func (pl *List) Choose(ctx context.Context, req *transport.Request) (peer.Peer, 
 }
 
 func (pl *List) newNotRunningError(err error) error {
-	return yarpcerrors.Newf(yarpcerrors.CodeFailedPrecondition, "%s peer list is not running: %s", pl.name, err.Error())
+	return intyarpcerrors.AnnotateWithInfo(err, "%s peer list is not running", pl.name)
 }
 
 // IsRunning returns whether the peer list is running.

--- a/peer/peerlist/list.go
+++ b/peer/peerlist/list.go
@@ -353,7 +353,7 @@ func (pl *List) removeFromUnavailablePeers(t *peerThunk) {
 // Choose selects the next available peer in the peer list
 func (pl *List) Choose(ctx context.Context, req *transport.Request) (peer.Peer, func(error), error) {
 	if err := pl.once.WaitUntilRunning(ctx); err != nil {
-		return nil, nil, pl.newNotRunningError(err)
+		return nil, nil, intyarpcerrors.AnnotateWithInfo(yarpcerrors.FromError(err), "%s peer list is not running", pl.name)
 	}
 
 	for {
@@ -371,10 +371,6 @@ func (pl *List) Choose(ctx context.Context, req *transport.Request) (peer.Peer, 
 			return nil, nil, err
 		}
 	}
-}
-
-func (pl *List) newNotRunningError(err error) error {
-	return intyarpcerrors.AnnotateWithInfo(err, "%s peer list is not running", pl.name)
 }
 
 // IsRunning returns whether the peer list is running.

--- a/peer/pendingheap/list_test.go
+++ b/peer/pendingheap/list_test.go
@@ -39,7 +39,7 @@ var (
 )
 
 func newNotRunningError(err string) error {
-	return yarpcerrors.FailedPreconditionErrorf("fewest-pending-requests peer list is not running: err: %s", err)
+	return yarpcerrors.FailedPreconditionErrorf("fewest-pending-requests peer list is not running: %s", err)
 }
 
 func newUnavailableError(err error) error {

--- a/peer/pendingheap/list_test.go
+++ b/peer/pendingheap/list_test.go
@@ -38,8 +38,8 @@ var (
 	_noContextDeadlineError = yarpcerrors.Newf(yarpcerrors.CodeInvalidArgument, "can't wait for peer without a context deadline for a fewest-pending-requests peer list")
 )
 
-func newNotRunningError(err error) error {
-	return yarpcerrors.FailedPreconditionErrorf("fewest-pending-requests peer list is not running: %s", err.Error())
+func newNotRunningError(err string) error {
+	return yarpcerrors.FailedPreconditionErrorf("fewest-pending-requests peer list is not running: err: %s", err)
 }
 
 func newUnavailableError(err error) error {
@@ -125,7 +125,7 @@ func TestPeerHeapList(t *testing.T) {
 				UpdateAction{AddedPeerIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"}},
 				StopAction{},
 				ChooseAction{
-					ExpectedErr:         newNotRunningError(context.DeadlineExceeded),
+					ExpectedErr:         newNotRunningError("could not wait for instance to start running: current state is \"stopped\""),
 					InputContextTimeout: 10 * time.Millisecond,
 				},
 			},
@@ -269,11 +269,11 @@ func TestPeerHeapList(t *testing.T) {
 			msg: "choose before start",
 			peerListActions: []PeerListAction{
 				ChooseAction{
-					ExpectedErr:         newNotRunningError(context.DeadlineExceeded),
+					ExpectedErr:         newNotRunningError("context finished while waiting for instance to start: context deadline exceeded"),
 					InputContextTimeout: 10 * time.Millisecond,
 				},
 				ChooseAction{
-					ExpectedErr:         newNotRunningError(context.DeadlineExceeded),
+					ExpectedErr:         newNotRunningError("context finished while waiting for instance to start: context deadline exceeded"),
 					InputContextTimeout: 10 * time.Millisecond,
 				},
 			},

--- a/peer/roundrobin/list_test.go
+++ b/peer/roundrobin/list_test.go
@@ -41,7 +41,7 @@ var (
 )
 
 func newNotRunningError(err string) error {
-	return yarpcerrors.FailedPreconditionErrorf("roundrobin peer list is not running: err: %s", err)
+	return yarpcerrors.FailedPreconditionErrorf("roundrobin peer list is not running: %s", err)
 }
 
 func newUnavailableError(err error) error {

--- a/peer/roundrobin/list_test.go
+++ b/peer/roundrobin/list_test.go
@@ -40,8 +40,8 @@ var (
 	_noContextDeadlineError = yarpcerrors.Newf(yarpcerrors.CodeInvalidArgument, "can't wait for peer without a context deadline for a roundrobin peer list")
 )
 
-func newNotRunningError(err error) error {
-	return yarpcerrors.FailedPreconditionErrorf("roundrobin peer list is not running: %s", err.Error())
+func newNotRunningError(err string) error {
+	return yarpcerrors.FailedPreconditionErrorf("roundrobin peer list is not running: err: %s", err)
 }
 
 func newUnavailableError(err error) error {
@@ -130,7 +130,7 @@ func TestRoundRobinList(t *testing.T) {
 				UpdateAction{AddedPeerIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"}},
 				StopAction{},
 				ChooseAction{
-					ExpectedErr:         newNotRunningError(context.DeadlineExceeded),
+					ExpectedErr:         newNotRunningError("could not wait for instance to start running: current state is \"stopped\""),
 					InputContextTimeout: 10 * time.Millisecond,
 				},
 			},
@@ -266,11 +266,11 @@ func TestRoundRobinList(t *testing.T) {
 			msg: "choose before start",
 			peerListActions: []PeerListAction{
 				ChooseAction{
-					ExpectedErr:         newNotRunningError(context.DeadlineExceeded),
+					ExpectedErr:         newNotRunningError("context finished while waiting for instance to start: context deadline exceeded"),
 					InputContextTimeout: 10 * time.Millisecond,
 				},
 				ChooseAction{
-					ExpectedErr:         newNotRunningError(context.DeadlineExceeded),
+					ExpectedErr:         newNotRunningError("context finished while waiting for instance to start: context deadline exceeded"),
 					InputContextTimeout: 10 * time.Millisecond,
 				},
 			},

--- a/peer/x/peerheap/list.go
+++ b/peer/x/peerheap/list.go
@@ -115,7 +115,7 @@ func (pl *List) Update(updates peer.ListUpdates) error {
 	ctx, cancel := context.WithTimeout(context.Background(), pl.startupWait)
 	defer cancel()
 	if err := pl.once.WaitUntilRunning(ctx); err != nil {
-		return newNotRunningError(err)
+		return intyarpcerrors.AnnotateWithInfo(yarpcerrors.FromError(err), "%s peer list is not running", "peer heap")
 	}
 
 	var errs error
@@ -200,7 +200,7 @@ func (pl *List) clearPeers() error {
 // receive nil.
 func (pl *List) Choose(ctx context.Context, _ *transport.Request) (peer.Peer, func(error), error) {
 	if err := pl.once.WaitUntilRunning(ctx); err != nil {
-		return nil, nil, newNotRunningError(err)
+		return nil, nil, intyarpcerrors.AnnotateWithInfo(yarpcerrors.FromError(err), "%s peer list is not running", "peer heap")
 	}
 
 	for {
@@ -214,11 +214,6 @@ func (pl *List) Choose(ctx context.Context, _ *transport.Request) (peer.Peer, fu
 			return nil, nil, err
 		}
 	}
-}
-
-func newNotRunningError(err error) error {
-	return intyarpcerrors.AnnotateWithInfo(err, "%s peer list is not running", "peer heap")
-
 }
 
 func (pl *List) get() (*peerScore, bool) {

--- a/peer/x/peerheap/list_test.go
+++ b/peer/x/peerheap/list_test.go
@@ -31,6 +31,7 @@ import (
 	"go.uber.org/multierr"
 	"go.uber.org/yarpc/api/peer"
 	. "go.uber.org/yarpc/api/peer/peertest"
+	"go.uber.org/yarpc/yarpcerrors"
 )
 
 func TestPeerHeapList(t *testing.T) {
@@ -115,7 +116,7 @@ func TestPeerHeapList(t *testing.T) {
 				UpdateAction{AddedPeerIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"}},
 				StopAction{},
 				ChooseAction{
-					ExpectedErr:         newNotRunningError(context.DeadlineExceeded),
+					ExpectedErr:         newNotRunningError(yarpcerrors.FailedPreconditionErrorf("could not wait for instance to start running: current state is \"stopped\"")),
 					InputContextTimeout: 10 * time.Millisecond,
 				},
 			},
@@ -159,7 +160,10 @@ func TestPeerHeapList(t *testing.T) {
 			releasedPeerIDs:          []string{},
 			peerListActions: []PeerListAction{
 				StopAction{},
-				UpdateAction{AddedPeerIDs: []string{"1"}, ExpectedErr: context.DeadlineExceeded},
+				UpdateAction{
+					AddedPeerIDs: []string{"1"},
+					ExpectedErr:  newNotRunningError(yarpcerrors.FailedPreconditionErrorf("could not wait for instance to start running: current state is \"stopped\"")),
+				},
 			},
 			expectedRunning: false,
 		},
@@ -248,11 +252,11 @@ func TestPeerHeapList(t *testing.T) {
 			msg: "choose before start",
 			peerListActions: []PeerListAction{
 				ChooseAction{
-					ExpectedErr:         newNotRunningError(context.DeadlineExceeded),
+					ExpectedErr:         newNotRunningError(yarpcerrors.FailedPreconditionErrorf("context finished while waiting for instance to start: context deadline exceeded")),
 					InputContextTimeout: 10 * time.Millisecond,
 				},
 				ChooseAction{
-					ExpectedErr:         newNotRunningError(context.DeadlineExceeded),
+					ExpectedErr:         newNotRunningError(yarpcerrors.FailedPreconditionErrorf("context finished while waiting for instance to start: context deadline exceeded")),
 					InputContextTimeout: 10 * time.Millisecond,
 				},
 			},
@@ -280,7 +284,10 @@ func TestPeerHeapList(t *testing.T) {
 			peerListActions: []PeerListAction{
 				ConcurrentAction{
 					Actions: []PeerListAction{
-						UpdateAction{AddedPeerIDs: []string{"1"}, ExpectedErr: context.DeadlineExceeded},
+						UpdateAction{
+							AddedPeerIDs: []string{"1"},
+							ExpectedErr:  newNotRunningError(yarpcerrors.FailedPreconditionErrorf("context finished while waiting for instance to start: context deadline exceeded")),
+						},
 						StartAction{},
 					},
 					Wait: 50 * time.Millisecond,

--- a/peer/x/peerheap/list_test.go
+++ b/peer/x/peerheap/list_test.go
@@ -31,8 +31,14 @@ import (
 	"go.uber.org/multierr"
 	"go.uber.org/yarpc/api/peer"
 	. "go.uber.org/yarpc/api/peer/peertest"
+	intyarpcerrors "go.uber.org/yarpc/internal/yarpcerrors"
 	"go.uber.org/yarpc/yarpcerrors"
 )
+
+func newNotRunningError(err error) error {
+	return intyarpcerrors.AnnotateWithInfo(yarpcerrors.FromError(err), "%s peer list is not running", "peer heap")
+
+}
 
 func TestPeerHeapList(t *testing.T) {
 	type testStruct struct {

--- a/pkg/lifecycle/once_test.go
+++ b/pkg/lifecycle/once_test.go
@@ -488,3 +488,8 @@ func TestStopping(t *testing.T) {
 		return nil
 	})
 }
+
+func TestGetStateName(t *testing.T) {
+	assert.Equal(t, "idle", getStateName(Idle))
+	assert.Equal(t, "unknown", getStateName(State(1000)))
+}

--- a/transport/grpc/outbound.go
+++ b/transport/grpc/outbound.go
@@ -102,7 +102,7 @@ func (o *Outbound) Call(ctx context.Context, request *transport.Request) (*trans
 		return nil, yarpcerrors.InvalidArgumentErrorf("request for grpc outbound was nil")
 	}
 	if err := o.once.WaitUntilRunning(ctx); err != nil {
-		return nil, intyarpcerrors.AnnotateWithInfo(err, "error waiting for grpc outbound to start for service: %s", request.Service)
+		return nil, intyarpcerrors.AnnotateWithInfo(yarpcerrors.FromError(err), "error waiting for grpc outbound to start for service: %s", request.Service)
 	}
 	start := time.Now()
 

--- a/transport/grpc/outbound.go
+++ b/transport/grpc/outbound.go
@@ -98,8 +98,11 @@ func (o *Outbound) Chooser() peer.Chooser {
 
 // Call implements transport.UnaryOutbound#Call.
 func (o *Outbound) Call(ctx context.Context, request *transport.Request) (*transport.Response, error) {
+	if request == nil {
+		return nil, yarpcerrors.InvalidArgumentErrorf("request for grpc outbound was nil")
+	}
 	if err := o.once.WaitUntilRunning(ctx); err != nil {
-		return nil, err
+		return nil, intyarpcerrors.AnnotateWithInfo(err, "error waiting for grpc outbound to start for service: %s", request.Service)
 	}
 	start := time.Now()
 

--- a/transport/grpc/outbound_test.go
+++ b/transport/grpc/outbound_test.go
@@ -18,34 +18,20 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package yarpcerrors
+package grpc
 
 import (
-	"fmt"
+	"context"
+	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/yarpc/yarpcerrors"
 )
 
-// NewWithNamef calls yarpcerrors.Newf and WithName on the resulting Status.
-//
-// This is put in a separate package so that we can ignore this specific file
-// with staticcheck and existing transports can still use this logic, as
-// WithName is deprecated but we still want to handle name behavior for
-// backwards compatibility.
-func NewWithNamef(code yarpcerrors.Code, name string, format string, args ...interface{}) *yarpcerrors.Status {
-	return yarpcerrors.Newf(code, format, args...).WithName(name)
-}
+func TestNoRequest(t *testing.T) {
+	tran := NewTransport()
+	out := tran.NewSingleOutbound("localhost:0")
 
-// AnnotateWithInfo will take an error and add info to it's error message while
-// keeping the same status code.
-func AnnotateWithInfo(err error, format string, args ...interface{}) *yarpcerrors.Status {
-	status := yarpcerrors.FromError(err)
-	return yarpcerrors.Newf(status.Code(), "%s: err: %s", sprintf(format, args...), status.Message())
-}
-
-func sprintf(format string, args ...interface{}) string {
-	if len(args) == 0 {
-		return format
-	}
-	return fmt.Sprintf(format, args...)
+	_, err := out.Call(context.Background(), nil)
+	assert.Equal(t, yarpcerrors.InvalidArgumentErrorf("request for grpc outbound was nil"), err)
 }

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -208,7 +208,7 @@ func (o *Outbound) Call(ctx context.Context, treq *transport.Request) (*transpor
 		return nil, yarpcerrors.InvalidArgumentErrorf("request for http unary outbound was nil")
 	}
 	if err := o.once.WaitUntilRunning(ctx); err != nil {
-		return nil, intyarpcerrors.AnnotateWithInfo(err, "error waiting for http unary outbound to start for service: %s", treq.Service)
+		return nil, intyarpcerrors.AnnotateWithInfo(yarpcerrors.FromError(err), "error waiting for http unary outbound to start for service: %s", treq.Service)
 	}
 
 	start := time.Now()
@@ -224,7 +224,7 @@ func (o *Outbound) CallOneway(ctx context.Context, treq *transport.Request) (tra
 		return nil, yarpcerrors.InvalidArgumentErrorf("request for http oneway outbound was nil")
 	}
 	if err := o.once.WaitUntilRunning(ctx); err != nil {
-		return nil, intyarpcerrors.AnnotateWithInfo(err, "error waiting for http oneway outbound to start for service: %s", treq.Service)
+		return nil, intyarpcerrors.AnnotateWithInfo(yarpcerrors.FromError(err), "error waiting for http oneway outbound to start for service: %s", treq.Service)
 	}
 
 	start := time.Now()

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -204,8 +204,11 @@ func (o *Outbound) IsRunning() bool {
 
 // Call makes a HTTP request
 func (o *Outbound) Call(ctx context.Context, treq *transport.Request) (*transport.Response, error) {
+	if treq == nil {
+		return nil, yarpcerrors.InvalidArgumentErrorf("request for http unary outbound was nil")
+	}
 	if err := o.once.WaitUntilRunning(ctx); err != nil {
-		return nil, err
+		return nil, intyarpcerrors.AnnotateWithInfo(err, "error waiting for http unary outbound to start for service: %s", treq.Service)
 	}
 
 	start := time.Now()
@@ -217,8 +220,11 @@ func (o *Outbound) Call(ctx context.Context, treq *transport.Request) (*transpor
 
 // CallOneway makes a oneway request
 func (o *Outbound) CallOneway(ctx context.Context, treq *transport.Request) (transport.Ack, error) {
+	if treq == nil {
+		return nil, yarpcerrors.InvalidArgumentErrorf("request for http oneway outbound was nil")
+	}
 	if err := o.once.WaitUntilRunning(ctx); err != nil {
-		return nil, err
+		return nil, intyarpcerrors.AnnotateWithInfo(err, "error waiting for http oneway outbound to start for service: %s", treq.Service)
 	}
 
 	start := time.Now()

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -373,7 +373,7 @@ func TestCallWithoutStarting(t *testing.T) {
 		},
 	)
 
-	assert.Equal(t, yarpcerrors.FailedPreconditionErrorf("error waiting for http unary outbound to start for service: service: err: context finished while waiting for instance to start: context deadline exceeded"), err)
+	assert.Equal(t, yarpcerrors.FailedPreconditionErrorf("error waiting for http unary outbound to start for service: service: context finished while waiting for instance to start: context deadline exceeded"), err)
 }
 
 func TestGetPeerForRequestErr(t *testing.T) {

--- a/transport/tchannel/channel_outbound.go
+++ b/transport/tchannel/channel_outbound.go
@@ -105,8 +105,11 @@ func (o *ChannelOutbound) IsRunning() bool {
 
 // Call sends an RPC over this TChannel outbound.
 func (o *ChannelOutbound) Call(ctx context.Context, req *transport.Request) (*transport.Response, error) {
+	if req == nil {
+		return nil, yarpcerrors.InvalidArgumentErrorf("request for tchannel channel outbound was nil")
+	}
 	if err := o.once.WaitUntilRunning(ctx); err != nil {
-		return nil, err
+		return nil, intyarpcerrors.AnnotateWithInfo(err, "error waiting for tchannel channel outbound to start for service: %s", req.Service)
 	}
 	if _, ok := ctx.(tchannel.ContextWithHeaders); ok {
 		return nil, errDoNotUseContextWithHeaders

--- a/transport/tchannel/channel_outbound.go
+++ b/transport/tchannel/channel_outbound.go
@@ -109,7 +109,7 @@ func (o *ChannelOutbound) Call(ctx context.Context, req *transport.Request) (*tr
 		return nil, yarpcerrors.InvalidArgumentErrorf("request for tchannel channel outbound was nil")
 	}
 	if err := o.once.WaitUntilRunning(ctx); err != nil {
-		return nil, intyarpcerrors.AnnotateWithInfo(err, "error waiting for tchannel channel outbound to start for service: %s", req.Service)
+		return nil, intyarpcerrors.AnnotateWithInfo(yarpcerrors.FromError(err), "error waiting for tchannel channel outbound to start for service: %s", req.Service)
 	}
 	if _, ok := ctx.(tchannel.ContextWithHeaders); ok {
 		return nil, errDoNotUseContextWithHeaders

--- a/transport/tchannel/channel_outbound_test.go
+++ b/transport/tchannel/channel_outbound_test.go
@@ -449,7 +449,7 @@ func TestChannelCallWithoutStarting(t *testing.T) {
 				},
 			)
 
-			assert.Equal(t, yarpcerrors.FailedPreconditionErrorf("error waiting for tchannel channel outbound to start for service: service: err: context finished while waiting for instance to start: context deadline exceeded"), err)
+			assert.Equal(t, yarpcerrors.FailedPreconditionErrorf("error waiting for tchannel channel outbound to start for service: service: context finished while waiting for instance to start: context deadline exceeded"), err)
 		})
 	}
 }

--- a/transport/tchannel/channel_outbound_test.go
+++ b/transport/tchannel/channel_outbound_test.go
@@ -34,6 +34,7 @@ import (
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/raw"
 	"go.uber.org/yarpc/internal/testtime"
+	"go.uber.org/yarpc/yarpcerrors"
 	"golang.org/x/net/context"
 )
 
@@ -448,7 +449,21 @@ func TestChannelCallWithoutStarting(t *testing.T) {
 				},
 			)
 
-			assert.Equal(t, context.DeadlineExceeded, err)
+			assert.Equal(t, yarpcerrors.FailedPreconditionErrorf("error waiting for tchannel channel outbound to start for service: service: err: context finished while waiting for instance to start: context deadline exceeded"), err)
+		})
+	}
+}
+
+func TestChannelOutboundNoRequest(t *testing.T) {
+	for _, constructor := range constructors {
+		t.Run(constructor.desc, func(t *testing.T) {
+			out, err := constructor.new(testutils.NewClient(t, &testutils.ChannelOpts{
+				ServiceName: "caller",
+			}), "localhost:4040")
+			require.NoError(t, err)
+
+			_, err = out.Call(context.Background(), nil)
+			assert.Equal(t, yarpcerrors.InvalidArgumentErrorf("request for tchannel channel outbound was nil"), err)
 		})
 	}
 }

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -79,7 +79,7 @@ func (o *Outbound) Call(ctx context.Context, req *transport.Request) (*transport
 		return nil, yarpcerrors.InvalidArgumentErrorf("request for tchannel outbound was nil")
 	}
 	if err := o.once.WaitUntilRunning(ctx); err != nil {
-		return nil, intyarpcerrors.AnnotateWithInfo(err, "error waiting for tchannel outbound to start for service: %s", req.Service)
+		return nil, intyarpcerrors.AnnotateWithInfo(yarpcerrors.FromError(err), "error waiting for tchannel outbound to start for service: %s", req.Service)
 	}
 	if _, ok := ctx.(tchannel.ContextWithHeaders); ok {
 		return nil, errDoNotUseContextWithHeaders

--- a/transport/tchannel/outbound_test.go
+++ b/transport/tchannel/outbound_test.go
@@ -393,7 +393,7 @@ func TestCallWithoutStarting(t *testing.T) {
 		},
 	)
 
-	assert.Equal(t, yarpcerrors.FailedPreconditionErrorf("error waiting for tchannel outbound to start for service: service: err: context finished while waiting for instance to start: context deadline exceeded"), err)
+	assert.Equal(t, yarpcerrors.FailedPreconditionErrorf("error waiting for tchannel outbound to start for service: service: context finished while waiting for instance to start: context deadline exceeded"), err)
 }
 
 func TestNoRequest(t *testing.T) {

--- a/transport/tchannel/outbound_test.go
+++ b/transport/tchannel/outbound_test.go
@@ -34,6 +34,7 @@ import (
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/raw"
 	"go.uber.org/yarpc/internal/testtime"
+	"go.uber.org/yarpc/yarpcerrors"
 	"golang.org/x/net/context"
 )
 
@@ -392,5 +393,14 @@ func TestCallWithoutStarting(t *testing.T) {
 		},
 	)
 
-	assert.Equal(t, context.DeadlineExceeded, err)
+	assert.Equal(t, yarpcerrors.FailedPreconditionErrorf("error waiting for tchannel outbound to start for service: service: err: context finished while waiting for instance to start: context deadline exceeded"), err)
+}
+
+func TestNoRequest(t *testing.T) {
+	tran, err := NewTransport(ServiceName("caller"))
+	require.NoError(t, err)
+	out := tran.NewSingleOutbound("localhost:0")
+
+	_, err = out.Call(context.Background(), nil)
+	assert.Equal(t, yarpcerrors.InvalidArgumentErrorf("request for tchannel outbound was nil"), err)
 }


### PR DESCRIPTION
Summary: The errors returned from `WaitUntilRunning` are currently not
very descriptive (or annotated).  This PR updates the errors returned from
`WaitUntilRunning` to use the yarpcerrors API, and annotates the errors
at the outbound callsites with the service information.

In the process I also added nil checks immediately on the
transport.Request passed into an outbound since we'd be using the
information from that request to annotate immediately.