### PR TITLE
Add HTTP peer connection suspect state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.28.0] - 2018-03-13
 ### Changed
 - Enabled random shuffling of peerlist order by default.
+- The HTTP protocol now mitigates peers that are unavailable due to a half-open
+  TCP connection.
+  Previously, if a peer shut down unexpectedly, it might fail to send a TCP FIN
+  packet, leaving the sender unaware that the peer is unavailable.
+  The symptom is that requests sent down this connection will time out.
+  This change introduces a suspicion window for peers that time out.
+  Once per suspicion window, the HTTP transport's peer manager will attempt
+  to establish a fresh TCP connection to the peer.
+  Failing to establish a connection will transition the peer to the unavailable
+  state until a fresh TCP connection becomes available.
+  The HTTP transport now accepts an `InnocenceWindow` duration, and an
+  `innocenceWindow` config field.
 ### Added
 - Reintroduce envelope-agnostic Thrift inbounds. Thrift inbounds will now
   accept Thrift requests with or without envelopes.  This feature was

--- a/internal/examples/thrift-hello/hello/main.go
+++ b/internal/examples/thrift-hello/hello/main.go
@@ -31,15 +31,22 @@ import (
 	"time"
 
 	"go.uber.org/yarpc"
+	apipeer "go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/internal/examples/thrift-hello/hello/echo"
 	"go.uber.org/yarpc/internal/examples/thrift-hello/hello/echo/helloclient"
 	"go.uber.org/yarpc/internal/examples/thrift-hello/hello/echo/helloserver"
+	"go.uber.org/yarpc/peer"
+	"go.uber.org/yarpc/peer/hostport"
+	"go.uber.org/yarpc/peer/pendingheap"
+	"go.uber.org/yarpc/peer/roundrobin"
 	"go.uber.org/yarpc/transport/http"
 )
 
 var (
-	flagSet  = flag.NewFlagSet("thrift-hello", flag.ExitOnError)
-	flagWait = flagSet.Bool("wait", false, "Wait for a signal to exit")
+	flagSet   = flag.NewFlagSet("thrift-hello", flag.ExitOnError)
+	flagWait  = flagSet.Bool("wait", false, "Wait for a signal to exit")
+	flagRR    = flagSet.Bool("round-robin", false, "Use round-robin instead of fewest-pending-requests load balancer")
+	flagCount = flagSet.Int("count", 1, "How many requests to send, or -1 to run indefinitely")
 )
 
 func main() {
@@ -52,18 +59,35 @@ func do() error {
 	if err := flagSet.Parse(os.Args[1:]); err != nil {
 		return err
 	}
-	// configure a YARPC dispatcher for the service "hello",
+	// Configure a YARPC dispatcher for the service "hello",
 	// expose the service over an HTTP inbound on port 8086,
 	// and configure outbound calls to service "hello" over HTTP port 8086 as well
 	http := http.NewTransport()
+
+	// Choose a load balancer (peer list)
+	var pl apipeer.ChooserList
+	if *flagRR {
+		pl = roundrobin.New(http)
+	} else {
+		pl = pendingheap.New(http)
+	}
+
+	// Bind the peer list to a peer list updater (static peers), making the
+	// peer chooser.
+	pc := peer.Bind(pl, peer.BindPeers([]apipeer.Identifier{
+		hostport.Identify("127.0.0.1:8086"),
+		hostport.Identify("127.0.0.2:8086"),
+		hostport.Identify("127.0.0.3:8086"),
+	}))
+
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name: "hello",
 		Inbounds: yarpc.Inbounds{
-			http.NewInbound("127.0.0.1:8086"),
+			http.NewInbound(":8086"),
 		},
 		Outbounds: yarpc.Outbounds{
 			"hello": {
-				Unary: http.NewSingleOutbound("http://127.0.0.1:8086"),
+				Unary: http.NewOutbound(pc),
 			},
 		},
 	})
