### PR TITLE
Use a goroutine with function arguments for ConcurrentAction

### DIFF
--- a/x/yarpctest/repeat.go
+++ b/x/yarpctest/repeat.go
@@ -44,9 +44,8 @@ func ConcurrentAction(action Action, threads int) api.Action {
 	return api.ActionFunc(func(t testing.TB) {
 		var wg sync.WaitGroup
 		for i := 0; i < threads; i++ {
-			name := fmt.Sprint(i)
 			wg.Add(1)
-			go func() {
+			go func(name string) {
 				api.Run(
 					name,
 					t,
@@ -55,7 +54,7 @@ func ConcurrentAction(action Action, threads int) api.Action {
 					},
 				)
 				wg.Done()
-			}()
+			}(fmt.Sprint(i))
 		}
 		wg.Wait()
 	})


### PR DESCRIPTION
Summary: starting goroutines can potentially bleed implementation in a loop 
(since the loop values are changing).  This change in particular was probably NBD
but I ended up copying this code for another case and ended up shooting myself in the
foot, changing this code to save future selves.