### PR TITLE
[spring] Isolate v2 from v1 packages

### DIFF
--- a/v2/CHANGES
+++ b/v2/CHANGES
@@ -30,6 +30,9 @@
 - [ ] Construct PRs with retroactive continuity.
 - [ ] Nit: scrape name pid and change to just id throughout.
 - [ ] Audit docs
+      - [ ] gRPC
+      - [ ] TChannel
+      - [ ] HTTP
 - [ ] InvokeUnaryHandler: reduce package name noise at the call site by changing to a Do(ctx) method on UnaryInvokeRequest
 - [ ] support StreamHandlers in EncodingHandlerSpec
 
@@ -44,11 +47,11 @@ Encodings:
 
 Transports:
 - [ ] Port TChannel transport
-- [ ] Port or recreate gRPC transport
+- [x] Port or recreate gRPC transport
 - [ ] use `req` and `res` as variable names for consistency.
       - [x] HTTP
       - [ ] TChannel
-      - [ ] gRPC
+      - [x] gRPC
 
 To port peer lists forward:
 - [ ] Replace functional options with options struct pattern, like net in the

--- a/v2/backoff.go
+++ b/v2/backoff.go
@@ -18,11 +18,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package backoff
+package yarpc
 
 import "time"
 
-// Strategy is a factory for backoff algorithms.
+// BackoffStrategy is a factory for backoff algorithms.
 // Each backoff instance may capture some state, typically a random number
 // generator.
 // The strategy guarantees that these backoff instances are either
@@ -30,7 +30,7 @@ import "time"
 //
 // Backoff strategies are useful for configuring retry loops, balancing the
 // need to recover quickly against denial of service as a failure mode.
-type Strategy interface {
+type BackoffStrategy interface {
 	Backoff() Backoff
 }
 

--- a/v2/backoff.go
+++ b/v2/backoff.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package backoff
+
+import "time"
+
+// Strategy is a factory for backoff algorithms.
+// Each backoff instance may capture some state, typically a random number
+// generator.
+// The strategy guarantees that these backoff instances are either
+// referentially independent and lockless or thread safe.
+//
+// Backoff strategies are useful for configuring retry loops, balancing the
+// need to recover quickly against denial of service as a failure mode.
+type Strategy interface {
+	Backoff() Backoff
+}
+
+// Backoff is an algorithm for determining how long to wait after a number of
+// attempts to perform some action.
+// Backoff strategies typically use a random number generator that uses some
+// state for feedback.
+// Instances of backoff are intended to be used in the stack of a single
+// goroutine and must therefore either be referentially independent or lock
+// safe.
+type Backoff interface {
+	Duration(attempts uint) time.Duration
+}

--- a/v2/inbound_middleware_test.go
+++ b/v2/inbound_middleware_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	. "go.uber.org/yarpc/v2"
+	"go.uber.org/yarpc/v2"
 	"go.uber.org/yarpc/v2/internal/internaltesttime"
 	"go.uber.org/yarpc/v2/yarpctest"
 )
