### PR TITLE
Add transport headers to `transport.Response`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Additional transport headers were added to `transport.Request`: `ID`, `Host`
   and `Environment`.
+- Additional transport headers were added to `transport.Response`: `ID`,
+  `Host`, `Environment` and `Service`.
 
 ## [1.31.0] - 2018-07-09
 ### Added

--- a/api/transport/response.go
+++ b/api/transport/response.go
@@ -24,6 +24,27 @@ import "io"
 
 // Response is the low level response representation.
 type Response struct {
+	// ID of the response as chosen by the client. This MAY be a trace ID or
+	// UUID.
+	//
+	// If the corresponding transport.Request struct has this field set, this
+	// field MUST have the same value.
+	ID string
+
+	// Host is the name of the server responding with this reponse.
+	//
+	// It MAY be set by a an environment-aware middleware.
+	Host string
+
+	// Environment is the name of the host environment that the request was
+	// issued from. eg "staging", "production"
+	//
+	// It MAY be set by a an environment-aware middleware.
+	Environment string
+
+	// Service is the name of the responding service.
+	Service string
+
 	Headers          Headers
 	Body             io.ReadCloser
 	ApplicationError bool

--- a/api/transport/transporttest/reqres.go
+++ b/api/transport/transporttest/reqres.go
@@ -201,6 +201,27 @@ func (m ResponseMatcher) Matches(got interface{}) bool {
 		panic(fmt.Sprintf("expected *transport.Response, got %v", got))
 	}
 
+	if l.ID != r.ID {
+		m.t.Logf("ID fields do not match: %q != %q", l.ID, r.ID)
+		return false
+	}
+	if l.Host != r.Host {
+		m.t.Logf("Host fields do not match: %q != %q", l.Host, r.Host)
+		return false
+	}
+	if l.Environment != r.Environment {
+		m.t.Logf("Environment fields do not match: %q != %q", l.Environment, r.Environment)
+		return false
+	}
+	if l.Service != r.Service {
+		m.t.Logf("Service fields do not match: %q != %q", l.Service, r.Service)
+		return false
+	}
+	if l.ApplicationError != r.ApplicationError {
+		m.t.Logf("Application errors do not match: %v != %v", l.ApplicationError, r.ApplicationError)
+		return false
+	}
+
 	if err := checkSuperSet(l.Headers, r.Headers); err != nil {
 		m.t.Logf("Headers mismatch: %v != %v\n\t%v", l.Headers, r.Headers, err)
 		return false

--- a/api/transport/transporttest/reqres_test.go
+++ b/api/transport/transporttest/reqres_test.go
@@ -226,3 +226,97 @@ func TestRequestMatcher(t *testing.T) {
 		}))
 	})
 }
+
+func TestResponseMatcher(t *testing.T) {
+	resMatcher := NewResponseMatcher(t, &transport.Response{
+		ID:               "id",
+		Host:             "host-name",
+		Environment:      "testing",
+		Service:          "service-name",
+		Headers:          transport.NewHeaders().With("foo", "bar"),
+		Body:             ioutil.NopCloser(bytes.NewReader([]byte("my body"))),
+		ApplicationError: true,
+	})
+
+	t.Run("non-response", func(t *testing.T) {
+		require.Panics(t, func() {
+			resMatcher.Matches(&transport.Request{})
+		})
+	})
+
+	t.Run("ID mismatch", func(t *testing.T) {
+		require.False(t, resMatcher.Matches(&transport.Response{
+			ID: "wrong id",
+		}))
+	})
+
+	t.Run("Host mismatch", func(t *testing.T) {
+		require.False(t, resMatcher.Matches(&transport.Response{
+			ID:   "id",
+			Host: "wrong host-name",
+		}))
+	})
+
+	t.Run("Environment mismatch", func(t *testing.T) {
+		require.False(t, resMatcher.Matches(&transport.Response{
+			ID:          "id",
+			Host:        "host-name",
+			Environment: "wrong env",
+		}))
+	})
+
+	t.Run("Service mismatch", func(t *testing.T) {
+		require.False(t, resMatcher.Matches(&transport.Response{
+			ID:          "id",
+			Host:        "host-name",
+			Environment: "testing",
+			Service:     "wrong service-name",
+		}))
+	})
+
+	t.Run("Headers mismatch", func(t *testing.T) {
+		require.False(t, resMatcher.Matches(&transport.Response{
+			ID:          "id",
+			Host:        "host-name",
+			Environment: "testing",
+			Service:     "service-name",
+			Headers:     transport.NewHeaders().With("foo", "wrong"),
+		}))
+	})
+
+	t.Run("Body mismatch", func(t *testing.T) {
+		require.False(t, resMatcher.Matches(&transport.Response{
+			ID:               "id",
+			Host:             "host-name",
+			Environment:      "testing",
+			Service:          "service-name",
+			Headers:          transport.NewHeaders().With("foo", "bar"),
+			Body:             ioutil.NopCloser(bytes.NewReader([]byte("body"))),
+			ApplicationError: true,
+		}))
+	})
+
+	t.Run("ApplicationError mismatch", func(t *testing.T) {
+		require.False(t, resMatcher.Matches(&transport.Response{
+			ID:               "id",
+			Host:             "host-name",
+			Environment:      "testing",
+			Service:          "service-name",
+			Headers:          transport.NewHeaders().With("foo", "bar"),
+			Body:             ioutil.NopCloser(bytes.NewReader([]byte("my body"))),
+			ApplicationError: false,
+		}))
+	})
+
+	t.Run("Match", func(t *testing.T) {
+		require.True(t, resMatcher.Matches(&transport.Response{
+			ID:               "id",
+			Host:             "host-name",
+			Environment:      "testing",
+			Service:          "service-name",
+			Headers:          transport.NewHeaders().With("foo", "bar"),
+			Body:             ioutil.NopCloser(bytes.NewReader([]byte("my body"))),
+			ApplicationError: true,
+		}))
+	})
+}


### PR DESCRIPTION
This adds additional fields to the `transport.Response` struct:
- unique request ID for request/response validation
- host to determine which host server issued the request
- environment to indicate the environment of the deployed service
- service name for request/response validation

Relates to T1860945.
