### PR TITLE
hotfix: Address data races in yarpctest.FakeTransport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.32.4] - 2018-08-07
+### Fixed
+- Address data races in yarpctest.FakeTransport
+
 ## [1.32.3] - 2018-08-07
 ### Fixed
 - Revert Transport field match from RequestMatcher
@@ -995,6 +999,7 @@ This release requires regeneration of ThriftRW code.
 
 - Initial release.
 
+[1.32.4]: https://github.com/yarpc/yarpc-go/compare/v1.32.3...v1.32.4
 [1.32.3]: https://github.com/yarpc/yarpc-go/compare/v1.32.2...v1.32.3
 [1.32.2]: https://github.com/yarpc/yarpc-go/compare/v1.32.1...v1.32.2
 [1.32.1]: https://github.com/yarpc/yarpc-go/compare/v1.32.0...v1.32.1

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package yarpc // import "go.uber.org/yarpc"
 
 // Version is the current version of YARPC.
-const Version = "1.32.3"
+const Version = "1.32.4"

--- a/yarpctest/fake_peer.go
+++ b/yarpctest/fake_peer.go
@@ -26,7 +26,8 @@ import (
 
 // FakePeer is a fake peer with an identifier.
 type FakePeer struct {
-	id          peer.Identifier
+	id peer.Identifier
+	// subscribers needs to be modified under lock in FakeTransport
 	subscribers []peer.Subscriber
 	status      peer.Status
 }

--- a/yarpctest/fake_transport.go
+++ b/yarpctest/fake_transport.go
@@ -112,6 +112,8 @@ func (t *FakeTransport) Peer(id peer.Identifier) *FakePeer {
 // RetainPeer returns a fake peer.
 func (t *FakeTransport) RetainPeer(id peer.Identifier, ps peer.Subscriber) (peer.Peer, error) {
 	peer := t.Peer(id)
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	peer.subscribers = append(peer.subscribers, ps)
 	return peer, nil
 }
@@ -119,6 +121,8 @@ func (t *FakeTransport) RetainPeer(id peer.Identifier, ps peer.Subscriber) (peer
 // ReleasePeer does nothing.
 func (t *FakeTransport) ReleasePeer(id peer.Identifier, ps peer.Subscriber) error {
 	peer := t.Peer(id)
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	if subscribers, count := filterSubscriber(peer.subscribers, ps); count == 0 {
 		return fmt.Errorf("no such subscriber")
 	} else if count > 1 {

--- a/yarpctest/fake_transport_test.go
+++ b/yarpctest/fake_transport_test.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpctest_test
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"go.uber.org/yarpc/yarpctest"
+)
+
+type testPeer struct {
+	id string
+}
+
+func (p testPeer) Identifier() string {
+	return p.id
+}
+
+func TestFakeTransport(t *testing.T) {
+	trans := yarpctest.NewFakeTransport()
+	trans.Start()
+
+	wait := make(chan struct{}, 0)
+	var wg sync.WaitGroup
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+
+		go func(i int) {
+			p := &testPeer{id: fmt.Sprintf("foo %d", i%10)}
+
+			<-wait
+			trans.Peer(p)
+
+			wg.Done()
+		}(i)
+	}
+	close(wait)
+	wg.Wait()
+}


### PR DESCRIPTION
`yarpctest.FakeTransport` was not thread-safe causing an internal fx library to
fail `go test` with the `-race` flag. This fixes observed flaky tests.