### PR TITLE
Add service response header matching for TChannel

### DIFF
--- a/internal/crossdock/internal/header.go
+++ b/internal/crossdock/internal/header.go
@@ -20,7 +20,11 @@
 
 package internal
 
+import "go.uber.org/yarpc/transport/tchannel"
+
 // RemoveVariableMapKeys removes any headers that might have been added by tracing
+// or server handler
 func RemoveVariableMapKeys(headers map[string]string) {
 	delete(headers, "$tracing$uber-trace-id")
+	delete(headers, tchannel.ServiceHeaderKey)
 }

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -95,6 +95,9 @@ func (h handler) handle(ctx context.Context, call inboundCall) {
 	// you MUST close the responseWriter no matter what unless you have a tchannel.SystemError
 	responseWriter := newResponseWriter(call.Response(), call.Format(), h.headerCase)
 
+	// echo accepted rpc-service in response header
+	responseWriter.addHeader(ServiceHeaderKey, call.ServiceName())
+
 	err := h.callHandler(ctx, call, responseWriter)
 
 	// black-hole requests on resource exhausted errors

--- a/transport/tchannel/header.go
+++ b/transport/tchannel/header.go
@@ -38,12 +38,15 @@ const (
 	ErrorNameHeaderKey = "$rpc$-error-name"
 	// ErrorMessageHeaderKey is the response header key for the error message.
 	ErrorMessageHeaderKey = "$rpc$-error-message"
+	// ServiceHeaderKey is the response header key for the respond service
+	ServiceHeaderKey = "$rpc$-service"
 )
 
 var _reservedHeaderKeys = map[string]struct{}{
 	ErrorCodeHeaderKey:    {},
 	ErrorNameHeaderKey:    {},
 	ErrorMessageHeaderKey: {},
+	ServiceHeaderKey:      {},
 }
 
 func isReservedHeaderKey(key string) bool {

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -165,6 +165,12 @@ func callWithPeer(ctx context.Context, req *transport.Request, peer *tchannel.Pe
 		return nil, err
 	}
 
+	// service name match validation, return yarpcerrors.CodeInternal error if not match
+	if match, resSvcName := checkServiceMatchAndDeleteHeaderKey(req.Service, headers); !match {
+		return nil, yarpcerrors.InternalErrorf("service name sent from the request "+
+			"does not match the service name received in the response: sent %q, got: %q", req.Service, resSvcName)
+	}
+
 	return &transport.Response{
 		Headers:          headers,
 		Body:             resBody,


### PR DESCRIPTION
This PR contains the functional code for feature described in T1525167 for TChannel.

Test code also added in outbound_test.go. Cover the case when service name match and dismatch, and the case when no service name header in response. New test cases are embedded into existed test methods.

Overall logic is similar with #1502 
