### PR TITLE
[WIP] Add Ignored error code

### DIFF
--- a/transport/grpc/codes.go
+++ b/transport/grpc/codes.go
@@ -45,6 +45,7 @@ var (
 		yarpcerrors.CodeUnavailable:        codes.Unavailable,
 		yarpcerrors.CodeDataLoss:           codes.DataLoss,
 		yarpcerrors.CodeUnauthenticated:    codes.Unauthenticated,
+		yarpcerrors.CodeIgnored:            codes.Unavailable,
 	}
 
 	// _grpcCodeToCode maps all gRPC Codes to their corresponding Code.

--- a/transport/http/codes.go
+++ b/transport/http/codes.go
@@ -42,6 +42,7 @@ var (
 		yarpcerrors.CodeUnavailable:        503,
 		yarpcerrors.CodeDataLoss:           500,
 		yarpcerrors.CodeUnauthenticated:    401,
+		yarpcerrors.CodeIgnored:            503,
 	}
 
 	// _statusCodeToCodes maps HTTP status codes to a slice of their corresponding Codes.
@@ -67,7 +68,10 @@ var (
 			yarpcerrors.CodeDataLoss,
 		},
 		501: {yarpcerrors.CodeUnimplemented},
-		503: {yarpcerrors.CodeUnavailable},
+		503: {
+			yarpcerrors.CodeUnavailable,
+			yarpcerrors.CodeIgnored,
+		},
 		504: {yarpcerrors.CodeDeadlineExceeded},
 	}
 )

--- a/transport/tchannel/codes.go
+++ b/transport/tchannel/codes.go
@@ -40,6 +40,9 @@ var (
 		yarpcerrors.CodeUnavailable:       tchannel.ErrCodeDeclined,
 		yarpcerrors.CodeDataLoss:          tchannel.ErrCodeProtocol,
 		yarpcerrors.CodeResourceExhausted: tchannel.ErrCodeBusy,
+
+		// yarpcerrors.CodeIgnored is intentionally omitted. This error code will
+		// black hole requests and so, no error will be returned to the client.
 	}
 
 	// _tchannelCodeToCode maps TChannel SystemErrCodes to their corresponding Code.

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -94,6 +94,10 @@ func (h handler) handle(ctx context.Context, call inboundCall) {
 	responseWriter := newResponseWriter(call.Response(), call.Format())
 
 	err := h.callHandler(ctx, call, responseWriter)
+	if yarpcerrors.IsIgnored(err) {
+		return // drop request
+	}
+
 	if err != nil && !responseWriter.isApplicationError {
 		// TODO: log error
 		_ = call.Response().SendSystemError(getSystemError(err))

--- a/yarpcerrors/codes.go
+++ b/yarpcerrors/codes.go
@@ -136,6 +136,9 @@ const (
 	// CodeUnauthenticated means the request does not have valid authentication
 	// credentials for the operation.
 	CodeUnauthenticated Code = 16
+
+	// CodeIgnored means the request was ignored.
+	CodeIgnored Code = 17
 )
 
 var (
@@ -157,6 +160,7 @@ var (
 		CodeUnavailable:        "unavailable",
 		CodeDataLoss:           "data-loss",
 		CodeUnauthenticated:    "unauthenticated",
+		CodeIgnored:            "ignored",
 	}
 	_stringToCode = map[string]Code{
 		"ok":                  CodeOK,
@@ -176,6 +180,7 @@ var (
 		"unavailable":         CodeUnavailable,
 		"data-loss":           CodeDataLoss,
 		"unauthenticated":     CodeUnauthenticated,
+		"ignored":             CodeIgnored,
 	}
 )
 

--- a/yarpcerrors/errors.go
+++ b/yarpcerrors/errors.go
@@ -234,6 +234,12 @@ func UnauthenticatedErrorf(format string, args ...interface{}) error {
 	return Newf(CodeUnauthenticated, format, args...)
 }
 
+// IgnoredErrorf returns a new Status with code CodeIgnored
+// by calling Newf(CodeIgnore, format, args...).
+func IgnoredErrorf(format string, args ...interface{}) error {
+	return Newf(CodeIgnored, format, args...)
+}
+
 // IsCancelled returns true if FromError(err).Code() == CodeCancelled.
 func IsCancelled(err error) bool {
 	return FromError(err).Code() == CodeCancelled
@@ -312,6 +318,11 @@ func IsDataLoss(err error) bool {
 // IsUnauthenticated returns true if FromError(err).Code() == CodeUnauthenticated.
 func IsUnauthenticated(err error) bool {
 	return FromError(err).Code() == CodeUnauthenticated
+}
+
+// IsIgnored returns true if FromError(err).Code() == CodeIgnored.
+func IsIgnored(err error) bool {
+	return FromError(err).Code() == CodeIgnored
 }
 
 // IsYARPCError returns whether the provided error is a YARPC error.


### PR DESCRIPTION
This adds a `yarpcerrors.CodeIgnored` code to the errors API. This
is intended for applications/middleware to signal to the transport
that the inbound request should be ignored.

The TChannel transport will not respond to the request (black-hole)
causing clients to timeout. The client will never see the error
and therefore has no equivalent mapping to existing TChannel
error codes.

HTTP will return a `503: Service Unavailable` error to clients.