### PR TITLE
[WIP] Add ignore error for dropping requests

### DIFF
--- a/transport/http/handler.go
+++ b/transport/http/handler.go
@@ -62,6 +62,10 @@ func (h handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		responseWriter.Close(http.StatusOK)
 		return
 	}
+	if yarpcerrors.IsIgnore(status) {
+		// abrubtly close the connection
+		return
+	}
 	if statusCodeText, marshalErr := status.Code().MarshalText(); marshalErr != nil {
 		status = yarpcerrors.Newf(yarpcerrors.CodeInternal, "error %s had code %v which is unknown", status.Error(), status.Code())
 		responseWriter.AddSystemHeader(ErrorCodeHeader, "internal")

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -94,6 +94,12 @@ func (h handler) handle(ctx context.Context, call inboundCall) {
 	responseWriter := newResponseWriter(call.Response(), call.Format())
 
 	err := h.callHandler(ctx, call, responseWriter)
+
+	if yarpcerrors.IsIgnore(err) {
+		// let clients timeout -- this will slow down callers with aggresive retry policies
+		return
+	}
+
 	if err != nil && !responseWriter.isApplicationError {
 		// TODO: log error
 		_ = call.Response().SendSystemError(getSystemError(err))

--- a/yarpcerrors/errors.go
+++ b/yarpcerrors/errors.go
@@ -68,6 +68,8 @@ type Status struct {
 	code    Code
 	name    string
 	message string
+
+	isIgnoreErr bool
 }
 
 // WithName returns a new Status with the given name.
@@ -186,6 +188,17 @@ func ResourceExhaustedErrorf(format string, args ...interface{}) error {
 	return Newf(CodeResourceExhausted, format, args...)
 }
 
+// IgnoreErrorf returns a new Status with code CodeResourceExhausted
+// by calling Newf(CodeResourceExhausted, format, args...).
+//
+// Returned errors can be differentiated from ResourceExhaustedErrorf()
+// by calling IsIgnore(err).
+func IgnoreErrorf(format string, args ...interface{}) error {
+	s := Newf(CodeResourceExhausted, format, args...)
+	s.isIgnoreErr = true
+	return s
+}
+
 // FailedPreconditionErrorf returns a new Status with code CodeFailedPrecondition
 // by calling Newf(CodeFailedPrecondition, format, args...).
 func FailedPreconditionErrorf(format string, args ...interface{}) error {
@@ -272,6 +285,14 @@ func IsPermissionDenied(err error) bool {
 // IsResourceExhausted returns true if FromError(err).Code() == CodeResourceExhausted.
 func IsResourceExhausted(err error) bool {
 	return FromError(err).Code() == CodeResourceExhausted
+}
+
+// IsIgnore returns true if the error was created from IgnoreErrorf(...).
+func IsIgnore(err error) bool {
+	if status := FromError(err); status != nil {
+		return status.isIgnoreErr
+	}
+	return false
 }
 
 // IsFailedPrecondition returns true if FromError(err).Code() == CodeFailedPrecondition.


### PR DESCRIPTION
Pivoting from D1496049 and #1429, this WIP is new and improved!

This adds a  flag to `Status` which indicates to transports that, if supported, they  drop the request.
Transports that do not support this specifc behavior will see a YARPC resource exhausted error instead.

More testing is still required. The TChannel case works as expected where the client simply times out. In the HTTP case, clients would see something like
```
Failed while parsing response: cannot parse Thrift struct from response: unexpected EOF
```
Since these changes come about specifically slowing down aggressive TChannel clients, we can axe the HTTP changes if needed.