### PR TITLE
use an enum for headerCase instead of bool

### DIFF
--- a/transport/tchannel/handler_test.go
+++ b/transport/tchannel/handler_test.go
@@ -342,7 +342,7 @@ func TestResponseWriter(t *testing.T) {
 		arg2             []byte
 		arg3             []byte
 		applicationError bool
-		exactCaseHeader  bool
+		headerCase       headerCase
 	}{
 		{
 			format: tchannel.Raw,
@@ -376,8 +376,8 @@ func TestResponseWriter(t *testing.T) {
 				0x00, 0x03, 'F', 'o', 'O',
 				0x00, 0x03, 'b', 'A', 'r',
 			},
-			arg3:            []byte("hello world"),
-			exactCaseHeader: true,
+			arg3:       []byte("hello world"),
+			headerCase: originalHeaderCase,
 		},
 		{
 			format: tchannel.Raw,
@@ -411,9 +411,9 @@ func TestResponseWriter(t *testing.T) {
 				_, err := w.Write([]byte("{}"))
 				require.NoError(t, err)
 			},
-			arg2:            []byte(`{"FoO":"bAr"}` + "\n"),
-			arg3:            []byte("{}"),
-			exactCaseHeader: true,
+			arg2:       []byte(`{"FoO":"bAr"}` + "\n"),
+			arg3:       []byte("{}"),
+			headerCase: originalHeaderCase,
 		},
 		{
 			format: tchannel.JSON,
@@ -442,7 +442,7 @@ func TestResponseWriter(t *testing.T) {
 		resp := newResponseRecorder()
 		call.resp = resp
 
-		w := newResponseWriter(call.Response(), call.Format(), tt.exactCaseHeader)
+		w := newResponseWriter(call.Response(), call.Format(), tt.headerCase)
 		tt.apply(w)
 		assert.NoError(t, w.Close())
 
@@ -479,7 +479,7 @@ func TestResponseWriterFailure(t *testing.T) {
 		resp := newResponseRecorder()
 		tt.setupResp(resp)
 
-		w := newResponseWriter(resp, tchannel.Raw, false /* exactItems */)
+		w := newResponseWriter(resp, tchannel.Raw, canonicalizedHeaderCase)
 		_, err := w.Write([]byte("foo"))
 		assert.NoError(t, err)
 		_, err = w.Write([]byte("bar"))
@@ -494,7 +494,7 @@ func TestResponseWriterFailure(t *testing.T) {
 
 func TestResponseWriterEmptyBodyHeaders(t *testing.T) {
 	res := newResponseRecorder()
-	w := newResponseWriter(res, tchannel.Raw, false)
+	w := newResponseWriter(res, tchannel.Raw, canonicalizedHeaderCase)
 
 	w.AddHeaders(transport.NewHeaders().With("foo", "bar"))
 	require.NoError(t, w.Close())

--- a/transport/tchannel/header.go
+++ b/transport/tchannel/header.go
@@ -181,6 +181,15 @@ func encodeHeaders(hs map[string]string) []byte {
 	return out
 }
 
+func headerMap(hs transport.Headers, headerCase headerCase) map[string]string {
+	switch headerCase {
+	case originalHeaderCase:
+		return hs.OriginalItems()
+	default:
+		return hs.Items()
+	}
+}
+
 // _putStr16 writes the bytes `in` into `out` using the encoding `s~2`.
 func _putStr16(in string, out []byte) int {
 	binary.BigEndian.PutUint16(out, uint16(len(in)))

--- a/transport/tchannel/options.go
+++ b/transport/tchannel/options.go
@@ -177,7 +177,7 @@ func ConnBackoff(s backoffapi.Strategy) TransportOption {
 	}
 }
 
-// OriginalHeaders specifies whether to forward headers without canonicalizing it
+// OriginalHeaders specifies whether to forward headers without canonicalizing them
 func OriginalHeaders() TransportOption {
 	return func(options *transportOptions) {
 		options.originalHeaders = true


### PR DESCRIPTION
In #1426, @kriskowal left comments about using an enum instead of a bool to decide how we handle header cases. This is the change. 
