### PR TITLE
buildkite: Update docker-compose plugin

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,14 +1,14 @@
 steps:
   - name: ":docker: :package: 1.9"
     plugins:
-      docker-compose#v1.5.2:
+      docker-compose#v2.0.0:
         build: yarpc-go-1.9
         image-repository: 027047743804.dkr.ecr.us-east-2.amazonaws.com/uber
     agents:
       queue: builders
   - name: ":docker: :package: 1.10"
     plugins:
-      docker-compose#v1.5.2:
+      docker-compose#v2.0.0:
         build: yarpc-go-1.10
         image-repository: 027047743804.dkr.ecr.us-east-2.amazonaws.com/uber
     agents:
@@ -18,21 +18,21 @@ steps:
     command: "make test"
     parallelism: 2
     plugins:
-      docker-compose#v1.5.2:
+      docker-compose#v2.0.0:
         run: yarpc-go-1.9
     agents:
       queue: workers
   - name: ":go: 1.9 lint"
     command: "make lint"
     plugins:
-      docker-compose#v1.5.2:
+      docker-compose#v2.0.0:
         run: yarpc-go-1.9
     agents:
       queue: workers
   - name: ":go: 1.9 examples"
     command: "make examples"
     plugins:
-      docker-compose#v1.5.2:
+      docker-compose#v2.0.0:
         run: yarpc-go-1.9
     agents:
       queue: workers
@@ -40,21 +40,21 @@ steps:
     command: "make codecov"
     parallelism: 6
     plugins:
-      docker-compose#v1.5.2:
+      docker-compose#v2.0.0:
         run: yarpc-go-1.10
     agents:
       queue: workers
   - name: ":go: 1.10 lint"
     command: "make lint"
     plugins:
-      docker-compose#v1.5.2:
+      docker-compose#v2.0.0:
         run: yarpc-go-1.10
     agents:
       queue: workers
   - name: ":go: 1.10 examples"
     command: "make examples"
     plugins:
-      docker-compose#v1.5.2:
+      docker-compose#v2.0.0:
         run: yarpc-go-1.10
     agents:
       queue: workers


### PR DESCRIPTION
This updates the docker-compose plugin we use for BuildKite to the
latest version. There were no breaking changes between 1.5.2 and 1.8.4.

The change that caused a 2.0 to be released was because an internal key
was changed which would make it impossible to mix and match versions:
You couldn't use docker-compose#v1.8.4 with the version that had that
change. This required a major version bump. As long as all usages of the
plugin in the repo are using the same version, this is completely fine.