### PR TITLE
Adding connection failure detection for remotely closed peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Adds `thrift.Named` option for appropriately labelling procedures inherited
   from other thrift services.
+- The HTTP protocol now marks peers as unavailable immediately when the remote
+side closes the connection.
+
 ### Fixed
 - Calling extended Thrift service procedures previously called the base service's
   procedures.

--- a/transport/http/config_test.go
+++ b/transport/http/config_test.go
@@ -496,6 +496,6 @@ func useFakeBuildClient(t *testing.T, want *wantHTTPClient) TransportOption {
 		assert.Equal(t, want.DisableCompression, options.disableCompression, "http.Client: DisableCompression should match")
 		assert.Equal(t, want.ResponseHeaderTimeout, options.responseHeaderTimeout, "http.Client: ResponseHeaderTimeout should match")
 		assert.Equal(t, want.ConnTimeout, options.connTimeout, "http.Client: ConnTimeout should match")
-		return buildHTTPClient(options)
+		return options.buildHTTPClient(nil)
 	})
 }

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -520,7 +520,7 @@ func (o *Outbound) doWithPeer(
 
 		// Note that the connection may have been lost so the peer connection
 		// maintenance loop resumes probing for availability.
-		p.OnDisconnected()
+		p.onDisconnected()
 
 		return nil, yarpcerrors.Newf(yarpcerrors.CodeUnknown, "unknown error from http client: %s", err.Error())
 	}

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -24,6 +24,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -111,6 +112,81 @@ func TestCallSuccess(t *testing.T) {
 	if assert.NoError(t, err) {
 		assert.Equal(t, []byte("great success"), body)
 	}
+}
+
+type dialerTestFn struct {
+	name   string
+	callCh chan struct{}
+}
+
+func newCallee(name string) *dialerTestFn {
+	ch := make(chan struct{})
+	return &dialerTestFn{
+		name:   name,
+		callCh: ch,
+	}
+}
+
+func (c *dialerTestFn) Call() {
+	close(c.callCh)
+}
+
+func (c *dialerTestFn) Expect(t *testing.T, timeout time.Duration, f func()) error {
+	f()
+
+	timer := time.NewTimer(timeout)
+
+	select {
+	case <-c.callCh:
+		timer.Stop()
+		return nil
+	case <-timer.C:
+		return fmt.Errorf("timed out waiting for %s name", c.name)
+	}
+}
+
+func TestCallSuccessDialer(t *testing.T) {
+	// This tests verifies that dialer interception code will correctly disconnect a peer if
+	// Dialer library will catch an error on a connected peer.
+	successServer := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, req *http.Request) {
+			defer req.Body.Close()
+		},
+	))
+
+	dialer := newCallee("dialer")
+	closer := newCallee("closer")
+
+	httpTransport := NewTransport(
+		DialerCalled(dialer.Call),
+		CloserCalled(closer.Call))
+
+	out := httpTransport.NewSingleOutbound(successServer.URL)
+	require.NoError(t, out.Start(), "failed to start outbound")
+	defer out.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
+	defer cancel()
+	res, err := out.Call(ctx, &transport.Request{})
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	t.Run("expect closer call", func(t *testing.T) {
+		assert.NoError(t,
+			closer.Expect(t, testtime.Second, func() {
+				successServer.Close()
+			}))
+	})
+
+	t.Run("expect dialer call", func(t *testing.T) {
+		ctx, cancel = context.WithTimeout(context.Background(), testtime.Second)
+		defer cancel()
+		assert.NoError(t,
+			dialer.Expect(t, time.Second, func() {
+				_, err = out.Call(ctx, &transport.Request{})
+				require.Error(t, err)
+			}))
+	})
 }
 
 func TestAddReservedHeader(t *testing.T) {

--- a/transport/http/peer.go
+++ b/transport/http/peer.go
@@ -103,9 +103,8 @@ func (p *httpPeer) OnSuspect() {
 	}
 }
 
-func (p *httpPeer) OnDisconnected() {
+func (p *httpPeer) onDisconnected() {
 	p.Peer.SetStatus(peer.Connecting)
-
 	// Kick the state change channel (if it hasn't been kicked already).
 	select {
 	case p.changed <- struct{}{}:
@@ -130,7 +129,7 @@ func (p *httpPeer) MaintainConn() {
 	p.Peer.SetStatus(peer.Connecting)
 	for {
 		// Invariant: Status is Connecting initially, or after exponential
-		// back-off, or after OnDisconnected, but still Available after
+		// back-off, or after onDisconnected, but still Available after
 		// OnSuspect.
 		if p.isAvailable() {
 			p.Peer.SetStatus(peer.Available)
@@ -140,7 +139,7 @@ func (p *httpPeer) MaintainConn() {
 				break
 			}
 			// Invariant: the status is Connecting if change is triggered by
-			// OnDisconnected, but remains Available if triggered by OnSuspect.
+			// onDisconnected, but remains Available if triggered by OnSuspect.
 		} else {
 			p.Peer.SetStatus(peer.Unavailable)
 			// Back-off on fail

--- a/transport/http/transport_test.go
+++ b/transport/http/transport_test.go
@@ -41,6 +41,22 @@ func NoJitter() TransportOption {
 	}
 }
 
+// DialerCalled is used for tests to see whether we reached a certain point in tests. Currently we check
+// if we caught an error from Dialer.
+func DialerCalled(dialerCalled func()) TransportOption {
+	return func(options *transportOptions) {
+		options.dialerCalled = dialerCalled
+	}
+}
+
+// CloserCalled is used for tests to see whether we reached a certain point in tests. Currently we check
+// if we caught an error from Dialer.
+func CloserCalled(closerCalled func()) TransportOption {
+	return func(options *transportOptions) {
+		options.closerCalled = closerCalled
+	}
+}
+
 type peerExpectation struct {
 	id          string
 	subscribers []string


### PR DESCRIPTION
Intercepting low-level connection FIN packets received from remotely closed peers and disconnecting those peers.