### PR TITLE
[spring] Remove dot imports

### DIFF
--- a/v2/inbound_middleware_test.go
+++ b/v2/inbound_middleware_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	. "go.uber.org/yarpc/v2"
+	"go.uber.org/yarpc/v2"
 	"go.uber.org/yarpc/v2/internal/internaltesttime"
 	"go.uber.org/yarpc/v2/yarpctest"
 )
@@ -38,17 +38,17 @@ func TestUnaryNopInboundMiddleware(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	h := yarpctest.NewMockUnaryTransportHandler(mockCtrl)
-	wrappedH := ApplyUnaryInboundTransportMiddleware(h, NopUnaryInboundTransportMiddleware)
+	wrappedH := yarpc.ApplyUnaryInboundTransportMiddleware(h, yarpc.NopUnaryInboundTransportMiddleware)
 
 	ctx, cancel := context.WithTimeout(context.Background(), internaltesttime.Second)
 	defer cancel()
-	req := &Request{
+	req := &yarpc.Request{
 		Caller:    "somecaller",
 		Service:   "someservice",
-		Encoding:  Encoding("raw"),
+		Encoding:  yarpc.Encoding("raw"),
 		Procedure: "hello",
 	}
-	reqBuf := NewBufferBytes([]byte{1, 2, 3})
+	reqBuf := yarpc.NewBufferBytes([]byte{1, 2, 3})
 
 	err := errors.New("great sadness")
 	h.EXPECT().Handle(ctx, req, reqBuf).Return(nil, nil, err)
@@ -62,14 +62,14 @@ func TestNilInboundMiddleware(t *testing.T) {
 	defer ctrl.Finish()
 
 	ctx := context.Background()
-	req := &Request{}
+	req := &yarpc.Request{}
 
 	t.Run("unary", func(t *testing.T) {
 		handler := yarpctest.NewMockUnaryTransportHandler(ctrl)
-		mw := ApplyUnaryInboundTransportMiddleware(handler, nil)
+		mw := yarpc.ApplyUnaryInboundTransportMiddleware(handler, nil)
 
-		handler.EXPECT().Handle(ctx, req, &Buffer{})
-		_, _, err := mw.Handle(ctx, req, &Buffer{})
+		handler.EXPECT().Handle(ctx, req, &yarpc.Buffer{})
+		_, _, err := mw.Handle(ctx, req, &yarpc.Buffer{})
 		require.NoError(t, err, "unexpected error calling handler")
 	})
 }
@@ -79,8 +79,8 @@ func TestStreamNopInboundMiddleware(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	h := yarpctest.NewMockStreamTransportHandler(mockCtrl)
-	wrappedH := ApplyStreamInboundTransportMiddleware(h, NopStreamInboundTransportMiddleware)
-	s, err := NewServerStream(yarpctest.NewMockStream(mockCtrl))
+	wrappedH := yarpc.ApplyStreamInboundTransportMiddleware(h, yarpc.NopStreamInboundTransportMiddleware)
+	s, err := yarpc.NewServerStream(yarpctest.NewMockStream(mockCtrl))
 	require.NoError(t, err)
 
 	err = errors.New("great sadness")
@@ -94,6 +94,6 @@ func TestStreamDefaultsToHandlerWhenNil(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	h := yarpctest.NewMockStreamTransportHandler(mockCtrl)
-	wrappedH := ApplyStreamInboundTransportMiddleware(h, nil)
+	wrappedH := yarpc.ApplyStreamInboundTransportMiddleware(h, nil)
 	assert.Equal(t, wrappedH, h)
 }

--- a/v2/outbound_middleware_test.go
+++ b/v2/outbound_middleware_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	. "go.uber.org/yarpc/v2"
+	"go.uber.org/yarpc/v2"
 	"go.uber.org/yarpc/v2/internal/internaltesttime"
 	"go.uber.org/yarpc/v2/yarpctest"
 )
@@ -37,19 +37,19 @@ func TestUnaryNopOutboundMiddleware(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	o := yarpctest.NewMockUnaryOutbound(mockCtrl)
-	wrappedO := ApplyUnaryOutboundTransportMiddleware(o, NopUnaryOutboundTransportMiddleware)
+	wrappedO := yarpc.ApplyUnaryOutboundTransportMiddleware(o, yarpc.NopUnaryOutboundTransportMiddleware)
 
 	ctx, cancel := context.WithTimeout(context.Background(), internaltesttime.Second)
 	defer cancel()
-	req := &Request{
+	req := &yarpc.Request{
 		Caller:    "somecaller",
 		Service:   "someservice",
-		Encoding:  Encoding("raw"),
+		Encoding:  yarpc.Encoding("raw"),
 		Procedure: "hello",
 	}
-	reqBuf := NewBufferBytes([]byte{1, 2, 3})
-	resp := &Response{}
-	respBuf := NewBufferBytes([]byte{4, 5, 6})
+	reqBuf := yarpc.NewBufferBytes([]byte{1, 2, 3})
+	resp := &yarpc.Response{}
+	respBuf := yarpc.NewBufferBytes([]byte{4, 5, 6})
 	o.EXPECT().Call(ctx, req, reqBuf).Return(resp, respBuf, nil)
 
 	gotResp, gotRespBuf, err := wrappedO.Call(ctx, req, reqBuf)
@@ -65,7 +65,7 @@ func TestNilOutboundMiddleware(t *testing.T) {
 
 	t.Run("unary", func(t *testing.T) {
 		out := yarpctest.NewMockUnaryOutbound(ctrl)
-		_ = ApplyUnaryOutboundTransportMiddleware(out, nil)
+		_ = yarpc.ApplyUnaryOutboundTransportMiddleware(out, nil)
 	})
 }
 
@@ -76,7 +76,7 @@ func TestOutboundMiddleware(t *testing.T) {
 	t.Run("unary", func(t *testing.T) {
 		out := yarpctest.NewMockUnaryOutbound(ctrl)
 		mw := yarpctest.NewMockUnaryOutboundTransportMiddleware(ctrl)
-		_ = ApplyUnaryOutboundTransportMiddleware(out, mw)
+		_ = yarpc.ApplyUnaryOutboundTransportMiddleware(out, mw)
 	})
 }
 
@@ -85,14 +85,14 @@ func TestStreamNopOutboundMiddleware(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	o := yarpctest.NewMockStreamOutbound(mockCtrl)
-	wrappedO := ApplyStreamOutboundTransportMiddleware(o, NopStreamOutboundTransportMiddleware)
+	wrappedO := yarpc.ApplyStreamOutboundTransportMiddleware(o, yarpc.NopStreamOutboundTransportMiddleware)
 
 	ctx, cancel := context.WithTimeout(context.Background(), internaltesttime.Second)
 	defer cancel()
-	req := &Request{
+	req := &yarpc.Request{
 		Caller:    "somecaller",
 		Service:   "someservice",
-		Encoding:  Encoding("raw"),
+		Encoding:  yarpc.Encoding("raw"),
 		Procedure: "hello",
 	}
 
@@ -109,7 +109,7 @@ func TestStreamDefaultsToOutboundWhenNil(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	o := yarpctest.NewMockStreamOutbound(mockCtrl)
-	wrappedO := ApplyStreamOutboundTransportMiddleware(o, nil)
+	wrappedO := yarpc.ApplyStreamOutboundTransportMiddleware(o, nil)
 	assert.Equal(t, wrappedO, o)
 }
 
@@ -118,5 +118,5 @@ func TestStreamMiddlewareCallsUnderlyingFunctions(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	o := yarpctest.NewMockStreamOutbound(mockCtrl)
-	_ = ApplyStreamOutboundTransportMiddleware(o, NopStreamOutboundTransportMiddleware)
+	_ = yarpc.ApplyStreamOutboundTransportMiddleware(o, yarpc.NopStreamOutboundTransportMiddleware)
 }

--- a/v2/request_test.go
+++ b/v2/request_test.go
@@ -26,21 +26,21 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	. "go.uber.org/yarpc/v2"
+	"go.uber.org/yarpc/v2"
 	"go.uber.org/zap/zapcore"
 )
 
 func TestValidator(t *testing.T) {
 	tests := []struct {
-		req           *Request
-		transportType Type
+		req           *yarpc.Request
+		transportType yarpc.Type
 		ttl           time.Duration
 
 		wantMissingParams []string
 	}{
 		{
 			// No error
-			req: &Request{
+			req: &yarpc.Request{
 				Caller:    "caller",
 				Service:   "service",
 				Encoding:  "raw",
@@ -50,7 +50,7 @@ func TestValidator(t *testing.T) {
 		},
 		{
 			// encoding is not required
-			req: &Request{
+			req: &yarpc.Request{
 				Caller:    "caller",
 				Service:   "service",
 				Procedure: "hello",
@@ -58,7 +58,7 @@ func TestValidator(t *testing.T) {
 			wantMissingParams: []string{"encoding"},
 		},
 		{
-			req: &Request{
+			req: &yarpc.Request{
 				Service:   "service",
 				Procedure: "hello",
 				Encoding:  "raw",
@@ -66,7 +66,7 @@ func TestValidator(t *testing.T) {
 			wantMissingParams: []string{"caller"},
 		},
 		{
-			req: &Request{
+			req: &yarpc.Request{
 				Caller:    "caller",
 				Procedure: "hello",
 				Encoding:  "raw",
@@ -74,7 +74,7 @@ func TestValidator(t *testing.T) {
 			wantMissingParams: []string{"service"},
 		},
 		{
-			req: &Request{
+			req: &yarpc.Request{
 				Caller:   "caller",
 				Service:  "service",
 				Encoding: "raw",
@@ -82,26 +82,26 @@ func TestValidator(t *testing.T) {
 			wantMissingParams: []string{"procedure"},
 		},
 		{
-			req: &Request{
+			req: &yarpc.Request{
 				Caller:    "caller",
 				Service:   "service",
 				Procedure: "hello",
 				Encoding:  "raw",
 			},
-			transportType:     Unary,
+			transportType:     yarpc.Unary,
 			wantMissingParams: []string{"TTL"},
 		},
 		{
-			req:               &Request{},
+			req:               &yarpc.Request{},
 			wantMissingParams: []string{"encoding", "caller", "service", "procedure"},
 		},
 	}
 
 	for _, tt := range tests {
 		ctx := context.Background()
-		err := ValidateRequest(tt.req)
+		err := yarpc.ValidateRequest(tt.req)
 
-		if err == nil && tt.transportType == Unary {
+		if err == nil && tt.transportType == yarpc.Unary {
 			var cancel func()
 
 			if tt.ttl != 0 {
@@ -109,7 +109,7 @@ func TestValidator(t *testing.T) {
 				defer cancel()
 			}
 
-			err = ValidateRequestContext(ctx)
+			err = yarpc.ValidateRequestContext(ctx)
 		}
 
 		if len(tt.wantMissingParams) > 0 {
@@ -125,13 +125,13 @@ func TestValidator(t *testing.T) {
 }
 
 func TestRequestLogMarshaling(t *testing.T) {
-	r := &Request{
+	r := &yarpc.Request{
 		Caller:          "caller",
 		Service:         "service",
 		Transport:       "transport",
 		Encoding:        "raw",
 		Procedure:       "procedure",
-		Headers:         NewHeaders().With("password", "super-secret"),
+		Headers:         yarpc.NewHeaders().With("password", "super-secret"),
 		ShardKey:        "shard01",
 		RoutingKey:      "routing-key",
 		RoutingDelegate: "routing-delegate",

--- a/v2/router_middleware_test.go
+++ b/v2/router_middleware_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	. "go.uber.org/yarpc/v2"
+	"go.uber.org/yarpc/v2"
 	"go.uber.org/yarpc/v2/yarpctest"
 )
 
@@ -37,9 +37,9 @@ func TestApplyRouteTable(t *testing.T) {
 	routerMiddleware := yarpctest.NewMockRouterMiddleware(ctrl)
 	routeTable := yarpctest.NewMockRouteTable(ctrl)
 
-	rtWithMW := ApplyRouteTable(routeTable, routerMiddleware)
+	rtWithMW := yarpc.ApplyRouteTable(routeTable, routerMiddleware)
 
-	routeTableWithMW, ok := rtWithMW.(RouteTableWithMiddleware)
+	routeTableWithMW, ok := rtWithMW.(yarpc.RouteTableWithMiddleware)
 	require.True(t, ok, "unexpected RouteTable type")
 
 	assert.Equal(t, routeTableWithMW.GetRouterMiddleware(), routerMiddleware)
@@ -54,14 +54,14 @@ func TestRouteTableMiddleware(t *testing.T) {
 	routeTable := yarpctest.NewMockRouteTable(ctrl)
 
 	ctx := context.Background()
-	req := &Request{}
-	spec := NewUnaryTransportHandlerSpec(yarpctest.NewMockUnaryTransportHandler(ctrl))
+	req := &yarpc.Request{}
+	spec := yarpc.NewUnaryTransportHandlerSpec(yarpctest.NewMockUnaryTransportHandler(ctrl))
 
-	routeTableWithMW := ApplyRouteTable(routeTable, routerMiddleware)
+	routeTableWithMW := yarpc.ApplyRouteTable(routeTable, routerMiddleware)
 
 	// register procedures
 	routeTable.EXPECT().Register(gomock.Any())
-	routeTableWithMW.Register([]Procedure{})
+	routeTableWithMW.Register([]yarpc.Procedure{})
 
 	// choose handlerSpec
 	routerMiddleware.EXPECT().Choose(ctx, req, routeTable).Return(spec, nil)
@@ -70,6 +70,6 @@ func TestRouteTableMiddleware(t *testing.T) {
 	assert.Equal(t, spec, spec)
 
 	// get procedures
-	routerMiddleware.EXPECT().Procedures(routeTable).Return([]Procedure{})
+	routerMiddleware.EXPECT().Procedures(routeTable).Return([]yarpc.Procedure{})
 	routeTableWithMW.Procedures()
 }


### PR DESCRIPTION
Using dot imports cause some issues in the past for name collisions on
a libraries depending on yarpc. Let's prefer to be explicit with our
imports.