### PR TITLE
Observability middleware: Log client side YARPC errors at debug level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   This addresses a data race observed in production that results in broken peer
   list invariants.
 
+### Changed
+- Observability middleware: Log client side YARPC errors at debug level
+
 ## [1.35.2] - 2018-11-06
 ### Removed
 - Reverted HTTP transport marking peers as unavailable when the remote side
@@ -53,7 +56,6 @@ side closes the connection.
 ### Changed
 - HTTP inbounds gracefully shutdown with an optional timeout, defaulting to 5
   seconds.
-- Observability middleware: Log client side YARPC errors at debug level
 
 ## [1.32.4] - 2018-08-07
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ side closes the connection.
 ### Changed
 - HTTP inbounds gracefully shutdown with an optional timeout, defaulting to 5
   seconds.
+- Observability middleware: Log client side YARPC errors at debug level
 
 ## [1.32.4] - 2018-08-07
 ### Fixed

--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -154,7 +154,8 @@ func (c call) isClientSideErrorCode(errCode yarpcerrors.Code) bool {
 		yarpcerrors.CodeAborted,
 		yarpcerrors.CodeOutOfRange,
 		yarpcerrors.CodeUnimplemented,
-		yarpcerrors.CodeUnauthenticated:
+		yarpcerrors.CodeUnauthenticated,
+		yarpcerrors.CodeDeadlineExceeded:
 		return true
 	default:
 		return false

--- a/internal/observability/common_test.go
+++ b/internal/observability/common_test.go
@@ -39,7 +39,6 @@ type fakeHandler struct {
 func (h fakeHandler) Handle(_ context.Context, _ *transport.Request, rw transport.ResponseWriter) error {
 	if h.applicationErr {
 		rw.SetApplicationError()
-		return nil
 	}
 	return h.err
 }

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -57,7 +57,7 @@ func TestMiddlewareLogging(t *testing.T) {
 	sreq := &transport.StreamRequest{Meta: req.ToRequestMeta()}
 	failed := errors.New("fail")
 	clientError := yarpcerrors.Newf(yarpcerrors.CodeInvalidArgument, "Invalid input")
-	serverError := yarpcerrors.Newf(yarpcerrors.CodeInternal, "Internal ")
+	serverError := yarpcerrors.Newf(yarpcerrors.CodeInternal, "Internal server error")
 
 	baseFields := func() []zapcore.Field {
 		return []zapcore.Field{


### PR DESCRIPTION
This changes the logging level in the observability middleware to only log at error level when it is an "server error" according to the YARPC error codes. "Client side" errors are logged at debug level

This follows the HTTP approach where 4xx errors are caused by the client and not by a problem in the server