### PR TITLE
Fix flaky test

### DIFF
--- a/encoding/thrift/thriftrw-plugin-yarpc/fx_test.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/fx_test.go
@@ -113,7 +113,7 @@ func TestFxServer(t *testing.T) {
 	)
 	defer serverApp.RequireStart().RequireStop()
 
-	inbound := http.NewTransport().NewInbound(":0")
+	inbound := http.NewTransport().NewInbound("127.0.0.1:0")
 	serverD := yarpc.NewDispatcher(yarpc.Config{
 		Name:     "myserver",
 		Inbounds: yarpc.Inbounds{inbound},


### PR DESCRIPTION
Summary: We appear to be having issues with ipv6 endpoints in go1.8 in travis.  This test has been failing since travis updated to their new environment.