### PR TITLE
Refactor TChannel header deletion

### DIFF
--- a/transport/tchannel/header.go
+++ b/transport/tchannel/header.go
@@ -194,6 +194,12 @@ func headerMap(hs transport.Headers, headerCase headerCase) map[string]string {
 	}
 }
 
+func deleteReservedHeaders(headers transport.Headers) {
+	for headerKey := range _reservedHeaderKeys {
+		headers.Del(headerKey)
+	}
+}
+
 // this check ensures that the service we're issuing a request to is the one
 // responding
 func validateServiceName(requestService, responseService string) error {

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -170,11 +170,15 @@ func callWithPeer(ctx context.Context, req *transport.Request, peer *tchannel.Pe
 		return nil, err
 	}
 
-	return &transport.Response{
+	err = getResponseError(headers)
+	deleteReservedHeaders(headers)
+
+	resp := &transport.Response{
 		Headers:          headers,
 		Body:             resBody,
 		ApplicationError: res.ApplicationError(),
-	}, getResponseErrorAndDeleteHeaderKeys(headers)
+	}
+	return resp, err
 }
 
 func (o *Outbound) getPeerForRequest(ctx context.Context, treq *transport.Request) (*tchannelPeer, func(error), error) {


### PR DESCRIPTION
This cosmetic change is a needed clean up for future changes regarding
additional response headers. `getResponseErrorAndDeleteHeaderKeys` is
broken up into two separate functions for better control flow and
function reuse.

Note: since this is a cosmetic change, this will be merged into dev
instead of the response header feature branch.