### PR TITLE
headers: Don't use global emptyMap

### DIFF
--- a/api/transport/header.go
+++ b/api/transport/header.go
@@ -88,17 +88,11 @@ func (h Headers) Len() int {
 	return len(h.items)
 }
 
-// Global empty map used by Items() for the case where h.items is nil.
-var emptyMap = map[string]string{}
-
 // Items returns the underlying map for this Headers object. The returned map
 // MUST NOT be changed. Doing so will result in undefined behavior.
 //
 // Keys in the map are normalized using CanonicalizeHeaderKey.
 func (h Headers) Items() map[string]string {
-	if h.items == nil {
-		return emptyMap
-	}
 	return h.items
 }
 

--- a/transport/tchannel/header.go
+++ b/transport/tchannel/header.go
@@ -109,6 +109,8 @@ func writeRequestHeaders(
 	return writeHeaders(format, headers, getWriter)
 }
 
+var emptyMap = map[string]string{}
+
 // writeHeaders writes the given headers using the given function to get the
 // arg writer.
 //
@@ -119,7 +121,12 @@ func writeRequestHeaders(
 func writeHeaders(format tchannel.Format, headers transport.Headers, getWriter func() (tchannel.ArgWriter, error)) error {
 	if format == tchannel.JSON {
 		// JSON is special
-		return tchannel.NewArgWriter(getWriter()).WriteJSON(headers.Items())
+		items := headers.Items()
+		if items == nil {
+			// We want to write "{}", not "null" for empty map.
+			items = emptyMap
+		}
+		return tchannel.NewArgWriter(getWriter()).WriteJSON(items)
 	}
 	return tchannel.NewArgWriter(getWriter()).Write(encodeHeaders(headers))
 }


### PR DESCRIPTION
Instead of returning a global `emptyMap`, we now return `nil` for empty
headers since `nil` is a valid empty map.

One caveat of this is that the map will JSON-encode into `"null"`, not
`"{}"`, which is why the TChannel JSON handling had to be changed.