### PR TITLE
Expose phased dispatcher start & stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   form, instead of normalizing their case.
 - Adds an option to disable observability middleware, in the event you
   provide alternate observability middleware.
+- Add methods to start and stop a dispatcher's transports, inbounds, and
+  outbounds separately.
 
 ## [1.27.2] - 2017-01-23
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Added
+- Add methods to start and stop a dispatcher's transports, inbounds, and
+  outbounds separately.
 
 ## [1.28.0] - 2018-04-13
 ### Changed
@@ -19,8 +21,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   form, instead of normalizing their case.
 - Adds an option to disable observability middleware, in the event you
   provide alternate observability middleware.
-- Add methods to start and stop a dispatcher's transports, inbounds, and
-  outbounds separately.
 
 ## [1.27.2] - 2017-01-23
 ### Fixed

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -23,14 +23,12 @@ package yarpc
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"go.uber.org/multierr"
 	"go.uber.org/net/metrics"
 	"go.uber.org/yarpc/api/middleware"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal"
-	"go.uber.org/yarpc/internal/errorsync"
 	"go.uber.org/yarpc/internal/inboundmiddleware"
 	"go.uber.org/yarpc/internal/observability"
 	"go.uber.org/yarpc/internal/outboundmiddleware"
@@ -309,10 +307,9 @@ func (d *Dispatcher) Register(rs []transport.Procedure) {
 	d.table.Register(procedures)
 }
 
-// Start starts the Dispatcher, allowing it to accept and processing new
-// incoming requests.
-//
-// This starts all inbounds and outbounds configured on this Dispatcher.
+// Start starts the Dispatcher, allowing it to accept and process new incoming
+// requests. This starts all inbounds and outbounds configured on this
+// Dispatcher.
 //
 // This function returns immediately after everything has been started.
 // Servers should add a `select {}` to block to process all incoming requests.
