### PR TITLE
Simplify map-as-set type in TChannel transport

### DIFF
--- a/transport/tchannel/header.go
+++ b/transport/tchannel/header.go
@@ -40,10 +40,10 @@ const (
 	ErrorMessageHeaderKey = "$rpc$-error-message"
 )
 
-var _reservedHeaderKeys = map[string]bool{
-	ErrorCodeHeaderKey:    true,
-	ErrorNameHeaderKey:    true,
-	ErrorMessageHeaderKey: true,
+var _reservedHeaderKeys = map[string]struct{}{
+	ErrorCodeHeaderKey:    {},
+	ErrorNameHeaderKey:    {},
+	ErrorMessageHeaderKey: {},
 }
 
 func isReservedHeaderKey(key string) bool {


### PR DESCRIPTION
This internal map type in TChannel is used as a set.
Reducing to its essence.
Tests still pass.