### PR TITLE
bufferpool: Detect use-after-free / concurrent operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   dispatcher metrics configuration, in lieu of a Tally Scope.  Metrics scopes
   support in memory and Prometheus collection.
 
+### Changed
+- Detect buffer pooling bugs by detecting concurrent accesses in production
+  and more thorough use-after-free detection in tests.
+
 ### Fixed
 - Removed buffer pooling from GRPC inbound responses which had possible data
   corruption issues.

--- a/internal/bufferpool/buffer.go
+++ b/internal/bufferpool/buffer.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package bufferpool
+
+import (
+	"bytes"
+	"io"
+)
+
+// Buffer represents a poolable buffer. It wraps an underlying
+// *bytes.Buffer with lightweight detection of races.
+type Buffer struct {
+	pool *Pool
+
+	version uint
+	buf     *bytes.Buffer
+}
+
+func newBuffer(pool *Pool) *Buffer {
+	return &Buffer{
+		pool:    pool,
+		version: 0,
+		buf:     &bytes.Buffer{},
+	}
+}
+
+func (b *Buffer) preOp() uint {
+	if b.buf == nil {
+		panic("use-after-free of pooled buffer, or pending Bytes() call")
+	}
+
+	b.version++
+	cur := b.version
+	return cur
+}
+
+func (b *Buffer) postOp(v uint) {
+	if v != b.version {
+		panic("concurrent use of pooled buffer")
+	}
+	b.version++
+}
+
+// Read is the same as bytes.Buffer.Read.
+func (b *Buffer) Read(p []byte) (int, error) {
+	version := b.preOp()
+	n, err := b.buf.Read(p)
+	b.postOp(version)
+	return n, err
+}
+
+// ReadFrom is the same as bytes.Buffer.ReadFrom.
+func (b *Buffer) ReadFrom(r io.Reader) (int64, error) {
+	version := b.preOp()
+	n, err := b.buf.ReadFrom(r)
+	b.postOp(version)
+	return n, err
+}
+
+// Write is the same as bytes.Buffer.Write.
+func (b *Buffer) Write(p []byte) (int, error) {
+	version := b.preOp()
+	n, err := b.buf.Write(p)
+	b.postOp(version)
+	return n, err
+}
+
+// WriteTo is the same as bytes.Buffer.WriteTo.
+func (b *Buffer) WriteTo(w io.Writer) (int64, error) {
+	version := b.preOp()
+	n, err := b.buf.WriteTo(w)
+	b.postOp(version)
+	return n, err
+}
+
+// Bytes returns the bytes in the underlying buffer, as well as a
+// function to call when the caller is done using the bytes.
+// This is easy to mis-use and lead to a use-after-free that
+// cannot be detected, so it is strongly recommended that this method
+// is NOT used.
+func (b *Buffer) Bytes() []byte {
+	return b.buf.Bytes()
+}
+
+// Len is the same as bytes.Buffer.Len.
+func (b *Buffer) Len() int {
+	version := b.preOp()
+	n := b.buf.Len()
+	b.postOp(version)
+	return n
+}
+
+// Reset is the same as bytes.Buffer.Reset.
+func (b *Buffer) Reset() {
+	version := b.preOp()
+	b.buf.Reset()
+	b.postOp(version)
+}
+
+// Release releases the buffer back to the buffer pool.
+func (b *Buffer) Release() {
+	v := b.preOp()
+	b.postOp(v)
+
+	if !b.pool.testDetectUseAfterFree {
+		b.Reset()
+		b.pool.release(b)
+		return
+	}
+
+	// Detect any lingering reads of the underlying data by resetting the data.
+	// We repeat it in a goroutine to trigger the race detector.
+	overwriteData(b.Bytes())
+	go overwriteData(b.Bytes())
+
+	// This will cause any future accesses to panic.
+	b.buf = nil
+}
+
+func overwriteData(bs []byte) {
+	for i := range bs {
+		bs[i] = byte(i)
+	}
+}

