### PR TITLE
Add GiveTimeout option to yarpctest infra.

### DIFF
--- a/x/yarpctest/api/request_unary.go
+++ b/x/yarpctest/api/request_unary.go
@@ -22,6 +22,7 @@ package api
 
 import (
 	"bytes"
+	"time"
 
 	"go.uber.org/yarpc/api/transport"
 )
@@ -30,6 +31,7 @@ import (
 // to make on the response.
 type RequestOpts struct {
 	Port         uint16
+	GiveTimeout  time.Duration
 	GiveRequest  *transport.Request
 	WantResponse *transport.Response
 	WantError    error
@@ -38,6 +40,7 @@ type RequestOpts struct {
 // NewRequestOpts initializes a RequestOpts struct.
 func NewRequestOpts() RequestOpts {
 	return RequestOpts{
+		GiveTimeout: time.Second * 10,
 		GiveRequest: &transport.Request{
 			Caller:   "unknown",
 			Encoding: transport.Encoding("raw"),

--- a/x/yarpctest/request_unary.go
+++ b/x/yarpctest/request_unary.go
@@ -55,7 +55,7 @@ func HTTPRequest(options ...api.RequestOption) api.Action {
 		require.NoError(t, out.Start())
 		defer func() { assert.NoError(t, out.Stop()) }()
 
-		resp, cancel, err := sendRequest(out, opts.GiveRequest)
+		resp, cancel, err := sendRequest(out, opts.GiveRequest, opts.GiveTimeout)
 		defer cancel()
 		validateError(t, err, opts.WantError)
 		if opts.WantError == nil {
@@ -82,7 +82,7 @@ func TChannelRequest(options ...api.RequestOption) api.Action {
 		require.NoError(t, out.Start())
 		defer func() { assert.NoError(t, out.Stop()) }()
 
-		resp, cancel, err := sendRequest(out, opts.GiveRequest)
+		resp, cancel, err := sendRequest(out, opts.GiveRequest, opts.GiveTimeout)
 		defer cancel()
 		validateError(t, err, opts.WantError)
 		if opts.WantError == nil {
@@ -108,7 +108,7 @@ func GRPCRequest(options ...api.RequestOption) api.Action {
 		require.NoError(t, out.Start())
 		defer func() { assert.NoError(t, out.Stop()) }()
 
-		resp, cancel, err := sendRequest(out, opts.GiveRequest)
+		resp, cancel, err := sendRequest(out, opts.GiveRequest, opts.GiveTimeout)
 		defer cancel()
 		validateError(t, err, opts.WantError)
 		if opts.WantError == nil {
@@ -117,8 +117,8 @@ func GRPCRequest(options ...api.RequestOption) api.Action {
 	})
 }
 
-func sendRequest(out transport.UnaryOutbound, request *transport.Request) (*transport.Response, context.CancelFunc, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+func sendRequest(out transport.UnaryOutbound, request *transport.Request, timeout time.Duration) (*transport.Response, context.CancelFunc, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	resp, err := out.Call(ctx, request)
 	return resp, cancel, err
 }
@@ -158,6 +158,13 @@ func validateResponse(t testing.TB, actualResp *transport.Response, expectedResp
 func Body(msg string) api.RequestOption {
 	return api.RequestOptionFunc(func(opts *api.RequestOpts) {
 		opts.GiveRequest.Body = bytes.NewBufferString(msg)
+	})
+}
+
+// GiveTimeout will set the timeout for the request.
+func GiveTimeout(duration time.Duration) api.RequestOption {
+	return api.RequestOptionFunc(func(opts *api.RequestOpts) {
+		opts.GiveTimeout = duration
 	})
 }
 

--- a/x/yarpctest/roundtrip_test.go
+++ b/x/yarpctest/roundtrip_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/internal/testtime"
 	"go.uber.org/yarpc/yarpcerrors"
 )
 
@@ -48,6 +49,7 @@ func TestServiceRouting(t *testing.T) {
 				RepeatAction(
 					HTTPRequest(
 						p.NamedPort("1"),
+						GiveTimeout(testtime.Second),
 						Body("test body"),
 						Service("myservice"),
 						Procedure("echo"),
@@ -71,6 +73,7 @@ func TestServiceRouting(t *testing.T) {
 				RepeatAction(
 					TChannelRequest(
 						p.NamedPort("2"),
+						GiveTimeout(testtime.Second),
 						Body("test body"),
 						Service("myservice"),
 						Procedure("echo"),
@@ -94,6 +97,7 @@ func TestServiceRouting(t *testing.T) {
 				RepeatAction(
 					GRPCRequest(
 						p.NamedPort("3"),
+						GiveTimeout(testtime.Second),
 						Body("test body"),
 						Service("myservice"),
 						Procedure("echo"),


### PR DESCRIPTION
Summary: Add a configuration option to the yarpctest infra request actions to 
support setting the timeout for requests (previously they were hardcoded to 10s).
  