### PR TITLE
[spring] Update JSON encoding to match new Request/Response API

### DIFF
--- a/v2/CHANGES
+++ b/v2/CHANGES
@@ -6,6 +6,11 @@
       - [x] Consider removing Body from Request and Response entirely, making
             them positional, to avoid separating and embedding Meta* for the
             streaming case.
+      - [ ] Now that we propogate a Response struct back, the Response should hold the actual
+            application error. Errors returned by the handler (not through the Response)
+            could be considered fatal (T1995085). This affects transports and encodings.
+            - [ ] JSON encoding
+            - [ ] HTTP transport
 - [x] Change Request and Response body to yarpc.Buffer type
       - [ ] Accumulate request bodies at the inbound
 - [ ] yarpcrouter.Router needs to accept middleware to decorate registered
@@ -23,6 +28,7 @@
 - [ ] Construct PRs with retroactive continuity.
 - [ ] Nit: scrape name pid and change to just id throughout.
 - [ ] Audit docs
+- [ ] choose to use either `req` and `resp` or `request` and `response` as variable names for consistency.
 
 Encodings:
 - [x] Drop raw encoding

--- a/v2/yarpcjson/inbound_test.go
+++ b/v2/yarpcjson/inbound_test.go
@@ -55,10 +55,7 @@ func TestHandleStructSuccess(t *testing.T) {
 		handler: reflect.ValueOf(h),
 	}
 
