### PR TITLE
[spring/yarpcprotobuf] Add integration tests for generated streaming APIs

### DIFF
--- a/v2/yarpcprotobuf/protoc-gen-yarpc-go/integration_test.go
+++ b/v2/yarpcprotobuf/protoc-gen-yarpc-go/integration_test.go
@@ -78,7 +78,7 @@ func newHelloClient(t *testing.T, address string) streampb.HelloYARPCClient {
 	})
 }
 
-func startProcedures(t *testing.T, transport, service string, procedures []yarpc.Procedure) (address string, stop func()) {
+func startInbounds(t *testing.T, transport, service string, procedures []yarpc.Procedure) (address string, stop func()) {
 	router := yarpcrouter.NewMapRouter(service)
 	router.Register(procedures)
 
@@ -108,7 +108,7 @@ func setupStreamingEnv(t *testing.T) (client streampb.HelloYARPCClient, stop fun
 	procedures := streampb.BuildHelloYARPCProcedures(stream.NewServer())
 	assert.Equal(t, 6, len(procedures))
 
-	addr, stop := startProcedures(t, "grpc", "hello", procedures)
+	addr, stop := startInbounds(t, "grpc", "hello", procedures)
 	return newHelloClient(t, addr), stop
 }
 
@@ -117,7 +117,7 @@ func TestIntegration(t *testing.T) {
 		procedures := keyvaluepb.BuildStoreYARPCProcedures(keyvalue.NewServer())
 		assert.Equal(t, 4, len(procedures))
 
-		addr, stop := startProcedures(t, "http", "keyvalue", procedures)
+		addr, stop := startInbounds(t, "http", "keyvalue", procedures)
 		defer stop()
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)

--- a/v2/yarpcprotobuf/protoc-gen-yarpc-go/integration_test.go
+++ b/v2/yarpcprotobuf/protoc-gen-yarpc-go/integration_test.go
@@ -185,11 +185,11 @@ func TestIntegration(t *testing.T) {
 
 		res, err := stream.Recv()
 		require.NoError(t, err)
-		assert.Equal(t, `Received "Greetings!"`, res.Response)
+		assert.Equal(t, `Received "Greetings!"`, res.GetResponse())
 
 		assert.NoError(t, stream.Send(&streampb.HelloRequest{Greeting: "exit"}))
 
-		res, err = stream.Recv()
+		_, err = stream.Recv()
 		assert.Equal(t, err, io.EOF)
 	})
 }

--- a/v2/yarpcprotobuf/protoc-gen-yarpc-go/internal/tests/src/stream/stream.go
+++ b/v2/yarpcprotobuf/protoc-gen-yarpc-go/internal/tests/src/stream/stream.go
@@ -35,6 +35,10 @@ func NewServer() streampb.HelloYARPCServer {
 	return &helloServer{}
 }
 
+// In represents a simple server-side streaming procedure. The number of messages
+// the server responds with is equal to the length of the request's greeting.
+// If the client sends a greeting "hello", for example, the server will respond
+// with five individual messages.
 func (h *helloServer) In(req *streampb.HelloRequest, s streampb.HelloInYARPCStreamServer) error {
 	for i := 0; i < len(req.GetGreeting()); i++ {
 		resp := fmt.Sprintf("Received %d", i)
@@ -45,6 +49,9 @@ func (h *helloServer) In(req *streampb.HelloRequest, s streampb.HelloInYARPCStre
 	return nil
 }
 
+// Out represents a simple client-side streaming procedure. The server will
+// collect greetings received from the stream and join them together in its
+// response.
 func (h *helloServer) Out(s streampb.HelloOutYARPCStreamServer) (*streampb.HelloResponse, error) {
 	var msgs []string
 	for {
@@ -60,6 +67,8 @@ func (h *helloServer) Out(s streampb.HelloOutYARPCStreamServer) (*streampb.Hello
 	}
 }
 
+// Bidirectional represents a simple bidirectional streaming procedure. The server
+// will continue to respond to greetings until it receives "exit".
 func (h *helloServer) Bidirectional(s streampb.HelloBidirectionalYARPCStreamServer) error {
 	for {
 		req, err := s.Recv()


### PR DESCRIPTION
Now that the gRPC transport layer has been migrated to the v2 APIs,
this adds integration tests for the generated streaming APIs in
the new `protoc-gen-yarpc-go` plugin.

This includes a test for each of the different gRPC handler types:
unary, client-side streaming, server-side streaming, and bidirectional
streaming.

Note that this integration test primarily concerns itself with the
`yarpcprotobuf` encoding layer. A more sophisticated integration test
will be added in a later change.