### PR TITLE
Enable handlers to write response headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   and `Environment`.
 - Additional transport headers were added to `transport.Response`: `ID`,
   `Host`, `Environment` and `Service`.
+- Added `transport.ResponseMetaWriter` and `transport.ResponseMeta` to support
+  writing `transport.Response` fields in handlers.
 ### Changed
 - HTTP inbounds gracefully shutdown with an optional timeout, defaulting to 5
   seconds.

--- a/api/transport/response.go
+++ b/api/transport/response.go
@@ -68,3 +68,46 @@ type ResponseWriter interface {
 	// of Write().
 	SetApplicationError()
 }
+
+// ResponseMetaWriter returns a ResponseMeta struct that handlers and inbound
+// middleware may use to modify transport.Response fields.
+//
+// ResponseWriter implementations should implement this interface with the
+// intention of users attempting an upcast.
+type ResponseMetaWriter interface {
+	ResponseMeta() *ResponseMeta
+}
+
+// ResponseMeta is the low level response metadata representation. This struct
+// MUST be inspected by transports to map corresponding transport.Response
+// fields, after a handler is called.
+//
+// ResponseWriters should expose this struct using the ResponseMetaWriter
+// interface.
+//
+// There should be one per request.
+type ResponseMeta struct {
+	// ID of the response as chosen by the client. This MAY be a trace ID or
+	// UUID.
+	//
+	// If the corresponding transport.Request struct has this field set, this
+	// field MUST have the same value.
+	ID string
+
+	// Host is the name of the server responding with this reponse.
+	//
+	// It MAY be set by a an environment-aware middleware.
+	Host string
+
+	// Environment is the name of the host environment that the request was
+	// issued from. eg "staging", "production"
+	//
+	// It MAY be set by a an environment-aware middleware.
+	Environment string
+
+	// Service is the name of the responding service.
+	Service string
+
+	Headers          Headers
+	ApplicationError bool
+}

