### PR TITLE
Propagate Request and Response meta in TChannel

### DIFF
--- a/transport/roundtrip_test.go
+++ b/transport/roundtrip_test.go
@@ -511,8 +511,12 @@ func TestRoundTripMeta(t *testing.T) {
 			service: yarpctest.HTTPService(append(serviceOpts, ports.NamedPort("http"))...),
 			request: yarpctest.HTTPRequest(append(requestOpts, ports.NamedPort("http"))...),
 		},
+		{
+			name:    "TChannel",
+			service: yarpctest.TChannelService(append(serviceOpts, ports.NamedPort("TChannel"))...),
+			request: yarpctest.TChannelRequest(append(requestOpts, ports.NamedPort("TChannel"))...),
+		},
 		// TODO(apeatsbond): add gRPC test
-		// TODO(apeatsbond): add TChannel test
 	}
 
 	for _, tt := range tests {

--- a/transport/tchannel/channel_outbound.go
+++ b/transport/tchannel/channel_outbound.go
@@ -191,19 +191,23 @@ func (o *ChannelOutbound) Call(ctx context.Context, req *transport.Request) (*tr
 		return nil, toYARPCError(req, err)
 	}
 
-	respService, _ := headers.Get(ServiceHeaderKey) // validateServiceName handles empty strings
-	if err := validateServiceName(req.Service, respService); err != nil {
+	headerItems := headers.Items()
+	if err := validateServiceName(req.Service, headerItems[ServiceHeaderKey]); err != nil {
 		return nil, err
 	}
 
-	err = getResponseError(headers)
-	deleteReservedHeaders(headers)
-
 	resp := &transport.Response{
+		ID:               headerItems[IDHeaderKey],
+		Host:             headerItems[HostHeaderKey],
+		Environment:      headerItems[EnvironmentHeaderKey],
+		Service:          headerItems[ServiceHeaderKey],
 		Headers:          headers,
 		Body:             resBody,
 		ApplicationError: res.ApplicationError(),
 	}
+
+	err = getResponseError(headers)
+	deleteReservedHeaders(headers)
 	return resp, err
 }
 


### PR DESCRIPTION
This change propagates the additional `transport.Request` and
`transport.Response`, added in #1520 and #1521.

Note that this change will be merged into a feature branch.