### PR TITLE
[WIP] Propagate application errors to observability middleware

### DIFF
--- a/api/transport/response.go
+++ b/api/transport/response.go
@@ -42,8 +42,14 @@ type ResponseWriter interface {
 	AddHeaders(Headers)
 	// TODO(abg): Ability to set individual headers instead?
 
+	// DEPRECATED
 	// SetApplicationError specifies that this response contains an
 	// application error. If called, this MUST be called before any invocation
 	// of Write().
 	SetApplicationError()
+
+	// SetVerboseApplicationError allows to verbosely specify application error
+	// If called, this MUST be called before any invocation
+	// of Write().
+	SetVerboseApplicationError(err error)
 }

--- a/api/transport/response.go
+++ b/api/transport/response.go
@@ -42,14 +42,8 @@ type ResponseWriter interface {
 	AddHeaders(Headers)
 	// TODO(abg): Ability to set individual headers instead?
 
-	// DEPRECATED
 	// SetApplicationError specifies that this response contains an
 	// application error. If called, this MUST be called before any invocation
 	// of Write().
-	SetApplicationError()
-
-	// SetVerboseApplicationError allows to verbosely specify application error
-	// If called, this MUST be called before any invocation
-	// of Write().
-	SetVerboseApplicationError(err error)
+	SetApplicationError(err error)
 }

--- a/api/transport/transporttest/reqres.go
+++ b/api/transport/transporttest/reqres.go
@@ -209,7 +209,7 @@ type FakeResponseWriter struct {
 }
 
 // SetApplicationError for FakeResponseWriter.
-func (fw *FakeResponseWriter) SetApplicationError() {
+func (fw *FakeResponseWriter) SetApplicationError(_ error) {
 	fw.IsApplicationError = true
 }
 

--- a/encoding/json/inbound.go
+++ b/encoding/json/inbound.go
@@ -72,7 +72,7 @@ func (h jsonHandler) Handle(ctx context.Context, treq *transport.Request, rw tra
 	}
 
 	if appErr, _ := results[1].Interface().(error); appErr != nil {
-		rw.SetVerboseApplicationError(appErr)
+		rw.SetApplicationError(appErr)
 		return appErr
 	}
 

--- a/encoding/json/inbound.go
+++ b/encoding/json/inbound.go
@@ -72,7 +72,7 @@ func (h jsonHandler) Handle(ctx context.Context, treq *transport.Request, rw tra
 	}
 
 	if appErr, _ := results[1].Interface().(error); appErr != nil {
-		rw.SetApplicationError()
+		rw.SetVerboseApplicationError(appErr)
 		return appErr
 	}
 

--- a/encoding/protobuf/inbound.go
+++ b/encoding/protobuf/inbound.go
@@ -68,7 +68,7 @@ func (u *unaryHandler) Handle(ctx context.Context, transportRequest *transport.R
 		return err
 	}
 	if appErr != nil {
-		responseWriter.SetVerboseApplicationError(appErr)
+		responseWriter.SetApplicationError(appErr)
 	}
 	return appErr
 }

--- a/encoding/protobuf/inbound.go
+++ b/encoding/protobuf/inbound.go
@@ -68,7 +68,7 @@ func (u *unaryHandler) Handle(ctx context.Context, transportRequest *transport.R
 		return err
 	}
 	if appErr != nil {
-		responseWriter.SetApplicationError()
+		responseWriter.SetVerboseApplicationError(appErr)
 	}
 	return appErr
 }

--- a/encoding/raw/inbound.go
+++ b/encoding/raw/inbound.go
@@ -62,7 +62,7 @@ func (r rawUnaryHandler) Handle(ctx context.Context, treq *transport.Request, rw
 		_, writeErr = rw.Write(resBody)
 	}
 	if appErr != nil {
-		rw.SetVerboseApplicationError(appErr)
+		rw.SetApplicationError(appErr)
 		return appErr
 	}
 	return writeErr

--- a/encoding/raw/inbound.go
+++ b/encoding/raw/inbound.go
@@ -62,7 +62,7 @@ func (r rawUnaryHandler) Handle(ctx context.Context, treq *transport.Request, rw
 		_, writeErr = rw.Write(resBody)
 	}
 	if appErr != nil {
-		rw.SetApplicationError()
+		rw.SetVerboseApplicationError(appErr)
 		return appErr
 	}
 	return writeErr