--- a/internal/bufferpool/buffer.go
+++ b/internal/bufferpool/buffer.go
@@ -36,9 +36,8 @@ type Buffer struct {
 
 func newBuffer(pool *Pool) *Buffer {
 	return &Buffer{
-		pool:    pool,
-		version: 0,
-		buf:     &bytes.Buffer{},
+		pool: pool,
+		buf:  &bytes.Buffer{},
 	}
 }
 
@@ -48,8 +47,7 @@ func (b *Buffer) preOp() uint {
 	}
 
 	b.version++
-	cur := b.version
-	return cur
+	return b.version
 }
 
 func (b *Buffer) postOp(v uint) {

--- a/internal/bufferpool/bufferpool.go
+++ b/internal/bufferpool/bufferpool.go
@@ -39,9 +39,9 @@ type Pool struct {
 }
 
 func init() {
-	// FIXME: This is a huge hack just for prototyping.
-	// This detects whether we're running as part of a test, and if so
-	// enables the use-after-free detection.
+	// This is a hacky way to determine whether we are running in unit tests where
+	// we want to enable use-after-free detection.
+	// https://stackoverflow.com/a/36666114
 	if flag.Lookup("test.v") != nil {
 		_pool = NewPool(DetectUseAfterFreeForTests())
 	}

--- a/internal/bufferpool/bufferpool.go
+++ b/internal/bufferpool/bufferpool.go
@@ -23,24 +23,66 @@
 package bufferpool
 
 import (
-	"bytes"
+	"flag"
 	"sync"
 )
 
-var _bufferPool = sync.Pool{
-	New: func() interface{} {
-		return &bytes.Buffer{}
-	},
+var _pool = NewPool()
+
+// Option configures a buffer pool.
+type Option func(*Pool)
+
+// Pool represents a buffer pool with a set of options.
+type Pool struct {
+	testDetectUseAfterFree bool
+	pool                   sync.Pool
 }
 
-// Get returns a new Buffer from the Buffer pool that has been reset.
-func Get() *bytes.Buffer {
-	buf := _bufferPool.Get().(*bytes.Buffer)
-	buf.Reset()
+func init() {
+	// FIXME: This is a huge hack just for prototyping.
+	// This detects whether we're running as part of a test, and if so
+	// enables the use-after-free detection.
+	if flag.Lookup("test.v") != nil {
+		_pool = NewPool(DetectUseAfterFreeForTests())
+	}
+}
+
+// NewPool returns a pool that we can allocate buffers from.
+func NewPool(opts ...Option) *Pool {
+	pool := &Pool{}
+	for _, opt := range opts {
+		opt(pool)
+	}
+	return pool
+}
+
+// DetectUseAfterFreeForTests is an option that allows unit tests to detect
+// bad use of a pooled buffer after it has been released to the pool.
+func DetectUseAfterFreeForTests() Option {
+	return func(p *Pool) {
+		p.testDetectUseAfterFree = true
+	}
+}
+
+// Get returns a buffer from the pool.
+func (p *Pool) Get() *Buffer {
+	buf, ok := p.pool.Get().(*Buffer)
+	if !ok {
+		buf = newBuffer(p)
+	}
 	return buf
 }
 
+func (p *Pool) release(buf *Buffer) {
+	p.pool.Put(buf)
+}
+
+// Get returns a new Buffer from the Buffer pool that has been reset.
+func Get() *Buffer {
+	return _pool.Get()
+}
+
 // Put returns a Buffer to the Buffer pool.
-func Put(buf *bytes.Buffer) {
-	_bufferPool.Put(buf)
+func Put(buf *Buffer) {
+	buf.Release()
 }

--- a/internal/bufferpool/bufferpool.go
+++ b/internal/bufferpool/bufferpool.go
@@ -69,6 +69,8 @@ func (p *Pool) Get() *Buffer {
 	buf, ok := p.pool.Get().(*Buffer)
 	if !ok {
 		buf = newBuffer(p)
+	} else {
+		buf.reuse()
 	}
 	return buf
 }

--- a/transport/http/handler.go
+++ b/transport/http/handler.go
@@ -219,7 +219,7 @@ func (h handler) createSpan(ctx context.Context, req *http.Request, treq *transp
 // responseWriter adapts a http.ResponseWriter into a transport.ResponseWriter.
 type responseWriter struct {
 	w      http.ResponseWriter
-	buffer *bytes.Buffer
+	buffer *bufferpool.Buffer
 }
 
 func newResponseWriter(w http.ResponseWriter) *responseWriter {

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -21,7 +21,6 @@
 package tchannel
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"time"
@@ -190,7 +189,7 @@ type responseWriter struct {
 	failedWith         error
 	format             tchannel.Format
 	headers            transport.Headers
-	buffer             *bytes.Buffer
+	buffer             *bufferpool.Buffer
 	response           inboundCallResponse
 	isApplicationError bool
 }

--- a/transport/tchannel/handler_test.go
+++ b/transport/tchannel/handler_test.go
@@ -459,7 +459,7 @@ func TestResponseWriterFailure(t *testing.T) {
 		_, err = w.Write([]byte("bar"))
 		assert.NoError(t, err)
 		err = w.Close()
-		assert.Error(t, w.Close())
+		assert.Error(t, err)
 		for _, msg := range tt.messages {
 			assert.Contains(t, err.Error(), msg)
 		}


### PR DESCRIPTION
This updates the buffer pool implementation to be mostly compatible with the existing YARPC interface, but adds use-after-free detection, as well as any concurrent misuse of the buffers.

In production, it will detect concurrent accesses to the same buffer
(Which are usually caused by a use-after-free because a buffer was
released too early). In tests, we can implement additional
use-after-free detection which will disable pooling, but will detect any
operations performed after the free.

This is inspired by the [TChannel protectmem pool](https://github.com/uber/tchannel-go/blob/master/frame_utils_test.go#L45) as well as the [M3 pool](https://godoc.org/github.com/m3db/m3x/pool).

Some differences:
 * TChannel uses the `mprotect` syscall, which requires using `unsafe` and page allocations.
 * m3x/pool is not API compatible with `*bytes.Buffer`
 * m3x/pool does not catch bad uses of the `[]byte` after they have been freed.

We'll likely move this out into a separate top-level repo that we can use between multiple projects, but let's start with an internal package to iron out the API and implementation.