### PR TITLE
examples: Don't register global flags

### DIFF
--- a/internal/examples/json-keyvalue/client/main.go
+++ b/internal/examples/json-keyvalue/client/main.go
@@ -85,13 +85,17 @@ func main() {
 }
 
 func do() error {
+	flagSet := flag.NewFlagSet("json-keyvalue", flag.ExitOnError)
+
 	outboundName := ""
-	flag.StringVar(
+	flagSet.StringVar(
 		&outboundName,
 		"outbound", "", "name of the outbound to use (http/tchannel/grpc)",
 	)
 
-	flag.Parse()
+	if err := flagSet.Parse(os.Args[1:]); err != nil {
+		return err
+	}
 
 	httpTransport := http.NewTransport()
 	tchannelTransport, err := tchannel.NewChannelTransport(tchannel.ServiceName("keyvalue-client"))

--- a/internal/examples/json-keyvalue/server/main.go
+++ b/internal/examples/json-keyvalue/server/main.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"os"
 	"strings"
 	"sync"
 
@@ -38,7 +39,10 @@ import (
 	"go.uber.org/yarpc/yarpcerrors"
 )
 
-var flagInbound = flag.String("inbound", "", "name of the inbound to use (http/tchannel/grpc)")
+var (
+	flagSet     = flag.NewFlagSet("server", flag.ExitOnError)
+	flagInbound = flagSet.String("inbound", "", "name of the inbound to use (http/tchannel/grpc)")
+)
 
 type getRequest struct {
 	Key string `json:"key"`
@@ -94,7 +98,9 @@ func main() {
 }
 
 func do() error {
-	flag.Parse()
+	if err := flagSet.Parse(os.Args[1:]); err != nil {
+		return err
+	}
 	var inbound transport.Inbound
 	switch strings.ToLower(*flagInbound) {
 	case "http":

--- a/internal/examples/protobuf/main.go
+++ b/internal/examples/protobuf/main.go
@@ -41,12 +41,17 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-var flagOutbound = flag.String("outbound", "tchannel", "The outbound to use for unary calls")
-var flagGoogleGRPC = flag.Bool("google-grpc", false, "Use google grpc for outbound KeyValue calls")
-var flagBlock = flag.Bool("block", false, "Block and run the server forever instead of running the client")
+var (
+	flagSet        = flag.NewFlagSet("protobuf", flag.ExitOnError)
+	flagOutbound   = flagSet.String("outbound", "tchannel", "The outbound to use for unary calls")
+	flagGoogleGRPC = flagSet.Bool("google-grpc", false, "Use google grpc for outbound KeyValue calls")
+	flagBlock      = flagSet.Bool("block", false, "Block and run the server forever instead of running the client")
+)
 
 func main() {
-	flag.Parse()
+	if err := flagSet.Parse(os.Args[1:]); err != nil {
+		log.Fatal(err)
+	}
 	if err := do(); err != nil {
 		log.Fatal(err)
 	}

--- a/internal/examples/thrift-hello/hello/main.go
+++ b/internal/examples/thrift-hello/hello/main.go
@@ -37,7 +37,10 @@ import (
 	"go.uber.org/yarpc/transport/http"
 )
 
-var flagWait = flag.Bool("wait", false, "Wait for a signal to exit")
+var (
+	flagSet  = flag.NewFlagSet("thrift-hello", flag.ExitOnError)
+	flagWait = flagSet.Bool("wait", false, "Wait for a signal to exit")
+)
 
 func main() {
 	if err := do(); err != nil {
@@ -46,7 +49,9 @@ func main() {
 }
 
 func do() error {
-	flag.Parse()
+	if err := flagSet.Parse(os.Args[1:]); err != nil {
+		return err
+	}
 	// configure a YARPC dispatcher for the service "hello",
 	// expose the service over an HTTP inbound on port 8086,
 	// and configure outbound calls to service "hello" over HTTP port 8086 as well

--- a/internal/examples/thrift-keyvalue/keyvalue/client/main.go
+++ b/internal/examples/thrift-keyvalue/keyvalue/client/main.go
@@ -45,13 +45,16 @@ func main() {
 }
 
 func do() error {
+	flagSet := flag.NewFlagSet("client", flag.ExitOnError)
 	outboundName := ""
-	flag.StringVar(
+	flagSet.StringVar(
 		&outboundName,
 		"outbound", "", "name of the outbound to use (http/tchannel/grpc)",
 	)
 
-	flag.Parse()
+	if err := flagSet.Parse(os.Args[1:]); err != nil {
+		return err
+	}
 
 	httpTransport := http.NewTransport()
 	tchannelTransport, err := tchannel.NewChannelTransport(tchannel.ServiceName("keyvalue-client"))

--- a/internal/examples/thrift-keyvalue/keyvalue/server/main.go
+++ b/internal/examples/thrift-keyvalue/keyvalue/server/main.go
@@ -27,6 +27,7 @@ import (
 	"log"
 	"net"
 	gohttp "net/http"
+	"os"
 	"strings"
 	"sync"
 
@@ -40,7 +41,10 @@ import (
 	"go.uber.org/yarpc/x/yarpcmeta"
 )
 
-var flagInbound = flag.String("inbound", "", "name of the inbound to use (http/tchannel/grpc)")
+var (
+	flagSet     = flag.NewFlagSet("server", flag.ExitOnError)
+	flagInbound = flagSet.String("inbound", "", "name of the inbound to use (http/tchannel/grpc)")
+)
 
 type handler struct {
 	sync.RWMutex
@@ -73,7 +77,9 @@ func main() {
 }
 
 func do() error {
-	flag.Parse()
+	if err := flagSet.Parse(os.Args[1:]); err != nil {
+		return err
+	}
 	var inbound transport.Inbound
 	switch strings.ToLower(*flagInbound) {
 	case "http":

--- a/internal/service-test/main.go
+++ b/internal/service-test/main.go
@@ -32,17 +32,20 @@ import (
 )
 
 var (
-	flagDir            = flag.String("dir", "", "The relative directory to operate from, defaults to current directory")
-	flagConfigFilePath = flag.String("file", "service-test.yaml", "The configuration file to use relative to the context directory")
-	flagTimeout        = flag.Duration("timeout", 5*time.Second, "The time to wait until timing out")
-	flagNoVerifyOutput = flag.Bool("no-validate-output", false, "Do not validate output and just run the commands")
-	flagDebug          = flag.Bool("debug", false, "Log debug information")
+	flagSet            = flag.NewFlagSet("service-test", flag.ExitOnError)
+	flagDir            = flagSet.String("dir", "", "The relative directory to operate from, defaults to current directory")
+	flagConfigFilePath = flagSet.String("file", "service-test.yaml", "The configuration file to use relative to the context directory")
+	flagTimeout        = flagSet.Duration("timeout", 5*time.Second, "The time to wait until timing out")
+	flagNoVerifyOutput = flagSet.Bool("no-validate-output", false, "Do not validate output and just run the commands")
+	flagDebug          = flagSet.Bool("debug", false, "Log debug information")
 
 	errSignal = errors.New("signal")
 )
 
 func main() {
-	flag.Parse()
+	if err := flagSet.Parse(os.Args[1:]); err != nil {
+		log.Fatal(err)
+	}
 	if err := do(
 		*flagDir,
 		*flagConfigFilePath,


### PR DESCRIPTION
YARPC examples currently alter the global flag set by using
`flag.StringVar`, etc. This will cause panics if you try to use Go
1.10's brand new cross-package coverage support because multiple
examples attempt to register the same flags.

This changes all examples to stop registering against the global flag
set and instead set up a flag set for each example separately.