### PR TITLE
[POC][Not Landing] Websocket streaming transport

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: a9abc8ee6e2a88c459540342c2ad822f647af15707b93652b85ac3767e438835
-updated: 2017-12-12T15:04:33.199853466-08:00
+hash: 53837f164adcd2aa33b88883af028786ff92790bf5c4878ac5458532495c16da
+updated: 2017-12-18T15:48:31.436436595-08:00
 imports:
 - name: github.com/apache/thrift
   version: 53dd39833a08ce33582e5ff31fa18bb4735d6731
@@ -22,6 +22,17 @@ imports:
   - spew
 - name: github.com/facebookgo/clock
   version: 600d898af40aa09a7a93ecb9265d87b0504b6f03
+- name: github.com/gobwas/httphead
+  version: 01c9b01b368a438f615030bbbd5e4f9e0023e15c
+- name: github.com/gobwas/pool
+  version: 32dbaa12caca20fad12253c30591227e04f62cdd
+  subpackages:
+  - pbufio
+  - pbytes
+- name: github.com/gobwas/ws
+  version: 915eed3240022c5265584c55032ef1b8c8f84168
+  subpackages:
+  - wsutil
 - name: github.com/gogo/protobuf
   version: 342cbe0a04158f6dcb03ca0079991a51a4248c02
   subpackages:
@@ -36,13 +47,15 @@ imports:
   subpackages:
   - gomock
 - name: github.com/golang/protobuf
-  version: 17ce1425424ab154092bbb43af630bd647f3bb0d
+  version: 1e59b77b52bf8e4b449a57e6f79f21226d571845
   subpackages:
   - proto
   - ptypes
   - ptypes/any
   - ptypes/duration
   - ptypes/timestamp
+- name: github.com/gorilla/websocket
+  version: ea4d1f681babbce9545c9c5f3d5194a789c89f5b
 - name: github.com/mattn/go-shellwords
   version: 02e3cf038dcea8290e44424da473dd12be796a8a
 - name: github.com/matttproud/golang_protobuf_extensions
@@ -65,21 +78,21 @@ imports:
   - prometheus
   - prometheus/promhttp
 - name: github.com/prometheus/client_model
-  version: 6f3806018612930941127f2a7c6c453ba2c527d2
+  version: 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 2f17f4a9d485bf34b4bfaccc273805040e4f86c8
+  version: 2e54d0b93cba2fd133edc32211dcc32c06ef72ca
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: e645f4e5aaa8506fc71d6edbc5c4ff02c04c46f2
+  version: a6e9df898b1336106c743392c48ee0b71f5c4efa
   subpackages:
   - xfs
 - name: github.com/stretchr/testify
-  version: 890a5c3458b43e6104ff5da8dfa139d013d77544
+  version: 2aa2c176b9dab406a6970f6a55f513e8a8c8b18f
   subpackages:
   - assert
   - require
@@ -168,7 +181,7 @@ imports:
   - zapcore
   - zaptest/observer
 - name: golang.org/x/net
-  version: d866cfc389cec985d6fda2859936a575a55a3ab6
+  version: a8b9294777976932365dabb6640cf1468d95c70f
   repo: https://github.com/golang/net
   subpackages:
   - bpf
@@ -185,26 +198,28 @@ imports:
   - lex/httplex
   - trace
 - name: golang.org/x/sys
-  version: 53aa286056ef226755cd898109dbcdaba8ac0b81
+  version: a204229cd828a74741ee7b5da9bf4794497f85ed
   repo: https://github.com/golang/sys
+  subpackages:
+  - unix
 - name: golang.org/x/text
-  version: acd49d43e9b95df46670431bf5c7ae59586daad8
+  version: 88f656faf3f37f690df1a32515b479415e1a6769
   subpackages:
   - secure/bidirule
   - transform
   - unicode/bidi
   - unicode/norm
 - name: golang.org/x/tools
-  version: 64890f4e2b733655fee5077a5435a8812404c3a3
+  version: 6d70fb2e85323e81c89374331d3d2b93304faa36
   repo: https://github.com/golang/tools
   subpackages:
   - go/ast/astutil
 - name: google.golang.org/genproto
