### PR TITLE
rhang/adding-logging-to-tchannel-handler

### DIFF
--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -589,5 +589,4 @@ func TestMiddlewareFailureSnapshot(t *testing.T) {
 			},
 		},
 	}
-	assert.Equal(t, want, snap, "Unexpected snapshot of metrics.")
-}
+	assert.Equal(t, want, snap, "Unexpected snapshot of metrics."}

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -589,4 +589,5 @@ func TestMiddlewareFailureSnapshot(t *testing.T) {
 			},
 		},
 	}
-	assert.Equal(t, want, snap, "Unexpected snapshot of metrics."}
+	assert.Equal(t, want, snap, "Unexpected snapshot of metrics.")
+}

--- a/transport/tchannel/channel_transport.go
+++ b/transport/tchannel/channel_transport.go
@@ -139,7 +139,12 @@ func (t *ChannelTransport) start() error {
 		for s := range services {
 			sc := t.ch.GetSubChannel(s)
 			existing := sc.GetHandlers()
-			sc.SetHandler(handler{existing: existing, router: t.router, tracer: t.tracer})
+
+			if t.logger == nil {
+				t.logger = zap.NewNop()
+			}
+
+			sc.SetHandler(handler{existing: existing, router: t.router, tracer: t.tracer, logger: t.logger, newResponseWriter: newTchannelResponseWriter})
 		}
 	}
 

