### PR TITLE
Relax transport coupling to hostport peer identifiers

### DIFF
--- a/transport/grpc/transport_test.go
+++ b/transport/grpc/transport_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc/api/peer"
-	"go.uber.org/yarpc/peer/hostport"
 	"google.golang.org/grpc"
 )
 
@@ -54,10 +53,10 @@ func TestRetainReleasePeerSuccess(t *testing.T) {
 	address := listener.Addr().String()
 	peerSubscriber := testPeerSubscriber{}
 
-	peer, err := transport.RetainPeer(hostport.Identify(address), peerSubscriber)
+	peer, err := transport.RetainPeer(testIdentifier{address}, peerSubscriber)
 	assert.NoError(t, err)
 	assert.Equal(t, peer, transport.addressToPeer[address])
-	assert.NoError(t, transport.ReleasePeer(hostport.Identify(address), peerSubscriber))
+	assert.NoError(t, transport.ReleasePeer(testIdentifier{address}, peerSubscriber))
 }
 
 func TestRetainReleasePeerErrorPeerIdentifier(t *testing.T) {
@@ -77,9 +76,17 @@ func TestReleasePeerErrorNoPeer(t *testing.T) {
 	assert.Equal(t, peer.ErrTransportHasNoReferenceToPeer{
 		TransportName:  "grpc.Transport",
 		PeerIdentifier: address,
-	}, transport.ReleasePeer(hostport.Identify(address), peerSubscriber))
+	}, transport.ReleasePeer(testIdentifier{address}, peerSubscriber))
 }
 
 type testPeerSubscriber struct{}
 
 func (testPeerSubscriber) NotifyStatusChanged(peer.Identifier) {}
+
+type testIdentifier struct {
+	id string
+}
+
+func (i testIdentifier) Identifier() string {
+	return i.id
+}

--- a/transport/grpc/transport_test.go
+++ b/transport/grpc/transport_test.go
@@ -64,20 +64,6 @@ func TestRetainReleasePeerErrorPeerIdentifier(t *testing.T) {
 	transport := NewTransport()
 	assert.NoError(t, transport.Start())
 	defer func() { assert.NoError(t, transport.Stop()) }()
-
-	address := "foo:1234"
-	peerSubscriber := testPeerSubscriber{}
-
-	_, err := transport.RetainPeer(testPeerIdentifier(address), peerSubscriber)
-	assert.Equal(t, peer.ErrInvalidPeerType{
-		ExpectedType:   "hostport.PeerIdentifier",
-		PeerIdentifier: testPeerIdentifier(address),
-	}, err)
-	err = transport.ReleasePeer(testPeerIdentifier(address), peerSubscriber)
-	assert.Equal(t, peer.ErrInvalidPeerType{
-		ExpectedType:   "hostport.PeerIdentifier",
-		PeerIdentifier: testPeerIdentifier(address),
-	}, err)
 }
 
 func TestReleasePeerErrorNoPeer(t *testing.T) {
@@ -94,23 +80,6 @@ func TestReleasePeerErrorNoPeer(t *testing.T) {
 	}, transport.ReleasePeer(hostport.Identify(address), peerSubscriber))
 }
 
-func TestGetPeerAddress(t *testing.T) {
-	s, err := getPeerAddress(hostport.Identify("foo:1234"))
-	assert.NoError(t, err)
-	assert.Equal(t, "foo:1234", s)
-	_, err = getPeerAddress(testPeerIdentifier("foo:1234"))
-	assert.Equal(t, peer.ErrInvalidPeerType{
-		ExpectedType:   "hostport.PeerIdentifier",
-		PeerIdentifier: testPeerIdentifier("foo:1234"),
-	}, err)
-}
-
 type testPeerSubscriber struct{}
 
 func (testPeerSubscriber) NotifyStatusChanged(peer.Identifier) {}
-
-type testPeerIdentifier string
-
-func (p testPeerIdentifier) Identifier() string {
-	return string(p)
-}

--- a/transport/http/peer.go
+++ b/transport/http/peer.go
@@ -38,7 +38,7 @@ type httpPeer struct {
 	timer     *time.Timer
 }
 