-  version: 595979c8a7bf586b2d293fb42246bf91a0b893d9
+  version: 7f0da29060c682909f650ad8ed4e515bd74fa12a
   subpackages:
   - googleapis/rpc/status
 - name: google.golang.org/grpc
-  version: be077907e29fdb945d351e4284eb5361e7f8924e
+  version: e687fa4e6424368ece6e4fe727cea2c806a0fcb4
   repo: https://github.com/grpc/grpc-go
   subpackages:
   - balancer
@@ -222,19 +237,18 @@ imports:
   - peer
   - resolver
   - resolver/dns
-  - resolver/manual
   - resolver/passthrough
   - stats
   - status
   - tap
   - transport
 - name: gopkg.in/yaml.v2
-  version: eb3733d160e74a9c7e442f435eb3bea458e1d19f
+  version: 287cf08546ab5e7e37d55a84f7ed3fd1db036de5
 testImports:
 - name: github.com/codahale/hdrhistogram
   version: 3a0bb77429bd3a61596f5e8a3172445844342120
 - name: github.com/golang/lint
-  version: f635bddafc7154957bd70209ee858a4b97e64a9b
+  version: 6aaf7c34af0f4c36a57e0c429bace4d706d8e931
   subpackages:
   - golint
 - name: github.com/kisielk/errcheck

--- a/glide.yaml
+++ b/glide.yaml
@@ -61,6 +61,8 @@ import:
   version: '>= 0.1, < 2.0'
 - package: github.com/golang/mock
   version: ^1
+- package: github.com/gorilla/websocket
+  version: ^1.2.0
 testImport:
 - package: github.com/golang/lint
   subpackages:

--- a/internal/examples/streaming/client/main.go
+++ b/internal/examples/streaming/client/main.go
@@ -23,6 +23,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"flag"
 	"fmt"
 	"io"
 	"log"