@@ -83,16 +107,21 @@ func do() error {
 	// using the dispatcher and associated "hello" outbound
 	client := helloclient.New(dispatcher.ClientConfig("hello"))
 
-	// build a context with a 1 second deadline
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
+	for i := 0; i != *flagCount; i++ {
+		// build a context with a 1 second deadline
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 
-	// use the Thrift client to call the Echo procedure using YARPC
-	res, err := client.Echo(ctx, &echo.EchoRequest{Message: "Hello world", Count: 1})
-	if err != nil {
-		return err
+		// use the Thrift client to call the Echo procedure using YARPC
+		res, err := client.Echo(ctx, &echo.EchoRequest{Message: "Hello world", Count: 1})
+		if err != nil {
+			fmt.Println(err)
+		} else {
+			fmt.Println(res)
+		}
+
+		cancel()
+		time.Sleep(100 * time.Millisecond)
 	}
-	fmt.Println(res)
 
 	if *flagWait {
 		// Gracefully shut down if we receive an interrupt (^C) or a kill signal.

--- a/internal/integrationtest/util.go
+++ b/internal/integrationtest/util.go
@@ -232,6 +232,6 @@ func Register(dispatcher *yarpc.Dispatcher) {
 	}))
 	dispatcher.Register(raw.Procedure("timeout", func(ctx context.Context, req []byte) ([]byte, error) {
 		<-ctx.Done()
-		return nil, nil
+		return nil, context.DeadlineExceeded
 	}))
 }

--- a/internal/integrationtest/util.go
+++ b/internal/integrationtest/util.go
@@ -219,10 +219,19 @@ func Call(ctx context.Context, rawClient raw.Client) error {
 	return nil
 }
 
+// Timeout sends a request to the client, which will timeout on the server.
+func Timeout(ctx context.Context, rawClient raw.Client) error {
+	_, err := rawClient.Call(ctx, "timeout", []byte{})
+	return err
+}
+
 // Register registers an echo procedure handler on a dispatcher.
 func Register(dispatcher *yarpc.Dispatcher) {
-	handle := func(ctx context.Context, req []byte) ([]byte, error) {
+	dispatcher.Register(raw.Procedure("echo", func(ctx context.Context, req []byte) ([]byte, error) {
 		return req, nil
-	}
-	dispatcher.Register(raw.Procedure("echo", handle))
+	}))
+	dispatcher.Register(raw.Procedure("timeout", func(ctx context.Context, req []byte) ([]byte, error) {
+		<-ctx.Done()
+		return nil, nil
+	}))
 }

--- a/transport/http/constants.go
+++ b/transport/http/constants.go
@@ -24,7 +24,10 @@ import "time"
 
 const transportName = "http"
 
