### PR TITLE
Reintroduce envelope-agnostic Thrift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
 - Enabled random shuffling of peerlist order by default.
+### Added
+- Reintroduce envelope-agnostic Thrift inbounds. Thrift inbounds will now
+  accept Thrift requests with or without envelopes.  This feature was
+  originally added in 1.26.0 and removed in 1.26.1 because the implementation
+  introduced an inbound request data corruption hazard.
 
 ## [1.27.2] - 2017-01-23
 ### Fixed

--- a/encoding/thrift/fakes_test.go
+++ b/encoding/thrift/fakes_test.go
@@ -20,7 +20,11 @@
 
 package thrift
 
-import "go.uber.org/thriftrw/wire"
+import (
+	"io"
+
+	"go.uber.org/thriftrw/wire"
+)
 
 type fakeEnveloper wire.EnvelopeType
 
@@ -34,4 +38,29 @@ func (e fakeEnveloper) EnvelopeType() wire.EnvelopeType {
 
 func (fakeEnveloper) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{}), nil
+}
+
+type errorEnveloper struct {
+	envelopeType wire.EnvelopeType
+	err          error
+}
+
+func (errorEnveloper) MethodName() string {
+	return "someMethod"
+}
+
+func (e errorEnveloper) EnvelopeType() wire.EnvelopeType {
+	return e.envelopeType
+}
+
+func (e errorEnveloper) ToWire() (wire.Value, error) {
+	return wire.Value{}, e.err
+}
+
+type errorResponder struct {
+	err error
+}
+
+func (e errorResponder) EncodeResponse(v wire.Value, et wire.EnvelopeType, w io.Writer) error {
+	return e.err
 }

