### PR TITLE
Add unknown flag handler to protoplugin.NewRunner

### DIFF
--- a/encoding/protobuf/protoc-gen-yarpc-go/internal/lib/lib.go
+++ b/encoding/protobuf/protoc-gen-yarpc-go/internal/lib/lib.go
@@ -507,6 +507,9 @@ var Runner = protoplugin.NewRunner(
 		name := file.GetName()
 		return fmt.Sprintf("%s.pb.yarpc.go", strings.TrimSuffix(name, filepath.Ext(name))), nil
 	},
+	func(key string, value string) error {
+		return nil
+	},
 )
 
 func checkTemplateInfo(templateInfo *protoplugin.TemplateInfo) error {

--- a/internal/protoplugin/protoplugin.go
+++ b/internal/protoplugin/protoplugin.go
@@ -97,8 +97,9 @@ func NewRunner(
 	templateInfoChecker func(*TemplateInfo) error,
 	baseImports []string,
 	fileToOutputFilename func(*File) (string, error),
+	unknownFlagHandler func(key string, value string) error,
 ) Runner {
-	return newRunner(tmpl, templateInfoChecker, baseImports, fileToOutputFilename)
+	return newRunner(tmpl, templateInfoChecker, baseImports, fileToOutputFilename, unknownFlagHandler)
 }
 
 // NewMultiRunner returns a new Runner that executes all the given Runners and


### PR DESCRIPTION
This adds a `func(key string, value string) error` unknown flag handle when constructing the Protobuf plugin wrapping logic. For example, if you had:

```
protoc --yarpc-go_out=Mfoo/foo.proto=github.com/uber/foo,bar=bat,baz=,ban=bam:. foo/foo.proto
```

The `M` component is something the `Runner` handles and will be used, but the unknown flag handler will be called with:

```go
unknownFlagHandler("bar", "bat")
unknownFlagHandler("baz, "")
unknownFlagHandler("ban", "bam")
```

This will allow adding the `type-suffix` flag in a follow-up PR so we can specify whether to add the `YARPC` suffix to generated interfaces/functions in the future.

This also keyifies the construction of the `runner` private struct.

The code in `internal/protoplugin` is a bad part of our codebase, but this is a smaller change and the function `protoplugin.NewRunner` is only called in one place internally.