### PR TITLE
buildkite: Update dependencies automatically

### DIFF
--- a/.buildkite/pipeline-update-deps.yml
+++ b/.buildkite/pipeline-update-deps.yml
@@ -1,0 +1,22 @@
+steps:
+  - name: ":docker: :package: 1.10"
+    plugins:
+      docker-compose#v2.0.0:
+        build: yarpc-go-1.10
+        image-repository: 027047743804.dkr.ecr.us-east-2.amazonaws.com/uber
+    agents:
+      queue: builders
+  - wait
+  - name: ":go: 1.10 update-deps"
+    command: "etc/bin/update-deps.sh"
+    plugins:
+      docker-compose#v2.0.0:
+        run: yarpc-go-1.10
+        env:
+          # The script needs the following environment variables in addition
+          # to those provided by the docker-compose.
+          - GITHUB_USER
+          - GITHUB_TOKEN
+          - GITHUB_REPO
+    agents:
+      queue: workers

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 version: '3'
 services:
+
   yarpc-go-1.9:
     build:
       context: .
@@ -13,11 +14,15 @@ services:
       - CI=true
       - BUILDKITE
       - BUILDKITE_BRANCH
+      - BUILDKITE_BUILD_CREATOR
+      - BUILDKITE_BUILD_CREATOR_EMAIL
       - BUILDKITE_BUILD_NUMBER
-      - BUILDKITE_JOB_ID
       - BUILDKITE_BUILD_URL
-      - BUILDKITE_PROJECT_SLUG
       - BUILDKITE_COMMIT
+      - BUILDKITE_JOB_ID
+      - BUILDKITE_PROJECT_SLUG
+      - BUILDKITE_REPO
+
   yarpc-go-1.10:
     build:
       context: .
@@ -31,8 +36,17 @@ services:
       - CI=true
       - BUILDKITE
       - BUILDKITE_BRANCH
+      - BUILDKITE_BUILD_CREATOR
+      - BUILDKITE_BUILD_CREATOR_EMAIL
       - BUILDKITE_BUILD_NUMBER
-      - BUILDKITE_JOB_ID
       - BUILDKITE_BUILD_URL
-      - BUILDKITE_PROJECT_SLUG
       - BUILDKITE_COMMIT
+      - BUILDKITE_JOB_ID
+      - BUILDKITE_PROJECT_SLUG
+      - BUILDKITE_REPO
+      - SSH_AUTH_SOCK=/ssh-agent
+    volumes:
+      - $SSH_AUTH_SOCK:/ssh-agent
+    # We mount the host's SSH Agent unix socket at /ssh-agent in the container
+    # and tell the container where to find it so that the container can
+    # actually push commits.