--- a/encoding/thrift/inbound.go
+++ b/encoding/thrift/inbound.go
@@ -148,11 +148,11 @@ func decodeRequest(
 	// Discover or choose the appropriate envelope
 	if agnosticProto, ok := proto.(protocol.EnvelopeAgnosticProtocol); ok {
 		return agnosticProto.DecodeRequest(reqEnvelopeType, reader)
-	} else if enveloping {
-		return decodeEnvelopedRequest(treq, reqEnvelopeType, proto, reader)
-	} else {
-		return decodeUnenvelopedRequest(proto, reader)
 	}
+	if enveloping {
+		return decodeEnvelopedRequest(treq, reqEnvelopeType, proto, reader)
+	}
+	return decodeUnenvelopedRequest(proto, reader)
 }
 
 func decodeEnvelopedRequest(

--- a/encoding/thrift/inbound.go
+++ b/encoding/thrift/inbound.go
@@ -105,6 +105,7 @@ func (t thriftOnewayHandler) HandleOneway(ctx context.Context, treq *transport.R
 // decodeRequest is a utility shared by Unary and Oneway handlers, to decode
 // the request, regardless of enveloping.
 func decodeRequest(
+	// call is an inboundCall populated from the transport request and context.
 	call *encodingapi.InboundCall,
 	// buf is a byte buffer from the buffer pool, that will be released back to
 	// the buffer pool by the caller after it is finished with the decoded
@@ -121,11 +122,10 @@ func decodeRequest(
 	// protocol is not envelope agnostic.
 	enveloping bool,
 ) (
-	// call is an inboundCall populated from the transport request and context.
-	// reqValue is the wire representation of the decoded request.
+	// the wire representation of the decoded request.
 	// decodeRequest does not surface the envelope.
 	wire.Value,
-	// responder indicates how to encode the response, with the enveloping
+	// how to encode the response, with the enveloping
 	// strategy corresponding to the request. It is not used for oneway handlers.
 	protocol.Responder,
 	error,

--- a/encoding/thrift/inbound.go
+++ b/encoding/thrift/inbound.go
@@ -47,41 +47,15 @@ type thriftOnewayHandler struct {
 }
 
 func (t thriftUnaryHandler) Handle(ctx context.Context, treq *transport.Request, rw transport.ResponseWriter) error {
-	if err := errors.ExpectEncodings(treq, Encoding); err != nil {
-		return err
-	}
-
-	ctx, call := encodingapi.NewInboundCall(ctx)
-	if err := call.ReadFromRequest(treq); err != nil {
-		return err
-	}
-
 	buf := bufferpool.Get()
 	defer bufferpool.Put(buf)
-	if _, err := buf.ReadFrom(treq.Body); err != nil {
+
+	ctx, call, reqValue, responder, err := decodeRequest(ctx, buf, treq, wire.Call, t.Protocol, t.Enveloping)
+	if err != nil {
 		return err
 	}
 
-	// We disable enveloping if either the client or the transport requires it.
-	proto := t.Protocol
-	if !t.Enveloping {
-		proto = disableEnvelopingProtocol{
-			Protocol: proto,
-			Type:     wire.Call, // we only decode requests
-		}
-	}
-
-	envelope, err := proto.DecodeEnveloped(bytes.NewReader(buf.Bytes()))
-	if err != nil {
-		return errors.RequestBodyDecodeError(treq, err)
-	}
-
-	if envelope.Type != wire.Call {
-		return errors.RequestBodyDecodeError(
-			treq, errUnexpectedEnvelopeType(envelope.Type))
-	}
-
-	res, err := t.UnaryHandler(ctx, envelope.Value)
+	res, err := t.UnaryHandler(ctx, reqValue)
 	if err != nil {
 		return err
 	}
@@ -101,58 +75,100 @@ func (t thriftUnaryHandler) Handle(ctx context.Context, treq *transport.Request,
 	}
 
 	if err := call.WriteToResponse(rw); err != nil {
+		// not reachable
 		return err
 	}
 
-	err = proto.EncodeEnveloped(wire.Envelope{
-		Name:  res.Body.MethodName(),
-		Type:  res.Body.EnvelopeType(),
-		SeqID: envelope.SeqID,
-		Value: value,
-	}, rw)
-	if err != nil {
+	if err = responder.EncodeResponse(value, wire.Reply, rw); err != nil {
 		return errors.ResponseBodyEncodeError(treq, err)
 	}
 
 	return nil
 }
 
-// TODO(apb): reduce commonality between Handle and HandleOneway
-
 func (t thriftOnewayHandler) HandleOneway(ctx context.Context, treq *transport.Request) error {
-	if err := errors.ExpectEncodings(treq, Encoding); err != nil {
-		return err
-	}
-
-	ctx, call := encodingapi.NewInboundCall(ctx)
-	if err := call.ReadFromRequest(treq); err != nil {
-		return err
-	}
-
 	buf := bufferpool.Get()
 	defer bufferpool.Put(buf)
-	if _, err := buf.ReadFrom(treq.Body); err != nil {
+
+	ctx, _, reqValue, _, err := decodeRequest(ctx, buf, treq, wire.OneWay, t.Protocol, t.Enveloping)
+	if err != nil {
 		return err
 	}
 
-	// We disable enveloping if either the client or the transport requires it.
-	proto := t.Protocol
-	if !t.Enveloping {
-		proto = disableEnvelopingProtocol{
-			Protocol: proto,
-			Type:     wire.OneWay, // we only decode oneway requests
+	return t.OnewayHandler(ctx, reqValue)
+}
+
+// decodeRequest is a utility shared by Unary and Oneway handlers, to decode
+// the request, regardless of enveloping.
+func decodeRequest(
+	parentCtx context.Context,
+	// buf is a byte buffer from the buffer pool, that will be released back to
+	// the buffer pool by the caller after it is finished with the decoded
+	// request payload. Thrift requests read sets, maps, and lists lazilly.
+	buf *bufferpool.Buffer,
+	treq *transport.Request,
+	// reqEnvelopeType indicates the expected envelope type, if an envelope is
+	// present.
+	reqEnvelopeType wire.EnvelopeType,
+	// proto is the encoding protocol (e.g., Binary) or an
+	// EnvelopeAgnosticProtocol (e.g., EnvelopeAgnosticBinary)
+	proto protocol.Protocol,
+	// enveloping indicates that requests must be enveloped, used only if the
+	// protocol is not envelope agnostic.
+	enveloping bool,
+) (
+	// ctx is a context including the inbound call.
+	ctx context.Context,
+	// call is an inboundCall populated from the transport request and context.
+	call *encodingapi.InboundCall,
+	// reqValue is the wire representation of the decoded request.
+	// decodeRequest does not surface the envelope.
+	reqValue wire.Value,
+	// responder indicates how to encode the response, with the enveloping
+	// strategy corresponding to the request. It is not used for oneway handlers.
+	responder protocol.Responder,
+	err error,
+) {
+	ctx = parentCtx
+
+	if err = errors.ExpectEncodings(treq, Encoding); err != nil {
+		return
+	}
+
+	ctx, call = encodingapi.NewInboundCall(ctx)
+	if err = call.ReadFromRequest(treq); err != nil {
+		// not reachable
+		return
+	}
+
+	if _, err = buf.ReadFrom(treq.Body); err != nil {
+		return
+	}
+
+	reader := bytes.NewReader(buf.Bytes())
+
+	// Discover or choose the appropriate envelope
+	if agnosticProto, ok := proto.(protocol.EnvelopeAgnosticProtocol); ok {
+		// Envelope-agnostic
+		reqValue, responder, err = agnosticProto.DecodeRequest(reqEnvelopeType, reader)
+	} else if enveloping {
+		// Enveloped
+		var envelope wire.Envelope
+		envelope, err = proto.DecodeEnveloped(reader)
+		if err != nil {
+			return
 		}
+		if envelope.Type != reqEnvelopeType {
+			err = errors.RequestBodyDecodeError(treq, errUnexpectedEnvelopeType(envelope.Type))
+			return
+		}
+		reqValue = envelope.Value
+		responder = protocol.EnvelopeV1Responder{Name: envelope.Name, SeqID: envelope.SeqID}
+	} else {
+		// Not-enveloped
+		reqValue, err = proto.Decode(reader, wire.TStruct)
+		responder = protocol.NoEnvelopeResponder
 	}
 
-	envelope, err := proto.DecodeEnveloped(bytes.NewReader(buf.Bytes()))
-	if err != nil {
-		return errors.RequestBodyDecodeError(treq, err)
-	}
-
-	if envelope.Type != wire.OneWay {
-		return errors.RequestBodyDecodeError(
-			treq, errUnexpectedEnvelopeType(envelope.Type))
-	}
-
-	return t.OnewayHandler(ctx, envelope.Value)
+	return
 }


### PR DESCRIPTION
This change reintroduces envelope-agnostic Thrift. This time without free-after-use bugs!

Unlike #1389, this moves the buffer pool work out to the caller, so that it throws the buffer back into the pool only after the handler has finished using the request.