### PR TITLE
Expose capacity option for pending heap peer chooser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Added `Outbounds()` on `Dispatcher` to provide access to the configured outbounds.
 - Expose capacity option to configurator for the round-robin peer chooser.
+- Expose capacity option to configurator for the fewest pending heap peer chooser.
 
 ### Changed
 - TChannel inbounds will blackhole requests when handlers return resource

--- a/peer/pendingheap/config.go
+++ b/peer/pendingheap/config.go
@@ -21,6 +21,8 @@
 package pendingheap
 
 import (
+	"fmt"
+
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/yarpcconfig"
 	"go.uber.org/yarpc/yarpcerrors"
@@ -59,7 +61,8 @@ func Spec() yarpcconfig.PeerListSpec {
 			}
 
 			if *cfg.Capacity <= 0 {
-				return nil, yarpcerrors.Newf(yarpcerrors.CodeInvalidArgument, "Capacity must be greater than 0")
+				return nil, yarpcerrors.Newf(yarpcerrors.CodeInvalidArgument,
+					fmt.Sprintf("Capacity must be greater than 0. Got: %d.", *cfg.Capacity))
 			}
 
 			return New(t, Capacity(*cfg.Capacity)), nil

--- a/peer/pendingheap/config.go
+++ b/peer/pendingheap/config.go
@@ -23,7 +23,13 @@ package pendingheap
 import (
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/yarpcconfig"
+	"go.uber.org/yarpc/yarpcerrors"
 )
+
+// Configuration descripes how to build a fewest pending heap peer list.
+type Configuration struct {
+	Capacity *int `config:"capacity"`
+}
 
 // Spec returns a configuration specification for the pending heap peer list
 // implementation, making it possible to select the least recently chosen peer
@@ -40,14 +46,23 @@ import (
 //        http:
 //          url: https://host:port/rpc
 //          fewest-pending-requests:
+//            capacity: 25
 //            peers:
 //              - 127.0.0.1:8080
 //              - 127.0.0.1:8081
 func Spec() yarpcconfig.PeerListSpec {
 	return yarpcconfig.PeerListSpec{
 		Name: "fewest-pending-requests",
-		BuildPeerList: func(c struct{}, t peer.Transport, k *yarpcconfig.Kit) (peer.ChooserList, error) {
-			return New(t), nil
+		BuildPeerList: func(cfg Configuration, t peer.Transport, k *yarpcconfig.Kit) (peer.ChooserList, error) {
+			if cfg.Capacity == nil {
+				return New(t), nil
+			}
+
+			if *cfg.Capacity <= 0 {
+				return nil, yarpcerrors.Newf(yarpcerrors.CodeInvalidArgument, "Capacity must be greater than 0")
+			}
+
+			return New(t, Capacity(*cfg.Capacity)), nil
 		},
 	}
 }

--- a/peer/pendingheap/config_test.go
+++ b/peer/pendingheap/config_test.go
@@ -73,7 +73,7 @@ func TestPendingHeapConfig(t *testing.T) {
 
 			} else {
 				require.NoError(t, err)
-				pl.Update(peer.ListUpdates{Additions: []peer.Identifier{hostport.PeerIdentifier("127.0.0.1:8080")}})
+				pl.Update(peer.ListUpdates{Additions: []peer.Identifier{hostport.PeerIdentifier("foo-host:port")}})
 			}
 		})
 	}

--- a/peer/pendingheap/list.go
+++ b/peer/pendingheap/list.go
@@ -69,10 +69,17 @@ func New(transport peer.Transport, opts ...ListOption) *List {
 			&pendingHeap{},
 			plOpts...,
 		),
+		capacity: cfg.capacity,
 	}
 }
 
 // List is a PeerList which rotates which peers are to be selected in a circle
 type List struct {
 	*peerlist.List
+	capacity int
+}
+
+// Capacity is the maximum number of peers the peer list will hold.
+func (l *List) Capacity() int {
+	return l.capacity
 }

--- a/peer/pendingheap/list_test.go
+++ b/peer/pendingheap/list_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/multierr"
 	"go.uber.org/yarpc/api/peer"
 	. "go.uber.org/yarpc/api/peer/peertest"
@@ -611,6 +612,14 @@ func TestPeerHeapList(t *testing.T) {
 			assert.Equal(t, tt.expectedRunning, pl.IsRunning(), "Peer list should match expected final running state")
 		})
 	}
+}
+
+func TestCapacity(t *testing.T) {
+	const capacity = 37
+	pl := New(nil /*transport*/, Capacity(capacity))
+
+	require.NotNil(t, pl)
+	assert.Equal(t, capacity, pl.Capacity())
 }
 
 var noShuffle ListOption = func(c *listConfig) {

--- a/yarpcconfig/chooser_test.go
+++ b/yarpcconfig/chooser_test.go
@@ -398,8 +398,9 @@ func TestChooserConfigurator(t *testing.T) {
 				outbound := c.Outbounds["their-service"]
 				unary := outbound.Unary.(*yarpctest.FakeOutbound)
 				chooser := unary.Chooser().(*peer.BoundChooser)
-				_, ok := chooser.ChooserList().(*pendingheap.List)
+				list, ok := chooser.ChooserList().(*pendingheap.List)
 				require.True(t, ok, "use pending heap")
+				require.Equal(t, 10, list.Capacity(), "expected default of 10")
 			},
 		},
 		{
@@ -417,8 +418,9 @@ func TestChooserConfigurator(t *testing.T) {
 				outbound := c.Outbounds["their-service"]
 				unary := outbound.Unary.(*yarpctest.FakeOutbound)
 				chooser := unary.Chooser().(*peer.BoundChooser)
-				_, ok := chooser.ChooserList().(*pendingheap.List)
+				list, ok := chooser.ChooserList().(*pendingheap.List)
 				require.True(t, ok, "use pending heap")
+				require.Equal(t, 50, list.Capacity())
 			},
 		},
 		{

--- a/yarpcconfig/chooser_test.go
+++ b/yarpcconfig/chooser_test.go
@@ -403,6 +403,26 @@ func TestChooserConfigurator(t *testing.T) {
 			},
 		},
 		{
+			desc: "use fewest-pending-requests chooser with capacity",
+			given: whitespace.Expand(`
+				outbounds:
+					their-service:
+						unary:
+							fake-transport:
+								fewest-pending-requests:
+									capacity: 50
+									fake-updater: {}
+			`),
+			test: func(t *testing.T, c yarpc.Config) {
+				outbound := c.Outbounds["their-service"]
+				unary := outbound.Unary.(*yarpctest.FakeOutbound)
+				chooser := unary.Chooser().(*peer.BoundChooser)
+				list, ok := chooser.ChooserList().(*pendingheap.List)
+				require.True(t, ok, "use pending heap")
+				_ = list
+			},
+		},
+		{
 			desc: "HTTP single peer implied by URL",
 			given: whitespace.Expand(`
 				outbounds:

--- a/yarpcconfig/chooser_test.go
+++ b/yarpcconfig/chooser_test.go
@@ -417,9 +417,8 @@ func TestChooserConfigurator(t *testing.T) {
 				outbound := c.Outbounds["their-service"]
 				unary := outbound.Unary.(*yarpctest.FakeOutbound)
 				chooser := unary.Chooser().(*peer.BoundChooser)
-				list, ok := chooser.ChooserList().(*pendingheap.List)
+				_, ok := chooser.ChooserList().(*pendingheap.List)
 				require.True(t, ok, "use pending heap")
-				_ = list
 			},
 		},
 		{


### PR DESCRIPTION
This change threads the existing `Capacity` option through such that
it can be used with YARPC's configurator.