### PR TITLE
buildkite: Propagate GITHUB_EMAIL to Docker

### DIFF
--- a/.buildkite/pipeline-update-deps.yml
+++ b/.buildkite/pipeline-update-deps.yml
@@ -16,6 +16,7 @@ steps:
           # The script needs the following environment variables in addition
           # to those provided by the docker-compose.
           - GITHUB_USER
+          - GITHUB_EMAIL
           - GITHUB_TOKEN
           - GITHUB_REPO
     agents:


### PR DESCRIPTION
The email address for the bot wasn't being propagated to the Docker
image. This is why the script was falling back to me (the creator of the
job) as the author.