### PR TITLE
use originalItems to copy headers in transporttest

### DIFF
--- a/api/transport/transporttest/reqres.go
+++ b/api/transport/transporttest/reqres.go
@@ -215,7 +215,7 @@ func (fw *FakeResponseWriter) SetApplicationError() {
 
 // AddHeaders for FakeResponseWriter.
 func (fw *FakeResponseWriter) AddHeaders(h transport.Headers) {
-	for k, v := range h.Items() {
+	for k, v := range h.OriginalItems() {
 		fw.Headers = fw.Headers.With(k, v)
 	}
 }


### PR DESCRIPTION
Fix an issue in api/transporttest#AddHeaders where pass-in header case will be normalized to lower case during addition.
