### PR TITLE
http: Inbound.Stop should shutdown http.Server

### DIFF
--- a/internal/crossdock/server/apachethrift/server.go
+++ b/internal/crossdock/server/apachethrift/server.go
@@ -21,6 +21,7 @@
 package apachethrift
 
 import (
+	"context"
 	"log"
 	"net/http"
 	"time"
@@ -73,7 +74,7 @@ func Start() {
 
 // Stop stops the Apache Thrift server.
 func Stop() {
-	if err := server.Stop(); err != nil {
+	if err := server.Shutdown(context.Background()); err != nil {
 		log.Printf("failed to stop Apache Thrift server: %v", err)
 	}
 }

--- a/internal/crossdock/server/http/server.go
+++ b/internal/crossdock/server/http/server.go
@@ -21,6 +21,7 @@
 package http
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/http"
@@ -56,7 +57,7 @@ func Start() {
 
 // Stop stops the HTTP server.
 func Stop() {
-	if err := server.Stop(); err != nil {
+	if err := server.Shutdown(context.Background()); err != nil {
 		log.Printf("failed to stop HTTP server: %v", err)
 	}
 }

--- a/internal/net/httpserver.go
+++ b/internal/net/httpserver.go
@@ -139,8 +139,8 @@ func (h *HTTPServer) shutdownServer(ctx context.Context) (wasRunning bool, _ err
 	err := h.Server.Shutdown(ctx)
 
 	// It's possible that the serve goroutine hasn't yet started, so the server
-	// might not know about the listener. We ignore errors are we may be closing
-	// the same listener twice.
+	// might not know about the listener. We ignore errors since we may b
+	// closing the same listener twice.
 	h.listener.Close()
 
 	h.listener = nil

--- a/transport/http/inbound.go
+++ b/transport/http/inbound.go
@@ -189,12 +189,12 @@ func (i *Inbound) Stop() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	return i.Shutdown(ctx)
+	return i.shutdown(ctx)
 }
 
-// Shutdown the inbound, closing the listening socket, closing idle
+// shutdown the inbound, closing the listening socket, closing idle
 // connections, and waiting for all pending calls to complete.
-func (i *Inbound) Shutdown(ctx context.Context) error {
+func (i *Inbound) shutdown(ctx context.Context) error {
 	return i.once.Stop(func() error {
 		if i.server == nil {
 			return nil

--- a/transport/http/inbound.go
+++ b/transport/http/inbound.go
@@ -21,9 +21,11 @@
 package http
 
 import (
+	"context"
 	"net"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/opentracing/opentracing-go"
 	"go.uber.org/yarpc/api/transport"
@@ -182,16 +184,24 @@ func (i *Inbound) start() error {
 	return nil
 }
 
-// Stop the inbound, closing the listening socket.
+// Stop the inbound using Shutdown, but with a fixed timeout.
 func (i *Inbound) Stop() error {
-	return i.once.Stop(i.stop)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	return i.Shutdown(ctx)
 }
 
-func (i *Inbound) stop() error {
-	if i.server == nil {
-		return nil
-	}
-	return i.server.Stop()
+// Shutdown the inbound, closing the listening socket, closing idle
+// connections, and waiting for all pending calls to complete.
+func (i *Inbound) Shutdown(ctx context.Context) error {
+	return i.once.Stop(func() error {
+		if i.server == nil {
+			return nil
+		}
+
+		return i.server.Shutdown(ctx)
+	})
 }
 
 // IsRunning returns whether the inbound is currently running


### PR DESCRIPTION
The Inbound.Stop method currently stops the net.Listener, which stops
accepting new connections, but existing idle connections can
successfully make more requests.

Using Shutdown ensures we've closed all idle connections, and it waits
for all pending calls to complete.

The Shutdown method accepts a context, but we don't have a context
when stopping inbounds, so we have a couple of options:
 * Come up with an arbitrary timeout (e.g., 5 seconds)
 * Use `context.Background` and allow Stop to block forever.

Neither seems ideal, so I went with the arbitrary timeout for now.

Without this change, the newly added test fails with:
```
=== RUN   TestRequestAfterStop
--- FAIL: TestRequestAfterStop (0.00s)
	inbound_test.go:264: 
			Error Trace:	inbound_test.go:264
			Error:      	An error is expected but got nil.
			Test:       	TestRequestAfterStop
			Messages:   	requests should fail once inbound is stopped
FAIL
```