### PR TITLE
Black-hole TChannel requests on resource exhausted errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Changed
+- TChannel inbounds will blackhole requests when handlers return resource
+  exhausted errors.
 
 ## [1.30.0] - 2018-05-03
 ### Added

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -96,6 +96,13 @@ func (h handler) handle(ctx context.Context, call inboundCall) {
 	responseWriter := newResponseWriter(call.Response(), call.Format(), h.headerCase)
 
 	err := h.callHandler(ctx, call, responseWriter)
+
+	// black-hole requests on resource exhausted errors
+	if yarpcerrors.FromError(err).Code() == yarpcerrors.CodeResourceExhausted {
+		// all TChannel clients will time out instead of receiving an error
+		call.Response().Blackhole()
+		return
+	}
 	if err != nil && !responseWriter.isApplicationError {
 		// TODO: log error
 		_ = call.Response().SendSystemError(getSystemError(err))

--- a/transport/tchannel/tchannel_integration_test.go
+++ b/transport/tchannel/tchannel_integration_test.go
@@ -29,6 +29,7 @@ import (
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/x/yarpctest"
 	"go.uber.org/yarpc/x/yarpctest/api"
+	"go.uber.org/yarpc/x/yarpctest/types"
 	"go.uber.org/yarpc/yarpcerrors"
 )
 
@@ -37,11 +38,11 @@ func TestHandleResourceExhausted(t *testing.T) {
 	procedureName := "test-procedure"
 	port := uint16(8000)
 
-	resourceExhaustedHandler := yarpctest.EchoHandler(api.UnaryInboundMiddlewareFunc(
-		func(context.Context, *transport.Request, transport.ResponseWriter, transport.UnaryHandler) error {
+	resourceExhaustedHandler := &types.UnaryHandler{
+		Handler: api.UnaryHandlerFunc(func(context.Context, *transport.Request, transport.ResponseWriter) error {
 			// eg: simulating a rate limiter that's reached its limit
 			return yarpcerrors.Newf(yarpcerrors.CodeResourceExhausted, "resource exhausted: rate limit exceeded")
-		}))
+		})}
 
 	service := yarpctest.TChannelService(
 		yarpctest.Name(serviceName),

--- a/transport/tchannel/tchannel_integration_test.go
+++ b/transport/tchannel/tchannel_integration_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tchannel_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/x/yarpctest"
+	"go.uber.org/yarpc/x/yarpctest/api"
+	"go.uber.org/yarpc/yarpcerrors"
+)
+
+func TestHandleResourceExhausted(t *testing.T) {
+	serviceName := "test-service"
+	procedureName := "test-procedure"
+	port := uint16(8000)
+
+	resourceExhaustedHandler := yarpctest.EchoHandler(api.UnaryInboundMiddlewareFunc(
+		func(context.Context, *transport.Request, transport.ResponseWriter, transport.UnaryHandler) error {
+			// eg: simulating a rate limiter that's reached its limit
+			return yarpcerrors.Newf(yarpcerrors.CodeResourceExhausted, "resource exhausted: rate limit exceeded")
+		}))
+
+	service := yarpctest.TChannelService(
+		yarpctest.Name(serviceName),
+		yarpctest.Port(port),
+		yarpctest.Proc(yarpctest.Name(procedureName), resourceExhaustedHandler),
+	)
+	require.NoError(t, service.Start(t))
+	defer func() { require.NoError(t, service.Stop(t)) }()
+
+	requests := yarpctest.ConcurrentAction(
+		yarpctest.TChannelRequest(
+			yarpctest.Service(serviceName),
+			yarpctest.Port(port),
+			yarpctest.Procedure(procedureName),
+			yarpctest.GiveTimeout(time.Millisecond*100),
+
+			// all TChannel requests should timeout and never actually receive
+			// the resource exhausted error
+			yarpctest.WantError("timeout"),
+		),
+		10,
+	)
+	requests.Run(t)
+}


### PR DESCRIPTION
This change will blackhole all inbound TChannel requests when handlers
return a YARPC resource exhausted error. This slows down abusive
TChannel clients with aggressive retry policies.