### PR TITLE
Fix data race with responses using gRPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   support in memory and Prometheus collection.
 
 ### Fixed
+- Removed buffer pooling from GRPC inbound responses which had possible data
+  corruption issues.
 - TChannel inbound response errors are now properly mapped from YARPC errors.
 
 

--- a/transport/grpc/handler.go
+++ b/transport/grpc/handler.go
@@ -184,13 +184,9 @@ func (h *handler) handleUnary(
 	// which grpc can modify. Without this, the test TestDataRace in integration_test.go
 	// will be set off.
 	data := responseWriter.Bytes()
-	var b []byte
-	if len(data) > 0 {
-		b = make([]byte, len(data))
-		copy(b, data)
-	}
+
 	// Send the response attributes back and end the stream.
-	if sendErr := serverStream.SendMsg(b); sendErr != nil {
+	if sendErr := serverStream.SendMsg(data); sendErr != nil {
 		// We couldn't send the response.
 		return sendErr
 	}

--- a/transport/grpc/handler.go
+++ b/transport/grpc/handler.go
@@ -177,16 +177,8 @@ func (h *handler) handleUnary(
 	err := h.handleUnaryBeforeErrorConversion(ctx, transportRequest, responseWriter, start, handler)
 	err = handlerErrorToGRPCError(err, responseWriter)
 
-	// We need to copy the bytes out so that we do not use the buffer-pool-backed byte slices.
-	// grpc does a send back to the client on a loop in a separate goroutine, which may occur
-	// after we return from this dunction. Because our codec is a passthrough, the "marshalled"
-	// data from the interface{} given to SendMsg is the original byte buffer from the buffer pool,
-	// which grpc can modify. Without this, the test TestDataRace in integration_test.go
-	// will be set off.
-	data := responseWriter.Bytes()
-
 	// Send the response attributes back and end the stream.
-	if sendErr := serverStream.SendMsg(data); sendErr != nil {
+	if sendErr := serverStream.SendMsg(responseWriter.Bytes()); sendErr != nil {
 		// We couldn't send the response.
 		return sendErr
 	}

--- a/transport/grpc/integration_test.go
+++ b/transport/grpc/integration_test.go
@@ -170,7 +170,7 @@ func TestYARPCMaxMsgSize(t *testing.T) {
 	})
 }
 
-func TestDataRace(t *testing.T) {
+func TestLargeEcho(t *testing.T) {
 	t.Parallel()
 	value := strings.Repeat("a", 32768)
 	doWithTestEnv(t, nil, nil, nil, func(t *testing.T, e *testEnv) {

--- a/transport/grpc/integration_test.go
+++ b/transport/grpc/integration_test.go
@@ -170,6 +170,17 @@ func TestYARPCMaxMsgSize(t *testing.T) {
 	})
 }
 
+func TestDataRace(t *testing.T) {
+	t.Parallel()
+	value := strings.Repeat("a", 32768)
+	doWithTestEnv(t, nil, nil, nil, func(t *testing.T, e *testEnv) {
+		assert.NoError(t, e.SetValueYARPC(context.Background(), "foo", value))
+		getValue, err := e.GetValueYARPC(context.Background(), "foo")
+		assert.NoError(t, err)
+		assert.Equal(t, value, getValue)
+	})
+}
+
 func TestApplicationErrorPropagation(t *testing.T) {
 	t.Parallel()
 	doWithTestEnv(t, nil, nil, nil, func(t *testing.T, e *testEnv) {

--- a/transport/grpc/response_writer.go
+++ b/transport/grpc/response_writer.go
@@ -25,7 +25,6 @@ import (
 
 	"go.uber.org/multierr"
 	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/internal/bufferpool"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -41,7 +40,7 @@ func newResponseWriter() *responseWriter {
 
 func (r *responseWriter) Write(p []byte) (int, error) {
 	if r.buffer == nil {
-		r.buffer = bufferpool.Get()
+		r.buffer = bytes.NewBuffer(make([]byte, 0, 1024))
 	}
 	return r.buffer.Write(p)
 }
@@ -72,8 +71,5 @@ func (r *responseWriter) Bytes() []byte {
 }
 
 func (r *responseWriter) Close() {
-	if r.buffer != nil {
-		bufferpool.Put(r.buffer)
-	}
 	r.buffer = nil
 }

--- a/transport/grpc/response_writer.go
+++ b/transport/grpc/response_writer.go
@@ -40,7 +40,7 @@ func newResponseWriter() *responseWriter {
 
 func (r *responseWriter) Write(p []byte) (int, error) {
 	if r.buffer == nil {
-		r.buffer = bytes.NewBuffer(make([]byte, 0, 1024))
+		r.buffer = bytes.NewBuffer(make([]byte, 0, len(p)))
 	}
 	return r.buffer.Write(p)
 }

--- a/transport/grpc/stream.go
+++ b/transport/grpc/stream.go
@@ -68,7 +68,6 @@ func (ss *serverStream) SendMessage(_ context.Context, m *transport.StreamMessag
 }
 
 func (ss *serverStream) ReceiveMessage(_ context.Context) (*transport.StreamMessage, error) {
-	// TODO used pooled buffers for performance.
 	var msg []byte
 	if err := ss.stream.RecvMsg(&msg); err != nil {
 		return nil, toYARPCStreamError(err)
@@ -107,8 +106,6 @@ func (cs *clientStream) SendMessage(_ context.Context, m *transport.StreamMessag
 	}
 	// TODO can we make a "Bytes" interface to get direct access to the bytes
 	// (instead of resorting to ReadAll (which is not necessarily performant))
-	// Alternatively we can pool Buffers to read the message and clear the
-	// buffers after we've sent the Messages.
 	msg, err := ioutil.ReadAll(m.Body)
 	_ = m.Body.Close()
 	if err != nil {


### PR DESCRIPTION
https://github.com/yarpc/yarpc-go/issues/1415

See the comment in the file:

```
We need to copy the bytes out so that we do not use the buffer-pool-backed byte slices.
grpc does a send back to the client on a loop in a separate goroutine, which may occur
after we return from this function. Because our codec is a passthrough, the "marshalled"
data from the interface{} given to SendMsg is the original byte buffer from the buffer pool,
which grpc can modify. Without this, the test TestDataRace in integration_test.go
will be set off.
```

I looked at other cases in `transport/grpc` and I think this is the only occurrence. There are potentially cleaner solutions but this fixes the problem for now