### PR TITLE
Add go report card badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# yarpc [![GoDoc][doc-img]][doc] [![GitHub release][release-img]][release] [![Mit License][mit-img]][mit] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov]
+# yarpc [![GoDoc][doc-img]][doc] [![GitHub release][release-img]][release] [![Mit License][mit-img]][mit] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov] [![Go Report Card][report-img]][report]
 
 A message passing platform for Go that lets you:
 
@@ -40,3 +40,6 @@ the containing `x` package and their APIs will be locked.
 
 [cov-img]: https://codecov.io/gh/yarpc/yarpc-go/branch/master/graph/badge.svg
 [cov]: https://codecov.io/gh/yarpc/yarpc-go/branch/master
+
+[report-img]: https://goreportcard.com/badge/go.uber.org/yarpc
+[report]: https://goreportcard.com/report/go.uber.org/yarpc


### PR DESCRIPTION
This adds the [go report card](https://goreportcard.com/report/go.uber.org/yarpc) badge to the README file. The site gives YARPC an `A+` rating, which takes into account things like `gofmt`, `govet`, `golint` as well as comment misspellings.

I think it's a nice to have, which shows our commitment to writing solid Go libraries. We can also add this to our other OSS repos if everyone is in.