### PR TITLE
Randomize insertion order for fewest-pending-heap

### DIFF
--- a/peer/pendingheap/heap.go
+++ b/peer/pendingheap/heap.go
@@ -172,14 +172,14 @@ func (ph *pendingHeap) pushPeer(ps *peerScore) {
 	heap.Push(ph, ps)
 }
 
-// pushPeerRandom must be called in the context of a lock.
-//
-// It inserts a peer randomly into the heap among equally scored peers. This is
-// expected to be called only by Add.
+// pushPeerRandom inserts a peer randomly into the heap among equally scored
+// peers. This is expected to be called only by Add.
 //
 // This ensures that batches of peer updates are inserted randomly throughout
 // the heap, preventing hearding behavior that may be observed during batch
 // deployments.
+//
+// This must be called in the context of a lock.
 func (ph *pendingHeap) pushPeerRandom(ps *peerScore) {
 	ph.next++
 	ps.last = ph.next

--- a/peer/pendingheap/heap.go
+++ b/peer/pendingheap/heap.go
@@ -39,6 +39,12 @@ type pendingHeap struct {
 	// scores are equal. This ends up implementing round-robin when scores are
 	// equal.
 	next int
+
+	// nextRand is used for random insertions among equally scored peers when new
+	// peers are added.
+	//
+	// nextRand MUST return a number in [0, numPeers)
+	nextRand func(numPeers int) int
 }
 
 var _ peerlist.Implementation = (*pendingHeap)(nil)
@@ -68,7 +74,7 @@ func (ph *pendingHeap) Add(p peer.StatusPeer, _ peer.Identifier) peer.Subscriber
 	ps.score = scorePeer(p)
 
 	ph.Lock()
-	ph.pushPeer(ps)
+	ph.pushPeerRandom(ps)
 	ph.Unlock()
 	return ps
 }
@@ -163,6 +169,28 @@ func (ph *pendingHeap) delete(index int) {
 func (ph *pendingHeap) pushPeer(ps *peerScore) {
 	ph.next++
 	ps.last = ph.next
+	heap.Push(ph, ps)
+}
+
+// pushPeerRandom must be called in the context of a lock.
+//
+// It inserts a peer randomly into the heap among equally scored peers. This is
+// expected to be called only by Add.
+//
+// This ensures that batches of peer updates are inserted randomly throughout
+// the heap, preventing hearding behavior that may be observed during batch
+// deployments.
+func (ph *pendingHeap) pushPeerRandom(ps *peerScore) {
+	ph.next++
+	ps.last = ph.next
+
+	random := ph.nextRand(len(ph.peers) + 1)
+	if random < len(ph.peers) {
+		randPeer := ph.peers[random]
+		ps.last, randPeer.last = randPeer.last, ps.last
+		heap.Fix(ph, random)
+	}
+
 	heap.Push(ph, ps)
 }
 

--- a/peer/pendingheap/heap_test.go
+++ b/peer/pendingheap/heap_test.go
@@ -39,7 +39,7 @@ func TestPeerHeapEmpty(t *testing.T) {
 	popAndVerifyHeap(t, &ph)
 }
 
-func TestPeerHeapOrdering(t *testing.T) {
+func TestRoundRobinHeapOrdering(t *testing.T) {
 	p1 := &peerScore{score: 1}
 	p2 := &peerScore{score: 2}
 	p3 := &peerScore{score: 3}
@@ -55,7 +55,9 @@ func TestPeerHeapOrdering(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		var h pendingHeap
+		h := pendingHeap{
+			nextRand: nextRand(0), /* irrelevant since we're not doing random insertions*/
+		}
 		for _, ps := range tt {
 			h.pushPeer(ps)
 		}
@@ -65,8 +67,63 @@ func TestPeerHeapOrdering(t *testing.T) {
 	}
 }
 
+func TestPeerHeapInsertionOrdering(t *testing.T) {
+	p1 := &peerScore{score: 1}
+	p2 := &peerScore{score: 2}
+	p3 := &peerScore{score: 3}
+	p4 := &peerScore{score: 3} // same score as p3
+
+	tests := []struct {
+		name          string
+		give          []*peerScore
+		nextRandIndex int
+		insert        *peerScore
+		want          []*peerScore
+	}{
+		{
+			name:   "p3.last < p4.last",
+			give:   []*peerScore{p1, p2, p3},
+			insert: p4,
+			// no swap since nextRandIndex+1 == len(list)
+			nextRandIndex: 3,
+			want:          []*peerScore{p1, p2, p3, p4},
+			// p1.last = 1
+			// p2.last = 2
+			// p3.last = 3
+			// p4.last = 4
+		},
+		{
+			name:          "p4.last < p3.last",
+			give:          []*peerScore{p1, p2, p3},
+			insert:        p4,
+			nextRandIndex: 0, // swap p1.last
+			want:          []*peerScore{p1, p2, p4, p3},
+			// p1.last = 4
+			// p2.last = 2
+			// p4.last = 1
+			// p3.last = 3
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := pendingHeap{nextRand: nextRandFromSlice([]int{tt.nextRandIndex})}
+			// prepare list
+			for _, ps := range tt.give {
+				h.pushPeer(ps)
+			}
+
+			// new peer added
+			h.pushPeerRandom(tt.insert)
+
+			popped := popAndVerifyHeap(t, &h)
+			assert.Equal(t, tt.want, popped, "Unexpected ordering of peers")
+		})
+	}
+}
+
 func TestPeerHeapUpdate(t *testing.T) {
-	var h pendingHeap
+	h := pendingHeap{nextRand: nextRand(0)}
 	p1 := &peerScore{score: 1}
 	p2 := &peerScore{score: 2}
 	p3 := &peerScore{score: 3}
@@ -90,7 +147,7 @@ func TestPeerHeapUpdate(t *testing.T) {
 func TestPeerHeapDelete(t *testing.T) {
 	const numPeers = 10
 
-	var h pendingHeap
+	h := pendingHeap{nextRand: nextRand(0)}
 	peers := make([]*peerScore, numPeers)
 	for i := range peers {
 		peers[i] = &peerScore{score: int64(i)}
@@ -114,7 +171,7 @@ func (ph *pendingHeap) validate(ps *peerScore) error {
 }
 
 func TestPeerHeapValidate(t *testing.T) {
-	var h pendingHeap
+	h := pendingHeap{nextRand: nextRand(0)}
 	ps := &peerScore{score: 1}
 	h.pushPeer(ps)
 	assert.Nil(t, h.validate(ps), "peer %v should validate", ps)


### PR DESCRIPTION
This ensures that peers are randomly inserted into the heap among
equally scored peers, by randomly swapping 'last' with another peer on
insertion.

We've observed behaviour where batch deploys 'herd' towards a select
few instances. The theory is that when the FPH degenerates to
round-robin behaviour, batches of peers being inserted into the list
get added to the end of the ring. Relates to T2152727.

This will need to be ported to the 'spring' branch as well