### PR TITLE
[POC][No Land] Move Frontcar Relay code into open-source

### DIFF
--- a/x/relay/config.go
+++ b/x/relay/config.go
@@ -1,0 +1,132 @@
+package relay
+
+import (
+	"fmt"
+	"strings"
+
+	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/api/middleware"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/zap"
+)
+
+const (
+	unary  = "unary"
+	oneway = "oneway"
+
+	_true  = "true"
+	_false = "false"
+)
+
+// Configuration specifies the type of proxies that can be defined on the
+// Frontcar
+type Configuration struct {
+	// ServiceProxies are proxies from a `Service` to an `Outbound`
+	ServiceProxies map[string]RouteConfig `yaml:"service-proxies"`
+
+	// ShardProxies are proxies from a `ShardKey` to an `Outbound`
+	ShardProxies map[string]RouteConfig `yaml:"shardkey-proxies"`
+
+	// Default is the default route config.
+	Default RouteConfig `yaml:"default"`
+}
+
+// GenerateServiceHandlers generates a map of service to HandlerSpec for requests.
+func (c Configuration) GenerateServiceHandlers(d *yarpc.Dispatcher, logger *zap.Logger) []ServiceHandler {
+	handlers := make([]ServiceHandler, 0, len(c.ServiceProxies))
+	for service, cfg := range c.ServiceProxies {
+		if cfg.OverrideServiceName != _true { // If not explicitly true, don't override the service name.
+			cfg.OverrideServiceName = _false
+		}
+		handlers = append(handlers, ServiceHandler{
+			Service:     service,
+			HandlerSpec: cfg.generateHandlerSpec(d, logger),
+			Signature:   fmt.Sprintf("Proxy(Service=%q, Outbound=%q)", service, cfg.OutboundKey),
+		})
+	}
+	return handlers
+}
+
+// GenerateShardKeyHandlers generates a map of shardkey to HandlerSpec for requests.
+func (c Configuration) GenerateShardKeyHandlers(d *yarpc.Dispatcher, logger *zap.Logger) []ShardKeyHandler {
+	handlers := make([]ShardKeyHandler, 0, len(c.ShardProxies))
+	for shard, cfg := range c.ShardProxies {
+		if cfg.OverrideServiceName != _false { // if not explicitly false, override the service name.
+			cfg.OverrideServiceName = _true
+		}
+		handlers = append(handlers, ShardKeyHandler{
+			ShardKey:    shard,
+			HandlerSpec: cfg.generateHandlerSpec(d, logger),
+			Signature:   fmt.Sprintf("Proxy(ShardKey=%q, Outbound=%q)", shard, cfg.OutboundKey),
+		})
+	}
+	return handlers
+}
+
+// GenerateDefaultHandler generates a procedure for the default handler, the
+// default handler is optional, so it will return an ok boolean to determine if
+// a default was set.
+func (c Configuration) GenerateDefaultHandler(d *yarpc.Dispatcher, logger *zap.Logger) (_ transport.Procedure, ok bool) {
+	if (RouteConfig{}) == c.Default {
+		return transport.Procedure{}, false
+	}
+	return transport.Procedure{
+		Name:        "*", // `*` means that we are a proxy
+		Service:     "*", // `*` means that we are a proxy
+		HandlerSpec: c.Default.generateHandlerSpec(d, logger),
+		Signature:   fmt.Sprintf("DefaultProxy(Outbound=%q)", c.Default.OutboundKey),
+	}, true
+}
+
+// RouteConfig defines how a proxy is configured
+type RouteConfig struct {
+	// OutboundKey specifies an outbound defined in the rpc dispatcher
+	// where we want to proxy traffic.
+	OutboundKey string `yaml:"outbound"`
+
+	// RPCType specifies the request type that will be going through this proxy.
+	// (unary/oneway)
+	RPCType string `yaml:"rpctype"`
+
+	// OverrideServiceName specifies the service name of the request will be
+	// overridden with the service name from the outbound.
+	// This can be set to one of "true" or "false".  If this is not set it will
+	// be set to whatever the default for the proxy type is (Service proxies are
+	// set to "false", Shard proxies set it to "true").
+	OverrideServiceName string `yaml:"overrideServiceName"`
+}
+
+func (r RouteConfig) generateHandlerSpec(d *yarpc.Dispatcher, logger *zap.Logger) transport.HandlerSpec {
+	overrideServiceName := r.OverrideServiceName == _true
+	cc := d.ClientConfig(r.OutboundKey)
+	switch strings.ToLower(r.RPCType) {
+	case unary:
+		var h transport.UnaryHandler
+		if overrideServiceName {
+			h = UnaryProxyHandler(cc.GetUnaryOutbound(), WithServiceName(cc.Service()), WithLogger(logger))
+		} else {
+			h = UnaryProxyHandler(cc.GetUnaryOutbound(), WithLogger(logger))
+		}
+		return transport.NewUnaryHandlerSpec(
+			middleware.ApplyUnaryInbound(
+				h,
+				d.InboundMiddleware().Unary,
+			),
+		)
+	case oneway:
+		var h transport.OnewayHandler
+		if overrideServiceName {
+			h = OnewayProxyHandler(cc.GetOnewayOutbound(), WithServiceName(cc.Service()), WithLogger(logger))
+		} else {
+			h = OnewayProxyHandler(cc.GetOnewayOutbound(), WithLogger(logger))
+		}
+		return transport.NewOnewayHandlerSpec(
+			middleware.ApplyOnewayInbound(
+				h,
+				d.InboundMiddleware().Oneway,
+			),
+		)
+	default:
+		panic("Unsupported transport type for proxies " + r.RPCType)
+	}
+}