--- a/encoding/thrift/inbound.go
+++ b/encoding/thrift/inbound.go
@@ -73,7 +73,7 @@ func (t thriftUnaryHandler) Handle(ctx context.Context, treq *transport.Request,
 	}
 
 	if res.ApplicationError != nil {
-		rw.SetVerboseApplicationError(res.ApplicationError)
+		rw.SetApplicationError(res.ApplicationError)
 	}
 
 	if err := call.WriteToResponse(rw); err != nil {

--- a/encoding/thrift/inbound.go
+++ b/encoding/thrift/inbound.go
@@ -72,8 +72,8 @@ func (t thriftUnaryHandler) Handle(ctx context.Context, treq *transport.Request,
 		return err
 	}
 
-	if res.IsApplicationError {
-		rw.SetApplicationError()
+	if res.ApplicationError != nil {
+		rw.SetVerboseApplicationError(res.ApplicationError)
 	}
 
 	if err := call.WriteToResponse(rw); err != nil {

--- a/encoding/thrift/inbound_test.go
+++ b/encoding/thrift/inbound_test.go
@@ -23,6 +23,7 @@ package thrift
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -100,7 +101,10 @@ func TestDecodeRequestApplicationError(t *testing.T) {
 
 	handler := func(ctx context.Context, w wire.Value) (Response, error) {
 		// XXX setting application error bit
-		return Response{Body: fakeEnveloper(wire.Reply), IsApplicationError: true}, nil
+		return Response{
+			Body:             fakeEnveloper(wire.Reply),
+			ApplicationError: errors.New("application_error"),
+		}, nil
 	}
 	h := thriftUnaryHandler{Protocol: proto, UnaryHandler: handler}
 

--- a/encoding/thrift/response.go
+++ b/encoding/thrift/response.go
@@ -26,7 +26,5 @@ import "go.uber.org/thriftrw/envelope"
 type Response struct {
 	Body envelope.Enveloper
 
-	// DEPRECATED
-	IsApplicationError bool
-	ApplicationError   error
+	ApplicationError error
 }

--- a/encoding/thrift/response.go
+++ b/encoding/thrift/response.go
@@ -26,5 +26,7 @@ import "go.uber.org/thriftrw/envelope"
 type Response struct {
 	Body envelope.Enveloper
 
+	// DEPRECATED
 	IsApplicationError bool
+	ApplicationError   error
 }

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/readonlystoreserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/readonlystoreserver/server.go
@@ -60,14 +60,13 @@ func (h handler) Integer(ctx context.Context, body wire.Value) (thrift.Response,
 		return thrift.Response{}, err
 	}
 
-	success, err := h.impl.Integer(ctx, args.Key)
+	success, appErr := h.impl.Integer(ctx, args.Key)
 
-	hadError := err != nil
-	result, err := atomic.ReadOnlyStore_Integer_Helper.WrapResponse(success, err)
+	result, err := atomic.ReadOnlyStore_Integer_Helper.WrapResponse(success, appErr)
 
 	var response thrift.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storeserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storeserver/server.go
@@ -93,14 +93,13 @@ func (h handler) CompareAndSwap(ctx context.Context, body wire.Value) (thrift.Re
 		return thrift.Response{}, err
 	}
 
-	err := h.impl.CompareAndSwap(ctx, args.Request)
+	appErr := h.impl.CompareAndSwap(ctx, args.Request)
 
-	hadError := err != nil
-	result, err := atomic.Store_CompareAndSwap_Helper.WrapResponse(err)
+	result, err := atomic.Store_CompareAndSwap_Helper.WrapResponse(appErr)
 
 	var response thrift.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err
@@ -121,14 +120,13 @@ func (h handler) Increment(ctx context.Context, body wire.Value) (thrift.Respons
 		return thrift.Response{}, err
 	}
 
-	err := h.impl.Increment(ctx, args.Key, args.Value)
+	appErr := h.impl.Increment(ctx, args.Key, args.Value)
 
-	hadError := err != nil
-	result, err := atomic.Store_Increment_Helper.WrapResponse(err)
+	result, err := atomic.Store_Increment_Helper.WrapResponse(appErr)
 
 	var response thrift.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/baseserviceserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/baseserviceserver/server.go
@@ -55,14 +55,13 @@ func (h handler) Healthy(ctx context.Context, body wire.Value) (thrift.Response,
 		return thrift.Response{}, err
 	}
 
-	success, err := h.impl.Healthy(ctx)
+	success, appErr := h.impl.Healthy(ctx)
 
-	hadError := err != nil
-	result, err := common.BaseService_Healthy_Helper.WrapResponse(success, err)
+	result, err := common.BaseService_Healthy_Helper.WrapResponse(success, appErr)
 
 	var response thrift.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendemptyserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendemptyserver/server.go
@@ -59,14 +59,13 @@ func (h handler) Hello(ctx context.Context, body wire.Value) (thrift.Response, e
 		return thrift.Response{}, err
 	}
 
-	err := h.impl.Hello(ctx)
+	appErr := h.impl.Hello(ctx)
 
-	hadError := err != nil
-	result, err := common.ExtendEmpty_Hello_Helper.WrapResponse(err)
+	result, err := common.ExtendEmpty_Hello_Helper.WrapResponse(appErr)
 
 	var response thrift.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/weather/weatherserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/weather/weatherserver/server.go
@@ -55,14 +55,13 @@ func (h handler) Check(ctx context.Context, body wire.Value) (thrift.Response, e
 		return thrift.Response{}, err
 	}
 
-	success, err := h.impl.Check(ctx)
+	success, appErr := h.impl.Check(ctx)
 
-	hadError := err != nil
-	result, err := weather.Weather_Check_Helper.WrapResponse(success, err)
+	result, err := weather.Weather_Check_Helper.WrapResponse(success, appErr)
 
 	var response thrift.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err

--- a/encoding/thrift/thriftrw-plugin-yarpc/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/server.go
@@ -126,17 +126,17 @@ func (h handler) <.Name>(ctx <$context>.Context, body <$wire>.Value) (<$thrift>.
 	}
 
 	<if .ReturnType>
-		success, err := h.impl.<.Name>(ctx, <range .Arguments>args.<.Name>,<end>)
+		success, appErr := h.impl.<.Name>(ctx, <range .Arguments>args.<.Name>,<end>)
 	<else>
-		err := h.impl.<.Name>(ctx, <range .Arguments>args.<.Name>,<end>)
+		appErr := h.impl.<.Name>(ctx, <range .Arguments>args.<.Name>,<end>)
 	<end>
 
-	hadError := err != nil
-	result, err := <$prefix>Helper.WrapResponse(<if .ReturnType>success,<end> err)
+	result, err := <$prefix>Helper.WrapResponse(<if .ReturnType>success,<end> appErr)
 
 	var response <$thrift>.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.IsApplicationError = appErr != nil
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err

--- a/encoding/thrift/thriftrw-plugin-yarpc/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/server.go
@@ -135,7 +135,6 @@ func (h handler) <.Name>(ctx <$context>.Context, body <$wire>.Value) (<$thrift>.
 
 	var response <$thrift>.Response
 	if err == nil {
-		response.IsApplicationError = appErr != nil
 		response.ApplicationError = appErr
 		response.Body = result
 	}

--- a/internal/crossdock/thrift/echo/echoserver/server.go
+++ b/internal/crossdock/thrift/echo/echoserver/server.go
@@ -76,14 +76,13 @@ func (h handler) Echo(ctx context.Context, body wire.Value) (thrift.Response, er
 		return thrift.Response{}, err
 	}
 
-	success, err := h.impl.Echo(ctx, args.Ping)
+	success, appErr := h.impl.Echo(ctx, args.Ping)
 
-	hadError := err != nil
-	result, err := echo.Echo_Echo_Helper.WrapResponse(success, err)
+	result, err := echo.Echo_Echo_Helper.WrapResponse(success, appErr)
 
 	var response thrift.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err

--- a/internal/crossdock/thrift/gauntlet/secondserviceserver/server.go
+++ b/internal/crossdock/thrift/gauntlet/secondserviceserver/server.go
@@ -91,14 +91,13 @@ func (h handler) BlahBlah(ctx context.Context, body wire.Value) (thrift.Response
 		return thrift.Response{}, err
 	}
 
-	err := h.impl.BlahBlah(ctx)
+	appErr := h.impl.BlahBlah(ctx)
 
-	hadError := err != nil
-	result, err := gauntlet.SecondService_BlahBlah_Helper.WrapResponse(err)
+	result, err := gauntlet.SecondService_BlahBlah_Helper.WrapResponse(appErr)
 
 	var response thrift.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err
@@ -110,14 +109,13 @@ func (h handler) SecondtestString(ctx context.Context, body wire.Value) (thrift.
 		return thrift.Response{}, err
 	}
 
-	success, err := h.impl.SecondtestString(ctx, args.Thing)
+	success, appErr := h.impl.SecondtestString(ctx, args.Thing)
 
-	hadError := err != nil
-	result, err := gauntlet.SecondService_SecondtestString_Helper.WrapResponse(success, err)
+	result, err := gauntlet.SecondService_SecondtestString_Helper.WrapResponse(success, appErr)
 
 	var response thrift.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err

--- a/internal/crossdock/thrift/gauntlet/thrifttestserver/server.go
+++ b/internal/crossdock/thrift/gauntlet/thrifttestserver/server.go
@@ -401,14 +401,13 @@ func (h handler) TestBinary(ctx context.Context, body wire.Value) (thrift.Respon
 		return thrift.Response{}, err
 	}
 
-	success, err := h.impl.TestBinary(ctx, args.Thing)
+	success, appErr := h.impl.TestBinary(ctx, args.Thing)
 
-	hadError := err != nil
-	result, err := gauntlet.ThriftTest_TestBinary_Helper.WrapResponse(success, err)
+	result, err := gauntlet.ThriftTest_TestBinary_Helper.WrapResponse(success, appErr)
 
 	var response thrift.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err
@@ -420,14 +419,13 @@ func (h handler) TestByte(ctx context.Context, body wire.Value) (thrift.Response
 		return thrift.Response{}, err
 	}
 
-	success, err := h.impl.TestByte(ctx, args.Thing)
+	success, appErr := h.impl.TestByte(ctx, args.Thing)
 
-	hadError := err != nil
-	result, err := gauntlet.ThriftTest_TestByte_Helper.WrapResponse(success, err)
+	result, err := gauntlet.ThriftTest_TestByte_Helper.WrapResponse(success, appErr)
 
 	var response thrift.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err
@@ -439,14 +437,13 @@ func (h handler) TestDouble(ctx context.Context, body wire.Value) (thrift.Respon
 		return thrift.Response{}, err
 	}
 
-	success, err := h.impl.TestDouble(ctx, args.Thing)
+	success, appErr := h.impl.TestDouble(ctx, args.Thing)
 
-	hadError := err != nil
-	result, err := gauntlet.ThriftTest_TestDouble_Helper.WrapResponse(success, err)
+	result, err := gauntlet.ThriftTest_TestDouble_Helper.WrapResponse(success, appErr)
 
 	var response thrift.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err
@@ -458,14 +455,13 @@ func (h handler) TestEnum(ctx context.Context, body wire.Value) (thrift.Response
 		return thrift.Response{}, err
 	}
 
-	success, err := h.impl.TestEnum(ctx, args.Thing)
+	success, appErr := h.impl.TestEnum(ctx, args.Thing)
 
-	hadError := err != nil
-	result, err := gauntlet.ThriftTest_TestEnum_Helper.WrapResponse(success, err)
+	result, err := gauntlet.ThriftTest_TestEnum_Helper.WrapResponse(success, appErr)
 
 	var response thrift.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err
@@ -477,14 +473,13 @@ func (h handler) TestException(ctx context.Context, body wire.Value) (thrift.Res
 		return thrift.Response{}, err
 	}
 
-	err := h.impl.TestException(ctx, args.Arg)
+	appErr := h.impl.TestException(ctx, args.Arg)
 
-	hadError := err != nil
-	result, err := gauntlet.ThriftTest_TestException_Helper.WrapResponse(err)
+	result, err := gauntlet.ThriftTest_TestException_Helper.WrapResponse(appErr)
 
 	var response thrift.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err
@@ -496,14 +491,13 @@ func (h handler) TestI32(ctx context.Context, body wire.Value) (thrift.Response,
 		return thrift.Response{}, err
 	}
 
-	success, err := h.impl.TestI32(ctx, args.Thing)
+	success, appErr := h.impl.TestI32(ctx, args.Thing)
 
-	hadError := err != nil
-	result, err := gauntlet.ThriftTest_TestI32_Helper.WrapResponse(success, err)
+	result, err := gauntlet.ThriftTest_TestI32_Helper.WrapResponse(success, appErr)
 
 	var response thrift.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err
@@ -515,14 +509,13 @@ func (h handler) TestI64(ctx context.Context, body wire.Value) (thrift.Response,
 		return thrift.Response{}, err
 	}
 
-	success, err := h.impl.TestI64(ctx, args.Thing)
+	success, appErr := h.impl.TestI64(ctx, args.Thing)
 
-	hadError := err != nil
-	result, err := gauntlet.ThriftTest_TestI64_Helper.WrapResponse(success, err)
+	result, err := gauntlet.ThriftTest_TestI64_Helper.WrapResponse(success, appErr)
 
 	var response thrift.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err
@@ -534,14 +527,13 @@ func (h handler) TestInsanity(ctx context.Context, body wire.Value) (thrift.Resp
 		return thrift.Response{}, err
 	}
 
-	success, err := h.impl.TestInsanity(ctx, args.Argument)
+	success, appErr := h.impl.TestInsanity(ctx, args.Argument)
 
-	hadError := err != nil
-	result, err := gauntlet.ThriftTest_TestInsanity_Helper.WrapResponse(success, err)
+	result, err := gauntlet.ThriftTest_TestInsanity_Helper.WrapResponse(success, appErr)
 
 	var response thrift.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err
@@ -553,14 +545,13 @@ func (h handler) TestList(ctx context.Context, body wire.Value) (thrift.Response
 		return thrift.Response{}, err
 	}
 
-	success, err := h.impl.TestList(ctx, args.Thing)
+	success, appErr := h.impl.TestList(ctx, args.Thing)
 
-	hadError := err != nil
-	result, err := gauntlet.ThriftTest_TestList_Helper.WrapResponse(success, err)
+	result, err := gauntlet.ThriftTest_TestList_Helper.WrapResponse(success, appErr)
 
 	var response thrift.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err
@@ -572,14 +563,13 @@ func (h handler) TestMap(ctx context.Context, body wire.Value) (thrift.Response,
 		return thrift.Response{}, err
 	}
 
-	success, err := h.impl.TestMap(ctx, args.Thing)
+	success, appErr := h.impl.TestMap(ctx, args.Thing)
 
-	hadError := err != nil
-	result, err := gauntlet.ThriftTest_TestMap_Helper.WrapResponse(success, err)
+	result, err := gauntlet.ThriftTest_TestMap_Helper.WrapResponse(success, appErr)
 
 	var response thrift.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err
@@ -591,14 +581,13 @@ func (h handler) TestMapMap(ctx context.Context, body wire.Value) (thrift.Respon
 		return thrift.Response{}, err
 	}
 
-	success, err := h.impl.TestMapMap(ctx, args.Hello)
+	success, appErr := h.impl.TestMapMap(ctx, args.Hello)
 
-	hadError := err != nil
-	result, err := gauntlet.ThriftTest_TestMapMap_Helper.WrapResponse(success, err)
+	result, err := gauntlet.ThriftTest_TestMapMap_Helper.WrapResponse(success, appErr)
 
 	var response thrift.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err
@@ -610,14 +599,13 @@ func (h handler) TestMulti(ctx context.Context, body wire.Value) (thrift.Respons
 		return thrift.Response{}, err
 	}
 
-	success, err := h.impl.TestMulti(ctx, args.Arg0, args.Arg1, args.Arg2, args.Arg3, args.Arg4, args.Arg5)
+	success, appErr := h.impl.TestMulti(ctx, args.Arg0, args.Arg1, args.Arg2, args.Arg3, args.Arg4, args.Arg5)
 
-	hadError := err != nil
-	result, err := gauntlet.ThriftTest_TestMulti_Helper.WrapResponse(success, err)
+	result, err := gauntlet.ThriftTest_TestMulti_Helper.WrapResponse(success, appErr)
 
 	var response thrift.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err
@@ -629,14 +617,13 @@ func (h handler) TestMultiException(ctx context.Context, body wire.Value) (thrif
 		return thrift.Response{}, err
 	}
 
-	success, err := h.impl.TestMultiException(ctx, args.Arg0, args.Arg1)
+	success, appErr := h.impl.TestMultiException(ctx, args.Arg0, args.Arg1)
 
-	hadError := err != nil
-	result, err := gauntlet.ThriftTest_TestMultiException_Helper.WrapResponse(success, err)
+	result, err := gauntlet.ThriftTest_TestMultiException_Helper.WrapResponse(success, appErr)
 
 	var response thrift.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err
@@ -648,14 +635,13 @@ func (h handler) TestNest(ctx context.Context, body wire.Value) (thrift.Response
 		return thrift.Response{}, err
 	}
 
-	success, err := h.impl.TestNest(ctx, args.Thing)
+	success, appErr := h.impl.TestNest(ctx, args.Thing)
 
-	hadError := err != nil
-	result, err := gauntlet.ThriftTest_TestNest_Helper.WrapResponse(success, err)
+	result, err := gauntlet.ThriftTest_TestNest_Helper.WrapResponse(success, appErr)
 
 	var response thrift.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err
@@ -676,14 +662,13 @@ func (h handler) TestSet(ctx context.Context, body wire.Value) (thrift.Response,
 		return thrift.Response{}, err
 	}
 
-	success, err := h.impl.TestSet(ctx, args.Thing)
+	success, appErr := h.impl.TestSet(ctx, args.Thing)
 
-	hadError := err != nil
-	result, err := gauntlet.ThriftTest_TestSet_Helper.WrapResponse(success, err)
+	result, err := gauntlet.ThriftTest_TestSet_Helper.WrapResponse(success, appErr)
 
 	var response thrift.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err
@@ -695,14 +680,13 @@ func (h handler) TestString(ctx context.Context, body wire.Value) (thrift.Respon
 		return thrift.Response{}, err
 	}
 
-	success, err := h.impl.TestString(ctx, args.Thing)
+	success, appErr := h.impl.TestString(ctx, args.Thing)
 
-	hadError := err != nil
-	result, err := gauntlet.ThriftTest_TestString_Helper.WrapResponse(success, err)
+	result, err := gauntlet.ThriftTest_TestString_Helper.WrapResponse(success, appErr)
 
 	var response thrift.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err
@@ -714,14 +698,13 @@ func (h handler) TestStringMap(ctx context.Context, body wire.Value) (thrift.Res
 		return thrift.Response{}, err
 	}
 
-	success, err := h.impl.TestStringMap(ctx, args.Thing)
+	success, appErr := h.impl.TestStringMap(ctx, args.Thing)
 
-	hadError := err != nil
-	result, err := gauntlet.ThriftTest_TestStringMap_Helper.WrapResponse(success, err)
+	result, err := gauntlet.ThriftTest_TestStringMap_Helper.WrapResponse(success, appErr)
 
 	var response thrift.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err
@@ -733,14 +716,13 @@ func (h handler) TestStruct(ctx context.Context, body wire.Value) (thrift.Respon
 		return thrift.Response{}, err
 	}
 
-	success, err := h.impl.TestStruct(ctx, args.Thing)
+	success, appErr := h.impl.TestStruct(ctx, args.Thing)
 
-	hadError := err != nil
-	result, err := gauntlet.ThriftTest_TestStruct_Helper.WrapResponse(success, err)
+	result, err := gauntlet.ThriftTest_TestStruct_Helper.WrapResponse(success, appErr)
 
 	var response thrift.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err
@@ -752,14 +734,13 @@ func (h handler) TestTypedef(ctx context.Context, body wire.Value) (thrift.Respo
 		return thrift.Response{}, err
 	}
 
-	success, err := h.impl.TestTypedef(ctx, args.Thing)
+	success, appErr := h.impl.TestTypedef(ctx, args.Thing)
 
-	hadError := err != nil
-	result, err := gauntlet.ThriftTest_TestTypedef_Helper.WrapResponse(success, err)
+	result, err := gauntlet.ThriftTest_TestTypedef_Helper.WrapResponse(success, appErr)
 
 	var response thrift.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err
@@ -771,14 +752,13 @@ func (h handler) TestVoid(ctx context.Context, body wire.Value) (thrift.Response
 		return thrift.Response{}, err
 	}
 
-	err := h.impl.TestVoid(ctx)
+	appErr := h.impl.TestVoid(ctx)
 
-	hadError := err != nil
-	result, err := gauntlet.ThriftTest_TestVoid_Helper.WrapResponse(err)
+	result, err := gauntlet.ThriftTest_TestVoid_Helper.WrapResponse(appErr)
 
 	var response thrift.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err

--- a/internal/examples/thrift-hello/hello/echo/helloserver/server.go
+++ b/internal/examples/thrift-hello/hello/echo/helloserver/server.go
@@ -76,14 +76,13 @@ func (h handler) Echo(ctx context.Context, body wire.Value) (thrift.Response, er
 		return thrift.Response{}, err
 	}
 
-	success, err := h.impl.Echo(ctx, args.Echo)
+	success, appErr := h.impl.Echo(ctx, args.Echo)
 
-	hadError := err != nil
-	result, err := echo.Hello_Echo_Helper.WrapResponse(success, err)
+	result, err := echo.Hello_Echo_Helper.WrapResponse(success, appErr)
 
 	var response thrift.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err

--- a/internal/examples/thrift-keyvalue/keyvalue/kv/keyvalueserver/server.go
+++ b/internal/examples/thrift-keyvalue/keyvalue/kv/keyvalueserver/server.go
@@ -93,14 +93,13 @@ func (h handler) GetValue(ctx context.Context, body wire.Value) (thrift.Response
 		return thrift.Response{}, err
 	}
 
-	success, err := h.impl.GetValue(ctx, args.Key)
+	success, appErr := h.impl.GetValue(ctx, args.Key)
 
-	hadError := err != nil
-	result, err := kv.KeyValue_GetValue_Helper.WrapResponse(success, err)
+	result, err := kv.KeyValue_GetValue_Helper.WrapResponse(success, appErr)
 
 	var response thrift.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err
@@ -112,14 +111,13 @@ func (h handler) SetValue(ctx context.Context, body wire.Value) (thrift.Response
 		return thrift.Response{}, err
 	}
 
-	err := h.impl.SetValue(ctx, args.Key, args.Value)
+	appErr := h.impl.SetValue(ctx, args.Key, args.Value)
 
-	hadError := err != nil
-	result, err := kv.KeyValue_SetValue_Helper.WrapResponse(err)
+	result, err := kv.KeyValue_SetValue_Helper.WrapResponse(appErr)
 
 	var response thrift.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err

--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -76,12 +76,7 @@ func (c call) endLogs(elapsed time.Duration, err error, isApplicationError bool)
 	fields = append(fields, zap.Bool("successful", err == nil))
 	fields = append(fields, c.extract(c.ctx))
 
-	if isApplicationError {
-		fields = append(
-			fields,
-			zap.String(_error, "application_error"),
-		)
-	} else {
+	if !isApplicationError {
 		fields = append(fields, zap.Error(err))
 	}
 

--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -81,9 +81,9 @@ func (c call) endLogs(elapsed time.Duration, err error, isApplicationError bool)
 			fields,
 			zap.String(_error, "application_error"),
 		)
+	} else {
+		fields = append(fields, zap.Error(err))
 	}
-
-	fields = append(fields, zap.Error(err))
 
 	ce.Write(fields...)
 }

--- a/internal/observability/common_test.go
+++ b/internal/observability/common_test.go
@@ -38,7 +38,7 @@ type fakeHandler struct {
 
 func (h fakeHandler) Handle(_ context.Context, _ *transport.Request, rw transport.ResponseWriter) error {
 	if h.applicationErr {
-		rw.SetApplicationError()
+		rw.SetApplicationError(h.err)
 		return nil
 	}
 	return h.err

--- a/internal/observability/middleware.go
+++ b/internal/observability/middleware.go
@@ -22,6 +22,7 @@ package observability
 
 import (
 	"context"
+	"errors"
 	"sync"
 
 	"go.uber.org/net/metrics"
@@ -82,11 +83,15 @@ func (m *Middleware) Call(ctx context.Context, req *transport.Request, out trans
 	call := m.graph.begin(ctx, transport.Unary, _directionOutbound, req)
 	res, err := out.Call(ctx, req)
 
-	isApplicationError := false
-	if res != nil {
-		isApplicationError = res.ApplicationError
+	var appErr error
+	if res != nil && res.ApplicationError {
+		// This is a stub until outbound application error could be properly
+		// propagated
+		appErr = errors.New("application_error")
 	}
-	call.EndWithAppError(err, isApplicationError)
+
+	call.EndWithAppError(err, appErr)
+
 	return res, err
 }
 

--- a/internal/observability/middleware.go
+++ b/internal/observability/middleware.go
@@ -90,7 +90,8 @@ func (m *Middleware) Handle(ctx context.Context, req *transport.Request, w trans
 func (m *Middleware) Call(ctx context.Context, req *transport.Request, out transport.UnaryOutbound) (*transport.Response, error) {
 	call := m.graph.begin(ctx, transport.Unary, _directionOutbound, req)
 	res, err := out.Call(ctx, req)
-	call.EndWithAppError(err, res.ApplicationError)
+	isApplicationError := res != nil && res.ApplicationError
+	call.EndWithAppError(err, isApplicationError)
 	return res, err
 }
 

--- a/internal/observability/middleware.go
+++ b/internal/observability/middleware.go
@@ -43,6 +43,7 @@ type writer struct {
 
 func newWriter(rw transport.ResponseWriter) *writer {
 	w := _writerPool.Get().(*writer)
+	w.applicationError = nil
 	w.ResponseWriter = rw
 	return w
 }

--- a/internal/observability/middleware.go
+++ b/internal/observability/middleware.go
@@ -73,16 +73,14 @@ func (m *Middleware) Handle(ctx context.Context, req *transport.Request, w trans
 	wrappedWriter := newWriter(w)
 	err := h.Handle(ctx, req, wrappedWriter)
 
-	isApplicationError := false
-
 	// In case the application error happened, we want it to override
 	// whatever other error might have happened along
 	if wrappedWriter.applicationError != nil {
-		err = wrappedWriter.applicationError
-		isApplicationError = true
+		call.EndWithAppError(wrappedWriter.applicationError, true)
+	} else {
+		call.EndWithAppError(err, false)
 	}
 
-	call.EndWithAppError(err, isApplicationError)
 	wrappedWriter.free()
 
 	return err

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -385,7 +385,7 @@ func TestUnaryInboundApplicationErrors(t *testing.T) {
 		context.Background(),
 		req,
 		&transporttest.FakeResponseWriter{},
-		fakeHandler{err: nil, applicationErr: true},
+		fakeHandler{err: errors.New("some_weird_error"), applicationErr: true},
 	), "Unexpected transport error.")
 
 	expected := observer.LoggedEntry{

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -375,7 +375,6 @@ func TestUnaryInboundApplicationErrors(t *testing.T) {
 		zap.Duration("latency", 0),
 		zap.Bool("successful", false),
 		zap.Skip(),
-		zap.String("error", "application_error"),
 	}
 
 	core, logs := observer.New(zap.DebugLevel)

--- a/transport/grpc/response_writer.go
+++ b/transport/grpc/response_writer.go
@@ -52,7 +52,7 @@ func (r *responseWriter) AddHeaders(headers transport.Headers) {
 	r.headerErr = multierr.Combine(r.headerErr, addApplicationHeaders(r.md, headers))
 }
 
-func (r *responseWriter) SetApplicationError() {
+func (r *responseWriter) SetApplicationError(_ error) {
 	r.AddSystemHeader(ApplicationErrorHeader, ApplicationErrorHeaderValue)
 }
 

--- a/transport/http/handler.go
+++ b/transport/http/handler.go
@@ -238,7 +238,7 @@ func (rw *responseWriter) AddHeaders(h transport.Headers) {
 	applicationHeaders.ToHTTPHeaders(h, rw.w.Header())
 }
 
-func (rw *responseWriter) SetApplicationError() {
+func (rw *responseWriter) SetApplicationError(_ error) {
 	rw.w.Header().Set(ApplicationStatusHeader, ApplicationErrorStatus)
 }
 

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -191,7 +191,9 @@ type responseWriter struct {
 	headers            transport.Headers
 	buffer             *bufferpool.Buffer
 	response           inboundCallResponse
+
 	isApplicationError bool
+	verboseApplicationError error
 }
 
 func newResponseWriter(response inboundCallResponse, format tchannel.Format) *responseWriter {
@@ -218,6 +220,11 @@ func (rw *responseWriter) addHeader(key string, value string) {
 
 func (rw *responseWriter) SetApplicationError() {
 	rw.isApplicationError = true
+}
+
+func (rw *responseWriter) SetVerboseApplicationError(err error) {
+	rw.isApplicationError = true
+	rw.verboseApplicationError = err
 }
 
 func (rw *responseWriter) Write(s []byte) (int, error) {

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -191,9 +191,7 @@ type responseWriter struct {
 	headers            transport.Headers
 	buffer             *bufferpool.Buffer
 	response           inboundCallResponse
-
 	isApplicationError bool
-	verboseApplicationError error
 }
 
 func newResponseWriter(response inboundCallResponse, format tchannel.Format) *responseWriter {
@@ -218,13 +216,8 @@ func (rw *responseWriter) addHeader(key string, value string) {
 	rw.headers = rw.headers.With(key, value)
 }
 
-func (rw *responseWriter) SetApplicationError() {
+func (rw *responseWriter) SetApplicationError(_ error) {
 	rw.isApplicationError = true
-}
-
-func (rw *responseWriter) SetVerboseApplicationError(err error) {
-	rw.isApplicationError = true
-	rw.verboseApplicationError = err
 }
 
 func (rw *responseWriter) Write(s []byte) (int, error) {

--- a/transport/tchannel/handler_test.go
+++ b/transport/tchannel/handler_test.go
@@ -401,7 +401,7 @@ func TestResponseWriter(t *testing.T) {
 		{
 			format: tchannel.Raw,
 			apply: func(w *responseWriter) {
-				w.SetApplicationError()
+				w.SetApplicationError(errors.New("application_error"))
 				_, err := w.Write([]byte("hello"))
 				require.NoError(t, err)
 			},


### PR DESCRIPTION
This allows to be more verbose around what particular `application_error` happened in metrics/logs.

This is WIP, and put out to gather early feedback.

This will also require some scaffolding inside the `thriftrw` for generated Thrift exceptions to have `Name` method