--- a/transport/tchannel/channel_transport.go
+++ b/transport/tchannel/channel_transport.go
@@ -139,11 +139,6 @@ func (t *ChannelTransport) start() error {
 		for s := range services {
 			sc := t.ch.GetSubChannel(s)
 			existing := sc.GetHandlers()
-
-			if t.logger == nil {
-				t.logger = zap.NewNop()
-			}
-
 			sc.SetHandler(handler{existing: existing, router: t.router, tracer: t.tracer, logger: t.logger, newResponseWriter: newTchannelResponseWriter})
 		}
 	}

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -124,7 +124,7 @@ func (h handler) handle(ctx context.Context, call inboundCall) {
 	if err != nil && !responseWriter.IsApplicationError() {
 
 		_ = call.Response().SendSystemError(getSystemError(err))
-		h.logger.Error("tchannel callHandler error", zap.Error(err))
+		h.logger.Error("tchannel transport handler request failed", zap.Error(err))
 		return
 	}
 	if err != nil && responseWriter.IsApplicationError() {

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -72,7 +72,7 @@ type inboundCallResponse interface {
 
 // responseWriter provides an interface similar to newTchannelResponseWriter.
 //
-// responseWriter allows us to control the tchannelResponseWriter during testing.
+// It allows us to control tchannelResponseWriter during testing.
 type responseWriter interface {
 	AddHeaders(h transport.Headers)
 	AddHeader(key string, value string)
@@ -124,7 +124,7 @@ func (h handler) handle(ctx context.Context, call inboundCall) {
 	if err != nil && !responseWriter.IsApplicationError() {
 
 		_ = call.Response().SendSystemError(getSystemError(err))
-		h.logger.Error("callHandler error", zap.Error(err))
+		h.logger.Error("tchannel callHandler error", zap.Error(err))
 		return
 	}
 	if err != nil && responseWriter.IsApplicationError() {
@@ -144,7 +144,7 @@ func (h handler) handle(ctx context.Context, call inboundCall) {
 	}
 	if err := responseWriter.Close(); err != nil {
 		_ = call.Response().SendSystemError(getSystemError(err))
-		h.logger.Error("responseWriter failed to close", zap.Error(err))
+		h.logger.Error("tchannel responseWriter failed to close", zap.Error(err))
 	}
 }
 

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -70,6 +70,18 @@ type inboundCallResponse interface {
 	SetApplicationError() error
 }
 
+// responseWriter provides an interface similar to newTchannelResponseWriter.
+//
+// responseWriter allows us to control the tchannelResponseWriter during testing.
+type responseWriter interface {
+	AddHeaders(h transport.Headers)
+	AddHeader(key string, value string)
+	SetApplicationError()
+	IsApplicationError() bool
+	Write(s []byte) (int, error)
+	Close() error
+}
+
 // tchannelCall wraps a TChannel InboundCall into an inboundCall.
 //
 // We need to do this so that we can change the return type of call.Response()
@@ -82,11 +94,12 @@ func (c tchannelCall) Response() inboundCallResponse {
 
 // handler wraps a transport.UnaryHandler into a TChannel Handler.
 type handler struct {
-	existing   map[string]tchannel.Handler
-	router     transport.Router
-	tracer     opentracing.Tracer
-	headerCase headerCase
-	logger     *zap.Logger
+	existing          map[string]tchannel.Handler
+	router            transport.Router
+	tracer            opentracing.Tracer
+	headerCase        headerCase
+	logger            *zap.Logger
+	newResponseWriter func(inboundCallResponse, tchannel.Format, headerCase) responseWriter
 }
 
 func (h handler) Handle(ctx ncontext.Context, call *tchannel.InboundCall) {
@@ -95,10 +108,10 @@ func (h handler) Handle(ctx ncontext.Context, call *tchannel.InboundCall) {
 
 func (h handler) handle(ctx context.Context, call inboundCall) {
 	// you MUST close the responseWriter no matter what unless you have a tchannel.SystemError
-	responseWriter := newResponseWriter(call.Response(), call.Format(), h.headerCase)
+	responseWriter := h.newResponseWriter(call.Response(), call.Format(), h.headerCase)
 
 	// echo accepted rpc-service in response header
-	responseWriter.addHeader(ServiceHeaderKey, call.ServiceName())
+	responseWriter.AddHeader(ServiceHeaderKey, call.ServiceName())
 
 	err := h.callHandler(ctx, call, responseWriter)
 
@@ -108,33 +121,34 @@ func (h handler) handle(ctx context.Context, call inboundCall) {
 		call.Response().Blackhole()
 		return
 	}
-	if err != nil && !responseWriter.isApplicationError {
-		// TODO: log error
+	if err != nil && !responseWriter.IsApplicationError() {
+
 		_ = call.Response().SendSystemError(getSystemError(err))
+		h.logger.Error("callHandler error", zap.Error(err))
 		return
 	}
-	if err != nil && responseWriter.isApplicationError {
+	if err != nil && responseWriter.IsApplicationError() {
 		// we have an error, so we're going to propagate it as a yarpc error,
 		// regardless of whether or not it is a system error.
 		status := yarpcerrors.FromError(errors.WrapHandlerError(err, call.ServiceName(), call.MethodString()))
 		// TODO: what to do with error? we could have a whole complicated scheme to
 		// return a SystemError here, might want to do that
 		text, _ := status.Code().MarshalText()
-		responseWriter.addHeader(ErrorCodeHeaderKey, string(text))
+		responseWriter.AddHeader(ErrorCodeHeaderKey, string(text))
 		if status.Name() != "" {
-			responseWriter.addHeader(ErrorNameHeaderKey, status.Name())
+			responseWriter.AddHeader(ErrorNameHeaderKey, status.Name())
 		}
 		if status.Message() != "" {
-			responseWriter.addHeader(ErrorMessageHeaderKey, status.Message())
+			responseWriter.AddHeader(ErrorMessageHeaderKey, status.Message())
 		}
 	}
 	if err := responseWriter.Close(); err != nil {
-		// TODO: log error
 		_ = call.Response().SendSystemError(getSystemError(err))
+		h.logger.Error("responseWriter failed to close", zap.Error(err))
 	}
 }
 
-func (h handler) callHandler(ctx context.Context, call inboundCall, responseWriter *responseWriter) error {
+func (h handler) callHandler(ctx context.Context, call inboundCall, responseWriter responseWriter) error {
 	start := time.Now()
 	_, ok := ctx.Deadline()
 	if !ok {
@@ -207,80 +221,84 @@ func (h handler) callHandler(ctx context.Context, call inboundCall, responseWrit
 	}
 }
 
-type responseWriter struct {
-	failedWith         error
-	format             tchannel.Format
-	headers            transport.Headers
-	buffer             *bufferpool.Buffer
-	response           inboundCallResponse
-	isApplicationError bool
-	headerCase         headerCase
+type tchannelResponseWriter struct {
+	FailedWith       error
+	Format           tchannel.Format
+	Headers          transport.Headers
+	Buffer           *bufferpool.Buffer
+	Response         inboundCallResponse
+	ApplicationError bool
+	HeaderCase       headerCase
 }
 
-func newResponseWriter(response inboundCallResponse, format tchannel.Format, headerCase headerCase) *responseWriter {
-	return &responseWriter{
-		response:   response,
-		format:     format,
-		headerCase: headerCase,
+func newTchannelResponseWriter(response inboundCallResponse, format tchannel.Format, headerCase headerCase) responseWriter {
+	return &tchannelResponseWriter{
+		Response:   response,
+		Format:     format,
+		HeaderCase: headerCase,
 	}
 }
 
-func (rw *responseWriter) AddHeaders(h transport.Headers) {
+func (rw *tchannelResponseWriter) AddHeaders(h transport.Headers) {
 	for k, v := range h.OriginalItems() {
 		// TODO: is this considered a breaking change?
 		if isReservedHeaderKey(k) {
-			rw.failedWith = appendError(rw.failedWith, fmt.Errorf("cannot use reserved header key: %s", k))
+			rw.FailedWith = appendError(rw.FailedWith, fmt.Errorf("cannot use reserved header key: %s", k))
 			return
 		}
-		rw.addHeader(k, v)
+		rw.AddHeader(k, v)
 	}
 }
 
-func (rw *responseWriter) addHeader(key string, value string) {
-	rw.headers = rw.headers.With(key, value)
+func (rw *tchannelResponseWriter) AddHeader(key string, value string) {
+	rw.Headers = rw.Headers.With(key, value)
 }
 
-func (rw *responseWriter) SetApplicationError() {
-	rw.isApplicationError = true
+func (rw *tchannelResponseWriter) SetApplicationError() {
+	rw.ApplicationError = true
 }
 
-func (rw *responseWriter) Write(s []byte) (int, error) {
-	if rw.failedWith != nil {
-		return 0, rw.failedWith
+func (rw *tchannelResponseWriter) IsApplicationError() bool {
+	return rw.ApplicationError
+}
+
+func (rw *tchannelResponseWriter) Write(s []byte) (int, error) {
+	if rw.FailedWith != nil {
+		return 0, rw.FailedWith
 	}
 
-	if rw.buffer == nil {
-		rw.buffer = bufferpool.Get()
+	if rw.Buffer == nil {
+		rw.Buffer = bufferpool.Get()
 	}
 
-	n, err := rw.buffer.Write(s)
+	n, err := rw.Buffer.Write(s)
 	if err != nil {
-		rw.failedWith = appendError(rw.failedWith, err)
+		rw.FailedWith = appendError(rw.FailedWith, err)
 	}
 	return n, err
 }
 
-func (rw *responseWriter) Close() error {
-	retErr := rw.failedWith
-	if rw.isApplicationError {
-		if err := rw.response.SetApplicationError(); err != nil {
+func (rw *tchannelResponseWriter) Close() error {
+	retErr := rw.FailedWith
+	if rw.IsApplicationError() {
+		if err := rw.Response.SetApplicationError(); err != nil {
 			retErr = appendError(retErr, fmt.Errorf("SetApplicationError() failed: %v", err))
 		}
 	}
 
-	headers := headerMap(rw.headers, rw.headerCase)
-	retErr = appendError(retErr, writeHeaders(rw.format, headers, nil, rw.response.Arg2Writer))
+	headers := headerMap(rw.Headers, rw.HeaderCase)
+	retErr = appendError(retErr, writeHeaders(rw.Format, headers, nil, rw.Response.Arg2Writer))
 
 	// Arg3Writer must be opened and closed regardless of if there is data
 	// However, if there is a system error, we do not want to do this
-	bodyWriter, err := rw.response.Arg3Writer()
+	bodyWriter, err := rw.Response.Arg3Writer()
 	if err != nil {
 		return appendError(retErr, err)
 	}
 	defer func() { retErr = appendError(retErr, bodyWriter.Close()) }()
-	if rw.buffer != nil {
-		defer bufferpool.Put(rw.buffer)
-		if _, err := rw.buffer.WriteTo(bodyWriter); err != nil {
+	if rw.Buffer != nil {
+		defer bufferpool.Put(rw.Buffer)
+		if _, err := rw.Buffer.WriteTo(bodyWriter); err != nil {
 			return appendError(retErr, err)
 		}
 	}

--- a/transport/tchannel/handler_test.go
+++ b/transport/tchannel/handler_test.go
@@ -195,7 +195,7 @@ func TestHandlerFailures(t *testing.T) {
 			},
 			wantStatus:     tchannel.ErrCodeBadRequest,
 			wantLogLevel:   zapcore.ErrorLevel,
-			wantLogMessage: "tchannel callHandler error",
+			wantLogMessage: "tchannel transport handler request failed",
 			wantNumLogs:    1,
 		},
 		{
@@ -210,7 +210,7 @@ func TestHandlerFailures(t *testing.T) {
 			},
 			wantStatus:     tchannel.ErrCodeBadRequest,
 			wantLogLevel:   zapcore.ErrorLevel,
-			wantLogMessage: "tchannel callHandler error",
+			wantLogMessage: "tchannel transport handler request failed",
 			wantNumLogs:    1,
 		},
 		{
@@ -225,7 +225,7 @@ func TestHandlerFailures(t *testing.T) {
 			},
 			wantStatus:     tchannel.ErrCodeBadRequest,
 			wantLogLevel:   zapcore.ErrorLevel,
-			wantLogMessage: "tchannel callHandler error",
+			wantLogMessage: "tchannel transport handler request failed",
 			wantNumLogs:    1,
 		},
 		{
@@ -240,7 +240,7 @@ func TestHandlerFailures(t *testing.T) {
 			},
 			wantStatus:     tchannel.ErrCodeUnexpected,
 			wantLogLevel:   zapcore.ErrorLevel,
-			wantLogMessage: "tchannel callHandler error",
+			wantLogMessage: "tchannel transport handler request failed",
 			wantNumLogs:    1,
 		},
 		{
@@ -270,7 +270,7 @@ func TestHandlerFailures(t *testing.T) {
 			},
 			wantStatus:     tchannel.ErrCodeUnexpected,
 			wantLogLevel:   zapcore.ErrorLevel,
-			wantLogMessage: "tchannel callHandler error",
+			wantLogMessage: "tchannel transport handler request failed",
 			wantNumLogs:    1,
 		},
 		{
@@ -303,7 +303,7 @@ func TestHandlerFailures(t *testing.T) {
 			},
 			wantStatus:     tchannel.ErrCodeBadRequest,
 			wantLogLevel:   zapcore.ErrorLevel,
-			wantLogMessage: "tchannel callHandler error",
+			wantLogMessage: "tchannel transport handler request failed",
 			wantNumLogs:    1,
 		},
 		{
@@ -339,7 +339,7 @@ func TestHandlerFailures(t *testing.T) {
 			},
 			wantStatus:     tchannel.ErrCodeTimeout,
 			wantLogLevel:   zapcore.ErrorLevel,
-			wantLogMessage: "tchannel callHandler error",
+			wantLogMessage: "tchannel transport handler request failed",
 			wantNumLogs:    1,
 		},
 		{

--- a/transport/tchannel/handler_test.go
+++ b/transport/tchannel/handler_test.go
@@ -89,7 +89,7 @@ func TestHandlerErrors(t *testing.T) {
 			wantError:        true,
 			wantNumLogs:      1,
 			wantLogLevel:     zapcore.ErrorLevel,
-			wantLogMessage:   "responseWriter failed to close",
+			wantLogMessage:   "tchannel responseWriter failed to close",
 			wantErrorMessage: "faultyResponseWriter failed to close",
 		},
 	}
@@ -195,7 +195,7 @@ func TestHandlerFailures(t *testing.T) {
 			},
 			wantStatus:     tchannel.ErrCodeBadRequest,
 			wantLogLevel:   zapcore.ErrorLevel,
-			wantLogMessage: "callHandler error",
+			wantLogMessage: "tchannel callHandler error",
 			wantNumLogs:    1,
 		},
 		{
@@ -210,7 +210,7 @@ func TestHandlerFailures(t *testing.T) {
 			},
 			wantStatus:     tchannel.ErrCodeBadRequest,
 			wantLogLevel:   zapcore.ErrorLevel,
-			wantLogMessage: "callHandler error",
+			wantLogMessage: "tchannel callHandler error",
 			wantNumLogs:    1,
 		},
 		{
@@ -225,7 +225,7 @@ func TestHandlerFailures(t *testing.T) {
 			},
 			wantStatus:     tchannel.ErrCodeBadRequest,
 			wantLogLevel:   zapcore.ErrorLevel,
-			wantLogMessage: "callHandler error",
+			wantLogMessage: "tchannel callHandler error",
 			wantNumLogs:    1,
 		},
 		{
@@ -240,7 +240,7 @@ func TestHandlerFailures(t *testing.T) {
 			},
 			wantStatus:     tchannel.ErrCodeUnexpected,
 			wantLogLevel:   zapcore.ErrorLevel,
-			wantLogMessage: "callHandler error",
+			wantLogMessage: "tchannel callHandler error",
 			wantNumLogs:    1,
 		},
 		{
@@ -270,7 +270,7 @@ func TestHandlerFailures(t *testing.T) {
 			},
 			wantStatus:     tchannel.ErrCodeUnexpected,
 			wantLogLevel:   zapcore.ErrorLevel,
-			wantLogMessage: "callHandler error",
+			wantLogMessage: "tchannel callHandler error",
 			wantNumLogs:    1,
 		},
 		{
@@ -303,7 +303,7 @@ func TestHandlerFailures(t *testing.T) {
 			},
 			wantStatus:     tchannel.ErrCodeBadRequest,
 			wantLogLevel:   zapcore.ErrorLevel,
-			wantLogMessage: "callHandler error",
+			wantLogMessage: "tchannel callHandler error",
 			wantNumLogs:    1,
 		},
 		{
@@ -339,7 +339,7 @@ func TestHandlerFailures(t *testing.T) {
 			},
 			wantStatus:     tchannel.ErrCodeTimeout,
 			wantLogLevel:   zapcore.ErrorLevel,
-			wantLogMessage: "callHandler error",
+			wantLogMessage: "tchannel callHandler error",
 			wantNumLogs:    1,
 		},
 		{

--- a/transport/tchannel/tchannel_utils_test.go
+++ b/transport/tchannel/tchannel_utils_test.go
@@ -145,7 +145,7 @@ func (rr *responseRecorder) Blackhole() {
 	rr.blackholed = true
 }
 
-// faultyResponseWriter mocks a responseWriter.Close() error inorder to test logging behaviour
+// faultyResponseWriter mocks a responseWriter.Close() error to test logging behaviour
 // inside tchannel.Handle.
 type faultyResponseWriter struct{ tchannelResponseWriter }
 

--- a/transport/tchannel/tchannel_utils_test.go
+++ b/transport/tchannel/tchannel_utils_test.go
@@ -144,3 +144,21 @@ func (rr *responseRecorder) SetApplicationError() error {
 func (rr *responseRecorder) Blackhole() {
 	rr.blackholed = true
 }
+
+// faultyResponseWriter mocks a responseWriter.Close() error inorder to test logging behaviour
+// inside tchannel.Handle.
+type faultyResponseWriter struct{ tchannelResponseWriter }
+
+func (frw *faultyResponseWriter) Close() error {
+	return errors.New("faultyResponseWriter failed to close")
+}
+
+func newFaultyResponseWriter(response inboundCallResponse, format tchannel.Format, headerCase headerCase) responseWriter {
+	return &faultyResponseWriter{
+		tchannelResponseWriter{
+			Response:   response,
+			Format:     format,
+			HeaderCase: headerCase,
+		},
+	}
+}

--- a/transport/tchannel/transport.go
+++ b/transport/tchannel/transport.go
@@ -198,10 +198,11 @@ func (t *Transport) start() error {
 	chopts := tchannel.ChannelOptions{
 		Tracer: t.tracer,
 		Handler: handler{
-			router:     t.router,
-			tracer:     t.tracer,
-			headerCase: t.headerCase,
-			logger:     t.logger,
+			router:            t.router,
+			tracer:            t.tracer,
+			headerCase:        t.headerCase,
+			logger:            t.logger,
+			newResponseWriter: newTchannelResponseWriter,
 		},
 		OnPeerStatusChanged: t.onPeerStatusChanged,
 	}


### PR DESCRIPTION
PR to add zap Error level logging to two error cases within tchannel handler.
Major changes include:

Changing the responseWriter type to an interface in order to support testing of error behavior via faultyResponseWriter during testing.
Declaring a newResponseWriter factory method a field within handler to give the faultyResponseWriter stub access to tchannel handler's internals.
Adding a zap Nop logger if a logger is not provided to handler{}.