@@ -323,176 +320,90 @@ func (d *Dispatcher) Register(rs []transport.Procedure) {
 // 	defer dispatcher.Stop()
 //
 // 	select {}
+//
+// Start and PhasedStart are mutually exclusive. See the PhasedStart
+// documentation for details.
 func (d *Dispatcher) Start() error {
-	return d.once.Start(d.start)
+	starter := &PhasedStarter{
+		dispatcher: d,
+		log:        d.log,
+	}
+	return d.once.Start(func() error {
+		d.log.Info("starting dispatcher")
+		starter.setRouters()
+		if err := starter.StartTransports(); err != nil {
+			return err
+		}
+		if err := starter.StartOutbounds(); err != nil {
+			return err
+		}
+		if err := starter.StartInbounds(); err != nil {
+			return err
+		}
+		d.log.Info("dispatcher startup complete")
+		return nil
+	})
 }
 
-func (d *Dispatcher) start() error {
-	// NOTE: These MUST be started in the order transports, outbounds, and
-	// then inbounds.
-	//
-	// If the outbounds are started before the transports, we might get a
-	// network request before the transports are ready.
-	//
-	// If the inbounds are started before the outbounds, an inbound request
-	// might result in an outbound call before the outbound is ready.
-
-	var (
-		mu         sync.Mutex
-		allStarted []transport.Lifecycle
-	)
-
-	d.log.Info("Starting up.")
-	start := func(s transport.Lifecycle) func() error {
-		return func() error {
-			if s == nil {
-				return nil
-			}
-
-			if err := s.Start(); err != nil {
-				return err
-			}
-
-			mu.Lock()
-			allStarted = append(allStarted, s)
-			mu.Unlock()
-			return nil
-		}
+// PhasedStart is a more granular alternative to Start, and is intended only
+// for advanced users. Rather than starting all transports, inbounds, and
+// outbounds at once, it lets the user start them separately.
+//
+// Start and PhasedStart are mutually exclusive. If Start is called first,
+// PhasedStart is a no-op and returns the same error (if any) that Start
+// returned. If PhasedStart is called first, Start is a no-op and always
+// returns a nil error; the caller is responsible for using the PhasedStarter
+// to complete startup.
+func (d *Dispatcher) PhasedStart() (*PhasedStarter, error) {
+	starter := &PhasedStarter{
+		dispatcher: d,
+		log:        d.log,
 	}
-
-	abort := func(errs []error) error {
-		// Failed to start so stop everything that was started.
-		wait := errorsync.ErrorWaiter{}
-		for _, s := range allStarted {
-			wait.Submit(s.Stop)
-		}
-		if newErrors := wait.Wait(); len(newErrors) > 0 {
-			errs = append(errs, newErrors...)
-		}
-
-		return multierr.Combine(errs...)
-	}
-
-	// Set router for all inbounds
-	for _, i := range d.inbounds {
-		i.SetRouter(d.table)
-	}
-	d.log.Debug("Set router for inbounds.")
-
-	// Start Transports
-	wait := errorsync.ErrorWaiter{}
-	d.log.Debug("Starting transports.")
-	for _, t := range d.transports {
-		wait.Submit(start(t))
-	}
-	if errs := wait.Wait(); len(errs) != 0 {
-		return abort(errs)
-	}
-	d.log.Debug("Started transports.")
-
-	// Start Outbounds
-	wait = errorsync.ErrorWaiter{}
-	d.log.Debug("Starting outbounds.")
-	for _, o := range d.outbounds {
-		wait.Submit(start(o.Unary))
-		wait.Submit(start(o.Oneway))
-		wait.Submit(start(o.Stream))
-	}
-	if errs := wait.Wait(); len(errs) != 0 {
-		return abort(errs)
-	}
-	d.log.Debug("Started outbounds.")
-
-	// Start Inbounds
-	wait = errorsync.ErrorWaiter{}
-	d.log.Debug("Starting inbounds.")
-	for _, i := range d.inbounds {
-		wait.Submit(start(i))
-	}
-	if errs := wait.Wait(); len(errs) != 0 {
-		return abort(errs)
-	}
-	d.log.Debug("Started inbounds.")
-
-	d.log.Info("Started up.")
-	return nil
+	err := d.once.Start(func() error {
+		starter.log.Info("beginning phased dispatcher start")
+		starter.setRouters()
+		return nil
+	})
+	return starter, err
 }
 
-// Stop stops the Dispatcher.
+// Stop stops the Dispatcher, shutting down all inbounds, outbounds, and
+// transports. This function returns after everything has been stopped.
 //
-// This stops all outbounds and inbounds owned by this Dispatcher.
-//
-// This function returns after everything has been stopped.
+// Stop and PhasedStop are mutually exclusive. See the PhasedStop
+// documentation for details.
 func (d *Dispatcher) Stop() error {
-	return d.once.Stop(d.stop)
+	stopper := &PhasedStopper{
+		dispatcher: d,
+		log:        d.log,
+	}
+	return d.once.Stop(func() error {
+		d.log.Info("shutting down dispatcher")
+		return multierr.Combine(
+			stopper.StopInbounds(),
+			stopper.StopOutbounds(),
+			stopper.StopTransports(),
+		)
+	})
 }
 
-func (d *Dispatcher) stop() error {
-	// NOTE: These MUST be stopped in the order inbounds, outbounds, and then
-	// transports.
-	//
-	// If the outbounds are stopped before the inbounds, we might receive a
-	// request which needs to use a stopped outbound from a still-going
-	// inbound.
-	//
-	// If the transports are stopped before the outbounds, the peers contained
-	// in the outbound might be deleted from the transport's perspective and
-	// cause issues.
-	var allErrs []error
-	d.log.Info("Starting shutdown.")
-
-	// Stop Inbounds
-	d.log.Debug("Stopping inbounds.")
-	wait := errorsync.ErrorWaiter{}
-	for _, i := range d.inbounds {
-		wait.Submit(i.Stop)
+// PhasedStop is a more granular alternative to Stop, and is intended only for
+// advanced users. Rather than stopping all inbounds, outbounds, and
+// transports at once, it lets the user stop them separately.
+//
+// Stop and PhasedStop are mutually exclusive. If Stop is called first,
+// PhasedStop is a no-op and returns the same error (if any) that Stop
+// returned. If PhasedStop is called first, Stop is a no-op and always returns
+// a nil error; the caller is responsible for using the PhasedStopper to
+// complete shutdown.
+func (d *Dispatcher) PhasedStop() (*PhasedStopper, error) {
+	if err := d.once.Stop(func() error { return nil }); err != nil {
+		return nil, err
 	}
-	if errs := wait.Wait(); len(errs) > 0 {
-		allErrs = append(allErrs, errs...)
-	}
-	d.log.Debug("Stopped inbounds.")
-
-	// Stop Outbounds
-	d.log.Debug("Stopping outbounds.")
-	wait = errorsync.ErrorWaiter{}
-	for _, o := range d.outbounds {
-		if o.Unary != nil {
-			wait.Submit(o.Unary.Stop)
-		}
-		if o.Oneway != nil {
-			wait.Submit(o.Oneway.Stop)
-		}
-		if o.Stream != nil {
-			wait.Submit(o.Stream.Stop)
-		}
-	}
-	if errs := wait.Wait(); len(errs) > 0 {
-		allErrs = append(allErrs, errs...)
-	}
-	d.log.Debug("Stopped outbounds.")
-
-	// Stop Transports
-	d.log.Debug("Stopping transports.")
-	wait = errorsync.ErrorWaiter{}
-	for _, t := range d.transports {
-		wait.Submit(t.Stop)
-	}
-	if errs := wait.Wait(); len(errs) > 0 {
-		allErrs = append(allErrs, errs...)
-	}
-	d.log.Debug("Stopped transports.")
-
-	if err := multierr.Combine(allErrs...); err != nil {
-		return err
-	}
-
-	// Stop pushing metrics to Tally.
-	d.log.Debug("Stopping metrics push loop, if any.")
-	d.stopMeter()
-	d.log.Debug("Stopped metrics push loop, if any.")
-
-	d.log.Info("Completed shutdown.")
-	return nil
+	return &PhasedStopper{
+		dispatcher: d,
+		log:        d.log,
+	}, nil
 }
 
 // Router returns the procedure router.

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -359,12 +359,14 @@ func (d *Dispatcher) PhasedStart() (*PhasedStarter, error) {
 		dispatcher: d,
 		log:        d.log,
 	}
-	err := d.once.Start(func() error {
+	if err := d.once.Start(func() error {
 		starter.log.Info("beginning phased dispatcher start")
 		starter.setRouters()
 		return nil
-	})
-	return starter, err
+	}); err != nil {
+		return nil, err
+	}
+	return starter, nil
 }
 
 // Stop stops the Dispatcher, shutting down all inbounds, outbounds, and

--- a/dispatcher_startup.go
+++ b/dispatcher_startup.go
@@ -1,0 +1,269 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpc
+
+import (
+	"errors"
+	"sync"
+
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/errorsync"
+
+	"go.uber.org/atomic"
+	"go.uber.org/multierr"
+	"go.uber.org/zap"
+)
+
+// PhasedStarter is a more granular alternative to the Dispatcher's all-in-one
+// Start method. Rather than starting the transports, inbounds, and outbounds
+// in one call, it lets the user choose when to trigger each phase of
+// dispatcher startup. For details on the interaction of Start and phased
+// startup, see the documentation for the Dispatcher's PhasedStart method.
+//
+// The user of a PhasedStarter is responsible for correctly ordering startup:
+// transports MUST be started before outbounds, which MUST be started before
+// inbounds. Attempting startup in any other order will return an error.
+type PhasedStarter struct {
+	startedMu sync.Mutex
+	started   []transport.Lifecycle
+
+	dispatcher *Dispatcher
+	log        *zap.Logger
+
+	transportsStartInitiated atomic.Bool
+	transportsStarted        atomic.Bool
+	outboundsStartInitiated  atomic.Bool
+	outboundsStarted         atomic.Bool
+	inboundsStartInitiated   atomic.Bool
+}
+
+// StartTransports is the first step in startup. It starts all transports
+// configured on the dispatcher, which is a necessary precondition for making
+// and receiving RPCs. It's safe to call concurrently, but all calls after the
+// first return an error.
+func (s *PhasedStarter) StartTransports() error {
+	if s.transportsStartInitiated.Swap(true) {
+		return errors.New("already began starting transports")
+	}
+	defer s.transportsStarted.Store(true)
+	s.log.Info("starting transports")
+	wait := errorsync.ErrorWaiter{}
+	for _, t := range s.dispatcher.transports {
+		wait.Submit(s.start(t))
+	}
+	if errs := wait.Wait(); len(errs) != 0 {
+		return s.abort(errs)
+	}
+	s.log.Debug("started transports")
+	return nil
+}
+
+// StartOutbounds is the second phase of startup. It starts all outbounds
+// configured on the dispatcher, which allows users of the dispatcher to
+// construct clients and begin making outbound RPCs. It's safe to call
+// concurrently, but all calls after the first return an error.
+func (s *PhasedStarter) StartOutbounds() error {
+	if !s.transportsStarted.Load() {
+		return errors.New("must start outbounds after transports")
+	}
+	if s.outboundsStartInitiated.Swap(true) {
+		return errors.New("already began starting outbounds")
+	}
+	defer s.outboundsStarted.Store(true)
+	s.log.Info("starting outbounds")
+	wait := errorsync.ErrorWaiter{}
+	for _, o := range s.dispatcher.outbounds {
+		wait.Submit(s.start(o.Unary))
+		wait.Submit(s.start(o.Oneway))
+		wait.Submit(s.start(o.Stream))
+	}
+	if errs := wait.Wait(); len(errs) != 0 {
+		return s.abort(errs)
+	}
+	s.log.Debug("started outbounds")
+	return nil
+}
+
+// StartInbounds is the final phase of startup. It starts all inbounds
+// configured on the dispatcher, which allows any registered procedures to
+// begin receiving requests. It's safe to call concurrently, but all calls
+// after the first return an error.
+func (s *PhasedStarter) StartInbounds() error {
+	if !s.transportsStarted.Load() || !s.outboundsStarted.Load() {
+		return errors.New("must start inbounds after transports and outbounds")
+	}
+	if s.inboundsStartInitiated.Swap(true) {
+		return errors.New("already began starting inbounds")
+	}
+	s.log.Info("starting inbounds")
+	wait := errorsync.ErrorWaiter{}
+	for _, i := range s.dispatcher.inbounds {
+		wait.Submit(s.start(i))
+	}
+	if errs := wait.Wait(); len(errs) != 0 {
+		return s.abort(errs)
+	}
+	s.log.Debug("started inbounds")
+	return nil
+}
+
+func (s *PhasedStarter) start(lc transport.Lifecycle) func() error {
+	return func() error {
+		if lc == nil {
+			return nil
+		}
+
+		if err := lc.Start(); err != nil {
+			return err
+		}
+
+		s.startedMu.Lock()
+		s.started = append(s.started, lc)
+		s.startedMu.Unlock()
+
+		return nil
+	}
+}
+
+func (s *PhasedStarter) abort(errs []error) error {
+	// Failed to start so stop everything that was started.
+	wait := errorsync.ErrorWaiter{}
+	s.startedMu.Lock()
+	for _, lc := range s.started {
+		wait.Submit(lc.Stop)
+	}
+	s.startedMu.Unlock()
+	if newErrors := wait.Wait(); len(newErrors) > 0 {
+		errs = append(errs, newErrors...)
+	}
+
+	return multierr.Combine(errs...)
+}
+
+func (s *PhasedStarter) setRouters() {
+	// Don't need synchronization, since we always call this in a lifecycle.Once
+	// in the dispatcher.
+	s.log.Debug("setting router for inbounds")
+	for _, ib := range s.dispatcher.inbounds {
+		ib.SetRouter(s.dispatcher.table)
+	}
+	s.log.Debug("set router for inbounds")
+}
+
+// PhasedStopper is a more granular alternative to the Dispatcher's all-in-one
+// Stop method. Rather than stopping the inbounds, outbounds, and transports
+// in one call, it lets the user choose when to trigger each phase of
+// dispatcher shutdown. For details on the interaction of Stop and phased
+// shutdown, see the documentation for the Dispatcher's PhasedStop method.
+//
+// The user of a PhasedStopper is responsible for correctly ordering shutdown:
+// inbounds MUST be stopped before outbounds, which MUST be stopped before
+// transports. Attempting shutdown in any other order will return an error.
+type PhasedStopper struct {
+	dispatcher *Dispatcher
+	log        *zap.Logger
+
+	inboundsStopInitiated   atomic.Bool
+	inboundsStopped         atomic.Bool
+	outboundsStopInitiated  atomic.Bool
+	outboundsStopped        atomic.Bool
+	transportsStopInitiated atomic.Bool
+}
+
+// StopInbounds is the first step in shutdown. It stops all inbounds
+// configured on the dispatcher, which stops routing RPCs to all registered
+// procedures. It's safe to call concurrently, but all calls after the first
+// return an error.
+func (s *PhasedStopper) StopInbounds() error {
+	if s.inboundsStopInitiated.Swap(true) {
+		return errors.New("already began stopping inbounds")
+	}
+	defer s.inboundsStopped.Store(true)
+	s.log.Debug("stopping inbounds")
+	wait := errorsync.ErrorWaiter{}
+	for _, ib := range s.dispatcher.inbounds {
+		wait.Submit(ib.Stop)
+	}
+	if errs := wait.Wait(); len(errs) > 0 {
+		return multierr.Combine(errs...)
+	}
+	s.log.Debug("stopped inbounds")
+	return nil
+}
+
+// StopOutbounds is the second step in shutdown. It stops all outbounds
+// configured on the dispatcher, which stops clients from making outbound
+// RPCs. It's safe to call concurrently, but all calls after the first return
+// an error.
+func (s *PhasedStopper) StopOutbounds() error {
+	if !s.inboundsStopped.Load() {
+		return errors.New("must stop inbounds first")
+	}
+	if s.outboundsStopInitiated.Swap(true) {
+		return errors.New("already began stopping outbounds")
+	}
+	defer s.outboundsStopped.Store(true)
+	s.log.Debug("stopping outbounds")
+	wait := errorsync.ErrorWaiter{}
+	for _, o := range s.dispatcher.outbounds {
+		if o.Unary != nil {
+			wait.Submit(o.Unary.Stop)
+		}
+		if o.Oneway != nil {
+			wait.Submit(o.Oneway.Stop)
+		}
+		if o.Stream != nil {
+			wait.Submit(o.Stream.Stop)
+		}
+	}
+	if errs := wait.Wait(); len(errs) > 0 {
+		return multierr.Combine(errs...)
+	}
+	s.log.Debug("stopped outbounds")
+	return nil
+}
+
+// StopTransports is the final step in shutdown. It stops all transports
+// configured on the dispatcher and cleans up any ancillary goroutines. It's
+// safe to call concurrently, but all calls after the first return an error.
+func (s *PhasedStopper) StopTransports() error {
+	if !s.inboundsStopped.Load() || !s.outboundsStopped.Load() {
+		return errors.New("must stop inbounds and outbounds first")
+	}
+	if s.transportsStopInitiated.Swap(true) {
+		return errors.New("already began stopping transports")
+	}
+	s.log.Debug("stopping transports")
+	wait := errorsync.ErrorWaiter{}
+	for _, t := range s.dispatcher.transports {
+		wait.Submit(t.Stop)
+	}
+	if errs := wait.Wait(); len(errs) > 0 {
+		return multierr.Combine(errs...)
+	}
+	s.log.Debug("stopped transports")
+
+	s.log.Debug("stopping metrics push loop, if any")
+	s.dispatcher.stopMeter()
+	s.log.Debug("stopped metrics push loop, if any")
+
+	return nil
+}

--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -25,15 +25,10 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/uber-go/tally"
-	tchannelgo "github.com/uber/tchannel-go"
-	thriftrwversion "go.uber.org/thriftrw/version"
 	. "go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/api/transport/transporttest"
@@ -41,6 +36,15 @@ import (
 	"go.uber.org/yarpc/internal/observability"
 	"go.uber.org/yarpc/transport/http"
 	"go.uber.org/yarpc/transport/tchannel"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
+	tchannelgo "github.com/uber/tchannel-go"
+	"go.uber.org/atomic"
+	"go.uber.org/multierr"
+	thriftrwversion "go.uber.org/thriftrw/version"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
@@ -58,6 +62,14 @@ func basicConfig(t testing.TB) Config {
 			httpTransport.NewInbound(":0"),
 		},
 	}
+}
+
+func outboundConfig(t testing.TB) Config {
+	cfg := basicConfig(t)
+	cfg.Outbounds = Outbounds{"my-test-service": {
+		Unary: http.NewTransport().NewSingleOutbound("http://127.0.0.1:1234"),
+	}}
+	return cfg
 }
 
 func basicDispatcher(t testing.TB) *Dispatcher {
@@ -397,6 +409,138 @@ func TestStartStopFailures(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPhasedStartStop(t *testing.T) {
+	t.Run("in order", func(t *testing.T) {
+		d := NewDispatcher(outboundConfig(t))
+		starter, err := d.PhasedStart()
+		require.NoError(t, err, "constructing phased starter failed")
+		startErr := multierr.Combine(
+			starter.StartTransports(),
+			starter.StartOutbounds(),
+			starter.StartInbounds(),
+		)
+		require.NoError(t, startErr, "phased startup failed")
+		stopper, err := d.PhasedStop()
+		require.NoError(t, err, "constructing phased stopped failed")
+		stopErr := multierr.Combine(
+			stopper.StopInbounds(),
+			stopper.StopOutbounds(),
+			stopper.StopTransports(),
+		)
+		require.NoError(t, stopErr, "phased shutdown failed")
+	})
+
+	t.Run("start out of order", func(t *testing.T) {
+		d := NewDispatcher(outboundConfig(t))
+		starter, err := d.PhasedStart()
+		require.NoError(t, err, "constructing phased starter failed")
+
+		// Must start transports first.
+		assert.Error(t, starter.StartInbounds(), "succeeded inbounds before transports")
+		assert.Error(t, starter.StartOutbounds(), "succeeded started outbounds before transports")
+		require.NoError(t, starter.StartTransports(), "starting transports failed")
+
+		// Must start outbounds second.
+		assert.Error(t, starter.StartTransports(), "succeeded starting transports again")
+		assert.Error(t, starter.StartInbounds(), "succeeded started inbounds before outbounds")
+		require.NoError(t, starter.StartOutbounds(), "starting outbounds failed")
+
+		// Must start inbounds last.
+		assert.Error(t, starter.StartTransports(), "succeeded starting transports again")
+		assert.Error(t, starter.StartOutbounds(), "succeeded starting outbounds again")
+		require.NoError(t, starter.StartInbounds(), "starting inbounds failed")
+
+		assert.NoError(t, d.Stop(), "shutting down dispatcher failed")
+	})
+
+	t.Run("stop out of order", func(t *testing.T) {
+		d := NewDispatcher(outboundConfig(t))
+		require.NoError(t, d.Start(), "starting dispatcher failed")
+
+		stopper, err := d.PhasedStop()
+		require.NoError(t, err, "constructing phased stopper failed")
+
+		// Must stop inbounds first.
+		assert.Error(t, stopper.StopTransports(), "succeeded stopping transports before inbounds")
+		assert.Error(t, stopper.StopOutbounds(), "succeeded stopping outbounds before inbounds")
+		require.NoError(t, stopper.StopInbounds(), "stopping inbunds failed")
+
+		// Must stop outbounds second.
+		assert.Error(t, stopper.StopInbounds(), "succeeded stopping inbounds again")
+		assert.Error(t, stopper.StopTransports(), "succeeded stopping transports before outbounds")
+		require.NoError(t, stopper.StopOutbounds(), "stopping outbounds failed")
+
+		// Must stop transports last.
+		assert.Error(t, stopper.StopInbounds(), "succeeded stopping inbounds again")
+		assert.Error(t, stopper.StopOutbounds(), "succeeded stopping outbounds again")
+		require.NoError(t, stopper.StopTransports(), "stopping transports failed")
+	})
+}
+
+func TestPhasedStartRaces(t *testing.T) {
+	d := NewDispatcher(outboundConfig(t))
+	starter, err := d.PhasedStart()
+	require.NoError(t, err, "constructing phased starter failed")
+
+	const concurrency = 100
+	run := make(chan struct{})
+	errs := atomic.NewInt64(0)
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-run
+			if err := starter.StartTransports(); err != nil {
+				errs.Inc()
+			}
+			if err := starter.StartOutbounds(); err != nil {
+				errs.Inc()
+			}
+			if err := starter.StartInbounds(); err != nil {
+				errs.Inc()
+			}
+		}()
+	}
+	close(run)
+	wg.Wait()
+	// Expect repeat calls to Start* to fail.
+	assert.Equal(t, 3*concurrency-3, int(errs.Load()), "wrong number of errors")
+	require.NoError(t, d.Stop(), "failed to cleanly shut down dispatcher")
+}
+
+func TestPhasedStopRaces(t *testing.T) {
+	d := NewDispatcher(outboundConfig(t))
+	require.NoError(t, d.Start(), "starting dispatcher failed")
+	stopper, err := d.PhasedStop()
+	require.NoError(t, err, "constructing phased stopper failed")
+
+	const concurrency = 100
+	run := make(chan struct{})
+	errs := atomic.NewInt64(0)
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-run
+			if err := stopper.StopInbounds(); err != nil {
+				errs.Inc()
+			}
+			if err := stopper.StopOutbounds(); err != nil {
+				errs.Inc()
+			}
+			if err := stopper.StopTransports(); err != nil {
+				errs.Inc()
+			}
+		}()
+	}
+	close(run)
+	wg.Wait()
+	// Expect repeat calls to Stop* to fail.
+	assert.Equal(t, 3*concurrency-3, int(errs.Load()), "wrong number of errors")
 }
 
 func TestNoOutboundsForService(t *testing.T) {


### PR DESCRIPTION
Today, the dispatcher exposes its lifecycle via all-in-one start and
stop methods. This requires that users start and stop all transports,
inbounds, and outbounds at the same time. In our internal Fx module,
this makes it impossible to correctly order `OnStart` and `OnStop`
hooks: ideally, the dispatcher would start all transports and outbounds,
then consumers of the `ClientConfig` would start (including all
user-supplied procedures and their dependencies), and then the
dispatcher would start inbounds. This requires registering hooks for the
transports and outbounds during dispatcher construction and registering
hooks for inbounds during procedure registration.

This commit exposes two new methods on the dispatcher: `PhasedStart` and
`PhasedStop`. Each method returns a builder-style struct that strongly
suggests the correct startup and shutdown order. `PhasedStart` and `Start`
are mutually exclusive, as are `PhasedStop` and `Stop`. Unlike the `Start` and
`Stop` methods, the builders aren't safe for concurrent or repeated use
(though I'm happy to discuss changing that if it's controversial).

- [x] Description and context for reviewers: one partner, one stranger
- [x] Docs (package doc)
- [x] Entry in CHANGELOG.md
