### PR TITLE
Consolidate TChannel service name validation

### DIFF
--- a/transport/tchannel/channel_outbound.go
+++ b/transport/tchannel/channel_outbound.go
@@ -191,10 +191,9 @@ func (o *ChannelOutbound) Call(ctx context.Context, req *transport.Request) (*tr
 		return nil, toYARPCError(req, err)
 	}
 
-	// service name match validation, return yarpcerrors.CodeInternal error if not match
-	if match, resSvcName := checkServiceMatchAndDeleteHeaderKey(req.Service, headers); !match {
-		return nil, yarpcerrors.InternalErrorf("service name sent from the request "+
-			"does not match the service name received in the response: sent %q, got: %q", req.Service, resSvcName)
+	respService, _ := headers.Get(ServiceHeaderKey) // validateServiceName handles empty strings
+	if err := validateServiceName(req.Service, respService); err != nil {
+		return nil, err
 	}
 
 	return &transport.Response{
@@ -240,6 +239,7 @@ func fromSystemError(err tchannel.SystemError) error {
 
 func getResponseErrorAndDeleteHeaderKeys(headers transport.Headers) error {
 	defer func() {
+		headers.Del(ServiceHeaderKey)
 		headers.Del(ErrorCodeHeaderKey)
 		headers.Del(ErrorNameHeaderKey)
 		headers.Del(ErrorMessageHeaderKey)
@@ -258,14 +258,4 @@ func getResponseErrorAndDeleteHeaderKeys(headers transport.Headers) error {
 	errorName, _ := headers.Get(ErrorNameHeaderKey)
 	errorMessage, _ := headers.Get(ErrorMessageHeaderKey)
 	return intyarpcerrors.NewWithNamef(errorCode, errorName, errorMessage)
-}
-
-// ServiceHeaderKey is internal key used by YARPC, we need to remove it before give response to client
-// only does verification when there is a response service header.
-func checkServiceMatchAndDeleteHeaderKey(reqSvcName string, resHeaders transport.Headers) (bool, string) {
-	if resSvcName, ok := resHeaders.Get(ServiceHeaderKey); ok {
-		resHeaders.Del(ServiceHeaderKey)
-		return reqSvcName == resSvcName, resSvcName
-	}
-	return true, ""
 }

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -165,10 +165,9 @@ func callWithPeer(ctx context.Context, req *transport.Request, peer *tchannel.Pe
 		return nil, err
 	}
 
-	// service name match validation, return yarpcerrors.CodeInternal error if not match
-	if match, resSvcName := checkServiceMatchAndDeleteHeaderKey(req.Service, headers); !match {
-		return nil, yarpcerrors.InternalErrorf("service name sent from the request "+
-			"does not match the service name received in the response: sent %q, got: %q", req.Service, resSvcName)
+	respService, _ := headers.Get(ServiceHeaderKey) // validateServiceName handles empty strings
+	if err := validateServiceName(req.Service, respService); err != nil {
+		return nil, err
 	}
 
 	return &transport.Response{


### PR DESCRIPTION
This cosmetic change consolidates service name validation so that both
`ChannelOutbound` and `Outbound` can share implementations.