### PR TITLE
Change protoplugin function to produce output filename to take a File instead of the file name

### DIFF
--- a/encoding/protobuf/protoc-gen-yarpc-go/internal/lib/lib.go
+++ b/encoding/protobuf/protoc-gen-yarpc-go/internal/lib/lib.go
@@ -503,7 +503,8 @@ var Runner = protoplugin.NewRunner(
 		"go.uber.org/yarpc/api/transport",
 		"go.uber.org/yarpc/encoding/protobuf",
 	},
-	func(name string) (string, error) {
+	func(file *protoplugin.File) (string, error) {
+		name := file.GetName()
 		return fmt.Sprintf("%s.pb.yarpc.go", strings.TrimSuffix(name, filepath.Ext(name))), nil
 	},
 )

--- a/internal/protoplugin/generator.go
+++ b/internal/protoplugin/generator.go
@@ -37,11 +37,11 @@ var (
 )
 
 type generator struct {
-	registry                      *registry
-	tmpl                          *template.Template
-	templateInfoChecker           func(*TemplateInfo) error
-	baseImports                   []*GoPackage
-	protoFilenameToOutputFilename func(string) (string, error)
+	registry             *registry
+	tmpl                 *template.Template
+	templateInfoChecker  func(*TemplateInfo) error
+	baseImports          []*GoPackage
+	fileToOutputFilename func(*File) (string, error)
 }
 
 func newGenerator(
@@ -49,7 +49,7 @@ func newGenerator(
 	tmpl *template.Template,
 	templateInfoChecker func(*TemplateInfo) error,
 	baseImportStrings []string,
-	protoFilenameToOutputFilename func(string) (string, error),
+	fileToOutputFilename func(*File) (string, error),
 ) *generator {
 	var baseImports []*GoPackage
 	for _, pkgpath := range baseImportStrings {
@@ -74,7 +74,7 @@ func newGenerator(
 		tmpl,
 		templateInfoChecker,
 		baseImports,
-		protoFilenameToOutputFilename,
+		fileToOutputFilename,
 	}
 }
 
@@ -92,7 +92,7 @@ func (g *generator) Generate(targets []*File) ([]*plugin_go.CodeGeneratorRespons
 		if err != nil {
 			return nil, fmt.Errorf("could not format go code: %v\n%s", err, code)
 		}
-		output, err := g.protoFilenameToOutputFilename(file.GetName())
+		output, err := g.fileToOutputFilename(file)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/protoplugin/protoplugin.go
+++ b/internal/protoplugin/protoplugin.go
@@ -96,9 +96,9 @@ func NewRunner(
 	tmpl *template.Template,
 	templateInfoChecker func(*TemplateInfo) error,
 	baseImports []string,
-	protoFilenameToOutputFilename func(string) (string, error),
+	fileToOutputFilename func(*File) (string, error),
 ) Runner {
-	return newRunner(tmpl, templateInfoChecker, baseImports, protoFilenameToOutputFilename)
+	return newRunner(tmpl, templateInfoChecker, baseImports, fileToOutputFilename)
 }
 
 // NewMultiRunner returns a new Runner that executes all the given Runners and

--- a/internal/protoplugin/runner.go
+++ b/internal/protoplugin/runner.go
@@ -29,19 +29,19 @@ import (
 )
 
 type runner struct {
-	tmpl                          *template.Template
-	templateInfoChecker           func(*TemplateInfo) error
-	baseImports                   []string
-	protoFilenameToOutputFilename func(string) (string, error)
+	tmpl                 *template.Template
+	templateInfoChecker  func(*TemplateInfo) error
+	baseImports          []string
+	fileToOutputFilename func(*File) (string, error)
 }
 
 func newRunner(
 	tmpl *template.Template,
 	templateInfoChecker func(*TemplateInfo) error,
 	baseImports []string,
-	protoFilenameToOutputFilename func(string) (string, error),
+	fileToOutputFilename func(*File) (string, error),
 ) *runner {
-	return &runner{tmpl, templateInfoChecker, baseImports, protoFilenameToOutputFilename}
+	return &runner{tmpl, templateInfoChecker, baseImports, fileToOutputFilename}
 }
 
 func (r *runner) Run(request *plugin_go.CodeGeneratorRequest) *plugin_go.CodeGeneratorResponse {
@@ -67,7 +67,7 @@ func (r *runner) Run(request *plugin_go.CodeGeneratorRequest) *plugin_go.CodeGen
 		r.tmpl,
 		r.templateInfoChecker,
 		r.baseImports,
-		r.protoFilenameToOutputFilename,
+		r.fileToOutputFilename,
 	)
 	if err := registry.Load(request); err != nil {
 		return newResponseError(err)


### PR DESCRIPTION
I need the information on the `File` struct, which contains the file name and the output go package, to replicate thrift behavior in #1449. This changes the function used for this that we added in #1450 to take a `File` instead of the `string` file name.