--- a/x/relay/config_test.go
+++ b/x/relay/config_test.go
@@ -1,0 +1,344 @@
+package relay
+
+import (
+	"testing"
+
+	"strings"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
+	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/api/transport/transporttest"
+	"go.uber.org/zap"
+)
+
+func TestConfig(t *testing.T) {
+	testCases := []struct {
+		name   string
+		Config Configuration
+
+		// give{Unary,Oneway}Outbounds specifies a series of mock unary/oneway
+		// outbounds to create in the dispatcher.
+		giveUnaryOutbounds  []string
+		giveOnewayOutbounds []string
+
+		wantPanic bool
+	}{
+		{
+			name: "single service unary",
+			Config: Configuration{
+				ServiceProxies: map[string]RouteConfig{
+					"myservice": {
+						OutboundKey: "myout",
+						RPCType:     "unary",
+					},
+				},
+			},
+			giveUnaryOutbounds: []string{"myout"},
+			wantPanic:          false,
+		},
+		{
+			name: "missing service unary outbound",
+			Config: Configuration{
+				ServiceProxies: map[string]RouteConfig{
+					"myservice": {
+						OutboundKey: "myout",
+						RPCType:     "unary",
+					},
+				},
+			},
+			wantPanic: true,
+		},
+		{
+			name: "single service oneway",
+			Config: Configuration{
+				ServiceProxies: map[string]RouteConfig{
+					"myservice": {
+						OutboundKey: "myout",
+						RPCType:     "oneway",
+					},
+				},
+			},
+			giveOnewayOutbounds: []string{"myout"},
+			wantPanic:           false,
+		},
+		{
+			name: "missing service oneway outbound",
+			Config: Configuration{
+				ServiceProxies: map[string]RouteConfig{
+					"myservice": {
+						OutboundKey: "myout",
+						RPCType:     "oneway",
+					},
+				},
+			},
+			wantPanic: true,
+		},
+		{
+			name: "invalid service rpctype",
+			Config: Configuration{
+				ServiceProxies: map[string]RouteConfig{
+					"myservice": {
+						OutboundKey: "myout",
+						RPCType:     "totally-real-type",
+					},
+				},
+			},
+			giveUnaryOutbounds: []string{"myout"},
+			wantPanic:          true,
+		},
+		{
+			name: "multiple services",
+			Config: Configuration{
+				ServiceProxies: map[string]RouteConfig{
+					"myservice": {
+						OutboundKey: "myout",
+						RPCType:     "unary",
+					},
+					"myservice2": {
+						OutboundKey: "myout2",
+						RPCType:     "oneway",
+					},
+					"myservice3": {
+						OutboundKey: "myout",
+						RPCType:     "unary",
+					},
+					"myservice4": {
+						OutboundKey: "myout4",
+						RPCType:     "unary",
+					},
+				},
+			},
+			giveUnaryOutbounds:  []string{"myout", "myout4"},
+			giveOnewayOutbounds: []string{"myout2"},
+			wantPanic:           false,
+		},
+		{
+			name: "single shard unary",
+			Config: Configuration{
+				ShardProxies: map[string]RouteConfig{
+					"myshard": {
+						OutboundKey: "myout",
+						RPCType:     "unary",
+					},
+				},
+			},
+			giveUnaryOutbounds: []string{"myout"},
+			wantPanic:          false,
+		},
+		{
+			name: "missing shard unary outbound",
+			Config: Configuration{
+				ShardProxies: map[string]RouteConfig{
+					"myshard": {
+						OutboundKey: "myout",
+						RPCType:     "unary",
+					},
+				},
+			},
+			wantPanic: true,
+		},
+		{
+			name: "single shard oneway",
+			Config: Configuration{
+				ShardProxies: map[string]RouteConfig{
+					"myshard": {
+						OutboundKey: "myout",
+						RPCType:     "oneway",
+					},
+				},
+			},
+			giveOnewayOutbounds: []string{"myout"},
+			wantPanic:           false,
+		},
+		{
+			name: "missing shard oneway outbound",
+			Config: Configuration{
+				ShardProxies: map[string]RouteConfig{
+					"myshard": {
+						OutboundKey: "myout",
+						RPCType:     "oneway",
+					},
+				},
+			},
+			wantPanic: true,
+		},
+		{
+			name: "invalid shard rpctype",
+			Config: Configuration{
+				ShardProxies: map[string]RouteConfig{
+					"myshard": {
+						OutboundKey: "myout",
+						RPCType:     "totally-real-type",
+					},
+				},
+			},
+			giveUnaryOutbounds: []string{"myout"},
+			wantPanic:          true,
+		},
+		{
+			name: "multiple shards",
+			Config: Configuration{
+				ShardProxies: map[string]RouteConfig{
+					"myshard": {
+						OutboundKey: "myout",
+						RPCType:     "unary",
+					},
+					"myshard2": {
+						OutboundKey: "myout2",
+						RPCType:     "oneway",
+					},
+					"myshard3": {
+						OutboundKey: "myout",
+						RPCType:     "unary",
+					},
+					"myshard4": {
+						OutboundKey: "myout4",
+						RPCType:     "unary",
+					},
+				},
+			},
+			giveUnaryOutbounds:  []string{"myout", "myout4"},
+			giveOnewayOutbounds: []string{"myout2"},
+			wantPanic:           false,
+		},
+		{
+			name: "multiple shards and services",
+			Config: Configuration{
+				ServiceProxies: map[string]RouteConfig{
+					"myservice": {
+						OutboundKey: "myserviceout",
+						RPCType:     "unary",
+					},
+					"myservice2": {
+						OutboundKey: "myserviceout2",
+						RPCType:     "oneway",
+					},
+					"myservice3": {
+						OutboundKey: "myserviceout",
+						RPCType:     "unary",
+					},
+					"myservice4": {
+						OutboundKey: "myserviceout4",
+						RPCType:     "unary",
+					},
+				},
+				ShardProxies: map[string]RouteConfig{
+					"myshard": {
+						OutboundKey: "myout",
+						RPCType:     "unary",
+					},
+					"myshard2": {
+						OutboundKey: "myout2",
+						RPCType:     "oneway",
+					},
+					"myshard3": {
+						OutboundKey: "myout",
+						RPCType:     "unary",
+					},
+					"myshard4": {
+						OutboundKey: "myout4",
+						RPCType:     "unary",
+					},
+				},
+			},
+			giveUnaryOutbounds:  []string{"myout", "myout4", "myserviceout", "myserviceout4"},
+			giveOnewayOutbounds: []string{"myout2", "myserviceout2"},
+			wantPanic:           false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			dispatcher := getDispatcherWithOutbounds(
+				tc.giveUnaryOutbounds,
+				tc.giveOnewayOutbounds,
+				mockCtrl,
+			)
+
+			if tc.wantPanic {
+				assert.Panics(t, func() {
+					tc.Config.GenerateServiceHandlers(dispatcher, zap.NewNop())
+					tc.Config.GenerateShardKeyHandlers(dispatcher, zap.NewNop())
+				})
+				return
+			}
+
+			serviceHandlers := tc.Config.GenerateServiceHandlers(dispatcher, zap.NewNop())
+			serviceHandlerMap := make(map[string]ServiceHandler)
+			for _, handler := range serviceHandlers {
+				serviceHandlerMap[handler.Service] = handler
+			}
+			assert.Len(t, serviceHandlers, len(tc.Config.ServiceProxies))
+			for service, cfg := range tc.Config.ServiceProxies {
+				h, ok := serviceHandlerMap[strings.ToLower(service)]
+				require.True(t, ok, "no handler was created for %s", service)
+				require.NotNil(t, h, "handler for %s was nil", service)
+
+				switch strings.ToLower(cfg.RPCType) {
+				case unary:
+					assert.Equal(t, h.HandlerSpec.Type(), transport.Unary, "invalid handler type for %s", service)
+				case oneway:
+					assert.Equal(t, h.HandlerSpec.Type(), transport.Oneway, "invalid handler type for %s", service)
+				default:
+					assert.Fail(t, "invalid handler type (want(%s), got(%s)) for %s", cfg.RPCType, string(h.HandlerSpec.Type()), service)
+				}
+			}
+
+			shardHandlers := tc.Config.GenerateShardKeyHandlers(dispatcher, zap.NewNop())
+			shardHandlerMap := make(map[string]ShardKeyHandler)
+			for _, handler := range shardHandlers {
+				shardHandlerMap[handler.ShardKey] = handler
+			}
+			assert.Len(t, shardHandlers, len(tc.Config.ShardProxies))
+			for shard, cfg := range tc.Config.ShardProxies {
+				h, ok := shardHandlerMap[strings.ToLower(shard)]
+				require.True(t, ok, "no handler was created for %s", shard)
+				require.NotNil(t, h, "handler for %s was nil", shard)
+
+				switch strings.ToLower(cfg.RPCType) {
+				case unary:
+					assert.Equal(t, h.HandlerSpec.Type(), transport.Unary, "invalid handler type for %s", shard)
+				case oneway:
+					assert.Equal(t, h.HandlerSpec.Type(), transport.Oneway, "invalid handler type for %s", shard)
+				default:
+					assert.Fail(t, "invalid handler type (want(%s), got(%s)) for %s", cfg.RPCType, string(h.HandlerSpec.Type()), shard)
+				}
+			}
+		})
+	}
+}
+
+func getDispatcherWithOutbounds(unaryOuts, onewayOuts []string, mockCtrl *gomock.Controller) *yarpc.Dispatcher {
+	outbounds := make(yarpc.Outbounds, len(unaryOuts)+len(onewayOuts))
+	for _, outKey := range unaryOuts {
+		out := transporttest.NewMockUnaryOutbound(mockCtrl)
+		out.EXPECT().Transports().AnyTimes().Return([]transport.Transport{})
+		outbounds[outKey] = transport.Outbounds{
+			Unary: out,
+		}
+	}
+	for _, outKey := range onewayOuts {
+		out := transporttest.NewMockOnewayOutbound(mockCtrl)
+		out.EXPECT().Transports().AnyTimes().Return([]transport.Transport{})
+		outbounds[outKey] = transport.Outbounds{
+			Oneway: out,
+		}
+	}
+
+	cfg := yarpc.Config{
+		Name:      "service",
+		Outbounds: outbounds,
+		Metrics: yarpc.MetricsConfig{
+			Tally: tally.NoopScope,
+		},
+	}
+
+	return yarpc.NewDispatcher(cfg)
+}

