### PR TITLE
[spring] Fix JSON encoding test

### DIFF
--- a/v2/yarpcjson/inbound.go
+++ b/v2/yarpcjson/inbound.go
@@ -59,28 +59,28 @@ func (h jsonHandler) Handle(ctx context.Context, req *yarpc.Request, reqBuf *yar
 
 	results := h.handler.Call([]reflect.Value{reflect.ValueOf(ctx), reqBody})
 
-	response := &yarpc.Response{}
-	responseBuf := &yarpc.Buffer{}
-	call.WriteToResponse(response)
+	res := &yarpc.Response{}
+	resBuf := &yarpc.Buffer{}
+	call.WriteToResponse(res)
 
 	// we want to return the appErr if it exists as this is what
 	// the previous behavior was so we deprioritize this error
 	var encodeErr error
 	if result := results[0].Interface(); result != nil {
-		if err := json.NewEncoder(responseBuf).Encode(result); err != nil {
+		if err := json.NewEncoder(resBuf).Encode(result); err != nil {
 			encodeErr = yarpcencoding.ResponseBodyEncodeError(req, err)
 		}
 	}
 
 	if appErr, _ := results[1].Interface().(error); appErr != nil {
-		response.ApplicationError = true
+		res.ApplicationError = true
 		// TODO(apeatsbond): now that we propogate a Response struct back, the
 		// Response should hold the actual application error. Errors returned by the
 		// handler (not through the Response) could be considered fatal.
-		return response, responseBuf, appErr
+		return res, resBuf, appErr
 	}
 
-	return response, responseBuf, encodeErr
+	return res, resBuf, encodeErr
 }
 
 // requestReader is used to parse a JSON request argument from a JSON decoder.

--- a/v2/yarpcjson/inbound_test.go
+++ b/v2/yarpcjson/inbound_test.go
@@ -101,13 +101,13 @@ func TestHandleInterfaceEmptySuccess(t *testing.T) {
 	handler := jsonHandler{reader: ifaceEmptyReader{}, handler: reflect.ValueOf(h)}
 
 	reqBuf := yarpc.NewBufferString(`["a", "b", "c"]`)
-	_, respBuf, err := handler.Handle(context.Background(), &yarpc.Request{
+	_, resBuf, err := handler.Handle(context.Background(), &yarpc.Request{
 		Procedure: "foo",
 		Encoding:  "json",
 	}, reqBuf)
 
 	require.NoError(t, err)
-	assert.JSONEq(t, `["a", "b", "c"]`, respBuf.String())
+	assert.JSONEq(t, `["a", "b", "c"]`, resBuf.String())
 }
 
 func TestHandleSuccessWithResponseHeaders(t *testing.T) {

--- a/v2/yarpcjson/outbound.go
+++ b/v2/yarpcjson/outbound.go
@@ -46,37 +46,37 @@ type Client struct {
 // Returns the response or an error if the request failed.
 func (c Client) Call(ctx context.Context, procedure string, reqBody interface{}, resBodyOut interface{}, opts ...yarpc.CallOption) error {
 	call := yarpc.NewOutboundCall(opts...)
-	request := yarpc.Request{
+	req := yarpc.Request{
 		Caller:    c.c.Caller,
 		Service:   c.c.Service,
 		Procedure: procedure,
 		Encoding:  Encoding,
 	}
 
-	ctx, err := call.WriteToRequest(ctx, &request)
+	ctx, err := call.WriteToRequest(ctx, &req)
 	if err != nil {
 		return err
 	}
 
 	encoded, err := json.Marshal(reqBody)
 	if err != nil {
-		return yarpcencoding.RequestBodyEncodeError(&request, err)
+		return yarpcencoding.RequestBodyEncodeError(&req, err)
 	}
 
-	response, responseBuf, appErr := c.c.Unary.Call(ctx, &request, yarpc.NewBufferBytes(encoded))
-	if response == nil {
+	res, resBuf, appErr := c.c.Unary.Call(ctx, &req, yarpc.NewBufferBytes(encoded))
+	if res == nil {
 		return appErr
 	}
 
 	// we want to return the appErr if it exists as this is what
 	// the previous behavior was so we deprioritize this error
 	var decodeErr error
-	if _, err = call.ReadFromResponse(ctx, response); err != nil {
+	if _, err = call.ReadFromResponse(ctx, res); err != nil {
 		decodeErr = err
 	}
-	if responseBuf != nil {
-		if err := json.NewDecoder(responseBuf).Decode(resBodyOut); err != nil && decodeErr == nil {
-			decodeErr = yarpcencoding.ResponseBodyDecodeError(&request, err)
+	if resBuf != nil {
+		if err := json.NewDecoder(resBuf).Decode(resBodyOut); err != nil && decodeErr == nil {
+			decodeErr = yarpcencoding.ResponseBodyDecodeError(&req, err)
 		}
 	}
 


### PR DESCRIPTION
This tiny change fixes up a test from #1567 and puts consistent
naming `req` and `res`

Once this and #1573 land, the entire `spring` branch, except for
the `yarpcroundrobin` and `yarpctest` will be buildable and testable.