### PR TITLE
Add service response header matching for HTTP

### DIFF
--- a/transport/http/constants.go
+++ b/transport/http/constants.go
@@ -45,7 +45,8 @@ const (
 	ProcedureHeader = "Rpc-Procedure"
 
 	// Name of the service to which the request is being sent. This
-	// corresponds to the Request.Service attribute.
+	// corresponds to the Request.Service attribute. This header is also used
+	// in responses to ensure requests are processed by the correct service.
 	ServiceHeader = "Rpc-Service"
 
 	// Shard key used by the destined service to shard the request. This

--- a/transport/http/handler.go
+++ b/transport/http/handler.go
@@ -57,6 +57,8 @@ func (h handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	service := popHeader(req.Header, ServiceHeader)
 	procedure := popHeader(req.Header, ProcedureHeader)
 	bothResponseError := popHeader(req.Header, AcceptsBothResponseErrorHeader) == AcceptTrue
+	// add response header to echo accepted rpc-service
+	responseWriter.AddSystemHeader(ServiceHeader, service)
 	status := yarpcerrors.FromError(errors.WrapHandlerError(h.callHandler(responseWriter, req, service, procedure), service, procedure))
 	if status == nil {
 		responseWriter.Close(http.StatusOK)


### PR DESCRIPTION
This PR contains the functional code for feature described in T1525167 for HTTP.

Test code also added in outbound_test.go. Cover the case when service name match and dismatch, and the case when no service name header in response.
