### PR TITLE
Convert all tchannel outbound errors to yarpcerrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ v1.26.0-dev (unreleased)
 --------------------
 
 -   Wrap errors returned from lifecycle.Once functions in the yarpcerrors API.
+-   Wrap errors returned from tchannel outbounds in the yarpcerrors API.
 
 
 v1.25.1 (2017-12-05)

--- a/transport/tchannel/channel_outbound.go
+++ b/transport/tchannel/channel_outbound.go
@@ -153,7 +153,7 @@ func (o *ChannelOutbound) Call(ctx context.Context, req *transport.Request) (*tr
 	}
 
 	if err != nil {
-		return nil, err
+		return nil, toYARPCError(req, err)
 	}
 
 	// Inject tracing system baggage
@@ -166,7 +166,7 @@ func (o *ChannelOutbound) Call(ctx context.Context, req *transport.Request) (*tr
 	}
 
 	if err := writeBody(req.Body, call); err != nil {
-		return nil, err
+		return nil, toYARPCError(req, err)
 	}
 
 	res := call.Response()
@@ -185,7 +185,7 @@ func (o *ChannelOutbound) Call(ctx context.Context, req *transport.Request) (*tr
 		if err, ok := err.(tchannel.SystemError); ok {
 			return nil, fromSystemError(err)
 		}
-		return nil, err
+		return nil, toYARPCError(req, err)
 	}
 
 	return &transport.Response{

--- a/transport/tchannel/error.go
+++ b/transport/tchannel/error.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tchannel
+
+import (
+	"context"
+
+	"github.com/uber/tchannel-go"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/yarpcerrors"
+)
+
+func toYARPCError(req *transport.Request, err error) error {
+	if err == nil {
+		return err
+	}
+	if yarpcerrors.IsStatus(err) {
+		return err
+	}
+	if err, ok := err.(tchannel.SystemError); ok {
+		return fromSystemError(err)
+	}
+	if err == context.DeadlineExceeded {
+		return yarpcerrors.DeadlineExceededErrorf("deadline exceeded for service: %q, procedure: %q", req.Service, req.Procedure)
+	}
+	return yarpcerrors.UnknownErrorf("received unknown error calling service: %q, procedure: %q, err: %s", req.Service, req.Procedure, err.Error())
+}

--- a/transport/tchannel/error_test.go
+++ b/transport/tchannel/error_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tchannel
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uber/tchannel-go"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/yarpcerrors"
+)
+
+func TestToYARPCError(t *testing.T) {
+	tests := []struct {
+		name    string
+		giveErr error
+		giveReq *transport.Request
+		wantErr error
+	}{
+		{
+			name:    "nil",
+			giveErr: nil,
+			wantErr: nil,
+		},
+		{
+			name:    "yarpcerror",
+			giveErr: yarpcerrors.InvalidArgumentErrorf("test"),
+			wantErr: yarpcerrors.InvalidArgumentErrorf("test"),
+		},
+		{
+			name:    "tchannel error",
+			giveErr: tchannel.NewSystemError(tchannel.ErrCodeBadRequest, "test"),
+			wantErr: fromSystemError(tchannel.NewSystemError(tchannel.ErrCodeBadRequest, "test").(tchannel.SystemError)),
+		},
+		{
+			name:    "deadline exceeded",
+			giveErr: context.DeadlineExceeded,
+			giveReq: &transport.Request{Service: "serv", Procedure: "proc"},
+			wantErr: yarpcerrors.DeadlineExceededErrorf("deadline exceeded for service: %q, procedure: %q", "serv", "proc"),
+		},
+		{
+			name:    "unknown",
+			giveErr: errors.New("test"),
+			giveReq: &transport.Request{Service: "serv", Procedure: "proc"},
+			wantErr: yarpcerrors.UnknownErrorf("received unknown error calling service: %q, procedure: %q, err: %s", "serv", "proc", "test"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotErr := toYARPCError(tt.giveReq, tt.giveErr)
+			assert.Equal(t, tt.wantErr, gotErr)
+		})
+	}
+}

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -95,22 +95,6 @@ func (o *Outbound) Call(ctx context.Context, req *transport.Request) (*transport
 	return res, toYARPCError(req, err)
 }
 
