### PR TITLE
Add http.Inbound shutdown timeout configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - x/yarpctest: Add a retry option to HTTP/TChannel/GRPCRequest.
 - Added `peer/tworandomchoices`, an implementation of the Two Random Choices
   load balancer algorithm.
-- HTTP inbounds can be configured with a shutdown timeout to wait for requests
-  to drain.
+### Changed
+- HTTP inbounds gracefully shutdown with an optional timeout, defaulting to 5
+  seconds.
 
 ## [1.32.4] - 2018-08-07
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
 - x/yarpctest: Add a retry option to HTTP/TChannel/GRPCRequest.
 - Added `peer/tworandomchoices`, an implementation of the Two Random Choices
   load balancer algorithm.
+- HTTP inbounds can be configured with a shutdown timeout to wait for requests
+  to drain.
 
 ## [1.32.4] - 2018-08-07
 ### Fixed

--- a/transport/http/config.go
+++ b/transport/http/config.go
@@ -176,7 +176,7 @@ func (ts *transportSpec) buildInbound(ic *InboundConfig, t transport.Transport, 
 
 	if ic.ShutdownTimeout != nil {
 		if *ic.ShutdownTimeout < 0 {
-			return nil, fmt.Errorf("shutdownTimeout must be at least 0, got: %q", ic.ShutdownTimeout)
+			return nil, fmt.Errorf("shutdownTimeout must not be negative, got: %q", ic.ShutdownTimeout)
 		}
 		inboundOptions = append(inboundOptions, ShutdownTimeout(*ic.ShutdownTimeout))
 	}

--- a/transport/http/config.go
+++ b/transport/http/config.go
@@ -154,12 +154,15 @@ func (ts *transportSpec) buildTransport(tc *TransportConfig, k *yarpcconfig.Kit)
 //      grabHeaders:
 //        - x-foo
 //        - x-bar
+//      shutdownTimeout: 5s
 type InboundConfig struct {
 	// Address to listen on. This field is required.
 	Address string `config:"address,interpolate"`
 	// The additional headers, starting with x, that should be
 	// propagated to handlers. This field is optional.
 	GrabHeaders []string `config:"grabHeaders"`
+	// The maximum amount of time to wait for the inbound to shutdown.
+	ShutdownTimeout *time.Duration `config:"shutdownTimeout"`
 }
 
 func (ts *transportSpec) buildInbound(ic *InboundConfig, t transport.Transport, k *yarpcconfig.Kit) (transport.Inbound, error) {
@@ -170,6 +173,14 @@ func (ts *transportSpec) buildInbound(ic *InboundConfig, t transport.Transport, 
 	if len(ic.GrabHeaders) > 0 {
 		inboundOptions = append(inboundOptions, GrabHeaders(ic.GrabHeaders...))
 	}
+
+	if ic.ShutdownTimeout != nil {
+		if *ic.ShutdownTimeout < 0 {
+			return nil, fmt.Errorf("shutdownTimeout must be at least 0, got: %q", ic.ShutdownTimeout)
+		}
+		inboundOptions = append(inboundOptions, ShutdownTimeout(*ic.ShutdownTimeout))
+	}
+
 	return t.(*Transport).NewInbound(ic.Address, inboundOptions...), nil
 }
 

--- a/transport/http/config_test.go
+++ b/transport/http/config_test.go
@@ -193,7 +193,7 @@ func TestTransportSpec(t *testing.T) {
 		{
 			desc:       "shutdown timeout err",
 			cfg:        attrs{"address": ":8080", "shutdownTimeout": "-1s"},
-			wantErrors: []string{`shutdownTimeout must be at least 0, got: "-1s"`},
+			wantErrors: []string{`shutdownTimeout must not be negative, got: "-1s"`},
 		},
 	}
 

--- a/transport/http/config_test.go
+++ b/transport/http/config_test.go
@@ -56,10 +56,11 @@ func TestTransportSpec(t *testing.T) {
 	}
 
 	type wantInbound struct {
-		Address     string
-		Mux         *http.ServeMux
-		MuxPattern  string
-		GrabHeaders map[string]struct{}
+		Address         string
+		Mux             *http.ServeMux
+		MuxPattern      string
+		GrabHeaders     map[string]struct{}
+		ShutdownTimeout time.Duration
 	}
 
 	type inboundTest struct {
@@ -149,18 +150,22 @@ func TestTransportSpec(t *testing.T) {
 		{
 			desc:        "simple inbound",
 			cfg:         attrs{"address": ":8080"},
-			wantInbound: &wantInbound{Address: ":8080"},
+			wantInbound: &wantInbound{Address: ":8080", ShutdownTimeout: defaultShutdownTimeout},
 		},
 		{
-			desc:        "simple inbound with grab headers",
-			cfg:         attrs{"address": ":8080", "grabHeaders": []string{"x-foo", "x-bar"}},
-			wantInbound: &wantInbound{Address: ":8080", GrabHeaders: map[string]struct{}{"x-foo": {}, "x-bar": {}}},
+			desc: "simple inbound with grab headers",
+			cfg:  attrs{"address": ":8080", "grabHeaders": []string{"x-foo", "x-bar"}},
+			wantInbound: &wantInbound{
+				Address:         ":8080",
+				GrabHeaders:     map[string]struct{}{"x-foo": {}, "x-bar": {}},
+				ShutdownTimeout: defaultShutdownTimeout,
+			},
 		},
 		{
 			desc:        "inbound interpolation",
 			cfg:         attrs{"address": "${HOST:}:${PORT}"},
 			env:         map[string]string{"HOST": "127.0.0.1", "PORT": "80"},
-			wantInbound: &wantInbound{Address: "127.0.0.1:80"},
+			wantInbound: &wantInbound{Address: "127.0.0.1:80", ShutdownTimeout: defaultShutdownTimeout},
 		},
 		{
 			desc: "serve mux",
@@ -169,10 +174,26 @@ func TestTransportSpec(t *testing.T) {
 				Mux("/yarpc", serveMux),
 			},
 			wantInbound: &wantInbound{
-				Address:    ":8080",
-				Mux:        serveMux,
-				MuxPattern: "/yarpc",
+				Address:         ":8080",
+				Mux:             serveMux,
+				MuxPattern:      "/yarpc",
+				ShutdownTimeout: defaultShutdownTimeout,
 			},
+		},
+		{
+			desc:        "shutdown timeout",
+			cfg:         attrs{"address": ":8080", "shutdownTimeout": "1s"},
+			wantInbound: &wantInbound{Address: ":8080", ShutdownTimeout: time.Second},
+		},
+		{
+			desc:        "shutdown timeout 0",
+			cfg:         attrs{"address": ":8080", "shutdownTimeout": "0s"},
+			wantInbound: &wantInbound{Address: ":8080", ShutdownTimeout: 0},
+		},
+		{
+			desc:       "shutdown timeout err",
+			cfg:        attrs{"address": ":8080", "shutdownTimeout": "-1s"},
+			wantErrors: []string{`shutdownTimeout must be at least 0, got: "-1s"`},
 		},
 	}
 
@@ -406,6 +427,7 @@ func TestTransportSpec(t *testing.T) {
 				} else {
 					assert.Empty(t, ib.grabHeaders)
 				}
+				assert.Equal(t, want.ShutdownTimeout, ib.shutdownTimeout, "shutdownTimeout should match")
 			}
 		}
 


### PR DESCRIPTION
Following from #1545, this enables configuring the HTTP inbound
shutdown timeout. Default timeout is left at 5 seconds.