### PR TITLE
Change protoplugin runner to take function to produce filename instead of file suffix

### DIFF
--- a/encoding/protobuf/protoc-gen-yarpc-go/internal/lib/lib.go
+++ b/encoding/protobuf/protoc-gen-yarpc-go/internal/lib/lib.go
@@ -24,6 +24,8 @@
 package lib
 
 import (
+	"fmt"
+	"path/filepath"
 	"strings"
 	"text/template"
 
@@ -501,7 +503,9 @@ var Runner = protoplugin.NewRunner(
 		"go.uber.org/yarpc/api/transport",
 		"go.uber.org/yarpc/encoding/protobuf",
 	},
-	"pb.yarpc.go",
+	func(name string) (string, error) {
+		return fmt.Sprintf("%s.pb.yarpc.go", strings.TrimSuffix(name, filepath.Ext(name))), nil
+	},
 )
 
 func checkTemplateInfo(templateInfo *protoplugin.TemplateInfo) error {

--- a/internal/protoplugin/generator.go
+++ b/internal/protoplugin/generator.go
@@ -26,8 +26,6 @@ import (
 	"fmt"
 	"go/format"
 	"path"
-	"path/filepath"
-	"strings"
 	"text/template"
 
 	"github.com/gogo/protobuf/proto"
@@ -39,11 +37,11 @@ var (
 )
 
 type generator struct {
-	registry            *registry
-	tmpl                *template.Template
-	templateInfoChecker func(*TemplateInfo) error
-	baseImports         []*GoPackage
-	fileSuffix          string
+	registry                      *registry
+	tmpl                          *template.Template
+	templateInfoChecker           func(*TemplateInfo) error
+	baseImports                   []*GoPackage
+	protoFilenameToOutputFilename func(string) (string, error)
 }
 
 func newGenerator(
@@ -51,7 +49,7 @@ func newGenerator(
 	tmpl *template.Template,
 	templateInfoChecker func(*TemplateInfo) error,
 	baseImportStrings []string,
-	fileSuffix string,
+	protoFilenameToOutputFilename func(string) (string, error),
 ) *generator {
 	var baseImports []*GoPackage
 	for _, pkgpath := range baseImportStrings {
@@ -76,7 +74,7 @@ func newGenerator(
 		tmpl,
 		templateInfoChecker,
 		baseImports,
-		fileSuffix,
+		protoFilenameToOutputFilename,
 	}
 }
 
@@ -94,10 +92,10 @@ func (g *generator) Generate(targets []*File) ([]*plugin_go.CodeGeneratorRespons
 		if err != nil {
 			return nil, fmt.Errorf("could not format go code: %v\n%s", err, code)
 		}
-		name := file.GetName()
-		ext := filepath.Ext(name)
-		base := strings.TrimSuffix(name, ext)
-		output := fmt.Sprintf("%s.%s", base, g.fileSuffix)
+		output, err := g.protoFilenameToOutputFilename(file.GetName())
+		if err != nil {
+			return nil, err
+		}
 		files = append(files, &plugin_go.CodeGeneratorResponse_File{
 			Name:    proto.String(output),
 			Content: proto.String(string(formatted)),

--- a/internal/protoplugin/protoplugin.go
+++ b/internal/protoplugin/protoplugin.go
@@ -96,9 +96,9 @@ func NewRunner(
 	tmpl *template.Template,
 	templateInfoChecker func(*TemplateInfo) error,
 	baseImports []string,
-	fileSuffix string,
+	protoFilenameToOutputFilename func(string) (string, error),
 ) Runner {
-	return newRunner(tmpl, templateInfoChecker, baseImports, fileSuffix)
+	return newRunner(tmpl, templateInfoChecker, baseImports, protoFilenameToOutputFilename)
 }
 
 // TemplateInfo is the info passed to a template.

--- a/internal/protoplugin/runner.go
+++ b/internal/protoplugin/runner.go
@@ -29,19 +29,19 @@ import (
 )
 
 type runner struct {
-	tmpl                *template.Template
-	templateInfoChecker func(*TemplateInfo) error
-	baseImports         []string
-	fileSuffix          string
+	tmpl                          *template.Template
+	templateInfoChecker           func(*TemplateInfo) error
+	baseImports                   []string
+	protoFilenameToOutputFilename func(string) (string, error)
 }
 
 func newRunner(
 	tmpl *template.Template,
 	templateInfoChecker func(*TemplateInfo) error,
 	baseImports []string,
-	fileSuffix string,
+	protoFilenameToOutputFilename func(string) (string, error),
 ) *runner {
-	return &runner{tmpl, templateInfoChecker, baseImports, fileSuffix}
+	return &runner{tmpl, templateInfoChecker, baseImports, protoFilenameToOutputFilename}
 }
 
 func (r *runner) Run(request *plugin_go.CodeGeneratorRequest) *plugin_go.CodeGeneratorResponse {
@@ -67,7 +67,7 @@ func (r *runner) Run(request *plugin_go.CodeGeneratorRequest) *plugin_go.CodeGen
 		r.tmpl,
 		r.templateInfoChecker,
 		r.baseImports,
-		r.fileSuffix,
+		r.protoFilenameToOutputFilename,
 	)
 	if err := registry.Load(request); err != nil {
 		return newResponseError(err)


### PR DESCRIPTION
This changes the wrapper Protobuf plugin code to take a function that converts from Protobuf filename to output filename instead of taking a suffix. Example:

```
# before you could only do this given fileSuffix = "pb.yarpc.go":
foo.proto -> foo.pb.yarpc.go
# now, you could have three separate functions that produce the following:
foo.proto -> foo.pb.yarpc.go
foo.proto -> keyvalueclientfx/foo.pb.go
foo.proto -> keyvalueserverfx/foo.whatever.go
```

This is needed if we want to output multiple packages for #1449. There will be another PR that makes it easy to have multiple `protoplugin.Runners` after this.