### PR TITLE
Use Go 1.10's multi-package coverage

### DIFF
--- a/etc/bin/cover.sh
+++ b/etc/bin/cover.sh
@@ -10,17 +10,10 @@ if echo "${GOPATH}" | grep : >/dev/null; then
 	exit 1
 fi
 
-COVER=cover
 ROOT_PKG=go.uber.org/yarpc
-CONCURRENCY=1
-
-if [[ -d "$COVER" ]]; then
-	rm -rf "$COVER"
-fi
-mkdir -p "$COVER"
+OUTFILE=coverage.txt
 
 ignorePkgs=""
-
 filterIgnorePkgs() {
   if [[ -z "${ignorePkgs}" ]]; then
     cat
@@ -31,74 +24,19 @@ filterIgnorePkgs() {
 
 # If a package directory has a .nocover file, don't count it when calculating
 # coverage.
-filter=""
 for pkg in "$@"; do
-	if [[ -f "$GOPATH/src/$pkg/.nocover" ]]; then
-		if [[ -n "$filter" ]]; then
-			ignorePkgs="$ignorePkgs\|"
-			filter="$filter, "
-		fi
-		ignorePkgs="$ignorePkgs$pkg/"
-		filter="$filter\"$pkg\": true"
-	fi
-done
-
-i=0
-commands_file="$(mktemp)"
-echo 'commands:' >> "${commands_file}"
-trap 'rm -rf "${commands_file}"' EXIT
-for pkg in "$@"; do
-	if ! ls "${GOPATH}/src/${pkg}" | grep _test\.go$ >/dev/null; then
-		continue
-	fi
-	i=$((i + 1))
-
-	extracoverpkg=""
-	if [[ -f "$GOPATH/src/$pkg/.extra-coverpkg" ]]; then
-		extracoverpkg=$( \
-			sed -e "s|^|$pkg/|g" < "$GOPATH/src/$pkg/.extra-coverpkg" \
-			| tr '\n' ',')
-	fi
-
-	coverpkg=$(go list -json "$pkg" | jq -r '
-		.Deps + .TestImports + .XTestImports
-		| . + ["'"$pkg"'"]
-		| unique
-		| map
-			( select(startswith("'"$ROOT_PKG"'"))
-			| select(contains("/vendor/") | not)
-			| select({'"$filter"'}[.] | not)
-			)
-		| join(",")
-	')
-	if [[ -n "$extracoverpkg" ]]; then
-		coverpkg="$extracoverpkg$coverpkg"
-	fi
-
-	args=""
-	if [[ -n "$coverpkg" ]]; then
-		args="-coverprofile $COVER/cover.${i}.out -covermode=count -coverpkg $coverpkg"
-	fi
-
-  if [[ "${CONCURRENCY}" == "1" ]]; then
-    go test ${args} "${pkg}" 2>&1 | grep -v 'warning: no packages being tested depend on'
-  else
-    echo " - go test ${args} \"${pkg}\"" >> "${commands_file}"
+  if [[ -f "$GOPATH/src/$pkg/.nocover" ]]; then
+    if [[ -n "$ignorePkgs" ]]; then
+      ignorePkgs="$ignorePkgs\\|"
+    fi
+    ignorePkgs="$ignorePkgs$pkg/"
   fi
 done
-if [[ "${CONCURRENCY}" != "1" ]]; then
-  parallel-exec --fast-fail --no-log --max-concurrent-cmds ${CONCURRENCY} --dir "${DIR}" "${commands_file}" 2>&1 \
-      | grep -v 'warning: no packages being tested depend on'
-fi
 
-rm -f coverage.txt
-
-# Merge cross-package coverage and then split the result into main and
-# experimental coverages.
-#
-# We ignore packages in the form "footest" and any mock files.
-gocovmerge "$COVER"/*.out \
-	| grep -v '/internal/examples/\|/internal/tests/\|/mocks/' \
-	| grep -v '/[a-z]\+test/' \
-	| filterIgnorePkgs \
-	> coverage.txt
+rm -f "$OUTFILE.tmp" "$OUTFILE"
+go test -coverprofile "$OUTFILE.tmp" -covermode=count -coverpkg="$ROOT_PKG/..." "$@"
+filterIgnorePkgs < "$OUTFILE.tmp" \
+  | grep -v '/interna/examples/\|/internal/tests/\|/mocks/' \
+  | grep -v '/[a-z]\+test/' \
+  > "$OUTFILE"
+rm -f "$OUTFILE.tmp"

--- a/etc/make/deps.mk
+++ b/etc/make/deps.mk
@@ -11,9 +11,6 @@ GEN_GO_BIN_DEPS = \
 EXTRA_GO_BIN_DEPS = \
 	github.com/kisielk/errcheck \
 	golang.org/x/lint/golint \
-	github.com/wadey/gocovmerge \
-	golang.org/x/tools/cmd/cover \
-	go.uber.org/tools/parallel-exec \
 	honnef.co/go/tools/cmd/staticcheck
 
 # all we want is go get -u github.com/Masterminds/glide
@@ -126,9 +123,6 @@ THRIFTRW = $(BIN)/thriftrw
 GOLINT = $(BIN)/golint
 ERRCHECK = $(BIN)/errcheck
 STATICCHECK = $(BIN)/staticcheck
-COVER = $(BIN)/cover
-GOCOVMERGE = $(BIN)/gocovmerge
-PARALLEL_EXEC = $(BIN)/parallel-exec
 
 .PHONY: predeps
 predeps: $(GLIDE) $(THRIFT) $(PROTOC) $(RAGEL)

--- a/etc/make/local.mk
+++ b/etc/make/local.mk
@@ -132,7 +132,7 @@ test: $(THRIFTRW) __eval_chunked_packages ## run chunked tests
 	PATH=$(BIN):$$PATH go test -race $(CHUNKED_PACKAGES)
 
 .PHONY: cover
-cover: $(THRIFTRW) $(GOCOVMERGE) $(PARALLEL_EXEC) $(COVER) __eval_chunked_packages ## run chunked tests and output code coverage
+cover: $(THRIFTRW) __eval_chunked_packages ## run chunked tests and output code coverage
 	PATH=$(BIN):$$PATH ./etc/bin/cover.sh $(CHUNKED_PACKAGES)
 	go tool cover -html=coverage.txt -o cover.html
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: d5feb657f754428789806e021da6d3ebc63f38bf2517d4e5ec2ab925e9946344
-updated: 2018-04-06T10:59:05.548371928-07:00
+hash: f42c5f4769c7a1714be5ee8c287f0cd3526afa2f8c1554a7e43a5a619ba53990
+updated: 2018-04-06T11:55:43.72291436-07:00
 imports:
 - name: github.com/apache/thrift
   version: 53dd39833a08ce33582e5ff31fa18bb4735d6731
@@ -136,7 +136,7 @@ imports:
   - internal/fxreflect
   - internal/lifecycle
 - name: go.uber.org/multierr
-  version: a3d1fc1f1316d4132fc61f4ea1159ae0613fb474
+  version: 3c4937480c32f4c13a875a1829af76c98ca3d40a
 - name: go.uber.org/net/metrics
   version: 1e19de5b971489a45d178e12a0f72a78c70e300e
   subpackages:
@@ -245,12 +245,9 @@ testImports:
   version: 4267858c0679cd4e47cefed8d7f70fd386cfb567
   subpackages:
   - metrics
-- name: github.com/wadey/gocovmerge
-  version: b5bfa59ec0adc420475f97f89b58045c721d761c
 - name: go.uber.org/tools
   version: ce2550dad7144b81ae2f67dc5e55597643f6902b
   subpackages:
-  - parallel-exec
   - update-license
 - name: golang.org/x/lint
   version: 85993ffd0a6cd043291f3f63d45d656d97b165bd

--- a/glide.yaml
+++ b/glide.yaml
@@ -68,11 +68,9 @@ testImport:
   repo: https://github.com/golang/lint
 - package: github.com/kisielk/errcheck
 - package: github.com/kisielk/gotool
-- package: github.com/wadey/gocovmerge
 - package: go.uber.org/tools
   version: master
   subpackages:
-  - parallel-exec
   - update-license
 - package: honnef.co/go/tools
   subpackages:


### PR DESCRIPTION
This changes YARPC to rely on Go 1.10's multi-package coverage support
rather than the hacky cover.sh script we've had in the past.

The script still needs to exist to support the .nocover files but it's now
greatly simplified and we don't need to rely on gocovmerge, parallel-exec,
etc.

We've also not had to rely on the external cover tool since Go 1.5 so I dropped
that too.