### PR TITLE
Dispatcher: Expose configured outbounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Added method to the Dispatcher to allow reading the set of configured
-  outbounds.
+- Added `Outbounds()` on `Dispatcher` to provide access to the configured outbounds.
+
 ### Changed
 - TChannel inbounds will blackhole requests when handlers return resource
   exhausted errors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added method to the Dispatcher to allow reading the set of configured
+  outbounds.
 ### Changed
-- Added an Outbounds method to the Dispatcher to allow reading the set of configured
-  outbounds
 - TChannel inbounds will blackhole requests when handlers return resource
   exhausted errors.
 - Change log level to reflect error statuses. Previously all logs are logged at debug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
+- Added an Outbounds method to the Dispatcher to allow reading the set of configured
+  outbounds
 - TChannel inbounds will blackhole requests when handlers return resource
   exhausted errors.
 - Change log level to reflect error statuses. Previously all logs are logged at debug

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -224,6 +224,17 @@ func (d *Dispatcher) Inbounds() Inbounds {
 	return inbounds
 }
 
+// Outbounds returns a copy of the list of outbounds for this RPC object.
+func (d *Dispatcher) Outbounds() Outbounds {
+	outbounds := make(Outbounds, len(d.outbounds))
+
+	for k, v := range d.outbounds {
+		outbounds[k] = v
+	}
+
+	return outbounds
+}
+
 // ClientConfig provides the configuration needed to talk to the given
 // service through an outboundKey. This configuration may be directly
 // passed into encoding-specific RPC clients.

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -227,11 +227,9 @@ func (d *Dispatcher) Inbounds() Inbounds {
 // Outbounds returns a copy of the list of outbounds for this RPC object.
 func (d *Dispatcher) Outbounds() Outbounds {
 	outbounds := make(Outbounds, len(d.outbounds))
-
 	for k, v := range d.outbounds {
 		outbounds[k] = v
 	}
-
 	return outbounds
 }
 

--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -158,7 +158,6 @@ func TestInboundsOrderAfterStart(t *testing.T) {
 }
 
 func TestOutboundsReturnsACopy(t *testing.T) {
-
 	testService := "my-test-service"
 	d := NewDispatcher(Config{
 		Name: "test",

--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -157,6 +157,31 @@ func TestInboundsOrderAfterStart(t *testing.T) {
 	assert.NotNil(t, httpInbound.Addr(), "expected an HTTP addr")
 }
 
+func TestOutboundsReturnsACopy(t *testing.T) {
+
+	testService := "my-test-service"
+	d := NewDispatcher(Config{
+		Name: "test",
+		Outbounds: Outbounds{
+			testService: {
+				Unary: http.NewTransport().NewSingleOutbound("http://127.0.0.1:1234"),
+			},
+		},
+	})
+
+	outbounds := d.Outbounds()
+	require.Len(t, outbounds, 1, "expected one outbound")
+	assert.Contains(t, outbounds, testService, "must contain my-test-service")
+
+	// Mutate the map and verify that the next call still returns non-nil
+	// results.
+	delete(outbounds, "my-test-service")
+
+	outbounds = d.Outbounds()
+	require.Len(t, outbounds, 1, "expected one outbound")
+	assert.Contains(t, outbounds, testService, "must contain my-test-service")
+}
+
 func TestStartStopFailures(t *testing.T) {
 	tests := []struct {
 		desc string


### PR DESCRIPTION
This pull request creates an `Outbounds` method that is symmetrical with `Inbounds`.  It allows reading off all of the configured outbounds in one shot.

The intention behind this is to make it somewhat easier to read off a YARPC configuration, rather than trying to recreate it by hand when created via `yarpcfx` or some other dependency injection framework.

I suspect that this could be a potentially controversial change, and I am definitely open to alternatives (including the no-build alternative).

Thanks for taking a look,
Zach

