### PR TITLE
Clean up roundtrip transport test

### DIFF
--- a/transport/roundtrip_test.go
+++ b/transport/roundtrip_test.go
@@ -246,7 +246,7 @@ func TestSimpleRoundTrip(t *testing.T) {
 
 	for _, tt := range tests {
 		for _, trans := range transports {
-			t.Run(tt.name+"-"+trans.Name(), func(t *testing.T) {
+			t.Run(tt.name+"/"+trans.Name(), func(t *testing.T) {
 				requestMatcher := transporttest.NewRequestMatcher(t, &transport.Request{
 					Caller:    testCaller,
 					Service:   testService,

--- a/transport/roundtrip_test.go
+++ b/transport/roundtrip_test.go
@@ -244,7 +244,6 @@ func TestSimpleRoundTrip(t *testing.T) {
 		},
 	}
 
-	rootCtx := context.Background()
 	for _, tt := range tests {
 		for _, trans := range transports {
 			t.Run(tt.name+"-"+trans.Name(), func(t *testing.T) {
@@ -276,7 +275,7 @@ func TestSimpleRoundTrip(t *testing.T) {
 					return err
 				})
 
-				ctx, cancel := context.WithTimeout(rootCtx, 200*testtime.Millisecond)
+				ctx, cancel := context.WithTimeout(context.Background(), 200*testtime.Millisecond)
 				defer cancel()
 
 				router := staticRouter{Handler: handler}


### PR DESCRIPTION
While developing out a new feature, these tests were failing as
expected, but were difficult to pinpoint the exact isse. This minor
change primarily restructures the existing test to use subtests and
removes two redundant test cases.