### PR TITLE
Thread remaining HTTP transport options

### DIFF
--- a/transport/http/config.go
+++ b/transport/http/config.go
@@ -81,7 +81,11 @@ func (ts *transportSpec) Spec() yarpcconfig.TransportSpec {
 //  transports:
 //    http:
 //      keepAlive: 30s
+//      maxIdleConns: 2
 //      maxIdleConnsPerHost: 2
+//      disableKeepAlives: false
+//      disableCompression: false
+//      responseHeaderTimeout: 0s
 //      connTimeout: 500ms
 //      connBackoff:
 //        exponential:
@@ -93,10 +97,15 @@ func (ts *transportSpec) Spec() yarpcconfig.TransportSpec {
 type TransportConfig struct {
 	// Specifies the keep-alive period for all HTTP clients. This field is
 	// optional.
-	KeepAlive           time.Duration       `config:"keepAlive"`
-	MaxIdleConnsPerHost int                 `config:"maxIdleConnsPerHost"`
-	ConnTimeout         time.Duration       `config:"connTimeout"`
-	ConnBackoff         yarpcconfig.Backoff `config:"connBackoff"`
+	KeepAlive             time.Duration       `config:"keepAlive"`
+	MaxIdleConns          int                 `config:"maxIdleConns"`
+	MaxIdleConnsPerHost   int                 `config:"maxIdleConnsPerHost"`
+	IdleConnTimeout       time.Duration       `config:"idleConnTimeout"`
+	DisableKeepAlives     bool                `config:"disableKeepAlives"`
+	DisableCompression    bool                `config:"disableCompression"`
+	ResponseHeaderTimeout time.Duration       `config:"responseHeaderTimeout"`
+	ConnTimeout           time.Duration       `config:"connTimeout"`
+	ConnBackoff           yarpcconfig.Backoff `config:"connBackoff"`
 }
 
 func (ts *transportSpec) buildTransport(tc *TransportConfig, k *yarpcconfig.Kit) (transport.Transport, error) {
@@ -109,8 +118,20 @@ func (ts *transportSpec) buildTransport(tc *TransportConfig, k *yarpcconfig.Kit)
 	if tc.KeepAlive > 0 {
 		options.keepAlive = tc.KeepAlive
 	}
+	if tc.MaxIdleConns > 0 {
+		options.maxIdleConns = tc.MaxIdleConns
+	}
 	if tc.MaxIdleConnsPerHost > 0 {
 		options.maxIdleConnsPerHost = tc.MaxIdleConnsPerHost
+	}
+	if tc.DisableKeepAlives {
+		options.disableKeepAlives = true
+	}
+	if tc.DisableCompression {
+		options.disableCompression = true
+	}
+	if tc.ResponseHeaderTimeout > 0 {
+		options.responseHeaderTimeout = tc.ResponseHeaderTimeout
 	}
 	if tc.ConnTimeout > 0 {
 		options.connTimeout = tc.ConnTimeout

--- a/transport/http/transport.go
+++ b/transport/http/transport.go
@@ -111,8 +111,10 @@ func IdleConnTimeout(t time.Duration) TransportOption {
 
 // DisableKeepAlives prevents re-use of TCP connections between different HTTP
 // requests.
-var DisableKeepAlives TransportOption = func(options *transportOptions) {
-	options.disableKeepAlives = true
+func DisableKeepAlives() TransportOption {
+	return func(options *transportOptions) {
+		options.disableKeepAlives = true
+	}
 }
 
 // DisableCompression if true prevents the Transport from requesting
@@ -121,8 +123,10 @@ var DisableKeepAlives TransportOption = func(options *transportOptions) {
 // on its own and gets a gzipped response, it's transparently decoded in the
 // Response.Body. However, if the user explicitly requested gzip it is not
 // automatically uncompressed.
-var DisableCompression TransportOption = func(options *transportOptions) {
-	options.disableCompression = true
+func DisableCompression() TransportOption {
+	return func(options *transportOptions) {
+		options.disableCompression = true
+	}
 }
 
 // ResponseHeaderTimeout if non-zero specifies the amount of time to wait for

--- a/transport/http/transport.go
+++ b/transport/http/transport.go
@@ -37,13 +37,18 @@ import (
 )
 
 type transportOptions struct {
-	keepAlive           time.Duration
-	maxIdleConnsPerHost int
-	connTimeout         time.Duration
-	connBackoffStrategy backoffapi.Strategy
-	tracer              opentracing.Tracer
-	buildClient         func(*transportOptions) *http.Client
-	logger              *zap.Logger
+	keepAlive             time.Duration
+	maxIdleConns          int
+	maxIdleConnsPerHost   int
+	idleConnTimeout       time.Duration
+	disableKeepAlives     bool
+	disableCompression    bool
+	responseHeaderTimeout time.Duration
+	connTimeout           time.Duration
+	connBackoffStrategy   backoffapi.Strategy
+	tracer                opentracing.Tracer
+	buildClient           func(*transportOptions) *http.Client
+	logger                *zap.Logger
 }
 
 var defaultTransportOptions = transportOptions{
@@ -75,6 +80,14 @@ func KeepAlive(t time.Duration) TransportOption {
 	}
 }
 
+// MaxIdleConns controls the maximum number of idle (keep-alive) connections
+// across all hosts. Zero means no limit.
+func MaxIdleConns(i int) TransportOption {
+	return func(options *transportOptions) {
+		options.maxIdleConns = i
+	}
+}
+
 // MaxIdleConnsPerHost specifies the number of idle (keep-alive) HTTP
 // connections that will be maintained per host.
 // Existing idle connections will be used instead of creating new HTTP
@@ -84,6 +97,41 @@ func KeepAlive(t time.Duration) TransportOption {
 func MaxIdleConnsPerHost(i int) TransportOption {
 	return func(options *transportOptions) {
 		options.maxIdleConnsPerHost = i
+	}
+}
+
+// IdleConnTimeout is the maximum amount of time an idle (keep-alive)
+// connection will remain idle before closing itself.
+// Zero means no limit.
+func IdleConnTimeout(t time.Duration) TransportOption {
+	return func(options *transportOptions) {
+		options.idleConnTimeout = t
+	}
+}
+
+// DisableKeepAlives prevents re-use of TCP connections between different HTTP
+// requests.
+var DisableKeepAlives TransportOption = func(options *transportOptions) {
+	options.disableKeepAlives = true
+}
+
+// DisableCompression, if true, prevents the Transport from requesting
+// compression with an "Accept-Encoding: gzip" request header when the Request
+// contains no existing Accept-Encoding value. If the Transport requests gzip
+// on its own and gets a gzipped response, it's transparently decoded in the
+// Response.Body. However, if the user explicitly requested gzip it is not
+// automatically uncompressed.
+var DisableCompression TransportOption = func(options *transportOptions) {
+	options.disableCompression = true
+}
+
+// ResponseHeaderTimeout, if non-zero, specifies the amount of time to wait for
+// a server's response headers after fully writing the request (including its
+// body, if any).  This time does not include the time to read the response
+// body.
+func ResponseHeaderTimeout(t time.Duration) TransportOption {
+	return func(options *transportOptions) {
+		options.responseHeaderTimeout = t
 	}
 }
 
@@ -170,7 +218,12 @@ func buildHTTPClient(options *transportOptions) *http.Client {
 			}).Dial,
 			TLSHandshakeTimeout:   10 * time.Second,
 			ExpectContinueTimeout: 1 * time.Second,
+			MaxIdleConns:          options.maxIdleConns,
 			MaxIdleConnsPerHost:   options.maxIdleConnsPerHost,
+			IdleConnTimeout:       options.idleConnTimeout,
+			DisableKeepAlives:     options.disableKeepAlives,
+			DisableCompression:    options.disableCompression,
+			ResponseHeaderTimeout: options.responseHeaderTimeout,
 		},
 	}
 }

--- a/transport/http/transport.go
+++ b/transport/http/transport.go
@@ -115,7 +115,7 @@ var DisableKeepAlives TransportOption = func(options *transportOptions) {
 	options.disableKeepAlives = true
 }
 
-// DisableCompression, if true, prevents the Transport from requesting
+// DisableCompression if true prevents the Transport from requesting
 // compression with an "Accept-Encoding: gzip" request header when the Request
 // contains no existing Accept-Encoding value. If the Transport requests gzip
 // on its own and gets a gzipped response, it's transparently decoded in the
@@ -125,7 +125,7 @@ var DisableCompression TransportOption = func(options *transportOptions) {
 	options.disableCompression = true
 }
 
-// ResponseHeaderTimeout, if non-zero, specifies the amount of time to wait for
+// ResponseHeaderTimeout if non-zero specifies the amount of time to wait for
 // a server's response headers after fully writing the request (including its
 // body, if any).  This time does not include the time to read the response
 // body.

--- a/transport/http/transport_test.go
+++ b/transport/http/transport_test.go
@@ -22,6 +22,7 @@ package http
 
 import (
 	"testing"
+	"time"
 
 	"github.com/crossdock/crossdock-go/assert"
 	"github.com/golang/mock/gomock"
@@ -281,18 +282,18 @@ func TestTransportClient(t *testing.T) {
 	assert.NotNil(t, transport.client)
 }
 
-func TestTransportClientWithKeepAlive(t *testing.T) {
+func TestTransportClientOpaqueOptions(t *testing.T) {
 	// Unfortunately the KeepAlive is obfuscated in the client, so we can't really
 	// assert this worked.
-	transport := NewTransport(KeepAlive(testtime.Second))
-
-	assert.NotNil(t, transport.client)
-}
-
-func TestTransportClientWithMaxIdleConnections(t *testing.T) {
-	// Unfortunately the MaxIdleConnsPerHost is obfuscated in the client, so we can't really
-	// assert this worked.
-	transport := NewTransport(MaxIdleConnsPerHost(100))
+	transport := NewTransport(
+		KeepAlive(testtime.Second),
+		MaxIdleConns(100),
+		MaxIdleConnsPerHost(10),
+		IdleConnTimeout(1*time.Second),
+		DisableCompression(),
+		DisableKeepAlives(),
+		ResponseHeaderTimeout(1*time.Second),
+	)
 
 	assert.NotNil(t, transport.client)
 }


### PR DESCRIPTION
I suspect some connection health issues, would be mitigated by disabiling keep
alives, for some cases.

This change adds options and config properties to thread the remaining options
supported by the underlying HTTP transport implementation.

- [x] cover new options