### PR TITLE
Change error log level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - TChannel inbounds will blackhole requests when handlers return resource
   exhausted errors.
-- Change log level to reflect error status. Previously all logs are logged at debug
-  level, errors are now logged at error level.
+- Change log level to reflect error statuses. Previously all logs are logged at debug
+  level. Errors are now logged at error level.
 
 ## [1.30.0] - 2018-05-03
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - TChannel inbounds will blackhole requests when handlers return resource
   exhausted errors.
+- Change log level to reflect error status. Previously all logs are logged at debug
+  level, errors are now logged at error level.
 
 ## [1.30.0] - 2018-05-03
 ### Added

--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -66,7 +66,7 @@ func (c call) EndWithAppError(err error, isApplicationError bool) {
 
 func (c call) endLogs(elapsed time.Duration, err error, isApplicationError bool) {
 	var ce *zapcore.CheckedEntry
-	if err == nil {
+	if err == nil && !isApplicationError {
 		msg := _successfulInbound
 		if c.direction != _directionInbound {
 			msg = _successfulOutbound

--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -30,7 +30,13 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-const _error = "error"
+const (
+	_error              = "error"
+	_successfulInbound  = "Handled inbound request."
+	_successfulOutbound = "Made outbound call."
+	_errorInbound       = "Error handling inbound request."
+	_errorOutbound      = "Error making outbound call."
+)
 
 // A call represents a single RPC along an edge.
 //
@@ -61,15 +67,15 @@ func (c call) EndWithAppError(err error, isApplicationError bool) {
 func (c call) endLogs(elapsed time.Duration, err error, isApplicationError bool) {
 	var ce *zapcore.CheckedEntry
 	if err == nil {
-		msg := "Handled inbound request."
+		msg := _successfulInbound
 		if c.direction != _directionInbound {
-			msg = "Made outbound call."
+			msg = _successfulOutbound
 		}
 		ce = c.edge.logger.Check(zap.DebugLevel, msg)
 	} else {
-		msg := "Error handling inbound request."
+		msg := _errorInbound
 		if c.direction != _directionInbound {
-			msg = "Error making outbound call."
+			msg = _errorOutbound
 		}
 		ce = c.edge.logger.Check(zap.ErrorLevel, msg)
 	}

--- a/internal/observability/common_test.go
+++ b/internal/observability/common_test.go
@@ -55,14 +55,15 @@ func (h fakeHandler) HandleStream(*transport.ServerStream) error {
 type fakeOutbound struct {
 	transport.Outbound
 
-	err error
+	err            error
+	applicationErr bool
 }
 
 func (o fakeOutbound) Call(context.Context, *transport.Request) (*transport.Response, error) {
 	if o.err != nil {
 		return nil, o.err
 	}
-	return &transport.Response{}, nil
+	return &transport.Response{ApplicationError: o.applicationErr}, nil
 }
 
 func (o fakeOutbound) CallOneway(context.Context, *transport.Request) (transport.Ack, error) {

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -70,13 +70,19 @@ func TestMiddlewareLogging(t *testing.T) {
 	}
 
 	tests := []struct {
-		desc           string
-		err            error // downstream error
-		applicationErr bool  // downstream application error
-		wantFields     []zapcore.Field
+		desc            string
+		err             error // downstream error
+		applicationErr  bool  // downstream application error
+		wantErrLevel    zapcore.Level
+		wantInboundMsg  string
+		wantOutboundMsg string
+		wantFields      []zapcore.Field
 	}{
 		{
-			desc: "no downstream errors",
+			desc:            "no downstream errors",
+			wantErrLevel:    zapcore.DebugLevel,
+			wantInboundMsg:  "Handled inbound request.",
+			wantOutboundMsg: "Made outbound call.",
 			wantFields: []zapcore.Field{
 				zap.Duration("latency", 0),
 				zap.Bool("successful", true),
@@ -85,8 +91,11 @@ func TestMiddlewareLogging(t *testing.T) {
 			},
 		},
 		{
-			desc: "downstream transport error",
-			err:  failed,
+			desc:            "downstream transport error",
+			err:             failed,
+			wantErrLevel:    zapcore.ErrorLevel,
+			wantInboundMsg:  "Error handling inbound request.",
+			wantOutboundMsg: "Error making outbound call.",
 			wantFields: []zapcore.Field{
 				zap.Duration("latency", 0),
 				zap.Bool("successful", false),
@@ -132,8 +141,8 @@ func TestMiddlewareLogging(t *testing.T) {
 			logContext = append(logContext, tt.wantFields...)
 			expected := observer.LoggedEntry{
 				Entry: zapcore.Entry{
-					Level:   zapcore.DebugLevel,
-					Message: "Handled inbound request.",
+					Level:   tt.wantErrLevel,
+					Message: tt.wantInboundMsg,
 				},
 				Context: logContext,
 			}
@@ -153,8 +162,8 @@ func TestMiddlewareLogging(t *testing.T) {
 			logContext = append(logContext, tt.wantFields...)
 			expected := observer.LoggedEntry{
 				Entry: zapcore.Entry{
-					Level:   zapcore.DebugLevel,
-					Message: "Made outbound call.",
+					Level:   tt.wantErrLevel,
+					Message: tt.wantOutboundMsg,
 				},
 				Context: logContext,
 			}
@@ -171,8 +180,8 @@ func TestMiddlewareLogging(t *testing.T) {
 			logContext = append(logContext, tt.wantFields...)
 			expected := observer.LoggedEntry{
 				Entry: zapcore.Entry{
-					Level:   zapcore.DebugLevel,
-					Message: "Handled inbound request.",
+					Level:   tt.wantErrLevel,
+					Message: tt.wantInboundMsg,
 				},
 				Context: logContext,
 			}
@@ -192,8 +201,8 @@ func TestMiddlewareLogging(t *testing.T) {
 			}
 			expected := observer.LoggedEntry{
 				Entry: zapcore.Entry{
-					Level:   zapcore.DebugLevel,
-					Message: "Made outbound call.",
+					Level:   tt.wantErrLevel,
+					Message: tt.wantOutboundMsg,
 				},
 				Context: logContext,
 			}
@@ -212,8 +221,8 @@ func TestMiddlewareLogging(t *testing.T) {
 			logContext = append(logContext, tt.wantFields...)
 			expected := observer.LoggedEntry{
 				Entry: zapcore.Entry{
-					Level:   zapcore.DebugLevel,
-					Message: "Handled inbound request.",
+					Level:   tt.wantErrLevel,
+					Message: tt.wantInboundMsg,
 				},
 				Context: logContext,
 			}
@@ -233,8 +242,8 @@ func TestMiddlewareLogging(t *testing.T) {
 			}
 			expected := observer.LoggedEntry{
 				Entry: zapcore.Entry{
-					Level:   zapcore.DebugLevel,
-					Message: "Made outbound call.",
+					Level:   tt.wantErrLevel,
+					Message: tt.wantOutboundMsg,
 				},
 				Context: logContext,
 			}


### PR DESCRIPTION
Changed log level to reflect error statuses. Previously all logs were logged at debug level regardless of the error status. Errors are now logged at error level.