--- a/x/relay/observer.go
+++ b/x/relay/observer.go
@@ -1,0 +1,74 @@
+package relay
+
+import "github.com/uber-go/tally"
+
+var (
+	_callsName           = "frontcar_choose_calls"
+	_successesName       = "frontcar_choose_successes"
+	_failureName         = "frontcar_choose_failures"
+	_matchType           = "match_type"
+	_errorType           = "error_type"
+	_serviceProcedureTag = "service_procedure"
+	_serviceTag          = "service"
+	_shardKeyTag         = "shard_key"
+	_defaultTag          = "default"
+	_unknownTag          = "unknown"
+	_noHandlerTag        = "no_handler"
+)
+
+type observer struct {
+	calls                   tally.Counter
+	serviceProcedureMatches tally.Counter
+	serviceMatches          tally.Counter
+	shardKeyMatches         tally.Counter
+	defaultMatches          tally.Counter
+	noHandlerErrs           tally.Counter
+	unknownErrs             tally.Counter
+}
+
+func newObserver(scope tally.Scope) *observer {
+	serviceProcedureMatchScope := scope.Tagged(map[string]string{_matchType: _serviceProcedureTag})
+	serviceMatchScope := scope.Tagged(map[string]string{_matchType: _serviceTag})
+	shardKeyMatchScope := scope.Tagged(map[string]string{_matchType: _shardKeyTag})
+	defaultMatchScope := scope.Tagged(map[string]string{_matchType: _defaultTag})
+	unknownTagErrScope := scope.Tagged(map[string]string{_errorType: _unknownTag})
+	noHandlerTagScope := scope.Tagged(map[string]string{_errorType: _noHandlerTag})
+
+	return &observer{
+		calls: scope.Counter(_callsName),
+		serviceProcedureMatches: serviceProcedureMatchScope.Counter(_successesName),
+		serviceMatches:          serviceMatchScope.Counter(_successesName),
+		shardKeyMatches:         shardKeyMatchScope.Counter(_successesName),
+		defaultMatches:          defaultMatchScope.Counter(_successesName),
+		unknownErrs:             unknownTagErrScope.Counter(_failureName),
+		noHandlerErrs:           noHandlerTagScope.Counter(_failureName),
+	}
+}
+
+func (o *observer) call() {
+	o.calls.Inc(1)
+}
+
+func (o *observer) serviceProcedureMatch() {
+	o.serviceProcedureMatches.Inc(1)
+}
+
+func (o *observer) serviceMatch() {
+	o.serviceMatches.Inc(1)
+}
+
+func (o *observer) shardKeyMatch() {
+	o.shardKeyMatches.Inc(1)
+}
+
+func (o *observer) defaultMatch() {
+	o.defaultMatches.Inc(1)
+}
+
+func (o *observer) unknownError() {
+	o.unknownErrs.Inc(1)
+}
+
+func (o *observer) noHandleError() {
+	o.noHandlerErrs.Inc(1)
+}

--- a/x/relay/options.go
+++ b/x/relay/options.go
@@ -1,0 +1,47 @@
+package relay
+
+import (
+	"github.com/uber-go/tally"
+	"go.uber.org/zap"
+)
+
+// Option describes a func that can modify options.
+type Option interface {
+	apply(*options)
+}
+
+type optionFunc func(*options)
+
+// opts represents the combined options supplied by the user.
+type options struct {
+	logger *zap.Logger
+	scope  tally.Scope
+}
+
+// Scope specifies the scope to be used along
+func Scope(s tally.Scope) Option {
+	return optionFunc(func(opts *options) {
+		opts.scope = s
+	})
+}
+
+// Logger specifies the logger that should be used to log.
+func Logger(logger *zap.Logger) Option {
+	return optionFunc(func(opts *options) {
+		opts.logger = logger
+	})
+}
+
+func (f optionFunc) apply(options *options) { f(options) }
+
+// applyOptions creates new opts based on the given options.
+func applyOptions(opts ...Option) options {
+	options := options{
+		logger: zap.NewNop(),
+		scope:  tally.NoopScope,
+	}
+	for _, opt := range opts {
+		opt.apply(&options)
+	}
+	return options
+}

--- a/x/relay/options_test.go
+++ b/x/relay/options_test.go
@@ -1,0 +1,31 @@
+package relay
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
+)
+
+func TestScopeOption(t *testing.T) {
+	scope := tally.NoopScope
+	option := Scope(scope)
+	opts := applyOptions(option)
+	assert.Equal(t, scope, opts.scope)
+}
+
+func TestLoggerOption(t *testing.T) {
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+	option := Logger(logger)
+	opts := applyOptions(option)
+	assert.Equal(t, logger, opts.logger)
+}
+
+func TestNilLoggerOption(t *testing.T) {
+	opts := applyOptions()
+	assert.NotNil(t, opts.logger)
+}

