### PR TITLE
travis: Disable codecov step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ env:
     - TEST_TIME_SCALE=5
 matrix:
   include:
-    - env: CI_TYPES='codecov'
     - env: CI_TYPES='lint test examples' DOCKER_GO_VERSION=1.9
     - env: CI_TYPES='lint test examples' DOCKER_GO_VERSION=1.10
 script:


### PR DESCRIPTION
As part of experimenting with BuildKite, we're letting BuildKite push
code coverage metrics.  This disables pushing of codecov from Travis so
that we don't have conflicting pushes.