### PR TITLE
Randomize the order of peers in peerlists.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+- Enabled random shuffling of peerlist order by default.
 
 ## [1.27.2] - 2017-01-23
 ### Fixed

--- a/peer/peerlist/list.go
+++ b/peer/peerlist/list.go
@@ -23,7 +23,9 @@ package peerlist
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"sync"
+	"time"
 
 	"go.uber.org/atomic"
 	"go.uber.org/multierr"
@@ -41,10 +43,14 @@ var (
 
 type listOptions struct {
 	capacity int
+	shuffle  bool
+	seed     int64
 }
 
 var defaultListOptions = listOptions{
 	capacity: 10,
+	shuffle:  true,
+	seed:     time.Now().UnixNano(),
 }
 
 // ListOption customizes the behavior of a list.
@@ -66,6 +72,20 @@ func Capacity(capacity int) ListOption {
 	})
 }
 
+// NoShuffle disables the default behavior of shuffling peerlist order.
+var NoShuffle listOptionFunc = func(options *listOptions) {
+	options.shuffle = false
+}
+
+// Seed specifies the random seed to use for shuffling peers
+//
+// Defaults to approximately the process start time in nanoseconds.
+func Seed(seed int64) ListOption {
+	return listOptionFunc(func(options *listOptions) {
+		options.seed = seed
+	})
+}
+
 // New creates a new peer list with an identifier chooser for available peers.
 func New(name string, transport peer.Transport, availableChooser peer.ListImplementation, opts ...ListOption) *List {
 	options := defaultListOptions
@@ -81,6 +101,8 @@ func New(name string, transport peer.Transport, availableChooser peer.ListImplem
 		availablePeers:     make(map[string]*peerThunk, options.capacity),
 		availableChooser:   availableChooser,
 		transport:          transport,
+		shuffle:            options.shuffle,
+		randSrc:            rand.NewSource(options.seed),
 		peerAvailableEvent: make(chan struct{}, 1),
 	}
 }
@@ -107,6 +129,9 @@ type List struct {
 	availableChooser   peer.ListImplementation
 	peerAvailableEvent chan struct{}
 	transport          peer.Transport
+
+	shuffle bool
+	randSrc rand.Source
 
 	once *lifecycle.Once
 }
@@ -139,7 +164,12 @@ func (pl *List) updateInitialized(updates peer.ListUpdates) error {
 		errs = multierr.Append(errs, pl.removePeerIdentifier(peerID))
 	}
 
-	for _, peerID := range updates.Additions {
+	add := updates.Additions
+	if pl.shuffle {
+		add = shuffle(pl.randSrc, add)
+	}
+
+	for _, peerID := range add {
 		errs = multierr.Append(errs, pl.addPeerIdentifier(peerID))
 	}
 	return errs
@@ -222,10 +252,15 @@ func (pl *List) start() error {
 		return err
 	}
 
+	add := values(pl.uninitializedPeers)
+	if pl.shuffle {
+		add = shuffle(pl.randSrc, add)
+	}
+
 	var errs error
-	for k, pid := range pl.uninitializedPeers {
+	for _, pid := range add {
 		errs = multierr.Append(errs, pl.addPeerIdentifier(pid))
-		delete(pl.uninitializedPeers, k)
+		delete(pl.uninitializedPeers, pid.Identifier())
 	}
 
 	pl.shouldRetainPeers.Store(true)
@@ -567,4 +602,26 @@ func (pl *List) Introspect() introspection.ChooserStatus {
 			len(availables)+len(unavailables)),
 		Peers: peersStatus,
 	}
+}
+
+// shuffle randomizes the order of a slice of peers.
+// see: https://en.wikipedia.org/wiki/Fisher-Yates_shuffle
+func shuffle(src rand.Source, in []peer.Identifier) []peer.Identifier {
+	shuffled := make([]peer.Identifier, len(in))
+	r := rand.New(src)
+	copy(shuffled, in)
+	for i := len(in) - 1; i > 0; i-- {
+		j := r.Intn(i + 1)
+		shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
+	}
+	return shuffled
+}
+
+// values returns a slice of the values contained in a map of peers.
+func values(m map[string]peer.Identifier) []peer.Identifier {
+	vs := make([]peer.Identifier, 0, len(m))
+	for _, v := range m {
+		vs = append(vs, v)
+	}
+	return vs
 }

--- a/peer/pendingheap/list.go
+++ b/peer/pendingheap/list.go
@@ -27,10 +27,12 @@ import (
 
 type listConfig struct {
 	capacity int
+	shuffle  bool
 }
 
 var defaultListConfig = listConfig{
 	capacity: 10,
+	shuffle:  true,
 }
 
 // ListOption customizes the behavior of a pending requests peer heap.
@@ -53,12 +55,19 @@ func New(transport peer.Transport, opts ...ListOption) *List {
 		o(&cfg)
 	}
 
+	plOpts := []peerlist.ListOption{
+		peerlist.Capacity(cfg.capacity),
+	}
+	if !cfg.shuffle {
+		plOpts = append(plOpts, peerlist.NoShuffle)
+	}
+
 	return &List{
 		List: peerlist.New(
 			"fewest-pending-requests",
 			transport,
 			&pendingHeap{},
-			peerlist.Capacity(cfg.capacity),
+			plOpts...,
 		),
 	}
 }

--- a/peer/pendingheap/list_test.go
+++ b/peer/pendingheap/list_test.go
@@ -585,7 +585,8 @@ func TestPeerHeapList(t *testing.T) {
 			ExpectPeerRetainsWithError(transport, tt.errRetainedPeerIDs, tt.retainErr)
 			ExpectPeerReleases(transport, tt.errReleasedPeerIDs, tt.releaseErr)
 
-			pl := New(transport, Capacity(0))
+			opts := []ListOption{Capacity(0), noShuffle}
+			pl := New(transport, opts...)
 
 			deps := ListActionDeps{
 				Peers: peerMap,
@@ -610,4 +611,8 @@ func TestPeerHeapList(t *testing.T) {
 			assert.Equal(t, tt.expectedRunning, pl.IsRunning(), "Peer list should match expected final running state")
 		})
 	}
+}
+
+var noShuffle ListOption = func(c *listConfig) {
+	c.shuffle = false
 }

--- a/yarpcconfig/chooser_test.go
+++ b/yarpcconfig/chooser_test.go
@@ -321,7 +321,8 @@ func TestChooserConfigurator(t *testing.T) {
 				require.NoError(t, err, "error choosing peer")
 				defer onFinish(nil)
 
-				assert.Equal(t, peer.Identifier(), "127.0.0.1:8080", "chooses first peer")
+				expectedPeers := []string{"127.0.0.1:8080", "127.0.0.1:8081"}
+				assert.Contains(t, expectedPeers, peer.Identifier(), "chooses one of the provided peers")
 			},
 		},
 		{


### PR DESCRIPTION
Previously, peers would always be used in the order as input.

This can lead to non-uniform load on the peers in some cases.
For example:
- rpc callers are crash looping and repeatedly coming back up
  and hitting the first peer. (first peer will be hammered)
- many callers are started around the same time, and perform
  rpcs on a fixed schedule (each peer will be hammered in turn)

Instead, randomly shuffle peers as they are added.

By default, the random-number generator used for shuffling is
seeded with the current time in nanoseconds.

Support an Option for setting the random seed, to allow for
deterministic tests.

- [x] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [x] Entry in CHANGELOG.md