-func toYARPCError(req *transport.Request, err error) error {
-	if err == nil {
-		return err
-	}
-	if yarpcerrors.IsStatus(err) {
-		return err
-	}
-	if err, ok := err.(tchannel.SystemError); ok {
-		return fromSystemError(err)
-	}
-	if err == context.DeadlineExceeded {
-		return yarpcerrors.DeadlineExceededErrorf("deadline exceeded for service: %q, procedure: %q", req.Service, req.Procedure)
-	}
-	return yarpcerrors.UnknownErrorf("received unknown error calling service: %q, procedure: %q, err: %s", req.Service, req.Procedure, err.Error())
-}
-
 // callWithPeer sends a request with the chosen peer.
 func (o *Outbound) callWithPeer(ctx context.Context, req *transport.Request, peer *tchannel.Peer) (*transport.Response, error) {
 	// NB(abg): Under the current API, the local service's name is required

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -87,12 +87,28 @@ func (o *Outbound) Call(ctx context.Context, req *transport.Request) (*transport
 	root := o.transport.ch.RootPeers()
 	p, onFinish, err := o.getPeerForRequest(ctx, req)
 	if err != nil {
-		return nil, err
+		return nil, toYARPCError(req, err)
 	}
 	tp := root.GetOrAdd(p.HostPort())
 	res, err := o.callWithPeer(ctx, req, tp)
 	onFinish(err)
-	return res, err
+	return res, toYARPCError(req, err)
+}
+
+func toYARPCError(req *transport.Request, err error) error {
+	if err == nil {
+		return err
+	}
+	if yarpcerrors.IsStatus(err) {
+		return err
+	}
+	if err, ok := err.(tchannel.SystemError); ok {
+		return fromSystemError(err)
+	}
+	if err == context.DeadlineExceeded {
+		return yarpcerrors.DeadlineExceededErrorf("deadline exceeded for service: %q, procedure: %q", req.Service, req.Procedure)
+	}
+	return yarpcerrors.UnknownErrorf("received unknown error calling service: %q, procedure: %q, err: %s", req.Service, req.Procedure, err.Error())
 }
 
 // callWithPeer sends a request with the chosen peer.

--- a/transport/tchannel/outbound_test.go
+++ b/transport/tchannel/outbound_test.go
@@ -22,6 +22,7 @@ package tchannel
 
 import (
 	"bytes"
+	"errors"
 	"io/ioutil"
 	"sync"
 	"testing"
@@ -403,4 +404,47 @@ func TestNoRequest(t *testing.T) {
 
 	_, err = out.Call(context.Background(), nil)
 	assert.Equal(t, yarpcerrors.InvalidArgumentErrorf("request for tchannel outbound was nil"), err)
+}
+
+func TestToYARPCError(t *testing.T) {
+	tests := []struct {
+		name    string
+		giveErr error
+		giveReq *transport.Request
+		wantErr error
+	}{
+		{
+			name:    "nil",
+			giveErr: nil,
+			wantErr: nil,
+		},
+		{
+			name:    "yarpcerror",
+			giveErr: yarpcerrors.InvalidArgumentErrorf("test"),
+			wantErr: yarpcerrors.InvalidArgumentErrorf("test"),
+		},
+		{
+			name:    "tchannel error",
+			giveErr: tchannel.NewSystemError(tchannel.ErrCodeBadRequest, "test"),
+			wantErr: fromSystemError(tchannel.NewSystemError(tchannel.ErrCodeBadRequest, "test").(tchannel.SystemError)),
+		},
+		{
+			name:    "deadline exceeded",
+			giveErr: context.DeadlineExceeded,
+			giveReq: &transport.Request{Service: "serv", Procedure: "proc"},
+			wantErr: yarpcerrors.DeadlineExceededErrorf("deadline exceeded for service: %q, procedure: %q", "serv", "proc"),
+		},
+		{
+			name:    "unknown",
+			giveErr: errors.New("test"),
+			giveReq: &transport.Request{Service: "serv", Procedure: "proc"},
+			wantErr: yarpcerrors.UnknownErrorf("received unknown error calling service: %q, procedure: %q, err: %s", "serv", "proc", "test"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotErr := toYARPCError(tt.giveReq, tt.giveErr)
+			assert.Equal(t, tt.wantErr, gotErr)
+		})
+	}
 }


### PR DESCRIPTION
Summary: There are a few cases where we have seen unannotated errors
coming from the tchannel outbounds in yarpc.  This is likely because
we're not converting all the errors to yarpcerrors.  We have some custom
logic around headers, but we don't wrap the peer.BeginCall or connection
errors.  Instead of trying to get every return individually, this PR
wraps ALL errors that come out of "callWithPeer" and will appropriately
wrap them as yarpcerrors.