### PR TITLE
Add protoplugin.NewMultiRunner

### DIFF
--- a/internal/protoplugin/multi_runner.go
+++ b/internal/protoplugin/multi_runner.go
@@ -43,17 +43,17 @@ func (m *multiRunner) Run(request *plugin_go.CodeGeneratorRequest) *plugin_go.Co
 		response := runner.Run(request)
 		if responseErrString := response.GetError(); responseErrString != "" {
 			responseErr = multierr.Append(responseErr, errors.New(responseErrString))
-		} else {
-			for _, file := range response.GetFile() {
-				name := file.GetName()
-				if name == "" {
-					return newResponseError(errors.New("no name on CodeGeneratorResponse_File"))
-				}
-				if _, ok := nameToFile[name]; ok {
-					return newResponseError(fmt.Errorf("duplicate name for CodeGeneratorResponse_File: %s", name))
-				}
-				nameToFile[name] = file
+			continue
+		}
+		for _, file := range response.GetFile() {
+			name := file.GetName()
+			if name == "" {
+				return newResponseError(errors.New("no name on CodeGeneratorResponse_File"))
 			}
+			if _, ok := nameToFile[name]; ok {
+				return newResponseError(fmt.Errorf("duplicate name for CodeGeneratorResponse_File: %s", name))
+			}
+			nameToFile[name] = file
 		}
 	}
 	if responseErr != nil {

--- a/internal/protoplugin/multi_runner.go
+++ b/internal/protoplugin/multi_runner.go
@@ -23,6 +23,7 @@ package protoplugin
 import (
 	"errors"
 	"fmt"
+	"sort"
 
 	"github.com/gogo/protobuf/protoc-gen-gogo/plugin"
 	"go.uber.org/multierr"
@@ -63,5 +64,6 @@ func (m *multiRunner) Run(request *plugin_go.CodeGeneratorRequest) *plugin_go.Co
 	for _, file := range nameToFile {
 		files = append(files, file)
 	}
+	sort.Slice(files, func(i int, j int) bool { return files[i].GetName() < files[j].GetName() })
 	return newResponseFiles(files)
 }

--- a/internal/protoplugin/multi_runner.go
+++ b/internal/protoplugin/multi_runner.go
@@ -29,6 +29,8 @@ import (
 	"go.uber.org/multierr"
 )
 
+var errNoFileName = errors.New("no name on CodeGeneratorResponse_File")
+
 type multiRunner struct {
 	runners []Runner
 }
@@ -49,10 +51,10 @@ func (m *multiRunner) Run(request *plugin_go.CodeGeneratorRequest) *plugin_go.Co
 		for _, file := range response.GetFile() {
 			name := file.GetName()
 			if name == "" {
-				return newResponseError(errors.New("no name on CodeGeneratorResponse_File"))
+				return newResponseError(errNoFileName)
 			}
 			if _, ok := nameToFile[name]; ok {
-				return newResponseError(fmt.Errorf("duplicate name for CodeGeneratorResponse_File: %s", name))
+				return newResponseError(newErrorDuplicateFileName(name))
 			}
 			nameToFile[name] = file
 		}
@@ -66,4 +68,8 @@ func (m *multiRunner) Run(request *plugin_go.CodeGeneratorRequest) *plugin_go.Co
 	}
 	sort.Slice(files, func(i int, j int) bool { return files[i].GetName() < files[j].GetName() })
 	return newResponseFiles(files)
+}
+
+func newErrorDuplicateFileName(name string) error {
+	return fmt.Errorf("duplicate name for CodeGeneratorResponse_File: %s", name)
 }

--- a/internal/protoplugin/multi_runner.go
+++ b/internal/protoplugin/multi_runner.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package protoplugin
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/gogo/protobuf/protoc-gen-gogo/plugin"
+	"go.uber.org/multierr"
+)
+
+type multiRunner struct {
+	runners []Runner
+}
+
+func newMultiRunner(runners ...Runner) *multiRunner {
+	return &multiRunner{runners: runners}
+}
+
+func (m *multiRunner) Run(request *plugin_go.CodeGeneratorRequest) *plugin_go.CodeGeneratorResponse {
+	nameToFile := make(map[string]*plugin_go.CodeGeneratorResponse_File)
+	var responseErr error
+	for _, runner := range m.runners {
+		response := runner.Run(request)
+		if responseErrString := response.GetError(); responseErrString != "" {
+			responseErr = multierr.Append(responseErr, errors.New(responseErrString))
+		} else {
+			for _, file := range response.GetFile() {
+				name := file.GetName()
+				if name == "" {
+					return newResponseError(errors.New("no name on CodeGeneratorResponse_File"))
+				}
+				if _, ok := nameToFile[name]; ok {
+					return newResponseError(fmt.Errorf("duplicate name for CodeGeneratorResponse_File: %s", name))
+				}
+				nameToFile[name] = file
+			}
+		}
+	}
+	if responseErr != nil {
+		return newResponseError(responseErr)
+	}
+	files := make([]*plugin_go.CodeGeneratorResponse_File, 0, len(nameToFile))
+	for _, file := range nameToFile {
+		files = append(files, file)
+	}
+	return newResponseFiles(files)
+}

