### PR TITLE
Add simple client TLS option for gRPC

### DIFF
--- a/transport/grpc/config.go
+++ b/transport/grpc/config.go
@@ -69,6 +69,7 @@ type TransportConfig struct {
 	ServerMaxSendMsgSize int                 `config:"serverMaxSendMsgSize"`
 	ClientMaxRecvMsgSize int                 `config:"clientMaxRecvMsgSize"`
 	ClientMaxSendMsgSize int                 `config:"clientMaxSendMsgSize"`
+	ClientTLS            bool                `config:"clientTLS"`
 	Backoff              yarpcconfig.Backoff `config:"backoff"`
 }
 
@@ -141,6 +142,9 @@ func (t *transportSpec) buildTransport(transportConfig *TransportConfig, _ *yarp
 	}
 	if transportConfig.ClientMaxSendMsgSize > 0 {
 		options = append(options, ClientMaxSendMsgSize(transportConfig.ClientMaxSendMsgSize))
+	}
+	if transportConfig.ClientTLS {
+		options = append(options, ClientTLS())
 	}
 	backoffStrategy, err := transportConfig.Backoff.Strategy()
 	if err != nil {

--- a/transport/grpc/config_test.go
+++ b/transport/grpc/config_test.go
@@ -91,6 +91,7 @@ func TestTransportSpec(t *testing.T) {
 		ServerMaxSendMsgSize int
 		ClientMaxRecvMsgSize int
 		ClientMaxSendMsgSize int
+		ClientTLS            bool
 	}
 
 	type wantOutbound struct {
@@ -209,6 +210,17 @@ func TestTransportSpec(t *testing.T) {
 				ClientMaxSendMsgSize: 8192,
 			},
 		},
+		{
+			desc: "inbound and transport with client TLS",
+			transportCfg: attrs{
+				"clientTLS": true,
+			},
+			inboundCfg: attrs{"address": ":54572"},
+			wantInbound: &wantInbound{
+				Address:   ":54572",
+				ClientTLS: true,
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -268,6 +280,7 @@ func TestTransportSpec(t *testing.T) {
 				} else {
 					assert.Equal(t, defaultClientMaxSendMsgSize, inbound.t.options.clientMaxSendMsgSize)
 				}
+				assert.Equal(t, tt.wantInbound.ClientTLS, inbound.t.options.clientTLS)
 			} else {
 				assert.Len(t, cfg.Inbounds, 0)
 			}

--- a/transport/grpc/options.go
+++ b/transport/grpc/options.go
@@ -119,6 +119,15 @@ func ClientMaxSendMsgSize(clientMaxSendMsgSize int) TransportOption {
 	}
 }
 
+// ClientTLS says to use TLS with the system certificate pool on the client side.
+//
+// The default is to not use TLS.
+func ClientTLS() TransportOption {
+	return func(transportOptions *transportOptions) {
+		transportOptions.clientTLS = true
+	}
+}
+
 // InboundOption is an option for an inbound.
 type InboundOption func(*inboundOptions)
 
@@ -137,6 +146,7 @@ type transportOptions struct {
 	serverMaxSendMsgSize int
 	clientMaxRecvMsgSize int
 	clientMaxSendMsgSize int
+	clientTLS            bool
 }
 
 func newTransportOptions(options []TransportOption) *transportOptions {


### PR DESCRIPTION
This is a much simplified version of https://github.com/yarpc/yarpc-go/pull/1461 that says to use the system cert pool for client TLS. Per Jacob's comment, we might want to make it so you can optionally provide a `tls.Config`, which is possible with https://godoc.org/google.golang.org/grpc/credentials#NewTLS. I'll leave it up to @kriskowal as to how we want to expose this, but this is the absolute minimal option we can provide.