-	reqBuf := &yarpc.Buffer{}
-	_, err := reqBuf.WriteString(`{"name": "foo", "attributes": {"bar": 42}}`)
-	require.NoError(err)
-
+	reqBuf := yarpc.NewBufferString(`{"name": "foo", "attributes": {"bar": 42}}`)
 	_, resBuf, err := handler.Handle(context.Background(), &yarpc.Request{
 		Procedure: "simpleCall",
 		Encoding:  "json",
@@ -83,10 +80,7 @@ func TestHandleMapSuccess(t *testing.T) {
 		handler: reflect.ValueOf(h),
 	}
 
-	reqBuf := &yarpc.Buffer{}
-	_, err := reqBuf.WriteString(`{"foo": 42, "bar": ["a", "b", "c"]}`)
-	require.NoError(err)
-
+	reqBuf := yarpc.NewBufferString(`{"foo": 42, "bar": ["a", "b", "c"]}`)
 	_, resBuf, err := handler.Handle(context.Background(), &yarpc.Request{
 		Procedure: "foo",
 		Encoding:  "json",
@@ -106,11 +100,8 @@ func TestHandleInterfaceEmptySuccess(t *testing.T) {
 
 	handler := jsonHandler{reader: ifaceEmptyReader{}, handler: reflect.ValueOf(h)}
 
-	reqBuf := &yarpc.Buffer{}
-	_, err := reqBuf.WriteString(`["a", "b", "c"]`)
-	require.NoError(err)
-
-	_, resBuf, err := handler.Handle(context.Background(), &yarpc.Request{
+	reqBuf := yarpc.NewBufferString(`["a", "b", "c"]`)
+	_, _, err := handler.Handle(context.Background(), &yarpc.Request{
 		Procedure: "foo",
 		Encoding:  "json",
 	}, reqBuf)
@@ -130,11 +121,8 @@ func TestHandleSuccessWithResponseHeaders(t *testing.T) {
 		handler: reflect.ValueOf(h),
 	}
 
-	reqBuf := &yarpc.Buffer{}
-	_, err := reqBuf.WriteString(`{"name": "foo", "attributes": {"bar": 42}}`)
-	require.NoError(err)
-
-	res, resBuf, err := handler.Handle(context.Background(), &yarpc.Request{
+	reqBuf := yarpc.NewBufferString(`{"name": "foo", "attributes": {"bar": 42}}`)
+	res, _, err := handler.Handle(context.Background(), &yarpc.Request{
 		Procedure: "simpleCall",
 		Encoding:  "json",
 	}, reqBuf)
@@ -157,10 +145,7 @@ func TestHandleBothResponseError(t *testing.T) {
 		handler: reflect.ValueOf(h),
 	}
 
-	reqBuf := &yarpc.Buffer{}
-	_, err := reqBuf.WriteString(`{"name": "foo", "attributes": {"bar": 42}}`)
-	require.NoError(err)
-
+	reqBuf := yarpc.NewBufferString(`{"name": "foo", "attributes": {"bar": 42}}`)
 	_, resBuf, err := handler.Handle(context.Background(), &yarpc.Request{
 		Procedure: "simpleCall",
 		Encoding:  "json",

--- a/v2/yarpcjson/inbound_test.go
+++ b/v2/yarpcjson/inbound_test.go
@@ -21,18 +21,15 @@
 package yarpcjson
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
-	"io"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc/v2"
-	"go.uber.org/yarpc/v2/yarpctest"
 )
 
 type simpleRequest struct {
@@ -58,17 +55,18 @@ func TestHandleStructSuccess(t *testing.T) {
 		handler: reflect.ValueOf(h),
 	}
 
-	resw := new(yarpctest.FakeResponseWriter)
-	err := handler.Handle(context.Background(), &yarpc.Request{
+	reqBuf := &yarpc.Buffer{}
+	_, err := reqBuf.WriteString(`{"name": "foo", "attributes": {"bar": 42}}`)
+	require.NoError(err)
+
+	_, resBuf, err := handler.Handle(context.Background(), &yarpc.Request{
 		Procedure: "simpleCall",
 		Encoding:  "json",
-		Body:      jsonBody(`{"name": "foo", "attributes": {"bar": 42}}`),
-	}, resw)
+	}, reqBuf)
 	require.NoError(t, err)
 
 	var response simpleResponse
-	require.NoError(t, json.Unmarshal(resw.Body.Bytes(), &response))
-
+	require.NoError(t, json.Unmarshal(resBuf.Bytes(), &response))
 	assert.Equal(t, simpleResponse{Success: true}, response)
 }
 
@@ -85,16 +83,19 @@ func TestHandleMapSuccess(t *testing.T) {
 		handler: reflect.ValueOf(h),
 	}
 
-	resw := new(yarpctest.FakeResponseWriter)
-	err := handler.Handle(context.Background(), &yarpc.Request{
+	reqBuf := &yarpc.Buffer{}
+	_, err := reqBuf.WriteString(`{"foo": 42, "bar": ["a", "b", "c"]}`)
+	require.NoError(err)
+
+	_, resBuf, err := handler.Handle(context.Background(), &yarpc.Request{
 		Procedure: "foo",
 		Encoding:  "json",
-		Body:      jsonBody(`{"foo": 42, "bar": ["a", "b", "c"]}`),
-	}, resw)
+	}, reqBuf)
+
 	require.NoError(t, err)
 
 	var response struct{ Success string }
-	require.NoError(t, json.Unmarshal(resw.Body.Bytes(), &response))
+	require.NoError(t, json.Unmarshal(resBuf.Bytes(), &response))
 	assert.Equal(t, "true", response.Success)
 }
 
@@ -105,15 +106,17 @@ func TestHandleInterfaceEmptySuccess(t *testing.T) {
 
 	handler := jsonHandler{reader: ifaceEmptyReader{}, handler: reflect.ValueOf(h)}
 
-	resw := new(yarpctest.FakeResponseWriter)
-	err := handler.Handle(context.Background(), &yarpc.Request{
+	reqBuf := &yarpc.Buffer{}
+	_, err := reqBuf.WriteString(`["a", "b", "c"]`)
+	require.NoError(err)
+
+	_, resBuf, err := handler.Handle(context.Background(), &yarpc.Request{
 		Procedure: "foo",
 		Encoding:  "json",
-		Body:      jsonBody(`["a", "b", "c"]`),
-	}, resw)
-	require.NoError(t, err)
+	}, reqBuf)
 
-	assert.JSONEq(t, `["a", "b", "c"]`, resw.Body.String())
+	require.NoError(t, err)
+	assert.JSONEq(t, `["a", "b", "c"]`, reqBuf.String())
 }
 
 func TestHandleSuccessWithResponseHeaders(t *testing.T) {
@@ -127,15 +130,17 @@ func TestHandleSuccessWithResponseHeaders(t *testing.T) {
 		handler: reflect.ValueOf(h),
 	}
 
-	resw := new(yarpctest.FakeResponseWriter)
-	err := handler.Handle(context.Background(), &yarpc.Request{
+	reqBuf := &yarpc.Buffer{}
+	_, err := reqBuf.WriteString(`{"name": "foo", "attributes": {"bar": 42}}`)
+	require.NoError(err)
+
+	res, resBuf, err := handler.Handle(context.Background(), &yarpc.Request{
 		Procedure: "simpleCall",
 		Encoding:  "json",
-		Body:      jsonBody(`{"name": "foo", "attributes": {"bar": 42}}`),
-	}, resw)
-	require.NoError(t, err)
+	}, reqBuf)
 
-	assert.Equal(t, yarpc.NewHeaders().With("foo", "bar"), resw.Headers)
+	require.NoError(t, err)
+	assert.Equal(t, yarpc.NewHeaders().With("foo", "bar"), res.Headers)
 }
 
 func TestHandleBothResponseError(t *testing.T) {
@@ -152,20 +157,18 @@ func TestHandleBothResponseError(t *testing.T) {
 		handler: reflect.ValueOf(h),
 	}
 
-	resw := new(yarpctest.FakeResponseWriter)
-	err := handler.Handle(context.Background(), &yarpc.Request{
+	reqBuf := &yarpc.Buffer{}
+	_, err := reqBuf.WriteString(`{"name": "foo", "attributes": {"bar": 42}}`)
+	require.NoError(err)
+
+	_, resBuf, err := handler.Handle(context.Background(), &yarpc.Request{
 		Procedure: "simpleCall",
 		Encoding:  "json",
-		Body:      jsonBody(`{"name": "foo", "attributes": {"bar": 42}}`),
-	}, resw)
+	}, reqBuf)
+
 	require.Equal(t, errors.New("bar"), err)
 
 	var response simpleResponse
-	require.NoError(t, json.Unmarshal(resw.Body.Bytes(), &response))
-
+	require.NoError(t, json.Unmarshal(resBuf.Bytes(), &response))
 	assert.Equal(t, simpleResponse{Success: true}, response)
-}
-
-func jsonBody(s string) io.Reader {
-	return bytes.NewReader([]byte(s))
 }

--- a/v2/yarpcjson/outbound.go
+++ b/v2/yarpcjson/outbound.go
@@ -63,12 +63,7 @@ func (c Client) Call(ctx context.Context, procedure string, reqBody interface{},
 		return yarpcencoding.RequestBodyEncodeError(&request, err)
 	}
 
-	requestBuf := &yarpc.Buffer{}
-	if _, err := requestBuf.Write(encoded); err != nil {
-		return err
-	}
-
-	response, responseBuf, appErr := c.c.Unary.Call(ctx, &request, requestBuf)
+	response, responseBuf, appErr := c.c.Unary.Call(ctx, &request, yarpc.NewBufferBytes(encoded))
 	if response == nil {
 		return appErr
 	}

--- a/v2/yarpcjson/outbound.go
+++ b/v2/yarpcjson/outbound.go
@@ -21,7 +21,6 @@
 package yarpcjson
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 
@@ -47,41 +46,42 @@ type Client struct {
 // Returns the response or an error if the request failed.
 func (c Client) Call(ctx context.Context, procedure string, reqBody interface{}, resBodyOut interface{}, opts ...yarpc.CallOption) error {
 	call := yarpc.NewOutboundCall(opts...)
-	treq := yarpc.Request{
+	request := yarpc.Request{
 		Caller:    c.c.Caller,
 		Service:   c.c.Service,
 		Procedure: procedure,
 		Encoding:  Encoding,
 	}
 
-	ctx, err := call.WriteToRequest(ctx, &treq)
+	ctx, err := call.WriteToRequest(ctx, &request)
 	if err != nil {
 		return err
 	}
 
 	encoded, err := json.Marshal(reqBody)
 	if err != nil {
-		return yarpcencoding.RequestBodyEncodeError(&treq, err)
+		return yarpcencoding.RequestBodyEncodeError(&request, err)
 	}
 
-	treq.Body = bytes.NewReader(encoded)
-	tres, appErr := c.c.Unary.Call(ctx, &treq)
-	if tres == nil {
+	requestBuf := &yarpc.Buffer{}
+	if _, err := requestBuf.Write(encoded); err != nil {
+		return err
+	}
+
+	response, responseBuf, appErr := c.c.Unary.Call(ctx, &request, requestBuf)
+	if response == nil {
 		return appErr
 	}
 
 	// we want to return the appErr if it exists as this is what
 	// the previous behavior was so we deprioritize this error
 	var decodeErr error
-	if _, err = call.ReadFromResponse(ctx, tres); err != nil {
+	if _, err = call.ReadFromResponse(ctx, response); err != nil {
 		decodeErr = err
 	}
-	if tres.Body != nil {
-		if err := json.NewDecoder(tres.Body).Decode(resBodyOut); err != nil && decodeErr == nil {
-			decodeErr = yarpcencoding.ResponseBodyDecodeError(&treq, err)
-		}
-		if err := tres.Body.Close(); err != nil && decodeErr == nil {
-			decodeErr = err
+	if responseBuf != nil {
+		if err := json.NewDecoder(responseBuf).Decode(resBodyOut); err != nil && decodeErr == nil {
+			decodeErr = yarpcencoding.ResponseBodyDecodeError(&request, err)
 		}
 	}
 

--- a/v2/yarpcjson/outbound_test.go
+++ b/v2/yarpcjson/outbound_test.go
@@ -21,10 +21,8 @@
 package yarpcjson
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"io/ioutil"
 	"reflect"
 	"testing"
 
@@ -115,21 +113,20 @@ func TestCall(t *testing.T) {
 
 		if !tt.noCall {
 			outbound.EXPECT().Call(gomock.Any(),
-				yarpctest.NewRequestMatcher(t,
-					&yarpc.Request{
-						Caller:    caller,
-						Service:   service,
-						Procedure: tt.procedure,
-						Encoding:  Encoding,
-						Headers:   yarpc.HeadersFromMap(tt.headers),
-						Body:      bytes.NewReader([]byte(tt.encodedRequest)),
-					}),
+				&yarpc.Request{
+					Caller:    caller,
+					Service:   service,
+					Procedure: tt.procedure,
+					Encoding:  Encoding,
+					Headers:   yarpc.HeadersFromMap(tt.headers),
+				},
+				yarpc.NewBufferString(tt.encodedRequest),
 			).Return(
 				&yarpc.Response{
-					Body: ioutil.NopCloser(
-						bytes.NewReader([]byte(tt.encodedResponse))),
 					Headers: yarpc.HeadersFromMap(tt.wantHeaders),
-				}, tt.responseErr)
+				},
+				yarpc.NewBufferString(tt.encodedResponse),
+				tt.responseErr)
 		}
 
 		var wantType reflect.Type


### PR DESCRIPTION
This follows from #1566. Now that the `Request`/`Response` API has
changed to be more symmetric, this updates the JSON encoding to
respect the new interfaces.

This removes the `ResponseWriter` and introduces a preliminary
`yarpc.Buffer`.

Note: Build errors are expected as this is being merged into the feature branch.