### PR TITLE
[WIP] Add additional transport headers to request and response

### DIFF
--- a/api/transport/request.go
+++ b/api/transport/request.go
@@ -31,6 +31,23 @@ import (
 
 // Request is the low level request representation.
 type Request struct {
+	// ID is a unique identifier for a request/response pair. This MAY be a
+	// trace ID or UUID.
+	//
+	// This MAY be set by transports or middleware.
+	ID string
+
+	// Host is the name of the server issuing this request.
+	//
+	// It MAY be set by a an environment-aware middleware.
+	Host string
+
+	// Environment is the name of the host environment that the request was
+	// issued from. eg "staging", "production"
+	//
+	// It MAY be set by a an environment-aware middleware.
+	Environment string
+
 	// Name of the service making the request.
 	Caller string
 

--- a/api/transport/response.go
+++ b/api/transport/response.go
@@ -24,6 +24,27 @@ import "io"
 
 // Response is the low level response representation.
 type Response struct {
+	// ID is a unique identifier for a request/response pair. This MAY be a
+	// trace ID or UUID.
+	//
+	// If the corresponding transport.Request struct has this field set, this
+	// field MUST also be set.
+	ID string
+
+	// Service is the name of the responding service.
+	Service string
+
+	// Host is the name of the server responding with this reponse.
+	//
+	// It MAY be set by a an environment-aware middleware.
+	Host string
+
+	// Environment is the name of the host environment that the request was
+	// issued from. eg "staging", "production"
+	//
+	// It MAY be set by a an environment-aware middleware.
+	Environment string
+
 	Headers          Headers
 	Body             io.ReadCloser
 	ApplicationError bool

--- a/api/transport/transporttest/reqres.go
+++ b/api/transport/transporttest/reqres.go
@@ -73,6 +73,21 @@ func (m RequestMatcher) Matches(got interface{}) bool {
 		panic(fmt.Sprintf("expected *transport.Request, got %v", got))
 	}
 
+	if l.ID != r.ID {
+		m.t.Logf("ID mismatch: %s != %s", l.ID, r.ID)
+		return false
+	}
+
+	if l.Host != r.Host {
+		m.t.Logf("Host mismatch: %s != %s", l.Host, r.Host)
+		return false
+	}
+
+	if l.Environment != r.Environment {
+		m.t.Logf("Environment mismatch: %s != %s", l.Environment, r.Environment)
+		return false
+	}
+
 	if l.Caller != r.Caller {
 		m.t.Logf("Caller mismatch: %s != %s", l.Caller, r.Caller)
 		return false


### PR DESCRIPTION
This change adds additional headers to the `transport.Request` and
`transport.Response` structs. This change will help consolidate
transport header validation in a follow up change; service name and
request ID matching validation can be moved to the validator outbound
for instance.

This is a WIP since threading the request information needs to take place
in a few places still (ie call context, request meta).

Relates to T1860945

- [ ] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [ ] Entry in CHANGELOG.md
