### PR TITLE
Propagate Request and Response meta in HTTP

### DIFF
--- a/transport/http/constants.go
+++ b/transport/http/constants.go
@@ -31,6 +31,19 @@ var (
 
 // HTTP headers used in requests and responses to send YARPC metadata.
 const (
+	// ID for a request/response pair as chosen by the client. This corresponds to
+	// the ID field for transport.Request and transport.Response.
+	IDHeader = "Rpc-Id"
+
+	// Host name of the server issuing/responding to the request. This corresponds
+	// to the Host field for transport.Request and transport.Response.
+	HostHeader = "Rpc-Host"
+
+	// Environment of the host issuing/responding the request. eg "staging",
+	// "production". This corresponds to the ID field for transport.Request and
+	// transport.Response.
+	EnvironmentHeader = "Rpc-Environment"
+
 	// Name of the service sending the request. This corresponds to the
 	// Request.Caller attribute.
 	CallerHeader = "Rpc-Caller"
@@ -47,9 +60,8 @@ const (
 	// Request.Procedure attribute.
 	ProcedureHeader = "Rpc-Procedure"
 
-	// Name of the service to which the request is being sent. This
-	// corresponds to the Request.Service attribute. This header is also used
-	// in responses to ensure requests are processed by the correct service.
+	// Name of the service to which the request is being sent. This corresponds to
+	// the Service field for transport.Request and transport.Response.
 	ServiceHeader = "Rpc-Service"
 
 	// Shard key used by the destined service to shard the request. This

--- a/transport/http/handler_test.go
+++ b/transport/http/handler_test.go
@@ -417,13 +417,16 @@ func headerCopyWithout(headers http.Header, names ...string) http.Header {
 
 func TestResponseWriter(t *testing.T) {
 	recorder := httptest.NewRecorder()
-	writer := newResponseWriter(recorder)
+	writer := newResponseWriter(recorder, nil /*http.Header*/)
 
 	headers := transport.HeadersFromMap(map[string]string{
 		"foo":       "bar",
 		"shard-key": "123",
 	})
 	writer.AddHeaders(headers)
+
+	meta := writer.ResponseMeta()
+	require.NotNil(t, meta)
 
 	_, err := writer.Write([]byte("hello"))
 	require.NoError(t, err)

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -264,6 +264,10 @@ func (o *Outbound) call(ctx context.Context, treq *transport.Request) (*transpor
 	}
 
 	tres := &transport.Response{
+		ID:               response.Header.Get(IDHeader),
+		Host:             response.Header.Get(HostHeader),
+		Environment:      response.Header.Get(EnvironmentHeader),
+		Service:          response.Header.Get(ServiceHeader),
 		Headers:          applicationHeaders.FromHTTPHeaders(response.Header, transport.NewHeaders()),
 		Body:             response.Body,
 		ApplicationError: response.Header.Get(ApplicationStatusHeader) == ApplicationErrorStatus,
@@ -348,6 +352,15 @@ func (o *Outbound) withCoreHeaders(req *http.Request, treq *transport.Request, t
 		}
 	}
 
+	if treq.ID != "" {
+		req.Header.Set(IDHeader, treq.ID)
+	}
+	if treq.Host != "" {
+		req.Header.Set(HostHeader, treq.Host)
+	}
+	if treq.Environment != "" {
+		req.Header.Set(EnvironmentHeader, treq.Environment)
+	}
 	req.Header.Set(CallerHeader, treq.Caller)
 	req.Header.Set(ServiceHeader, treq.Service)
 	req.Header.Set(ProcedureHeader, treq.Procedure)
@@ -456,6 +469,9 @@ func (o *Outbound) roundTrip(hreq *http.Request, treq *transport.Request, start 
 	// transport header conventions.
 	if treq == nil {
 		treq = &transport.Request{
+			ID:              hreq.Header.Get(IDHeader),
+			Host:            hreq.Header.Get(HostHeader),
+			Environment:     hreq.Header.Get(EnvironmentHeader),
 			Caller:          hreq.Header.Get(CallerHeader),
 			Service:         hreq.Header.Get(ServiceHeader),
 			Encoding:        transport.Encoding(hreq.Header.Get(EncodingHeader)),


### PR DESCRIPTION
This change propagates the additional `transport.Request` and
`transport.Response`, added in #1520 and #1521 for HTTP requests and sets up a
larger test to validate gRPC and TChannel in later PRs.

The first commit adds the propagation changes, the second adds a round-trip test
that will be expanded on by other transports.

Note that this change will be merged into a feature branch.