### PR TITLE
Add transport headers to `transport.Request`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet
+### Added
+- Additional transport headers were added to `transport.Request`: `ID`, `Host`
+  and `Environment`.
 
 ## [1.31.0] - 2018-07-09
 ### Added

--- a/api/encoding/call.go
+++ b/api/encoding/call.go
@@ -59,6 +59,30 @@ func (c *Call) WriteResponseHeader(k, v string) error {
 	return nil
 }
 
+// ID returns the ID for the request.
+func (c *Call) ID() string {
+	if c == nil {
+		return ""
+	}
+	return c.ic.req.ID
+}
+
+// Host returns the name of the sever making this request.
+func (c *Call) Host() string {
+	if c == nil {
+		return ""
+	}
+	return c.ic.req.Host
+}
+
+// Environment returns the environment this request was made in.
+func (c *Call) Environment() string {
+	if c == nil {
+		return ""
+	}
+	return c.ic.req.Environment
+}
+
 // Caller returns the name of the service making this request.
 func (c *Call) Caller() string {
 	if c == nil {

--- a/api/encoding/call_test.go
+++ b/api/encoding/call_test.go
@@ -33,6 +33,9 @@ func TestNilCall(t *testing.T) {
 	call := CallFromContext(context.Background())
 	require.Nil(t, call)
 
+	assert.Equal(t, "", call.ID())
+	assert.Equal(t, "", call.Host())
+	assert.Equal(t, "", call.Environment())
 	assert.Equal(t, "", call.Caller())
 	assert.Equal(t, "", call.Service())
 	assert.Equal(t, "", call.Transport())
@@ -50,6 +53,9 @@ func TestNilCall(t *testing.T) {
 func TestReadFromRequest(t *testing.T) {
 	ctx, icall := NewInboundCall(context.Background())
 	icall.ReadFromRequest(&transport.Request{
+		ID:              "id",
+		Host:            "host-name",
+		Environment:     "env",
 		Service:         "service",
 		Transport:       "transport",
 		Caller:          "caller",
@@ -63,6 +69,9 @@ func TestReadFromRequest(t *testing.T) {
 	call := CallFromContext(ctx)
 	require.NotNil(t, call)
 
+	assert.Equal(t, "id", call.ID())
+	assert.Equal(t, "host-name", call.Host())
+	assert.Equal(t, "env", call.Environment())
 	assert.Equal(t, "caller", call.Caller())
 	assert.Equal(t, "service", call.Service())
 	assert.Equal(t, "transport", call.Transport())
@@ -82,8 +91,11 @@ func TestReadFromRequest(t *testing.T) {
 func TestReadFromRequestMeta(t *testing.T) {
 	ctx, icall := NewInboundCall(context.Background())
 	icall.ReadFromRequestMeta(&transport.RequestMeta{
-		Service:         "service",
+		ID:              "id",
+		Host:            "host-name",
+		Environment:     "env",
 		Caller:          "caller",
+		Service:         "service",
 		Transport:       "transport",
 		Encoding:        transport.Encoding("raw"),
 		Procedure:       "proc",
@@ -95,6 +107,9 @@ func TestReadFromRequestMeta(t *testing.T) {
 	call := CallFromContext(ctx)
 	require.NotNil(t, call)
 
+	assert.Equal(t, "id", call.ID())
+	assert.Equal(t, "host-name", call.Host())
+	assert.Equal(t, "env", call.Environment())
 	assert.Equal(t, "caller", call.Caller())
 	assert.Equal(t, "service", call.Service())
 	assert.Equal(t, "transport", call.Transport())
@@ -114,6 +129,9 @@ func TestReadFromRequestMeta(t *testing.T) {
 func TestDisabledResponseHeaders(t *testing.T) {
 	ctx, icall := NewInboundCallWithOptions(context.Background(), DisableResponseHeaders())
 	icall.ReadFromRequest(&transport.Request{
+		ID:              "id",
+		Host:            "host-name",
+		Environment:     "env",
 		Service:         "service",
 		Transport:       "transport",
 		Caller:          "caller",
@@ -127,6 +145,9 @@ func TestDisabledResponseHeaders(t *testing.T) {
 	call := CallFromContext(ctx)
 	require.NotNil(t, call)
 
+	assert.Equal(t, "id", call.ID())
+	assert.Equal(t, "host-name", call.Host())
+	assert.Equal(t, "env", call.Environment())
 	assert.Equal(t, "caller", call.Caller())
 	assert.Equal(t, "service", call.Service())
 	assert.Equal(t, "transport", call.Transport())

--- a/api/transport/request.go
+++ b/api/transport/request.go
@@ -31,6 +31,23 @@ import (
 
 // Request is the low level request representation.
 type Request struct {
+	// ID for a request/response pair as chosen by the client. This MAY be a
+	// trace ID or UUID.
+	//
+	// This MAY be set by transports or middleware.
+	ID string
+
+	// Host is the name of the server issuing this request.
+	//
+	// It MAY be set by a an environment-aware middleware.
+	Host string
+
+	// Environment is the name of the host environment that the request was
+	// issued from. eg "staging", "production"
+	//
+	// It MAY be set by a an environment-aware middleware.
+	Environment string
+
 	// Name of the service making the request.
 	Caller string
 
@@ -71,6 +88,9 @@ type Request struct {
 // ToRequestMeta converts a Request into a RequestMeta.
 func (r *Request) ToRequestMeta() *RequestMeta {
 	return &RequestMeta{
+		ID:              r.ID,
+		Host:            r.Host,
+		Environment:     r.Environment,
 		Caller:          r.Caller,
 		Service:         r.Service,
 		Transport:       r.Transport,
@@ -86,6 +106,9 @@ func (r *Request) ToRequestMeta() *RequestMeta {
 // MarshalLogObject implements zap.ObjectMarshaler.
 func (r *Request) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	// TODO (#788): Include headers once we can omit PII.
+	enc.AddString("id", r.ID)
+	enc.AddString("host", r.Host)
+	enc.AddString("environment", r.Environment)
 	enc.AddString("caller", r.Caller)
 	enc.AddString("service", r.Service)
 	enc.AddString("transport", r.Transport)
@@ -152,6 +175,23 @@ func ValidateRequestContext(ctx context.Context) error {
 // include any "body" information, and should only be used for information about
 // a connection's metadata.
 type RequestMeta struct {
+	// ID is a unique identifier for a request/response pair. This MAY be a
+	// trace ID or UUID.
+	//
+	// This MAY be set by transports or middleware.
+	ID string
+
+	// Host is the name of the server issuing this request.
+	//
+	// It MAY be set by a an environment-aware middleware.
+	Host string
+
+	// Environment is the name of the host environment that the request was
+	// issued from. eg "staging", "production"
+	//
+	// It MAY be set by a an environment-aware middleware.
+	Environment string
+
 	// Name of the service making the request.
 	Caller string
 
@@ -192,6 +232,9 @@ func (r *RequestMeta) ToRequest() *Request {
 		return &Request{}
 	}
 	return &Request{
+		ID:              r.ID,
+		Host:            r.Host,
+		Environment:     r.Environment,
 		Caller:          r.Caller,
 		Service:         r.Service,
 		Transport:       r.Transport,

--- a/api/transport/request_test.go
+++ b/api/transport/request_test.go
@@ -127,6 +127,9 @@ func TestValidator(t *testing.T) {
 
 func TestRequestLogMarshaling(t *testing.T) {
 	r := &transport.Request{
+		ID:              "id",
+		Host:            "host",
+		Environment:     "environment",
 		Caller:          "caller",
 		Service:         "service",
 		Transport:       "transport",
@@ -141,6 +144,9 @@ func TestRequestLogMarshaling(t *testing.T) {
 	enc := zapcore.NewMapObjectEncoder()
 	assert.NoError(t, r.MarshalLogObject(enc), "Unexpected error marshaling request.")
 	assert.Equal(t, map[string]interface{}{
+		"id":              "id",
+		"host":            "host",
+		"environment":     "environment",
 		"caller":          "caller",
 		"service":         "service",
 		"transport":       "transport",
@@ -154,6 +160,9 @@ func TestRequestLogMarshaling(t *testing.T) {
 
 func TestRequestMetaToRequestConversionAndBack(t *testing.T) {
 	reqMeta := &transport.RequestMeta{
+		ID:              "id",
+		Host:            "host",
+		Environment:     "environment",
 		Caller:          "caller",
 		Service:         "service",
 		Transport:       "transport",

--- a/api/transport/transporttest/reqres.go
+++ b/api/transport/transporttest/reqres.go
@@ -73,6 +73,21 @@ func (m RequestMatcher) Matches(got interface{}) bool {
 		panic(fmt.Sprintf("expected *transport.Request, got %v", got))
 	}
 
+	if l.ID != r.ID {
+		m.t.Logf("ID mismatch: %s != %s", l.ID, r.ID)
+		return false
+	}
+
+	if l.Host != r.Host {
+		m.t.Logf("Host mismatch: %s != %s", l.Host, r.Host)
+		return false
+	}
+
+	if l.Environment != r.Environment {
+		m.t.Logf("Environment mismatch: %s != %s", l.Environment, r.Environment)
+		return false
+	}
+
 	if l.Caller != r.Caller {
 		m.t.Logf("Caller mismatch: %s != %s", l.Caller, r.Caller)
 		return false

--- a/api/transport/transporttest/reqres_test.go
+++ b/api/transport/transporttest/reqres_test.go
@@ -1,0 +1,228 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package transporttest
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/api/transport"
+)
+
+func TestRequestMatcher(t *testing.T) {
+	resMatcher := NewRequestMatcher(t, &transport.Request{
+		ID:              "id",
+		Host:            "host-name",
+		Environment:     "testing",
+		Caller:          "caller",
+		Service:         "service-name",
+		Transport:       "transport",
+		Encoding:        "encoding",
+		Procedure:       "procedure",
+		Headers:         transport.NewHeaders().With("foo", "bar"),
+		ShardKey:        "shardkey",
+		RoutingKey:      "routingkey",
+		RoutingDelegate: "routingdelegate",
+		Body:            ioutil.NopCloser(bytes.NewReader([]byte("my body"))),
+	})
+
+	t.Run("non-request", func(t *testing.T) {
+		require.Panics(t, func() {
+			resMatcher.Matches(&transport.Response{})
+		})
+	})
+
+	t.Run("ID mismatch", func(t *testing.T) {
+		require.False(t, resMatcher.Matches(&transport.Request{
+			ID: "wrong id",
+		}))
+	})
+
+	t.Run("Host mismatch", func(t *testing.T) {
+		require.False(t, resMatcher.Matches(&transport.Request{
+			ID:   "id",
+			Host: "wrong host-name",
+		}))
+	})
+
+	t.Run("Environment mismatch", func(t *testing.T) {
+		require.False(t, resMatcher.Matches(&transport.Request{
+			ID:          "id",
+			Host:        "host-name",
+			Environment: "wrong env",
+		}))
+	})
+
+	t.Run("Caller mismatch", func(t *testing.T) {
+		require.False(t, resMatcher.Matches(&transport.Request{
+			ID:          "id",
+			Host:        "host-name",
+			Environment: "testing",
+			Caller:      "wrong-caller",
+		}))
+	})
+
+	t.Run("Service mismatch", func(t *testing.T) {
+		require.False(t, resMatcher.Matches(&transport.Request{
+			ID:          "id",
+			Host:        "host-name",
+			Environment: "testing",
+			Caller:      "caller",
+			Service:     "wrong service-name",
+		}))
+	})
+
+	t.Run("Transport mismatch", func(t *testing.T) {
+		require.False(t, resMatcher.Matches(&transport.Request{
+			ID:          "id",
+			Host:        "host-name",
+			Environment: "testing",
+			Caller:      "caller",
+			Service:     "service-name",
+			Transport:   "wrong transport",
+		}))
+	})
+
+	t.Run("Encoding mismatch", func(t *testing.T) {
+		require.False(t, resMatcher.Matches(&transport.Request{
+			ID:          "id",
+			Host:        "host-name",
+			Environment: "testing",
+			Caller:      "caller",
+			Service:     "service-name",
+			Transport:   "transport",
+			Encoding:    "wrong encoding",
+		}))
+	})
+
+	t.Run("Procedure mismatch", func(t *testing.T) {
+		require.False(t, resMatcher.Matches(&transport.Request{
+			ID:          "id",
+			Host:        "host-name",
+			Environment: "testing",
+			Caller:      "caller",
+			Service:     "service-name",
+			Transport:   "transport",
+			Encoding:    "encoding",
+			Procedure:   "wrong procedure",
+		}))
+	})
+
+	t.Run("Headers mismatch", func(t *testing.T) {
+		require.False(t, resMatcher.Matches(&transport.Request{
+			ID:          "id",
+			Host:        "host-name",
+			Environment: "testing",
+			Caller:      "caller",
+			Service:     "service-name",
+			Transport:   "transport",
+			Encoding:    "encoding",
+			Procedure:   "procedure",
+			Headers:     transport.NewHeaders().With("foo", "wrong"),
+		}))
+	})
+
+	t.Run("ShardKey mismatch", func(t *testing.T) {
+		require.False(t, resMatcher.Matches(&transport.Request{
+			ID:          "id",
+			Host:        "host-name",
+			Environment: "testing",
+			Caller:      "caller",
+			Service:     "service-name",
+			Transport:   "transport",
+			Encoding:    "encoding",
+			Procedure:   "procedure",
+			Headers:     transport.NewHeaders().With("foo", "bar"),
+			ShardKey:    "wrong shardkey",
+		}))
+	})
+
+	t.Run("RoutingKey mismatch", func(t *testing.T) {
+		require.False(t, resMatcher.Matches(&transport.Request{
+			ID:          "id",
+			Host:        "host-name",
+			Environment: "testing",
+			Caller:      "caller",
+			Service:     "service-name",
+			Transport:   "transport",
+			Encoding:    "encoding",
+			Procedure:   "procedure",
+			Headers:     transport.NewHeaders().With("foo", "bar"),
+			ShardKey:    "shardkey",
+			RoutingKey:  "wrong routingkey",
+		}))
+	})
+
+	t.Run("RoutingDelegate mismatch", func(t *testing.T) {
+		require.False(t, resMatcher.Matches(&transport.Request{
+			ID:              "id",
+			Host:            "host-name",
+			Environment:     "testing",
+			Caller:          "caller",
+			Service:         "service-name",
+			Transport:       "transport",
+			Encoding:        "encoding",
+			Procedure:       "procedure",
+			Headers:         transport.NewHeaders().With("foo", "bar"),
+			ShardKey:        "shardkey",
+			RoutingKey:      "routingkey",
+			RoutingDelegate: "wrong routingdelegate",
+		}))
+	})
+
+	t.Run("Body mismatch", func(t *testing.T) {
+		require.False(t, resMatcher.Matches(&transport.Request{
+			ID:              "id",
+			Host:            "host-name",
+			Environment:     "testing",
+			Caller:          "caller",
+			Service:         "service-name",
+			Transport:       "transport",
+			Encoding:        "encoding",
+			Procedure:       "procedure",
+			Headers:         transport.NewHeaders().With("foo", "bar"),
+			ShardKey:        "shardkey",
+			RoutingKey:      "routingkey",
+			RoutingDelegate: "routingdelegate",
+			Body:            ioutil.NopCloser(bytes.NewReader([]byte("wrong body"))),
+		}))
+	})
+
+	t.Run("match", func(t *testing.T) {
+		require.False(t, resMatcher.Matches(&transport.Request{
+			ID:              "id",
+			Host:            "host-name",
+			Environment:     "testing",
+			Caller:          "caller",
+			Service:         "service-name",
+			Transport:       "transport",
+			Encoding:        "encoding",
+			Procedure:       "procedure",
+			Headers:         transport.NewHeaders().With("foo", "bar"),
+			ShardKey:        "shardkey",
+			RoutingKey:      "routingkey",
+			RoutingDelegate: "routingdelegate",
+			Body:            ioutil.NopCloser(bytes.NewReader([]byte("body"))),
+		}))
+	})
+}

--- a/call.go
+++ b/call.go
@@ -109,6 +109,21 @@ func (c *Call) WriteResponseHeader(k, v string) error {
 	return (*encoding.Call)(c).WriteResponseHeader(k, v)
 }
 
+// ID returns the ID for the request.
+func (c *Call) ID() string {
+	return (*encoding.Call)(c).ID()
+}
+
+// Host returns the name of the sever making this request.
+func (c *Call) Host() string {
+	return (*encoding.Call)(c).Host()
+}
+
+// Environment returns the environment this request was made in.
+func (c *Call) Environment() string {
+	return (*encoding.Call)(c).Environment()
+}
+
 // Caller returns the name of the service making this request.
 func (c *Call) Caller() string {
 	return (*encoding.Call)(c).Caller()

--- a/call_test.go
+++ b/call_test.go
@@ -53,6 +53,9 @@ func TestCallFromContext(t *testing.T) {
 	ctx, inboundCall := encoding.NewInboundCall(context.Background())
 	err := inboundCall.ReadFromRequest(
 		&transport.Request{
+			ID:              "id",
+			Host:            "host",
+			Environment:     "env",
 			Caller:          "foo",
 			Service:         "bar",
 			Transport:       "trans",
@@ -66,6 +69,9 @@ func TestCallFromContext(t *testing.T) {
 	)
 	assert.NoError(t, err)
 	call := yarpc.CallFromContext(ctx)
+	assert.Equal(t, "id", call.ID())
+	assert.Equal(t, "host", call.Host())
+	assert.Equal(t, "env", call.Environment())
 	assert.Equal(t, "foo", call.Caller())
 	assert.Equal(t, "bar", call.Service())
 	assert.Equal(t, "trans", call.Transport())


### PR DESCRIPTION
This adds additional fields to the `transport.Request` struct:
- unique request ID for later request/response validation
- host to determine which host server issued the request
- environment to indicate the environment of the deployed service

Relates to T1860945.