--- a/internal/protoplugin/multi_runner_test.go
+++ b/internal/protoplugin/multi_runner_test.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package protoplugin
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/gogo/protobuf/protoc-gen-gogo/plugin"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/multierr"
+)
+
+func TestMultiRunnerRun(t *testing.T) {
+	testMultiRunnerRun(
+		t,
+		[]Runner{
+			newSuccessTestRunner("foo"),
+			newSuccessTestRunner("bar", "baz"),
+			newSuccessTestRunner("bat"),
+		},
+		[]string{
+			"bar",
+			"bat",
+			"baz",
+			"foo",
+		},
+		nil,
+	)
+	testMultiRunnerRun(
+		t,
+		[]Runner{
+			newSuccessTestRunner("foo"),
+			newSuccessTestRunner("bar", "baz"),
+			newSuccessTestRunner(""),
+		},
+		nil,
+		errNoFileName,
+	)
+	testMultiRunnerRun(
+		t,
+		[]Runner{
+			newSuccessTestRunner("foo"),
+			newSuccessTestRunner("bar", "baz"),
+			newSuccessTestRunner("foo"),
+		},
+		nil,
+		newErrorDuplicateFileName("foo"),
+	)
+	testMultiRunnerRun(
+		t,
+		[]Runner{
+			newSuccessTestRunner("foo"),
+			newErrorTestRunner(errors.New("value")),
+			newSuccessTestRunner("bar"),
+		},
+		nil,
+		errors.New("value"),
+	)
+	testMultiRunnerRun(
+		t,
+		[]Runner{
+			newSuccessTestRunner("foo"),
+			newErrorTestRunner(errors.New("value")),
+			newErrorTestRunner(errors.New("value2")),
+		},
+		nil,
+		multierr.Append(
+			errors.New("value"),
+			errors.New("value2"),
+		),
+	)
+}
+
+func testMultiRunnerRun(
+	t *testing.T,
+	runners []Runner,
+	expectedFileNames []string,
+	expectedError error,
+) {
+	response := NewMultiRunner(runners...).Run(nil)
+	if expectedError != nil {
+		assert.Equal(t, newResponseError(expectedError), response)
+	} else {
+		fileNames := make([]string, 0, len(expectedFileNames))
+		for _, file := range response.GetFile() {
+			fileNames = append(fileNames, file.GetName())
+		}
+		assert.Equal(t, expectedFileNames, fileNames)
+	}
+}
+
+type testRunner struct {
+	fileNames []string
+	err       error
+}
+
+func newSuccessTestRunner(fileNames ...string) *testRunner {
+	return &testRunner{
+		fileNames: fileNames,
+	}
+}
+
+func newErrorTestRunner(err error) *testRunner {
+	return &testRunner{
+		err: err,
+	}
+}
+
+func (r *testRunner) Run(*plugin_go.CodeGeneratorRequest) *plugin_go.CodeGeneratorResponse {
+	if r.err != nil {
+		return newResponseError(r.err)
+	}
+	files := make([]*plugin_go.CodeGeneratorResponse_File, 0, len(r.fileNames))
+	for _, fileName := range r.fileNames {
+		files = append(files, &plugin_go.CodeGeneratorResponse_File{
+			Name: proto.String(fileName),
+		})
+	}
+	return newResponseFiles(files)
+}

--- a/internal/protoplugin/protoplugin.go
+++ b/internal/protoplugin/protoplugin.go
@@ -101,6 +101,12 @@ func NewRunner(
 	return newRunner(tmpl, templateInfoChecker, baseImports, fileSuffix)
 }
 
+// NewMultiRunner returns a new Runner that executes all the given Runners and
+// merges the resulting CodeGeneratorResponses.
+func NewMultiRunner(runners ...Runner) Runner {
+	return newMultiRunner(runners...)
+}
+
 // TemplateInfo is the info passed to a template.
 type TemplateInfo struct {
 	*File


### PR DESCRIPTION
This adds a new function `protoplugin.NewMultiRunner` that takes multiple `protoplugin.Runners` and returns a new `Runner` that executes all of them. This is needed so we can have e.g. a main protoc-gen-yarpc-go `Runner` as we do now, plus other `Runners` that use different templates for Fx. This is for #1449 - in combination with #1450, this will enable us to have multiple output files.