@@ -38,17 +38,17 @@ func TestUnaryNopInboundMiddleware(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	h := yarpctest.NewMockUnaryTransportHandler(mockCtrl)
-	wrappedH := ApplyUnaryInboundTransportMiddleware(h, NopUnaryInboundTransportMiddleware)
+	wrappedH := yarpc.ApplyUnaryInboundTransportMiddleware(h, yarpc.NopUnaryInboundTransportMiddleware)
 
 	ctx, cancel := context.WithTimeout(context.Background(), internaltesttime.Second)
 	defer cancel()
-	req := &Request{
+	req := &yarpc.Request{
 		Caller:    "somecaller",
 		Service:   "someservice",
-		Encoding:  Encoding("raw"),
+		Encoding:  yarpc.Encoding("raw"),
 		Procedure: "hello",
 	}
-	reqBuf := NewBufferBytes([]byte{1, 2, 3})
+	reqBuf := yarpc.NewBufferBytes([]byte{1, 2, 3})
 
 	err := errors.New("great sadness")
 	h.EXPECT().Handle(ctx, req, reqBuf).Return(nil, nil, err)
@@ -62,14 +62,14 @@ func TestNilInboundMiddleware(t *testing.T) {
 	defer ctrl.Finish()
 
 	ctx := context.Background()
-	req := &Request{}
+	req := &yarpc.Request{}
 
 	t.Run("unary", func(t *testing.T) {
 		handler := yarpctest.NewMockUnaryTransportHandler(ctrl)
-		mw := ApplyUnaryInboundTransportMiddleware(handler, nil)
+		mw := yarpc.ApplyUnaryInboundTransportMiddleware(handler, nil)
 
-		handler.EXPECT().Handle(ctx, req, &Buffer{})
-		_, _, err := mw.Handle(ctx, req, &Buffer{})
+		handler.EXPECT().Handle(ctx, req, &yarpc.Buffer{})
+		_, _, err := mw.Handle(ctx, req, &yarpc.Buffer{})
 		require.NoError(t, err, "unexpected error calling handler")
 	})
 }
@@ -79,8 +79,8 @@ func TestStreamNopInboundMiddleware(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	h := yarpctest.NewMockStreamTransportHandler(mockCtrl)
-	wrappedH := ApplyStreamInboundTransportMiddleware(h, NopStreamInboundTransportMiddleware)
-	s, err := NewServerStream(yarpctest.NewMockStream(mockCtrl))
+	wrappedH := yarpc.ApplyStreamInboundTransportMiddleware(h, yarpc.NopStreamInboundTransportMiddleware)
+	s, err := yarpc.NewServerStream(yarpctest.NewMockStream(mockCtrl))
 	require.NoError(t, err)
 
 	err = errors.New("great sadness")
@@ -94,6 +94,6 @@ func TestStreamDefaultsToHandlerWhenNil(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	h := yarpctest.NewMockStreamTransportHandler(mockCtrl)
-	wrappedH := ApplyStreamInboundTransportMiddleware(h, nil)
+	wrappedH := yarpc.ApplyStreamInboundTransportMiddleware(h, nil)
 	assert.Equal(t, wrappedH, h)
 }

--- a/v2/inbound_middleware_test.go
+++ b/v2/inbound_middleware_test.go
@@ -28,8 +28,8 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/yarpc/internal/testtime"
 	. "go.uber.org/yarpc/v2"
+	"go.uber.org/yarpc/v2/internal/internaltesttime"
 	"go.uber.org/yarpc/v2/yarpctest"
 )
 
@@ -40,7 +40,7 @@ func TestUnaryNopInboundMiddleware(t *testing.T) {
 	h := yarpctest.NewMockUnaryTransportHandler(mockCtrl)
 	wrappedH := ApplyUnaryInboundTransportMiddleware(h, NopUnaryInboundTransportMiddleware)
 
-	ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), internaltesttime.Second)
 	defer cancel()
 	req := &Request{
 		Caller:    "somecaller",

--- a/v2/internal/bufferpool/buffer.go
+++ b/v2/internal/bufferpool/buffer.go
@@ -1,0 +1,166 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package bufferpool
+
+import (
+	"bytes"
+	"io"
+)
+
+// Buffer represents a poolable buffer. It wraps an underlying
+// *bytes.Buffer with lightweight detection of races.
+type Buffer struct {
+	pool *Pool
+
+	// version is an ever-incrementing integer on every operation.
+	// it ensures that we don't perform multiple overlapping operations.
+	version uint
+
+	// released tracks whether the buffer has been released.
+	released bool
+
+	buf *bytes.Buffer
+}
+
+func newBuffer(pool *Pool) *Buffer {
+	return &Buffer{
+		pool: pool,
+		buf:  &bytes.Buffer{},
+	}
+}
+
+func (b *Buffer) checkUseAfterFree() {
+	if b.released || b.buf == nil {
+		panic("use-after-free of pooled buffer")
+	}
+}
+
+func (b *Buffer) preOp() uint {
+	b.checkUseAfterFree()
+	b.version++
+	return b.version
+}
+
+func (b *Buffer) postOp(v uint) {
+	b.checkUseAfterFree()
+	if v != b.version || b.released {
+		panic("concurrent use of pooled buffer")
+	}
+	b.version++
+}
+
+// Read is the same as bytes.Buffer.Read.
+func (b *Buffer) Read(p []byte) (int, error) {
+	version := b.preOp()
+	n, err := b.buf.Read(p)
+	b.postOp(version)
+	return n, err
+}
+
+// ReadFrom is the same as bytes.Buffer.ReadFrom.
+func (b *Buffer) ReadFrom(r io.Reader) (int64, error) {
+	version := b.preOp()
+	n, err := b.buf.ReadFrom(r)
+	b.postOp(version)
+	return n, err
+}
+
+// Write is the same as bytes.Buffer.Write.
+func (b *Buffer) Write(p []byte) (int, error) {
+	version := b.preOp()
+	n, err := b.buf.Write(p)
+	b.postOp(version)
+	return n, err
+}
+
+// WriteTo is the same as bytes.Buffer.WriteTo.
+func (b *Buffer) WriteTo(w io.Writer) (int64, error) {
+	version := b.preOp()
+	n, err := b.buf.WriteTo(w)
+	b.postOp(version)
+	return n, err
+}
+
+// Bytes returns the bytes in the underlying buffer, as well as a
+// function to call when the caller is done using the bytes.
+// This is easy to mis-use and lead to a use-after-free that
+// cannot be detected, so it is strongly recommended that this method
+// is NOT used.
+func (b *Buffer) Bytes() []byte {
+	return b.buf.Bytes()
+}
+
+// Len is the same as bytes.Buffer.Len.
+func (b *Buffer) Len() int {
+	version := b.preOp()
+	n := b.buf.Len()
+	b.postOp(version)
+	return n
+}
+
+// Reset is the same as bytes.Buffer.Reset.
+func (b *Buffer) Reset() {
+	version := b.preOp()
+	b.buf.Reset()
+	b.postOp(version)
+}
+
+// Release releases the buffer back to the buffer pool.
+func (b *Buffer) Release() {
+	// Increment the version so overlapping operations fail.
+	b.postOp(b.preOp())
+
+	if b.pool.testDetectUseAfterFree {
+		b.releaseDetectUseAfterFree()
+		return
+	}
+
+	// Before releasing a buffer, we should reset it to "clear" the buffer
+	// while holding on to the capacity of the buffer.
+	b.Reset()
+
+	// We must mark released after the `Reset`, so that `Reset` doesn't
+	// trigger use-after-free.
+	b.released = true
+
+	b.pool.release(b)
+}
+
+func (b *Buffer) reuse() {
+	b.released = false
+}
+
+func (b *Buffer) releaseDetectUseAfterFree() {
+	// Detect any lingering reads of the underlying data by resetting the data.
+	// We repeat it in a goroutine to trigger the race detector.
+	overwriteData(b.Bytes())
+	go overwriteData(b.Bytes())
+
+	// This will cause any future accesses to panic.
+	b.released = true
+	b.buf = nil
+}
+
+func overwriteData(bs []byte) {
+	for i := range bs {
+		bs[i] = byte(i)
+	}
+}

--- a/v2/internal/bufferpool/bufferpool.go
+++ b/v2/internal/bufferpool/bufferpool.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package bufferpool maintains a pool of bytes.Buffers for use in
+// encoding and transport implementations.
+package bufferpool
+
+import (
+	"flag"
+	"sync"
+)
+
+var _pool = NewPool()
+
+// Option configures a buffer pool.
+type Option func(*Pool)
+
+// Pool represents a buffer pool with a set of options.
+type Pool struct {
+	testDetectUseAfterFree bool
+	pool                   sync.Pool
+}
+
+func init() {
+	// This is a hacky way to determine whether we are running in unit tests where
+	// we want to enable use-after-free detection.
+	// https://stackoverflow.com/a/36666114
+	if flag.Lookup("test.v") != nil {
+		_pool = NewPool(DetectUseAfterFreeForTests())
+	}
+}
+
+// NewPool returns a pool that we can allocate buffers from.
+func NewPool(opts ...Option) *Pool {
+	pool := &Pool{}
+	for _, opt := range opts {
+		opt(pool)
+	}
+	return pool
+}
+
+// DetectUseAfterFreeForTests is an option that allows unit tests to detect
+// bad use of a pooled buffer after it has been released to the pool.
+func DetectUseAfterFreeForTests() Option {
+	return func(p *Pool) {
+		p.testDetectUseAfterFree = true
+	}
+}
+
+// Get returns a buffer from the pool.
+func (p *Pool) Get() *Buffer {
+	buf, ok := p.pool.Get().(*Buffer)
+	if !ok {
+		buf = newBuffer(p)
+	} else {
+		buf.reuse()
+	}
+	return buf
+}
+
+func (p *Pool) release(buf *Buffer) {
+	p.pool.Put(buf)
+}
+
+// Get returns a new Buffer from the Buffer pool that has been reset.
+func Get() *Buffer {
+	return _pool.Get()
+}
+
+// Put returns a Buffer to the Buffer pool.
+func Put(buf *Buffer) {
+	buf.Release()
+}

--- a/v2/internal/bufferpool/bufferpool_test.go
+++ b/v2/internal/bufferpool/bufferpool_test.go
@@ -1,0 +1,191 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package bufferpool
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBufferWrite(t *testing.T) {
+	runTestWithBuffer(t, func(t *testing.T, buf *Buffer) {
+		buf.Write([]byte("hello world"))
+		assert.Equal(t, "hello world", string(buf.Bytes()), "Unexpected written bytes")
+	})
+}
+
+func TestBufferWriteTo(t *testing.T) {
+	runTestWithBuffer(t, func(t *testing.T, buf *Buffer) {
+		buf.Write([]byte("hello world"))
+
+		sink := &bytes.Buffer{}
+		buf.WriteTo(sink)
+		assert.Equal(t, "hello world", string(sink.Bytes()), "Unexpected written bytes")
+	})
+}
+
+func TestBufferRead(t *testing.T) {
+	runTestWithBuffer(t, func(t *testing.T, buf *Buffer) {
+		io.WriteString(buf, "hello world")
+
+		got, err := ioutil.ReadAll(buf)
+		require.NoError(t, err, "Read failed")
+		assert.Equal(t, "hello world", string(got), "Unexpected read bytes")
+	})
+}
+
+func TestBufferReadFrom(t *testing.T) {
+	runTestWithBuffer(t, func(t *testing.T, buf *Buffer) {
+		_, err := buf.ReadFrom(strings.NewReader("hello world"))
+		require.NoError(t, err, "ReadFrom failed")
+
+		assert.Equal(t, "hello world", string(buf.Bytes()), "Unexpected read bytes")
+	})
+}
+
+func TestBufferPrePostOp(t *testing.T) {
+	runTest(t, func(t *testing.T, pool *Pool) {
+		buf := pool.Get()
+		defer buf.Release()
+
+		v := buf.preOp()
+		assert.NotPanics(t, func() {
+			buf.postOp(v)
+		})
+
+		// Doing the postOp twice will panic
+		assert.Panics(t, func() {
+			buf.postOp(v)
+		})
+	})
+}
+
+func TestBufferReuse(t *testing.T) {
+	runTest(t, func(t *testing.T, pool *Pool) {
+		runConcurrently(t, func() {
+			buf := pool.Get()
+			io.WriteString(buf, "test")
+			buf.Release()
+		})
+	})
+}
+
+func TestBufferUseAfterRelease(t *testing.T) {
+	runTest(t, func(t *testing.T, pool *Pool) {
+		buf := pool.Get()
+		buf.Release()
+
+		assert.Panics(t, func() {
+			io.WriteString(buf, "test")
+		})
+	})
+}
+
+func TestBufferReleaseTwice(t *testing.T) {
+	runTest(t, func(t *testing.T, pool *Pool) {
+		buf := pool.Get()
+
+		buf.Release()
+		assert.Panics(t, func() {
+			buf.Release()
+		})
+	})
+}
+
+func TestBuffers(t *testing.T) {
+	runConcurrently(t, func() {
+		buf := Get()
+		assert.Zero(t, buf.Len(), "Expected truncated buffer")
+
+		bs := randBytes(rand.Intn(5000))
+		_, err := rand.Read(bs)
+		assert.NoError(t, err, "Unexpected error from rand.Read")
+		_, err = buf.Write(bs)
+		assert.NoError(t, err, "Unexpected error from buffer.Write")
+
+		assert.Equal(t, buf.Len(), len(bs), "Expected same buffer size")
+
+		Put(buf)
+	})
+}
+
+func runTestWithBuffer(t *testing.T, f func(t *testing.T, buf *Buffer)) {
+	runTest(t, func(t *testing.T, pool *Pool) {
+		buf := pool.Get()
+		defer buf.Release()
+
+		f(t, buf)
+	})
+}
+
+// runTest runs a given test function with pools created using
+// different options.
+// It also runs the test multiple times to trigger buffer reuse.
+func runTest(t *testing.T, f func(t *testing.T, pool *Pool)) {
+	const numIterations = 10
+
+	t.Run("no use-after-free detection", func(t *testing.T) {
+		for i := 0; i < numIterations; i++ {
+			f(t, NewPool())
+		}
+	})
+
+	t.Run("with use-after-free detection", func(t *testing.T) {
+		for i := 0; i < numIterations; i++ {
+			f(t, NewPool(DetectUseAfterFreeForTests()))
+		}
+	})
+}
+
+func runConcurrently(t *testing.T, f func()) {
+	const (
+		numGoroutines = 5
+		numIterations = 20
+	)
+
+	var wg sync.WaitGroup
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			for j := 0; j < 10; j++ {
+				f()
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+func randBytes(n int) []byte {
+	buf := make([]byte, n)
+	rand.Read(buf)
+	return buf
+}

--- a/v2/internal/internalbufferpool/buffer.go
+++ b/v2/internal/internalbufferpool/buffer.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package bufferpool
+package internalbufferpool
 
 import (
 	"bytes"

--- a/v2/internal/internalbufferpool/bufferpool.go
+++ b/v2/internal/internalbufferpool/bufferpool.go
@@ -18,9 +18,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Package bufferpool maintains a pool of bytes.Buffers for use in
+// Package internalbufferpool maintains a pool of bytes.Buffers for use in
 // encoding and transport implementations.
-package bufferpool
+package internalbufferpool
 
 import (
 	"flag"

--- a/v2/internal/internalbufferpool/bufferpool_test.go
+++ b/v2/internal/internalbufferpool/bufferpool_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package bufferpool
+package internalbufferpool
 
 import (
 	"bytes"

--- a/v2/internal/internalhttp/httpserver_test.go
+++ b/v2/internal/internalhttp/httpserver_test.go
@@ -31,8 +31,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/yarpc/internal/testtime"
-	"go.uber.org/yarpc/internal/yarpctest"
+	"go.uber.org/yarpc/v2/internal/internaltesttime"
+	"go.uber.org/yarpc/v2/internal/internalyarpctest"
 )
 
 func TestStartAndShutdown(t *testing.T) {
@@ -40,7 +40,7 @@ func TestStartAndShutdown(t *testing.T) {
 	require.NoError(t, server.ListenAndServe())
 
 	require.NotNil(t, server.Listener())
-	addr := yarpctest.ZeroAddrToHostPort(server.Listener().Addr())
+	addr := internalyarpctest.ZeroAddrToHostPort(server.Listener().Addr())
 
 	conn, err := net.Dial("tcp", addr)
 	require.NoError(t, err)
@@ -56,7 +56,7 @@ func TestStartAddrInUse(t *testing.T) {
 	require.NoError(t, s1.ListenAndServe())
 	defer s1.Shutdown(context.Background())
 
-	addr := yarpctest.ZeroAddrToHostPort(s1.Listener().Addr())
+	addr := internalyarpctest.ZeroAddrToHostPort(s1.Listener().Addr())
 	s2 := NewHTTPServer(&http.Server{Addr: addr})
 	err := s2.ListenAndServe()
 
@@ -103,6 +103,6 @@ func TestShutdownError(t *testing.T) {
 	server := NewHTTPServer(&http.Server{Addr: ":0"})
 	require.NoError(t, server.ListenAndServe())
 	require.NoError(t, server.Listener().Close())
-	time.Sleep(5 * testtime.Millisecond)
+	time.Sleep(5 * internaltesttime.Millisecond)
 	require.Error(t, server.Shutdown(context.Background()))
 }

--- a/v2/internal/internaltesttime/scale.go
+++ b/v2/internal/internaltesttime/scale.go
@@ -18,9 +18,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Package testtime provides ways to scale time for tests running on CPU
+// Package internaltesttime provides ways to scale time for tests running on CPU
 // starved systems.
-package testtime
+package internaltesttime
 
 import (
 	"fmt"

--- a/v2/internal/testtime/scale.go
+++ b/v2/internal/testtime/scale.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package testtime provides ways to scale time for tests running on CPU
+// starved systems.
+package testtime
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+)
+
+var (
+	// X is the multiplier from the TEST_TIME_SCALE environment variable.
+	X = 1.0
+	// Millisecond is a millisecond dilated into test time by TEST_TIME_SCALE.
+	Millisecond = time.Millisecond
+	// Second is a second dilated into test time by TEST_TIME_SCALE.
+	Second = time.Second
+)
+
+func init() {
+	if v := os.Getenv("TEST_TIME_SCALE"); v != "" {
+		fv, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			panic(err)
+		}
+		X = fv
+		fmt.Fprintln(os.Stderr, "Scaling test time by factor", X)
+	}
+
+	Millisecond = Scale(time.Millisecond)
+	Second = Scale(time.Second)
+}
+
+// Scale returns the timeout multiplied by any set multiplier.
+func Scale(timeout time.Duration) time.Duration {
+	return time.Duration(X * float64(timeout))
+}
+
+// Sleep sleeps the given duration in test time scale.
+func Sleep(duration time.Duration) {
+	time.Sleep(Scale(duration))
+}

--- a/v2/outbound_middleware_test.go
+++ b/v2/outbound_middleware_test.go
@@ -27,8 +27,8 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/yarpc/internal/testtime"
 	. "go.uber.org/yarpc/v2"
+	"go.uber.org/yarpc/v2/internal/internaltesttime"
 	"go.uber.org/yarpc/v2/yarpctest"
 )
 
@@ -39,7 +39,7 @@ func TestUnaryNopOutboundMiddleware(t *testing.T) {
 	o := yarpctest.NewMockUnaryOutbound(mockCtrl)
 	wrappedO := ApplyUnaryOutboundTransportMiddleware(o, NopUnaryOutboundTransportMiddleware)
 
-	ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), internaltesttime.Second)
 	defer cancel()
 	req := &Request{
 		Caller:    "somecaller",
@@ -87,7 +87,7 @@ func TestStreamNopOutboundMiddleware(t *testing.T) {
 	o := yarpctest.NewMockStreamOutbound(mockCtrl)
 	wrappedO := ApplyStreamOutboundTransportMiddleware(o, NopStreamOutboundTransportMiddleware)
 
-	ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), internaltesttime.Second)
 	defer cancel()
 	req := &Request{
 		Caller:    "somecaller",

--- a/v2/outbound_middleware_test.go
+++ b/v2/outbound_middleware_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	. "go.uber.org/yarpc/v2"
+	"go.uber.org/yarpc/v2"
 	"go.uber.org/yarpc/v2/internal/internaltesttime"
 	"go.uber.org/yarpc/v2/yarpctest"
 )
@@ -37,19 +37,19 @@ func TestUnaryNopOutboundMiddleware(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	o := yarpctest.NewMockUnaryOutbound(mockCtrl)
-	wrappedO := ApplyUnaryOutboundTransportMiddleware(o, NopUnaryOutboundTransportMiddleware)
+	wrappedO := yarpc.ApplyUnaryOutboundTransportMiddleware(o, yarpc.NopUnaryOutboundTransportMiddleware)
 
 	ctx, cancel := context.WithTimeout(context.Background(), internaltesttime.Second)
 	defer cancel()
-	req := &Request{
+	req := &yarpc.Request{
 		Caller:    "somecaller",
 		Service:   "someservice",
-		Encoding:  Encoding("raw"),
+		Encoding:  yarpc.Encoding("raw"),
 		Procedure: "hello",
 	}
-	reqBuf := NewBufferBytes([]byte{1, 2, 3})
-	resp := &Response{}
-	respBuf := NewBufferBytes([]byte{4, 5, 6})
+	reqBuf := yarpc.NewBufferBytes([]byte{1, 2, 3})
+	resp := &yarpc.Response{}
+	respBuf := yarpc.NewBufferBytes([]byte{4, 5, 6})
 	o.EXPECT().Call(ctx, req, reqBuf).Return(resp, respBuf, nil)
 
 	gotResp, gotRespBuf, err := wrappedO.Call(ctx, req, reqBuf)
@@ -65,7 +65,7 @@ func TestNilOutboundMiddleware(t *testing.T) {
 
 	t.Run("unary", func(t *testing.T) {
 		out := yarpctest.NewMockUnaryOutbound(ctrl)
-		_ = ApplyUnaryOutboundTransportMiddleware(out, nil)
+		_ = yarpc.ApplyUnaryOutboundTransportMiddleware(out, nil)
 	})
 }
 
@@ -76,7 +76,7 @@ func TestOutboundMiddleware(t *testing.T) {
 	t.Run("unary", func(t *testing.T) {
 		out := yarpctest.NewMockUnaryOutbound(ctrl)
 		mw := yarpctest.NewMockUnaryOutboundTransportMiddleware(ctrl)
-		_ = ApplyUnaryOutboundTransportMiddleware(out, mw)
+		_ = yarpc.ApplyUnaryOutboundTransportMiddleware(out, mw)
 	})
 }
 
@@ -85,14 +85,14 @@ func TestStreamNopOutboundMiddleware(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	o := yarpctest.NewMockStreamOutbound(mockCtrl)
-	wrappedO := ApplyStreamOutboundTransportMiddleware(o, NopStreamOutboundTransportMiddleware)
+	wrappedO := yarpc.ApplyStreamOutboundTransportMiddleware(o, yarpc.NopStreamOutboundTransportMiddleware)
 
 	ctx, cancel := context.WithTimeout(context.Background(), internaltesttime.Second)
 	defer cancel()
-	req := &Request{
+	req := &yarpc.Request{
 		Caller:    "somecaller",
 		Service:   "someservice",
-		Encoding:  Encoding("raw"),
+		Encoding:  yarpc.Encoding("raw"),
 		Procedure: "hello",
 	}
 
@@ -109,7 +109,7 @@ func TestStreamDefaultsToOutboundWhenNil(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	o := yarpctest.NewMockStreamOutbound(mockCtrl)
-	wrappedO := ApplyStreamOutboundTransportMiddleware(o, nil)
+	wrappedO := yarpc.ApplyStreamOutboundTransportMiddleware(o, nil)
 	assert.Equal(t, wrappedO, o)
 }
 
@@ -118,5 +118,5 @@ func TestStreamMiddlewareCallsUnderlyingFunctions(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	o := yarpctest.NewMockStreamOutbound(mockCtrl)
-	_ = ApplyStreamOutboundTransportMiddleware(o, NopStreamOutboundTransportMiddleware)
+	_ = yarpc.ApplyStreamOutboundTransportMiddleware(o, yarpc.NopStreamOutboundTransportMiddleware)
 }

--- a/v2/request_test.go
+++ b/v2/request_test.go
@@ -26,21 +26,21 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	. "go.uber.org/yarpc/v2"
+	"go.uber.org/yarpc/v2"
 	"go.uber.org/zap/zapcore"
 )
 
 func TestValidator(t *testing.T) {
 	tests := []struct {
-		req           *Request
-		transportType Type
+		req           *yarpc.Request
+		transportType yarpc.Type
 		ttl           time.Duration
 
 		wantMissingParams []string
 	}{
 		{
 			// No error
-			req: &Request{
+			req: &yarpc.Request{
 				Caller:    "caller",
 				Service:   "service",
 				Encoding:  "raw",
@@ -50,7 +50,7 @@ func TestValidator(t *testing.T) {
 		},
 		{
 			// encoding is not required
-			req: &Request{
+			req: &yarpc.Request{
 				Caller:    "caller",
 				Service:   "service",
 				Procedure: "hello",
@@ -58,7 +58,7 @@ func TestValidator(t *testing.T) {
 			wantMissingParams: []string{"encoding"},
 		},
 		{
-			req: &Request{
+			req: &yarpc.Request{
 				Service:   "service",
 				Procedure: "hello",
 				Encoding:  "raw",
@@ -66,7 +66,7 @@ func TestValidator(t *testing.T) {
 			wantMissingParams: []string{"caller"},
 		},
 		{
-			req: &Request{
+			req: &yarpc.Request{
 				Caller:    "caller",
 				Procedure: "hello",
 				Encoding:  "raw",
@@ -74,7 +74,7 @@ func TestValidator(t *testing.T) {
 			wantMissingParams: []string{"service"},
 		},
 		{
-			req: &Request{
+			req: &yarpc.Request{
 				Caller:   "caller",
 				Service:  "service",
 				Encoding: "raw",
@@ -82,26 +82,26 @@ func TestValidator(t *testing.T) {
 			wantMissingParams: []string{"procedure"},
 		},
 		{
-			req: &Request{
+			req: &yarpc.Request{
 				Caller:    "caller",
 				Service:   "service",
 				Procedure: "hello",
 				Encoding:  "raw",
 			},
-			transportType:     Unary,
+			transportType:     yarpc.Unary,
 			wantMissingParams: []string{"TTL"},
 		},
 		{
-			req:               &Request{},
+			req:               &yarpc.Request{},
 			wantMissingParams: []string{"encoding", "caller", "service", "procedure"},
 		},
 	}
 
 	for _, tt := range tests {
 		ctx := context.Background()
-		err := ValidateRequest(tt.req)
+		err := yarpc.ValidateRequest(tt.req)
 
-		if err == nil && tt.transportType == Unary {
+		if err == nil && tt.transportType == yarpc.Unary {
 			var cancel func()
 
 			if tt.ttl != 0 {
@@ -109,7 +109,7 @@ func TestValidator(t *testing.T) {
 				defer cancel()
 			}
 
-			err = ValidateRequestContext(ctx)
+			err = yarpc.ValidateRequestContext(ctx)
 		}
 
 		if len(tt.wantMissingParams) > 0 {
@@ -125,13 +125,13 @@ func TestValidator(t *testing.T) {
 }
 
 func TestRequestLogMarshaling(t *testing.T) {
-	r := &Request{
+	r := &yarpc.Request{
 		Caller:          "caller",
 		Service:         "service",
 		Transport:       "transport",
 		Encoding:        "raw",
 		Procedure:       "procedure",
-		Headers:         NewHeaders().With("password", "super-secret"),
+		Headers:         yarpc.NewHeaders().With("password", "super-secret"),
 		ShardKey:        "shard01",
 		RoutingKey:      "routing-key",
 		RoutingDelegate: "routing-delegate",

--- a/v2/router_middleware_test.go
+++ b/v2/router_middleware_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	. "go.uber.org/yarpc/v2"
+	"go.uber.org/yarpc/v2"
 	"go.uber.org/yarpc/v2/yarpctest"
 )
 
@@ -37,9 +37,9 @@ func TestApplyRouteTable(t *testing.T) {
 	routerMiddleware := yarpctest.NewMockRouterMiddleware(ctrl)
 	routeTable := yarpctest.NewMockRouteTable(ctrl)
 
-	rtWithMW := ApplyRouteTable(routeTable, routerMiddleware)
+	rtWithMW := yarpc.ApplyRouteTable(routeTable, routerMiddleware)
 
-	routeTableWithMW, ok := rtWithMW.(RouteTableWithMiddleware)
+	routeTableWithMW, ok := rtWithMW.(yarpc.RouteTableWithMiddleware)
 	require.True(t, ok, "unexpected RouteTable type")
 
 	assert.Equal(t, routeTableWithMW.GetRouterMiddleware(), routerMiddleware)
@@ -54,14 +54,14 @@ func TestRouteTableMiddleware(t *testing.T) {
 	routeTable := yarpctest.NewMockRouteTable(ctrl)
 
 	ctx := context.Background()
-	req := &Request{}
-	spec := NewUnaryTransportHandlerSpec(yarpctest.NewMockUnaryTransportHandler(ctrl))
+	req := &yarpc.Request{}
+	spec := yarpc.NewUnaryTransportHandlerSpec(yarpctest.NewMockUnaryTransportHandler(ctrl))
 
-	routeTableWithMW := ApplyRouteTable(routeTable, routerMiddleware)
+	routeTableWithMW := yarpc.ApplyRouteTable(routeTable, routerMiddleware)
 
 	// register procedures
 	routeTable.EXPECT().Register(gomock.Any())
-	routeTableWithMW.Register([]Procedure{})
+	routeTableWithMW.Register([]yarpc.Procedure{})
 
 	// choose handlerSpec
 	routerMiddleware.EXPECT().Choose(ctx, req, routeTable).Return(spec, nil)
@@ -70,6 +70,6 @@ func TestRouteTableMiddleware(t *testing.T) {
 	assert.Equal(t, spec, spec)
 
 	// get procedures
-	routerMiddleware.EXPECT().Procedures(routeTable).Return([]Procedure{})
+	routerMiddleware.EXPECT().Procedures(routeTable).Return([]yarpc.Procedure{})
 	routeTableWithMW.Procedures()
 }

--- a/v2/yarpcbackoff/exponential.go
+++ b/v2/yarpcbackoff/exponential.go
@@ -1,0 +1,176 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package backoff
+
+import (
+	"errors"
+	"math/rand"
+	"time"
+
+	"go.uber.org/multierr"
+	"go.uber.org/yarpc/api/backoff"
+)
+
+var (
+	errInvalidFirst = errors.New("invalid first duration for exponential backoff, need greater than zero")
+	errInvalidMax   = errors.New("invalid max for exponential backoff, need greater than or equal to zero")
+)
+
+// ExponentialOption defines options that can be applied to an
+// exponential backoff strategy
+type ExponentialOption func(*exponentialOptions)
+
+// exponentialOptions are the configuration options for an exponential backoff
+type exponentialOptions struct {
+	first, max time.Duration
+	newRand    func() *rand.Rand
+}
+
+func (e exponentialOptions) validate() (err error) {
+	if e.first <= 0 {
+		err = multierr.Append(err, errInvalidFirst)
+	}
+	if e.max < 0 {
+		err = multierr.Append(err, errInvalidMax)
+	}
+	return err
+}
+
+func newRand() *rand.Rand {
+	return rand.New(rand.NewSource(time.Now().UnixNano()))
+}
+
+var defaultExponentialOpts = exponentialOptions{
+	first:   10 * time.Millisecond,
+	max:     time.Minute,
+	newRand: newRand,
+}
+
+// DefaultExponential is an exponential backoff.Strategy with full jitter.
+// The first attempt has a range of 0 to 10ms and each successive attempt
+// doubles the range of the possible delay.
+//
+// Exponential strategies are not thread safe.
+// The Backoff() method returns a referentially independent backoff generator
+// and random number generator.
+var DefaultExponential = &ExponentialStrategy{
+	opts: defaultExponentialOpts,
+}
+
+// FirstBackoff sets the initial range of durations that the first backoff
+// duration will provide.
+// The range of durations will double for each successive attempt.
+func FirstBackoff(t time.Duration) ExponentialOption {
+	return func(options *exponentialOptions) {
+		options.first = t
+	}
+}
+
+// MaxBackoff sets absolute max time that will ever be returned for a backoff.
+func MaxBackoff(t time.Duration) ExponentialOption {
+	return func(options *exponentialOptions) {
+		options.max = t
+	}
+}
+
+// randGenerator is an internal option for overriding the random number
+// generator.
+func randGenerator(newRand func() *rand.Rand) ExponentialOption {
+	return func(options *exponentialOptions) {
+		options.newRand = newRand
+	}
+}
+
+// ExponentialStrategy can create instances of the exponential backoff strategy
+// with full jitter.
+// Each instance has referentially independent random number generators.
+type ExponentialStrategy struct {
+	opts exponentialOptions
+}
+
+var _ backoff.Strategy = (*ExponentialStrategy)(nil)
+
+// NewExponential returns a new exponential backoff strategy, which in turn
+// returns backoff functions.
+//
+// Exponential is an exponential backoff strategy with jitter.  Under the
+// AWS backoff strategies this is a "Full Jitter" backoff implementation
+// https://www.awsarchitectureblog.com/2015/03/backoff.html with the addition
+// of a Min and Max Value.  The range of durations will be contained in
+// a closed [Min, Max] interval.
+//
+// Backoff functions are lockless and referentially independent, but not
+// thread-safe.
+func NewExponential(opts ...ExponentialOption) (*ExponentialStrategy, error) {
+	options := defaultExponentialOpts
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	if err := options.validate(); err != nil {
+		return nil, err
+	}
+
+	return &ExponentialStrategy{
+		opts: options,
+	}, nil
+}
+
+// Backoff returns an instance of the exponential backoff strategy with its own
+// random number generator.
+func (e *ExponentialStrategy) Backoff() backoff.Backoff {
+	return &exponentialBackoff{
+		first: e.opts.first,
+		max:   e.opts.max.Nanoseconds(),
+		rand:  e.opts.newRand(),
+	}
+}
+
+// IsEqual returns whether this strategy is equivalent to another strategy.
+func (e *ExponentialStrategy) IsEqual(o *ExponentialStrategy) bool {
+	if e.opts.first != o.opts.first {
+		return false
+	}
+	if e.opts.max != o.opts.max {
+		return false
+	}
+	return true
+}
+
+// ExponentialBackoff is an instance of the exponential backoff strategy with
+// full jitter.
+type exponentialBackoff struct {
+	first time.Duration
+	max   int64
+	rand  *rand.Rand
+}
+
+// Duration takes an attempt number and returns the duration the caller should
+// wait.
+func (e *exponentialBackoff) Duration(attempts uint) time.Duration {
+	spread := (1 << attempts) * e.first.Nanoseconds()
+	if spread <= 0 || spread > e.max {
+		spread = e.max
+	}
+	// Adding 1 to the spread ensures that the upper bound of the range of
+	// possible durations includes the maximum.
+	return time.Duration(e.rand.Int63n(spread + 1))
+}

--- a/v2/yarpcbackoff/exponential.go
+++ b/v2/yarpcbackoff/exponential.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package backoff
+package yarpcbackoff
 
 import (
 	"errors"
@@ -26,7 +26,7 @@ import (
 	"time"
 
 	"go.uber.org/multierr"
-	"go.uber.org/yarpc/api/backoff"
+	"go.uber.org/yarpc/v2"
 )
 
 var (
@@ -64,13 +64,12 @@ var defaultExponentialOpts = exponentialOptions{
 	newRand: newRand,
 }
 
-// DefaultExponential is an exponential backoff.Strategy with full jitter.
+// DefaultExponential is an exponential yarpc.BackoffStrategy with full jitter.
 // The first attempt has a range of 0 to 10ms and each successive attempt
 // doubles the range of the possible delay.
 //
-// Exponential strategies are not thread safe.
-// The Backoff() method returns a referentially independent backoff generator
-// and random number generator.
+// Exponential strategies are not thread safe. The Backoff() method returns a
+// referentially independent backoff generator and random number generator.
 var DefaultExponential = &ExponentialStrategy{
 	opts: defaultExponentialOpts,
 }
@@ -106,7 +105,7 @@ type ExponentialStrategy struct {
 	opts exponentialOptions
 }
 
-var _ backoff.Strategy = (*ExponentialStrategy)(nil)
+var _ yarpc.BackoffStrategy = (*ExponentialStrategy)(nil)
 
 // NewExponential returns a new exponential backoff strategy, which in turn
 // returns backoff functions.
@@ -136,7 +135,7 @@ func NewExponential(opts ...ExponentialOption) (*ExponentialStrategy, error) {
 
 // Backoff returns an instance of the exponential backoff strategy with its own
 // random number generator.
-func (e *ExponentialStrategy) Backoff() backoff.Backoff {
+func (e *ExponentialStrategy) Backoff() yarpc.Backoff {
 	return &exponentialBackoff{
 		first: e.opts.first,
 		max:   e.opts.max.Nanoseconds(),

--- a/v2/yarpcbackoff/exponential_test.go
+++ b/v2/yarpcbackoff/exponential_test.go
@@ -1,0 +1,196 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package backoff
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInvalidFirst(t *testing.T) {
+	_, err := NewExponential(
+		FirstBackoff(time.Duration(0)),
+	)
+	assert.Equal(t, err.Error(), "invalid first duration for exponential backoff, need greater than zero")
+}
+
+func TestInvalidMax(t *testing.T) {
+	_, err := NewExponential(
+		MaxBackoff(-1 * time.Second),
+	)
+	assert.Equal(t, err.Error(), "invalid max for exponential backoff, need greater than or equal to zero")
+}
+
+func TestInvalidFirstAndMax(t *testing.T) {
+	_, err := NewExponential(
+		FirstBackoff(time.Duration(0)),
+		MaxBackoff(-1*time.Second),
+	)
+	assert.Equal(t, err.Error(), "invalid first duration for exponential backoff, need greater than zero; invalid max for exponential backoff, need greater than or equal to zero")
+}
+
+func TestExponential(t *testing.T) {
+	type backoffAttempt struct {
+		msg            string
+		giveAttempt    uint
+		giveRandResult int64
+		wantBackoff    time.Duration
+	}
+	type testStruct struct {
+		msg string
+
+		giveFirst time.Duration
+		giveMax   time.Duration
+
+		attempts []backoffAttempt
+	}
+	tests := []testStruct{
+		{
+			msg:       "valid durations",
+			giveFirst: time.Nanosecond,
+			giveMax:   time.Nanosecond * 100,
+			attempts: []backoffAttempt{
+				{
+					msg:            "zero attempt max backoff",
+					giveAttempt:    0,
+					giveRandResult: int64(1 << 0),
+					wantBackoff:    time.Nanosecond,
+				},
+				{
+					msg:            "zero attempt min backoff",
+					giveAttempt:    0,
+					giveRandResult: 0,
+					wantBackoff:    time.Duration(0),
+				},
+				{
+					msg:            "zero attempt min backoff (with wrapped rand value)",
+					giveAttempt:    0,
+					giveRandResult: int64(1<<0) + 1,
+					wantBackoff:    time.Duration(0),
+				},
+				{
+					msg:            "one attempt max backoff",
+					giveAttempt:    1,
+					giveRandResult: int64(1 << 1),
+					wantBackoff:    time.Nanosecond * 2,
+				},
+				{
+					msg:            "two attempts max backoff",
+					giveAttempt:    2,
+					giveRandResult: int64(1 << 2),
+					wantBackoff:    time.Duration(int64(1 << 2)),
+				},
+				{
+					msg:            "three attempts max backoff",
+					giveAttempt:    3,
+					giveRandResult: int64(1 << 3),
+					wantBackoff:    time.Duration(int64(1 << 3)),
+				},
+				{
+					msg:            "four attempts max backoff",
+					giveAttempt:    4,
+					giveRandResult: int64(1 << 4),
+					wantBackoff:    time.Duration(int64(1 << 4)),
+				},
+				{
+					msg:            "four attempts min backoff (with wrapped rand value)",
+					giveAttempt:    4,
+					giveRandResult: int64(1<<4) + 1,
+					wantBackoff:    time.Duration(0),
+				},
+				{
+					msg:            "attempts range higher than max value",
+					giveAttempt:    30,
+					giveRandResult: 100,
+					wantBackoff:    time.Nanosecond * 100,
+				},
+				{
+					msg:            "attempts range higher than max value (with wrapped rand value)",
+					giveAttempt:    30,
+					giveRandResult: 100 + 1,
+					wantBackoff:    time.Duration(0),
+				},
+				{
+					msg:            "attempts that cause overflows should go to max",
+					giveAttempt:    63, // 1<<63 == -9223372036854775808
+					giveRandResult: 100,
+					wantBackoff:    time.Nanosecond * 100,
+				},
+				{
+					msg:            "attempts that cause overflows should go to max (with wrapped rand)",
+					giveAttempt:    63, // 1<<63 == -9223372036854775808
+					giveRandResult: 100 + 1,
+					wantBackoff:    time.Duration(0),
+				},
+				{
+					msg:            "attempts that go beyond overflows should go to max",
+					giveAttempt:    64, // 1<<64 == 0
+					giveRandResult: 100,
+					wantBackoff:    time.Nanosecond * 100,
+				},
+				{
+					msg:            "attempts that go beyond overflows should go to max (with wrapped rand)",
+					giveAttempt:    64, // 1<<64 == 0
+					giveRandResult: 100 + 1,
+					wantBackoff:    time.Duration(0),
+				},
+				{
+					msg:            "max value with a random value that i choose",
+					giveAttempt:    14,
+					giveRandResult: 68,
+					wantBackoff:    time.Duration(68),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			randSrc := &mutableRandSrc{val: 0}
+			strategy, err := NewExponential(
+				FirstBackoff(tt.giveFirst),
+				MaxBackoff(tt.giveMax),
+				randGenerator(func() *rand.Rand { return rand.New(randSrc) }),
+			)
+			assert.NoError(t, err)
+			backoff := strategy.Backoff()
+			for _, attempt := range tt.attempts {
+				randSrc.val = attempt.giveRandResult
+				assert.Equal(t, attempt.wantBackoff, backoff.Duration(attempt.giveAttempt), "backoff for backoffAttempt %q did not match", attempt.msg)
+			}
+		})
+	}
+}
+
+// mutableRandSrc implements the rand.Source interface so we can get our random
+// number generator to return whatever we want.
+type mutableRandSrc struct {
+	val int64
+}
+
+func (r *mutableRandSrc) Int63() int64 {
+	return r.val
+}
+
+func (*mutableRandSrc) Seed(int64) {}

--- a/v2/yarpcbackoff/exponential_test.go
+++ b/v2/yarpcbackoff/exponential_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package backoff
+package yarpcbackoff
 
 import (
 	"math/rand"

--- a/v2/yarpcbackoff/none.go
+++ b/v2/yarpcbackoff/none.go
@@ -18,19 +18,23 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package backoff
+package yarpcbackoff
 
-import "time"
+import (
+	"time"
+
+	"go.uber.org/yarpc/v2"
+)
 
 // None is a shorted backoff strategy that will always produce a 0ms duration.
 // This strategy is intended to minimize arbitrary delays during tests or
 // maximize load on a benchmark.
-var None Strategy = &none{}
+var None yarpc.BackoffStrategy = &none{}
 
 type none struct{}
 
 // Backoff implements Strategy.
-func (n *none) Backoff() Backoff {
+func (n *none) Backoff() yarpc.Backoff {
 	return n
 }
 

--- a/v2/yarpcbackoff/none.go
+++ b/v2/yarpcbackoff/none.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package backoff
+
+import "time"
+
+// None is a shorted backoff strategy that will always produce a 0ms duration.
+// This strategy is intended to minimize arbitrary delays during tests or
+// maximize load on a benchmark.
+var None Strategy = &none{}
+
+type none struct{}
+
+// Backoff implements Strategy.
+func (n *none) Backoff() Backoff {
+	return n
+}
+
+// Duration implements Backoff.
+func (*none) Duration(attempts uint) time.Duration {
+	return time.Duration(0)
+}

--- a/v2/yarpcbackoff/none_test.go
+++ b/v2/yarpcbackoff/none_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package backoff
+package yarpcbackoff
 
 import (
 	"testing"

--- a/v2/yarpcbackoff/none_test.go
+++ b/v2/yarpcbackoff/none_test.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package backoff
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNone(t *testing.T) {
+	boff := None.Backoff()
+	assert.Equal(t, time.Duration(0), boff.Duration(0))
+	assert.Equal(t, time.Duration(0), boff.Duration(1))
+	assert.Equal(t, time.Duration(0), boff.Duration(2))
+}

--- a/v2/yarpcgrpc/codec.go
+++ b/v2/yarpcgrpc/codec.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package grpc
+package yarpcgrpc
 
 import "fmt"
 

--- a/v2/yarpcgrpc/codec_test.go
+++ b/v2/yarpcgrpc/codec_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package grpc
+package yarpcgrpc
 
 import (
 	"testing"

--- a/v2/yarpcgrpc/codes.go
+++ b/v2/yarpcgrpc/codes.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package grpc
+package yarpcgrpc
 
 import (
 	"go.uber.org/yarpc/v2/yarpcerror"

--- a/v2/yarpcgrpc/codes_test.go
+++ b/v2/yarpcgrpc/codes_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package grpc
+package yarpcgrpc
 
 import (
 	"testing"

--- a/v2/yarpcgrpc/constants.go
+++ b/v2/yarpcgrpc/constants.go
@@ -18,6 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package grpc
+package yarpcgrpc
 
 const transportName = "grpc"

--- a/v2/yarpcgrpc/dialer.go
+++ b/v2/yarpcgrpc/dialer.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package grpc
+package yarpcgrpc
 
 import (
 	"context"

--- a/v2/yarpcgrpc/dialer.go
+++ b/v2/yarpcgrpc/dialer.go
@@ -28,11 +28,9 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 	"go.uber.org/multierr"
-	backoffapi "go.uber.org/yarpc/api/backoff"
-	"go.uber.org/yarpc/internal/backoff"
 	"go.uber.org/yarpc/v2"
+	"go.uber.org/yarpc/v2/yarpcbackoff"
 	"go.uber.org/yarpc/v2/yarpcpeer"
-	"go.uber.org/yarpc/yarpcconfig"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -59,17 +57,16 @@ type Dialer struct {
 	// The default is math.MaxInt32.
 	ClientMaxSendMsgSize int
 
+	// Credentials specifies connection level security credentials (e.g.,
+	// TLS/SSL) for outbound connections.
+	Credentials credentials.TransportCredentials
+
 	// BackoffStrategy specifies the backoff strategy for delays between
 	// connection attempts for each peer.
 	//
 	// The default is exponential backoff starting with 10ms fully jittered,
 	// doubling each attempt, with a maximum interval of 30s.
-	// TODO(apeatsbond): this is still a v1 package
-	Backoff yarpcconfig.Backoff
-
-	// Credentials specifies connection level security credentials (e.g.,
-	// TLS/SSL) for outbound connections.
-	Credentials credentials.TransportCredentials
+	Backoff yarpc.BackoffStrategy
 
 	// Tracer configures a logger for the dialer.
 	Logger *zap.Logger
@@ -85,7 +82,7 @@ type dialerInternals struct {
 	addressToPeer map[string]*grpcPeer
 
 	dialOptions []grpc.DialOption
-	backoff     backoffapi.Strategy
+	backoff     yarpc.BackoffStrategy
 
 	logger *zap.Logger
 	tracer opentracing.Tracer
@@ -95,11 +92,14 @@ type dialerInternals struct {
 func (d *Dialer) Start(context.Context) error {
 	d.internal = &dialerInternals{
 		addressToPeer: make(map[string]*grpcPeer),
-		backoff:       backoff.DefaultExponential,
+		backoff:       yarpcbackoff.DefaultExponential,
 		tracer:        opentracing.GlobalTracer(),
 		logger:        zap.NewNop(),
 	}
 
+	if d.Backoff != nil {
+		d.internal.backoff = d.Backoff
+	}
 	if d.Logger != nil {
 		d.internal.logger = d.Logger
 	}

--- a/v2/yarpcgrpc/dialer_test.go
+++ b/v2/yarpcgrpc/dialer_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package grpc
+package yarpcgrpc
 
 import (
 	"context"

--- a/v2/yarpcgrpc/doc.go
+++ b/v2/yarpcgrpc/doc.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Package grpc implements a YARPC transport based on the gRPC protocol.
+// Package yarpcgrpc implements a YARPC transport based on the gRPC protocol.
 // The gRPC transport provides support for Unary RPCs only.
 //
 // Usage
@@ -106,4 +106,4 @@
 // gRPC Project Page: https://grpc.io
 // gRPC Wire Protocol Definition: https://grpc.io/docs/guides/wire.html
 // gRPC Golang Library: https://github.com/grpc/grpc-go
-package grpc
+package yarpcgrpc

--- a/v2/yarpcgrpc/handler.go
+++ b/v2/yarpcgrpc/handler.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package grpc
+package yarpcgrpc
 
 import (
 	"strings"

--- a/v2/yarpcgrpc/handler_test.go
+++ b/v2/yarpcgrpc/handler_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package grpc
+package yarpcgrpc
 
 import (
 	"context"

--- a/v2/yarpcgrpc/headers.go
+++ b/v2/yarpcgrpc/headers.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package grpc
+package yarpcgrpc
 
 import (
 	"strings"

--- a/v2/yarpcgrpc/headers_test.go
+++ b/v2/yarpcgrpc/headers_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package grpc
+package yarpcgrpc
 
 import (
 	"testing"

--- a/v2/yarpcgrpc/inbound.go
+++ b/v2/yarpcgrpc/inbound.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package grpc
+package yarpcgrpc
 
 import (
 	"context"
@@ -61,7 +61,7 @@ type Inbound struct {
 
 	// ServerMaxSendMsgSize is the maximum message size the server can send.
 	//
-	// The default is unlimited.
+	// The default is math.MaxInt32.
 	ServerMaxSendMsgSize int
 
 	// Credentials specifies connection level security credentials (e.g.,

--- a/v2/yarpcgrpc/inbound_test.go
+++ b/v2/yarpcgrpc/inbound_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package grpc
+package yarpcgrpc
 
 import (
 	"context"

--- a/v2/yarpcgrpc/integration_test.go
+++ b/v2/yarpcgrpc/integration_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package grpc
+package yarpcgrpc
 
 import (
 	"context"

--- a/v2/yarpcgrpc/metadata_writer.go
+++ b/v2/yarpcgrpc/metadata_writer.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package grpc
+package yarpcgrpc
 
 import (
 	"go.uber.org/multierr"

--- a/v2/yarpcgrpc/outbound.go
+++ b/v2/yarpcgrpc/outbound.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package grpc
+package yarpcgrpc
 
 import (
 	"context"

--- a/v2/yarpcgrpc/outbound_test.go
+++ b/v2/yarpcgrpc/outbound_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package grpc
+package yarpcgrpc
 
 import (
 	"context"

--- a/v2/yarpcgrpc/peer.go
+++ b/v2/yarpcgrpc/peer.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package grpc
+package yarpcgrpc
 
 import (
 	"context"

--- a/v2/yarpcgrpc/stream.go
+++ b/v2/yarpcgrpc/stream.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package grpc
+package yarpcgrpc
 
 import (
 	"bytes"

--- a/v2/yarpcgrpc/stream_test.go
+++ b/v2/yarpcgrpc/stream_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package grpc_test
+package yarpcgrpc_test
 
 import (
 	"errors"

--- a/v2/yarpcgrpc/util.go
+++ b/v2/yarpcgrpc/util.go
@@ -18,22 +18,22 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package grpc
+package yarpcgrpc
 
 import (
 	"fmt"
 	"net/url"
 
-	"go.uber.org/yarpc/pkg/procedure"
-	"go.uber.org/yarpc/yarpcerrors"
+	"go.uber.org/yarpc/v2/yarpcerror"
+	"go.uber.org/yarpc/v2/yarpcprocedure"
 )
 
 const defaultServiceName = "__default__"
 
 func procedureNameToServiceNameMethodName(procedureName string) (string, string, error) {
-	serviceName, methodName := procedure.FromName(procedureName)
+	serviceName, methodName := yarpcprocedure.FromName(procedureName)
 	if serviceName == "" {
-		return "", "", yarpcerrors.InvalidArgumentErrorf("invalid procedure name: %s", procedureName)
+		return "", "", yarpcerror.InvalidArgumentErrorf("invalid procedure name: %s", procedureName)
 	}
 	if methodName == "" {
 		methodName = serviceName
@@ -69,5 +69,5 @@ func procedureToName(serviceName string, methodName string) (string, error) {
 	if serviceName == defaultServiceName {
 		return methodName, nil
 	}
-	return procedure.ToName(serviceName, methodName), nil
+	return yarpcprocedure.ToName(serviceName, methodName), nil
 }

--- a/v2/yarpcgrpc/util_test.go
+++ b/v2/yarpcgrpc/util_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package grpc
+package yarpcgrpc
 
 import (
 	"net/url"

--- a/v2/yarpchttp/dialer.go
+++ b/v2/yarpchttp/dialer.go
@@ -30,9 +30,8 @@ import (
 	"time"
 
 	"github.com/opentracing/opentracing-go"
-	backoffapi "go.uber.org/yarpc/api/backoff"
-	"go.uber.org/yarpc/internal/backoff"
 	"go.uber.org/yarpc/v2"
+	"go.uber.org/yarpc/v2/yarpcbackoff"
 	"go.uber.org/yarpc/v2/yarpcpeer"
 	"go.uber.org/zap"
 )
@@ -115,7 +114,7 @@ type Dialer struct {
 	//
 	// The default is exponential backoff starting with 10ms fully jittered,
 	// doubling each attempt, with a maximum interval of 30s.
-	ConnBackoff backoffapi.Strategy
+	ConnBackoff yarpc.BackoffStrategy
 
 	// InnocenceWindow is the duration after the peer connection management loop
 	// will suspend suspicion for a peer after successfully checking whether the
@@ -161,7 +160,7 @@ type dialerInternals struct {
 	keepAlive           time.Duration
 	maxIdleConnsPerHost int
 	connTimeout         time.Duration
-	connBackoffStrategy backoffapi.Strategy
+	connBackoffStrategy yarpc.BackoffStrategy
 	buildClient         func(*Dialer) *http.Client
 	innocenceWindow     time.Duration
 	jitter              func(int64) int64
@@ -176,7 +175,7 @@ func (d *Dialer) Start(_ context.Context) error {
 		keepAlive:           30 * time.Second,
 		maxIdleConnsPerHost: 2,
 		connTimeout:         defaultConnTimeout,
-		connBackoffStrategy: backoff.DefaultExponential,
+		connBackoffStrategy: yarpcbackoff.DefaultExponential,
 		innocenceWindow:     defaultInnocenceWindow,
 		jitter:              rand.Int63n,
 		peers:               make(map[string]*httpPeer),

--- a/v2/yarpchttp/inbound_test.go
+++ b/v2/yarpchttp/inbound_test.go
@@ -34,8 +34,8 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/yarpc/internal/testtime"
 	"go.uber.org/yarpc/v2"
+	"go.uber.org/yarpc/v2/internal/internaltesttime"
 	"go.uber.org/yarpc/v2/internal/internalyarpctest"
 	"go.uber.org/yarpc/v2/internal/routertest"
 	"go.uber.org/yarpc/v2/yarpcerror"
@@ -133,7 +133,7 @@ func TestInboundMux(t *testing.T) {
 		URL:    parseURL(url),
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), internaltesttime.Second)
 	defer cancel()
 	_, _, err = outbound.Call(ctx, &yarpc.Request{
 		Caller:    "foo",

--- a/v2/yarpchttp/outbound_test.go
+++ b/v2/yarpchttp/outbound_test.go
@@ -34,8 +34,8 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/yarpc/internal/testtime"
 	"go.uber.org/yarpc/v2"
+	"go.uber.org/yarpc/v2/internal/internaltesttime"
 	"go.uber.org/yarpc/v2/yarpcerror"
 	"go.uber.org/yarpc/v2/yarpctest"
 )
@@ -48,7 +48,7 @@ func TestCallSuccess(t *testing.T) {
 			ttl := httpReq.Header.Get(TTLMSHeader)
 			ttlms, err := strconv.Atoi(ttl)
 			assert.NoError(t, err, "can parse TTL header")
-			assert.InDelta(t, ttlms, testtime.X*1000.0, testtime.X*5.0, "ttl header within tolerance")
+			assert.InDelta(t, ttlms, internaltesttime.X*1000.0, internaltesttime.X*5.0, "ttl header within tolerance")
 
 			assert.Equal(t, "caller", httpReq.Header.Get(CallerHeader))
 			assert.Equal(t, "service", httpReq.Header.Get(ServiceHeader))
@@ -77,7 +77,7 @@ func TestCallSuccess(t *testing.T) {
 		URL:    parseURL(successServer.URL),
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), internaltesttime.Second)
 	defer cancel()
 	response, responseBuf, err := outbound.Call(ctx, &yarpc.Request{
 		Caller:    "caller",
@@ -180,7 +180,7 @@ func TestOutboundHeaders(t *testing.T) {
 			ctx := tt.context
 			if ctx == nil {
 				var cancel context.CancelFunc
-				ctx, cancel = context.WithTimeout(context.Background(), testtime.Second)
+				ctx, cancel = context.WithTimeout(context.Background(), internaltesttime.Second)
 				defer cancel()
 			}
 
@@ -245,7 +245,7 @@ func TestOutboundApplicationError(t *testing.T) {
 			outbound := &Outbound{Dialer: dialer, URL: parseURL(server.URL)}
 
 			ctx := context.Background()
-			ctx, cancel := context.WithTimeout(ctx, 100*testtime.Millisecond)
+			ctx, cancel := context.WithTimeout(ctx, 100*internaltesttime.Millisecond)
 			defer cancel()
 
 			response, _, err := outbound.Call(ctx, &yarpc.Request{
@@ -290,7 +290,7 @@ func TestCallFailures(t *testing.T) {
 
 			outbound := &Outbound{Dialer: dialer, URL: parseURL(tt.url)}
 
-			ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), internaltesttime.Second)
 			defer cancel()
 			_, _, err := outbound.Call(ctx, &yarpc.Request{
 				Caller:    "caller",
@@ -431,7 +431,7 @@ func TestServiceMatchSuccess(t *testing.T) {
 		URL:    parseURL(matchServer.URL),
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), internaltesttime.Second)
 	defer cancel()
 	_, _, err := outbound.Call(ctx, &yarpc.Request{Service: "Service"}, &yarpc.Buffer{})
 	require.NoError(t, err)
@@ -458,7 +458,7 @@ func TestServiceMatchFailed(t *testing.T) {
 		URL:    parseURL(mismatchServer.URL),
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), internaltesttime.Second)
 	defer cancel()
 	_, _, err := outbound.Call(ctx, &yarpc.Request{Service: "Service"}, &yarpc.Buffer{})
 	assert.Error(t, err, "expected failure for service name dismatch")
@@ -485,7 +485,7 @@ func TestServiceMatchNoHeader(t *testing.T) {
 		URL:    parseURL(noHeaderServer.URL),
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), internaltesttime.Second)
 	defer cancel()
 	_, _, err := outbound.Call(ctx, &yarpc.Request{Service: "Service"}, &yarpc.Buffer{})
 	require.NoError(t, err)

--- a/v2/yarpchttp/roundtrip_test.go
+++ b/v2/yarpchttp/roundtrip_test.go
@@ -31,7 +31,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/yarpc/internal/testtime"
+	"go.uber.org/yarpc/v2/internal/internaltesttime"
 	"go.uber.org/yarpc/v2/yarpcerror"
 )
 
@@ -77,7 +77,7 @@ func TestRoundTripSuccess(t *testing.T) {
 	hreq.Header.Add(headerKey, headerVal)
 
 	// add deadline
-	ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), internaltesttime.Second)
 	defer cancel()
 	hreq = hreq.WithContext(ctx)
 

--- a/v2/yarpcprotobuf/marshal.go
+++ b/v2/yarpcprotobuf/marshal.go
@@ -27,8 +27,8 @@ import (
 
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
-	"go.uber.org/yarpc/internal/bufferpool"
 	yarpc "go.uber.org/yarpc/v2"
+	"go.uber.org/yarpc/v2/internal/internalbufferpool"
 	"go.uber.org/yarpc/v2/yarpcerror"
 	"go.uber.org/yarpc/v2/yarpcjson"
 )
@@ -44,8 +44,8 @@ var (
 )
 
 func unmarshal(encoding yarpc.Encoding, reader io.Reader, message proto.Message) error {
-	buf := bufferpool.Get()
-	defer bufferpool.Put(buf)
+	buf := internalbufferpool.Get()
+	defer internalbufferpool.Put(buf)
 	if _, err := buf.ReadFrom(reader); err != nil {
 		return err
 	}
@@ -86,8 +86,8 @@ func marshalProto(message proto.Message) ([]byte, func(), error) {
 }
 
 func marshalJSON(message proto.Message) ([]byte, func(), error) {
-	buf := bufferpool.Get()
-	cleanup := func() { bufferpool.Put(buf) }
+	buf := internalbufferpool.Get()
+	cleanup := func() { internalbufferpool.Put(buf) }
 	if err := _jsonMarshaler.Marshal(buf, message); err != nil {
 		cleanup()
 		return nil, nil, err

--- a/v2/yarpctest/peerlistaction.go
+++ b/v2/yarpctest/peerlistaction.go
@@ -28,8 +28,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/yarpc/internal/testtime"
 	yarpc "go.uber.org/yarpc/v2"
+	"go.uber.org/yarpc/v2/internal/internaltesttime"
 )
 
 // ListActionDeps are passed through PeerListActions' Apply methods in order
@@ -89,7 +89,7 @@ func (a ChooseMultiAction) Apply(t *testing.T, pl yarpc.Chooser, deps ListAction
 	for _, expectedPeer := range a.ExpectedPeers {
 		action := ChooseAction{
 			ExpectedPeer:        expectedPeer,
-			InputContextTimeout: 50 * testtime.Millisecond,
+			InputContextTimeout: 50 * internaltesttime.Millisecond,
 		}
 		action.Apply(t, pl, deps)
 	}
@@ -186,7 +186,7 @@ func (a ConcurrentAction) Apply(t *testing.T, pl yarpc.Chooser, deps ListActionD
 		}(action)
 
 		if a.Wait > 0 {
-			testtime.Sleep(a.Wait)
+			internaltesttime.Sleep(a.Wait)
 		}
 	}
 


### PR DESCRIPTION
This change isolates much of `v2` from the rest of YARPC by subsuming the
`backoff`, `bufferpool` and `testtime` packages. Some follow up work is still
needed once this lands.

Note that the `bufferpool` package will eventually be moved to a top-level
`yarpcbuffer` package to consolidate buffer pooling.

Each commit should be reviewed individually. I've separated commits into `copy
from v1` and `update references`.