### PR TITLE
Expose capacity option for round-robin peer chooser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Added `Outbounds()` on `Dispatcher` to provide access to the configured outbounds.
+- Expose capacity option to configurator for the round-robin peer chooser.
 
 ### Changed
 - TChannel inbounds will blackhole requests when handlers return resource

--- a/peer/roundrobin/config.go
+++ b/peer/roundrobin/config.go
@@ -21,6 +21,8 @@
 package roundrobin
 
 import (
+	"fmt"
+
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/yarpcconfig"
 	"go.uber.org/yarpc/yarpcerrors"
@@ -58,7 +60,8 @@ func Spec() yarpcconfig.PeerListSpec {
 			}
 
 			if *cfg.Capacity <= 0 {
-				return nil, yarpcerrors.Newf(yarpcerrors.CodeInvalidArgument, "Capacity must be greater than 0")
+				return nil, yarpcerrors.Newf(yarpcerrors.CodeInvalidArgument,
+					fmt.Sprintf("Capacity must be greater than 0. Got: %d.", *cfg.Capacity))
 			}
 
 			return New(t, Capacity(*cfg.Capacity)), nil

--- a/peer/roundrobin/config_test.go
+++ b/peer/roundrobin/config_test.go
@@ -73,7 +73,7 @@ func TestPendingHeapConfig(t *testing.T) {
 
 			} else {
 				require.NoError(t, err)
-				pl.Update(peer.ListUpdates{Additions: []peer.Identifier{hostport.PeerIdentifier("127.0.0.1:8080")}})
+				pl.Update(peer.ListUpdates{Additions: []peer.Identifier{hostport.PeerIdentifier("foo-host:port")}})
 			}
 		})
 	}

--- a/peer/roundrobin/list.go
+++ b/peer/roundrobin/list.go
@@ -74,10 +74,17 @@ func New(transport peer.Transport, opts ...ListOption) *List {
 			newPeerRing(),
 			plOpts...,
 		),
+		capacity: cfg.capacity,
 	}
 }
 
 // List is a PeerList which rotates which peers are to be selected in a circle
 type List struct {
 	*peerlist.List
+	capacity int
+}
+
+// Capacity is the maximum number of peers the peer list will hold.
+func (l *List) Capacity() int {
+	return l.capacity
 }

--- a/peer/roundrobin/list_test.go
+++ b/peer/roundrobin/list_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/multierr"
 	"go.uber.org/yarpc/api/peer"
 	. "go.uber.org/yarpc/api/peer/peertest"
@@ -920,6 +921,14 @@ func TestRoundRobinList(t *testing.T) {
 			assert.Equal(t, tt.expectedRunning, pl.IsRunning(), "List was not in the expected state")
 		})
 	}
+}
+
+func TestCapacity(t *testing.T) {
+	const capacity = 37
+	pl := New(nil /*transport*/, Capacity(capacity))
+
+	require.NotNil(t, pl)
+	assert.Equal(t, capacity, pl.Capacity())
 }
 
 func TestIntrospect(t *testing.T) {

--- a/yarpcconfig/chooser_test.go
+++ b/yarpcconfig/chooser_test.go
@@ -345,6 +345,26 @@ func TestChooserConfigurator(t *testing.T) {
 			},
 		},
 		{
+			desc: "use round-robin chooser with capacity",
+			given: whitespace.Expand(`
+				outbounds:
+					their-service:
+						unary:
+							fake-transport:
+								round-robin:
+									capacity: 50
+									fake-updater: {}
+			`),
+			test: func(t *testing.T, c yarpc.Config) {
+				outbound := c.Outbounds["their-service"]
+				unary := outbound.Unary.(*yarpctest.FakeOutbound)
+				chooser := unary.Chooser().(*peer.BoundChooser)
+				list, ok := chooser.ChooserList().(*roundrobin.List)
+				require.True(t, ok, "use round robin")
+				_ = list
+			},
+		},
+		{
 			desc: "use least-pending chooser",
 			given: whitespace.Expand(`
 				outbounds:

--- a/yarpcconfig/chooser_test.go
+++ b/yarpcconfig/chooser_test.go
@@ -359,9 +359,8 @@ func TestChooserConfigurator(t *testing.T) {
 				outbound := c.Outbounds["their-service"]
 				unary := outbound.Unary.(*yarpctest.FakeOutbound)
 				chooser := unary.Chooser().(*peer.BoundChooser)
-				list, ok := chooser.ChooserList().(*roundrobin.List)
+				_, ok := chooser.ChooserList().(*roundrobin.List)
 				require.True(t, ok, "use round robin")
-				_ = list
 			},
 		},
 		{

--- a/yarpcconfig/chooser_test.go
+++ b/yarpcconfig/chooser_test.go
@@ -341,7 +341,7 @@ func TestChooserConfigurator(t *testing.T) {
 				chooser := unary.Chooser().(*peer.BoundChooser)
 				list, ok := chooser.ChooserList().(*roundrobin.List)
 				require.True(t, ok, "use round robin")
-				_ = list
+				require.Equal(t, 10, list.Capacity(), "expected default of 10")
 			},
 		},
 		{
@@ -359,8 +359,9 @@ func TestChooserConfigurator(t *testing.T) {
 				outbound := c.Outbounds["their-service"]
 				unary := outbound.Unary.(*yarpctest.FakeOutbound)
 				chooser := unary.Chooser().(*peer.BoundChooser)
-				_, ok := chooser.ChooserList().(*roundrobin.List)
+				list, ok := chooser.ChooserList().(*roundrobin.List)
 				require.True(t, ok, "use round robin")
+				require.Equal(t, 50, list.Capacity())
 			},
 		},
 		{


### PR DESCRIPTION
This change threads the existing `Capacity` option through such that
it can be used with YARPC's configurator.