--- a/x/relay/proxy.go
+++ b/x/relay/proxy.go
@@ -1,0 +1,132 @@
+package relay
+
+import (
+	"context"
+
+	"go.uber.org/multierr"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/iopool"
+	"go.uber.org/zap"
+)
+
+type handlerOpts struct {
+	serviceName string
+	logger      *zap.Logger
+}
+
+func newHandlerOpts() handlerOpts {
+	return handlerOpts{
+		logger: zap.NewNop(),
+	}
+}
+
+// HandlerOption are options for configuring a Proxy.
+type HandlerOption interface {
+	apply(opts *handlerOpts)
+}
+
+type handlerOptionFunc func(opts *handlerOpts)
+
+func (u handlerOptionFunc) apply(opts *handlerOpts) { u(opts) }
+
+// WithLogger overrides the logger used to log errors in the service.
+func WithLogger(logger *zap.Logger) HandlerOption {
+	return handlerOptionFunc(func(opts *handlerOpts) {
+		opts.logger = logger
+	})
+}
+
+// WithServiceName overrides the service name for outbound calls.
+func WithServiceName(service string) HandlerOption {
+	return handlerOptionFunc(func(opts *handlerOpts) {
+		opts.serviceName = service
+	})
+}
+
+// UnaryProxyHandler creates a unary proxy handler to redirect traffic
+// to the specified outbound
+func UnaryProxyHandler(out transport.UnaryOutbound, options ...HandlerOption) transport.UnaryHandler {
+	opts := newHandlerOpts()
+	for _, option := range options {
+		option.apply(&opts)
+	}
+	return &unaryProxyHandler{out: out, opts: opts}
+}
+
+// unaryProxyHandler implements the transport.UnaryHandler interface and routes
+// all requests to the UnaryOutbound.
+type unaryProxyHandler struct {
+	out  transport.UnaryOutbound
+	opts handlerOpts
+}
+
+// Handle implements YARPC's transport.UnaryHandler interface.
+func (p *unaryProxyHandler) Handle(ctx context.Context, req *transport.Request, resw transport.ResponseWriter) error {
+	if p.opts.serviceName != "" {
+		req.Service = p.opts.serviceName
+	}
+	req.RoutingKey = ""
+	req.RoutingDelegate = ""
+
+	resp, err := p.out.Call(ctx, req)
+	if err != nil {
+		p.opts.logger.Error(
+			"error proxying unary request",
+			zap.String("caller", req.Caller),
+			zap.String("service", req.Service),
+			zap.String("procedure", req.Procedure),
+			zap.String("shardkey", req.ShardKey),
+			zap.Error(err),
+		)
+		return err
+	}
+
+	if resp.ApplicationError {
+		resw.SetApplicationError()
+	}
+
+	resw.AddHeaders(resp.Headers)
+
+	_, err = iopool.Copy(resw, resp.Body)
+	err = multierr.Append(err, resp.Body.Close())
+	return err
+}
+
+// OnewayProxyHandler creates a oneway proxy handler to redirect traffic
+// to the specified outbound.
+func OnewayProxyHandler(out transport.OnewayOutbound, options ...HandlerOption) transport.OnewayHandler {
+	opts := newHandlerOpts()
+	for _, option := range options {
+		option.apply(&opts)
+	}
+	return &onewayProxyHandler{out: out, opts: opts}
+}
+
+// onewayProxyHandler implements the transport.OnewayHandler interface and
+// routes all requests to the OnewayOutbound.
+type onewayProxyHandler struct {
+	out  transport.OnewayOutbound
+	opts handlerOpts
+}
+
+// HandleOneway implements YARPC's transport.OnewayHandler interface.
+func (p *onewayProxyHandler) HandleOneway(ctx context.Context, req *transport.Request) error {
+	if p.opts.serviceName != "" {
+		req.Service = p.opts.serviceName
+	}
+	req.RoutingKey = ""
+	req.RoutingDelegate = ""
+
+	_, err := p.out.CallOneway(ctx, req)
+	if err != nil {
+		p.opts.logger.Error(
+			"error proxying oneway request",
+			zap.String("caller", req.Caller),
+			zap.String("service", req.Service),
+			zap.String("procedure", req.Procedure),
+			zap.String("shardkey", req.ShardKey),
+			zap.Error(err),
+		)
+	}
+	return err
+}

--- a/x/relay/proxy_test.go
+++ b/x/relay/proxy_test.go
@@ -1,0 +1,177 @@
+package relay
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io/ioutil"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/api/transport/transporttest"
+)
+
+func TestUnaryProxy(t *testing.T) {
+	testCases := []struct {
+		name                     string
+		requestBody              []byte
+		requestHeaders           transport.Headers
+		responseBody             []byte
+		responseHeaders          transport.Headers
+		responseApplicationError bool
+		responseErr              error
+		expectedHandlerErr       error
+	}{
+		{
+			name:                     "successful proxy",
+			requestBody:              []byte("this is the request"),
+			requestHeaders:           transport.NewHeaders().With("key", "val"),
+			responseBody:             []byte("this is the response"),
+			responseHeaders:          transport.NewHeaders().With("respKey", "respVal"),
+			responseApplicationError: false,
+		},
+		{
+			name:                     "empty response body",
+			requestBody:              []byte("this is the request"),
+			requestHeaders:           transport.NewHeaders().With("key", "val"),
+			responseBody:             []byte(nil),
+			responseHeaders:          transport.NewHeaders().With("respKey", "respVal"),
+			responseApplicationError: false,
+		},
+		{
+			name:                     "application error",
+			requestBody:              []byte("this is the request"),
+			requestHeaders:           transport.NewHeaders().With("key", "val"),
+			responseBody:             []byte("this is the response"),
+			responseHeaders:          transport.NewHeaders().With("respKey", "respVal"),
+			responseApplicationError: true,
+		},
+		{
+			name:                     "propagate client error",
+			requestBody:              []byte("this is the request"),
+			requestHeaders:           transport.NewHeaders().With("key", "val"),
+			responseBody:             []byte("this is the response"),
+			responseHeaders:          transport.NewHeaders().With("respKey", "respVal"),
+			responseApplicationError: false,
+			responseErr:              errors.New("failure"),
+			expectedHandlerErr:       errors.New("failure"),
+		},
+		{
+			name:                     "empty response body",
+			requestBody:              []byte("this is the request"),
+			requestHeaders:           transport.NewHeaders().With("key", "val"),
+			responseBody:             nil,
+			responseHeaders:          transport.NewHeaders().With("respKey", "respVal"),
+			responseApplicationError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			ctx := context.Background()
+			giveReq := &transport.Request{
+				Caller:          "caller-" + tc.name,
+				Service:         "service-" + tc.name,
+				Procedure:       "procedure-" + tc.name,
+				Encoding:        transport.Encoding("encoding-" + tc.name),
+				Body:            bytes.NewBuffer(tc.requestBody),
+				Headers:         tc.requestHeaders,
+				RoutingKey:      "test",
+				RoutingDelegate: "test",
+			}
+			wantReq := &transport.Request{
+				Caller:    "caller-" + tc.name,
+				Service:   "service-" + tc.name,
+				Procedure: "procedure-" + tc.name,
+				Encoding:  transport.Encoding("encoding-" + tc.name),
+				Body:      bytes.NewBuffer(tc.requestBody),
+				Headers:   tc.requestHeaders,
+			}
+			resp := &transport.Response{
+				Headers:          tc.responseHeaders,
+				Body:             ioutil.NopCloser(bytes.NewBuffer(tc.responseBody)),
+				ApplicationError: tc.responseApplicationError,
+			}
+			resw := new(transporttest.FakeResponseWriter)
+
+			o := transporttest.NewMockUnaryOutbound(mockCtrl)
+			o.EXPECT().Call(ctx, wantReq).Return(resp, tc.responseErr)
+
+			handler := UnaryProxyHandler(o)
+			err := handler.Handle(ctx, giveReq, resw)
+
+			if tc.expectedHandlerErr != nil {
+				assert.Equal(t, tc.expectedHandlerErr, err)
+				return
+			}
+			assert.Nil(t, err, "expected no handler error")
+			assert.Equal(t, tc.responseBody, resw.Body.Bytes())
+			assert.Equal(t, tc.responseHeaders, resw.Headers)
+			assert.Equal(t, tc.responseApplicationError, resw.IsApplicationError)
+		})
+	}
+}
+
+func TestOnewayProxy(t *testing.T) {
+	testCases := []struct {
+		name               string
+		requestBody        []byte
+		requestHeaders     transport.Headers
+		responseErr        error
+		expectedHandlerErr error
+	}{
+		{
+			name:           "successful oneway proxy",
+			requestBody:    []byte("this is the request"),
+			requestHeaders: transport.NewHeaders().With("key", "val"),
+		},
+		{
+			name:               "propagate error",
+			requestBody:        []byte("this is the request"),
+			requestHeaders:     transport.NewHeaders().With("key", "val"),
+			responseErr:        errors.New("failure"),
+			expectedHandlerErr: errors.New("failure"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			ctx := context.Background()
+			giveReq := &transport.Request{
+				Caller:          "caller-" + tc.name,
+				Service:         "service-" + tc.name,
+				Procedure:       "procedure-" + tc.name,
+				Encoding:        transport.Encoding("encoding-" + tc.name),
+				Body:            bytes.NewBuffer(tc.requestBody),
+				Headers:         tc.requestHeaders,
+				RoutingDelegate: "test",
+				RoutingKey:      "test",
+			}
+			wantReq := &transport.Request{
+				Caller:    "caller-" + tc.name,
+				Service:   "service-" + tc.name,
+				Procedure: "procedure-" + tc.name,
+				Encoding:  transport.Encoding("encoding-" + tc.name),
+				Body:      bytes.NewBuffer(tc.requestBody),
+				Headers:   tc.requestHeaders,
+			}
+
+			o := transporttest.NewMockOnewayOutbound(mockCtrl)
+			o.EXPECT().CallOneway(ctx, wantReq).Return(time.Now(), tc.responseErr)
+
+			handler := OnewayProxyHandler(o)
+			err := handler.HandleOneway(ctx, giveReq)
+
+			assert.Equal(t, tc.expectedHandlerErr, err)
+		})
+	}
+}