--- a/api/transport/response.go
+++ b/api/transport/response.go
@@ -72,15 +72,24 @@ type ResponseWriter interface {
 // ResponseMetaWriter returns a ResponseMeta struct that handlers and inbound
 // middleware may use to modify transport.Response fields.
 //
-// ResponseWriter implementations should implement this interface with the
-// intention of users attempting an upcast.
+// Middleware and handlers may attempt to upcast ResponseWriters to
+// ResponseMetaWriters to access and write response metadata. Failure to cast
+// MUST be handled.
+//
+//   if metaW, ok := resW.(transport.ResponseMetaWriter); !ok {
+//     meta := metaW.ResponseMeta()
+//     meta.ID = "foo"
+//   }
+//
+// Transport implementations that support writing response metadata should have
+// their ResponseWriters implement ResponseMetaWriter to facilitate this.
 type ResponseMetaWriter interface {
 	ResponseMeta() *ResponseMeta
 }
 
-// ResponseMeta is the low level response metadata representation. This struct
-// MUST be inspected by transports to map corresponding transport.Response
-// fields, after a handler is called.
+// ResponseMeta is the low level response metadata representation. Transports
+// that support writing response metadata with ResponseMetaWriter MUST inspect
+// the final ResponseMeta before writing the response body.
 //
 // ResponseWriters should expose this struct using the ResponseMetaWriter
 // interface.

--- a/api/transport/response.go
+++ b/api/transport/response.go
@@ -76,10 +76,12 @@ type ResponseWriter interface {
 // ResponseMetaWriters to access and write response metadata. Failure to cast
 // MUST be handled.
 //
-//   if metaW, ok := resW.(transport.ResponseMetaWriter); !ok {
-//     meta := metaW.ResponseMeta()
-//     meta.ID = "foo"
+//  if metaW, ok := resW.(transport.ResponseMetaWriter); ok {
+//   if meta := metaW.ResponseMeta(); meta != nil{
+//     meta.Host = "foo"
+//     ...
 //   }
+//  }
 //
 // Transport implementations that support writing response metadata should have
 // their ResponseWriters implement ResponseMetaWriter to facilitate this.

--- a/api/transport/response.go
+++ b/api/transport/response.go
@@ -120,3 +120,10 @@ type ResponseMeta struct {
 	Headers          Headers
 	ApplicationError bool
 }
+
+// AddHeaders is a convenience function for appending to existing Headers.
+func (meta *ResponseMeta) AddHeaders(headers Headers) {
+	for k, v := range headers.OriginalItems() {
+		meta.Headers = meta.Headers.With(k, v)
+	}
+}

--- a/api/transport/response_test.go
+++ b/api/transport/response_test.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package transport
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddHeaders(t *testing.T) {
+	meta := ResponseMeta{}
+
+	meta.AddHeaders(NewHeaders().With("foo", "bar"))
+	meta.AddHeaders(NewHeaders().With("FizZ", "BuzZ"))
+
+	headers := meta.Headers.OriginalItems()
+	require.Len(t, headers, 2)
+
+	assert.Equal(t, "bar", headers["foo"])
+	assert.Equal(t, "BuzZ", headers["FizZ"])
+}

--- a/api/transport/response_test.go
+++ b/api/transport/response_test.go
@@ -24,18 +24,17 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestAddHeaders(t *testing.T) {
 	meta := ResponseMeta{}
-
 	meta.AddHeaders(NewHeaders().With("foo", "bar"))
 	meta.AddHeaders(NewHeaders().With("FizZ", "BuzZ"))
 
-	headers := meta.Headers.OriginalItems()
-	require.Len(t, headers, 2)
+	wantHeaders := map[string]string{
+		"foo":  "bar",
+		"FizZ": "BuzZ",
+	}
 
-	assert.Equal(t, "bar", headers["foo"])
-	assert.Equal(t, "BuzZ", headers["FizZ"])
+	assert.Equal(t, wantHeaders, meta.Headers.OriginalItems(), "headers did not match")
 }

--- a/internal/observability/middleware.go
+++ b/internal/observability/middleware.go
@@ -33,6 +33,9 @@ var _writerPool = sync.Pool{New: func() interface{} {
 	return &writer{}
 }}
 
+var _ transport.ResponseMetaWriter = (*writer)(nil)
+var _ transport.ResponseWriter = (*writer)(nil)
+
 // writer wraps a transport.ResponseWriter so the observing middleware can
 // detect application errors.
 type writer struct {
@@ -51,6 +54,13 @@ func newWriter(rw transport.ResponseWriter) *writer {
 func (w *writer) SetApplicationError() {
 	w.isApplicationError = true
 	w.ResponseWriter.SetApplicationError()
+}
+
+func (w *writer) ResponseMeta() *transport.ResponseMeta {
+	if respMetaWriter, ok := w.ResponseWriter.(transport.ResponseMetaWriter); ok {
+		return respMetaWriter.ResponseMeta()
+	}
+	return nil
 }
 
 func (w *writer) free() {

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -591,3 +591,38 @@ func TestMiddlewareFailureSnapshot(t *testing.T) {
 	}
 	assert.Equal(t, want, snap, "Unexpected snapshot of metrics.")
 }
+
+var _ transport.ResponseWriter = (*testResponseWriter)(nil)
+
+type testResponseWriter struct{}
+
+func (*testResponseWriter) AddHeaders(transport.Headers) {}
+func (*testResponseWriter) SetApplicationError()         {}
+func (*testResponseWriter) Write([]byte) (int, error) {
+	return 0, nil
+}
+
+var _ transport.ResponseWriter = (*testResponseMetaWriter)(nil)
+
+type testResponseMetaWriter struct{}
+
+func (*testResponseMetaWriter) AddHeaders(transport.Headers) {}
+func (*testResponseMetaWriter) SetApplicationError()         {}
+func (*testResponseMetaWriter) Write([]byte) (int, error) {
+	return 0, nil
+}
+func (*testResponseMetaWriter) ResponseMeta() *transport.ResponseMeta {
+	return &transport.ResponseMeta{}
+}
+
+func TestResponseMetaWriter(t *testing.T) {
+	t.Run("not a ResponseMetaWriter", func(t *testing.T) {
+		w := newWriter(&testResponseWriter{})
+		require.Nil(t, w.ResponseMeta())
+	})
+
+	t.Run("implements ResponseMetaWriter", func(t *testing.T) {
+		w := newWriter(&testResponseMetaWriter{})
+		require.NotNil(t, w.ResponseMeta())
+	})
+}


### PR DESCRIPTION
There is a deficiency in the current `ResponseWriter` API where
handlers and inbound middleware cannot write transport-level response
headers. Adding to the existing `ResponseWriter` interface would be a
breaking change so this introduces a new interface,
`ResponseHeaderWriter`, that existing `ResponseWriter`s can optionally
be upcasted to.

The observability `ResponseWriter` now implements the
`transport.ResponseMetaWriter` since it wraps all `ResponseWriter`s to set
application errors.

HTTP, gRPC and TChannel `ResponseWriter`s will be updated in follow up
PRs.