### PR TITLE
update-deps: glide cc before update

### DIFF
--- a/etc/bin/update-deps.sh
+++ b/etc/bin/update-deps.sh
@@ -123,7 +123,7 @@ if [ -n "$(git_status --porcelain)" ]; then
 fi
 
 echo "--- Updating dependencies"
-make glide-up
+make glide-cc glide-up
 
 case "$(git_status --porcelain)" in
   "")

--- a/etc/make/deps.mk
+++ b/etc/make/deps.mk
@@ -137,3 +137,7 @@ glide: $(GLIDE) ## install glide dependencies
 .PHONY: glide-up
 glide-up: $(GLIDE) ## update glide dependencies
 	PATH=$$PATH:$(BIN) glide up
+
+.PHONY: glide-cc
+glide-cc: $(GLIDE) ## clear the glide cache
+	PATH=$$PATH:$(BIN) glide cc


### PR DESCRIPTION
This changes update-deps to always glide cc before updating. We were
missing some updates because the dependencies were being cached.