### PR TITLE
[WIP] Annotate tchannel tracing with errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ v1.26.0-dev (unreleased)
 --------------------
 
 -   Wrap errors returned from lifecycle.Once functions in the yarpcerrors API.
+-   Annotate traces with errors on tchannel inbounds.
 
 
 v1.25.1 (2017-12-05)


### PR DESCRIPTION
Summary: This has caused me some headaches debugging one of our internal
services, I really want to be able to get error information for traced
errors, currently for all tchannel outbounds/inbounds we don't annotate
any error information on the response.

Test Plan: Haven't really tested this thoroughly, I want to get some
tracing tests integrated into x/yarpctest to get this end to end
validated.  That will take a bit of time, just wanted to get this out
for now.