### PR TITLE
[WIP] Add per-request uuid for gRPC, http, tchannel

### DIFF
--- a/api/transport/request.go
+++ b/api/transport/request.go
@@ -25,12 +25,16 @@ import (
 	"io"
 	"strings"
 
+	"github.com/satori/go.uuid"
 	"go.uber.org/yarpc/yarpcerrors"
 	"go.uber.org/zap/zapcore"
 )
 
 // Request is the low level request representation.
 type Request struct {
+	// UUID of the request, this field will be random generated
+	UUID uuid.UUID
+
 	// Name of the service making the request.
 	Caller string
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: a42f2c917dbbdb0ebc3052a09ba38d91eb37088d5ba2be498c8e8399d7663dd5
-updated: 2018-06-27T15:05:20.495389762Z
+hash: 30d26e4ffb4dd8a5dd9fde7b5aa4e7c22aa81884ad788889dda422a99e788e95
+updated: 2018-06-27T18:46:05.376580457-07:00
 imports:
 - name: github.com/apache/thrift
   version: 53dd39833a08ce33582e5ff31fa18bb4735d6731
@@ -171,7 +171,7 @@ imports:
   - zapcore
   - zaptest/observer
 - name: golang.org/x/net
-  version: afe8f62b1d6bbd81f31868121a50b06d8188e1f9
+  version: 9ef9f5bb98a1fdc41f8cf6c250a4404b4085e389
   repo: https://github.com/golang/net
   subpackages:
   - bpf
@@ -243,6 +243,8 @@ testImports:
   version: 55d8f507faff4d6eddd0c41a3e713e2567fca4e5
 - name: github.com/kisielk/gotool
   version: 80517062f582ea3340cd4baf70e86d539ae7d84d
+- name: github.com/satori/go.uuid
+  version: f58768cc1a7a7e77a3bd49e98cdd21419399b6a3
 - name: github.com/uber/jaeger-lib
   version: ed3a127ec5fef7ae9ea95b01b542c47fbd999ce5
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -76,3 +76,5 @@ testImport:
   subpackages:
   - cmd/staticcheck
 - package: github.com/stretchr/testify
+- package: github.com/satori/go.uuid
+  version: ^1.1.0

--- a/internal/crossdock/internal/header.go
+++ b/internal/crossdock/internal/header.go
@@ -27,4 +27,5 @@ import "go.uber.org/yarpc/transport/tchannel"
 func RemoveVariableMapKeys(headers map[string]string) {
 	delete(headers, "$tracing$uber-trace-id")
 	delete(headers, tchannel.ServiceHeaderKey)
+	delete(headers, tchannel.RequestUUIDHeaderKey)
 }

--- a/transport/grpc/handler.go
+++ b/transport/grpc/handler.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/opentracing/opentracing-go"
+	"github.com/satori/go.uuid"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/bufferpool"
@@ -177,6 +178,10 @@ func (h *handler) handleUnary(
 
 	// Echo accepted rpc-service in response header
 	responseWriter.AddSystemHeader(ServiceHeader, transportRequest.Service)
+	if !uuid.Equal(transportRequest.UUID, uuid.Nil) {
+		// Echo accepted request's uuid
+		responseWriter.AddSystemHeader(RequestUUIDHeader, transportRequest.UUID.String())
+	}
 
 	err := h.handleUnaryBeforeErrorConversion(ctx, transportRequest, responseWriter, start, handler)
 	err = handlerErrorToGRPCError(err, responseWriter)

--- a/transport/http/constants.go
+++ b/transport/http/constants.go
@@ -49,6 +49,10 @@ const (
 	// in responses to ensure requests are processed by the correct service.
 	ServiceHeader = "Rpc-Service"
 
+	// UUID associated with each request. Echo this header on the response
+	// ensures it sent to correct client
+	RequestUUIDHeader = "Rpc-Request-UUID"
+
 	// Shard key used by the destined service to shard the request. This
 	// corresponds to the Request.ShardKey attribute.
 	ShardKeyHeader = "Rpc-Shard-Key"

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -156,6 +156,11 @@ func (h handler) callHandler(ctx context.Context, call inboundCall, responseWrit
 	}
 	treq.Headers = headers
 
+	// echo request uuid if it exists
+	if uuid, ok := treq.Headers.Get(RequestUUIDHeaderKey); ok {
+		responseWriter.addHeader(RequestUUIDHeaderKey, uuid)
+	}
+
 	if tcall, ok := call.(tchannelCall); ok {
 		tracer := h.tracer
 		ctx = tchannel.ExtractInboundSpan(ctx, tcall.InboundCall, headers.Items(), tracer)

--- a/transport/tchannel/header.go
+++ b/transport/tchannel/header.go
@@ -40,6 +40,8 @@ const (
 	ErrorMessageHeaderKey = "$rpc$-error-message"
 	// ServiceHeaderKey is the response header key for the respond service
 	ServiceHeaderKey = "$rpc$-service"
+	// Per-request uuid header
+	RequestUUIDHeaderKey = "$rpc$-request-uuid"
 )
 
 var _reservedHeaderKeys = map[string]struct{}{
@@ -47,6 +49,7 @@ var _reservedHeaderKeys = map[string]struct{}{
 	ErrorNameHeaderKey:    {},
 	ErrorMessageHeaderKey: {},
 	ServiceHeaderKey:      {},
+	RequestUUIDHeaderKey:  {},
 }
 
 func isReservedHeaderKey(key string) bool {


### PR DESCRIPTION
building failure is expected.

TODO:
1. Good implementation of Tchannel UUID. This version just append UUID as normal `Headers`, other methods may need changes in `tchannel-go` or add support in `yarpc`.
2. Tchannel UUID tests. Currently, multiple tests failed because we add UUID as normal Headers but this header should be reserved. Request for suggestions of work arounds. 
3. Style and conflicts.

Changes:
1. Add a uuid field in transport.Request. 
2.Generate a new random uuid instead of using trace ID for each incoming request in transport outbound.
3. Echo the request uuid in transport inbound if uuid field is not nil. 
4. Do validation in outbound, return error if not match.

Tests:
1. Tests for gRPC
2. Tests for http.