-func newPeer(pid hostport.PeerIdentifier, t *Transport) *httpPeer {
+func newPeer(addr string, t *Transport) *httpPeer {
 	// Create a defused timer for later use.
 	timer := time.NewTimer(0)
 	if !timer.Stop() {
@@ -46,9 +46,9 @@ func newPeer(pid hostport.PeerIdentifier, t *Transport) *httpPeer {
 	}
 
 	return &httpPeer{
-		Peer:      hostport.NewPeer(pid, t),
+		Peer:      hostport.NewPeer(hostport.PeerIdentifier(addr), t),
 		transport: t,
-		addr:      pid.Identifier(),
+		addr:      addr,
 		changed:   make(chan struct{}, 1),
 		released:  make(chan struct{}, 0),
 		timer:     timer,

--- a/transport/http/transport_test.go
+++ b/transport/http/transport_test.go
@@ -259,23 +259,6 @@ func TestTransport(t *testing.T) {
 	}
 }
 
-func TestTransportRetainWithInvalidPeerIdentifierType(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	transport := NewTransport()
-	pid := NewMockIdentifier(mockCtrl)
-
-	expectedErr := peer.ErrInvalidPeerType{
-		ExpectedType:   "hostport.PeerIdentifier",
-		PeerIdentifier: pid,
-	}
-
-	_, err := transport.RetainPeer(pid, NewMockSubscriber(mockCtrl))
-
-	assert.Equal(t, expectedErr, err, "did not return error on invalid peer identifier")
-}
-
 func TestTransportClient(t *testing.T) {
 	transport := NewTransport()
 

--- a/transport/http/transport_test.go
+++ b/transport/http/transport_test.go
@@ -29,7 +29,6 @@ import (
 	"go.uber.org/yarpc/api/peer"
 	. "go.uber.org/yarpc/api/peer/peertest"
 	"go.uber.org/yarpc/internal/testtime"
-	"go.uber.org/yarpc/peer/hostport"
 )
 
 type peerExpectation struct {
@@ -40,7 +39,7 @@ type peerExpectation struct {
 func createPeerIdentifierMap(ids []string) map[string]peer.Identifier {
 	pids := make(map[string]peer.Identifier, len(ids))
 	for _, id := range ids {
-		pids[id] = hostport.PeerIdentifier(id)
+		pids[id] = &testIdentifier{id}
 	}
 	return pids
 }
@@ -279,4 +278,12 @@ func TestTransportClientOpaqueOptions(t *testing.T) {
 	)
 
 	assert.NotNil(t, transport.client)
+}
+
+type testIdentifier struct {
+	id string
+}
+
+func (i testIdentifier) Identifier() string {
+	return i.id
 }

--- a/transport/tchannel/peer.go
+++ b/transport/tchannel/peer.go
@@ -37,7 +37,7 @@ type tchannelPeer struct {
 	timer     *time.Timer
 }
 
-func newPeer(pid hostport.PeerIdentifier, t *Transport) *tchannelPeer {
+func newPeer(addr string, t *Transport) *tchannelPeer {
 	// Create a defused timer for later use.
 	timer := time.NewTimer(0)
 	if !timer.Stop() {
@@ -45,8 +45,8 @@ func newPeer(pid hostport.PeerIdentifier, t *Transport) *tchannelPeer {
 	}
 
 	return &tchannelPeer{
-		addr:      pid.Identifier(),
-		Peer:      hostport.NewPeer(pid, t),
+		addr:      addr,
+		Peer:      hostport.NewPeer(hostport.PeerIdentifier(addr), t),
 		transport: t,
 		changed:   make(chan struct{}, 1),
 		released:  make(chan struct{}, 0),

--- a/transport/tchannel/peer_test.go
+++ b/transport/tchannel/peer_test.go
@@ -32,12 +32,11 @@ import (
 	"go.uber.org/yarpc/internal/integrationtest"
 	"go.uber.org/yarpc/internal/testtime"
 	"go.uber.org/yarpc/internal/yarpctest"
-	"go.uber.org/yarpc/peer/hostport"
 	"go.uber.org/yarpc/transport/tchannel"
 )
 
 var spec = integrationtest.TransportSpec{
-	Identify: hostport.Identify,
+	Identify: identify,
 	NewServerTransport: func(t *testing.T, addr string) peer.Transport {
 		x, err := tchannel.NewTransport(
 			tchannel.ServiceName("service"),
@@ -133,6 +132,18 @@ func TestCancelMaintainConn(t *testing.T) {
 	require.NoError(t, err)
 	transport.Start()
 	transport.Stop()
-	_, err = transport.RetainPeer(hostport.PeerIdentifier("127.0.0.1:66408"), noSub{})
+	_, err = transport.RetainPeer(identify("127.0.0.1:66408"), noSub{})
 	require.NoError(t, err)
+}
+
+func identify(id string) peer.Identifier {
+	return &testIdentifier{id}
+}
+
+type testIdentifier struct {
+	id string
+}
+
+func (i testIdentifier) Identifier() string {
+	return i.id
 }


### PR DESCRIPTION
Currently, all YARPC transports require that peers be Retained and Released using hostport.PeerIdentifier concretely. This is unnecessary and precludes using alternate peer.Identifier implementations. This change relaxes that constraint and unblocks using other kinds of peer identifiers.