--- a/etc/bin/update-deps.sh
+++ b/etc/bin/update-deps.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+
+# This script will update the dependencies for the branch that it was executed
+# with. If the update didn't cause any generated code to change and the tests
+# continue to pass, the change will be pushed directly to the branch. If the
+# generated code changed or the tests failed, the change will be pushed to a
+# new branch and a pull request will be created.
+#
+# Variables to control the behavior of this script:
+#
+# GITHUB_USER (required)
+#   GitHub username used to authenticate requests.
+# GITHUB_TOKEN (required)
+#   GitHub token to authenticate $GITHUB_USER.
+# GITHUB_REPO (optional)
+#   GitHub repository in the form $user/$repo. This will usually be inferred
+#   automatically from BUILDKITE_REPO.
+# GIT_REMOTE (optional)
+#   Name of the git remote to which changes will be pushed. Defaults to
+#   "origin".
+#
+# The following variables set by BuildKite are also accepted.
+#
+#   BUILDKITE_BRANCH
+#   BUILDKITE_BUILD_CREATOR (optional)
+#   BUILDKITE_BUILD_CREATOR_EMAIL (optional)
+#   BUILDKITE_BUILD_NUMBER (optional)
+#   BUILDKITE_REPO (optional)
+#
+# See https://buildkite.com/docs/builds/environment-variables for what they mean.
+
+set -euo pipefail
+
+if [ -z "${GITHUB_USER:-}" ] || [ -z "${GITHUB_TOKEN:-}" ]; then
+  echo "GITHUB_USER or GITHUB_TOKEN is unset."
+  echo "Please set these variables."
+  exit 1
+fi
+
+if [ -z "${BUILDKITE_BRANCH:-}" ]; then
+  echo "BUILDKITE_BRANCH is unset. Is this running on BuildKite?"
+  exit 1
+fi
+
+REMOTE="${GIT_REMOTE:-origin}"
+BRANCH="$BUILDKITE_BRANCH"
+
+GITHUB_REPO=${GITHUB_REPO:-}
+if [ -z "$GITHUB_REPO" ]; then
+  case "${BUILDKITE_REPO:-}" in
+    "git@github.com:"*)
+      GITHUB_REPO="${BUILDKITE_REPO#git@github.com:}"
+      GITHUB_REPO="${GITHUB_REPO%.git}"
+      ;;
+    "https://github.com/"*)
+      GITHUB_REPO="${BUILDKITE_REPO#https://github.com/}"
+      GITHUB_REPO="${GITHUB_REPO%.git}"
+      ;;
+    *)
+      echo "Could not determine GITHUB_REPO from BUILDKITE_REPO."
+      echo "You can set it explicitly if you're not running this from CI."
+      exit 1
+  esac
+fi
+
+# git needs a user.email and user.name to make new commits. If these are
+# unset, we set the corresponding environment variables. We use information
+# from BuildKite when available and fall back to GitHub user information if
+# it's unavailable.
+if ! git config user.name >/dev/nul; then
+  export GIT_AUTHOR_NAME="${BUILDKITE_BUILD_CREATOR:-$GITHUB_USER}"
+  export GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME"
+fi
+
+if ! git config user.email >/dev/null; then
+  FALLBACK_EMAIL="$GITHUB_USER@users.noreply.github.com"
+  export GIT_AUTHOR_EMAIL="${BUILDKITE_BUILD_CREATOR_EMAIL:-$FALLBACK_EMAIL}"
+  export GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
+fi
+
+# When pushing over ssh, automatically add the host to known_hosts instead of
+# prompting with,
+#
+#   The authenticity of host '...' can't be established.
+#   RSA key fingerprint is ...
+#   Are you sure you want to continue connecting (yes/no)?
+export GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no"
+
+# Returns the current date in ISO8601 format.
+now() {
+  date +%Y-%m-%dT%H:%M:%S
+}
+
+# Use this instead of calling `git status` directly.
+git_status()
+{
+  # BuildKite's docker-compose plugin generates a fake docker-compose so we
+  # need to ignore it anytime we do git status.
+  git status "$@" | grep -v '?? docker-compose.buildkite'
+}
+
+if [ -n "$(git_status --porcelain)" ]; then
+  echo "Working tree is dirty."
+  echo "Please verify that you don't have any uncommitted changes."
+  git status
+  exit 1
+fi
+
+echo "--- Updating dependencies"
+make glide-up
+
+case "$(git_status --porcelain)" in
+  "")
+    echo "Nothing changed. Exiting."
+    exit 0
+    ;;
+  " M glide.lock")
+    echo "--- glide.lock changed"
+    # Keep going
+    ;;
+  *)
+    echo "Unexpected changes after a glide up:"
+    git_status
+    exit 1
+esac
+
+git add glide.lock
+git commit -m "Update dependencies at $(now)"
+
+echo "--- Updating generated code"
+make generate
+
+# We want to push directly to the remote only if the generated code did not
+# change and all tests pass.
+if [ -z "$(git_status --porcelain)" ]; then
+  if make lint test examples; then
+    echo "--- Generated code did not change and the tests passed."
+    echo "--- Pushing changes and exiting."
+    git push "$REMOTE" HEAD:"$BRANCH"
+    exit 0
+  fi
+else
+  # Check in the generated code ignoring the BuildKite docker-compose.
+  git add -A
+  git rm --cached docker-compose.buildkite*
+  git commit -m "Update generated code at $(now)"
+fi
+
+PR_BRANCH=""
+if [ -z "${BUILDKITE_BUILD_NUMBER:-}" ]; then
+  # Use a different branch namespace if we're not running in BuildKite.
+  PR_BRANCH="update-deps/$(now)"
+else
+  PR_BRANCH="update-deps/buildkite/$BUILDKITE_BUILD_NUMBER"
+fi
+
+echo "--- Creating a pull request using branch $PR_BRANCH"
+git push "$REMOTE" HEAD:"refs/heads/$PR_BRANCH"
+
+MESSAGE=$(echo 'I tried to update the dependencies but either the generated
+code changed or some tests failed, so I need someone to validate or fix this
+change.
+
+Thanks!' | perl -p -e 's/\n/\\n/g')
+
+curl --user "$GITHUB_USER:$GITHUB_TOKEN" -X POST \
+  --data @- "https://api.github.com/repos/$GITHUB_REPO/pulls" <<EOF
+{
+  "title": "Update dependencies on $(now)",
+  "head": "$PR_BRANCH",
+  "base": "$BRANCH",
+  "body": "$MESSAGE",
+  "maintainer_can_modify": true
+}
+EOF

--- a/etc/bin/update-deps.sh
+++ b/etc/bin/update-deps.sh
@@ -12,6 +12,8 @@
 #   GitHub username used to authenticate requests.
 # GITHUB_TOKEN (required)
 #   GitHub token to authenticate $GITHUB_USER.
+# GITHUB_EMAIL (optional)
+#   Email address of the GitHub user.
 # GITHUB_REPO (optional)
 #   GitHub repository in the form $user/$repo. This will usually be inferred
 #   automatically from BUILDKITE_REPO.
@@ -73,9 +75,12 @@ if ! git config user.name >/dev/nul; then
 fi
 
 if ! git config user.email >/dev/null; then
-  FALLBACK_EMAIL="$GITHUB_USER@users.noreply.github.com"
-  export GIT_AUTHOR_EMAIL="${BUILDKITE_BUILD_CREATOR_EMAIL:-$FALLBACK_EMAIL}"
-  export GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
+  EMAIL="${BUILDKITE_BUILD_CREATOR_EMAIL:-${GITHUB_EMAIL:-}}"
+  if [ -z "$EMAIL" ]; then
+    EMAIL="$GITHUB_USER@users.noreply.github.com"
+  fi
+  export GIT_AUTHOR_EMAIL="$EMAIL"
+  export GIT_COMMITTER_EMAIL="$EMAIL"
 fi
 
 # When pushing over ssh, automatically add the host to known_hosts instead of

--- a/etc/bin/update-deps.sh
+++ b/etc/bin/update-deps.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
 
 # This script will update the dependencies for the branch that it was executed
 # with. If the update didn't cause any generated code to change and the tests
@@ -30,8 +32,6 @@
 #   BUILDKITE_REPO (optional)
 #
 # See https://buildkite.com/docs/builds/environment-variables for what they mean.
-
-set -euo pipefail
 
 if [ -z "${GITHUB_USER:-}" ] || [ -z "${GITHUB_TOKEN:-}" ]; then
   echo "GITHUB_USER or GITHUB_TOKEN is unset."

--- a/etc/make/deps.mk
+++ b/etc/make/deps.mk
@@ -133,3 +133,7 @@ deps: predeps glide $(GEN_BINS) $(EXTRA_BINS) ## install all dependencies
 .PHONY: glide
 glide: $(GLIDE) ## install glide dependencies
 	PATH=$$PATH:$(BIN) glide install
+
+.PHONY: glide-up
+glide-up: $(GLIDE) ## update glide dependencies
+	PATH=$$PATH:$(BIN) glide up


### PR DESCRIPTION
This sets up automatic update of glide.lock for YARPC. It handles the
following scenarios:

- Nothing changed: Do nothing
- Only dependencies changed and tests continue to pass: Push directly to
  the target branch
- Dependencies and generated code changed: Create a pull request
- Tests failed: Create a pull request

For most cases, we will have an up-to-date glide.lock. When something
breaks, we'll get a PR and we'll have to figure out what went wrong and
fix it.

The following needs to be done before this is functional.

- [x] Set up a @yarpcbot account
- [x] Give yarpcbot write access to YARPC
- [x] Generate SSH keys and a GitHub token for yarpcbot
- [x] Upload the keys and token to the secret store

After this lands, we need to set up a scheduled build with
`YARPC_PIPELINE=update-deps`.