### PR TITLE
yarpc.Config: Option to disable observability middleware

### DIFF
--- a/config.go
+++ b/config.go
@@ -172,4 +172,11 @@ type Config struct {
 
 	// Configures telemetry.
 	Metrics MetricsConfig
+
+	// DisableAutoObservabilityMiddleware is used to stop the dispatcher from
+	// automatically attaching observability middleware to all inbounds and
+	// outbounds.  It is the assumption that if if this option is disabled the
+	// observability middleware is being inserted in the Inbound/Outbound
+	// Middleware.
+	DisableAutoObservabilityMiddleware bool
 }

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -98,6 +98,10 @@ func NewDispatcher(cfg Config) *Dispatcher {
 }
 
 func addObservingMiddleware(cfg Config, meter *metrics.Scope, logger *zap.Logger, extractor observability.ContextExtractor) Config {
+	if cfg.DisableAutoObservabilityMiddleware {
+		return cfg
+	}
+
 	observer := observability.NewMiddleware(logger, meter, extractor)
 
 	cfg.InboundMiddleware.Unary = inboundmiddleware.UnaryChain(observer, cfg.InboundMiddleware.Unary)


### PR DESCRIPTION
Summary: In order to allow some users to customize how they attach
observability middleware (e.g. users that want to log stats with shard
key).  This PR adds the ability to not add the built in observability
middleware on the dispatcher.  By default it's currently always added.
This will allow users to input their own middleware for observability
explicitly.  Since it would be a breaking change to remove it silently,
this needs to be an new option that explicitly disables the middleware..