### PR TITLE
Add outbound middleware to x/yarpctest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   and `Environment`.
 - Additional transport headers were added to `transport.Response`: `ID`,
   `Host`, `Environment` and `Service`.
+- x/yarpctest: Added outbound middleware.
 
 ## [1.31.0] - 2018-07-09
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   and `Environment`.
 - Additional transport headers were added to `transport.Response`: `ID`,
   `Host`, `Environment` and `Service`.
-- x/yarpctest: Added outbound middleware.
+- x/yarpctest: Added support for specifying outbound middleware.
 
 ## [1.31.0] - 2018-07-09
 ### Added

--- a/x/yarpctest/api/request_unary.go
+++ b/x/yarpctest/api/request_unary.go
@@ -22,19 +22,23 @@ package api
 
 import (
 	"bytes"
+	"context"
+	"testing"
 	"time"
 
+	"go.uber.org/yarpc/api/middleware"
 	"go.uber.org/yarpc/api/transport"
 )
 
 // RequestOpts are configuration options for a yarpc Request and assertions
 // to make on the response.
 type RequestOpts struct {
-	Port         uint16
-	GiveTimeout  time.Duration
-	GiveRequest  *transport.Request
-	WantResponse *transport.Response
-	WantError    error
+	Port            uint16
+	UnaryMiddleware []middleware.UnaryOutbound
+	GiveTimeout     time.Duration
+	GiveRequest     *transport.Request
+	WantResponse    *transport.Response
+	WantError       error
 }
 
 // NewRequestOpts initializes a RequestOpts struct.
@@ -63,3 +67,26 @@ type RequestOptionFunc func(*RequestOpts)
 
 // ApplyRequest implements RequestOption.
 func (f RequestOptionFunc) ApplyRequest(opts *RequestOpts) { f(opts) }
+
+// UnaryOutboundMiddleware is a wrapper around the middleware.UnaryOutbound and
+// Lifecycle interfaces.
+type UnaryOutboundMiddleware interface {
+	Lifecycle
+	middleware.UnaryOutbound
+}
+
+var _ UnaryOutboundMiddleware = (UnaryOutboundMiddlewareFunc)(nil)
+
+// UnaryOutboundMiddlewareFunc converts a function into a transport.UnaryOutboundMiddleware.
+type UnaryOutboundMiddlewareFunc func(context.Context, *transport.Request, transport.UnaryOutbound) (*transport.Response, error)
+
+// Call implements yarpc/api/transport#UnaryOutboundMiddleware.
+func (f UnaryOutboundMiddlewareFunc) Call(ctx context.Context, req *transport.Request, next transport.UnaryOutbound) (*transport.Response, error) {
+	return f(ctx, req, next)
+}
+
+// Start is a noop for wrapped functions.
+func (f UnaryOutboundMiddlewareFunc) Start(testing.TB) error { return nil }
+
+// Stop is a noop for wrapped functions.
+func (f UnaryOutboundMiddlewareFunc) Stop(testing.TB) error { return nil }

