### PR TITLE
Surface NoShuffle peer list option as a function

### DIFF
--- a/peer/pendingheap/list.go
+++ b/peer/pendingheap/list.go
@@ -59,7 +59,7 @@ func New(transport peer.Transport, opts ...ListOption) *List {
 		peerlist.Capacity(cfg.capacity),
 	}
 	if !cfg.shuffle {
-		plOpts = append(plOpts, peerlist.NoShuffle)
+		plOpts = append(plOpts, peerlist.NoShuffle())
 	}
 
 	return &List{

--- a/peer/roundrobin/list.go
+++ b/peer/roundrobin/list.go
@@ -64,7 +64,7 @@ func New(transport peer.Transport, opts ...ListOption) *List {
 		peerlist.Seed(cfg.seed),
 	}
 	if !cfg.shuffle {
-		plOpts = append(plOpts, peerlist.NoShuffle)
+		plOpts = append(plOpts, peerlist.NoShuffle())
 	}
 
 	return &List{


### PR DESCRIPTION
This change follows up on feedback from @prashantv for general advice for handling niladic options as functions so that their godocs are easier to scan.