### PR TITLE
Add options to use raw headers in TChannel transport

### DIFF
--- a/api/transport/header.go
+++ b/api/transport/header.go
@@ -38,6 +38,8 @@ func CanonicalizeHeaderKey(k string) string {
 type Headers struct {
 	// This representation allows us to make zero-value valid
 	items map[string]string
+	// non-canonicalized headers
+	rawItems map[string]string
 }
 
 // NewHeaders builds a new Headers object.
@@ -65,8 +67,12 @@ func (h Headers) With(k, v string) Headers {
 	if h.items == nil {
 		h.items = make(map[string]string)
 	}
+	if h.rawItems == nil {
+		h.rawItems = make(map[string]string)
+	}
 
 	h.items[CanonicalizeHeaderKey(k)] = v
+	h.rawItems[k] = v
 	return h
 }
 
@@ -75,6 +81,7 @@ func (h Headers) With(k, v string) Headers {
 // This is a no-op if the key does not exist.
 func (h Headers) Del(k string) {
 	delete(h.items, CanonicalizeHeaderKey(k))
+	delete(h.rawItems, k)
 }
 
 // Get retrieves the value associated with the given header name.
@@ -100,6 +107,16 @@ func (h Headers) Items() map[string]string {
 		return emptyMap
 	}
 	return h.items
+}
+
+// RawItems returns the non-canonicalized version of the underlying map
+// for this Headers object. The returned map MUST NOT be changed.
+// Doing so will result in undefined behavior.
+func (h Headers) RawItems() map[string]string {
+	if h.rawItems == nil {
+		return emptyMap
+	}
+	return h.rawItems
 }
 
 // HeadersFromMap builds a new Headers object from the given map of header

--- a/api/transport/header.go
+++ b/api/transport/header.go
@@ -40,6 +40,8 @@ type Headers struct {
 	items map[string]string
 	// original non-canonical headers, foo-bar will be treated as different value than Foo-bar
 	originalItems map[string]string
+	// cannoical to original mapping
+	toOriginal map[string]string
 }
 
 // NewHeaders builds a new Headers object.
@@ -56,6 +58,7 @@ func NewHeadersWithCapacity(capacity int) Headers {
 	return Headers{
 		items:         make(map[string]string, capacity),
 		originalItems: make(map[string]string, capacity),
+		toOriginal:    make(map[string]string, capacity),
 	}
 }
 
@@ -70,10 +73,16 @@ func (h Headers) With(k, v string) Headers {
 	if h.items == nil {
 		h.items = make(map[string]string)
 		h.originalItems = make(map[string]string)
+		h.toOriginal = make(map[string]string)
 	}
-
-	h.items[CanonicalizeHeaderKey(k)] = v
+	headerKey := CanonicalizeHeaderKey(k)
+	// remove from originalItem if canconical header is already present
+	if original, ok := h.toOriginal[headerKey]; ok {
+		delete(h.originalItems, original)
+	}
+	h.items[headerKey] = v
 	h.originalItems[k] = v
+	h.toOriginal[headerKey] = k
 	return h
 }
 
@@ -81,8 +90,12 @@ func (h Headers) With(k, v string) Headers {
 //
 // This is a no-op if the key does not exist.
 func (h Headers) Del(k string) {
-	delete(h.items, CanonicalizeHeaderKey(k))
-	delete(h.originalItems, k)
+	headerKey := CanonicalizeHeaderKey(k)
+	delete(h.items, headerKey)
+	if original, ok := h.toOriginal[headerKey]; ok {
+		delete(h.originalItems, original)
+	}
+	delete(h.toOriginal, headerKey)
 }
 
 // Get retrieves the value associated with the given header name.

--- a/api/transport/header.go
+++ b/api/transport/header.go
@@ -91,10 +91,10 @@ func (h Headers) With(k, v string) Headers {
 // This is a no-op if the key does not exist.
 func (h Headers) Del(k string) {
 	headerKey := CanonicalizeHeaderKey(k)
-	delete(h.items, headerKey)
 	if original, ok := h.toOriginal[headerKey]; ok {
 		delete(h.originalItems, original)
 	}
+	delete(h.items, headerKey)
 	delete(h.toOriginal, headerKey)
 }
 

--- a/api/transport/header.go
+++ b/api/transport/header.go
@@ -109,10 +109,10 @@ func (h Headers) Items() map[string]string {
 	return h.items
 }
 
-// ExactCaseItems returns the non-canonicalized version of the underlying map
+// OriginalItems returns the non-canonicalized version of the underlying map
 // for this Headers object. The returned map MUST NOT be changed.
 // Doing so will result in undefined behavior.
-func (h Headers) ExactCaseItems() map[string]string {
+func (h Headers) OriginalItems() map[string]string {
 	if h.originalItems == nil {
 		return emptyMap
 	}

--- a/api/transport/header.go
+++ b/api/transport/header.go
@@ -81,9 +81,8 @@ func (h Headers) With(k, v string) Headers {
 //
 // This is a no-op if the key does not exist.
 func (h Headers) Del(k string) {
-	canonicalizedKey := CanonicalizeHeaderKey(k)
-	delete(h.items, canonicalizedKey)
-	delete(h.originalItems, canonicalizedKey)
+	delete(h.items, CanonicalizeHeaderKey(k))
+	delete(h.originalItems, k)
 }
 
 // Get retrieves the value associated with the given header name.

--- a/api/transport/header_test.go
+++ b/api/transport/header_test.go
@@ -94,23 +94,22 @@ func TestItemsAndExactCaseItems(t *testing.T) {
 			"foo-bar-baz":  "FOO-BAR-BAZ",
 			"other-header": "other-value",
 		}
-		forwardingItems = map[string]string{
-			"foo-BAR-BaZ":  "foo-bar-baz",
+		exactCaseItems = map[string]string{
 			"Foo-bAr-baZ":  "FOO-BAR-BAZ",
 			"other-header": "other-value",
 		}
 		postDeletionItems = map[string]string{
-			"other-header": "other-value",
+			"foo-bar-baz": "FOO-BAR-BAZ",
 		}
 		postDeletionExactCaseItems1 = map[string]string{
-			"foo-BAR-BaZ":  "foo-bar-baz",
-			"Foo-bAr-baZ":  "FOO-BAR-BAZ",
-			"other-header": "other-value",
-		}
-		postDeletionExactCaseItems2 = map[string]string{
-			"foo-BAR-BaZ": "foo-bar-baz",
 			"Foo-bAr-baZ": "FOO-BAR-BAZ",
 		}
+		/*
+			postDeletionExactCaseItems2 = map[string]string{
+				"foo-BAR-BaZ": "foo-bar-baz",
+				"Foo-bAr-baZ": "FOO-BAR-BAZ",
+			}
+		*/
 	)
 
 	header := NewHeaders()
@@ -118,14 +117,15 @@ func TestItemsAndExactCaseItems(t *testing.T) {
 		header = header.With(v.key, v.val)
 	}
 
-	assert.Equal(t, forwardingItems, header.ExactCaseItems())
+	assert.Equal(t, exactCaseItems, header.ExactCaseItems())
 	assert.Equal(t, items, header.Items())
 
-	header.Del("foo-bar-BAZ")
+	header.Del("other-header")
 	assert.Equal(t, postDeletionItems, header.Items())
 	assert.Equal(t, postDeletionExactCaseItems1, header.ExactCaseItems())
 
-	header.Del("other-header")
+	header.Del("foo-bar-BAZ")
 	assert.Equal(t, map[string]string{}, header.Items())
-	assert.Equal(t, postDeletionExactCaseItems2, header.ExactCaseItems())
+	assert.Equal(t, map[string]string{}, header.ExactCaseItems())
+
 }

--- a/api/transport/header_test.go
+++ b/api/transport/header_test.go
@@ -102,10 +102,14 @@ func TestItemsAndExactCaseItems(t *testing.T) {
 		postDeletionItems = map[string]string{
 			"other-header": "other-value",
 		}
-		postDeletionExactCaseItems = map[string]string{
+		postDeletionExactCaseItems1 = map[string]string{
 			"foo-BAR-BaZ":  "foo-bar-baz",
 			"Foo-bAr-baZ":  "FOO-BAR-BAZ",
 			"other-header": "other-value",
+		}
+		postDeletionExactCaseItems2 = map[string]string{
+			"foo-BAR-BaZ": "foo-bar-baz",
+			"Foo-bAr-baZ": "FOO-BAR-BAZ",
 		}
 	)
 
@@ -119,5 +123,9 @@ func TestItemsAndExactCaseItems(t *testing.T) {
 
 	header.Del("foo-bar-BAZ")
 	assert.Equal(t, postDeletionItems, header.Items())
-	assert.Equal(t, postDeletionExactCaseItems, header.ExactCaseItems())
+	assert.Equal(t, postDeletionExactCaseItems1, header.ExactCaseItems())
+
+	header.Del("other-header")
+	assert.Equal(t, map[string]string{}, header.Items())
+	assert.Equal(t, postDeletionExactCaseItems2, header.ExactCaseItems())
 }

--- a/api/transport/header_test.go
+++ b/api/transport/header_test.go
@@ -80,3 +80,14 @@ func TestNewHeaders(t *testing.T) {
 		}
 	}
 }
+
+func TestItemsAndRawItems(t *testing.T) {
+	const (
+		headerKey          = "foo-BAR-BaZ"
+		headerKeyLowercase = "foo-bar-baz"
+		headerVal          = "FooBarBaz"
+	)
+	header := NewHeaders().With(headerKey, headerVal)
+	assert.Equal(t, map[string]string{headerKey: headerVal}, header.RawItems())
+	assert.Equal(t, map[string]string{headerKeyLowercase: headerVal}, header.Items())
+}

--- a/api/transport/header_test.go
+++ b/api/transport/header_test.go
@@ -83,10 +83,12 @@ func TestNewHeaders(t *testing.T) {
 
 func TestItemsAndForwardingItems(t *testing.T) {
 	var (
-		h = map[string]string{
-			"foo-BAR-BaZ":  "foo-bar-baz",
-			"Foo-bAr-baZ":  "FOO-BAR-BAZ",
-			"other-header": "other-value",
+		h = []struct {
+			key, val string
+		}{
+			{"foo-BAR-BaZ", "foo-bar-baz"},
+			{"Foo-bAr-baZ", "FOO-BAR-BAZ"},
+			{"other-header", "other-value"},
 		}
 		items = map[string]string{
 			"foo-bar-baz":  "FOO-BAR-BAZ",
@@ -102,8 +104,8 @@ func TestItemsAndForwardingItems(t *testing.T) {
 	)
 
 	header := NewHeaders()
-	for k, v := range h {
-		header = header.With(k, v)
+	for _, v := range h {
+		header = header.With(v.key, v.val)
 	}
 
 	assert.Equal(t, forwardingItems, header.ForwardingItems())

--- a/api/transport/header_test.go
+++ b/api/transport/header_test.go
@@ -95,77 +95,77 @@ func TestItemsAndExactCaseItems(t *testing.T) {
 		postDeletionExactCaseItems map[string]string
 	}{
 		{
-			"delete lowercase/canonical key",
-			"other-header",
-			[]headers{
+			msg:         "delete lowercase/canonical key",
+			toDeleteKey: "other-header",
+			headers: []headers{
 				{"foo-BAR-BaZ", "foo-bar-baz"},
 				{"Foo-bAr-baZ", "FOO-BAR-BAZ"},
 				{"other-header", "other-value"},
 			},
-			map[string]string{
+			preDeletionItems: map[string]string{
 				"foo-bar-baz":  "FOO-BAR-BAZ",
 				"other-header": "other-value",
 			},
-			map[string]string{
+			postDeletionItems: map[string]string{
 				"foo-bar-baz": "FOO-BAR-BAZ",
 			},
-			map[string]string{
+			preDeletionExactCaseItems: map[string]string{
 				"foo-BAR-BaZ":  "foo-bar-baz",
 				"Foo-bAr-baZ":  "FOO-BAR-BAZ",
 				"other-header": "other-value",
 			},
-			map[string]string{
+			postDeletionExactCaseItems: map[string]string{
 				"foo-BAR-BaZ": "foo-bar-baz",
 				"Foo-bAr-baZ": "FOO-BAR-BAZ",
 			},
 		},
 		{
-			"delete non-canonical key that does not exist in originalItem",
-			"fOo-BAR-Baz",
-			[]headers{
+			msg:         "delete non-canonical key that does not exist in originalItem",
+			toDeleteKey: "fOo-BAR-Baz",
+			headers: []headers{
 				{"foo-BAR-BaZ", "foo-bar-baz"},
 				{"Foo-bAr-baZ", "FOO-BAR-BAZ"},
 				{"other-header", "other-value"},
 			},
-			map[string]string{
+			preDeletionItems: map[string]string{
 				"foo-bar-baz":  "FOO-BAR-BAZ",
 				"other-header": "other-value",
 			},
-			map[string]string{
+			postDeletionItems: map[string]string{
 				"other-header": "other-value",
 			},
-			map[string]string{
+			preDeletionExactCaseItems: map[string]string{
 				"foo-BAR-BaZ":  "foo-bar-baz",
 				"Foo-bAr-baZ":  "FOO-BAR-BAZ",
 				"other-header": "other-value",
 			},
-			map[string]string{
+			postDeletionExactCaseItems: map[string]string{
 				"foo-BAR-BaZ":  "foo-bar-baz",
 				"Foo-bAr-baZ":  "FOO-BAR-BAZ",
 				"other-header": "other-value",
 			},
 		},
 		{
-			"delete non-canonical key that also exists in originalItem",
-			"foo-BAR-BaZ",
-			[]headers{
+			msg:         "delete non-canonical key that also exists in originalItem",
+			toDeleteKey: "foo-BAR-BaZ",
+			headers: []headers{
 				{"foo-BAR-BaZ", "foo-bar-baz"},
 				{"Foo-bAr-baZ", "FOO-BAR-BAZ"},
 				{"other-header", "other-value"},
 			},
-			map[string]string{
+			preDeletionItems: map[string]string{
 				"foo-bar-baz":  "FOO-BAR-BAZ",
 				"other-header": "other-value",
 			},
-			map[string]string{
+			postDeletionItems: map[string]string{
 				"other-header": "other-value",
 			},
-			map[string]string{
+			preDeletionExactCaseItems: map[string]string{
 				"foo-BAR-BaZ":  "foo-bar-baz",
 				"Foo-bAr-baZ":  "FOO-BAR-BAZ",
 				"other-header": "other-value",
 			},
-			map[string]string{
+			postDeletionExactCaseItems: map[string]string{
 				"Foo-bAr-baZ":  "FOO-BAR-BAZ",
 				"other-header": "other-value",
 			},

--- a/api/transport/header_test.go
+++ b/api/transport/header_test.go
@@ -104,12 +104,6 @@ func TestItemsAndExactCaseItems(t *testing.T) {
 		postDeletionExactCaseItems1 = map[string]string{
 			"Foo-bAr-baZ": "FOO-BAR-BAZ",
 		}
-		/*
-			postDeletionExactCaseItems2 = map[string]string{
-				"foo-BAR-BaZ": "foo-bar-baz",
-				"Foo-bAr-baZ": "FOO-BAR-BAZ",
-			}
-		*/
 	)
 
 	header := NewHeaders()

--- a/api/transport/header_test.go
+++ b/api/transport/header_test.go
@@ -81,18 +81,18 @@ func TestNewHeaders(t *testing.T) {
 	}
 }
 
-func TestItemsAndExactCaseItems(t *testing.T) {
+func TestItemsAndOriginalItems(t *testing.T) {
 	type headers struct {
 		key, val string
 	}
 	tests := []struct {
-		msg                        string
-		toDeleteKey                string
-		headers                    []headers
-		preDeletionItems           map[string]string
-		postDeletionItems          map[string]string
-		preDeletionExactCaseItems  map[string]string
-		postDeletionExactCaseItems map[string]string
+		msg                       string
+		toDeleteKey               string
+		headers                   []headers
+		preDeletionItems          map[string]string
+		postDeletionItems         map[string]string
+		preDeletionOriginalItems  map[string]string
+		postDeletionOriginalItems map[string]string
 	}{
 		{
 			msg:         "delete lowercase/canonical key",
@@ -109,12 +109,12 @@ func TestItemsAndExactCaseItems(t *testing.T) {
 			postDeletionItems: map[string]string{
 				"foo-bar-baz": "FOO-BAR-BAZ",
 			},
-			preDeletionExactCaseItems: map[string]string{
+			preDeletionOriginalItems: map[string]string{
 				"foo-BAR-BaZ":  "foo-bar-baz",
 				"Foo-bAr-baZ":  "FOO-BAR-BAZ",
 				"other-header": "other-value",
 			},
-			postDeletionExactCaseItems: map[string]string{
+			postDeletionOriginalItems: map[string]string{
 				"foo-BAR-BaZ": "foo-bar-baz",
 				"Foo-bAr-baZ": "FOO-BAR-BAZ",
 			},
@@ -134,12 +134,12 @@ func TestItemsAndExactCaseItems(t *testing.T) {
 			postDeletionItems: map[string]string{
 				"other-header": "other-value",
 			},
-			preDeletionExactCaseItems: map[string]string{
+			preDeletionOriginalItems: map[string]string{
 				"foo-BAR-BaZ":  "foo-bar-baz",
 				"Foo-bAr-baZ":  "FOO-BAR-BAZ",
 				"other-header": "other-value",
 			},
-			postDeletionExactCaseItems: map[string]string{
+			postDeletionOriginalItems: map[string]string{
 				"foo-BAR-BaZ":  "foo-bar-baz",
 				"Foo-bAr-baZ":  "FOO-BAR-BAZ",
 				"other-header": "other-value",
@@ -160,12 +160,12 @@ func TestItemsAndExactCaseItems(t *testing.T) {
 			postDeletionItems: map[string]string{
 				"other-header": "other-value",
 			},
-			preDeletionExactCaseItems: map[string]string{
+			preDeletionOriginalItems: map[string]string{
 				"foo-BAR-BaZ":  "foo-bar-baz",
 				"Foo-bAr-baZ":  "FOO-BAR-BAZ",
 				"other-header": "other-value",
 			},
-			postDeletionExactCaseItems: map[string]string{
+			postDeletionOriginalItems: map[string]string{
 				"Foo-bAr-baZ":  "FOO-BAR-BAZ",
 				"other-header": "other-value",
 			},
@@ -180,11 +180,11 @@ func TestItemsAndExactCaseItems(t *testing.T) {
 			}
 
 			assert.Equal(t, tt.preDeletionItems, header.Items())
-			assert.Equal(t, tt.preDeletionExactCaseItems, header.ExactCaseItems())
+			assert.Equal(t, tt.preDeletionOriginalItems, header.OriginalItems())
 
 			header.Del(tt.toDeleteKey)
 			assert.Equal(t, tt.postDeletionItems, header.Items())
-			assert.Equal(t, tt.postDeletionExactCaseItems, header.ExactCaseItems())
+			assert.Equal(t, tt.postDeletionOriginalItems, header.OriginalItems())
 		})
 	}
 }

--- a/api/transport/header_test.go
+++ b/api/transport/header_test.go
@@ -81,13 +81,35 @@ func TestNewHeaders(t *testing.T) {
 	}
 }
 
-func TestItemsAndRawItems(t *testing.T) {
-	const (
-		headerKey          = "foo-BAR-BaZ"
-		headerKeyLowercase = "foo-bar-baz"
-		headerVal          = "FooBarBaz"
+func TestItemsAndForwardingItems(t *testing.T) {
+	var (
+		h = map[string]string{
+			"foo-BAR-BaZ":  "foo-bar-baz",
+			"Foo-bAr-baZ":  "FOO-BAR-BAZ",
+			"other-header": "other-value",
+		}
+		items = map[string]string{
+			"foo-bar-baz":  "FOO-BAR-BAZ",
+			"other-header": "other-value",
+		}
+		forwardingItems = map[string]string{
+			"Foo-bAr-baZ":  "FOO-BAR-BAZ",
+			"other-header": "other-value",
+		}
+		afterDeletion = map[string]string{
+			"other-header": "other-value",
+		}
 	)
-	header := NewHeaders().With(headerKey, headerVal)
-	assert.Equal(t, map[string]string{headerKey: headerVal}, header.RawItems())
-	assert.Equal(t, map[string]string{headerKeyLowercase: headerVal}, header.Items())
+
+	header := NewHeaders()
+	for k, v := range h {
+		header = header.With(k, v)
+	}
+
+	assert.Equal(t, forwardingItems, header.ForwardingItems())
+	assert.Equal(t, items, header.Items())
+
+	header.Del("foo-bar-BAZ")
+	assert.Equal(t, afterDeletion, header.ForwardingItems())
+	assert.Equal(t, afterDeletion, header.Items())
 }

--- a/api/transport/header_test.go
+++ b/api/transport/header_test.go
@@ -81,7 +81,7 @@ func TestNewHeaders(t *testing.T) {
 	}
 }
 
-func TestItemsAndForwardingItems(t *testing.T) {
+func TestItemsAndExactCaseItems(t *testing.T) {
 	var (
 		h = []struct {
 			key, val string
@@ -95,10 +95,16 @@ func TestItemsAndForwardingItems(t *testing.T) {
 			"other-header": "other-value",
 		}
 		forwardingItems = map[string]string{
+			"foo-BAR-BaZ":  "foo-bar-baz",
 			"Foo-bAr-baZ":  "FOO-BAR-BAZ",
 			"other-header": "other-value",
 		}
-		afterDeletion = map[string]string{
+		postDeletionItems = map[string]string{
+			"other-header": "other-value",
+		}
+		postDeletionExactCaseItems = map[string]string{
+			"foo-BAR-BaZ":  "foo-bar-baz",
+			"Foo-bAr-baZ":  "FOO-BAR-BAZ",
 			"other-header": "other-value",
 		}
 	)
@@ -108,10 +114,10 @@ func TestItemsAndForwardingItems(t *testing.T) {
 		header = header.With(v.key, v.val)
 	}
 
-	assert.Equal(t, forwardingItems, header.ForwardingItems())
+	assert.Equal(t, forwardingItems, header.ExactCaseItems())
 	assert.Equal(t, items, header.Items())
 
 	header.Del("foo-bar-BAZ")
-	assert.Equal(t, afterDeletion, header.ForwardingItems())
-	assert.Equal(t, afterDeletion, header.Items())
+	assert.Equal(t, postDeletionItems, header.Items())
+	assert.Equal(t, postDeletionExactCaseItems, header.ExactCaseItems())
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 7c7d875c128e2f5ee2218b87f3ec2b6fb335279d1cda2657c6cc4eb92a2ecdb9
-updated: 2018-01-31T14:57:48.544493-08:00
+updated: 2018-02-01T17:36:42.499728-08:00
 imports:
 - name: github.com/apache/thrift
   version: 53dd39833a08ce33582e5ff31fa18bb4735d6731
@@ -103,7 +103,7 @@ imports:
   - thrift-gen/zipkincore
   - utils
 - name: github.com/uber/tchannel-go
-  version: 7bcb33f4bb908c21374f8bfdc9d4b1ebcbb8dab0
+  version: acd4eb54c11531814d9cd0344fdc53bebe86ab12
   subpackages:
   - internal/argreader
   - json
@@ -168,7 +168,7 @@ imports:
   - zapcore
   - zaptest/observer
 - name: golang.org/x/net
-  version: 0ed95abb35c445290478a5348a7b38bb154135fd
+  version: b417086c80e91bfa321ef761574721644b8b9f61
   repo: https://github.com/golang/net
   subpackages:
   - bpf

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 7c7d875c128e2f5ee2218b87f3ec2b6fb335279d1cda2657c6cc4eb92a2ecdb9
-updated: 2018-02-04T14:32:04.466459-08:00
+updated: 2018-02-04T15:09:19.499281-08:00
 imports:
 - name: github.com/apache/thrift
   version: 53dd39833a08ce33582e5ff31fa18bb4735d6731
@@ -17,7 +17,7 @@ imports:
   - assert
   - require
 - name: github.com/davecgh/go-spew
-  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  version: 87df7c60d5820d0f8ae11afede5aa52325c09717
   subpackages:
   - spew
 - name: github.com/facebookgo/clock
@@ -36,7 +36,7 @@ imports:
   subpackages:
   - gomock
 - name: github.com/golang/protobuf
-  version: 17ce1425424ab154092bbb43af630bd647f3bb0d
+  version: bbd03ef6da3a115852eaf24c8a1c46aeb39aa175
   subpackages:
   - proto
   - ptypes
@@ -56,7 +56,7 @@ imports:
   - log
   - mocktracer
 - name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib
 - name: github.com/prometheus/client_golang
@@ -69,14 +69,16 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 2e54d0b93cba2fd133edc32211dcc32c06ef72ca
+  version: 89604d197083d4781071d3c65855d24ecfb0a563
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: a6e9df898b1336106c743392c48ee0b71f5c4efa
+  version: cb4147076ac75738c9a7d279075a253c0cc5acbd
   subpackages:
+  - internal/util
+  - nfs
   - xfs
 - name: github.com/stretchr/testify
   version: a726187e3128d0a0ec37f73ca7c4d3e508e6c2e5
@@ -185,22 +187,22 @@ imports:
   - lex/httplex
   - trace
 - name: golang.org/x/sys
-  version: a204229cd828a74741ee7b5da9bf4794497f85ed
+  version: 37707fdb30a5b38865cfb95e5aab41707daec7fd
   repo: https://github.com/golang/sys
 - name: golang.org/x/text
-  version: 2df9074612f50810d82416d2229398a1e7188c5c
+  version: e19ae1496984b1c655b8044a65c0300a3c878dd3
   subpackages:
   - secure/bidirule
   - transform
   - unicode/bidi
   - unicode/norm
 - name: golang.org/x/tools
-  version: 6d70fb2e85323e81c89374331d3d2b93304faa36
+  version: 66487607e2081c7c2af2281c62c14ee000d5024b
   repo: https://github.com/golang/tools
   subpackages:
   - go/ast/astutil
 - name: google.golang.org/genproto
-  version: 7f0da29060c682909f650ad8ed4e515bd74fa12a
+  version: 4eb30f4778eed4c258ba66527a0d4f9ec8a36c45
   subpackages:
   - googleapis/rpc/status
 - name: google.golang.org/grpc
@@ -229,10 +231,10 @@ imports:
   - tap
   - transport
 - name: gopkg.in/yaml.v2
-  version: a83829b6f1293c91addabc89d0571c246397bbf4
+  version: d670f9405373e636a5a2765eea47fac0c9bc91a4
 testImports:
 - name: github.com/codahale/hdrhistogram
-  version: f8ad88b59a584afeee9d334eff879b104439117b
+  version: 3a0bb77429bd3a61596f5e8a3172445844342120
 - name: github.com/golang/lint
   version: e14d9b0f1d332b1420c1ffa32562ad2dc84d645d
   subpackages:

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 7c7d875c128e2f5ee2218b87f3ec2b6fb335279d1cda2657c6cc4eb92a2ecdb9
-updated: 2018-01-17T11:45:33.306560761-08:00
+updated: 2018-02-04T15:09:19.499281-08:00
 imports:
 - name: github.com/apache/thrift
   version: 53dd39833a08ce33582e5ff31fa18bb4735d6731
@@ -17,7 +17,7 @@ imports:
   - assert
   - require
 - name: github.com/davecgh/go-spew
-  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
+  version: 87df7c60d5820d0f8ae11afede5aa52325c09717
   subpackages:
   - spew
 - name: github.com/facebookgo/clock
@@ -36,7 +36,7 @@ imports:
   subpackages:
   - gomock
 - name: github.com/golang/protobuf
-  version: 17ce1425424ab154092bbb43af630bd647f3bb0d
+  version: bbd03ef6da3a115852eaf24c8a1c46aeb39aa175
   subpackages:
   - proto
   - ptypes
@@ -56,7 +56,7 @@ imports:
   - log
   - mocktracer
 - name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib
 - name: github.com/prometheus/client_golang
@@ -65,21 +65,23 @@ imports:
   - prometheus
   - prometheus/promhttp
 - name: github.com/prometheus/client_model
-  version: 6f3806018612930941127f2a7c6c453ba2c527d2
+  version: 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 2f17f4a9d485bf34b4bfaccc273805040e4f86c8
+  version: 89604d197083d4781071d3c65855d24ecfb0a563
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: e645f4e5aaa8506fc71d6edbc5c4ff02c04c46f2
+  version: cb4147076ac75738c9a7d279075a253c0cc5acbd
   subpackages:
+  - internal/util
+  - nfs
   - xfs
 - name: github.com/stretchr/testify
-  version: 890a5c3458b43e6104ff5da8dfa139d013d77544
+  version: a726187e3128d0a0ec37f73ca7c4d3e508e6c2e5
   subpackages:
   - assert
   - require
@@ -103,7 +105,7 @@ imports:
   - thrift-gen/zipkincore
   - utils
 - name: github.com/uber/tchannel-go
-  version: 7bcb33f4bb908c21374f8bfdc9d4b1ebcbb8dab0
+  version: acd4eb54c11531814d9cd0344fdc53bebe86ab12
   subpackages:
   - internal/argreader
   - json
@@ -168,7 +170,7 @@ imports:
   - zapcore
   - zaptest/observer
 - name: golang.org/x/net
-  version: ab555f366c4508dbe0802550b1b20c46c5c18aa0
+  version: 2fb46b16b8dda405028c50f7c7f0f9dd1fa6bfb1
   repo: https://github.com/golang/net
   subpackages:
   - bpf
@@ -185,26 +187,26 @@ imports:
   - lex/httplex
   - trace
 - name: golang.org/x/sys
-  version: 53aa286056ef226755cd898109dbcdaba8ac0b81
+  version: 37707fdb30a5b38865cfb95e5aab41707daec7fd
   repo: https://github.com/golang/sys
 - name: golang.org/x/text
-  version: acd49d43e9b95df46670431bf5c7ae59586daad8
+  version: e19ae1496984b1c655b8044a65c0300a3c878dd3
   subpackages:
   - secure/bidirule
   - transform
   - unicode/bidi
   - unicode/norm
 - name: golang.org/x/tools
-  version: 64890f4e2b733655fee5077a5435a8812404c3a3
+  version: 66487607e2081c7c2af2281c62c14ee000d5024b
   repo: https://github.com/golang/tools
   subpackages:
   - go/ast/astutil
 - name: google.golang.org/genproto
-  version: 595979c8a7bf586b2d293fb42246bf91a0b893d9
+  version: 4eb30f4778eed4c258ba66527a0d4f9ec8a36c45
   subpackages:
   - googleapis/rpc/status
 - name: google.golang.org/grpc
-  version: 7cea4cc846bcf00cbb27595b07da5de875ef7de9
+  version: 6b51017f791ae1cfbec89c52efdf444b13b550ef
   repo: https://github.com/grpc/grpc-go
   subpackages:
   - balancer
@@ -229,12 +231,12 @@ imports:
   - tap
   - transport
 - name: gopkg.in/yaml.v2
-  version: eb3733d160e74a9c7e442f435eb3bea458e1d19f
+  version: d670f9405373e636a5a2765eea47fac0c9bc91a4
 testImports:
 - name: github.com/codahale/hdrhistogram
   version: 3a0bb77429bd3a61596f5e8a3172445844342120
 - name: github.com/golang/lint
-  version: f635bddafc7154957bd70209ee858a4b97e64a9b
+  version: e14d9b0f1d332b1420c1ffa32562ad2dc84d645d
   subpackages:
   - golint
 - name: github.com/kisielk/errcheck
@@ -253,6 +255,6 @@ testImports:
   - parallel-exec
   - update-license
 - name: honnef.co/go/tools
-  version: 376b3b58b9e4def403181ee2fd3d4cc7de8375ae
+  version: 8ed405e85c65fb38745a8eafe01ee9590523f172
   subpackages:
   - cmd/staticcheck

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 7c7d875c128e2f5ee2218b87f3ec2b6fb335279d1cda2657c6cc4eb92a2ecdb9
-updated: 2018-02-04T15:09:19.499281-08:00
+updated: 2018-01-17T11:45:33.306560761-08:00
 imports:
 - name: github.com/apache/thrift
   version: 53dd39833a08ce33582e5ff31fa18bb4735d6731
@@ -17,7 +17,7 @@ imports:
   - assert
   - require
 - name: github.com/davecgh/go-spew
-  version: 87df7c60d5820d0f8ae11afede5aa52325c09717
+  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
   subpackages:
   - spew
 - name: github.com/facebookgo/clock
@@ -36,7 +36,7 @@ imports:
   subpackages:
   - gomock
 - name: github.com/golang/protobuf
-  version: bbd03ef6da3a115852eaf24c8a1c46aeb39aa175
+  version: 17ce1425424ab154092bbb43af630bd647f3bb0d
   subpackages:
   - proto
   - ptypes
@@ -56,7 +56,7 @@ imports:
   - log
   - mocktracer
 - name: github.com/pmezard/go-difflib
-  version: 792786c7400a136282c1664665ae0a8db921c6c2
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
 - name: github.com/prometheus/client_golang
@@ -65,23 +65,21 @@ imports:
   - prometheus
   - prometheus/promhttp
 - name: github.com/prometheus/client_model
-  version: 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
+  version: 6f3806018612930941127f2a7c6c453ba2c527d2
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 89604d197083d4781071d3c65855d24ecfb0a563
+  version: 2f17f4a9d485bf34b4bfaccc273805040e4f86c8
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: cb4147076ac75738c9a7d279075a253c0cc5acbd
+  version: e645f4e5aaa8506fc71d6edbc5c4ff02c04c46f2
   subpackages:
-  - internal/util
-  - nfs
   - xfs
 - name: github.com/stretchr/testify
-  version: a726187e3128d0a0ec37f73ca7c4d3e508e6c2e5
+  version: 890a5c3458b43e6104ff5da8dfa139d013d77544
   subpackages:
   - assert
   - require
@@ -105,7 +103,7 @@ imports:
   - thrift-gen/zipkincore
   - utils
 - name: github.com/uber/tchannel-go
-  version: acd4eb54c11531814d9cd0344fdc53bebe86ab12
+  version: 7bcb33f4bb908c21374f8bfdc9d4b1ebcbb8dab0
   subpackages:
   - internal/argreader
   - json
@@ -170,7 +168,7 @@ imports:
   - zapcore
   - zaptest/observer
 - name: golang.org/x/net
-  version: 2fb46b16b8dda405028c50f7c7f0f9dd1fa6bfb1
+  version: ab555f366c4508dbe0802550b1b20c46c5c18aa0
   repo: https://github.com/golang/net
   subpackages:
   - bpf
@@ -187,26 +185,26 @@ imports:
   - lex/httplex
   - trace
 - name: golang.org/x/sys
-  version: 37707fdb30a5b38865cfb95e5aab41707daec7fd
+  version: 53aa286056ef226755cd898109dbcdaba8ac0b81
   repo: https://github.com/golang/sys
 - name: golang.org/x/text
-  version: e19ae1496984b1c655b8044a65c0300a3c878dd3
+  version: acd49d43e9b95df46670431bf5c7ae59586daad8
   subpackages:
   - secure/bidirule
   - transform
   - unicode/bidi
   - unicode/norm
 - name: golang.org/x/tools
-  version: 66487607e2081c7c2af2281c62c14ee000d5024b
+  version: 64890f4e2b733655fee5077a5435a8812404c3a3
   repo: https://github.com/golang/tools
   subpackages:
   - go/ast/astutil
 - name: google.golang.org/genproto
-  version: 4eb30f4778eed4c258ba66527a0d4f9ec8a36c45
+  version: 595979c8a7bf586b2d293fb42246bf91a0b893d9
   subpackages:
   - googleapis/rpc/status
 - name: google.golang.org/grpc
-  version: 6b51017f791ae1cfbec89c52efdf444b13b550ef
+  version: 7cea4cc846bcf00cbb27595b07da5de875ef7de9
   repo: https://github.com/grpc/grpc-go
   subpackages:
   - balancer
@@ -231,12 +229,12 @@ imports:
   - tap
   - transport
 - name: gopkg.in/yaml.v2
-  version: d670f9405373e636a5a2765eea47fac0c9bc91a4
+  version: eb3733d160e74a9c7e442f435eb3bea458e1d19f
 testImports:
 - name: github.com/codahale/hdrhistogram
   version: 3a0bb77429bd3a61596f5e8a3172445844342120
 - name: github.com/golang/lint
-  version: e14d9b0f1d332b1420c1ffa32562ad2dc84d645d
+  version: f635bddafc7154957bd70209ee858a4b97e64a9b
   subpackages:
   - golint
 - name: github.com/kisielk/errcheck
@@ -255,6 +253,6 @@ testImports:
   - parallel-exec
   - update-license
 - name: honnef.co/go/tools
-  version: 8ed405e85c65fb38745a8eafe01ee9590523f172
+  version: 376b3b58b9e4def403181ee2fd3d4cc7de8375ae
   subpackages:
   - cmd/staticcheck

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 7c7d875c128e2f5ee2218b87f3ec2b6fb335279d1cda2657c6cc4eb92a2ecdb9
-updated: 2018-01-17T11:45:33.306560761-08:00
+updated: 2018-01-31T14:57:48.544493-08:00
 imports:
 - name: github.com/apache/thrift
   version: 53dd39833a08ce33582e5ff31fa18bb4735d6731
@@ -17,7 +17,7 @@ imports:
   - assert
   - require
 - name: github.com/davecgh/go-spew
-  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
+  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
   subpackages:
   - spew
 - name: github.com/facebookgo/clock
@@ -65,21 +65,21 @@ imports:
   - prometheus
   - prometheus/promhttp
 - name: github.com/prometheus/client_model
-  version: 6f3806018612930941127f2a7c6c453ba2c527d2
+  version: 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 2f17f4a9d485bf34b4bfaccc273805040e4f86c8
+  version: 2e54d0b93cba2fd133edc32211dcc32c06ef72ca
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: e645f4e5aaa8506fc71d6edbc5c4ff02c04c46f2
+  version: a6e9df898b1336106c743392c48ee0b71f5c4efa
   subpackages:
   - xfs
 - name: github.com/stretchr/testify
-  version: 890a5c3458b43e6104ff5da8dfa139d013d77544
+  version: 12b6f73e6084dad08a7c6e575284b177ecafbc71
   subpackages:
   - assert
   - require
@@ -168,7 +168,7 @@ imports:
   - zapcore
   - zaptest/observer
 - name: golang.org/x/net
-  version: ab555f366c4508dbe0802550b1b20c46c5c18aa0
+  version: 0ed95abb35c445290478a5348a7b38bb154135fd
   repo: https://github.com/golang/net
   subpackages:
   - bpf
@@ -185,26 +185,26 @@ imports:
   - lex/httplex
   - trace
 - name: golang.org/x/sys
-  version: 53aa286056ef226755cd898109dbcdaba8ac0b81
+  version: a204229cd828a74741ee7b5da9bf4794497f85ed
   repo: https://github.com/golang/sys
 - name: golang.org/x/text
-  version: acd49d43e9b95df46670431bf5c7ae59586daad8
+  version: 2df9074612f50810d82416d2229398a1e7188c5c
   subpackages:
   - secure/bidirule
   - transform
   - unicode/bidi
   - unicode/norm
 - name: golang.org/x/tools
-  version: 64890f4e2b733655fee5077a5435a8812404c3a3
+  version: 6d70fb2e85323e81c89374331d3d2b93304faa36
   repo: https://github.com/golang/tools
   subpackages:
   - go/ast/astutil
 - name: google.golang.org/genproto
-  version: 595979c8a7bf586b2d293fb42246bf91a0b893d9
+  version: 7f0da29060c682909f650ad8ed4e515bd74fa12a
   subpackages:
   - googleapis/rpc/status
 - name: google.golang.org/grpc
-  version: 7cea4cc846bcf00cbb27595b07da5de875ef7de9
+  version: 6b51017f791ae1cfbec89c52efdf444b13b550ef
   repo: https://github.com/grpc/grpc-go
   subpackages:
   - balancer
@@ -229,12 +229,12 @@ imports:
   - tap
   - transport
 - name: gopkg.in/yaml.v2
-  version: eb3733d160e74a9c7e442f435eb3bea458e1d19f
+  version: a83829b6f1293c91addabc89d0571c246397bbf4
 testImports:
 - name: github.com/codahale/hdrhistogram
-  version: 3a0bb77429bd3a61596f5e8a3172445844342120
+  version: f8ad88b59a584afeee9d334eff879b104439117b
 - name: github.com/golang/lint
-  version: f635bddafc7154957bd70209ee858a4b97e64a9b
+  version: e14d9b0f1d332b1420c1ffa32562ad2dc84d645d
   subpackages:
   - golint
 - name: github.com/kisielk/errcheck
@@ -253,6 +253,6 @@ testImports:
   - parallel-exec
   - update-license
 - name: honnef.co/go/tools
-  version: 376b3b58b9e4def403181ee2fd3d4cc7de8375ae
+  version: 8ed405e85c65fb38745a8eafe01ee9590523f172
   subpackages:
   - cmd/staticcheck

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 7c7d875c128e2f5ee2218b87f3ec2b6fb335279d1cda2657c6cc4eb92a2ecdb9
-updated: 2018-02-01T17:36:42.499728-08:00
+updated: 2018-02-04T14:32:04.466459-08:00
 imports:
 - name: github.com/apache/thrift
   version: 53dd39833a08ce33582e5ff31fa18bb4735d6731
@@ -79,7 +79,7 @@ imports:
   subpackages:
   - xfs
 - name: github.com/stretchr/testify
-  version: 12b6f73e6084dad08a7c6e575284b177ecafbc71
+  version: a726187e3128d0a0ec37f73ca7c4d3e508e6c2e5
   subpackages:
   - assert
   - require
@@ -168,7 +168,7 @@ imports:
   - zapcore
   - zaptest/observer
 - name: golang.org/x/net
-  version: b417086c80e91bfa321ef761574721644b8b9f61
+  version: 2fb46b16b8dda405028c50f7c7f0f9dd1fa6bfb1
   repo: https://github.com/golang/net
   subpackages:
   - bpf

--- a/transport/http/header_test.go
+++ b/transport/http/header_test.go
@@ -28,17 +28,22 @@ import (
 	"go.uber.org/yarpc/api/transport"
 )
 
-func TestHeaders(t *testing.T) {
+func TestHTTPHeaders(t *testing.T) {
 	tests := []struct {
-		prefix    string
-		transport transport.Headers
-		http      http.Header
+		prefix        string
+		toTransport   transport.Headers
+		fromTransport transport.Headers
+		http          http.Header
 	}{
 		{
 			ApplicationHeaderPrefix,
 			transport.HeadersFromMap(map[string]string{
 				"foo":     "bar",
 				"foo-bar": "hello",
+			}),
+			transport.HeadersFromMap(map[string]string{
+				"Foo":     "bar",
+				"Foo-Bar": "hello",
 			}),
 			http.Header{
 				"Rpc-Header-Foo":     []string{"bar"},
@@ -49,8 +54,8 @@ func TestHeaders(t *testing.T) {
 
 	for _, tt := range tests {
 		m := headerMapper{tt.prefix}
-		assert.Equal(t, tt.transport, m.FromHTTPHeaders(tt.http, transport.Headers{}))
-		assert.Equal(t, tt.http, m.ToHTTPHeaders(tt.transport, nil))
+		assert.Equal(t, tt.fromTransport, m.FromHTTPHeaders(tt.http, transport.Headers{}))
+		assert.Equal(t, tt.http, m.ToHTTPHeaders(tt.toTransport, nil))
 	}
 }
 

--- a/transport/tchannel/channel_outbound.go
+++ b/transport/tchannel/channel_outbound.go
@@ -155,12 +155,9 @@ func (o *ChannelOutbound) Call(ctx context.Context, req *transport.Request) (*tr
 	if err != nil {
 		return nil, toYARPCError(req, err)
 	}
-	reqHeaders := req.Headers.Items()
-	if o.transport.exactCaseHeader {
-		reqHeaders = req.Headers.ExactCaseItems()
-	}
+
 	// Inject tracing system baggage
-	reqHeaders = tchannel.InjectOutboundSpan(call.Response(), reqHeaders)
+	reqHeaders := tchannel.InjectOutboundSpan(call.Response(), req.Headers.Items())
 
 	if err := writeRequestHeaders(ctx, format, reqHeaders, call.Arg2Writer, o.transport.exactCaseHeader); err != nil {
 		// TODO(abg): This will wrap IO errors while writing headers as encode

--- a/transport/tchannel/channel_outbound.go
+++ b/transport/tchannel/channel_outbound.go
@@ -157,10 +157,10 @@ func (o *ChannelOutbound) Call(ctx context.Context, req *transport.Request) (*tr
 	}
 
 	reqHeaders := req.Headers.Items()
-	if o.transport.originalHeader {
+	if o.transport.originalHeaders {
 		reqHeaders = req.Headers.OriginalItems()
 	}
-	// We do not want to canonicalize these headers as channel_outbound is deprecated
+	// baggage headers are transport implementation details that are stripped out (and stored in the context). Users don't interact with it
 	tracingBaggage := tchannel.InjectOutboundSpan(call.Response(), nil)
 	if err := writeHeaders(format, reqHeaders, tracingBaggage, call.Arg2Writer); err != nil {
 		// TODO(abg): This will wrap IO errors while writing headers as encode

--- a/transport/tchannel/channel_outbound.go
+++ b/transport/tchannel/channel_outbound.go
@@ -157,7 +157,7 @@ func (o *ChannelOutbound) Call(ctx context.Context, req *transport.Request) (*tr
 	}
 
 	reqHeaders := req.Headers.Items()
-	if o.transport.exactCaseHeader {
+	if o.transport.originalHeader {
 		reqHeaders = req.Headers.OriginalItems()
 	}
 	// We do not want to canonicalize these headers as channel_outbound is deprecated

--- a/transport/tchannel/channel_outbound.go
+++ b/transport/tchannel/channel_outbound.go
@@ -159,7 +159,7 @@ func (o *ChannelOutbound) Call(ctx context.Context, req *transport.Request) (*tr
 	// Inject tracing system baggage
 	reqHeaders := tchannel.InjectOutboundSpan(call.Response(), req.Headers.Items())
 
-	if err := writeRequestHeaders(ctx, format, reqHeaders, call.Arg2Writer, o.transport.forwardingHeader); err != nil {
+	if err := writeRequestHeaders(ctx, format, reqHeaders, call.Arg2Writer, o.transport.exactCaseHeader); err != nil {
 		// TODO(abg): This will wrap IO errors while writing headers as encode
 		// errors. We should fix that.
 		return nil, errors.RequestHeadersEncodeError(req, err)

--- a/transport/tchannel/channel_outbound.go
+++ b/transport/tchannel/channel_outbound.go
@@ -158,7 +158,7 @@ func (o *ChannelOutbound) Call(ctx context.Context, req *transport.Request) (*tr
 
 	reqHeaders := req.Headers.Items()
 	if o.transport.exactCaseHeader {
-		reqHeaders = req.Headers.ExactCaseItems()
+		reqHeaders = req.Headers.OriginalItems()
 	}
 
 	tracingBaggage := tchannel.InjectOutboundSpan(call.Response(), nil)

--- a/transport/tchannel/channel_outbound.go
+++ b/transport/tchannel/channel_outbound.go
@@ -160,10 +160,9 @@ func (o *ChannelOutbound) Call(ctx context.Context, req *transport.Request) (*tr
 	if o.transport.exactCaseHeader {
 		reqHeaders = req.Headers.ExactCaseItems()
 	}
-	// Inject tracing system baggage
-	reqHeaders = tchannel.InjectOutboundSpan(call.Response(), reqHeaders)
 
-	if err := writeHeaders(format, reqHeaders, call.Arg2Writer); err != nil {
+	tracingBaggage := tchannel.InjectOutboundSpan(call.Response(), nil)
+	if err := writeHeaders(format, reqHeaders, tracingBaggage, call.Arg2Writer); err != nil {
 		// TODO(abg): This will wrap IO errors while writing headers as encode
 		// errors. We should fix that.
 		return nil, errors.RequestHeadersEncodeError(req, err)

--- a/transport/tchannel/channel_outbound.go
+++ b/transport/tchannel/channel_outbound.go
@@ -155,9 +155,12 @@ func (o *ChannelOutbound) Call(ctx context.Context, req *transport.Request) (*tr
 	if err != nil {
 		return nil, toYARPCError(req, err)
 	}
-
+	reqHeaders := req.Headers.Items()
+	if o.transport.exactCaseHeader {
+		reqHeaders = req.Headers.ExactCaseItems()
+	}
 	// Inject tracing system baggage
-	reqHeaders := tchannel.InjectOutboundSpan(call.Response(), req.Headers.Items())
+	reqHeaders = tchannel.InjectOutboundSpan(call.Response(), reqHeaders)
 
 	if err := writeRequestHeaders(ctx, format, reqHeaders, call.Arg2Writer, o.transport.exactCaseHeader); err != nil {
 		// TODO(abg): This will wrap IO errors while writing headers as encode

--- a/transport/tchannel/channel_outbound.go
+++ b/transport/tchannel/channel_outbound.go
@@ -159,7 +159,7 @@ func (o *ChannelOutbound) Call(ctx context.Context, req *transport.Request) (*tr
 	// Inject tracing system baggage
 	reqHeaders := tchannel.InjectOutboundSpan(call.Response(), req.Headers.Items())
 
-	if err := writeRequestHeaders(ctx, format, reqHeaders, call.Arg2Writer); err != nil {
+	if err := writeRequestHeaders(ctx, format, reqHeaders, call.Arg2Writer, o.transport.rawHeader); err != nil {
 		// TODO(abg): This will wrap IO errors while writing headers as encode
 		// errors. We should fix that.
 		return nil, errors.RequestHeadersEncodeError(req, err)

--- a/transport/tchannel/channel_outbound.go
+++ b/transport/tchannel/channel_outbound.go
@@ -160,7 +160,7 @@ func (o *ChannelOutbound) Call(ctx context.Context, req *transport.Request) (*tr
 	if o.transport.exactCaseHeader {
 		reqHeaders = req.Headers.OriginalItems()
 	}
-
+	// We do not want to canonicalize these headers as channel_outbound is deprecated
 	tracingBaggage := tchannel.InjectOutboundSpan(call.Response(), nil)
 	if err := writeHeaders(format, reqHeaders, tracingBaggage, call.Arg2Writer); err != nil {
 		// TODO(abg): This will wrap IO errors while writing headers as encode

--- a/transport/tchannel/channel_outbound.go
+++ b/transport/tchannel/channel_outbound.go
@@ -159,7 +159,7 @@ func (o *ChannelOutbound) Call(ctx context.Context, req *transport.Request) (*tr
 	// Inject tracing system baggage
 	reqHeaders := tchannel.InjectOutboundSpan(call.Response(), req.Headers.Items())
 
-	if err := writeRequestHeaders(ctx, format, reqHeaders, call.Arg2Writer, o.transport.rawHeader); err != nil {
+	if err := writeRequestHeaders(ctx, format, reqHeaders, call.Arg2Writer, o.transport.forwardingHeader); err != nil {
 		// TODO(abg): This will wrap IO errors while writing headers as encode
 		// errors. We should fix that.
 		return nil, errors.RequestHeadersEncodeError(req, err)

--- a/transport/tchannel/channel_outbound.go
+++ b/transport/tchannel/channel_outbound.go
@@ -155,6 +155,7 @@ func (o *ChannelOutbound) Call(ctx context.Context, req *transport.Request) (*tr
 	if err != nil {
 		return nil, toYARPCError(req, err)
 	}
+
 	reqHeaders := req.Headers.Items()
 	if o.transport.exactCaseHeader {
 		reqHeaders = req.Headers.ExactCaseItems()
@@ -162,7 +163,7 @@ func (o *ChannelOutbound) Call(ctx context.Context, req *transport.Request) (*tr
 	// Inject tracing system baggage
 	reqHeaders = tchannel.InjectOutboundSpan(call.Response(), reqHeaders)
 
-	if err := writeRequestHeaders(ctx, format, reqHeaders, call.Arg2Writer, o.transport.exactCaseHeader); err != nil {
+	if err := writeHeaders(format, reqHeaders, call.Arg2Writer); err != nil {
 		// TODO(abg): This will wrap IO errors while writing headers as encode
 		// errors. We should fix that.
 		return nil, errors.RequestHeadersEncodeError(req, err)

--- a/transport/tchannel/channel_transport.go
+++ b/transport/tchannel/channel_transport.go
@@ -82,12 +82,12 @@ func (options transportOptions) newChannelTransport() *ChannelTransport {
 		logger = zap.NewNop()
 	}
 	return &ChannelTransport{
-		once:      lifecycle.NewOnce(),
-		ch:        options.ch,
-		addr:      options.addr,
-		tracer:    options.tracer,
-		logger:    logger,
-		rawHeader: options.rawHeader,
+		once:             lifecycle.NewOnce(),
+		ch:               options.ch,
+		addr:             options.addr,
+		tracer:           options.tracer,
+		logger:           logger,
+		forwardingHeader: options.forwardingHeader,
 	}
 }
 
@@ -96,13 +96,13 @@ func (options transportOptions) newChannelTransport() *ChannelTransport {
 // If you have a YARPC peer.Chooser, use the unqualified tchannel.Transport
 // instead.
 type ChannelTransport struct {
-	ch        Channel
-	name      string
-	addr      string
-	tracer    opentracing.Tracer
-	logger    *zap.Logger
-	router    transport.Router
-	rawHeader bool
+	ch               Channel
+	name             string
+	addr             string
+	tracer           opentracing.Tracer
+	logger           *zap.Logger
+	router           transport.Router
+	forwardingHeader bool
 
 	once *lifecycle.Once
 }

--- a/transport/tchannel/channel_transport.go
+++ b/transport/tchannel/channel_transport.go
@@ -82,11 +82,12 @@ func (options transportOptions) newChannelTransport() *ChannelTransport {
 		logger = zap.NewNop()
 	}
 	return &ChannelTransport{
-		once:   lifecycle.NewOnce(),
-		ch:     options.ch,
-		addr:   options.addr,
-		tracer: options.tracer,
-		logger: logger,
+		once:      lifecycle.NewOnce(),
+		ch:        options.ch,
+		addr:      options.addr,
+		tracer:    options.tracer,
+		logger:    logger,
+		rawHeader: options.rawHeader,
 	}
 }
 
@@ -95,12 +96,13 @@ func (options transportOptions) newChannelTransport() *ChannelTransport {
 // If you have a YARPC peer.Chooser, use the unqualified tchannel.Transport
 // instead.
 type ChannelTransport struct {
-	ch     Channel
-	name   string
-	addr   string
-	tracer opentracing.Tracer
-	logger *zap.Logger
-	router transport.Router
+	ch        Channel
+	name      string
+	addr      string
+	tracer    opentracing.Tracer
+	logger    *zap.Logger
+	router    transport.Router
+	rawHeader bool
 
 	once *lifecycle.Once
 }

--- a/transport/tchannel/channel_transport.go
+++ b/transport/tchannel/channel_transport.go
@@ -82,12 +82,12 @@ func (options transportOptions) newChannelTransport() *ChannelTransport {
 		logger = zap.NewNop()
 	}
 	return &ChannelTransport{
-		once:             lifecycle.NewOnce(),
-		ch:               options.ch,
-		addr:             options.addr,
-		tracer:           options.tracer,
-		logger:           logger,
-		forwardingHeader: options.forwardingHeader,
+		once:            lifecycle.NewOnce(),
+		ch:              options.ch,
+		addr:            options.addr,
+		tracer:          options.tracer,
+		logger:          logger,
+		exactCaseHeader: options.exactCaseHeader,
 	}
 }
 
@@ -96,13 +96,13 @@ func (options transportOptions) newChannelTransport() *ChannelTransport {
 // If you have a YARPC peer.Chooser, use the unqualified tchannel.Transport
 // instead.
 type ChannelTransport struct {
-	ch               Channel
-	name             string
-	addr             string
-	tracer           opentracing.Tracer
-	logger           *zap.Logger
-	router           transport.Router
-	forwardingHeader bool
+	ch              Channel
+	name            string
+	addr            string
+	tracer          opentracing.Tracer
+	logger          *zap.Logger
+	router          transport.Router
+	exactCaseHeader bool
 
 	once *lifecycle.Once
 }

--- a/transport/tchannel/channel_transport.go
+++ b/transport/tchannel/channel_transport.go
@@ -82,12 +82,12 @@ func (options transportOptions) newChannelTransport() *ChannelTransport {
 		logger = zap.NewNop()
 	}
 	return &ChannelTransport{
-		once:           lifecycle.NewOnce(),
-		ch:             options.ch,
-		addr:           options.addr,
-		tracer:         options.tracer,
-		logger:         logger,
-		originalHeader: options.originalHeader,
+		once:            lifecycle.NewOnce(),
+		ch:              options.ch,
+		addr:            options.addr,
+		tracer:          options.tracer,
+		logger:          logger,
+		originalHeaders: options.originalHeaders,
 	}
 }
 
@@ -96,13 +96,13 @@ func (options transportOptions) newChannelTransport() *ChannelTransport {
 // If you have a YARPC peer.Chooser, use the unqualified tchannel.Transport
 // instead.
 type ChannelTransport struct {
-	ch             Channel
-	name           string
-	addr           string
-	tracer         opentracing.Tracer
-	logger         *zap.Logger
-	router         transport.Router
-	originalHeader bool
+	ch              Channel
+	name            string
+	addr            string
+	tracer          opentracing.Tracer
+	logger          *zap.Logger
+	router          transport.Router
+	originalHeaders bool
 
 	once *lifecycle.Once
 }

--- a/transport/tchannel/channel_transport.go
+++ b/transport/tchannel/channel_transport.go
@@ -82,12 +82,12 @@ func (options transportOptions) newChannelTransport() *ChannelTransport {
 		logger = zap.NewNop()
 	}
 	return &ChannelTransport{
-		once:            lifecycle.NewOnce(),
-		ch:              options.ch,
-		addr:            options.addr,
-		tracer:          options.tracer,
-		logger:          logger,
-		exactCaseHeader: options.exactCaseHeader,
+		once:           lifecycle.NewOnce(),
+		ch:             options.ch,
+		addr:           options.addr,
+		tracer:         options.tracer,
+		logger:         logger,
+		originalHeader: options.originalHeader,
 	}
 }
 
@@ -96,13 +96,13 @@ func (options transportOptions) newChannelTransport() *ChannelTransport {
 // If you have a YARPC peer.Chooser, use the unqualified tchannel.Transport
 // instead.
 type ChannelTransport struct {
-	ch              Channel
-	name            string
-	addr            string
-	tracer          opentracing.Tracer
-	logger          *zap.Logger
-	router          transport.Router
-	exactCaseHeader bool
+	ch             Channel
+	name           string
+	addr           string
+	tracer         opentracing.Tracer
+	logger         *zap.Logger
+	router         transport.Router
+	originalHeader bool
 
 	once *lifecycle.Once
 }

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -251,7 +251,7 @@ func (rw *responseWriter) Close() error {
 			retErr = appendError(retErr, fmt.Errorf("SetApplicationError() failed: %v", err))
 		}
 	}
-	retErr = appendError(retErr, writeHeaders(rw.format, rw.headers, rw.response.Arg2Writer))
+	retErr = appendError(retErr, writeHeaders(rw.format, rw.headers, nil, rw.response.Arg2Writer))
 
 	// Arg3Writer must be opened and closed regardless of if there is data
 	// However, if there is a system error, we do not want to do this

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -243,7 +243,7 @@ func (rw *responseWriter) Close() error {
 			retErr = appendError(retErr, fmt.Errorf("SetApplicationError() failed: %v", err))
 		}
 	}
-	retErr = appendError(retErr, writeHeaders(rw.format, rw.headers, rw.response.Arg2Writer))
+	retErr = appendError(retErr, writeHeaders(rw.format, rw.headers.Items(), rw.response.Arg2Writer))
 
 	// Arg3Writer must be opened and closed regardless of if there is data
 	// However, if there is a system error, we do not want to do this

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -208,7 +208,7 @@ func newResponseWriter(response inboundCallResponse, format tchannel.Format, exa
 func (rw *responseWriter) AddHeaders(h transport.Headers) {
 	headers := h.Items()
 	if rw.exactCaseHeader {
-		headers = h.ExactCaseItems()
+		headers = h.OriginalItems()
 	}
 	for k, v := range headers {
 		// TODO: is this considered a breaking change?

--- a/transport/tchannel/handler_test.go
+++ b/transport/tchannel/handler_test.go
@@ -396,10 +396,7 @@ func TestResponseWriter(t *testing.T) {
 				headers := transport.HeadersFromMap(map[string]string{"foo": "bar"})
 				w.AddHeaders(headers)
 
-				_, err := w.Write([]byte("{"))
-				require.NoError(t, err)
-
-				_, err = w.Write([]byte("}"))
+				_, err := w.Write([]byte("{}"))
 				require.NoError(t, err)
 			},
 			arg2: []byte(`{"foo":"bar"}` + "\n"),
@@ -411,10 +408,7 @@ func TestResponseWriter(t *testing.T) {
 				headers := transport.HeadersFromMap(map[string]string{"FoO": "bAr"})
 				w.AddHeaders(headers)
 
-				_, err := w.Write([]byte("{"))
-				require.NoError(t, err)
-
-				_, err = w.Write([]byte("}"))
+				_, err := w.Write([]byte("{}"))
 				require.NoError(t, err)
 			},
 			arg2:            []byte(`{"FoO":"bAr"}` + "\n"),
@@ -424,10 +418,7 @@ func TestResponseWriter(t *testing.T) {
 		{
 			format: tchannel.JSON,
 			apply: func(w *responseWriter) {
-				_, err := w.Write([]byte("{"))
-				require.NoError(t, err)
-
-				_, err = w.Write([]byte("}"))
+				_, err := w.Write([]byte("{}"))
 				require.NoError(t, err)
 			},
 			arg2: []byte("{}\n"),
@@ -488,7 +479,7 @@ func TestResponseWriterFailure(t *testing.T) {
 		resp := newResponseRecorder()
 		tt.setupResp(resp)
 
-		w := newResponseWriter(resp, tchannel.Raw, false)
+		w := newResponseWriter(resp, tchannel.Raw, false /* exactItems */)
 		_, err := w.Write([]byte("foo"))
 		assert.NoError(t, err)
 		_, err = w.Write([]byte("bar"))

--- a/transport/tchannel/handler_test.go
+++ b/transport/tchannel/handler_test.go
@@ -342,6 +342,7 @@ func TestResponseWriter(t *testing.T) {
 		arg2             []byte
 		arg3             []byte
 		applicationError bool
+		exactCaseHeader  bool
 	}{
 		{
 			format: tchannel.Raw,
@@ -389,6 +390,22 @@ func TestResponseWriter(t *testing.T) {
 		{
 			format: tchannel.JSON,
 			apply: func(w *responseWriter) {
+				headers := transport.HeadersFromMap(map[string]string{"FoO": "bAr"})
+				w.AddHeaders(headers)
+
+				_, err := w.Write([]byte("{"))
+				require.NoError(t, err)
+
+				_, err = w.Write([]byte("}"))
+				require.NoError(t, err)
+			},
+			arg2:            []byte(`{"FoO":"bAr"}` + "\n"),
+			arg3:            []byte("{}"),
+			exactCaseHeader: true,
+		},
+		{
+			format: tchannel.JSON,
+			apply: func(w *responseWriter) {
 				_, err := w.Write([]byte("{"))
 				require.NoError(t, err)
 
@@ -416,7 +433,7 @@ func TestResponseWriter(t *testing.T) {
 		resp := newResponseRecorder()
 		call.resp = resp
 
-		w := newResponseWriter(call.Response(), call.Format())
+		w := newResponseWriter(call.Response(), call.Format(), tt.exactCaseHeader)
 		tt.apply(w)
 		assert.NoError(t, w.Close())
 
@@ -453,7 +470,7 @@ func TestResponseWriterFailure(t *testing.T) {
 		resp := newResponseRecorder()
 		tt.setupResp(resp)
 
-		w := newResponseWriter(resp, tchannel.Raw)
+		w := newResponseWriter(resp, tchannel.Raw, false)
 		_, err := w.Write([]byte("foo"))
 		assert.NoError(t, err)
 		_, err = w.Write([]byte("bar"))
@@ -468,7 +485,7 @@ func TestResponseWriterFailure(t *testing.T) {
 
 func TestResponseWriterEmptyBodyHeaders(t *testing.T) {
 	res := newResponseRecorder()
-	w := newResponseWriter(res, tchannel.Raw)
+	w := newResponseWriter(res, tchannel.Raw, false)
 
 	w.AddHeaders(transport.NewHeaders().With("foo", "bar"))
 	require.NoError(t, w.Close())

--- a/transport/tchannel/handler_test.go
+++ b/transport/tchannel/handler_test.go
@@ -364,6 +364,24 @@ func TestResponseWriter(t *testing.T) {
 		{
 			format: tchannel.Raw,
 			apply: func(w *responseWriter) {
+				headers := transport.HeadersFromMap(map[string]string{"FoO": "bAr"})
+				w.AddHeaders(headers)
+				_, err := w.Write([]byte("hello "))
+				require.NoError(t, err)
+				_, err = w.Write([]byte("world"))
+				require.NoError(t, err)
+			},
+			arg2: []byte{
+				0x00, 0x01,
+				0x00, 0x03, 'F', 'o', 'O',
+				0x00, 0x03, 'b', 'A', 'r',
+			},
+			arg3:            []byte("hello world"),
+			exactCaseHeader: true,
+		},
+		{
+			format: tchannel.Raw,
+			apply: func(w *responseWriter) {
 				_, err := w.Write([]byte("foo"))
 				require.NoError(t, err)
 				_, err = w.Write([]byte("bar"))

--- a/transport/tchannel/header.go
+++ b/transport/tchannel/header.go
@@ -98,15 +98,22 @@ func writeRequestHeaders(
 	format tchannel.Format,
 	appHeaders map[string]string,
 	getWriter func() (tchannel.ArgWriter, error),
+	rawHeader bool,
 ) error {
 	headers := transport.NewHeadersWithCapacity(len(appHeaders))
 	// TODO: zero-alloc version
-
 	for k, v := range appHeaders {
 		headers = headers.With(k, v)
 	}
 
-	return writeHeaders(format, headers, getWriter)
+	var items map[string]string
+	if rawHeader {
+		items = headers.RawItems()
+	} else {
+		items = headers.Items()
+	}
+
+	return writeHeaders(format, items, getWriter)
 }
 
 // writeHeaders writes the given headers using the given function to get the
@@ -116,10 +123,10 @@ func writeRequestHeaders(
 // InboundCallResponse.
 //
 // If the format is JSON, the headers are JSON encoded.
-func writeHeaders(format tchannel.Format, headers transport.Headers, getWriter func() (tchannel.ArgWriter, error)) error {
+func writeHeaders(format tchannel.Format, headers map[string]string, getWriter func() (tchannel.ArgWriter, error)) error {
 	if format == tchannel.JSON {
 		// JSON is special
-		return tchannel.NewArgWriter(getWriter()).WriteJSON(headers.Items())
+		return tchannel.NewArgWriter(getWriter()).WriteJSON(headers)
 	}
 	return tchannel.NewArgWriter(getWriter()).Write(encodeHeaders(headers))
 }
@@ -148,13 +155,13 @@ func decodeHeaders(r io.Reader) (transport.Headers, error) {
 // encodeHeaders encodes headers using the format:
 //
 // 	nh:2 (k~2 v~2){nh}
-func encodeHeaders(hs transport.Headers) []byte {
-	if hs.Len() == 0 {
+func encodeHeaders(hs map[string]string) []byte {
+	if len(hs) == 0 {
 		return []byte{0, 0} // nh = 2
 	}
 
 	size := 2 // nh:2
-	for k, v := range hs.Items() {
+	for k, v := range hs {
 		size += len(k) + 2 // k~2
 		size += len(v) + 2 // v~2
 	}
@@ -162,8 +169,8 @@ func encodeHeaders(hs transport.Headers) []byte {
 	out := make([]byte, size)
 
 	i := 2
-	binary.BigEndian.PutUint16(out, uint16(hs.Len())) // nh:2
-	for k, v := range hs.Items() {
+	binary.BigEndian.PutUint16(out, uint16(len(hs))) // nh:2
+	for k, v := range hs {
 		i += _putStr16(k, out[i:]) // k~2
 		i += _putStr16(v, out[i:]) // v~2
 	}

--- a/transport/tchannel/header.go
+++ b/transport/tchannel/header.go
@@ -93,25 +93,6 @@ func readHeaders(format tchannel.Format, getReader func() (tchannel.ArgReader, e
 	return headers, r.Close()
 }
 
-func writeRequestHeaders(
-	ctx context.Context,
-	format tchannel.Format,
-	appHeaders map[string]string,
-	getWriter func() (tchannel.ArgWriter, error),
-	writeExactHeaderCase bool,
-) error {
-	if writeExactHeaderCase {
-		return writeHeaders(format, appHeaders, getWriter)
-	}
-	headers := transport.NewHeadersWithCapacity(len(appHeaders))
-	// TODO: zero-alloc version
-	for k, v := range appHeaders {
-		headers = headers.With(k, v)
-	}
-
-	return writeHeaders(format, headers.Items(), getWriter)
-}
-
 // writeHeaders writes the given headers using the given function to get the
 // arg writer.
 //

--- a/transport/tchannel/header.go
+++ b/transport/tchannel/header.go
@@ -108,7 +108,7 @@ func writeRequestHeaders(
 
 	var items map[string]string
 	if rawHeader {
-		items = headers.RawItems()
+		items = headers.ForwardingItems()
 	} else {
 		items = headers.Items()
 	}

--- a/transport/tchannel/header.go
+++ b/transport/tchannel/header.go
@@ -98,22 +98,18 @@ func writeRequestHeaders(
 	format tchannel.Format,
 	appHeaders map[string]string,
 	getWriter func() (tchannel.ArgWriter, error),
-	rawHeader bool,
+	writeExactHeaderCase bool,
 ) error {
+	if writeExactHeaderCase {
+		return writeHeaders(format, appHeaders, getWriter)
+	}
 	headers := transport.NewHeadersWithCapacity(len(appHeaders))
 	// TODO: zero-alloc version
 	for k, v := range appHeaders {
 		headers = headers.With(k, v)
 	}
 
-	var items map[string]string
-	if rawHeader {
-		items = headers.ForwardingItems()
-	} else {
-		items = headers.Items()
-	}
-
-	return writeHeaders(format, items, getWriter)
+	return writeHeaders(format, headers.Items(), getWriter)
 }
 
 // writeHeaders writes the given headers using the given function to get the

--- a/transport/tchannel/header.go
+++ b/transport/tchannel/header.go
@@ -102,11 +102,11 @@ func readHeaders(format tchannel.Format, getReader func() (tchannel.ArgReader, e
 // If the format is JSON, the headers are JSON encoded.
 func writeHeaders(format tchannel.Format, headers map[string]string, tracingBaggage map[string]string, getWriter func() (tchannel.ArgWriter, error)) error {
 	merged := make(map[string]string, len(headers)+len(tracingBaggage))
-	// tracingBaggage should not override application headers. So this goes first
-	for k, v := range tracingBaggage {
+	for k, v := range headers {
 		merged[k] = v
 	}
-	for k, v := range headers {
+	// tracingBaggage should  override application headers. So this goes last
+	for k, v := range tracingBaggage {
 		merged[k] = v
 	}
 	if format == tchannel.JSON {

--- a/transport/tchannel/header_test.go
+++ b/transport/tchannel/header_test.go
@@ -54,7 +54,7 @@ func TestEncodeAndDecodeHeaders(t *testing.T) {
 
 	for _, tt := range tests {
 		headers := transport.HeadersFromMap(tt.headers)
-		assert.Equal(t, tt.bytes, encodeHeaders(headers))
+		assert.Equal(t, tt.bytes, encodeHeaders(tt.headers))
 
 		result, err := decodeHeaders(bytes.NewReader(tt.bytes))
 		if assert.NoError(t, err) {
@@ -130,7 +130,7 @@ func TestReadAndWriteHeaders(t *testing.T) {
 		headers := transport.HeadersFromMap(tt.headers)
 
 		buffer := newBufferArgWriter()
-		err := writeHeaders(tt.format, headers, func() (tchannel.ArgWriter, error) {
+		err := writeHeaders(tt.format, tt.headers, func() (tchannel.ArgWriter, error) {
 			return buffer, nil
 		})
 		require.NoError(t, err)

--- a/transport/tchannel/header_test.go
+++ b/transport/tchannel/header_test.go
@@ -160,7 +160,7 @@ func TestWriteHeaders(t *testing.T) {
 	tests := []struct {
 		msg string
 		// the headers are serialized in an undefined order so the encoding
-		// must be one of the following
+		// must be one of bytes or orBytes
 		bytes          []byte
 		orBytes        []byte
 		headers        map[string]string
@@ -179,7 +179,7 @@ func TestWriteHeaders(t *testing.T) {
 				0x00, 0x01, 'a', 0x00, 0x01, '1',
 			},
 			map[string]string{"a": "1", "b": "2"},
-			nil,
+			nil, /* tracingBaggage */
 		},
 		{
 			"mixed case header",
@@ -194,7 +194,22 @@ func TestWriteHeaders(t *testing.T) {
 				0x00, 0x01, 'A', 0x00, 0x01, '1',
 			},
 			map[string]string{"A": "1", "b": "2"},
-			nil,
+			nil, /* tracingBaggage */
+		},
+		{
+			"keys only differ by case",
+			[]byte{
+				0x00, 0x02,
+				0x00, 0x01, 'A', 0x00, 0x01, '1',
+				0x00, 0x01, 'a', 0x00, 0x01, '2',
+			},
+			[]byte{
+				0x00, 0x02,
+				0x00, 0x01, 'a', 0x00, 0x01, '2',
+				0x00, 0x01, 'A', 0x00, 0x01, '1',
+			},
+			map[string]string{"A": "1", "a": "2"},
+			nil, /* tracingBaggage */
 		},
 		{
 			"tracing bagger header",

--- a/transport/tchannel/options.go
+++ b/transport/tchannel/options.go
@@ -56,7 +56,7 @@ type transportOptions struct {
 	name                string
 	connTimeout         time.Duration
 	connBackoffStrategy backoffapi.Strategy
-	exactCaseHeader     bool
+	originalHeader      bool
 }
 
 // newTransportOptions constructs the default transport options struct
@@ -180,6 +180,6 @@ func ConnBackoff(s backoffapi.Strategy) TransportOption {
 // ExactCaseHeader specifies whether to forward headers without canonicalizing it
 func ExactCaseHeader() TransportOption {
 	return func(options *transportOptions) {
-		options.exactCaseHeader = true
+		options.originalHeader = true
 	}
 }

--- a/transport/tchannel/options.go
+++ b/transport/tchannel/options.go
@@ -56,7 +56,7 @@ type transportOptions struct {
 	name                string
 	connTimeout         time.Duration
 	connBackoffStrategy backoffapi.Strategy
-	forwardingHeader    bool
+	exactCaseHeader     bool
 }
 
 // newTransportOptions constructs the default transport options struct
@@ -177,9 +177,9 @@ func ConnBackoff(s backoffapi.Strategy) TransportOption {
 	}
 }
 
-// ForwardingHeader specifies whether to forward headers without canonicalizing it
-func ForwardingHeader() TransportOption {
+// ExactCaseHeader specifies whether to forward headers without canonicalizing it
+func ExactCaseHeader() TransportOption {
 	return func(options *transportOptions) {
-		options.forwardingHeader = true
+		options.exactCaseHeader = true
 	}
 }

--- a/transport/tchannel/options.go
+++ b/transport/tchannel/options.go
@@ -56,7 +56,7 @@ type transportOptions struct {
 	name                string
 	connTimeout         time.Duration
 	connBackoffStrategy backoffapi.Strategy
-	rawHeader           bool
+	forwardingHeader    bool
 }
 
 // newTransportOptions constructs the default transport options struct
@@ -177,9 +177,9 @@ func ConnBackoff(s backoffapi.Strategy) TransportOption {
 	}
 }
 
-// RawHeader specifies whether to use the raw header keys
-func RawHeader() TransportOption {
+// ForwardingHeader specifies whether to forward headers without canonicalizing it
+func ForwardingHeader() TransportOption {
 	return func(options *transportOptions) {
-		options.rawHeader = true
+		options.forwardingHeader = true
 	}
 }

--- a/transport/tchannel/options.go
+++ b/transport/tchannel/options.go
@@ -56,7 +56,7 @@ type transportOptions struct {
 	name                string
 	connTimeout         time.Duration
 	connBackoffStrategy backoffapi.Strategy
-	originalHeader      bool
+	originalHeaders     bool
 }
 
 // newTransportOptions constructs the default transport options struct
@@ -178,8 +178,8 @@ func ConnBackoff(s backoffapi.Strategy) TransportOption {
 }
 
 // ExactCaseHeader specifies whether to forward headers without canonicalizing it
-func ExactCaseHeader() TransportOption {
+func OriginalHeaders() TransportOption {
 	return func(options *transportOptions) {
-		options.originalHeader = true
+		options.originalHeaders = true
 	}
 }

--- a/transport/tchannel/options.go
+++ b/transport/tchannel/options.go
@@ -177,7 +177,7 @@ func ConnBackoff(s backoffapi.Strategy) TransportOption {
 	}
 }
 
-// RawHeader specifies to skip canonicalizing the header
+// RawHeader specifies whether to use the raw header keys
 func RawHeader() TransportOption {
 	return func(options *transportOptions) {
 		options.rawHeader = true

--- a/transport/tchannel/options.go
+++ b/transport/tchannel/options.go
@@ -56,7 +56,7 @@ type transportOptions struct {
 	name                string
 	connTimeout         time.Duration
 	connBackoffStrategy backoffapi.Strategy
-	canonicalHeader     bool
+	rawHeader           bool
 }
 
 // newTransportOptions constructs the default transport options struct
@@ -177,9 +177,9 @@ func ConnBackoff(s backoffapi.Strategy) TransportOption {
 	}
 }
 
-// CanonicalHeader specifies to skip canonicalizing the header
-func CanonicalHeader() TransportOption {
+// RawHeader specifies to skip canonicalizing the header
+func RawHeader() TransportOption {
 	return func(options *transportOptions) {
-		options.canonicalHeader = true
+		options.rawHeader = true
 	}
 }

--- a/transport/tchannel/options.go
+++ b/transport/tchannel/options.go
@@ -56,6 +56,7 @@ type transportOptions struct {
 	name                string
 	connTimeout         time.Duration
 	connBackoffStrategy backoffapi.Strategy
+	canonicalHeader     bool
 }
 
 // newTransportOptions constructs the default transport options struct
@@ -173,5 +174,12 @@ func ConnTimeout(d time.Duration) TransportOption {
 func ConnBackoff(s backoffapi.Strategy) TransportOption {
 	return func(options *transportOptions) {
 		options.connBackoffStrategy = s
+	}
+}
+
+// CanonicalHeader specifies to skip canonicalizing the header
+func CanonicalHeader() TransportOption {
+	return func(options *transportOptions) {
+		options.canonicalHeader = true
 	}
 }

--- a/transport/tchannel/options.go
+++ b/transport/tchannel/options.go
@@ -177,7 +177,7 @@ func ConnBackoff(s backoffapi.Strategy) TransportOption {
 	}
 }
 
-// ExactCaseHeader specifies whether to forward headers without canonicalizing it
+// OriginalHeaders specifies whether to forward headers without canonicalizing it
 func OriginalHeaders() TransportOption {
 	return func(options *transportOptions) {
 		options.originalHeaders = true

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -101,7 +101,7 @@ func (p *tchannelPeer) Call(ctx context.Context, req *transport.Request) (*trans
 }
 
 // callWithPeer sends a request with the chosen peer.
-func callWithPeer(ctx context.Context, req *transport.Request, peer *tchannel.Peer, rawHeader bool) (*transport.Response, error) {
+func callWithPeer(ctx context.Context, req *transport.Request, peer *tchannel.Peer, exactCaseHeader bool) (*transport.Response, error) {
 	// NB(abg): Under the current API, the local service's name is required
 	// twice: once when constructing the TChannel and then again when
 	// constructing the RPC.
@@ -134,8 +134,8 @@ func callWithPeer(ctx context.Context, req *transport.Request, peer *tchannel.Pe
 	}
 
 	var headerItems map[string]string
-	if rawHeader {
-		headerItems = req.Headers.ForwardingItems()
+	if exactCaseHeader {
+		headerItems = req.Headers.ExactCaseItems()
 	} else {
 		headerItems = req.Headers.Items()
 	}
@@ -143,7 +143,7 @@ func callWithPeer(ctx context.Context, req *transport.Request, peer *tchannel.Pe
 	// Inject tracing system baggage
 	reqHeaders := tchannel.InjectOutboundSpan(call.Response(), headerItems)
 
-	if err := writeRequestHeaders(ctx, format, reqHeaders, call.Arg2Writer, rawHeader); err != nil {
+	if err := writeRequestHeaders(ctx, format, reqHeaders, call.Arg2Writer, exactCaseHeader); err != nil {
 		// TODO(abg): This will wrap IO errors while writing headers as encode
 		// errors. We should fix that.
 		return nil, errors.RequestHeadersEncodeError(req, err)

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -97,11 +97,11 @@ func (o *Outbound) Call(ctx context.Context, req *transport.Request) (*transport
 func (p *tchannelPeer) Call(ctx context.Context, req *transport.Request) (*transport.Response, error) {
 	root := p.transport.ch.RootPeers()
 	tp := root.GetOrAdd(p.HostPort())
-	return callWithPeer(ctx, req, tp, p.transport.exactCaseHeader)
+	return callWithPeer(ctx, req, tp, p.transport.originalHeader)
 }
 
 // callWithPeer sends a request with the chosen peer.
-func callWithPeer(ctx context.Context, req *transport.Request, peer *tchannel.Peer, exactCaseHeader bool) (*transport.Response, error) {
+func callWithPeer(ctx context.Context, req *transport.Request, peer *tchannel.Peer, originalHeader bool) (*transport.Response, error) {
 	// NB(abg): Under the current API, the local service's name is required
 	// twice: once when constructing the TChannel and then again when
 	// constructing the RPC.
@@ -133,7 +133,7 @@ func callWithPeer(ctx context.Context, req *transport.Request, peer *tchannel.Pe
 		return nil, err
 	}
 	reqHeaders := req.Headers.Items()
-	if exactCaseHeader {
+	if originalHeader {
 		reqHeaders = req.Headers.OriginalItems()
 	}
 

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -97,7 +97,7 @@ func (o *Outbound) Call(ctx context.Context, req *transport.Request) (*transport
 func (p *tchannelPeer) Call(ctx context.Context, req *transport.Request) (*transport.Response, error) {
 	root := p.transport.ch.RootPeers()
 	tp := root.GetOrAdd(p.HostPort())
-	return callWithPeer(ctx, req, tp, p.transport.rawHeader)
+	return callWithPeer(ctx, req, tp, p.transport.forwardingHeader)
 }
 
 // callWithPeer sends a request with the chosen peer.
@@ -135,7 +135,7 @@ func callWithPeer(ctx context.Context, req *transport.Request, peer *tchannel.Pe
 
 	var headerItems map[string]string
 	if rawHeader {
-		headerItems = req.Headers.RawItems()
+		headerItems = req.Headers.ForwardingItems()
 	} else {
 		headerItems = req.Headers.Items()
 	}

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -134,7 +134,7 @@ func callWithPeer(ctx context.Context, req *transport.Request, peer *tchannel.Pe
 	}
 	reqHeaders := req.Headers.Items()
 	if exactCaseHeader {
-		reqHeaders = req.Headers.ExactCaseItems()
+		reqHeaders = req.Headers.OriginalItems()
 	}
 
 	tracingBaggage := tchannel.InjectOutboundSpan(call.Response(), nil)

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -97,7 +97,7 @@ func (o *Outbound) Call(ctx context.Context, req *transport.Request) (*transport
 func (p *tchannelPeer) Call(ctx context.Context, req *transport.Request) (*transport.Response, error) {
 	root := p.transport.ch.RootPeers()
 	tp := root.GetOrAdd(p.HostPort())
-	return callWithPeer(ctx, req, tp, p.transport.originalHeader)
+	return callWithPeer(ctx, req, tp, p.transport.originalHeaders)
 }
 
 // callWithPeer sends a request with the chosen peer.
@@ -137,6 +137,7 @@ func callWithPeer(ctx context.Context, req *transport.Request, peer *tchannel.Pe
 		reqHeaders = req.Headers.OriginalItems()
 	}
 
+	// baggage headers are transport implementation details that are stripped out (and stored in the context). Users don't interact with it
 	tracingBaggage := tchannel.InjectOutboundSpan(call.Response(), nil)
 	if err := writeHeaders(format, reqHeaders, tracingBaggage, call.Arg2Writer); err != nil {
 		// TODO(abg): This will wrap IO errors while writing headers as encode

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -22,7 +22,6 @@ package tchannel
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/uber/tchannel-go"
 	"go.uber.org/yarpc/api/peer"
@@ -98,12 +97,11 @@ func (o *Outbound) Call(ctx context.Context, req *transport.Request) (*transport
 func (p *tchannelPeer) Call(ctx context.Context, req *transport.Request) (*transport.Response, error) {
 	root := p.transport.ch.RootPeers()
 	tp := root.GetOrAdd(p.HostPort())
-	fmt.Println(p.transport.canonicalHeader)
-	return callWithPeer(ctx, req, tp, p.transport.canonicalHeader)
+	return callWithPeer(ctx, req, tp, p.transport.rawHeader)
 }
 
 // callWithPeer sends a request with the chosen peer.
-func callWithPeer(ctx context.Context, req *transport.Request, peer *tchannel.Peer, canonicalHeader bool) (*transport.Response, error) {
+func callWithPeer(ctx context.Context, req *transport.Request, peer *tchannel.Peer, rawHeader bool) (*transport.Response, error) {
 	// NB(abg): Under the current API, the local service's name is required
 	// twice: once when constructing the TChannel and then again when
 	// constructing the RPC.
@@ -135,15 +133,17 @@ func callWithPeer(ctx context.Context, req *transport.Request, peer *tchannel.Pe
 		return nil, err
 	}
 
-	headerItems := req.Headers.Items()
-	if canonicalHeader {
+	var headerItems map[string]string
+	if rawHeader {
 		headerItems = req.Headers.RawItems()
+	} else {
+		headerItems = req.Headers.Items()
 	}
 
 	// Inject tracing system baggage
 	reqHeaders := tchannel.InjectOutboundSpan(call.Response(), headerItems)
 
-	if err := writeRequestHeaders(ctx, format, reqHeaders, call.Arg2Writer); err != nil {
+	if err := writeRequestHeaders(ctx, format, reqHeaders, call.Arg2Writer, rawHeader); err != nil {
 		// TODO(abg): This will wrap IO errors while writing headers as encode
 		// errors. We should fix that.
 		return nil, errors.RequestHeadersEncodeError(req, err)

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -133,10 +133,14 @@ func callWithPeer(ctx context.Context, req *transport.Request, peer *tchannel.Pe
 		return nil, err
 	}
 
+	reqHeaders := req.Headers.Items()
+	if exactCaseHeader {
+		reqHeaders = req.Headers.ExactCaseItems()
+	}
 	// Inject tracing system baggage
-	reqHeaders := tchannel.InjectOutboundSpan(call.Response(), req.Headers.ExactCaseItems())
+	reqHeaders = tchannel.InjectOutboundSpan(call.Response(), reqHeaders)
 
-	if err := writeRequestHeaders(ctx, format, reqHeaders, call.Arg2Writer, exactCaseHeader); err != nil {
+	if err := writeHeaders(format, reqHeaders, call.Arg2Writer); err != nil {
 		// TODO(abg): This will wrap IO errors while writing headers as encode
 		// errors. We should fix that.
 		return nil, errors.RequestHeadersEncodeError(req, err)

--- a/transport/tchannel/outbound_test.go
+++ b/transport/tchannel/outbound_test.go
@@ -156,7 +156,7 @@ func TestCallSuccess(t *testing.T) {
 			assert.NoError(t, err, "failed to write response")
 		}))
 
-	x, err := NewTransport(ServiceName("caller"), RawHeader())
+	x, err := NewTransport(ServiceName("caller"), ForwardingHeader())
 	require.NoError(t, err)
 	require.NoError(t, x.Start(), "failed to start transport")
 

--- a/transport/tchannel/outbound_test.go
+++ b/transport/tchannel/outbound_test.go
@@ -149,73 +149,75 @@ func TestCallSuccess(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		server := testutils.NewServer(t, nil)
-		defer server.Close()
-		serverHostPort := server.PeerInfo().HostPort
+		t.Run(tt.msg, func(t *testing.T) {
+			server := testutils.NewServer(t, nil)
+			defer server.Close()
+			serverHostPort := server.PeerInfo().HostPort
 
-		server.GetSubChannel("service").SetHandler(tchannel.HandlerFunc(
-			func(ctx context.Context, call *tchannel.InboundCall) {
-				assert.Equal(t, "caller", call.CallerName())
-				assert.Equal(t, "service", call.ServiceName())
-				assert.Equal(t, tchannel.Raw, call.Format())
-				assert.Equal(t, "hello", call.MethodString())
-				headers, body, err := readArgs(call)
-				if assert.NoError(t, err, "failed to read request") {
-					assert.Equal(t, tt.headerVal, headers)
-					assert.Equal(t, []byte("world"), body)
-				}
+			server.GetSubChannel("service").SetHandler(tchannel.HandlerFunc(
+				func(ctx context.Context, call *tchannel.InboundCall) {
+					assert.Equal(t, "caller", call.CallerName())
+					assert.Equal(t, "service", call.ServiceName())
+					assert.Equal(t, tchannel.Raw, call.Format())
+					assert.Equal(t, "hello", call.MethodString())
+					headers, body, err := readArgs(call)
+					if assert.NoError(t, err, "failed to read request") {
+						assert.Equal(t, tt.headerVal, headers)
+						assert.Equal(t, []byte("world"), body)
+					}
 
-				dl, ok := ctx.Deadline()
-				assert.True(t, ok, "deadline expected")
-				assert.WithinDuration(t, time.Now(), dl, 200*testtime.Millisecond)
+					dl, ok := ctx.Deadline()
+					assert.True(t, ok, "deadline expected")
+					assert.WithinDuration(t, time.Now(), dl, 200*testtime.Millisecond)
 
-				err = writeArgs(call.Response(),
-					[]byte{
-						0x00, 0x01,
-						0x00, 0x03, 'f', 'o', 'o',
-						0x00, 0x03, 'b', 'a', 'r',
-					}, []byte("great success"))
-				assert.NoError(t, err, "failed to write response")
-			}))
+					err = writeArgs(call.Response(),
+						[]byte{
+							0x00, 0x01,
+							0x00, 0x03, 'f', 'o', 'o',
+							0x00, 0x03, 'b', 'a', 'r',
+						}, []byte("great success"))
+					assert.NoError(t, err, "failed to write response")
+				}))
 
-		x, err := NewTransport(tt.options...)
-		require.NoError(t, err)
-		require.NoError(t, x.Start(), "failed to start transport")
+			x, err := NewTransport(tt.options...)
+			require.NoError(t, err)
+			require.NoError(t, x.Start(), "failed to start transport")
 
-		out := x.NewSingleOutbound(serverHostPort)
-		require.NoError(t, out.Start(), "failed to start outbound")
-		defer out.Stop()
+			out := x.NewSingleOutbound(serverHostPort)
+			require.NoError(t, out.Start(), "failed to start outbound")
+			defer out.Stop()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 200*testtime.Millisecond)
-		defer cancel()
-		res, err := out.Call(
-			ctx,
-			&transport.Request{
-				Caller:    "caller",
-				Service:   "service",
-				Encoding:  raw.Encoding,
-				Procedure: "hello",
-				Headers:   transport.NewHeaders().With(headerKey, headerVal),
-				Body:      bytes.NewReader([]byte("world")),
-			},
-		)
+			ctx, cancel := context.WithTimeout(context.Background(), 200*testtime.Millisecond)
+			defer cancel()
+			res, err := out.Call(
+				ctx,
+				&transport.Request{
+					Caller:    "caller",
+					Service:   "service",
+					Encoding:  raw.Encoding,
+					Procedure: "hello",
+					Headers:   transport.NewHeaders().With(headerKey, headerVal),
+					Body:      bytes.NewReader([]byte("world")),
+				},
+			)
 
-		if !assert.NoError(t, err, "failed to make call") {
-			return
-		}
+			if !assert.NoError(t, err, "failed to make call") {
+				return
+			}
 
-		assert.Equal(t, false, res.ApplicationError, "not application error")
+			assert.Equal(t, false, res.ApplicationError, "not application error")
 
-		foo, ok := res.Headers.Get("foo")
-		assert.True(t, ok, "value for foo expected")
-		assert.Equal(t, "bar", foo, "foo value mismatch")
+			foo, ok := res.Headers.Get("foo")
+			assert.True(t, ok, "value for foo expected")
+			assert.Equal(t, "bar", foo, "foo value mismatch")
 
-		body, err := ioutil.ReadAll(res.Body)
-		if assert.NoError(t, err, "failed to read response body") {
-			assert.Equal(t, []byte("great success"), body)
-		}
+			body, err := ioutil.ReadAll(res.Body)
+			if assert.NoError(t, err, "failed to read response body") {
+				assert.Equal(t, []byte("great success"), body)
+			}
 
-		assert.NoError(t, res.Body.Close(), "failed to close response body")
+			assert.NoError(t, res.Body.Close(), "failed to close response body")
+		})
 	}
 }
 

--- a/transport/tchannel/outbound_test.go
+++ b/transport/tchannel/outbound_test.go
@@ -156,7 +156,7 @@ func TestCallSuccess(t *testing.T) {
 			assert.NoError(t, err, "failed to write response")
 		}))
 
-	x, err := NewTransport(ServiceName("caller"), ForwardingHeader())
+	x, err := NewTransport(ServiceName("caller"), ExactCaseHeader())
 	require.NoError(t, err)
 	require.NoError(t, x.Start(), "failed to start transport")
 

--- a/transport/tchannel/outbound_test.go
+++ b/transport/tchannel/outbound_test.go
@@ -134,10 +134,14 @@ func TestCallSuccess(t *testing.T) {
 			assert.Equal(t, "service", call.ServiceName())
 			assert.Equal(t, tchannel.Raw, call.Format())
 			assert.Equal(t, "hello", call.MethodString())
-
+			fmt.Println(call)
 			headers, body, err := readArgs(call)
 			if assert.NoError(t, err, "failed to read request") {
-				assert.Equal(t, []byte(fmt.Sprintf("%s:%s", headerKey, headerVal)), headers)
+				assert.Equal(t, []byte{
+					0x00, 0x01,
+					0x00, 0x0b, 'f', 'o', 'o', '-', 'B', 'A', 'R', '-', 'B', 'a', 'Z',
+					0x00, 0x09, 'F', 'o', 'o', 'B', 'a', 'r', 'B', 'a', 'z',
+				}, headers)
 				assert.Equal(t, []byte("world"), body)
 			}
 
@@ -154,7 +158,7 @@ func TestCallSuccess(t *testing.T) {
 			assert.NoError(t, err, "failed to write response")
 		}))
 
-	x, err := NewTransport(ServiceName("caller"), CanonicalHeader())
+	x, err := NewTransport(ServiceName("caller"), RawHeader())
 	require.NoError(t, err)
 	require.NoError(t, x.Start(), "failed to start transport")
 

--- a/transport/tchannel/outbound_test.go
+++ b/transport/tchannel/outbound_test.go
@@ -130,7 +130,7 @@ func TestCallSuccess(t *testing.T) {
 	}{
 		{
 			msg:     "exactCaseHeader options on",
-			options: []TransportOption{ServiceName("caller"), ExactCaseHeader()},
+			options: []TransportOption{ServiceName("caller"), OriginalHeaders()},
 			headerVal: []byte{
 				0x00, 0x01,
 				0x00, 0x0b, 'f', 'o', 'o', '-', 'B', 'A', 'R', '-', 'B', 'a', 'Z',

--- a/transport/tchannel/outbound_test.go
+++ b/transport/tchannel/outbound_test.go
@@ -22,7 +22,6 @@ package tchannel
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"sync"
 	"testing"
@@ -134,7 +133,6 @@ func TestCallSuccess(t *testing.T) {
 			assert.Equal(t, "service", call.ServiceName())
 			assert.Equal(t, tchannel.Raw, call.Format())
 			assert.Equal(t, "hello", call.MethodString())
-			fmt.Println(call)
 			headers, body, err := readArgs(call)
 			if assert.NoError(t, err, "failed to read request") {
 				assert.Equal(t, []byte{

--- a/transport/tchannel/transport.go
+++ b/transport/tchannel/transport.go
@@ -195,8 +195,9 @@ func (t *Transport) start() error {
 	chopts := tchannel.ChannelOptions{
 		Tracer: t.tracer,
 		Handler: handler{
-			router: t.router,
-			tracer: t.tracer,
+			router:          t.router,
+			tracer:          t.tracer,
+			exactCaseHeader: t.exactCaseHeader,
 		},
 		OnPeerStatusChanged: t.onPeerStatusChanged,
 	}

--- a/transport/tchannel/transport.go
+++ b/transport/tchannel/transport.go
@@ -59,7 +59,7 @@ type Transport struct {
 	connRetryBackoffFactor int
 	connectorsGroup        sync.WaitGroup
 	connBackoffStrategy    backoffapi.Strategy
-	forwardingHeader       bool
+	exactCaseHeader        bool
 
 	peers map[string]*tchannelPeer
 }
@@ -100,7 +100,7 @@ func (o transportOptions) newTransport() *Transport {
 		peers:               make(map[string]*tchannelPeer),
 		tracer:              o.tracer,
 		logger:              logger,
-		forwardingHeader:    o.forwardingHeader,
+		exactCaseHeader:     o.exactCaseHeader,
 	}
 }
 

--- a/transport/tchannel/transport.go
+++ b/transport/tchannel/transport.go
@@ -59,7 +59,7 @@ type Transport struct {
 	connRetryBackoffFactor int
 	connectorsGroup        sync.WaitGroup
 	connBackoffStrategy    backoffapi.Strategy
-	originalHeader         bool
+	originalHeaders        bool
 
 	peers map[string]*tchannelPeer
 }
@@ -100,7 +100,7 @@ func (o transportOptions) newTransport() *Transport {
 		peers:               make(map[string]*tchannelPeer),
 		tracer:              o.tracer,
 		logger:              logger,
-		originalHeader:      o.originalHeader,
+		originalHeaders:     o.originalHeaders,
 	}
 }
 
@@ -195,9 +195,9 @@ func (t *Transport) start() error {
 	chopts := tchannel.ChannelOptions{
 		Tracer: t.tracer,
 		Handler: handler{
-			router:         t.router,
-			tracer:         t.tracer,
-			originalHeader: t.originalHeader,
+			router:          t.router,
+			tracer:          t.tracer,
+			originalHeaders: t.originalHeaders,
 		},
 		OnPeerStatusChanged: t.onPeerStatusChanged,
 	}

--- a/transport/tchannel/transport.go
+++ b/transport/tchannel/transport.go
@@ -59,7 +59,7 @@ type Transport struct {
 	connRetryBackoffFactor int
 	connectorsGroup        sync.WaitGroup
 	connBackoffStrategy    backoffapi.Strategy
-	exactCaseHeader        bool
+	originalHeader         bool
 
 	peers map[string]*tchannelPeer
 }
@@ -100,7 +100,7 @@ func (o transportOptions) newTransport() *Transport {
 		peers:               make(map[string]*tchannelPeer),
 		tracer:              o.tracer,
 		logger:              logger,
-		exactCaseHeader:     o.exactCaseHeader,
+		originalHeader:      o.originalHeader,
 	}
 }
 
@@ -195,9 +195,9 @@ func (t *Transport) start() error {
 	chopts := tchannel.ChannelOptions{
 		Tracer: t.tracer,
 		Handler: handler{
-			router:          t.router,
-			tracer:          t.tracer,
-			exactCaseHeader: t.exactCaseHeader,
+			router:         t.router,
+			tracer:         t.tracer,
+			originalHeader: t.originalHeader,
 		},
 		OnPeerStatusChanged: t.onPeerStatusChanged,
 	}

--- a/transport/tchannel/transport.go
+++ b/transport/tchannel/transport.go
@@ -59,7 +59,7 @@ type Transport struct {
 	connRetryBackoffFactor int
 	connectorsGroup        sync.WaitGroup
 	connBackoffStrategy    backoffapi.Strategy
-	canonicalHeader        bool
+	rawHeader              bool
 
 	peers map[string]*tchannelPeer
 }
@@ -100,7 +100,7 @@ func (o transportOptions) newTransport() *Transport {
 		peers:               make(map[string]*tchannelPeer),
 		tracer:              o.tracer,
 		logger:              logger,
-		canonicalHeader:     o.canonicalHeader,
+		rawHeader:           o.rawHeader,
 	}
 }
 

--- a/transport/tchannel/transport.go
+++ b/transport/tchannel/transport.go
@@ -59,7 +59,7 @@ type Transport struct {
 	connRetryBackoffFactor int
 	connectorsGroup        sync.WaitGroup
 	connBackoffStrategy    backoffapi.Strategy
-	rawHeader              bool
+	forwardingHeader       bool
 
 	peers map[string]*tchannelPeer
 }
@@ -100,7 +100,7 @@ func (o transportOptions) newTransport() *Transport {
 		peers:               make(map[string]*tchannelPeer),
 		tracer:              o.tracer,
 		logger:              logger,
-		rawHeader:           o.rawHeader,
+		forwardingHeader:    o.forwardingHeader,
 	}
 }
 

--- a/transport/tchannel/transport.go
+++ b/transport/tchannel/transport.go
@@ -59,6 +59,7 @@ type Transport struct {
 	connRetryBackoffFactor int
 	connectorsGroup        sync.WaitGroup
 	connBackoffStrategy    backoffapi.Strategy
+	canonicalHeader        bool
 
 	peers map[string]*tchannelPeer
 }
@@ -99,6 +100,7 @@ func (o transportOptions) newTransport() *Transport {
 		peers:               make(map[string]*tchannelPeer),
 		tracer:              o.tracer,
 		logger:              logger,
+		canonicalHeader:     o.canonicalHeader,
 	}
 }
 


### PR DESCRIPTION
Summary: TChannel headers are case-sensitive and downstream TChannel
server could depend on some non-lowercase header keys. For proxying
purpose, we should not change case of the header keys. In this diff, we
provide an option in TChannel Transport. With it, the tchannel outbound
will use the non canonicalized header keys for requests. 