--- a/x/yarpctest/api/request_unary.go
+++ b/x/yarpctest/api/request_unary.go
@@ -22,8 +22,6 @@ package api
 
 import (
 	"bytes"
-	"context"
-	"testing"
 	"time"
 
 	"go.uber.org/yarpc/api/middleware"
@@ -67,26 +65,3 @@ type RequestOptionFunc func(*RequestOpts)
 
 // ApplyRequest implements RequestOption.
 func (f RequestOptionFunc) ApplyRequest(opts *RequestOpts) { f(opts) }
-
-// UnaryOutboundMiddleware is a wrapper around the middleware.UnaryOutbound and
-// Lifecycle interfaces.
-type UnaryOutboundMiddleware interface {
-	Lifecycle
-	middleware.UnaryOutbound
-}
-
-var _ UnaryOutboundMiddleware = (UnaryOutboundMiddlewareFunc)(nil)
-
-// UnaryOutboundMiddlewareFunc converts a function into a transport.UnaryOutboundMiddleware.
-type UnaryOutboundMiddlewareFunc func(context.Context, *transport.Request, transport.UnaryOutbound) (*transport.Response, error)
-
-// Call implements yarpc/api/transport#UnaryOutboundMiddleware.
-func (f UnaryOutboundMiddlewareFunc) Call(ctx context.Context, req *transport.Request, next transport.UnaryOutbound) (*transport.Response, error) {
-	return f(ctx, req, next)
-}
-
-// Start is a noop for wrapped functions.
-func (f UnaryOutboundMiddlewareFunc) Start(testing.TB) error { return nil }
-
-// Stop is a noop for wrapped functions.
-func (f UnaryOutboundMiddlewareFunc) Stop(testing.TB) error { return nil }

--- a/x/yarpctest/request_unary.go
+++ b/x/yarpctest/request_unary.go
@@ -174,9 +174,11 @@ func GiveTimeout(duration time.Duration) api.RequestOption {
 }
 
 // UnaryOutboundMiddleware sets unary outbound middleware for a request.
-func UnaryOutboundMiddleware(out ...middleware.UnaryOutbound) api.RequestOption {
+//
+// Multiple invocations will append to existing middleware.
+func UnaryOutboundMiddleware(mw ...middleware.UnaryOutbound) api.RequestOption {
 	return api.RequestOptionFunc(func(opts *api.RequestOpts) {
-		opts.UnaryMiddleware = out
+		opts.UnaryMiddleware = append(opts.UnaryMiddleware, mw...)
 	})
 }
 

--- a/x/yarpctest/roundtrip_test.go
+++ b/x/yarpctest/roundtrip_test.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc/api/middleware"
 	"go.uber.org/yarpc/api/transport"
@@ -372,7 +373,7 @@ func TestUnaryOutboundMiddleware(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			require.NoError(t, tt.service.Start(t))
-			defer func() { require.NoError(t, tt.service.Stop(t)) }()
+			defer func() { assert.NoError(t, tt.service.Stop(t)) }()
 			tt.request.Run(t)
 		})
 	}

--- a/x/yarpctest/roundtrip_test.go
+++ b/x/yarpctest/roundtrip_test.go
@@ -21,10 +21,13 @@
 package yarpctest
 
 import (
+	"context"
 	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/api/middleware"
+	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/testtime"
 	"go.uber.org/yarpc/yarpcerrors"
 )
@@ -297,6 +300,80 @@ func TestServiceRouting(t *testing.T) {
 			require.NoError(t, tt.services.Start(t))
 			defer func() { require.NoError(t, tt.services.Stop(t)) }()
 			tt.requests.Run(t)
+		})
+	}
+}
+
+func TestUnaryOutboundMiddleware(t *testing.T) {
+	p := NewPortProvider(t)
+
+	const (
+		service            = "service"
+		correctProcedure   = "correct-procedure"
+		incorrectProcedure = "inccorect"
+	)
+
+	mw := middleware.UnaryOutboundFunc(
+		func(ctx context.Context, req *transport.Request, next transport.UnaryOutbound) (*transport.Response, error) {
+			// fix procedure name
+			req.Procedure = correctProcedure
+			return next.Call(ctx, req)
+		})
+
+	tests := []struct {
+		name    string
+		service Lifecycle
+		request Action
+	}{
+		{
+			name: "HTTP",
+			service: HTTPService(
+				Name(service),
+				Proc(Name(correctProcedure), EchoHandler()),
+				p.NamedPort("http"),
+			),
+			request: HTTPRequest(
+				Service(service),
+				Procedure(incorrectProcedure),
+				UnaryOutboundMiddleware(mw),
+				p.NamedPort("http"),
+			),
+		},
+		{
+			name: "TChannel",
+			service: TChannelService(
+				Name(service),
+				Proc(Name(correctProcedure), EchoHandler()),
+				p.NamedPort("TChannel"),
+			),
+			request: TChannelRequest(
+				Service(service),
+				Procedure(incorrectProcedure),
+				UnaryOutboundMiddleware(mw),
+				p.NamedPort("TChannel"),
+			),
+		},
+		{
+			name: "gRPC",
+			service: GRPCService(
+				Name(service),
+				Proc(Name(correctProcedure), EchoHandler()),
+				p.NamedPort("grpc"),
+			),
+			request: GRPCRequest(
+				Service(service),
+				Procedure(incorrectProcedure),
+				UnaryOutboundMiddleware(mw),
+				p.NamedPort("grpc"),
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, tt.service.Start(t))
+			defer func() { require.NoError(t, tt.service.Stop(t)) }()
+			tt.request.Run(t)
 		})
 	}
 }


### PR DESCRIPTION
This enables outbound rquests that use the `x/yarpctest` package to
add unary middleware. Since the test suite creates a mock server and
uses adhoc requests, the middleware is injected via request options.

This will help, for example, when testing transport header
propagation.