### PR TITLE
New http outbound option for overriding http.Request creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added `peer/tworandomchoices`, an implementation of the Two Random Choices
   load balancer algorithm.
 - Reintroduce Transport field matching for `transporttest.RequestMatcher`.
+- New http outpound option 'RequestFactory' which allows clients to override the createRequest method in the transport/http/outbound.go.
 ### Changed
 - HTTP inbounds gracefully shutdown with an optional timeout, defaulting to 5
   seconds.


### PR DESCRIPTION
I have a usecase that requires each procedure to be sent to a specific peer (?) or endpoint. 

In one case, I have an HTTP API gateway that fixes RPC headers per-endpoint in between my client and server. To re-use existing YARPC transports, I need to modify the URL path per procedure. I'd like to avoid writing and maintaining a separate HTTP client - my application is used in different contexts, some with no gateway. 

e.g. 

```
                                 +---------------+
+-----------------------+        | Gateway       |         +----------------+
| Client                |        |               |         | Service        |
|                       |        |  +----------+ |         |                |
|  +-----------------+  |  HTTP  |  | /yarpc/A +-Fixed Header---> A()       |
|  |  proc A         +------------> |          | |   +----------> B()       |
|  +-----------------+  |        |  +----------+ |   |     |                |
|                       |        |               |   |     +----------------+
|  +-----------------+  |        |  +----------+ |   |
|  |  proc B         +------------> | /yarpc/B +-----+
|  +-----------------+  |        |  |          | |
+-----------------------+        |  +----------+ |
                                 +---------------+

```

In general, this could allow other http clients to map yarpc procedures to things like rest endpoints or to allow a service's RPC procedures to scale independently.

The minimal implementation is adding an option to the http transport for specifying procedure -> endpoint mappings:

```golang
// transport/http/outbound.go
func (o *Outbound) setURLOverrides(overrides map[string]string) {
	for proc, override := range overrides {
		parsedURL, err := url.Parse(override)
		if err != nil {
			log.Fatalf("failed to configure HTTP outbound: invalid URL override %q: %s", override, err)
		}
		o.urlOverrides[proc] = parsedURL
	}
}
...
func (o *Outbound) createRequest(treq *transport.Request) (*http.Request, error) {
	newURL := *o.urlTemplate
	if override, exists := o.urlOverrides[treq.Procedure]; exists {
		newURL = *override
	}
	return http.NewRequest("POST", newURL.String(), treq.Body)
}
```

 This could be made more general by allowing clients to specify a request builder in lieu of `createRequest` - see the PR.

Please let me know if this is a bad idea or there is a better way to approach this. Initially I thought I would implement a new peer identifier and peerlist type but don't think that makes sense - the peer will still be the same gateway only the path is changing.

--- 
These checks are not very descriptive, we should update them. Let me know how to proceed.

- [x] Description and context for reviewers: one partner, one stranger ?
- [x] Docs (package doc)
- [x] Entry in CHANGELOG.md