--- a/x/relay/router.go
+++ b/x/relay/router.go
@@ -1,0 +1,228 @@
+package relay
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/zap"
+)
+
+var (
+	_caller    = "Caller"
+	_component = "Component"
+	_frontCar  = "FrontCar"
+	_procedure = "Procedure"
+	_service   = "Service"
+	_shardKey  = "ShardKey"
+)
+
+// ServiceHandler is a handler that gets routed all requests for a specific service.
+type ServiceHandler struct {
+	// Service is the inbound `service` name that will determine if
+	// requests are routed to this handler.
+	Service string
+
+	// HandlerSpec that will be used for all calls to the service.
+	HandlerSpec transport.HandlerSpec
+
+	// Signature to allow introspection into the Handler (for debugging).
+	Signature string
+}
+
+// ShardKeyHandler is a handler that gets routed all requests with a shard key.
+type ShardKeyHandler struct {
+	// ShardKey is the inbound `shard key` name that will determine if
+	// requests are routed to this handler.
+	ShardKey string
+
+	// HandlerSpec that will be used for all calls to the service.
+	HandlerSpec transport.HandlerSpec
+
+	// Signature to allow introspection into the Handler (for debugging).
+	Signature string
+}
+
+// Router is a YARPC Router Middleware that
+// can be used to create service-based routing for requests.
+// The Router's routes will only be used if there is no
+// procedure available from the `regular` transport.Router
+type Router struct {
+	// serviceRoutes is a map from service name to associated transport.Procedure.
+	// The procedures in this map are only used for service-based routing.
+	serviceRoutes map[string]transport.Procedure
+
+	// shardRoutes is a map from shard key to associated transport.Procedure.
+	// The procedures in this map are only used for shard-based routing.
+	shardRoutes map[string]transport.Procedure
+
+	// hasDefault indicates that there is a default Route that will be used in
+	// fallback cases.
+	hasDefault bool
+
+	// defaultRoute is the fallback procedure that will be called if a request
+	// does not meet any of the serviceRoutes or shardRoutes.
+	defaultRoute transport.Procedure
+
+	// logger is a zap logger used for logging events / errors into.
+	logger *zap.Logger
+
+	// observer is a struct for recording metrics to tally.
+	observer *observer
+}
+
+// NewRouter creates a new Router.
+func NewRouter(options ...Option) *Router {
+	opts := applyOptions(options...)
+
+	return &Router{
+		serviceRoutes: make(map[string]transport.Procedure),
+		shardRoutes:   make(map[string]transport.Procedure),
+		logger:        opts.logger,
+		observer:      newObserver(opts.scope),
+	}
+}
+
+// RegisterService registers service handlers that will be used for calls to the
+// specified services.
+func (r *Router) RegisterService(handlers []ServiceHandler) {
+	for _, handler := range handlers {
+		if _, ok := r.serviceRoutes[handler.Service]; ok {
+			panic(fmt.Errorf("service %q already registered on Router", handler.Service))
+		}
+
+		r.serviceRoutes[handler.Service] = transport.Procedure{
+			Name:        "*", // `*` means that we are a proxy
+			Service:     handler.Service,
+			HandlerSpec: handler.HandlerSpec,
+			Signature:   handler.Signature,
+		}
+	}
+}
+
+// RegisterShard registeres shard handlers that will be used for calls to the
+// specified shard.
+func (r *Router) RegisterShard(handlers []ShardKeyHandler) {
+	for _, handler := range handlers {
+		if _, ok := r.shardRoutes[handler.ShardKey]; ok {
+			panic(fmt.Errorf("shard key %q already registered on Router", handler.ShardKey))
+		}
+
+		r.shardRoutes[handler.ShardKey] = transport.Procedure{
+			Name:        "*", // `*` means that we are a proxy
+			Service:     "*", // `*` means that we are a proxy
+			HandlerSpec: handler.HandlerSpec,
+			Signature:   handler.Signature,
+		}
+	}
+}
+
+// RegisterDefault registeres the default handler that will be used when no
+// service or shard matches.
+func (r *Router) RegisterDefault(proc transport.Procedure) {
+	r.hasDefault = true
+	r.defaultRoute = proc
+}
+
+// Procedures returns a list of supported procedures.  This includes procedures
+// from the passed in router as well as the procedures we've created for the
+// Router
+func (r *Router) Procedures(router transport.Router) []transport.Procedure {
+	procs := router.Procedures()
+	for _, v := range r.serviceRoutes {
+		procs = append(procs, v)
+	}
+	for _, v := range r.shardRoutes {
+		procs = append(procs, v)
+	}
+	return procs
+}
+
+// Choose returns a HandlerSpec for each request.  If the procedure is not
+// known, a HandlerSpec will be returned that routes the request to a known
+// service registered with RegisterService. If no known service knows how to
+// handle the request, we will look if there is a procedure for the shard key,
+// if there is no shard key registered, an error will be returned.
+func (r *Router) Choose(ctx context.Context, req *transport.Request, router transport.Router) (transport.HandlerSpec, error) {
+	r.logger.Debug("Choosing a router.",
+		zap.String(_service, req.Service),
+		zap.String(_caller, req.Caller),
+		zap.String(_component, _frontCar),
+		zap.String(_procedure, req.Procedure),
+		zap.String(_shardKey, req.ShardKey),
+	)
+	r.observer.call()
+	handlerSpec, err := router.Choose(ctx, req)
+	if err == nil {
+		r.logger.Debug("Service-Procedure match found.",
+			zap.String(_service, req.Service),
+			zap.String(_caller, req.Caller),
+			zap.String(_component, _frontCar),
+			zap.String(_procedure, req.Procedure),
+			zap.String(_shardKey, req.ShardKey),
+		)
+		r.observer.serviceProcedureMatch()
+		return handlerSpec, nil
+	}
+
+	// If the error is not UnrecognizedProcedure, return it immediately.
+	if !transport.IsUnrecognizedProcedureError(err) {
+		r.logger.Error("Unknown error.",
+			zap.String(_service, req.Service),
+			zap.String(_caller, req.Caller),
+			zap.String(_component, _frontCar),
+			zap.String(_procedure, req.Procedure),
+			zap.String(_shardKey, req.ShardKey),
+			zap.Error(err),
+		)
+		r.observer.unknownError()
+		return handlerSpec, err
+	}
+
+	if proc, ok := r.serviceRoutes[req.Service]; ok {
+		r.logger.Debug("Service match found.",
+			zap.String(_service, req.Service),
+			zap.String(_caller, req.Caller),
+			zap.String(_component, _frontCar),
+			zap.String(_procedure, req.Procedure),
+			zap.String(_shardKey, req.ShardKey),
+		)
+		r.observer.serviceMatch()
+		return proc.HandlerSpec, nil
+	}
+
+	if proc, ok := r.shardRoutes[req.ShardKey]; ok {
+		r.logger.Debug("Shardkey match found.",
+			zap.String(_service, req.Service),
+			zap.String(_caller, req.Caller),
+			zap.String(_component, _frontCar),
+			zap.String(_procedure, req.Procedure),
+			zap.String(_shardKey, req.ShardKey),
+		)
+		r.observer.shardKeyMatch()
+		return proc.HandlerSpec, nil
+	}
+
+	if r.hasDefault {
+		r.logger.Debug("No match found. Using default.",
+			zap.String(_service, req.Service),
+			zap.String(_caller, req.Caller),
+			zap.String(_component, _frontCar),
+			zap.String(_procedure, req.Procedure),
+			zap.String(_shardKey, req.ShardKey),
+		)
+		r.observer.defaultMatch()
+		return r.defaultRoute.HandlerSpec, nil
+	}
+
+	r.logger.Error("No handler found.",
+		zap.String(_service, req.Service),
+		zap.String(_caller, req.Caller),
+		zap.String(_component, _frontCar),
+		zap.String(_procedure, req.Procedure),
+		zap.String(_shardKey, req.ShardKey),
+		zap.Error(err),
+	)
+	r.observer.noHandleError()
+	return transport.HandlerSpec{}, err
+}

