### PR TITLE
Add PeerChooserSpec to yarpcconfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Releases
 v1.27.0-dev (unreleased)
 --------------------
 
--   No changes yet.
+-   Add support for creating peer choosers through config with PeerChooserSpec.
 
 
 v1.26.0 (2017-12-13)

--- a/yarpcconfig/chooser.go
+++ b/yarpcconfig/chooser.go
@@ -165,12 +165,25 @@ func (pc PeerChooser) BuildPeerChooser(transport peer.Transport, identify func(s
 }
 
 func (pc PeerChooser) buildPeerChooser(transport peer.Transport, identify func(string) peer.Identifier, kit *Kit) (peer.Chooser, error) {
-	peerListName, peerListConfig, err := getPeerListInfo(pc.Etc, kit)
+	peerChooserName, peerChooserConfig, err := getPeerListInfo(pc.Etc, kit)
 	if err != nil {
 		return nil, err
 	}
 
-	peerListSpec, err := kit.peerListSpec(peerListName)
+	if peerChooserSpec := kit.maybePeerChooserSpec(peerChooserName); peerChooserSpec != nil {
+		chooserBuilder, err := peerChooserSpec.PeerChooser.Decode(peerChooserConfig, config.InterpolateWith(kit.resolver))
+		if err != nil {
+			return nil, err
+		}
+		result, err := chooserBuilder.Build(transport, kit)
+		if err != nil {
+			return nil, err
+		}
+		return result.(peer.Chooser), nil
+	}
+
+	// if there was no chooser registered, we assume we have a peer list registered
+	peerListSpec, err := kit.peerListSpec(peerChooserName)
 	if err != nil {
 		return nil, err
 	}
@@ -185,16 +198,16 @@ func (pc PeerChooser) buildPeerChooser(transport peer.Transport, identify func(s
 	//
 	// We will be left with only failurePenalty in the map so that we can simply
 	// decode it into the peer list configuration type.
-	peerListUpdater, err := buildPeerListUpdater(peerListConfig, identify, kit)
+	peerListUpdater, err := buildPeerListUpdater(peerChooserConfig, identify, kit)
 	if err != nil {
 		return nil, err
 	}
 
-	chooserBuilder, err := peerListSpec.PeerList.Decode(peerListConfig, config.InterpolateWith(kit.resolver))
+	listBuilder, err := peerListSpec.PeerList.Decode(peerChooserConfig, config.InterpolateWith(kit.resolver))
 	if err != nil {
 		return nil, err
 	}
-	result, err := chooserBuilder.Build(transport, kit)
+	result, err := listBuilder.Build(transport, kit)
 	if err != nil {
 		return nil, err
 	}
@@ -225,7 +238,7 @@ func getPeerListInfo(etc config.AttributeMap, kit *Kit) (name string, config con
 	names := etc.Keys()
 	switch len(names) {
 	case 0:
-		err = fmt.Errorf("no peer list provided in config, need one of: %+v", kit.peerListSpecNames())
+		err = fmt.Errorf("no peer list or chooser provided in config, need one of: %+v", kit.peerChooserAndListSpecNames())
 	default:
 		err = fmt.Errorf("unrecognized attributes in outbound config: %+v", etc)
 	case 1:

--- a/yarpcconfig/chooser_test.go
+++ b/yarpcconfig/chooser_test.go
@@ -97,6 +97,46 @@ func TestChooserConfigurator(t *testing.T) {
 			},
 		},
 		{
+			desc: "custom chooser",
+			given: whitespace.Expand(`
+				transports:
+					fake-transport:
+						nop: ":1234"
+				outbounds:
+					their-service:
+						unary:
+							fake-transport:
+								fake-chooser:
+									nop: "*.*"
+			`),
+			test: func(t *testing.T, c yarpc.Config) {
+				outbound, ok := c.Outbounds["their-service"]
+				require.True(t, ok, "config has outbound")
+
+				require.NotNil(t, outbound.Unary, "must have unary outbound")
+				unary, ok := outbound.Unary.(*yarpctest.FakeOutbound)
+				require.True(t, ok, "unary outbound must be fake outbound")
+
+				transports := unary.Transports()
+				require.Equal(t, len(transports), 1, "must have one transport")
+
+				transport, ok := transports[0].(*yarpctest.FakeTransport)
+				require.True(t, ok, "must be a fake transport")
+				assert.Equal(t, transport.NopOption(), ":1234", "transport configured")
+
+				require.NotNil(t, unary.Chooser(), "must have chooser")
+				chooser, ok := unary.Chooser().(*yarpctest.FakePeerChooser)
+				require.True(t, ok, "unary chooser must be a fake peer chooser")
+				require.Equal(t, "*.*", chooser.Nop())
+
+				dispatcher := yarpc.NewDispatcher(c)
+				assert.NoError(t, dispatcher.Start(), "error starting")
+				assert.NoError(t, dispatcher.Stop(), "error stopping")
+
+				_ = chooser
+			},
+		},
+		{
 			desc: "multiple static peers",
 			given: whitespace.Expand(`
 				transports:
@@ -429,6 +469,24 @@ func TestChooserConfigurator(t *testing.T) {
 			},
 		},
 		{
+			desc: "invalid peer chooser",
+			given: whitespace.Expand(`
+				outbounds:
+					their-service:
+						unary:
+							fake-transport:
+								bogus-list: {}
+			`),
+			wantErr: []string{
+				`failed to configure unary outbound for "their-service": `,
+				`no recognized peer list or chooser "bogus-list"`,
+				`need one of`,
+				`fake-list`,
+				`least-pending`,
+				`round-robin`,
+			},
+		},
+		{
 			desc: "invalid peer list",
 			given: whitespace.Expand(`
 				outbounds:
@@ -440,7 +498,7 @@ func TestChooserConfigurator(t *testing.T) {
 			`),
 			wantErr: []string{
 				`failed to configure unary outbound for "their-service": `,
-				`no recognized peer list "bogus-list"`,
+				`no recognized peer list or chooser "bogus-list"`,
 				`need one of`,
 				`fake-list`,
 				`least-pending`,
@@ -461,6 +519,26 @@ func TestChooserConfigurator(t *testing.T) {
 				`no recognized peer chooser preset "bogus"`,
 				`need one of`,
 				`fake`,
+			},
+		},
+		{
+			desc: "invalid peer chooser decode",
+			given: whitespace.Expand(`
+				transports:
+					fake-transport:
+						nop: ":1234"
+				outbounds:
+					their-service:
+						unary:
+							fake-transport:
+								nop: "*.*"
+								fake-chooser:
+									- 127.0.0.1:8080
+									- 127.0.0.1:8081
+			`),
+			wantErr: []string{
+				`failed to configure unary outbound for "their-service": `,
+				`failed to read attribute "fake-chooser"`,
 			},
 		},
 		{
@@ -657,11 +735,25 @@ func TestChooserConfigurator(t *testing.T) {
 			`),
 			wantErr: []string{
 				`failed to configure unary outbound for "their-service": `,
-				`no peer list provided in config`,
+				`no peer list or chooser provided in config`,
 				`need one of`,
 				`fake-list`,
 				`least-pending`,
 				`round-robin`,
+			},
+		},
+		{
+			desc: "invalid peer chooser builder",
+			given: whitespace.Expand(`
+				outbounds:
+					their-service:
+						unary:
+							fake-transport:
+								invalid-chooser: {}
+			`),
+			wantErr: []string{
+				`failed to configure unary outbound for "their-service": `,
+				`could not create invalid-chooser`,
 			},
 		},
 		{
@@ -839,6 +931,7 @@ func TestChooserConfigurator(t *testing.T) {
 			configer.MustRegisterTransport(tchannel.TransportSpec(tchannel.Tracer(opentracing.NoopTracer{})))
 			configer.MustRegisterPeerList(peerheap.Spec())
 			configer.MustRegisterPeerList(roundrobin.Spec())
+			configer.MustRegisterPeerChooser(invalidPeerChooserSpec())
 			configer.MustRegisterPeerList(invalidPeerListSpec())
 			configer.MustRegisterPeerListUpdater(invalidPeerListUpdaterSpec())
 
@@ -859,6 +952,20 @@ func TestChooserConfigurator(t *testing.T) {
 				tt.test(t, config)
 			}
 		})
+	}
+}
+
+type invalidPeerChooserConfig struct {
+}
+
+func buildInvalidPeerChooserConfig(c *invalidPeerChooserConfig, t peerapi.Transport, kit *yarpcconfig.Kit) (peerapi.Chooser, error) {
+	return nil, errors.New("could not create invalid-chooser")
+}
+
+func invalidPeerChooserSpec() yarpcconfig.PeerChooserSpec {
+	return yarpcconfig.PeerChooserSpec{
+		Name:             "invalid-chooser",
+		BuildPeerChooser: buildInvalidPeerChooserConfig,
 	}
 }
 

--- a/yarpcconfig/chooser_test.go
+++ b/yarpcconfig/chooser_test.go
@@ -522,6 +522,25 @@ func TestChooserConfigurator(t *testing.T) {
 			},
 		},
 		{
+			desc: "invalid peer chooser decode error",
+			given: whitespace.Expand(`
+				transports:
+					fake-transport:
+						nop: ":1234"
+				outbounds:
+					their-service:
+						unary:
+							fake-transport:
+								nop: "*.*"
+								fake-chooser:
+									invalidValue: test
+			`),
+			wantErr: []string{
+				`failed to configure unary outbound for "their-service": `,
+				`failed to decode`,
+			},
+		},
+		{
 			desc: "invalid peer chooser decode",
 			given: whitespace.Expand(`
 				transports:

--- a/yarpcconfig/configurator.go
+++ b/yarpcconfig/configurator.go
@@ -42,6 +42,7 @@ import (
 // variants.
 type Configurator struct {
 	knownTransports       map[string]*compiledTransportSpec
+	knownPeerChoosers     map[string]*compiledPeerChooserSpec
 	knownPeerLists        map[string]*compiledPeerListSpec
 	knownPeerListUpdaters map[string]*compiledPeerListUpdaterSpec
 	resolver              interpolate.VariableResolver
@@ -52,6 +53,7 @@ type Configurator struct {
 func New(opts ...Option) *Configurator {
 	c := &Configurator{
 		knownTransports:       make(map[string]*compiledTransportSpec),
+		knownPeerChoosers:     make(map[string]*compiledPeerChooserSpec),
 		knownPeerLists:        make(map[string]*compiledPeerListSpec),
 		knownPeerListUpdaters: make(map[string]*compiledPeerListUpdaterSpec),
 		resolver:              os.LookupEnv,
@@ -97,6 +99,41 @@ func (c *Configurator) MustRegisterTransport(t TransportSpec) {
 	}
 }
 
+// RegisterPeerChooser registers a PeerChooserSpec with the given Configurator,
+// teaching it how to build peer choosers of this kind from configuration.
+//
+// An error is returned if the PeerChooserSpec is invalid. Use
+// MustRegisterPeerChooser to panic in the case of registration failure.
+//
+// If a peer chooser with the same name already exists, it will be replaced.
+//
+// If a peer list is registered with the same name, it will be ignored.
+//
+// See PeerChooserSpec for details on how to integrate your own peer chooser
+// with the system.
+func (c *Configurator) RegisterPeerChooser(s PeerChooserSpec) error {
+	if s.Name == "" {
+		return errors.New("name is required")
+	}
+
+	spec, err := compilePeerChooserSpec(&s)
+	if err != nil {
+		return fmt.Errorf("invalid PeerChooserSpec for %q: %v", s.Name, err)
+	}
+
+	c.knownPeerChoosers[s.Name] = spec
+	return nil
+}
+
+// MustRegisterPeerChooser registers the given PeerChooserSpec with the
+// Configurator.
+// This function panics if the PeerChooserSpec is invalid.
+func (c *Configurator) MustRegisterPeerChooser(s PeerChooserSpec) {
+	if err := c.RegisterPeerChooser(s); err != nil {
+		panic(err)
+	}
+}
+
 // RegisterPeerList registers a PeerListSpec with the given Configurator,
 // teaching it how to build peer lists of this kind from configuration.
 //
@@ -104,6 +141,9 @@ func (c *Configurator) MustRegisterTransport(t TransportSpec) {
 // MustRegisterPeerList to panic in the case of registration failure.
 //
 // If a peer list with the same name already exists, it will be replaced.
+//
+// If a peer chooser is registered with the same name, this list will be
+// ignored.
 //
 // See PeerListSpec for details on how to integrate your own peer list with
 // the system.

--- a/yarpcconfig/configurator_test.go
+++ b/yarpcconfig/configurator_test.go
@@ -36,10 +36,38 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-func TestConfiguratorRegisterTransportMissingName(t *testing.T) {
+func TestConfiguratorRegisterErrors(t *testing.T) {
+	require.Panics(t, func() { New().MustRegisterTransport(TransportSpec{}) })
 	err := New().RegisterTransport(TransportSpec{})
 	require.Error(t, err, "expected failure")
 	assert.Contains(t, err.Error(), "name is required")
+	err = New().RegisterTransport(TransportSpec{Name: "test"})
+	require.Error(t, err, "expected failure")
+	assert.Contains(t, err.Error(), "invalid TransportSpec for \"test\":")
+
+	require.Panics(t, func() { New().MustRegisterPeerChooser(PeerChooserSpec{}) })
+	err = New().RegisterPeerChooser(PeerChooserSpec{})
+	require.Error(t, err, "expected failure")
+	assert.Contains(t, err.Error(), "name is required")
+	err = New().RegisterPeerChooser(PeerChooserSpec{Name: "test"})
+	require.Error(t, err, "expected failure")
+	assert.Contains(t, err.Error(), "invalid PeerChooserSpec for \"test\":")
+
+	require.Panics(t, func() { New().MustRegisterPeerList(PeerListSpec{}) })
+	err = New().RegisterPeerList(PeerListSpec{})
+	require.Error(t, err, "expected failure")
+	assert.Contains(t, err.Error(), "name is required")
+	err = New().RegisterPeerList(PeerListSpec{Name: "test"})
+	require.Error(t, err, "expected failure")
+	assert.Contains(t, err.Error(), "invalid PeerListSpec for \"test\":")
+
+	require.Panics(t, func() { New().MustRegisterPeerListUpdater(PeerListUpdaterSpec{}) })
+	err = New().RegisterPeerListUpdater(PeerListUpdaterSpec{})
+	require.Error(t, err, "expected failure")
+	assert.Contains(t, err.Error(), "name is required")
+	err = New().RegisterPeerListUpdater(PeerListUpdaterSpec{Name: "test"})
+	require.Error(t, err, "expected failure")
+	assert.Contains(t, err.Error(), "invalid PeerListUpdaterSpec for \"test\":")
 }
 
 func TestConfigurator(t *testing.T) {

--- a/yarpcconfig/doc.go
+++ b/yarpcconfig/doc.go
@@ -28,8 +28,8 @@
 // responsible for loading your configuration. It does not yet know about the
 // different transports, peer lists, etc. that you want to use. You can inform
 // the Configurator about the different transports, peer lists, etc. by
-// registering them using RegisterTransport, RegisterPeerList, and
-// RegisterPeerListUpdater.
+// registering them using RegisterTransport, RegisterPeerChooser,
+// RegisterPeerList, and RegisterPeerListUpdater.
 //
 // 	cfg := config.New()
 // 	cfg.MustRegisterTransport(http.TransportSpec())
@@ -38,7 +38,8 @@
 // This object is re-usable and may be stored as a singleton in your
 // application. Custom transports, peer lists, and peer list updaters may be
 // integrated with the configuration system by registering more
-// TransportSpecs, PeerListSpecs, and PeerListUpdaterSpecs with it.
+// TransportSpecs, PeerChooserSpecs, PeerListSpecs, and PeerListUpdaterSpecs
+// with it.
 //
 // Use LoadConfigFromYAML to load a yarpc.Config from YAML and pass that to
 // yarpc.NewDispatcher.

--- a/yarpcconfig/kit.go
+++ b/yarpcconfig/kit.go
@@ -57,13 +57,17 @@ func (k *Kit) ServiceName() string { return k.name }
 
 var _typeOfKit = reflect.TypeOf((*Kit)(nil))
 
+func (k *Kit) maybePeerChooserSpec(name string) *compiledPeerChooserSpec {
+	return k.c.knownPeerChoosers[name]
+}
+
 func (k *Kit) peerListSpec(name string) (*compiledPeerListSpec, error) {
 	if spec := k.c.knownPeerLists[name]; spec != nil {
 		return spec, nil
 	}
 
-	msg := fmt.Sprintf("no recognized peer list %q", name)
-	if available := k.peerListSpecNames(); len(available) > 0 {
+	msg := fmt.Sprintf("no recognized peer list or chooser %q", name)
+	if available := k.peerChooserAndListSpecNames(); len(available) > 0 {
 		msg = fmt.Sprintf("%s; need one of %s", msg, strings.Join(available, ", "))
 	}
 
@@ -94,8 +98,11 @@ func (k *Kit) peerChooserPreset(name string) (*compiledPeerChooserPreset, error)
 	return nil, errors.New(msg)
 }
 
-func (k *Kit) peerListSpecNames() (names []string) {
+func (k *Kit) peerChooserAndListSpecNames() (names []string) {
 	for name := range k.c.knownPeerLists {
+		names = append(names, name)
+	}
+	for name := range k.c.knownPeerChoosers {
 		names = append(names, name)
 	}
 	sort.Strings(names)

--- a/yarpcconfig/spec_test.go
+++ b/yarpcconfig/spec_test.go
@@ -621,6 +621,14 @@ func TestCompilePeerChooserSpec(t *testing.T) {
 			wantErr: "invalid BuildPeerChooser func(int, int, int): must accept a struct or struct pointer as its first argument, found int",
 		},
 		{
+			desc: "wrong kind of second argument",
+			spec: PeerChooserSpec{
+				Name:             "much sadness",
+				BuildPeerChooser: func(c struct{}, t int, k *Kit) {},
+			},
+			wantErr: "invalid BuildPeerChooser func(struct {}, int, *yarpcconfig.Kit): must accept a peer.Transport as its second argument, found int",
+		},
+		{
 			desc: "wrong kind of third argument",
 			spec: PeerChooserSpec{
 				Name:             "much sadness",
@@ -721,6 +729,14 @@ func TestCompilePeerListSpec(t *testing.T) {
 				BuildPeerList: func(a, b, c int) {},
 			},
 			wantErr: "invalid BuildPeerList func(int, int, int): must accept a struct or struct pointer as its first argument, found int",
+		},
+		{
+			desc: "wrong kind of second argument",
+			spec: PeerListSpec{
+				Name:          "much sadness",
+				BuildPeerList: func(c struct{}, t int, k *Kit) {},
+			},
+			wantErr: "invalid BuildPeerList func(struct {}, int, *yarpcconfig.Kit): must accept a peer.Transport as its second argument, found int",
 		},
 		{
 			desc: "wrong kind of third argument",

--- a/yarpctest/fake_config.go
+++ b/yarpctest/fake_config.go
@@ -66,6 +66,25 @@ func FakeTransportSpec() yarpcconfig.TransportSpec {
 	}
 }
 
+// FakePeerChooserConfig configures the FakePeerChooser.
+type FakePeerChooserConfig struct {
+	Nop string `config:"nop,interpolate"`
+}
+
+func buildFakePeerChooser(c *FakePeerChooserConfig, t peer.Transport, kit *yarpcconfig.Kit) (peer.Chooser, error) {
+	return NewFakePeerChooser(ChooserNop(c.Nop)), nil
+}
+
+// FakePeerChooserSpec returns a configurator spec for the fake-chooser FakePeerChooser
+// peer selection strategy, suitable for passing to
+// Configurator.MustRegisterPeerChooser.
+func FakePeerChooserSpec() yarpcconfig.PeerChooserSpec {
+	return yarpcconfig.PeerChooserSpec{
+		Name:             "fake-chooser",
+		BuildPeerChooser: buildFakePeerChooser,
+	}
+}
+
 // FakePeerListConfig configures the FakePeerList.
 type FakePeerListConfig struct {
 	Nop string `config:"nop,interpolate"`
@@ -122,6 +141,7 @@ func FakePeerListUpdaterSpec() yarpcconfig.PeerListUpdaterSpec {
 func NewFakeConfigurator(opts ...yarpcconfig.Option) *yarpcconfig.Configurator {
 	configurator := yarpcconfig.New(opts...)
 	configurator.MustRegisterTransport(FakeTransportSpec())
+	configurator.MustRegisterPeerChooser(FakePeerChooserSpec())
 	configurator.MustRegisterPeerList(FakePeerListSpec())
 	configurator.MustRegisterPeerListUpdater(FakePeerListUpdaterSpec())
 	return configurator

--- a/yarpctest/fake_peer_chooser.go
+++ b/yarpctest/fake_peer_chooser.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpctest
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/pkg/lifecycletest"
+)
+
+// FakePeerChooserOption is an option for NewFakePeerChooser.
+type FakePeerChooserOption func(*FakePeerChooser)
+
+// ChooserNop is a fake option for NewFakePeerChooser that sets a nop var. It's fake.
+func ChooserNop(nop string) func(*FakePeerChooser) {
+	return func(u *FakePeerChooser) {
+		u.nop = nop
+	}
+}
+
+// FakePeerChooser is a fake peer chooser.
+type FakePeerChooser struct {
+	transport.Lifecycle
+
+	nop string
+}
+
+// NewFakePeerChooser returns a fake peer list.
+func NewFakePeerChooser(opts ...FakePeerChooserOption) *FakePeerChooser {
+	pl := &FakePeerChooser{
+		Lifecycle: lifecycletest.NewNop(),
+	}
+	for _, opt := range opts {
+		opt(pl)
+	}
+	return pl
+}
+
+// Choose pretends to choose a peer, but actually always returns an error. It's fake.
+func (c *FakePeerChooser) Choose(ctx context.Context, req *transport.Request) (peer.Peer, func(error), error) {
+	return nil, nil, fmt.Errorf(`fake peer chooser can't actually choose peers`)
+}
+
+// Nop returns the Peer Chooser's nop variable.
+func (c *FakePeerChooser) Nop() string {
+	return c.nop
+}


### PR DESCRIPTION
Summary: Was about to make a task for this, but figured it wouldn't take
too long.  We've been getting some requests via sharding and some custom
use cases where "ChooserList" is actually restrictive (we currently
require an Updater whenever you use a chooser).  This is unideal so this
PR introduces a ChooserSpec which will not have the requirement of the
updater.

This results in some overlap between the ListSpec and the ChooserSpec,
for now the model I've gone with is that Choosers take precedence
over Lists if both register under the same name.  We have the option
to fail the registration if there are duplicates. The current List
registration will simply override the existing Spec if it's registered
under the same name, not exactly sure what the "right" thing to do
here is, open to suggestions if people feel differently.

Test Plan: Added tests