### PR TITLE
Thread 'Transport' field through call stack and tests

### DIFF
--- a/api/encoding/call.go
+++ b/api/encoding/call.go
@@ -75,6 +75,14 @@ func (c *Call) Service() string {
 	return c.ic.req.Service
 }
 
+// Transport returns the name of the transport being called.
+func (c *Call) Transport() string {
+	if c == nil {
+		return ""
+	}
+	return c.ic.req.Transport
+}
+
 // Procedure returns the name of the procedure being called.
 func (c *Call) Procedure() string {
 	if c == nil {

--- a/api/encoding/call_test.go
+++ b/api/encoding/call_test.go
@@ -35,6 +35,7 @@ func TestNilCall(t *testing.T) {
 
 	assert.Equal(t, "", call.Caller())
 	assert.Equal(t, "", call.Service())
+	assert.Equal(t, "", call.Transport())
 	assert.Equal(t, "", string(call.Encoding()))
 	assert.Equal(t, "", call.Procedure())
 	assert.Equal(t, "", call.ShardKey())
@@ -50,6 +51,7 @@ func TestReadFromRequest(t *testing.T) {
 	ctx, icall := NewInboundCall(context.Background())
 	icall.ReadFromRequest(&transport.Request{
 		Service:         "service",
+		Transport:       "transport",
 		Caller:          "caller",
 		Encoding:        transport.Encoding("raw"),
 		Procedure:       "proc",
@@ -63,6 +65,7 @@ func TestReadFromRequest(t *testing.T) {
 
 	assert.Equal(t, "caller", call.Caller())
 	assert.Equal(t, "service", call.Service())
+	assert.Equal(t, "transport", call.Transport())
 	assert.Equal(t, "raw", string(call.Encoding()))
 	assert.Equal(t, "proc", call.Procedure())
 	assert.Equal(t, "sk", call.ShardKey())
@@ -81,6 +84,7 @@ func TestReadFromRequestMeta(t *testing.T) {
 	icall.ReadFromRequestMeta(&transport.RequestMeta{
 		Service:         "service",
 		Caller:          "caller",
+		Transport:       "transport",
 		Encoding:        transport.Encoding("raw"),
 		Procedure:       "proc",
 		ShardKey:        "sk",
@@ -93,6 +97,7 @@ func TestReadFromRequestMeta(t *testing.T) {
 
 	assert.Equal(t, "caller", call.Caller())
 	assert.Equal(t, "service", call.Service())
+	assert.Equal(t, "transport", call.Transport())
 	assert.Equal(t, "raw", string(call.Encoding()))
 	assert.Equal(t, "proc", call.Procedure())
 	assert.Equal(t, "sk", call.ShardKey())
@@ -110,6 +115,7 @@ func TestDisabledResponseHeaders(t *testing.T) {
 	ctx, icall := NewInboundCallWithOptions(context.Background(), DisableResponseHeaders())
 	icall.ReadFromRequest(&transport.Request{
 		Service:         "service",
+		Transport:       "transport",
 		Caller:          "caller",
 		Encoding:        transport.Encoding("raw"),
 		Procedure:       "proc",
@@ -123,6 +129,7 @@ func TestDisabledResponseHeaders(t *testing.T) {
 
 	assert.Equal(t, "caller", call.Caller())
 	assert.Equal(t, "service", call.Service())
+	assert.Equal(t, "transport", call.Transport())
 	assert.Equal(t, "raw", string(call.Encoding()))
 	assert.Equal(t, "proc", call.Procedure())
 	assert.Equal(t, "sk", call.ShardKey())

--- a/api/transport/request.go
+++ b/api/transport/request.go
@@ -38,7 +38,7 @@ type Request struct {
 	// The service refers to the canonical traffic group for the service.
 	Service string
 
-	// Name of the transport used for the call
+	// Name of the transport used for the call.
 	Transport string
 
 	// Name of the encoding used for the request body.
@@ -88,6 +88,7 @@ func (r *Request) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	// TODO (#788): Include headers once we can omit PII.
 	enc.AddString("caller", r.Caller)
 	enc.AddString("service", r.Service)
+	enc.AddString("transport", r.Transport)
 	enc.AddString("encoding", string(r.Encoding))
 	enc.AddString("procedure", r.Procedure)
 	enc.AddString("shardKey", r.ShardKey)
@@ -158,7 +159,7 @@ type RequestMeta struct {
 	// The service refers to the canonical traffic group for the service.
 	Service string
 
-	// Name of the transport used for the call
+	// Name of the transport used for the call.
 	Transport string
 
 	// Name of the encoding used for the request body.

--- a/api/transport/request_test.go
+++ b/api/transport/request_test.go
@@ -129,6 +129,7 @@ func TestRequestLogMarshaling(t *testing.T) {
 	r := &transport.Request{
 		Caller:          "caller",
 		Service:         "service",
+		Transport:       "transport",
 		Encoding:        "raw",
 		Procedure:       "procedure",
 		Headers:         transport.NewHeaders().With("password", "super-secret"),
@@ -142,6 +143,7 @@ func TestRequestLogMarshaling(t *testing.T) {
 	assert.Equal(t, map[string]interface{}{
 		"caller":          "caller",
 		"service":         "service",
+		"transport":       "transport",
 		"encoding":        "raw",
 		"procedure":       "procedure",
 		"shardKey":        "shard01",
@@ -154,6 +156,7 @@ func TestRequestMetaToRequestConversionAndBack(t *testing.T) {
 	reqMeta := &transport.RequestMeta{
 		Caller:          "caller",
 		Service:         "service",
+		Transport:       "transport",
 		Encoding:        "raw",
 		Procedure:       "hello",
 		Headers:         transport.NewHeaders().With("key", "val"),

--- a/api/transport/transporttest/reqres.go
+++ b/api/transport/transporttest/reqres.go
@@ -83,6 +83,11 @@ func (m RequestMatcher) Matches(got interface{}) bool {
 		return false
 	}
 
+	if l.Transport != r.Transport {
+		m.t.Logf("Transport mismatch: %s != %s", l.Transport, r.Transport)
+		return false
+	}
+
 	if l.Encoding != r.Encoding {
 		m.t.Logf("Encoding mismatch: %s != %s", l.Service, r.Service)
 		return false

--- a/call.go
+++ b/call.go
@@ -119,6 +119,11 @@ func (c *Call) Service() string {
 	return (*encoding.Call)(c).Service()
 }
 
+// Transport returns the name of the transport being called.
+func (c *Call) Transport() string {
+	return (*encoding.Call)(c).Transport()
+}
+
 // Procedure returns the name of the procedure being called.
 func (c *Call) Procedure() string {
 	return (*encoding.Call)(c).Procedure()

--- a/call_test.go
+++ b/call_test.go
@@ -55,6 +55,7 @@ func TestCallFromContext(t *testing.T) {
 		&transport.Request{
 			Caller:          "foo",
 			Service:         "bar",
+			Transport:       "trans",
 			Encoding:        transport.Encoding("baz"),
 			Procedure:       "hello",
 			Headers:         transport.NewHeaders().With("foo", "bar"),
@@ -67,6 +68,7 @@ func TestCallFromContext(t *testing.T) {
 	call := yarpc.CallFromContext(ctx)
 	assert.Equal(t, "foo", call.Caller())
 	assert.Equal(t, "bar", call.Service())
+	assert.Equal(t, "trans", call.Transport())
 	assert.Equal(t, transport.Encoding("baz"), call.Encoding())
 	assert.Equal(t, "hello", call.Procedure())
 	assert.Equal(t, "bar", call.Header("foo"))

--- a/transport/http/handler_test.go
+++ b/transport/http/handler_test.go
@@ -73,6 +73,7 @@ func TestHandlerSuccess(t *testing.T) {
 			t, &transport.Request{
 				Caller:          "moe",
 				Service:         "curly",
+				Transport:       "http",
 				Encoding:        raw.Encoding,
 				Procedure:       "nyuck",
 				ShardKey:        "shard",
@@ -170,6 +171,7 @@ func TestHandlerHeaders(t *testing.T) {
 				&transport.Request{
 					Caller:    "caller",
 					Service:   "service",
+					Transport: "http",
 					Encoding:  transport.Encoding(tt.giveEncoding),
 					Procedure: "hello",
 					Headers:   transport.HeadersFromMap(tt.wantHeaders),
@@ -328,6 +330,7 @@ func TestHandlerInternalFailure(t *testing.T) {
 			t, &transport.Request{
 				Caller:    "somecaller",
 				Service:   "fake",
+				Transport: "http",
 				Encoding:  raw.Encoding,
 				Procedure: "hello",
 				Body:      bytes.NewReader([]byte{}),

--- a/transport/tchannel/handler_test.go
+++ b/transport/tchannel/handler_test.go
@@ -85,6 +85,7 @@ func TestHandlerErrors(t *testing.T) {
 				&transport.Request{
 					Caller:          "caller",
 					Service:         "service",
+					Transport:       "tchannel",
 					Headers:         transport.HeadersFromMap(tt.wantHeaders),
 					Encoding:        transport.Encoding(tt.format),
 					Procedure:       "hello",
@@ -196,6 +197,7 @@ func TestHandlerFailures(t *testing.T) {
 						t, &transport.Request{
 							Caller:    "bar",
 							Service:   "foo",
+							Transport: "tchannel",
 							Encoding:  raw.Encoding,
 							Procedure: "hello",
 							Body:      bytes.NewReader([]byte{0x00}),
@@ -219,6 +221,7 @@ func TestHandlerFailures(t *testing.T) {
 				req := &transport.Request{
 					Caller:    "bar",
 					Service:   "foo",
+					Transport: "tchannel",
 					Encoding:  json.Encoding,
 					Procedure: "hello",
 					Body:      bytes.NewReader([]byte("{}")),
@@ -249,10 +252,11 @@ func TestHandlerFailures(t *testing.T) {
 			},
 			expectCall: func(h *transporttest.MockUnaryHandler) {
 				req := &transport.Request{
-					Service:   "foo",
 					Caller:    "bar",
-					Procedure: "waituntiltimeout",
+					Service:   "foo",
+					Transport: "tchannel",
 					Encoding:  raw.Encoding,
+					Procedure: "waituntiltimeout",
 					Body:      bytes.NewReader([]byte{0x00}),
 				}
 				h.EXPECT().Handle(
@@ -278,10 +282,11 @@ func TestHandlerFailures(t *testing.T) {
 			},
 			expectCall: func(h *transporttest.MockUnaryHandler) {
 				req := &transport.Request{
-					Service:   "foo",
 					Caller:    "bar",
-					Procedure: "panic",
+					Service:   "foo",
+					Transport: "tchannel",
 					Encoding:  raw.Encoding,
+					Procedure: "panic",
 					Body:      bytes.NewReader([]byte{0x00}),
 				}
 				h.EXPECT().Handle(


### PR DESCRIPTION
This finishes threading the `Transport` field on `transport.Request`
through call stack and testing structs. It enables the field to be 
marshaled into logs and exposes it in the `encoding.Call` struct.

Noticed while finishing up #1515.