### PR TITLE
WIP: Add gRPC TransportOptions for client TLS

### DIFF
--- a/transport/grpc/config.go
+++ b/transport/grpc/config.go
@@ -71,6 +71,7 @@ type TransportConfig struct {
 	ServerMaxSendMsgSize int                 `config:"serverMaxSendMsgSize"`
 	ClientMaxRecvMsgSize int                 `config:"clientMaxRecvMsgSize"`
 	ClientMaxSendMsgSize int                 `config:"clientMaxSendMsgSize"`
+	ClientCertFilePath   string              `config:"clientCertFilePath"`
 	Backoff              yarpcconfig.Backoff `config:"backoff"`
 }
 
@@ -143,6 +144,9 @@ func (t *transportSpec) buildTransport(transportConfig *TransportConfig, _ *yarp
 	}
 	if transportConfig.ClientMaxSendMsgSize > 0 {
 		options = append(options, ClientMaxSendMsgSize(transportConfig.ClientMaxSendMsgSize))
+	}
+	if transportConfig.ClientCertFilePath != "" {
+		options = append(options, ClientCertFilePath(transportConfig.ClientCertFilePath))
 	}
 	backoffStrategy, err := transportConfig.Backoff.Strategy()
 	if err != nil {

--- a/transport/grpc/config_test.go
+++ b/transport/grpc/config_test.go
@@ -85,12 +85,14 @@ func TestTransportSpecUnknownOption(t *testing.T) {
 func TestTransportSpec(t *testing.T) {
 	type attrs map[string]interface{}
 
+	// we use wantInbound to test TransportOptions as well
 	type wantInbound struct {
 		Address              string
 		ServerMaxRecvMsgSize int
 		ServerMaxSendMsgSize int
 		ClientMaxRecvMsgSize int
 		ClientMaxSendMsgSize int
+		ClientCertFilePath   string
 	}
 
 	type wantOutbound struct {
@@ -209,6 +211,17 @@ func TestTransportSpec(t *testing.T) {
 				ClientMaxSendMsgSize: 8192,
 			},
 		},
+		{
+			desc: "inbound and transport with client cert file path",
+			transportCfg: attrs{
+				"clientCertFilePath": "/path/to/cert",
+			},
+			inboundCfg: attrs{"address": ":54572"},
+			wantInbound: &wantInbound{
+				Address:            ":54572",
+				ClientCertFilePath: "/path/to/cert",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -267,6 +280,11 @@ func TestTransportSpec(t *testing.T) {
 					assert.Equal(t, tt.wantInbound.ClientMaxSendMsgSize, inbound.t.options.clientMaxSendMsgSize)
 				} else {
 					assert.Equal(t, defaultClientMaxSendMsgSize, inbound.t.options.clientMaxSendMsgSize)
+				}
+				if tt.wantInbound.ClientCertFilePath != "" {
+					assert.Equal(t, tt.wantInbound.ClientCertFilePath, inbound.t.options.clientCertFilePath)
+				} else {
+					assert.Empty(t, inbound.t.options.clientCertFilePath)
 				}
 			} else {
 				assert.Len(t, cfg.Inbounds, 0)

--- a/transport/grpc/options.go
+++ b/transport/grpc/options.go
@@ -21,6 +21,7 @@
 package grpc
 
 import (
+	"crypto/x509"
 	"math"
 
 	"github.com/opentracing/opentracing-go"
@@ -119,6 +120,28 @@ func ClientMaxSendMsgSize(clientMaxSendMsgSize int) TransportOption {
 	}
 }
 
+// ClientCertPool is the certificate pool to use when dialing.
+//
+// This overrides ClientCertFilePath.
+//
+// The default is to not use TLS.
+func ClientCertPool(clientCertPool *x509.CertPool) TransportOption {
+	return func(transportOptions *transportOptions) {
+		transportOptions.clientCertPool = clientCertPool
+	}
+}
+
+// ClientCertFilePath is the path to the certificate file to use when dialing.
+//
+// This is overridden by ClientCertPool.
+//
+// The default is to not use TLS.
+func ClientCertFilePath(clientCertFilePath string) TransportOption {
+	return func(transportOptions *transportOptions) {
+		transportOptions.clientCertFilePath = clientCertFilePath
+	}
+}
+
 // InboundOption is an option for an inbound.
 type InboundOption func(*inboundOptions)
 
@@ -137,6 +160,8 @@ type transportOptions struct {
 	serverMaxSendMsgSize int
 	clientMaxRecvMsgSize int
 	clientMaxSendMsgSize int
+	clientCertPool       *x509.CertPool
+	clientCertFilePath   string
 }
 
 func newTransportOptions(options []TransportOption) *transportOptions {


### PR DESCRIPTION
We got a feature request for this. This adds minimal support for client-side TLS in gRPC. In the config file, you can do:

```yaml
transports:
  grpc:
    clientCertFilePath: path/to/cert
```

Where the path is relative to the location the binary runs, or is absolute. This sets the `grpc.ClientCertFilePath` option. There is also a `grpc.ClientCertPool` option for library use. This does not expose the API from grpc-go, only exposing what we need. This will be tested by the user who requested it.

We may want to make this an `OutboundOption` instead to allow for multiple certificates for multiple outbounds, however this is non-trivial with our current peer selection code.