### PR TITLE
[POC][Not Landing] Prove stream APIs are forwards compatible

### DIFF
--- a/api/encoding/inbound_call.go
+++ b/api/encoding/inbound_call.go
@@ -117,3 +117,21 @@ func (ic *InboundCall) WriteToResponse(resw transport.ResponseWriter) error {
 
 	return nil
 }
+
+// WriteToResponse writes response information from the InboundCall onto the
+// given ResponseWriter.
+//
+// If used, this must be called before writing the response body to the
+// ResponseWriter.
+func (ic *InboundCall) WriteToStreamResponseProvider(provider transport.StreamResponseHeaderProvider) error {
+	var headers transport.Headers
+	for _, h := range ic.resHeaders {
+		headers = headers.With(h.k, h.v)
+	}
+
+	if headers.Len() > 0 {
+		return provider.SetResponseHeaders(headers)
+	}
+
+	return nil
+}

--- a/encoding/protobuf/outbound.go
+++ b/encoding/protobuf/outbound.go
@@ -175,7 +175,7 @@ func (c *client) CallStream(
 	if err != nil {
 		return nil, err
 	}
-	ctx, err = call.WriteToRequestMeta(ctx, streamRequest.Meta)
+	ctx, err = call.WriteToStreamRequest(ctx, streamRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -189,6 +189,9 @@ func (c *client) CallStream(
 	stream, err := streamOutbound.CallStream(ctx, streamRequest)
 	if err != nil {
 		return nil, err
+	}
+	if reader, ok := stream.GetResponseHeaderReader(); ok {
+		call.SetStreamResponseReader(reader)
 	}
 	return &ClientStream{stream: stream}, nil
 }

--- a/encoding/protobuf/testing/testing_test.go
+++ b/encoding/protobuf/testing/testing_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/api/encoding"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/examples/protobuf/example"
 	"go.uber.org/yarpc/internal/examples/protobuf/examplepb"
@@ -139,6 +140,9 @@ func testIntegration(
 		streamOptions = append(streamOptions, yarpc.WithHeader(k, v))
 		contextWrapper = contextWrapper.WithHeader(k, v)
 	}
+	//ctx, cancel := context.WithCancel(context.Background())
+	//streamOptions = append(streamOptions, yarpc.CallOption(encoding.WithStreamContext(ctx)))
+	//cancel()
 
 	messages := []string{"foo", "bar", "baz"}
 	gotMessages, err := echoOut(clients.FooYARPCClient, messages, streamOptions...)

--- a/transport/grpc/handler.go
+++ b/transport/grpc/handler.go
@@ -144,7 +144,7 @@ func (h *handler) handleStream(
 	defer span.Finish()
 
 	stream := newServerStream(ctx, &transport.StreamRequest{Meta: transportRequest.ToRequestMeta()}, serverStream)
-	tServerStream, err := transport.NewServerStream(stream)
+	tServerStream, err := transport.NewServerStream(stream, transport.WithStreamResponseHeaderProvider(stream))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Summary: These are POCs I wrote for the streaming APIs to prove that we
could add more API surface without introducing breaking changes.  I have
absolutely no plans to land these in their current form, but I wanted to
get them in a PR to prove this has been thought of.  I don't have time
to pull them over the line since I have other priorities right now.

The changes I proved out were:

- Adding a stream context which will own the "lifetime" of the grpc
stream connection
- Adding support for reading/setting gRPC response headers (trailers).