### PR TITLE
Propagate stream outbounds through config

### DIFF
--- a/api/transport/clientconfig.go
+++ b/api/transport/clientconfig.go
@@ -44,4 +44,5 @@ type ClientConfig interface {
 	// have already been started.
 	GetUnaryOutbound() UnaryOutbound
 	GetOnewayOutbound() OnewayOutbound
+	GetStreamOutbound() StreamOutbound
 }

--- a/api/transport/outboundconfig.go
+++ b/api/transport/outboundconfig.go
@@ -75,3 +75,16 @@ func (o *OutboundConfig) GetOnewayOutbound() OnewayOutbound {
 	}
 	return o.Outbounds.Oneway
 }
+
+// GetStreamOutbound returns an outbound to send the stream through or panics
+// if there is no stream outbound for this service.
+//
+// Implements ClientConfig#GetStreamOutbound.
+func (o *OutboundConfig) GetStreamOutbound() StreamOutbound {
+	// TODO: This function should be deprecated, it's for legacy support.
+	// Use Outbounds.Stream instead (and panic if you want).
+	if o.Outbounds.Stream == nil {
+		panic(fmt.Sprintf("service %q does not have a stream outbound", o.Outbounds.ServiceName))
+	}
+	return o.Outbounds.Stream
+}

--- a/api/transport/transporttest/clientconfig.go
+++ b/api/transport/transporttest/clientconfig.go
@@ -77,6 +77,18 @@ func (mr *MockClientConfigMockRecorder) GetOnewayOutbound() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOnewayOutbound", reflect.TypeOf((*MockClientConfig)(nil).GetOnewayOutbound))
 }
 
+// GetStreamOutbound mocks base method
+func (m *MockClientConfig) GetStreamOutbound() transport.StreamOutbound {
+	ret := m.ctrl.Call(m, "GetStreamOutbound")
+	ret0, _ := ret[0].(transport.StreamOutbound)
+	return ret0
+}
+
+// GetStreamOutbound indicates an expected call of GetStreamOutbound
+func (mr *MockClientConfigMockRecorder) GetStreamOutbound() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStreamOutbound", reflect.TypeOf((*MockClientConfig)(nil).GetStreamOutbound))
+}
+
 // GetUnaryOutbound mocks base method
 func (m *MockClientConfig) GetUnaryOutbound() transport.UnaryOutbound {
 	ret := m.ctrl.Call(m, "GetUnaryOutbound")

--- a/encoding/protobuf/outbound.go
+++ b/encoding/protobuf/outbound.go
@@ -67,6 +67,7 @@ func toOutboundConfig(cc transport.ClientConfig) *transport.OutboundConfig {
 		Outbounds: transport.Outbounds{
 			ServiceName: cc.Service(),
 			Unary:       cc.GetUnaryOutbound(),
+			Stream:      cc.GetStreamOutbound(),
 		},
 	}
 }

--- a/encoding/protobuf/outbound_test.go
+++ b/encoding/protobuf/outbound_test.go
@@ -49,6 +49,7 @@ func TestNonOutboundConfigWithUnaryClient(t *testing.T) {
 	cc.EXPECT().Caller().Return("caller")
 	cc.EXPECT().Service().Return("service")
 	cc.EXPECT().GetUnaryOutbound().Return(transporttest.NewMockUnaryOutbound(mockCtrl))
+	cc.EXPECT().GetStreamOutbound().Return(transporttest.NewMockStreamOutbound(mockCtrl))
 
 	assert.NotPanics(t, func() {
 		newClient("test", cc)

--- a/encoding/thrift/thriftrw-plugin-yarpc/sanitization_test.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/sanitization_test.go
@@ -98,3 +98,7 @@ func (cc testClientConfig) GetUnaryOutbound() transport.UnaryOutbound {
 func (cc testClientConfig) GetOnewayOutbound() transport.OnewayOutbound {
 	panic("Not implemented")
 }
+
+func (cc testClientConfig) GetStreamOutbound() transport.StreamOutbound {
+	panic("Not implemented")
+}


### PR DESCRIPTION
adds support for configuring stream outbounds, such that UDF are properly chained with the builtin stream middleware.