-var defaultConnTimeout = 500 * time.Millisecond
+var (
+	defaultConnTimeout     = 500 * time.Millisecond
+	defaultInnocenceWindow = 5 * time.Second
+)
 
 // HTTP headers used in requests and responses to send YARPC metadata.
 const (

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -506,6 +506,11 @@ func (o *Outbound) doWithPeer(
 		default:
 		}
 		if err == context.DeadlineExceeded {
+			// Note that the connection experienced a time out, which may
+			// indicate that the connection is half-open, that the destination
+			// died without sending a TCP FIN packet.
+			p.OnSuspect()
+
 			end := time.Now()
 			return nil, yarpcerrors.Newf(
 				yarpcerrors.CodeDeadlineExceeded,

--- a/transport/http/peer.go
+++ b/transport/http/peer.go
@@ -21,7 +21,6 @@
 package http
 
 import (
-	"math/rand"
 	"net"
 	"time"
 
@@ -93,8 +92,8 @@ func (p *httpPeer) OnSuspect() {
 	// Extend the window of innocence from the current time.
 	// Use Store instead of CAS since races at worst extend the innocence
 	// window to relatively similar distant times.
-	jitter := rand.Int63n(p.transport.innocenceWindow.Nanoseconds())
-	p.innocentUntilUnixNano.Store(now + jitter)
+	innocentDurationUnixNano := p.transport.jitter(p.transport.innocenceWindow.Nanoseconds())
+	p.innocentUntilUnixNano.Store(now + innocentDurationUnixNano)
 
 	// Kick the state change channel (if it hasn't been kicked already).
 	// But leave status as available.

--- a/transport/http/peer.go
+++ b/transport/http/peer.go
@@ -21,9 +21,11 @@
 package http
 
 import (
+	"math/rand"
 	"net"
 	"time"
 
+	"go.uber.org/atomic"
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/peer/hostport"
 )
@@ -31,17 +33,21 @@ import (
 type httpPeer struct {
 	*hostport.Peer
 
-	transport *Transport
-	addr      string
-	changed   chan struct{}
-	released  chan struct{}
-	timer     *time.Timer
+	transport             *Transport
+	addr                  string
+	changed               chan struct{}
+	released              chan struct{}
+	timer                 *time.Timer
+	innocentUntilUnixNano *atomic.Int64
 }
 
 func newPeer(addr string, t *Transport) *httpPeer {
 	// Create a defused timer for later use.
 	timer := time.NewTimer(0)
 	if !timer.Stop() {
+		// not reachable, but if the timer wins the race, it would mean
+		// deadlock later, so best to conditionally drain the channel just in
+		// that case.
 		<-timer.C
 	}
 
@@ -52,6 +58,7 @@ func newPeer(addr string, t *Transport) *httpPeer {
 		changed:   make(chan struct{}, 1),
 		released:  make(chan struct{}, 0),
 		timer:     timer,
+		innocentUntilUnixNano: atomic.NewInt64(0),
 	}
 }
 
@@ -73,8 +80,32 @@ func (p *httpPeer) isAvailable() bool {
 	return false
 }
 
+func (p *httpPeer) OnSuspect() {
+	now := time.Now().UnixNano()
+	innocentUntil := p.innocentUntilUnixNano.Load()
+
+	// Do not check for connectivity after every request timeout.
+	// Spread them out so they only occur once in every innocence window.
+	if now < innocentUntil {
+		return
+	}
+
+	// Extend the window of innocence from the current time.
+	// Use Store instead of CAS since races at worst extend the innocence
+	// window to relatively similar distant times.
+	jitter := rand.Int63n(p.transport.innocenceWindow.Nanoseconds())
+	p.innocentUntilUnixNano.Store(now + jitter)
+
+	// Kick the state change channel (if it hasn't been kicked already).
+	// But leave status as available.
+	select {
+	case p.changed <- struct{}{}:
+	default:
+	}
+}
+
 func (p *httpPeer) OnDisconnected() {
-	p.Peer.SetStatus(peer.Unavailable)
+	p.Peer.SetStatus(peer.Connecting)
 
 	// Kick the state change channel (if it hasn't been kicked already).
 	select {
@@ -97,8 +128,11 @@ func (p *httpPeer) MaintainConn() {
 
 	// Attempt to retain an open connection to each peer so long as it is
 	// retained.
+	p.Peer.SetStatus(peer.Connecting)
 	for {
-		p.Peer.SetStatus(peer.Connecting)
+		// Invariant: Status is Connecting initially, or after exponential
+		// back-off, or after OnDisconnected, but still Available after
+		// OnSuspect.
 		if p.isAvailable() {
 			p.Peer.SetStatus(peer.Available)
 			// Reset on success
@@ -106,6 +140,8 @@ func (p *httpPeer) MaintainConn() {
 			if !p.waitForChange() {
 				break
 			}
+			// Invariant: the status is Connecting if change is triggered by
+			// OnDisconnected, but remains Available if triggered by OnSuspect.
 		} else {
 			p.Peer.SetStatus(peer.Unavailable)
 			// Back-off on fail
@@ -113,6 +149,7 @@ func (p *httpPeer) MaintainConn() {
 				break
 			}
 			attempts++
+			p.Peer.SetStatus(peer.Connecting)
 		}
 	}
 	p.Peer.SetStatus(peer.Unavailable)
@@ -131,8 +168,6 @@ func (p *httpPeer) waitForChange() (changed bool) {
 		return true
 	case <-p.released:
 		return false
-	case <-p.transport.once.Stopping():
-		return false
 	}
 }
 
@@ -150,6 +185,8 @@ func (p *httpPeer) sleep(delay time.Duration) (completed bool) {
 	}
 
 	if !p.timer.Stop() {
+		// This branch is very difficult to reach, as stopping a timer almost
+		// always succeeds.
 		<-p.timer.C
 	}
 	return false

--- a/transport/http/transport.go
+++ b/transport/http/transport.go
@@ -45,6 +45,7 @@ type transportOptions struct {
 	responseHeaderTimeout time.Duration
 	connTimeout           time.Duration
 	connBackoffStrategy   backoffapi.Strategy
+	innocenceWindow       time.Duration
 	tracer                opentracing.Tracer
 	buildClient           func(*transportOptions) *http.Client
 	logger                *zap.Logger
@@ -56,6 +57,7 @@ var defaultTransportOptions = transportOptions{
 	connTimeout:         defaultConnTimeout,
 	connBackoffStrategy: backoff.DefaultExponential,
 	buildClient:         buildHTTPClient,
+	innocenceWindow:     defaultInnocenceWindow,
 }
 
 func newTransportOptions() transportOptions {
@@ -160,6 +162,24 @@ func ConnBackoff(s backoffapi.Strategy) TransportOption {
 	}
 }
 
+// InnocenceWindow is the duration after the peer connection management loop
+// will suspend suspicion for a peer after successfully checking whether the
+// peer is live with a fresh TCP connection.
+//
+// The default innocence window is 5 seconds.
+//
+// A timeout does not necessarily indicate that a peer is unavailable,
+// but it could indicate that the connection is half-open, that the peer died
+// without sending a TCP FIN packet.
+// In this case, the peer connection management loop attempts to open a TCP
+// connection in the background, once per innocence window, while suspicious of
+// the connection, leaving the peer available until it fails.
+func InnocenceWindow(d time.Duration) TransportOption {
+	return func(options *transportOptions) {
+		options.innocenceWindow = d
+	}
+}
+
 // Tracer configures a tracer for the transport and all its inbounds and
 // outbounds.
 func Tracer(tracer opentracing.Tracer) TransportOption {
@@ -204,6 +224,7 @@ func (o *transportOptions) newTransport() *Transport {
 		client:              o.buildClient(o),
 		connTimeout:         o.connTimeout,
 		connBackoffStrategy: o.connBackoffStrategy,
+		innocenceWindow:     o.innocenceWindow,
 		peers:               make(map[string]*httpPeer),
 		tracer:              o.tracer,
 		logger:              logger,
@@ -244,6 +265,7 @@ type Transport struct {
 	connTimeout         time.Duration
 	connBackoffStrategy backoffapi.Strategy
 	connectorsGroup     sync.WaitGroup
+	innocenceWindow     time.Duration
 
 	tracer opentracing.Tracer
 	logger *zap.Logger

--- a/transport/http/transport_test.go
+++ b/transport/http/transport_test.go
@@ -31,6 +31,16 @@ import (
 	"go.uber.org/yarpc/internal/testtime"
 )
 
+// NoJitter is a transport option only available in tests, to disable jitter
+// between connection attempts.
+func NoJitter() TransportOption {
+	return func(options *transportOptions) {
+		options.jitter = func(n int64) int64 {
+			return n
+		}
+	}
+}
+
 type peerExpectation struct {
 	id          string
 	subscribers []string


### PR DESCRIPTION
This change causes the HTTP transport to suspect that a peer might be
disconnected if a request times out.
In some cases, this indicates that the connection is half open, that the
destination died without sending a TCP FIN packet.
In the suspect state, the peer will remain available while the peer manager
attempts to make a new connection in the background.
If the connection manager fails, the peer will be demoted to unavailable.

- [x] Ensure that the connection management loop backs off when available but 
  suspect.