### PR TITLE
Update fakePeer to take peer.Identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added connection/disconnection simulation to the `yarpctest` fake transport
   and peers.
 - x/yarpctest: Added support for specifying outbound middleware.
+- yarpctest: Changed `FakePeer` id to use "go.uber.org/yarpc/api/peer".Identifier 
+  interface instead of the concrete "go.uber.org/peer/hostport".Identifier type.
 
 ## [1.31.0] - 2018-07-09
 ### Added

--- a/yarpctest/fake_peer.go
+++ b/yarpctest/fake_peer.go
@@ -22,19 +22,18 @@ package yarpctest
 
 import (
 	"go.uber.org/yarpc/api/peer"
-	"go.uber.org/yarpc/peer/hostport"
 )
 
 // FakePeer is a fake peer with an identifier.
 type FakePeer struct {
-	id          hostport.PeerIdentifier
+	id          peer.Identifier
 	subscribers []peer.Subscriber
 	status      peer.Status
 }
 
 // Identifier returns the fake peer identifier.
 func (p *FakePeer) Identifier() string {
-	return string(p.id)
+	return p.id.Identifier()
 }
 
 // Status returns the fake peer status.

--- a/yarpctest/fake_transport.go
+++ b/yarpctest/fake_transport.go
@@ -25,7 +25,6 @@ import (
 
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/peer/hostport"
 	"go.uber.org/yarpc/pkg/lifecycletest"
 )
 
@@ -95,7 +94,7 @@ func (t *FakeTransport) Peer(id peer.Identifier) *FakePeer {
 		return p
 	}
 	p := &FakePeer{
-		id: id.(hostport.PeerIdentifier),
+		id: id,
 		status: peer.Status{
 			ConnectionStatus: t.initialConnectionStatus,
 		},


### PR DESCRIPTION
Updates the fake peer struct to take a peer.Identifier interface so different peer identifiers can be used in the FakePeer and FakeTransprots.