### PR TITLE
Fix bug in tchannel handler where yarpcerrors are not being converted.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add support for creating peer choosers through config with PeerChooserSpec.
 
 ### Fixed
-- Tchannel inbound response errors are now properly mapped from yarpc errors.
+- TChannel inbound response errors are now properly mapped from YARPC errors.
 
 
 ## [1.26.1] - 2017-12-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add support for Inbound and Outbound streaming RPCs using gRPC and Protobuf.
 - Add support for creating peer choosers through config with PeerChooserSpec.
 
+### Fixed
+- Tchannel inbound response errors are now properly mapped from yarpc errors.
+
 
 ## [1.26.1] - 2017-12-21
 ### Removed

--- a/transport/tchannel/handler_test.go
+++ b/transport/tchannel/handler_test.go
@@ -499,6 +499,10 @@ func TestGetSystemError(t *testing.T) {
 			giveErr:  tchannel.NewSystemError(tchannel.ErrCodeBusy, "test"),
 			wantCode: tchannel.ErrCodeBusy,
 		},
+		{
+			giveErr:  yarpcerrors.Newf(yarpcerrors.Code(1235), "test"),
+			wantCode: tchannel.ErrCodeUnexpected,
+		},
 	}
 	for i, tt := range tests {
 		t.Run(string(i), func(t *testing.T) {


### PR DESCRIPTION
Summary: Noticed this while trying to proxy Unavailable errors. This
PR fixes the getSystemError function to properly convert yarpc errors
into tchannel system errors.