### PR TITLE
[spring] [Protobuf/Inbound] Update to match new Request/Response API

### DIFF
--- a/v2/yarpcprocedure/procedure.go
+++ b/v2/yarpcprocedure/procedure.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package yarpcprocedure contains utilities for handling procedure name mappings.
+package yarpcprocedure
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ToName gets the procedure name we should use for a method
+// with the given service name and method name.
+func ToName(serviceName string, methodName string) string {
+	return fmt.Sprintf("%s::%s", serviceName, methodName)
+}
+
+// FromName gets the service name and method name from a procdure name.
+func FromName(name string) (serviceName string, methodName string) {
+	parts := strings.SplitN(name, "::", 2)
+	if len(parts) == 1 {
+		return parts[0], ""
+	}
+	return parts[0], parts[1]
+}

--- a/v2/yarpcprocedure/procedure.go
+++ b/v2/yarpcprocedure/procedure.go
@@ -33,12 +33,15 @@ import (
 
 // ToName gets the procedure name we should use for a method
 // with the given service name and method name.
-func ToName(serviceName string, methodName string) string {
-	return fmt.Sprintf("%s::%s", serviceName, methodName)
+func ToName(service, method string) string {
+	return fmt.Sprintf("%s::%s", service, method)
 }
 
 // FromName gets the service name and method name from a procdure name.
-func FromName(name string) (serviceName string, methodName string) {
+// Not all encodings separate their procedure names into service and method
+// components. In these cases, such as JSON, the entire procedure name is
+// returned in the first result.
+func FromName(name string) (service, method string) {
 	parts := strings.SplitN(name, "::", 2)
 	if len(parts) == 1 {
 		return parts[0], ""

--- a/v2/yarpcprocedure/procedure.go
+++ b/v2/yarpcprocedure/procedure.go
@@ -19,6 +19,11 @@
 // THE SOFTWARE.
 
 // Package yarpcprocedure contains utilities for handling procedure name mappings.
+//
+// gRPC and Thrift, in particular, decompose all procedure names into a "service
+// interface" component and a "method name" component. YARPC conventionally delimits
+// these components with "::", such that an example procedure is represented as
+// "FooService::FooMethod".
 package yarpcprocedure
 
 import (

--- a/v2/yarpcprocedure/procedure_test.go
+++ b/v2/yarpcprocedure/procedure_test.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpcprocedure
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcedureSplitEmpty(t *testing.T) {
+	s, m := FromName("")
+	assert.Equal(t, "", s)
+	assert.Equal(t, "", m)
+}
+
+func TestProcedureNameAndSplit(t *testing.T) {
+	tests := []struct {
+		Procedure string
+		Service   string
+		Method    string
+	}{
+		{"foo::bar", "foo", "bar"},
+		{"::bar", "", "bar"},
+		{"foo::", "foo", ""},
+		{"::", "", ""},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.Procedure, ToName(tt.Service, tt.Method))
+		s, m := FromName(tt.Procedure)
+		assert.Equal(t, tt.Service, s)
+		assert.Equal(t, tt.Method, m)
+	}
+}

--- a/v2/yarpcprotobuf/constants.go
+++ b/v2/yarpcprotobuf/constants.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpcprotobuf
+
+import yarpc "go.uber.org/yarpc/v2"
+
+// Encoding is the name of this encoding.
+const Encoding yarpc.Encoding = "proto"

--- a/v2/yarpcprotobuf/inbound.go
+++ b/v2/yarpcprotobuf/inbound.go
@@ -33,17 +33,13 @@ type StreamHandlerParams struct {
 	Handle func(*ServerStream) error
 }
 
-// NewStreamHandler returns a new StreamHandler.
-func NewStreamHandler(params StreamHandlerParams) yarpc.StreamHandler {
-	return newStreamHandler(params.Handle)
-}
-
 type streamHandler struct {
 	handle func(*ServerStream) error
 }
 
-func newStreamHandler(handle func(*ServerStream) error) *streamHandler {
-	return &streamHandler{handle}
+// NewStreamHandler returns a new StreamHandler.
+func NewStreamHandler(p StreamHandlerParams) yarpc.StreamHandler {
+	return &streamHandler{p.Handle}
 }
 
 func (s *streamHandler) HandleStream(stream *yarpc.ServerStream) error {
@@ -64,21 +60,14 @@ type UnaryHandlerParams struct {
 	Create func() proto.Message
 }
 
-// NewUnaryHandler returns a new UnaryHandler.
-func NewUnaryHandler(params UnaryHandlerParams) yarpc.UnaryHandler {
-	return newUnaryHandler(params.Handle, params.Create)
-}
-
 type unaryHandler struct {
 	handle func(context.Context, proto.Message) (proto.Message, error)
 	create func() proto.Message
 }
 
-func newUnaryHandler(
-	handle func(context.Context, proto.Message) (proto.Message, error),
-	create func() proto.Message,
-) *unaryHandler {
-	return &unaryHandler{handle, create}
+// NewUnaryHandler returns a new UnaryHandler.
+func NewUnaryHandler(p UnaryHandlerParams) yarpc.UnaryHandler {
+	return &unaryHandler{p.Handle, p.Create}
 }
 
 func (u *unaryHandler) Handle(ctx context.Context, req *yarpc.Request, buf *yarpc.Buffer) (*yarpc.Response, *yarpc.Buffer, error) {

--- a/v2/yarpcprotobuf/inbound.go
+++ b/v2/yarpcprotobuf/inbound.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpcprotobuf
+
+import (
+	"context"
+
+	"github.com/gogo/protobuf/proto"
+	yarpc "go.uber.org/yarpc/v2"
+	"go.uber.org/yarpc/v2/yarpcencoding"
+)
+
+// StreamHandlerParams contains the parameters for creating a new StreamHandler.
+type StreamHandlerParams struct {
+	Handle func(*ServerStream) error
+}
+
+// NewStreamHandler returns a new StreamHandler.
+func NewStreamHandler(params StreamHandlerParams) yarpc.StreamHandler {
+	return newStreamHandler(params.Handle)
+}
+
+type streamHandler struct {
+	handle func(*ServerStream) error
+}
+
+func newStreamHandler(handle func(*ServerStream) error) *streamHandler {
+	return &streamHandler{handle}
+}
+
+func (s *streamHandler) HandleStream(stream *yarpc.ServerStream) error {
+	ctx, call := yarpc.NewInboundCall(stream.Context(), yarpc.DisableResponseHeaders())
+	if err := call.ReadFromRequest(stream.Request()); err != nil {
+		return err
+	}
+	protoStream := &ServerStream{
+		ctx:    ctx,
+		stream: stream,
+	}
+	return s.handle(protoStream)
+}
+
+// UnaryHandlerParams contains the parameters for creating a new UnaryHandler.
+type UnaryHandlerParams struct {
+	Handle func(context.Context, proto.Message) (proto.Message, error)
+	Create func() proto.Message
+}
+
+// NewUnaryHandler returns a new UnaryHandler.
+func NewUnaryHandler(params UnaryHandlerParams) yarpc.UnaryHandler {
+	return newUnaryHandler(params.Handle, params.Create)
+}
+
+type unaryHandler struct {
+	handle func(context.Context, proto.Message) (proto.Message, error)
+	create func() proto.Message
+}
+
+func newUnaryHandler(
+	handle func(context.Context, proto.Message) (proto.Message, error),
+	create func() proto.Message,
+) *unaryHandler {
+	return &unaryHandler{handle, create}
+}
+
+func (u *unaryHandler) Handle(ctx context.Context, req *yarpc.Request, buf *yarpc.Buffer) (*yarpc.Response, *yarpc.Buffer, error) {
+	ctx, call, request, err := toProtoRequest(ctx, req, buf, u.create)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	response := &yarpc.Response{}
+	responseBuf := &yarpc.Buffer{}
+	call.WriteToResponse(response)
+
+	protoResponse, appErr := u.handle(ctx, request)
+
+	// If the proto response is nil, return early
+	// so that we don't attempt to marshal a nil
+	// object.
+	if protoResponse == nil {
+		if appErr != nil {
+			response.ApplicationError = true
+		}
+		return response, responseBuf, appErr
+	}
+
+	body, cleanup, err := marshal(req.Encoding, protoResponse)
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if err != nil {
+		return response, responseBuf, yarpcencoding.ResponseBodyEncodeError(req, err)
+	}
+	if _, err := responseBuf.Write(body); err != nil {
+		return response, responseBuf, err
+	}
+	if appErr != nil {
+		// TODO(apeatsbond): now that we propogate a Response struct back, the
+		// Response should hold the actual application error. Errors returned by the
+		// handler (not through the Response) could be considered fatal.
+		response.ApplicationError = true
+	}
+	return response, responseBuf, appErr
+}
+
+func toProtoRequest(
+	ctx context.Context,
+	req *yarpc.Request,
+	body *yarpc.Buffer,
+	create func() proto.Message,
+) (context.Context, *yarpc.InboundCall, proto.Message, error) {
+	if err := yarpcencoding.ExpectEncodings(req, _protoEncoding, _jsonEncoding); err != nil {
+		return nil, nil, nil, err
+	}
+	ctx, call := yarpc.NewInboundCall(ctx)
+	if err := call.ReadFromRequest(req); err != nil {
+		return nil, nil, nil, err
+	}
+	request := create()
+	if err := unmarshal(req.Encoding, body, request); err != nil {
+		return nil, nil, nil, yarpcencoding.RequestBodyDecodeError(req, err)
+	}
+	return ctx, call, request, nil
+}

--- a/v2/yarpcprotobuf/inbound.go
+++ b/v2/yarpcprotobuf/inbound.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	yarpc "go.uber.org/yarpc/v2"
 	"go.uber.org/yarpc/v2/yarpcencoding"
+	"go.uber.org/yarpc/v2/yarpcjson"
 )
 
 // StreamHandlerParams contains the parameters for creating a new StreamHandler.
@@ -117,7 +118,7 @@ func toProtoRequest(
 	body *yarpc.Buffer,
 	create func() proto.Message,
 ) (context.Context, *yarpc.InboundCall, proto.Message, error) {
-	if err := yarpcencoding.ExpectEncodings(req, _protoEncoding, _jsonEncoding); err != nil {
+	if err := yarpcencoding.ExpectEncodings(req, Encoding, yarpcjson.Encoding); err != nil {
 		return nil, nil, nil, err
 	}
 	ctx, call := yarpc.NewInboundCall(ctx)

--- a/v2/yarpcprotobuf/marshal.go
+++ b/v2/yarpcprotobuf/marshal.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpcprotobuf
+
+import (
+	"bytes"
+	"io"
+	"sync"
+
+	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/proto"
+	"go.uber.org/yarpc/internal/bufferpool"
+	yarpc "go.uber.org/yarpc/v2"
+	"go.uber.org/yarpc/v2/yarpcerror"
+)
+
+var (
+	_jsonMarshaler   = &jsonpb.Marshaler{}
+	_jsonUnmarshaler = &jsonpb.Unmarshaler{AllowUnknownFields: true}
+	_bufferPool      = sync.Pool{
+		New: func() interface{} {
+			return proto.NewBuffer(make([]byte, 1024))
+		},
+	}
+
+	_protoEncoding yarpc.Encoding = "proto"
+	_jsonEncoding  yarpc.Encoding = "json"
+)
+
+func unmarshal(encoding yarpc.Encoding, reader io.Reader, message proto.Message) error {
+	buf := bufferpool.Get()
+	defer bufferpool.Put(buf)
+	if _, err := buf.ReadFrom(reader); err != nil {
+		return err
+	}
+	body := buf.Bytes()
+	if len(body) == 0 {
+		return nil
+	}
+	switch encoding {
+	case _protoEncoding:
+		return proto.Unmarshal(body, message)
+	case _jsonEncoding:
+		return _jsonUnmarshaler.Unmarshal(bytes.NewReader(body), message)
+	default:
+		return yarpcerror.Newf(yarpcerror.CodeInternal, "encoding.Expect should have handled encoding %q but did not", encoding)
+	}
+}
+
+func marshal(encoding yarpc.Encoding, message proto.Message) ([]byte, func(), error) {
+	switch encoding {
+	case _protoEncoding:
+		return marshalProto(message)
+	case _jsonEncoding:
+		return marshalJSON(message)
+	default:
+		return nil, nil, yarpcerror.Newf(yarpcerror.CodeInternal, "encoding.Expect should have handled encoding %q but did not", encoding)
+	}
+}
+
+func marshalProto(message proto.Message) ([]byte, func(), error) {
+	protoBuffer := getBuffer()
+	cleanup := func() { putBuffer(protoBuffer) }
+	if err := protoBuffer.Marshal(message); err != nil {
+		cleanup()
+		return nil, nil, err
+	}
+	return protoBuffer.Bytes(), cleanup, nil
+}
+
+func marshalJSON(message proto.Message) ([]byte, func(), error) {
+	buf := bufferpool.Get()
+	cleanup := func() { bufferpool.Put(buf) }
+	if err := _jsonMarshaler.Marshal(buf, message); err != nil {
+		cleanup()
+		return nil, nil, err
+	}
+	return buf.Bytes(), cleanup, nil
+}
+
+func getBuffer() *proto.Buffer {
+	buf := _bufferPool.Get().(*proto.Buffer)
+	buf.Reset()
+	return buf
+}
+
+func putBuffer(buf *proto.Buffer) {
+	_bufferPool.Put(buf)
+}

--- a/v2/yarpcprotobuf/marshal.go
+++ b/v2/yarpcprotobuf/marshal.go
@@ -30,6 +30,7 @@ import (
 	"go.uber.org/yarpc/internal/bufferpool"
 	yarpc "go.uber.org/yarpc/v2"
 	"go.uber.org/yarpc/v2/yarpcerror"
+	"go.uber.org/yarpc/v2/yarpcjson"
 )
 
 var (
@@ -40,9 +41,6 @@ var (
 			return proto.NewBuffer(make([]byte, 1024))
 		},
 	}
-
-	_protoEncoding yarpc.Encoding = "proto"
-	_jsonEncoding  yarpc.Encoding = "json"
 )
 
 func unmarshal(encoding yarpc.Encoding, reader io.Reader, message proto.Message) error {
@@ -56,9 +54,9 @@ func unmarshal(encoding yarpc.Encoding, reader io.Reader, message proto.Message)
 		return nil
 	}
 	switch encoding {
-	case _protoEncoding:
+	case Encoding:
 		return proto.Unmarshal(body, message)
-	case _jsonEncoding:
+	case yarpcjson.Encoding:
 		return _jsonUnmarshaler.Unmarshal(bytes.NewReader(body), message)
 	default:
 		return yarpcerror.Newf(yarpcerror.CodeInternal, "encoding.Expect should have handled encoding %q but did not", encoding)
@@ -67,9 +65,9 @@ func unmarshal(encoding yarpc.Encoding, reader io.Reader, message proto.Message)
 
 func marshal(encoding yarpc.Encoding, message proto.Message) ([]byte, func(), error) {
 	switch encoding {
-	case _protoEncoding:
+	case Encoding:
 		return marshalProto(message)
-	case _jsonEncoding:
+	case yarpcjson.Encoding:
 		return marshalJSON(message)
 	default:
 		return nil, nil, yarpcerror.Newf(yarpcerror.CodeInternal, "encoding.Expect should have handled encoding %q but did not", encoding)

--- a/v2/yarpcprotobuf/marshal.go
+++ b/v2/yarpcprotobuf/marshal.go
@@ -59,7 +59,7 @@ func unmarshal(encoding yarpc.Encoding, reader io.Reader, message proto.Message)
 	case yarpcjson.Encoding:
 		return _jsonUnmarshaler.Unmarshal(bytes.NewReader(body), message)
 	default:
-		return yarpcerror.Newf(yarpcerror.CodeInternal, "encoding.Expect should have handled encoding %q but did not", encoding)
+		return yarpcerror.Newf(yarpcerror.CodeInternal, "failed to unmarshal unexpected encoding %q", encoding)
 	}
 }
 
@@ -70,7 +70,7 @@ func marshal(encoding yarpc.Encoding, message proto.Message) ([]byte, func(), er
 	case yarpcjson.Encoding:
 		return marshalJSON(message)
 	default:
-		return nil, nil, yarpcerror.Newf(yarpcerror.CodeInternal, "encoding.Expect should have handled encoding %q but did not", encoding)
+		return nil, nil, yarpcerror.Newf(yarpcerror.CodeInternal, "failed to marshal unexpected encoding %q", encoding)
 	}
 }
 

--- a/v2/yarpcprotobuf/marshal_test.go
+++ b/v2/yarpcprotobuf/marshal_test.go
@@ -30,7 +30,13 @@ import (
 )
 
 func TestUnhandledEncoding(t *testing.T) {
-	assert.Equal(t, yarpcerror.CodeInternal, yarpcerror.FromError(unmarshal(yarpc.Encoding("foo"), bytes.NewReader([]byte("foo")), nil)).Code())
-	_, _, err := marshal(yarpc.Encoding("foo"), nil)
-	assert.Equal(t, yarpcerror.CodeInternal, yarpcerror.FromError(err).Code())
+	t.Run("Unmarshal: internal error", func(t *testing.T) {
+		err := unmarshal(yarpc.Encoding("foo"), bytes.NewReader([]byte("foo")), nil)
+		assert.Equal(t, yarpcerror.CodeInternal, yarpcerror.FromError(err).Code())
+	})
+
+	t.Run("Marshal: internal error", func(t *testing.T) {
+		_, _, err := marshal(yarpc.Encoding("foo"), nil)
+		assert.Equal(t, yarpcerror.CodeInternal, yarpcerror.FromError(err).Code())
+	})
 }

--- a/v2/yarpcprotobuf/marshal_test.go
+++ b/v2/yarpcprotobuf/marshal_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package protobuf
+package yarpcprotobuf
 
 import (
 	"bytes"

--- a/v2/yarpcprotobuf/marshal_test.go
+++ b/v2/yarpcprotobuf/marshal_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package protobuf
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	yarpc "go.uber.org/yarpc/v2"
+	"go.uber.org/yarpc/v2/yarpcerror"
+)
+
+func TestUnhandledEncoding(t *testing.T) {
+	assert.Equal(t, yarpcerror.CodeInternal, yarpcerror.FromError(unmarshal(yarpc.Encoding("foo"), bytes.NewReader([]byte("foo")), nil)).Code())
+	_, _, err := marshal(yarpc.Encoding("foo"), nil)
+	assert.Equal(t, yarpcerror.CodeInternal, yarpcerror.FromError(err).Code())
+}

--- a/v2/yarpcprotobuf/procedure.go
+++ b/v2/yarpcprotobuf/procedure.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpcprotobuf
+
+import (
+	yarpc "go.uber.org/yarpc/v2"
+	"go.uber.org/yarpc/v2/yarpcprocedure"
+)
+
+// ProceduresParams contains the parameters for constructing Procedures.
+type ProceduresParams struct {
+	Service string
+	Unary   []UnaryProceduresParams
+	Stream  []StreamProceduresParams
+}
+
+// UnaryProceduresParams contains the parameters for constructing Unary procedures.
+type UnaryProceduresParams struct {
+	Method  string
+	Handler yarpc.UnaryHandler
+}
+
+// StreamProceduresParams contains the parameters for constructing Stream procedures.
+type StreamProceduresParams struct {
+	Method  string
+	Handler yarpc.StreamHandler
+}
+
+// Procedures builds a slice of yarpc.Procedures.
+func Procedures(params ProceduresParams) []yarpc.Procedure {
+	procedures := make([]yarpc.Procedure, 0, 2*(len(params.Unary)+len(params.Stream)))
+	for _, u := range params.Unary {
+		procedures = append(
+			procedures,
+			yarpc.Procedure{
+				Name:        yarpcprocedure.ToName(params.Service, u.Method),
+				HandlerSpec: yarpc.NewUnaryHandlerSpec(u.Handler),
+				Encoding:    _protoEncoding,
+			},
+			yarpc.Procedure{
+				Name:        yarpcprocedure.ToName(params.Service, u.Method),
+				HandlerSpec: yarpc.NewUnaryHandlerSpec(u.Handler),
+				Encoding:    _jsonEncoding,
+			},
+		)
+	}
+	for _, s := range params.Stream {
+		procedures = append(
+			procedures,
+			yarpc.Procedure{
+				Name:        yarpcprocedure.ToName(params.Service, s.Method),
+				HandlerSpec: yarpc.NewStreamHandlerSpec(s.Handler),
+				Encoding:    _protoEncoding,
+			},
+			yarpc.Procedure{
+				Name:        yarpcprocedure.ToName(params.Service, s.Method),
+				HandlerSpec: yarpc.NewStreamHandlerSpec(s.Handler),
+				Encoding:    _jsonEncoding,
+			},
+		)
+	}
+	return procedures
+}

--- a/v2/yarpcprotobuf/procedure.go
+++ b/v2/yarpcprotobuf/procedure.go
@@ -22,6 +22,7 @@ package yarpcprotobuf
 
 import (
 	yarpc "go.uber.org/yarpc/v2"
+	"go.uber.org/yarpc/v2/yarpcjson"
 	"go.uber.org/yarpc/v2/yarpcprocedure"
 )
 
@@ -57,12 +58,12 @@ func Procedures(params ProceduresParams) []yarpc.Procedure {
 			yarpc.Procedure{
 				Name:        yarpcprocedure.ToName(params.Service, u.Method),
 				HandlerSpec: yarpc.NewUnaryHandlerSpec(u.Handler),
-				Encoding:    _protoEncoding,
+				Encoding:    Encoding,
 			},
 			yarpc.Procedure{
 				Name:        yarpcprocedure.ToName(params.Service, u.Method),
 				HandlerSpec: yarpc.NewUnaryHandlerSpec(u.Handler),
-				Encoding:    _jsonEncoding,
+				Encoding:    yarpcjson.Encoding,
 			},
 		)
 	}
@@ -72,12 +73,12 @@ func Procedures(params ProceduresParams) []yarpc.Procedure {
 			yarpc.Procedure{
 				Name:        yarpcprocedure.ToName(params.Service, s.Method),
 				HandlerSpec: yarpc.NewStreamHandlerSpec(s.Handler),
-				Encoding:    _protoEncoding,
+				Encoding:    Encoding,
 			},
 			yarpc.Procedure{
 				Name:        yarpcprocedure.ToName(params.Service, s.Method),
 				HandlerSpec: yarpc.NewStreamHandlerSpec(s.Handler),
-				Encoding:    _jsonEncoding,
+				Encoding:    yarpcjson.Encoding,
 			},
 		)
 	}

--- a/v2/yarpcprotobuf/procedure.go
+++ b/v2/yarpcprotobuf/procedure.go
@@ -26,6 +26,8 @@ import (
 )
 
 // ProceduresParams contains the parameters for constructing Procedures.
+// This is used to construct a slice of yarpc.Procedures from the context
+// of a protoc plugin, i.e. protoc-gen-yarpc-go.
 type ProceduresParams struct {
 	Service string
 	Unary   []UnaryProceduresParams
@@ -45,6 +47,8 @@ type StreamProceduresParams struct {
 }
 
 // Procedures builds a slice of yarpc.Procedures.
+// This is used to construct a slice of yarpc.Procedures from the context
+// of a protoc plugin, i.e. protoc-gen-yarpc-go.
 func Procedures(params ProceduresParams) []yarpc.Procedure {
 	procedures := make([]yarpc.Procedure, 0, 2*(len(params.Unary)+len(params.Stream)))
 	for _, u := range params.Unary {

--- a/v2/yarpcprotobuf/stream.go
+++ b/v2/yarpcprotobuf/stream.go
@@ -26,6 +26,7 @@ import (
 	"io"
 
 	"github.com/gogo/protobuf/proto"
+	"go.uber.org/multierr"
 	yarpc "go.uber.org/yarpc/v2"
 )
 
@@ -62,13 +63,13 @@ func readFromStream(
 	}
 	message := create()
 	if err := unmarshal(stream.Request().Encoding, streamMsg.Body, message); err != nil {
-		streamMsg.Body.Close()
-		return nil, err
+		return nil, multierr.Append(err, streamMsg.Body.Close())
 	}
+	var err error
 	if streamMsg.Body != nil {
-		streamMsg.Body.Close()
+		err = streamMsg.Body.Close()
 	}
-	return message, nil
+	return message, err
 }
 
 // writeToStream writes a proto.Message to a stream.

--- a/v2/yarpcprotobuf/stream.go
+++ b/v2/yarpcprotobuf/stream.go
@@ -65,7 +65,6 @@ func readFromStream(
 	if err := unmarshal(stream.Request().Encoding, streamMsg.Body, message); err != nil {
 		return nil, multierr.Append(err, streamMsg.Body.Close())
 	}
-	var err error
 	if streamMsg.Body != nil {
 		err = streamMsg.Body.Close()
 	}

--- a/v2/yarpcprotobuf/stream.go
+++ b/v2/yarpcprotobuf/stream.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpcprotobuf
+
+import (
+	"bytes"
+	"context"
+	"io"
+
+	"github.com/gogo/protobuf/proto"
+	yarpc "go.uber.org/yarpc/v2"
+)
+
+// ServerStream is a protobuf-specific server stream.
+type ServerStream struct {
+	ctx    context.Context
+	stream *yarpc.ServerStream
+}
+
+// Context returns the context of the stream.
+func (s *ServerStream) Context() context.Context {
+	return s.ctx
+}
+
+// Receive will receive a protobuf message from the server stream.
+func (s *ServerStream) Receive(create func() proto.Message, options ...yarpc.StreamOption) (proto.Message, error) {
+	return readFromStream(context.Background(), s.stream, create)
+}
+
+// Send will send a protobuf message to the server stream.
+func (s *ServerStream) Send(message proto.Message, options ...yarpc.StreamOption) error {
+	return writeToStream(context.Background(), s.stream, message)
+}
+
+// readFromStream reads a proto.Message from a stream.
+func readFromStream(
+	ctx context.Context,
+	stream yarpc.Stream,
+	create func() proto.Message,
+) (proto.Message, error) {
+	streamMsg, err := stream.ReceiveMessage(ctx)
+	if err != nil {
+		return nil, err
+	}
+	message := create()
+	if err := unmarshal(stream.Request().Encoding, streamMsg.Body, message); err != nil {
+		streamMsg.Body.Close()
+		return nil, err
+	}
+	if streamMsg.Body != nil {
+		streamMsg.Body.Close()
+	}
+	return message, nil
+}
+
+// writeToStream writes a proto.Message to a stream.
+func writeToStream(ctx context.Context, stream yarpc.Stream, message proto.Message) error {
+	messageData, cleanup, err := marshal(stream.Request().Encoding, message)
+	if err != nil {
+		return err
+	}
+	return stream.SendMessage(
+		ctx,
+		&yarpc.StreamMessage{
+			Body: readCloser{Reader: bytes.NewReader(messageData), closer: cleanup},
+		},
+	)
+}
+
+type readCloser struct {
+	io.Reader
+	closer func()
+}
+
+func (r readCloser) Close() error {
+	r.closer()
+	return nil
+}


### PR DESCRIPTION
Now that we've moved forward with the symmetric Request/Response API in https://github.com/yarpc/yarpc-go/pull/1566, this updates the Protobuf encoding implementation for inbounds, i.e. `UnaryHandler` and `StreamHandler`, and migrates the `./pkg/procedure` package into `./v2/yarpcprocedure`.

Note that many of the names previously used have been updated and shortened, such as 
with `BuildProceduresStreamHandlerParams` -> `StreamProceduresParams`.

Next up will be migrating the Protobuf encoding for outbounds and following that will be wiring it all together via `protoc-gen-yarpc-go`.