### PR TITLE
grpc-go client and server benchmark for protobuf

### DIFF
--- a/encoding/protobuf/testing/benchmark_test.go
+++ b/encoding/protobuf/testing/benchmark_test.go
@@ -23,6 +23,7 @@ package testing
 import (
 	"io/ioutil"
 	"log"
+	"net"
 	"testing"
 
 	"go.uber.org/yarpc/api/transport"
@@ -31,6 +32,7 @@ import (
 	"go.uber.org/yarpc/internal/examples/protobuf/exampleutil"
 	"go.uber.org/yarpc/internal/grpcctx"
 	"go.uber.org/yarpc/internal/testutils"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/grpclog"
 )
 
@@ -50,11 +52,27 @@ func BenchmarkIntegrationYARPC(b *testing.B) {
 	}
 }
 
-func BenchmarkIntegrationGRPC(b *testing.B) {
+func BenchmarkIntegrationGRPCClient(b *testing.B) {
 	benchmarkForTransportType(b, testutils.TransportTypeGRPC, func(clients *exampleutil.Clients) error {
 		benchmarkIntegrationGRPC(b, clients.KeyValueGRPCClient, clients.ContextWrapper)
 		return nil
 	})
+}
+
+func BenchmarkIntegrationGRPCAll(b *testing.B) {
+	server := grpc.NewServer()
+	examplepb.RegisterKeyValueServer(server, example.NewKeyValueYARPCServer())
+	listener, err := net.Listen("tcp", "0.0.0.0:1234")
+	if err != nil {
+		b.Fatal(err.Error())
+	}
+	go func() { _ = server.Serve(listener) }()
+	defer server.Stop()
+	grpcClientConn, err := grpc.Dial("0.0.0.0:1234", grpc.WithInsecure())
+	if err != nil {
+		b.Fatal(err.Error())
+	}
+	benchmarkIntegrationGRPC(b, examplepb.NewKeyValueClient(grpcClientConn), grpcctx.NewContextWrapper())
 }
 
 func benchmarkForTransportType(b *testing.B, transportType testutils.TransportType, f func(*exampleutil.Clients) error) {


### PR DESCRIPTION
This adds a grpc-go client to grpc-go server benchmark to the existing protobuf benchmarking. Right now we benchmark yarpc to yarpc http, tchannel, and thrift, and grpc-go client to yarpc-go server.

```
$ go test -bench Integration ./encoding/protobuf/testing
goos: darwin
goarch: amd64
pkg: go.uber.org/yarpc/encoding/protobuf/testing
BenchmarkIntegrationYARPC/http/Get-8         	   10000	    117196 ns/op
BenchmarkIntegrationYARPC/tchannel/Get-8     	   10000	    102670 ns/op
BenchmarkIntegrationYARPC/grpc/Get-8         	   10000	    148605 ns/op
BenchmarkIntegrationGRPCClient/Get-8         	   10000	    137745 ns/op
BenchmarkIntegrationGRPCAll/Get-8            	   10000	    104540 ns/op
PASS
ok  	go.uber.org/yarpc/encoding/protobuf/testing	6.220s
```