### PR TITLE
Add random peer selector

### DIFF
--- a/api/peer/list.go
+++ b/api/peer/list.go
@@ -71,6 +71,9 @@ type ChooserList interface {
 // peerlist.List and ListImplementation compose well with sharding schemes the
 // degenerate to returning the only available peer.
 //
+// The peerlist.List calls Add, Remove, and Choose under a write lock so the
+// implementation is free to perform mutations on its own data without locks.
+//
 // Deprecated in favor of "go.uber.org/yarpc/peer/peerlist/v2".Implementation.
 type ListImplementation interface {
 	transport.Lifecycle

--- a/peer/peerlist/v2/list.go
+++ b/peer/peerlist/v2/list.go
@@ -49,8 +49,11 @@ var (
 // Use "go.uber.org/yarpc/peer/peerlist".List in conjunction with a
 // ListImplementation to produce a "go.uber.org/yarpc/api/peer".List.
 //
-// peerlist.List and ListImplementation compose well with sharding schemes the
-// degenerate to returning the only available peer.
+// peerlist.List and peerlist.Implementation compose well with sharding schemes
+// the degenerate to returning the only available peer.
+//
+// The peerlist.List calls Add, Remove, and Choose under a write lock so the
+// implementation is free to perform mutations on its own data without locks.
 type Implementation interface {
 	transport.Lifecycle
 

--- a/peer/randpeer/config.go
+++ b/peer/randpeer/config.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package randpeer
 
 import (

--- a/peer/randpeer/config.go
+++ b/peer/randpeer/config.go
@@ -1,0 +1,33 @@
+package randpeer
+
+import (
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/yarpcconfig"
+)
+
+// Spec returns a configuration specification for the random peer list
+// implementation, making it possible to select a random peer with transports
+// that use outbound peer list configuration (like HTTP).
+//
+//  cfg := yarpcconfig.New()
+//  cfg.MustRegisterPeerList(random.Spec())
+//
+// This enables the random peer list:
+//
+//  outbounds:
+//    otherservice:
+//      unary:
+//        http:
+//          url: https://host:port/rpc
+//          random:
+//            peers:
+//              - 127.0.0.1:8080
+//              - 127.0.0.1:8081
+func Spec() yarpcconfig.PeerListSpec {
+	return yarpcconfig.PeerListSpec{
+		Name: "random",
+		BuildPeerList: func(c struct{}, t peer.Transport, k *yarpcconfig.Kit) (peer.ChooserList, error) {
+			return New(t), nil
+		},
+	}
+}

--- a/peer/randpeer/config_test.go
+++ b/peer/randpeer/config_test.go
@@ -1,0 +1,35 @@
+package randpeer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/yarpcconfig"
+	"go.uber.org/yarpc/yarpctest"
+)
+
+type attrs map[string]interface{}
+
+func TestConfig(t *testing.T) {
+	cfg := yarpcconfig.New()
+	cfg.RegisterPeerList(Spec())
+	cfg.RegisterTransport(yarpctest.FakeTransportSpec())
+	config, err := cfg.LoadConfig("our-service", attrs{
+		"outbounds": attrs{
+			"their-service": attrs{
+				"fake-transport": attrs{
+					"random": attrs{
+						"peers": []string{
+							"1.1.1.1:1111",
+							"2.2.2.2:2222",
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, config.Outbounds)
+	require.NotNil(t, config.Outbounds["their-service"])
+	require.NotNil(t, config.Outbounds["their-service"].Unary)
+}

--- a/peer/randpeer/config_test.go
+++ b/peer/randpeer/config_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package randpeer
 
 import (

--- a/peer/randpeer/list.go
+++ b/peer/randpeer/list.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package randpeer
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/peer/peerlist"
+)
+
+type listOptions struct {
+	capacity int
+	source   rand.Source
+}
+
+var defaultListOptions = listOptions{
+	capacity: 10,
+}
+
+// ListOption customizes the behavior of a roundrobin list.
+type ListOption interface {
+	apply(*listOptions)
+}
+
+type listOptionFunc func(*listOptions)
+
+func (f listOptionFunc) apply(options *listOptions) { f(options) }
+
+// Capacity specifies the default capacity of the underlying
+// data structures for this list.
+//
+// Defaults to 10.
+func Capacity(capacity int) ListOption {
+	return listOptionFunc(func(options *listOptions) {
+		options.capacity = capacity
+	})
+}
+
+// Seed specifies the seed for generating random choices.
+func Seed(seed int64) ListOption {
+	return listOptionFunc(func(options *listOptions) {
+		fmt.Printf("HERE %d\n", seed)
+		options.source = rand.NewSource(seed)
+	})
+}
+
+// Source is a source of randomness for the peer list.
+func Source(source rand.Source) ListOption {
+	return listOptionFunc(func(options *listOptions) {
+		options.source = source
+	})
+}
+
+// New creates a new round robin peer list.
+func New(transport peer.Transport, opts ...ListOption) *List {
+	options := defaultListOptions
+	for _, opt := range opts {
+		opt.apply(&options)
+	}
+
+	if options.source == nil {
+		options.source = rand.NewSource(time.Now().UnixNano())
+	}
+
+	plOpts := []peerlist.ListOption{
+		peerlist.Capacity(options.capacity),
+		peerlist.NoShuffle(),
+	}
+
+	return &List{
+		List: peerlist.New(
+			"random",
+			transport,
+			newRandomList(options.capacity, options.source),
+			plOpts...,
+		),
+	}
+}
+
+// List is a PeerList that rotates which peers are to be selected randomly
+type List struct {
+	*peerlist.List
+}

--- a/peer/randpeer/list.go
+++ b/peer/randpeer/list.go
@@ -26,7 +26,7 @@ import (
 	"time"
 
 	"go.uber.org/yarpc/api/peer"
-	"go.uber.org/yarpc/peer/peerlist"
+	"go.uber.org/yarpc/peer/peerlist/v2"
 )
 
 type listOptions struct {

--- a/peer/randpeer/list.go
+++ b/peer/randpeer/list.go
@@ -21,7 +21,6 @@
 package randpeer
 
 import (
-	"fmt"
 	"math/rand"
 	"time"
 
@@ -38,7 +37,7 @@ var defaultListOptions = listOptions{
 	capacity: 10,
 }
 
-// ListOption customizes the behavior of a roundrobin list.
+// ListOption customizes the behavior of a random list.
 type ListOption interface {
 	apply(*listOptions)
 }
@@ -60,7 +59,6 @@ func Capacity(capacity int) ListOption {
 // Seed specifies the seed for generating random choices.
 func Seed(seed int64) ListOption {
 	return listOptionFunc(func(options *listOptions) {
-		fmt.Printf("HERE %d\n", seed)
 		options.source = rand.NewSource(seed)
 	})
 }
@@ -72,7 +70,7 @@ func Source(source rand.Source) ListOption {
 	})
 }
 
-// New creates a new round robin peer list.
+// New creates a new random peer list.
 func New(transport peer.Transport, opts ...ListOption) *List {
 	options := defaultListOptions
 	for _, opt := range opts {

--- a/peer/randpeer/list_test.go
+++ b/peer/randpeer/list_test.go
@@ -1,0 +1,569 @@
+package randpeer_test
+
+import (
+	"context"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/multierr"
+	"go.uber.org/yarpc/api/peer"
+	. "go.uber.org/yarpc/api/peer/peertest"
+	"go.uber.org/yarpc/peer/randpeer"
+	"go.uber.org/yarpc/yarpcerrors"
+)
+
+var (
+	_noContextDeadlineError = yarpcerrors.Newf(yarpcerrors.CodeInvalidArgument, "can't wait for peer without a context deadline for a random peer list")
+)
+
+func newNotRunningError(err string) error {
+	return yarpcerrors.FailedPreconditionErrorf("random peer list is not running: %s", err)
+}
+
+func newUnavailableError(err error) error {
+	return yarpcerrors.UnavailableErrorf("random peer list timed out waiting for peer: %s", err.Error())
+}
+
+func TestRandPeer(t *testing.T) {
+	type testStruct struct {
+		msg string
+
+		// PeerIDs that will be returned from the transport's OnRetain with "Available" status
+		retainedAvailablePeerIDs []string
+
+		// PeerIDs that will be returned from the transport's OnRetain with "Unavailable" status
+		retainedUnavailablePeerIDs []string
+
+		// PeerIDs that will be released from the transport
+		releasedPeerIDs []string
+
+		// PeerIDs that will return "retainErr" from the transport's OnRetain function
+		errRetainedPeerIDs []string
+		retainErr          error
+
+		// PeerIDs that will return "releaseErr" from the transport's OnRelease function
+		errReleasedPeerIDs []string
+		releaseErr         error
+
+		// A list of actions that will be applied on the PeerList
+		peerListActions []PeerListAction
+
+		// PeerIDs expected to be in the PeerList's "Available" list after the actions have been applied
+		expectedAvailablePeers []string
+
+		// PeerIDs expected to be in the PeerList's "Unavailable" list after the actions have been applied
+		expectedUnavailablePeers []string
+
+		// Boolean indicating whether the PeerList is "running" after the actions have been applied
+		expectedRunning bool
+	}
+	tests := []testStruct{
+		{
+			msg: "setup",
+			retainedAvailablePeerIDs: []string{"1"},
+			expectedAvailablePeers:   []string{"1"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "setup with disconnected",
+			retainedAvailablePeerIDs:   []string{"1"},
+			retainedUnavailablePeerIDs: []string{"2"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1", "2"}},
+			},
+			expectedAvailablePeers:   []string{"1"},
+			expectedUnavailablePeers: []string{"2"},
+			expectedRunning:          true,
+		},
+		{
+			msg: "start",
+			retainedAvailablePeerIDs: []string{"1"},
+			expectedAvailablePeers:   []string{"1"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
+				ChooseAction{
+					ExpectedPeer: "1",
+				},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "start stop",
+			retainedAvailablePeerIDs:   []string{"1", "2", "3", "4", "5", "6"},
+			retainedUnavailablePeerIDs: []string{"7", "8", "9"},
+			releasedPeerIDs:            []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9"}},
+				StopAction{},
+				ChooseAction{
+					ExpectedErr:         newNotRunningError("could not wait for instance to start running: current state is \"stopped\""),
+					InputContextTimeout: 10 * time.Millisecond,
+				},
+			},
+			expectedRunning: false,
+		},
+		{
+			msg: "update, start, and choose",
+			retainedAvailablePeerIDs: []string{"1"},
+			expectedAvailablePeers:   []string{"1"},
+			peerListActions: []PeerListAction{
+				UpdateAction{AddedPeerIDs: []string{"1"}},
+				StartAction{},
+				ChooseAction{ExpectedPeer: "1"},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "start many and choose",
+			retainedAvailablePeerIDs: []string{"1", "2", "3", "4", "5", "6"},
+			expectedAvailablePeers:   []string{"1", "2", "3", "4", "5", "6"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1", "2", "3", "4", "5", "6"}},
+				ChooseAction{ExpectedPeer: "1"},
+				ChooseAction{ExpectedPeer: "1"},
+				ChooseAction{ExpectedPeer: "2"},
+				ChooseAction{ExpectedPeer: "5"},
+				ChooseAction{ExpectedPeer: "6"},
+				ChooseAction{ExpectedPeer: "5"},
+				ChooseAction{ExpectedPeer: "2"},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "assure start is idempotent",
+			retainedAvailablePeerIDs: []string{"1"},
+			expectedAvailablePeers:   []string{"1"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
+				StartAction{},
+				StartAction{},
+				ChooseAction{
+					ExpectedPeer: "1",
+				},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "stop no start",
+			retainedAvailablePeerIDs: []string{},
+			releasedPeerIDs:          []string{},
+			peerListActions: []PeerListAction{
+				StopAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
+			},
+			expectedRunning: false,
+		},
+		{
+			msg:                "update retain error",
+			errRetainedPeerIDs: []string{"1"},
+			retainErr:          peer.ErrInvalidPeerType{},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}, ExpectedErr: peer.ErrInvalidPeerType{}},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "update retain multiple errors",
+			retainedAvailablePeerIDs: []string{"2"},
+			errRetainedPeerIDs:       []string{"1", "3"},
+			retainErr:                peer.ErrInvalidPeerType{},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{
+					AddedPeerIDs: []string{"1", "2", "3"},
+					ExpectedErr:  multierr.Combine(peer.ErrInvalidPeerType{}, peer.ErrInvalidPeerType{}),
+				},
+			},
+			expectedAvailablePeers: []string{"2"},
+			expectedRunning:        true,
+		},
+		{
+			msg: "start stop release error",
+			retainedAvailablePeerIDs: []string{"1"},
+			errReleasedPeerIDs:       []string{"1"},
+			releaseErr:               peer.ErrTransportHasNoReferenceToPeer{},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
+				StopAction{
+					ExpectedErr: peer.ErrTransportHasNoReferenceToPeer{},
+				},
+			},
+			expectedRunning: false,
+		},
+		{
+			msg: "assure stop is idempotent",
+			retainedAvailablePeerIDs: []string{"1"},
+			errReleasedPeerIDs:       []string{"1"},
+			releaseErr:               peer.ErrTransportHasNoReferenceToPeer{},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
+				ConcurrentAction{
+					Actions: []PeerListAction{
+						StopAction{
+							ExpectedErr: peer.ErrTransportHasNoReferenceToPeer{},
+						},
+						StopAction{
+							ExpectedErr: peer.ErrTransportHasNoReferenceToPeer{},
+						},
+						StopAction{
+							ExpectedErr: peer.ErrTransportHasNoReferenceToPeer{},
+						},
+					},
+				},
+			},
+			expectedRunning: false,
+		},
+		{
+			msg: "start stop release multiple errors",
+			retainedAvailablePeerIDs: []string{"1", "2", "3"},
+			releasedPeerIDs:          []string{"2"},
+			errReleasedPeerIDs:       []string{"1", "3"},
+			releaseErr:               peer.ErrTransportHasNoReferenceToPeer{},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1", "2", "3"}},
+				StopAction{
+					ExpectedErr: multierr.Combine(
+						peer.ErrTransportHasNoReferenceToPeer{},
+						peer.ErrTransportHasNoReferenceToPeer{},
+					),
+				},
+			},
+			expectedRunning: false,
+		},
+		{
+			msg: "choose before start",
+			peerListActions: []PeerListAction{
+				ChooseAction{
+					ExpectedErr:         newNotRunningError("context finished while waiting for instance to start: context deadline exceeded"),
+					InputContextTimeout: 10 * time.Millisecond,
+				},
+				ChooseAction{
+					ExpectedErr:         newNotRunningError("context finished while waiting for instance to start: context deadline exceeded"),
+					InputContextTimeout: 10 * time.Millisecond,
+				},
+			},
+			expectedRunning: false,
+		},
+		{
+			msg: "update before start",
+			retainedAvailablePeerIDs: []string{"1"},
+			expectedAvailablePeers:   []string{"1"},
+			peerListActions: []PeerListAction{
+				ConcurrentAction{
+					Actions: []PeerListAction{
+						UpdateAction{AddedPeerIDs: []string{"1"}},
+						StartAction{},
+					},
+					Wait: 20 * time.Millisecond,
+				},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "start choose no peers",
+			peerListActions: []PeerListAction{
+				StartAction{},
+				ChooseAction{
+					InputContextTimeout: 20 * time.Millisecond,
+					ExpectedErr:         newUnavailableError(context.DeadlineExceeded),
+				},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "start then add",
+			retainedAvailablePeerIDs: []string{"1", "2"},
+			expectedAvailablePeers:   []string{"1", "2"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
+				UpdateAction{AddedPeerIDs: []string{"2"}},
+				ChooseAction{ExpectedPeer: "1"},
+				ChooseAction{ExpectedPeer: "1"},
+				ChooseAction{ExpectedPeer: "2"},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "start remove",
+			retainedAvailablePeerIDs: []string{"1", "2"},
+			expectedAvailablePeers:   []string{"2"},
+			releasedPeerIDs:          []string{"1"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1", "2"}},
+				UpdateAction{RemovedPeerIDs: []string{"1"}},
+				ChooseAction{ExpectedPeer: "2"},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "add retain error",
+			retainedAvailablePeerIDs: []string{"1", "2"},
+			expectedAvailablePeers:   []string{"1", "2"},
+			errRetainedPeerIDs:       []string{"3"},
+			retainErr:                peer.ErrInvalidPeerType{},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1", "2"}},
+				UpdateAction{
+					AddedPeerIDs: []string{"3"},
+					ExpectedErr:  peer.ErrInvalidPeerType{},
+				},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "add duplicate peer",
+			retainedAvailablePeerIDs: []string{"1", "2"},
+			expectedAvailablePeers:   []string{"1", "2"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1", "2"}},
+				UpdateAction{
+					AddedPeerIDs: []string{"2"},
+					ExpectedErr:  peer.ErrPeerAddAlreadyInList("2"),
+				},
+				ChooseAction{ExpectedPeer: "1"},
+				ChooseAction{ExpectedPeer: "1"},
+				ChooseAction{ExpectedPeer: "2"},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "remove peer not in list",
+			retainedAvailablePeerIDs: []string{"1", "2"},
+			expectedAvailablePeers:   []string{"1", "2"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1", "2"}},
+				UpdateAction{
+					RemovedPeerIDs: []string{"3"},
+					ExpectedErr:    peer.ErrPeerRemoveNotInList("3"),
+				},
+				ChooseAction{ExpectedPeer: "1"},
+				ChooseAction{ExpectedPeer: "1"},
+				ChooseAction{ExpectedPeer: "2"},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "remove release error",
+			retainedAvailablePeerIDs: []string{"1", "2"},
+			errReleasedPeerIDs:       []string{"2"},
+			releaseErr:               peer.ErrTransportHasNoReferenceToPeer{},
+			expectedAvailablePeers:   []string{"1"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1", "2"}},
+				UpdateAction{
+					RemovedPeerIDs: []string{"2"},
+					ExpectedErr:    peer.ErrTransportHasNoReferenceToPeer{},
+				},
+				ChooseAction{ExpectedPeer: "1"},
+				ChooseAction{ExpectedPeer: "1"},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "block but added too late",
+			retainedAvailablePeerIDs: []string{"1"},
+			expectedAvailablePeers:   []string{"1"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				ConcurrentAction{
+					Actions: []PeerListAction{
+						ChooseAction{
+							InputContextTimeout: 10 * time.Millisecond,
+							ExpectedErr:         newUnavailableError(context.DeadlineExceeded),
+						},
+						UpdateAction{AddedPeerIDs: []string{"1"}},
+					},
+					Wait: 20 * time.Millisecond,
+				},
+				ChooseAction{ExpectedPeer: "1"},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "no blocking with no context deadline",
+			peerListActions: []PeerListAction{
+				StartAction{},
+				ChooseAction{
+					InputContext: context.Background(),
+					ExpectedErr:  _noContextDeadlineError,
+				},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "add unavailable peer",
+			retainedAvailablePeerIDs:   []string{"1"},
+			retainedUnavailablePeerIDs: []string{"2"},
+			expectedAvailablePeers:     []string{"1"},
+			expectedUnavailablePeers:   []string{"2"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
+				UpdateAction{AddedPeerIDs: []string{"2"}},
+				ChooseAction{
+					ExpectedPeer:        "1",
+					InputContextTimeout: 20 * time.Millisecond,
+				},
+				ChooseAction{
+					ExpectedPeer:        "1",
+					InputContextTimeout: 20 * time.Millisecond,
+				},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "remove unavailable peer",
+			retainedUnavailablePeerIDs: []string{"1"},
+			releasedPeerIDs:            []string{"1"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
+				UpdateAction{RemovedPeerIDs: []string{"1"}},
+				ChooseAction{
+					InputContextTimeout: 10 * time.Millisecond,
+					ExpectedErr:         newUnavailableError(context.DeadlineExceeded),
+				},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "notify peer is now available",
+			retainedUnavailablePeerIDs: []string{"1"},
+			expectedAvailablePeers:     []string{"1"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
+				ChooseAction{
+					InputContextTimeout: 10 * time.Millisecond,
+					ExpectedErr:         newUnavailableError(context.DeadlineExceeded),
+				},
+				NotifyStatusChangeAction{PeerID: "1", NewConnectionStatus: peer.Available},
+				ChooseAction{ExpectedPeer: "1"},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "notify peer is still available",
+			retainedAvailablePeerIDs: []string{"1"},
+			expectedAvailablePeers:   []string{"1"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
+				ChooseAction{ExpectedPeer: "1"},
+				NotifyStatusChangeAction{PeerID: "1", NewConnectionStatus: peer.Available},
+				ChooseAction{ExpectedPeer: "1"},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "notify peer is now unavailable",
+			retainedAvailablePeerIDs: []string{"1"},
+			expectedUnavailablePeers: []string{"1"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
+				ChooseAction{ExpectedPeer: "1"},
+				NotifyStatusChangeAction{PeerID: "1", NewConnectionStatus: peer.Unavailable},
+				ChooseAction{
+					InputContextTimeout: 10 * time.Millisecond,
+					ExpectedErr:         newUnavailableError(context.DeadlineExceeded),
+				},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "notify peer is still unavailable",
+			retainedUnavailablePeerIDs: []string{"1"},
+			expectedUnavailablePeers:   []string{"1"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
+				NotifyStatusChangeAction{PeerID: "1", NewConnectionStatus: peer.Unavailable},
+				ChooseAction{
+					InputContextTimeout: 10 * time.Millisecond,
+					ExpectedErr:         newUnavailableError(context.DeadlineExceeded),
+				},
+			},
+			expectedRunning: true,
+		},
+		{
+			msg: "notify invalid peer",
+			retainedAvailablePeerIDs: []string{"1"},
+			releasedPeerIDs:          []string{"1"},
+			peerListActions: []PeerListAction{
+				StartAction{},
+				UpdateAction{AddedPeerIDs: []string{"1"}},
+				UpdateAction{RemovedPeerIDs: []string{"1"}},
+				NotifyStatusChangeAction{PeerID: "1", NewConnectionStatus: peer.Available},
+			},
+			expectedRunning: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			transport := NewMockTransport(mockCtrl)
+
+			// Healthy Transport Retain/Release
+			peerMap := ExpectPeerRetains(
+				transport,
+				tt.retainedAvailablePeerIDs,
+				tt.retainedUnavailablePeerIDs,
+			)
+			ExpectPeerReleases(transport, tt.releasedPeerIDs, nil)
+
+			// Unhealthy Transport Retain/Release
+			ExpectPeerRetainsWithError(transport, tt.errRetainedPeerIDs, tt.retainErr)
+			ExpectPeerReleases(transport, tt.errReleasedPeerIDs, tt.releaseErr)
+
+			pl := randpeer.New(transport, randpeer.Seed(0))
+
+			deps := ListActionDeps{
+				Peers: peerMap,
+			}
+			ApplyPeerListActions(t, pl, tt.peerListActions, deps)
+
+			var availablePeers []string
+			var unavailablePeers []string
+			for _, p := range pl.Peers() {
+				ps := p.Status()
+				if ps.ConnectionStatus == peer.Available {
+					availablePeers = append(availablePeers, p.Identifier())
+				} else if ps.ConnectionStatus == peer.Unavailable {
+					unavailablePeers = append(unavailablePeers, p.Identifier())
+				}
+			}
+			sort.Strings(availablePeers)
+			sort.Strings(unavailablePeers)
+
+			assert.Equal(t, availablePeers, tt.expectedAvailablePeers, "incorrect available peers")
+			assert.Equal(t, unavailablePeers, tt.expectedUnavailablePeers, "incorrect unavailable peers")
+			assert.Equal(t, tt.expectedRunning, pl.IsRunning(), "Peer list should match expected final running state")
+		})
+	}
+}

--- a/peer/randpeer/list_test.go
+++ b/peer/randpeer/list_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package randpeer_test
 
 import (

--- a/peer/randpeer/random.go
+++ b/peer/randpeer/random.go
@@ -52,14 +52,16 @@ func (r *randomList) Add(peer peer.StatusPeer, _ peer.Identifier) peer.Subscribe
 	return r.subscribers[index]
 }
 
-func (r *randomList) Remove(peer peer.StatusPeer, _ peer.Identifier, sub peer.Subscriber) {
-	if sub, ok := sub.(*subscriber); ok && len(r.subscribers) > 0 {
-		index := sub.index
-		last := len(r.subscribers) - 1
-		r.subscribers[index] = r.subscribers[last]
-		r.subscribers[index].index = index
-		r.subscribers = r.subscribers[0:last]
+func (r *randomList) Remove(peer peer.StatusPeer, _ peer.Identifier, ps peer.Subscriber) {
+	sub, ok := ps.(*subscriber)
+	if !ok || len(r.subscribers) == 0 {
+		return
 	}
+	index := sub.index
+	last := len(r.subscribers) - 1
+	r.subscribers[index] = r.subscribers[last]
+	r.subscribers[index].index = index
+	r.subscribers = r.subscribers[0:last]
 }
 
 func (r *randomList) Choose(_ context.Context, _ *transport.Request) peer.StatusPeer {

--- a/peer/randpeer/random.go
+++ b/peer/randpeer/random.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package randpeer
 
 import (

--- a/peer/randpeer/random.go
+++ b/peer/randpeer/random.go
@@ -89,4 +89,4 @@ type subscriber struct {
 
 var _ peer.Subscriber = (*subscriber)(nil)
 
-func (s *subscriber) NotifyStatusChanged(peer.Identifier) {}
+func (*subscriber) NotifyStatusChanged(peer.Identifier) {}

--- a/peer/randpeer/random.go
+++ b/peer/randpeer/random.go
@@ -1,0 +1,71 @@
+package randpeer
+
+import (
+	"context"
+	"math/rand"
+
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/api/transport"
+)
+
+type randomList struct {
+	subscribers []*subscriber
+	random      *rand.Rand
+}
+
+func newRandomList(cap int, source rand.Source) *randomList {
+	return &randomList{
+		subscribers: make([]*subscriber, 0, cap),
+		random:      rand.New(source),
+	}
+}
+
+var _ peer.ListImplementation = (*randomList)(nil)
+
+func (r *randomList) Add(peer peer.StatusPeer) peer.Subscriber {
+	index := len(r.subscribers)
+	r.subscribers = append(r.subscribers, &subscriber{
+		index: index,
+		peer:  peer,
+	})
+	return r.subscribers[index]
+}
+
+func (r *randomList) Remove(peer peer.StatusPeer, sub peer.Subscriber) {
+	if sub, ok := sub.(*subscriber); ok && len(r.subscribers) > 0 {
+		index := sub.index
+		last := len(r.subscribers) - 1
+		r.subscribers[index] = r.subscribers[last]
+		r.subscribers[index].index = index
+		r.subscribers = r.subscribers[0:last]
+	}
+}
+
+func (r *randomList) Choose(_ context.Context, _ *transport.Request) peer.StatusPeer {
+	if len(r.subscribers) == 0 {
+		return nil
+	}
+	index := r.random.Intn(len(r.subscribers))
+	return r.subscribers[index].peer
+}
+
+func (r *randomList) Start() error {
+	return nil
+}
+
+func (r *randomList) Stop() error {
+	return nil
+}
+
+func (r *randomList) IsRunning() bool {
+	return true
+}
+
+type subscriber struct {
+	index int
+	peer  peer.StatusPeer
+}
+
+var _ peer.Subscriber = (*subscriber)(nil)
+
+func (s *subscriber) NotifyStatusChanged(peer.Identifier) {}

--- a/peer/randpeer/random.go
+++ b/peer/randpeer/random.go
@@ -26,6 +26,7 @@ import (
 
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
+	peerlist "go.uber.org/yarpc/peer/peerlist/v2"
 )
 
 type randomList struct {
@@ -40,9 +41,9 @@ func newRandomList(cap int, source rand.Source) *randomList {
 	}
 }
 
-var _ peer.ListImplementation = (*randomList)(nil)
+var _ peerlist.Implementation = (*randomList)(nil)
 
-func (r *randomList) Add(peer peer.StatusPeer) peer.Subscriber {
+func (r *randomList) Add(peer peer.StatusPeer, _ peer.Identifier) peer.Subscriber {
 	index := len(r.subscribers)
 	r.subscribers = append(r.subscribers, &subscriber{
 		index: index,
@@ -51,7 +52,7 @@ func (r *randomList) Add(peer peer.StatusPeer) peer.Subscriber {
 	return r.subscribers[index]
 }
 
-func (r *randomList) Remove(peer peer.StatusPeer, sub peer.Subscriber) {
+func (r *randomList) Remove(peer peer.StatusPeer, _ peer.Identifier, sub peer.Subscriber) {
 	if sub, ok := sub.(*subscriber); ok && len(r.subscribers) > 0 {
 		index := sub.index
 		last := len(r.subscribers) - 1

--- a/yarpctest/fake_outbound.go
+++ b/yarpctest/fake_outbound.go
@@ -113,15 +113,15 @@ func (o *FakeOutbound) Call(ctx context.Context, req *transport.Request) (*trans
 	if o.callOverride != nil {
 		return o.callOverride(ctx, req)
 	}
-	return nil, fmt.Errorf(`no outbound callable specified on the outbound`)
+	return nil, fmt.Errorf(`no outbound callable specified on the fake outbound`)
 }
 
 // CallOneway pretends to send a oneway RPC, but actually just returns an error.
 func (o *FakeOutbound) CallOneway(ctx context.Context, req *transport.Request) (transport.Ack, error) {
-	return nil, fmt.Errorf(`call oneway outbound is unsupported`)
+	return nil, fmt.Errorf(`fake outbound does not support call oneway`)
 }
 
 // CallStream pretends to send a Stream RPC, but actually just returns an error.
 func (o *FakeOutbound) CallStream(ctx context.Context, req *transport.StreamRequest) (*transport.ClientStream, error) {
-	return nil, fmt.Errorf(`call stream outbound is unsupported`)
+	return nil, fmt.Errorf(`fake outbound does not support call stream`)
 }


### PR DESCRIPTION
This change finishes the collection of basic peer selection strategies for
YARPC.

- random
- round-robin
- fewest-pending-requests