@@ -34,6 +35,7 @@ import (
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/examples/streaming"
 	"go.uber.org/yarpc/transport/grpc"
+	"go.uber.org/yarpc/transport/x/websocket"
 )
 
 func main() {
@@ -43,8 +45,14 @@ func main() {
 }
 
 func do() error {
+	protocol := flag.String("protocol", "grpc", " Set which protocol you'd like to use (grpc, websockets)")
+	flag.Parse()
+
 	var outbound transport.StreamOutbound
 	outbound = grpc.NewTransport().NewSingleOutbound("127.0.0.1:24039")
+	if *protocol == "websocket" {
+		outbound = websocket.NewTransport().NewSingleOutbound("ws://127.0.0.1:24040")
+	}
 
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name: "keyvalue-client",

--- a/internal/examples/streaming/server/main.go
+++ b/internal/examples/streaming/server/main.go
@@ -32,6 +32,7 @@ import (
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/examples/streaming"
 	"go.uber.org/yarpc/transport/grpc"
+	"go.uber.org/yarpc/transport/x/websocket"
 )
 
 type handler struct {
@@ -102,9 +103,15 @@ func do() error {
 	}
 	inbound = grpc.NewTransport().NewInbound(listener)
 
+	webListener, err := net.Listen("tcp", "127.0.0.1:24040")
+	if err != nil {
+		return err
+	}
+	webInbound := websocket.NewTransport().NewInbound(webListener)
+
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name:     "keyvalue",
-		Inbounds: yarpc.Inbounds{inbound},
+		Inbounds: yarpc.Inbounds{inbound, webInbound},
 	})
 
 	handler := &handler{}

--- a/transport/x/websocket/handler.go
+++ b/transport/x/websocket/handler.go
@@ -1,0 +1,151 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package websocket
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"net/http"
+
+	"fmt"
+	"github.com/gorilla/websocket"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/yarpcerrors"
+	"time"
+)
+
+type handler struct {
+	i *Inbound
+}
+
+func newHandler(i *Inbound) *handler {
+	return &handler{i: i}
+}
+
+func (h *handler) handle(w http.ResponseWriter, r *http.Request) {
+	conn, err := websocket.Upgrade(w, r, nil, 400, 400)
+	if err != nil {
+		// TODO HANDLE
+		return
+	}
+
+	go func() {
+		defer conn.Close()
+		transportRequest, err := h.getBasicTransportRequest(r)
+
+		ctx := context.Background()
+		handlerSpec, err := h.i.router.Choose(ctx, transportRequest)
+		if err != nil {
+			return
+		}
+		switch handlerSpec.Type() {
+		case transport.Streaming:
+			err = h.handleStream(ctx, transportRequest, handlerSpec.Stream(), conn)
+			err = conn.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(getControlMessage(err), "testtest"), time.Now().Add(time.Second))
+			if err != nil {
+				fmt.Println("something horrible went wrong: ", err)
+			}
+		}
+		return
+	}()
+}
+
+func getControlMessage(err error) int {
+	if err == nil {
+		return websocket.CloseNormalClosure
+	}
+	if yarpcerrors.FromError(err).Code() == yarpcerrors.CodeInternal {
+		return websocket.CloseInternalServerErr
+	}
+	return websocket.CloseAbnormalClosure
+}
+
+func (h *handler) getBasicTransportRequest(r *http.Request) (*transport.Request, error) {
+	transportRequest := &transport.Request{
+		Caller:    r.Header["Rpc-Caller"][0],
+		Service:   r.Header["Rpc-Service"][0],
+		Procedure: r.Header["Rpc-Procedure"][0],
+		Encoding:  transport.Encoding(r.Header["Rpc-Encoding"][0]),
+	}
+	return transportRequest, nil
+}
+
+func (h *handler) handleStream(
+	ctx context.Context,
+	transportRequest *transport.Request,
+	streamHandler transport.StreamHandler,
+	conn *websocket.Conn,
+) error {
+	sreq := &transport.StreamRequest{
+		Meta: transportRequest.ToRequestMeta(),
+	}
+	stream, err := newServerStream(ctx, sreq, conn)
+	if err != nil {
+		return err
+	}
+	return transport.DispatchStreamHandler(
+		streamHandler,
+		stream,
+	)
+}
+
+type serverStream struct {
+	ctx  context.Context
+	req  *transport.StreamRequest
+	conn *websocket.Conn
+}
+
+func newServerStream(ctx context.Context, req *transport.StreamRequest, conn *websocket.Conn) (*transport.ServerStream, error) {
+	return transport.NewServerStream(&serverStream{
+		ctx:  ctx,
+		req:  req,
+		conn: conn,
+	})
+}
+
+func (ss *serverStream) Context() context.Context {
+	return ss.ctx
+}
+
+func (ss *serverStream) Request() *transport.StreamRequest {
+	return ss.req
+}
+
+func (ss *serverStream) SendMessage(_ context.Context, m *transport.StreamMessage) error {
+	msg, err := ioutil.ReadAll(m.Body)
+	_ = m.Body.Close()
+	if err != nil {
+		return wrapError(err)
+	}
+	return wrapError(ss.conn.WriteMessage(websocket.BinaryMessage, msg))
+}
+
+func (ss *serverStream) ReceiveMessage(_ context.Context) (*transport.StreamMessage, error) {
+	msgType, msg, err := ss.conn.ReadMessage()
+	if err != nil {
+		return nil, wrapError(err)
+	}
+	if msgType != websocket.BinaryMessage {
+		return nil, yarpcerrors.InternalErrorf("invalid websocket message type %s", msgType)
+	}
+	return &transport.StreamMessage{Body: ioutil.NopCloser(bytes.NewReader(msg))}, nil
+}

