### PR TITLE
transport: Use WriteTo instead of Write(buf.Bytes())

### DIFF
--- a/transport/http/handler.go
+++ b/transport/http/handler.go
@@ -256,7 +256,7 @@ func (rw *responseWriter) Close(httpStatusCode int) {
 	rw.w.WriteHeader(httpStatusCode)
 	if rw.buffer != nil {
 		// TODO: what to do with error?
-		_, _ = rw.w.Write(rw.buffer.Bytes())
+		_, _ = rw.buffer.WriteTo(rw.w)
 		bufferpool.Put(rw.buffer)
 	}
 }

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -255,7 +255,7 @@ func (rw *responseWriter) Close() error {
 	defer func() { retErr = appendError(retErr, bodyWriter.Close()) }()
 	if rw.buffer != nil {
 		defer bufferpool.Put(rw.buffer)
-		if _, err := bodyWriter.Write(rw.buffer.Bytes()); err != nil {
+		if _, err := rw.buffer.WriteTo(bodyWriter); err != nil {
 			return appendError(retErr, err)
 		}
 	}


### PR DESCRIPTION
WriteTo can be implemented more efficiently, is less code, and will
allow us to detect use-after-free (see #1408), which we cannot do with
an arbitrary byte slice.