--- a/x/relay/router_test.go
+++ b/x/relay/router_test.go
@@ -1,0 +1,567 @@
+package relay
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
+	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/api/transport/transporttest"
+)
+
+func TestRouting(t *testing.T) {
+	type shardProxyDef struct {
+		shard       string
+		outboundkey string
+		isUnary     bool
+	}
+	type serviceProxyDef struct {
+		service     string
+		outboundkey string
+		isUnary     bool
+	}
+	type procedureProxyDef struct {
+		service     string
+		procedure   string
+		outboundkey string
+		isUnary     bool
+	}
+	testCases := []struct {
+		name string
+
+		// give{Unary,Oneway}Outbounds specifies a series of mock unary/oneway
+		// outbounds to create in the dispatcher.
+		giveUnaryOutbounds  []string
+		giveOnewayOutbounds []string
+
+		// giveOutboundResponseErr is the error returned from all outbounds.
+		giveOutboundResponseErr error
+
+		// giveShardProxies specifies proxy definitions for shardkey-level
+		// handlers.
+		giveShardProxies []shardProxyDef
+
+		// giveServiceProxies specifies proxy definitions for service-level
+		// handlers.
+		giveServiceProxies []serviceProxyDef
+
+		// giveProcedureProxies specifies proxy definitions for procedure-level
+		// handlers.
+		giveProcedureProxies []procedureProxyDef
+
+		// giveRequest is the request used per test.
+		giveRequest *transport.Request
+
+		// expectToCallOutbound is the name of the outbound we expect to call
+		// for the request.
+		expectToCallOutbound string
+
+		// expectChooseErr is the error we expect to be returned from the
+		// router's `Choose` method.
+		expectChooseErr error
+
+		// expectHandlerErr is the error we expect to be returned from the
+		// proxy handler.
+		expectHandlerErr error
+
+		// These counters are the tally-compatible "name+tags" that point to
+		// the current counter value.
+		wantCounters map[string]int
+	}{
+		{
+			name:               "unary service proxy",
+			giveUnaryOutbounds: []string{"testOut"},
+			giveRequest: &transport.Request{
+				Caller:    "doesnotmatter",
+				Service:   "test",
+				Procedure: "doesnotmatter",
+				Encoding:  "doesnotmatter",
+			},
+			expectToCallOutbound: "testOut",
+			giveServiceProxies: []serviceProxyDef{
+				{service: "test", outboundkey: "testOut", isUnary: true},
+			},
+			wantCounters: map[string]int{
+				"frontcar_choose_calls+":                       1,
+				"frontcar_choose_successes+match_type=service": 1,
+			},
+		},
+		{
+			name:               "unary service proxy error",
+			giveUnaryOutbounds: []string{"testOut"},
+			giveServiceProxies: []serviceProxyDef{
+				{service: "test", outboundkey: "testOut", isUnary: true},
+			},
+			giveRequest: &transport.Request{
+				Caller:    "doesnotmatter",
+				Service:   "test",
+				Procedure: "doesnotmatter",
+				Encoding:  "doesnotmatter",
+			},
+			giveOutboundResponseErr: fmt.Errorf("Test error"),
+			expectHandlerErr:        fmt.Errorf("Test error"),
+			expectToCallOutbound:    "testOut",
+			wantCounters: map[string]int{
+				"frontcar_choose_calls+":                       1,
+				"frontcar_choose_successes+match_type=service": 1,
+			},
+		},
+		{
+			name:               "multiple unary service proxies",
+			giveUnaryOutbounds: []string{"testOut1", "testOut2", "testOut3"},
+			giveServiceProxies: []serviceProxyDef{
+				{service: "testOut1", outboundkey: "testOut1", isUnary: true},
+				{service: "testOut2", outboundkey: "testOut2", isUnary: true},
+				{service: "testOut3", outboundkey: "testOut3", isUnary: true},
+			},
+			giveRequest: &transport.Request{
+				Caller:    "doesnotmatter",
+				Service:   "testOut2",
+				Procedure: "doesnotmatter",
+				Encoding:  "doesnotmatter",
+			},
+			expectToCallOutbound: "testOut2",
+			wantCounters: map[string]int{
+				"frontcar_choose_calls+":                       1,
+				"frontcar_choose_successes+match_type=service": 1,
+			},
+		},
+		{
+			name:                "simple oneway service proxy",
+			giveOnewayOutbounds: []string{"testOut"},
+			giveRequest: &transport.Request{
+				Caller:    "doesnotmatter",
+				Service:   "test",
+				Procedure: "doesnotmatter",
+				Encoding:  "doesnotmatter",
+			},
+			expectToCallOutbound: "testOut",
+			giveServiceProxies: []serviceProxyDef{
+				{service: "test", outboundkey: "testOut", isUnary: false},
+			},
+			wantCounters: map[string]int{
+				"frontcar_choose_calls+":                       1,
+				"frontcar_choose_successes+match_type=service": 1,
+			},
+		},
+		{
+			name:                "oneway proxy service error",
+			giveOnewayOutbounds: []string{"testOut"},
+			giveServiceProxies: []serviceProxyDef{
+				{service: "testOut", outboundkey: "testOut", isUnary: false},
+			},
+			giveRequest: &transport.Request{
+				Caller:    "doesnotmatter",
+				Service:   "testOut",
+				Procedure: "doesnotmatter",
+				Encoding:  "doesnotmatter",
+			},
+			giveOutboundResponseErr: fmt.Errorf("Test error"),
+			expectHandlerErr:        fmt.Errorf("Test error"),
+			expectToCallOutbound:    "testOut",
+			wantCounters: map[string]int{
+				"frontcar_choose_calls+":                       1,
+				"frontcar_choose_successes+match_type=service": 1,
+			},
+		},
+		{
+			name:                "multiple oneway giveServiceProxies",
+			giveOnewayOutbounds: []string{"testOut1", "testOut2", "testOut3"},
+			giveServiceProxies: []serviceProxyDef{
+				{service: "testOut1", outboundkey: "testOut1", isUnary: false},
+				{service: "testOut2", outboundkey: "testOut2", isUnary: false},
+				{service: "testOut3", outboundkey: "testOut3", isUnary: false},
+			},
+			giveRequest: &transport.Request{
+				Caller:    "doesnotmatter",
+				Service:   "testOut2",
+				Procedure: "doesnotmatter",
+				Encoding:  "doesnotmatter",
+			},
+			expectToCallOutbound: "testOut2",
+			wantCounters: map[string]int{
+				"frontcar_choose_calls+":                       1,
+				"frontcar_choose_successes+match_type=service": 1,
+			},
+		},
+		{
+			name: "missing procedure",
+			giveRequest: &transport.Request{
+				Caller:    "doesnotmatter",
+				Service:   "invalidService",
+				Procedure: "invalidProcedure",
+				Encoding:  "doesnotmatter",
+			},
+			expectChooseErr: transport.UnrecognizedProcedureError(
+				&transport.Request{
+					Service:   "invalidService",
+					Procedure: "invalidProcedure",
+				},
+			),
+			wantCounters: map[string]int{
+				"frontcar_choose_calls+":                       1,
+				"frontcar_choose_successes+match_type=service": 1,
+			},
+		},
+		{
+			name:               "prioritize routing to a dispatcher procedure",
+			giveUnaryOutbounds: []string{"procedureOut", "serviceOut", "shardOut"},
+			giveServiceProxies: []serviceProxyDef{
+				{service: "myservice", outboundkey: "serviceOut", isUnary: true},
+			},
+			giveShardProxies: []shardProxyDef{
+				{shard: "myshard", outboundkey: "shardOut", isUnary: true},
+			},
+			giveProcedureProxies: []procedureProxyDef{
+				{service: "myservice", procedure: "myprocedure", outboundkey: "procedureOut", isUnary: true},
+			},
+			giveRequest: &transport.Request{
+				Caller:    "doesnotmatter",
+				Service:   "myservice",
+				Procedure: "myprocedure",
+				Encoding:  "doesnotmatter",
+				ShardKey:  "myshard",
+			},
+			expectToCallOutbound: "procedureOut",
+			wantCounters: map[string]int{
+				"frontcar_choose_calls+":                                 1,
+				"frontcar_choose_successes+match_type=service_procedure": 1,
+			},
+		},
+		{
+			name:                "prioritize routing oneway to a dispatcher procedure",
+			giveOnewayOutbounds: []string{"procedureOut", "serviceOut", "shardOut"},
+			giveServiceProxies: []serviceProxyDef{
+				{service: "myservice", outboundkey: "serviceOut", isUnary: false},
+			},
+			giveShardProxies: []shardProxyDef{
+				{shard: "myshard", outboundkey: "shardOut", isUnary: false},
+			},
+			giveProcedureProxies: []procedureProxyDef{
+				{service: "myservice", procedure: "myprocedure", outboundkey: "procedureOut", isUnary: false},
+			},
+			giveRequest: &transport.Request{
+				Caller:    "doesnotmatter",
+				Service:   "myservice",
+				Procedure: "myprocedure",
+				Encoding:  "doesnotmatter",
+				ShardKey:  "myshard",
+			},
+			expectToCallOutbound: "procedureOut",
+			wantCounters: map[string]int{
+				"frontcar_choose_calls+":                                 1,
+				"frontcar_choose_successes+match_type=service_procedure": 1,
+			},
+		},
+		{
+			name:               "unary shard proxy",
+			giveUnaryOutbounds: []string{"testOut"},
+			giveRequest: &transport.Request{
+				Caller:    "doesnotmatter",
+				Service:   "doesnotmatter",
+				Procedure: "doesnotmatter",
+				Encoding:  "doesnotmatter",
+				ShardKey:  "test",
+			},
+			expectToCallOutbound: "testOut",
+			giveShardProxies: []shardProxyDef{
+				{shard: "test", outboundkey: "testOut", isUnary: true},
+			},
+			wantCounters: map[string]int{
+				"frontcar_choose_calls+":                         1,
+				"frontcar_choose_successes+match_type=shard_key": 1,
+			},
+		},
+		{
+			name:               "unary shard proxy error",
+			giveUnaryOutbounds: []string{"testOut"},
+			giveShardProxies: []shardProxyDef{
+				{shard: "test", outboundkey: "testOut", isUnary: true},
+			},
+			giveRequest: &transport.Request{
+				Caller:    "doesnotmatter",
+				Service:   "doesnotmatter",
+				Procedure: "doesnotmatter",
+				Encoding:  "doesnotmatter",
+				ShardKey:  "test",
+			},
+			giveOutboundResponseErr: fmt.Errorf("Test error"),
+			expectHandlerErr:        fmt.Errorf("Test error"),
+			expectToCallOutbound:    "testOut",
+			wantCounters: map[string]int{
+				"frontcar_choose_calls+":                         1,
+				"frontcar_choose_successes+match_type=shard_key": 1,
+			},
+		},
+		{
+			name:               "multiple unary shard proxies",
+			giveUnaryOutbounds: []string{"testOut1", "testOut2", "testOut3"},
+			giveShardProxies: []shardProxyDef{
+				{shard: "testOut1", outboundkey: "testOut1", isUnary: true},
+				{shard: "testOut2", outboundkey: "testOut2", isUnary: true},
+				{shard: "testOut3", outboundkey: "testOut3", isUnary: true},
+			},
+			giveRequest: &transport.Request{
+				Caller:    "doesnotmatter",
+				Service:   "doesnotmatter",
+				Procedure: "doesnotmatter",
+				Encoding:  "doesnotmatter",
+				ShardKey:  "testOut2",
+			},
+			expectToCallOutbound: "testOut2",
+			wantCounters: map[string]int{
+				"frontcar_choose_calls+":                         1,
+				"frontcar_choose_successes+match_type=shard_key": 1,
+			},
+		},
+		{
+			name:                "simple oneway shard proxy",
+			giveOnewayOutbounds: []string{"testOut"},
+			giveRequest: &transport.Request{
+				Caller:    "doesnotmatter",
+				Service:   "doesnotmatter",
+				Procedure: "doesnotmatter",
+				Encoding:  "doesnotmatter",
+				ShardKey:  "test",
+			},
+			expectToCallOutbound: "testOut",
+			giveShardProxies: []shardProxyDef{
+				{shard: "test", outboundkey: "testOut", isUnary: false},
+			},
+			wantCounters: map[string]int{
+				"frontcar_choose_calls+":                         1,
+				"frontcar_choose_successes+match_type=shard_key": 1,
+			},
+		},
+		{
+			name:                "oneway proxy shard error",
+			giveOnewayOutbounds: []string{"testOut"},
+			giveShardProxies: []shardProxyDef{
+				{shard: "testOut", outboundkey: "testOut", isUnary: false},
+			},
+			giveRequest: &transport.Request{
+				Caller:    "doesnotmatter",
+				Service:   "doesnotmatter",
+				Procedure: "doesnotmatter",
+				Encoding:  "doesnotmatter",
+				ShardKey:  "testOut",
+			},
+			giveOutboundResponseErr: fmt.Errorf("Test error"),
+			expectHandlerErr:        fmt.Errorf("Test error"),
+			expectToCallOutbound:    "testOut",
+			wantCounters: map[string]int{
+				"frontcar_choose_calls+":                         1,
+				"frontcar_choose_successes+match_type=shard_key": 1,
+			},
+		},
+		{
+			name:                "multiple oneway shard proxies",
+			giveOnewayOutbounds: []string{"testOut1", "testOut2", "testOut3"},
+			giveShardProxies: []shardProxyDef{
+				{shard: "testOut1", outboundkey: "testOut1", isUnary: false},
+				{shard: "testOut2", outboundkey: "testOut2", isUnary: false},
+				{shard: "testOut3", outboundkey: "testOut3", isUnary: false},
+			},
+			giveRequest: &transport.Request{
+				Caller:    "doesnotmatter",
+				Service:   "doesnotmatter",
+				Procedure: "doesnotmatter",
+				Encoding:  "doesnotmatter",
+				ShardKey:  "testOut2",
+			},
+			expectToCallOutbound: "testOut2",
+			wantCounters: map[string]int{
+				"frontcar_choose_calls+":                         1,
+				"frontcar_choose_successes+match_type=shard_key": 1,
+			},
+		},
+		{
+			name:               "prioritize routing to a service procedure",
+			giveUnaryOutbounds: []string{"serviceOut", "shardOut"},
+			giveServiceProxies: []serviceProxyDef{
+				{service: "myservice", outboundkey: "serviceOut", isUnary: true},
+			},
+			giveShardProxies: []shardProxyDef{
+				{shard: "myshard", outboundkey: "shardOut", isUnary: true},
+			},
+			giveRequest: &transport.Request{
+				Caller:    "doesnotmatter",
+				Service:   "myservice",
+				Procedure: "myprocedure",
+				Encoding:  "doesnotmatter",
+				ShardKey:  "myshard",
+			},
+			expectToCallOutbound: "serviceOut",
+			wantCounters: map[string]int{
+				"frontcar_choose_calls+":                       1,
+				"frontcar_choose_successes+match_type=service": 1,
+			},
+		},
+		{
+			name:                "prioritize routing oneway to a service procedure",
+			giveOnewayOutbounds: []string{"serviceOut", "shardOut"},
+			giveServiceProxies: []serviceProxyDef{
+				{service: "myservice", outboundkey: "serviceOut", isUnary: false},
+			},
+			giveShardProxies: []shardProxyDef{
+				{shard: "myshard", outboundkey: "shardOut", isUnary: false},
+			},
+			giveRequest: &transport.Request{
+				Caller:    "doesnotmatter",
+				Service:   "myservice",
+				Procedure: "doesnotmatter",
+				Encoding:  "doesnotmatter",
+				ShardKey:  "myshard",
+			},
+			expectToCallOutbound: "serviceOut",
+			wantCounters: map[string]int{
+				"frontcar_choose_calls+":                       1,
+				"frontcar_choose_successes+match_type=service": 1,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			unaryResponse := []byte("This is a test response")
+
+			outbounds := make(yarpc.Outbounds, len(tc.giveUnaryOutbounds)+len(tc.giveOnewayOutbounds))
+			for _, outKey := range tc.giveUnaryOutbounds {
+				out := transporttest.NewMockUnaryOutbound(mockCtrl)
+				out.EXPECT().Transports().AnyTimes().Return([]transport.Transport{})
+				out.EXPECT().Start().AnyTimes()
+				out.EXPECT().Stop().AnyTimes()
+				if tc.expectToCallOutbound == outKey {
+					resp := &transport.Response{
+						Body: ioutil.NopCloser(bytes.NewBuffer(unaryResponse)),
+					}
+					out.EXPECT().Call(ctx, tc.giveRequest).Return(resp, tc.giveOutboundResponseErr)
+				}
+				outbounds[outKey] = transport.Outbounds{
+					Unary: out,
+				}
+			}
+			for _, outKey := range tc.giveOnewayOutbounds {
+				out := transporttest.NewMockOnewayOutbound(mockCtrl)
+				out.EXPECT().Transports().AnyTimes().Return([]transport.Transport{})
+				out.EXPECT().Start().AnyTimes()
+				out.EXPECT().Stop().AnyTimes()
+				if tc.expectToCallOutbound == outKey {
+					out.EXPECT().CallOneway(ctx, tc.giveRequest).Return(time.Now(), tc.giveOutboundResponseErr)
+				}
+				outbounds[outKey] = transport.Outbounds{
+					Oneway: out,
+				}
+			}
+
+			cfg := yarpc.Config{
+				Name:      "service",
+				Outbounds: outbounds,
+				Metrics: yarpc.MetricsConfig{
+					Tally: tally.NoopScope,
+				},
+			}
+
+			testScope := tally.NewTestScope("", map[string]string{})
+			sr := NewRouter(Scope(testScope))
+			cfg.RouterMiddleware = sr
+			dispatcher := yarpc.NewDispatcher(cfg)
+
+			numDefaultProcs := len(dispatcher.Router().Procedures())
+
+			for _, proxy := range tc.giveShardProxies {
+				handler := ShardKeyHandler{ShardKey: proxy.shard}
+				if proxy.isUnary {
+					handler.HandlerSpec = transport.NewUnaryHandlerSpec(
+						UnaryProxyHandler(dispatcher.ClientConfig(proxy.outboundkey).GetUnaryOutbound()),
+					)
+				} else {
+					handler.HandlerSpec = transport.NewOnewayHandlerSpec(
+						OnewayProxyHandler(dispatcher.ClientConfig(proxy.outboundkey).GetOnewayOutbound()),
+					)
+				}
+				sr.RegisterShard([]ShardKeyHandler{handler})
+			}
+
+			for _, proxy := range tc.giveServiceProxies {
+				handler := ServiceHandler{Service: proxy.service}
+				if proxy.isUnary {
+					handler.HandlerSpec = transport.NewUnaryHandlerSpec(
+						UnaryProxyHandler(dispatcher.ClientConfig(proxy.outboundkey).GetUnaryOutbound()),
+					)
+				} else {
+					handler.HandlerSpec = transport.NewOnewayHandlerSpec(
+						OnewayProxyHandler(dispatcher.ClientConfig(proxy.outboundkey).GetOnewayOutbound()),
+					)
+				}
+				sr.RegisterService([]ServiceHandler{handler})
+			}
+
+			for _, proxy := range tc.giveProcedureProxies {
+				proc := transport.Procedure{
+					Name:    proxy.procedure,
+					Service: proxy.service,
+				}
+				if proxy.isUnary {
+					proc.HandlerSpec = transport.NewUnaryHandlerSpec(
+						UnaryProxyHandler(dispatcher.ClientConfig(proxy.outboundkey).GetUnaryOutbound()),
+					)
+				} else {
+					proc.HandlerSpec = transport.NewOnewayHandlerSpec(
+						OnewayProxyHandler(dispatcher.ClientConfig(proxy.outboundkey).GetOnewayOutbound()),
+					)
+				}
+				dispatcher.Register([]transport.Procedure{proc})
+			}
+
+			require.NoError(t, dispatcher.Start())
+			defer dispatcher.Stop()
+
+			// Validate that the number of procedures equals the procedure & service proxies + the default procedures
+			assert.Len(t, dispatcher.Router().Procedures(), len(tc.giveShardProxies)+len(tc.giveProcedureProxies)+len(tc.giveServiceProxies)+numDefaultProcs)
+
+			spec, err := dispatcher.Router().Choose(ctx, tc.giveRequest)
+			if tc.expectChooseErr != nil {
+				assert.EqualError(t, err, tc.expectChooseErr.Error())
+				return
+			}
+			require.NoError(t, err)
+
+			switch spec.Type() {
+			case transport.Unary:
+				respWriter := new(transporttest.FakeResponseWriter)
+				err = spec.Unary().Handle(ctx, tc.giveRequest, respWriter)
+				if err == nil {
+					assert.Equal(t, unaryResponse, respWriter.Body.Bytes())
+				}
+			case transport.Oneway:
+				err = spec.Oneway().HandleOneway(ctx, tc.giveRequest)
+			default:
+				panic("unexpected spec type")
+			}
+			if tc.expectHandlerErr != nil {
+				assert.EqualError(t, err, tc.expectHandlerErr.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+
+			counters := testScope.Snapshot().Counters()
+			for nameAndTags, value := range tc.wantCounters {
+				require.Contains(t, counters, nameAndTags, "name+tag combo was not in the counters")
+				assert.Equal(t, int64(value), counters[nameAndTags].Value(), "counter %s was not as expected", nameAndTags)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Summary: This is a POC proving how easy it is to move the Frontcar code
into the open-source world of yarpc under a relay package. Ideally this
can be done alongside the relay/routing improvements I outlined in the
offboarding doc.