--- a/transport/x/websocket/inbound.go
+++ b/transport/x/websocket/inbound.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package websocket
+
+import (
+	"net"
+	"net/http"
+	"sync"
+
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/pkg/lifecycle"
+	"go.uber.org/yarpc/yarpcerrors"
+)
+
+var (
+	errRouterNotSet = yarpcerrors.InternalErrorf("router not set")
+
+	_ transport.Inbound = (*Inbound)(nil)
+)
+
+// Inbound is a grpc transport.Inbound.
+type Inbound struct {
+	once     *lifecycle.Once
+	lock     sync.Mutex
+	t        *Transport
+	router   transport.Router
+	listener net.Listener
+}
+
+// newInbound returns a new Inbound for the given listener.
+func newInbound(t *Transport, listener net.Listener) *Inbound {
+	return &Inbound{
+		once:     lifecycle.NewOnce(),
+		t:        t,
+		listener: listener,
+	}
+}
+
+// Start implements transport.Lifecycle#Start.
+func (i *Inbound) Start() error {
+	return i.once.Start(i.start)
+}
+
+// Stop implements transport.Lifecycle#Stop.
+func (i *Inbound) Stop() error {
+	return i.once.Stop(i.stop)
+}
+
+// IsRunning implements transport.Lifecycle#IsRunning.
+func (i *Inbound) IsRunning() bool {
+	return i.once.IsRunning()
+}
+
+// SetRouter implements transport.Inbound#SetRouter.
+func (i *Inbound) SetRouter(router transport.Router) {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+	i.router = router
+}
+
+// Transports implements transport.Inbound#Transports.
+func (i *Inbound) Transports() []transport.Transport {
+	return []transport.Transport{i.t}
+}
+
+func (i *Inbound) start() error {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+	if i.router == nil {
+		return errRouterNotSet
+	}
+
+	handler := newHandler(i)
+
+	go func() {
+		http.Serve(i.listener, http.HandlerFunc(handler.handle))
+	}()
+	return nil
+}
+
+func (i *Inbound) stop() error {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+	// TODO STOP!
+	return nil
+}
+
+type noopGrpcStruct struct{}

