### PR TITLE
Make the logger for the internal/testutils setup code a parameter so we can have no logger in testing/benchmarks

### DIFF
--- a/encoding/protobuf/testing/benchmark_test.go
+++ b/encoding/protobuf/testing/benchmark_test.go
@@ -61,7 +61,7 @@ func benchmarkForTransportType(b *testing.B, transportType testutils.TransportTy
 	keyValueYARPCServer := example.NewKeyValueYARPCServer()
 	sinkYARPCServer := example.NewSinkYARPCServer(false)
 	fooYARPCServer := example.NewFooYARPCServer(transport.NewHeaders())
-	exampleutil.WithClients(transportType, keyValueYARPCServer, sinkYARPCServer, fooYARPCServer, f)
+	exampleutil.WithClients(transportType, keyValueYARPCServer, sinkYARPCServer, fooYARPCServer, nil, f)
 }
 
 func benchmarkIntegrationYARPC(b *testing.B, keyValueYARPCClient examplepb.KeyValueYARPCClient) {

--- a/encoding/protobuf/testing/testing_test.go
+++ b/encoding/protobuf/testing/testing_test.go
@@ -61,6 +61,7 @@ func testIntegrationForTransportType(t *testing.T, transportType testutils.Trans
 			keyValueYARPCServer,
 			sinkYARPCServer,
 			fooYARPCServer,
+			nil,
 			func(clients *exampleutil.Clients) error {
 				testIntegration(t, clients, keyValueYARPCServer, sinkYARPCServer, expectedStreamingHeaders)
 				return nil

--- a/internal/examples/protobuf/exampleutil/exampleutil.go
+++ b/internal/examples/protobuf/exampleutil/exampleutil.go
@@ -26,6 +26,7 @@ import (
 	"go.uber.org/yarpc/internal/examples/protobuf/examplepb"
 	"go.uber.org/yarpc/internal/grpcctx"
 	"go.uber.org/yarpc/internal/testutils"
+	"go.uber.org/zap"
 )
 
 // Clients holds all clients.
@@ -48,6 +49,7 @@ func WithClients(
 	keyValueYARPCServer examplepb.KeyValueYARPCServer,
 	sinkYARPCServer examplepb.SinkYARPCServer,
 	fooYARPCServer examplepb.FooYARPCServer,
+	logger *zap.Logger,
 	f func(*Clients) error,
 ) error {
 	var procedures []transport.Procedure
@@ -64,6 +66,7 @@ func WithClients(
 		"example",
 		procedures,
 		transportType,
+		logger,
 		func(clientInfo *testutils.ClientInfo) error {
 			return f(
 				&Clients{

--- a/internal/examples/protobuf/main.go
+++ b/internal/examples/protobuf/main.go
@@ -37,6 +37,7 @@ import (
 	"go.uber.org/yarpc/internal/examples/protobuf/exampleutil"
 	"go.uber.org/yarpc/internal/testutils"
 	"go.uber.org/yarpc/yarpcerrors"
+	"go.uber.org/zap"
 	"google.golang.org/grpc/status"
 )
 
@@ -75,11 +76,16 @@ func run(
 	keyValueYARPCServer := example.NewKeyValueYARPCServer()
 	sinkYARPCServer := example.NewSinkYARPCServer(true)
 	fooYARPCServer := example.NewFooYARPCServer(transport.NewHeaders())
+	logger, err := zap.NewDevelopment()
+	if err != nil {
+		return err
+	}
 	return exampleutil.WithClients(
 		transportType,
 		keyValueYARPCServer,
 		sinkYARPCServer,
 		fooYARPCServer,
+		logger,
 		func(clients *exampleutil.Clients) error {
 			return doClient(
 				keyValueYARPCServer,

--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -99,12 +99,11 @@ type ClientInfo struct {
 // The server dispatcher will be brought up using all TransportTypes and with the serviceName.
 // The client dispatcher will be brought up using the given TransportType for Unary, HTTP for
 // Oneway, and the serviceName with a "-client" suffix.
-func WithClientInfo(serviceName string, procedures []transport.Procedure, transportType TransportType, f func(*ClientInfo) error) (err error) {
-	dispatcherConfig, err := NewDispatcherConfig(serviceName)
-	if err != nil {
-		return err
+func WithClientInfo(serviceName string, procedures []transport.Procedure, transportType TransportType, logger *zap.Logger, f func(*ClientInfo) error) (err error) {
+	if logger == nil {
+		logger = zap.NewNop()
 	}
-	logger, err := zap.NewDevelopment()
+	dispatcherConfig, err := NewDispatcherConfig(serviceName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This just makes it so we aren't locked to the `zap.NewDevelopment()` logger for all calls using `internal/testutils`. This makes benchmark reporting from `encoding/protobuf/testing` cleaner.