### PR TITLE
Remove capacity assertions

### DIFF
--- a/peer/pendingheap/config.go
+++ b/peer/pendingheap/config.go
@@ -48,7 +48,6 @@ type Configuration struct {
 //        http:
 //          url: https://host:port/rpc
 //          fewest-pending-requests:
-//            capacity: 25
 //            peers:
 //              - 127.0.0.1:8080
 //              - 127.0.0.1:8081

--- a/peer/pendingheap/list.go
+++ b/peer/pendingheap/list.go
@@ -69,17 +69,10 @@ func New(transport peer.Transport, opts ...ListOption) *List {
 			&pendingHeap{},
 			plOpts...,
 		),
-		capacity: cfg.capacity,
 	}
 }
 
 // List is a PeerList which rotates which peers are to be selected in a circle
 type List struct {
 	*peerlist.List
-	capacity int
-}
-
-// Capacity is the maximum number of peers the peer list will hold.
-func (l *List) Capacity() int {
-	return l.capacity
 }

--- a/peer/pendingheap/list_test.go
+++ b/peer/pendingheap/list_test.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"go.uber.org/multierr"
 	"go.uber.org/yarpc/api/peer"
 	. "go.uber.org/yarpc/api/peer/peertest"
@@ -612,14 +611,6 @@ func TestPeerHeapList(t *testing.T) {
 			assert.Equal(t, tt.expectedRunning, pl.IsRunning(), "Peer list should match expected final running state")
 		})
 	}
-}
-
-func TestCapacity(t *testing.T) {
-	const capacity = 37
-	pl := New(nil /*transport*/, Capacity(capacity))
-
-	require.NotNil(t, pl)
-	assert.Equal(t, capacity, pl.Capacity())
 }
 
 var noShuffle ListOption = func(c *listConfig) {

--- a/peer/roundrobin/list.go
+++ b/peer/roundrobin/list.go
@@ -74,17 +74,10 @@ func New(transport peer.Transport, opts ...ListOption) *List {
 			newPeerRing(),
 			plOpts...,
 		),
-		capacity: cfg.capacity,
 	}
 }
 
 // List is a PeerList which rotates which peers are to be selected in a circle
 type List struct {
 	*peerlist.List
-	capacity int
-}
-
-// Capacity is the maximum number of peers the peer list will hold.
-func (l *List) Capacity() int {
-	return l.capacity
 }

--- a/peer/roundrobin/list_test.go
+++ b/peer/roundrobin/list_test.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"go.uber.org/multierr"
 	"go.uber.org/yarpc/api/peer"
 	. "go.uber.org/yarpc/api/peer/peertest"
@@ -921,14 +920,6 @@ func TestRoundRobinList(t *testing.T) {
 			assert.Equal(t, tt.expectedRunning, pl.IsRunning(), "List was not in the expected state")
 		})
 	}
-}
-
-func TestCapacity(t *testing.T) {
-	const capacity = 37
-	pl := New(nil /*transport*/, Capacity(capacity))
-
-	require.NotNil(t, pl)
-	assert.Equal(t, capacity, pl.Capacity())
 }
 
 func TestIntrospect(t *testing.T) {

--- a/yarpcconfig/chooser_test.go
+++ b/yarpcconfig/chooser_test.go
@@ -340,9 +340,8 @@ func TestChooserConfigurator(t *testing.T) {
 				outbound := c.Outbounds["their-service"]
 				unary := outbound.Unary.(*yarpctest.FakeOutbound)
 				chooser := unary.Chooser().(*peer.BoundChooser)
-				list, ok := chooser.ChooserList().(*roundrobin.List)
+				_, ok := chooser.ChooserList().(*roundrobin.List)
 				require.True(t, ok, "use round robin")
-				require.Equal(t, 10, list.Capacity(), "expected default of 10")
 			},
 		},
 		{
@@ -360,9 +359,8 @@ func TestChooserConfigurator(t *testing.T) {
 				outbound := c.Outbounds["their-service"]
 				unary := outbound.Unary.(*yarpctest.FakeOutbound)
 				chooser := unary.Chooser().(*peer.BoundChooser)
-				list, ok := chooser.ChooserList().(*roundrobin.List)
+				_, ok := chooser.ChooserList().(*roundrobin.List)
 				require.True(t, ok, "use round robin")
-				require.Equal(t, 50, list.Capacity())
 			},
 		},
 		{
@@ -398,9 +396,8 @@ func TestChooserConfigurator(t *testing.T) {
 				outbound := c.Outbounds["their-service"]
 				unary := outbound.Unary.(*yarpctest.FakeOutbound)
 				chooser := unary.Chooser().(*peer.BoundChooser)
-				list, ok := chooser.ChooserList().(*pendingheap.List)
+				_, ok := chooser.ChooserList().(*pendingheap.List)
 				require.True(t, ok, "use pending heap")
-				require.Equal(t, 10, list.Capacity(), "expected default of 10")
 			},
 		},
 		{
@@ -418,9 +415,8 @@ func TestChooserConfigurator(t *testing.T) {
 				outbound := c.Outbounds["their-service"]
 				unary := outbound.Unary.(*yarpctest.FakeOutbound)
 				chooser := unary.Chooser().(*peer.BoundChooser)
-				list, ok := chooser.ChooserList().(*pendingheap.List)
+				_, ok := chooser.ChooserList().(*pendingheap.List)
 				require.True(t, ok, "use pending heap")
-				require.Equal(t, 50, list.Capacity())
 			},
 		},
 		{


### PR DESCRIPTION
This walks back a minor part of a change I just landed. Since the
`Capacity` option is only setting the *initial* capacity of peer
lists, this method is fairly usesless. This is especially true as the
underlying structures freely expand as necessary.

This function was initially exposed for testing assertions outside of
the respective peer list packages. However, this will likely cause
confusion among users.

This preserves the behaviour exposed in #1505 and #1506.
