### PR TITLE
Update doc.go

### DIFF
--- a/transport/tchannel/doc.go
+++ b/transport/tchannel/doc.go
@@ -51,7 +51,7 @@
 // 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 // 		Name: "myservice",
 // 		Outbounds: yarpc.OUtbounds{
-// 			{Unary: myserviceOutbound},
+// 			"outboundservice": {Unary: myserviceOutbound},
 // 		},
 // 	})
 //


### PR DESCRIPTION
Modify documentation to indicate that Outbounds is a map[string]transport.Outbounds instead of []transport.Outbounds

- [ ] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [ ] Entry in CHANGELOG.md
