### PR TITLE
Match Transport field in RequestMatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - x/yarpctest: Add a retry option to HTTP/TChannel/GRPCRequest.
 - Added `peer/tworandomchoices`, an implementation of the Two Random Choices
   load balancer algorithm.
-- Re-introduce Transport field matching for `transporttest.RequestMatcher`.
+- Reintroduce Transport field matching for `transporttest.RequestMatcher`.
 ### Changed
 - HTTP inbounds gracefully shutdown with an optional timeout, defaulting to 5
   seconds.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - x/yarpctest: Add a retry option to HTTP/TChannel/GRPCRequest.
 - Added `peer/tworandomchoices`, an implementation of the Two Random Choices
   load balancer algorithm.
+- Re-introduce Transport field matching for `transporttest.RequestMatcher`.
 ### Changed
 - HTTP inbounds gracefully shutdown with an optional timeout, defaulting to 5
   seconds.

--- a/api/transport/transporttest/reqres.go
+++ b/api/transport/transporttest/reqres.go
@@ -83,6 +83,13 @@ func (m RequestMatcher) Matches(got interface{}) bool {
 		return false
 	}
 
+	// We check if 'Transport' is set before comparing, since transports may
+	// modify the field after users define the struct.
+	if l.Transport != "" && l.Transport != r.Transport {
+		m.t.Logf("Transport mismatch: %s != %s", l.Transport, r.Transport)
+		return false
+	}
+
 	if l.Encoding != r.Encoding {
 		m.t.Logf("Encoding mismatch: %s != %s", l.Service, r.Service)
 		return false

--- a/api/transport/transporttest/reqres_test.go
+++ b/api/transport/transporttest/reqres_test.go
@@ -54,12 +54,12 @@ func TestRequestMatcherTransport(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			reqMatcher := NewRequestMatcher(t, &transport.Request{
 				Transport: tt.transport,
-				Body:      bytes.NewBufferString(""), // cannot be nil
+				Body:      &bytes.Buffer{},
 			})
 
 			req := &transport.Request{
 				Transport: "foo-transport",
-				Body:      bytes.NewBufferString(""),
+				Body:      &bytes.Buffer{},
 			}
 
 			if tt.wantMatch {

--- a/api/transport/transporttest/reqres_test.go
+++ b/api/transport/transporttest/reqres_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package transporttest
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/yarpc/api/transport"
+)
+
+func TestRequestMatcherTransport(t *testing.T) {
+	tests := []struct {
+		name      string
+		transport string
+		wantMatch bool
+	}{
+		{
+			name:      "unset",
+			transport: "",
+			wantMatch: true,
+		},
+		{
+			name:      "set",
+			transport: "foo-transport",
+			wantMatch: true,
+		},
+		{
+			name:      "no match",
+			transport: "bar-transport",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reqMatcher := NewRequestMatcher(t, &transport.Request{
+				Transport: tt.transport,
+				Body:      bytes.NewBufferString(""), // cannot be nil
+			})
+
+			req := &transport.Request{
+				Transport: "foo-transport",
+				Body:      bytes.NewBufferString(""),
+			}
+
+			if tt.wantMatch {
+				assert.True(t, reqMatcher.Matches(req), "unexpected match")
+			} else {
+				assert.False(t, reqMatcher.Matches(req), "expected match")
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is a follow up to #1541 which reverted matching the `Transport`
field in `transport.Request`s. This change reintroduces the match, but
first checks if the given request has that field specified.

The current behaviour of Transports (ie gRPC, TChannel, HTTP) is to set the
field while handling the request. When using the `RequestMatcher` for testing,
this means that _after_ a user makes a request, the `Transport` field is
transparently set. This enables users to make an explicit match.