--- a/transport/x/websocket/outbound.go
+++ b/transport/x/websocket/outbound.go
@@ -1,0 +1,156 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package websocket
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"net/http"
+	"sync"
+	//"time"
+
+	"github.com/gorilla/websocket"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/pkg/lifecycle"
+	"go.uber.org/yarpc/yarpcerrors"
+	"io"
+)
+
+var _ transport.StreamOutbound = (*Outbound)(nil)
+
+// Outbound is a transport.UnaryOutbound.
+type Outbound struct {
+	once    *lifecycle.Once
+	lock    sync.Mutex
+	t       *Transport
+	address string
+}
+
+func newSingleOutbound(t *Transport, address string) *Outbound {
+	return &Outbound{
+		once:    lifecycle.NewOnce(),
+		t:       t,
+		address: address,
+	}
+}
+
+// Start implements transport.Lifecycle#Start.
+func (o *Outbound) Start() error {
+	return nil
+}
+
+// Stop implements transport.Lifecycle#Stop.
+func (o *Outbound) Stop() error {
+	return nil
+}
+
+// IsRunning implements transport.Lifecycle#IsRunning.
+func (o *Outbound) IsRunning() bool {
+	return o.once.IsRunning()
+}
+
+// Transports implements transport.Inbound#Transports.
+func (o *Outbound) Transports() []transport.Transport {
+	return []transport.Transport{o.t}
+}
+
+// CallStream implements transport.StreamOutbound#CallStream.
+func (o *Outbound) CallStream(ctx context.Context, request *transport.StreamRequest) (*transport.ClientStream, error) {
+	return o.stream(ctx, request)
+}
+
+func (o *Outbound) stream(
+	ctx context.Context,
+	request *transport.StreamRequest,
+) (_ *transport.ClientStream, retErr error) {
+	header := http.Header{}
+	header.Add("rpc-procedure", request.Meta.Procedure)
+	header.Add("rpc-service", request.Meta.Service)
+	header.Add("rpc-encoding", string(request.Meta.Encoding))
+	header.Add("rpc-caller", string(request.Meta.Caller))
+	conn, _, err := websocket.DefaultDialer.Dial(o.address, header)
+	if err != nil {
+		return nil, err
+	}
+
+	return newClientStream(ctx, request, conn)
+}
+
+type clientStream struct {
+	ctx  context.Context
+	treq *transport.StreamRequest
+	conn *websocket.Conn
+}
+
+func newClientStream(ctx context.Context, treq *transport.StreamRequest, conn *websocket.Conn) (*transport.ClientStream, error) {
+	return transport.NewClientStream(&clientStream{
+		ctx:  ctx,
+		treq: treq,
+		conn: conn,
+	})
+}
+
+func (ss *clientStream) Context() context.Context {
+	return ss.ctx
+}
+
+func (ss *clientStream) Request() *transport.StreamRequest {
+	return ss.treq
+}
+
+func (ss *clientStream) SendMessage(ctx context.Context, m *transport.StreamMessage) error {
+	msg, err := ioutil.ReadAll(m.Body)
+	if err != nil {
+		return wrapError(err)
+	}
+	return wrapError(ss.conn.WriteMessage(websocket.BinaryMessage, msg))
+}
+
+func (ss *clientStream) ReceiveMessage(context.Context) (*transport.StreamMessage, error) {
+	msgType, msg, err := ss.conn.ReadMessage()
+	if err != nil {
+		return nil, wrapError(err)
+	}
+	if msgType != websocket.BinaryMessage {
+		return nil, yarpcerrors.InternalErrorf("invalid websocket message type %s", msgType)
+	}
+	return &transport.StreamMessage{Body: ioutil.NopCloser(bytes.NewReader(msg))}, nil
+}
+
+func (cs *clientStream) Close(context.Context) error {
+	return cs.conn.Close()
+	//cs.conn.WriteControl()
+	//return cs.conn.WriteControl(websocket.CloseMessage, nil, time.Now().Add(time.Second))
+}
+
+func wrapError(err error) error {
+	if closeErr, ok := err.(*websocket.CloseError); ok {
+		if closeErr.Code == websocket.CloseNormalClosure || closeErr.Code == websocket.CloseNoStatusReceived {
+			return io.EOF
+		}
+		if closeErr.Code == websocket.CloseInternalServerErr {
+			return yarpcerrors.InternalErrorf(closeErr.Error())
+		}
+		return yarpcerrors.UnknownErrorf(closeErr.Error())
+	}
+	return err
+}

--- a/transport/x/websocket/transport.go
+++ b/transport/x/websocket/transport.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package websocket
+
+import (
+	"net"
+	"sync"
+
+	"go.uber.org/yarpc/pkg/lifecycle"
+)
+
+// Transport is a grpc transport.Transport.
+//
+// This currently does not have any additional functionality over creating
+// an Inbound or Outbound separately, but may in the future.
+type Transport struct {
+	lock sync.Mutex
+	once *lifecycle.Once
+}
+
+// NewTransport returns a new Transport.
+func NewTransport() *Transport {
+	return &Transport{
+		once: lifecycle.NewOnce(),
+	}
+}
+
+// Start implements transport.Lifecycle#Start.
+func (t *Transport) Start() error {
+	return t.once.Start(nil)
+}
+
+// Stop implements transport.Lifecycle#Stop.
+func (t *Transport) Stop() error {
+	return t.once.Stop(nil)
+}
+
+// IsRunning implements transport.Lifecycle#IsRunning.
+func (t *Transport) IsRunning() bool {
+	return t.once.IsRunning()
+}
+
+// NewInbound returns a new Inbound for the given listener.
+func (t *Transport) NewInbound(listener net.Listener) *Inbound {
+	return newInbound(t, listener)
+}
+
+// NewSingleOutbound returns a new Outbound for the given adrress.
+func (t *Transport) NewSingleOutbound(address string) *Outbound {
+	return newSingleOutbound(t, address)
+}


### PR DESCRIPTION
Summary: This PR proves that another transport protocol (websockets)
can be built on top of the streaming APIs we've added for gRPC.  I
don't plan onlanding this in this current form, but, I wanted to prove
it was possible in a demoable sense before landing the streaming PRs.