### PR TITLE
Add "RepeatAction" and "ConcurrentAction" to yarpctest infra

### DIFF
--- a/transport/grpc/stream_test.go
+++ b/transport/grpc/stream_test.go
@@ -51,19 +51,23 @@ func TestStreaming(t *testing.T) {
 					),
 				),
 			),
-			requests: Actions(
-				GRPCStreamRequest(
-					p.NamedPort("1"),
-					Service("myservice"),
-					Procedure("proc"),
-					ClientStreamActions(
-						SendStreamMsg("test"),
-						RecvStreamMsg("test"),
-						SendStreamMsg("test2"),
-						RecvStreamMsg("test2"),
-						CloseStream(),
+			requests: ConcurrentAction(
+				RepeatAction(
+					GRPCStreamRequest(
+						p.NamedPort("1"),
+						Service("myservice"),
+						Procedure("proc"),
+						ClientStreamActions(
+							SendStreamMsg("test"),
+							RecvStreamMsg("test"),
+							SendStreamMsg("test2"),
+							RecvStreamMsg("test2"),
+							CloseStream(),
+						),
 					),
+					10,
 				),
+				3,
 			),
 		},
 		{

--- a/x/yarpctest/repeat.go
+++ b/x/yarpctest/repeat.go
@@ -43,9 +43,16 @@ func ConcurrentAction(action Action, threads int) api.Action {
 	return api.ActionFunc(func(t testing.TB) {
 		var wg sync.WaitGroup
 		for i := 0; i < threads; i++ {
+			name := string(i)
 			wg.Add(1)
 			go func() {
-				action.Run(t)
+				api.Run(
+					name,
+					t,
+					func(t testing.TB) {
+						action.Run(t)
+					},
+				)
 				wg.Done()
 			}()
 		}

--- a/x/yarpctest/repeat.go
+++ b/x/yarpctest/repeat.go
@@ -21,10 +21,11 @@
 package yarpctest
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 
 	"go.uber.org/yarpc/x/yarpctest/api"
-	"sync"
 )
 
 // RepeatAction will call the provided action a set number of times (the action
@@ -43,7 +44,7 @@ func ConcurrentAction(action Action, threads int) api.Action {
 	return api.ActionFunc(func(t testing.TB) {
 		var wg sync.WaitGroup
 		for i := 0; i < threads; i++ {
-			name := string(i)
+			name := fmt.Sprint(i)
 			wg.Add(1)
 			go func() {
 				api.Run(

--- a/x/yarpctest/repeat.go
+++ b/x/yarpctest/repeat.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Uber Technologies, Inc.
+// Copyright (c) 2018 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/x/yarpctest/repeat.go
+++ b/x/yarpctest/repeat.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpctest
+
+import (
+	"testing"
+
+	"go.uber.org/yarpc/x/yarpctest/api"
+	"sync"
+)
+
+// RepeatAction will call the provided action a set number of times (the action
+// must be idempotent).
+func RepeatAction(action Action, times int) api.Action {
+	return api.ActionFunc(func(t testing.TB) {
+		for i := 0; i < times; i++ {
+			action.Run(t)
+		}
+	})
+}
+
+// ConcurrentAction will call the provided action in n concurrent threads at the
+// same time.
+func ConcurrentAction(action Action, threads int) api.Action {
+	return api.ActionFunc(func(t testing.TB) {
+		var wg sync.WaitGroup
+		for i := 0; i < threads; i++ {
+			wg.Add(1)
+			go func() {
+				action.Run(t)
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+	})
+}

--- a/x/yarpctest/request_stream.go
+++ b/x/yarpctest/request_stream.go
@@ -35,11 +35,12 @@ import (
 
 // GRPCStreamRequest creates a new grpc stream request.
 func GRPCStreamRequest(options ...api.ClientStreamRequestOption) api.Action {
-	opts := api.NewClientStreamRequestOpts()
-	for _, option := range options {
-		option.ApplyClientStreamRequest(&opts)
-	}
 	return api.ActionFunc(func(t testing.TB) {
+		opts := api.NewClientStreamRequestOpts()
+		for _, option := range options {
+			option.ApplyClientStreamRequest(&opts)
+		}
+
 		trans := grpc.NewTransport()
 		out := trans.NewSingleOutbound(fmt.Sprintf("127.0.0.1:%d", opts.Port))
 

--- a/x/yarpctest/request_unary.go
+++ b/x/yarpctest/request_unary.go
@@ -40,11 +40,12 @@ import (
 
 // HTTPRequest creates a new YARPC http request.
 func HTTPRequest(options ...api.RequestOption) api.Action {
-	opts := api.NewRequestOpts()
-	for _, option := range options {
-		option.ApplyRequest(&opts)
-	}
 	return api.ActionFunc(func(t testing.TB) {
+		opts := api.NewRequestOpts()
+		for _, option := range options {
+			option.ApplyRequest(&opts)
+		}
+
 		trans := http.NewTransport()
 		out := trans.NewSingleOutbound(fmt.Sprintf("http://127.0.0.1:%d/", opts.Port))
 
@@ -65,11 +66,12 @@ func HTTPRequest(options ...api.RequestOption) api.Action {
 
 // TChannelRequest creates a new tchannel request.
 func TChannelRequest(options ...api.RequestOption) api.Action {
-	opts := api.NewRequestOpts()
-	for _, option := range options {
-		option.ApplyRequest(&opts)
-	}
 	return api.ActionFunc(func(t testing.TB) {
+		opts := api.NewRequestOpts()
+		for _, option := range options {
+			option.ApplyRequest(&opts)
+		}
+
 		trans, err := tchannel.NewTransport(tchannel.ServiceName(opts.GiveRequest.Caller))
 		require.NoError(t, err)
 		out := trans.NewSingleOutbound(fmt.Sprintf("127.0.0.1:%d", opts.Port))
@@ -91,11 +93,12 @@ func TChannelRequest(options ...api.RequestOption) api.Action {
 
 // GRPCRequest creates a new grpc unary request.
 func GRPCRequest(options ...api.RequestOption) api.Action {
-	opts := api.NewRequestOpts()
-	for _, option := range options {
-		option.ApplyRequest(&opts)
-	}
 	return api.ActionFunc(func(t testing.TB) {
+		opts := api.NewRequestOpts()
+		for _, option := range options {
+			option.ApplyRequest(&opts)
+		}
+
 		trans := grpc.NewTransport()
 		out := trans.NewSingleOutbound(fmt.Sprintf("127.0.0.1:%d", opts.Port))
 

--- a/x/yarpctest/roundtrip_test.go
+++ b/x/yarpctest/roundtrip_test.go
@@ -44,14 +44,18 @@ func TestServiceRouting(t *testing.T) {
 					Proc(Name("echo"), EchoHandler()),
 				),
 			),
-			requests: Actions(
-				HTTPRequest(
-					p.NamedPort("1"),
-					Body("test body"),
-					Service("myservice"),
-					Procedure("echo"),
-					WantRespBody("test body"),
+			requests: ConcurrentAction(
+				RepeatAction(
+					HTTPRequest(
+						p.NamedPort("1"),
+						Body("test body"),
+						Service("myservice"),
+						Procedure("echo"),
+						WantRespBody("test body"),
+					),
+					10,
 				),
+				3,
 			),
 		},
 		{
@@ -63,14 +67,18 @@ func TestServiceRouting(t *testing.T) {
 					Proc(Name("echo"), EchoHandler()),
 				),
 			),
-			requests: Actions(
-				TChannelRequest(
-					p.NamedPort("2"),
-					Body("test body"),
-					Service("myservice"),
-					Procedure("echo"),
-					WantRespBody("test body"),
+			requests: ConcurrentAction(
+				RepeatAction(
+					TChannelRequest(
+						p.NamedPort("2"),
+						Body("test body"),
+						Service("myservice"),
+						Procedure("echo"),
+						WantRespBody("test body"),
+					),
+					10,
 				),
+				3,
 			),
 		},
 		{
@@ -82,14 +90,18 @@ func TestServiceRouting(t *testing.T) {
 					Proc(Name("echo"), EchoHandler()),
 				),
 			),
-			requests: Actions(
-				GRPCRequest(
-					p.NamedPort("3"),
-					Body("test body"),
-					Service("myservice"),
-					Procedure("echo"),
-					WantRespBody("test body"),
+			requests: ConcurrentAction(
+				RepeatAction(
+					GRPCRequest(
+						p.NamedPort("3"),
+						Body("test body"),
+						Service("myservice"),
+						Procedure("echo"),
+						WantRespBody("test body"),
+					),
+					10,
 				),
+				3,
 			),
 		},
 		{

--- a/x/yarpctest/stream.go
+++ b/x/yarpctest/stream.go
@@ -22,6 +22,7 @@ package yarpctest
 
 import (
 	"bytes"
+	"io"
 	"io/ioutil"
 
 	"go.uber.org/yarpc/x/yarpctest/types"
@@ -29,14 +30,20 @@ import (
 
 // SendStreamMsg sends a message to a stream.
 func SendStreamMsg(sendMsg string) *types.SendStreamMsg {
-	return &types.SendStreamMsg{Body: ioutil.NopCloser(bytes.NewBufferString(sendMsg))}
+	return &types.SendStreamMsg{
+		BodyFunc: func() io.ReadCloser {
+			return ioutil.NopCloser(bytes.NewBufferString(sendMsg))
+		},
+	}
 }
 
 // SendStreamMsgAndExpectError sends a message on a stream and asserts on the
 // error returned.
 func SendStreamMsgAndExpectError(sendMsg string, wantErrMsgs ...string) *types.SendStreamMsg {
 	return &types.SendStreamMsg{
-		Body:        ioutil.NopCloser(bytes.NewBufferString(sendMsg)),
+		BodyFunc: func() io.ReadCloser {
+			return ioutil.NopCloser(bytes.NewBufferString(sendMsg))
+		},
 		WantErrMsgs: wantErrMsgs,
 	}
 }
@@ -45,7 +52,9 @@ func SendStreamMsgAndExpectError(sendMsg string, wantErrMsgs ...string) *types.S
 // message and asserts on the result.
 func SendStreamDecodeErrorAndExpectError(decodeErr error, wantErrMsgs ...string) *types.SendStreamMsg {
 	return &types.SendStreamMsg{
-		Body:        ioutil.NopCloser(readErr{decodeErr}),
+		BodyFunc: func() io.ReadCloser {
+			return ioutil.NopCloser(readErr{decodeErr})
+		},
 		WantErrMsgs: wantErrMsgs,
 	}
 }

--- a/x/yarpctest/types/stream.go
+++ b/x/yarpctest/types/stream.go
@@ -37,7 +37,7 @@ type SendStreamMsg struct {
 	api.SafeTestingTBOnStart
 	api.NoopStop
 
-	Body        io.ReadCloser
+	BodyFunc    func() io.ReadCloser
 	WantErrMsgs []string
 }
 
@@ -56,7 +56,7 @@ func (s *SendStreamMsg) applyStream(t testing.TB, c transport.Stream) {
 	err := c.SendMessage(
 		context.Background(),
 		&transport.StreamMessage{
-			Body: s.Body,
+			Body: s.BodyFunc(),
 		},
 	)
 	if len(s.WantErrMsgs) > 0 {


### PR DESCRIPTION
Summary: Sometimes we want to make sure that a request will succeed if
we call it multiple times, or concurrently, instead of needing to write
the request n times, we can wrap actions in a "RepeatAction" type and
the action will be executed n times.  Additionally wrapping the action
in a "ConcurrentAction" will execute the request in n different goroutines.

In the process of doing this, I updated all the request actions to be idempotent.