### PR TITLE
[spring] Remove Register API for routers and RouteTable interface

### DIFF
--- a/v2/router.go
+++ b/v2/router.go
@@ -82,12 +82,3 @@ type Router interface {
 	// select a handler for a request.
 	Choose(ctx context.Context, req *Request) (TransportHandlerSpec, error)
 }
-
-// RouteTable is an mutable interface for a Router that allows Registering new
-// Procedures
-type RouteTable interface {
-	Router
-
-	// Registers zero or more procedures with the route table.
-	Register([]TransportProcedure)
-}

--- a/v2/router_middleware.go
+++ b/v2/router_middleware.go
@@ -36,27 +36,23 @@ type RouterMiddleware interface {
 	Choose(context.Context, *Request, Router) (TransportHandlerSpec, error)
 }
 
-// ApplyRouteTable applies the given RouterMiddleware middleware to the given RouterMiddleware.
-func ApplyRouteTable(r RouteTable, m RouterMiddleware) RouteTable {
+// ApplyRouter applies the given RouterMiddleware middleware to the given Router.
+func ApplyRouter(r Router, m RouterMiddleware) Router {
 	if m == nil {
 		return r
 	}
-	return routeTableWithMiddleware{r: r, m: m}
+	return routerWithMiddleware{r: r, m: m}
 }
 
-type routeTableWithMiddleware struct {
-	r RouteTable
+type routerWithMiddleware struct {
+	r Router
 	m RouterMiddleware
 }
 
-func (r routeTableWithMiddleware) Procedures() []TransportProcedure {
+func (r routerWithMiddleware) Procedures() []TransportProcedure {
 	return r.m.Procedures(r.r)
 }
 
-func (r routeTableWithMiddleware) Choose(ctx context.Context, req *Request) (TransportHandlerSpec, error) {
+func (r routerWithMiddleware) Choose(ctx context.Context, req *Request) (TransportHandlerSpec, error) {
 	return r.m.Choose(ctx, req, r.r)
-}
-
-func (r routeTableWithMiddleware) Register(procedures []TransportProcedure) {
-	r.r.Register(procedures)
 }

--- a/v2/router_with_middleware_test.go
+++ b/v2/router_with_middleware_test.go
@@ -20,12 +20,12 @@
 
 package yarpc
 
-type RouteTableWithMiddleware = routeTableWithMiddleware
+type RouterWithMiddleware = routerWithMiddleware
 
-func (r RouteTableWithMiddleware) GetRouteTable() RouteTable {
+func (r RouterWithMiddleware) GetRouter() Router {
 	return r.r
 }
 
-func (r RouteTableWithMiddleware) GetRouterMiddleware() RouterMiddleware {
+func (r RouterWithMiddleware) GetRouterMiddleware() RouterMiddleware {
 	return r.m
 }

--- a/v2/yarpchttp/handler_test.go
+++ b/v2/yarpchttp/handler_test.go
@@ -375,13 +375,15 @@ func TestHandlerPanic(t *testing.T) {
 	dialer.Start(context.Background())
 	defer dialer.Stop(context.Background())
 
-	router := yarpcrouter.NewMapRouter("yarpc-test")
-	router.Register([]yarpc.TransportProcedure{
-		{
-			Name:        "panic",
-			HandlerSpec: yarpc.NewUnaryTransportHandlerSpec(panickedHandler{}),
+	router := yarpcrouter.NewMapRouter(
+		"yarpc-test",
+		[]yarpc.TransportProcedure{
+			{
+				Name:        "panic",
+				HandlerSpec: yarpc.NewUnaryTransportHandlerSpec(panickedHandler{}),
+			},
 		},
-	})
+	)
 	inbound := &Inbound{
 		Addr:   "localhost:0",
 		Router: router,

--- a/v2/yarpchttp/inbound_example_test.go
+++ b/v2/yarpchttp/inbound_example_test.go
@@ -28,12 +28,13 @@ import (
 	"net/http"
 	"os"
 
+	"go.uber.org/yarpc/v2"
 	"go.uber.org/yarpc/v2/yarpchttp"
 	"go.uber.org/yarpc/v2/yarpcrouter"
 )
 
 func ExampleInbound() {
-	router := yarpcrouter.NewMapRouter("my-service")
+	router := yarpcrouter.NewMapRouter("my-service", []yarpc.TransportProcedure{})
 	inbound := &yarpchttp.Inbound{
 		Addr:   ":8888",
 		Router: router,
@@ -53,7 +54,7 @@ func ExampleMux() {
 		}
 	})
 
-	router := yarpcrouter.NewMapRouter("my-service")
+	router := yarpcrouter.NewMapRouter("my-service", []yarpc.TransportProcedure{})
 	inbound := &yarpchttp.Inbound{
 		Addr:       ":8888",
 		Router:     router,
@@ -98,7 +99,7 @@ func ExampleInterceptor() {
 	}
 
 	// Create a new inbound, attaching the interceptor
-	router := yarpcrouter.NewMapRouter("server")
+	router := yarpcrouter.NewMapRouter("server", []yarpc.TransportProcedure{})
 	inbound := &yarpchttp.Inbound{
 		Addr:        ":8889",
 		Router:      router,

--- a/v2/yarpcprotobuf/protoc-gen-yarpc-go/integration_test.go
+++ b/v2/yarpcprotobuf/protoc-gen-yarpc-go/integration_test.go
@@ -79,8 +79,7 @@ func newHelloClient(t *testing.T, address string) streampb.HelloYARPCClient {
 }
 
 func startInbounds(t *testing.T, transport, service string, procedures []yarpc.TransportProcedure) (address string, stop func()) {
-	router := yarpcrouter.NewMapRouter(service)
-	router.Register(procedures)
+	router := yarpcrouter.NewMapRouter(service, procedures)
 
 	listener, err := net.Listen("tcp", ":0")
 	require.NoError(t, err)

--- a/v2/yarpcrouter/router.go
+++ b/v2/yarpcrouter/router.go
@@ -54,23 +54,25 @@ type MapRouter struct {
 }
 
 // NewMapRouter builds a new MapRouter that uses the given name as the
-// default service name.
-func NewMapRouter(defaultService string) MapRouter {
-	return MapRouter{
+// default service name and registers the given procedures.
+//
+// If a provided procedure does not specify its service name, it will
+// inherit the default service name. Multiple procedures with the
+// same name and service name may exist if they handle different encodings.
+// If a procedure does not specify an encoding, it can only support one handler.
+// The router will select that handler regardless of the encoding.
+func NewMapRouter(defaultService string, rs []yarpc.TransportProcedure) MapRouter {
+	router := MapRouter{
 		defaultService:            defaultService,
 		serviceProcedureEncodings: make(map[serviceProcedureEncoding]yarpc.TransportProcedure),
 		serviceNames:              map[string]struct{}{defaultService: {}},
 	}
+
+	router.register(rs)
+	return router
 }
 
-// Register registers the procedure with the MapRouter.
-// If the procedure does not specify its service name, the procedure will
-// inherit the default service name of the router.
-// Procedures should specify their encoding, and multiple procedures with the
-// same name and service name can exist if they handle different encodings.
-// If a procedure does not specify an encoding, it can only support one handler.
-// The router will select that handler regardless of the encoding.
-func (m MapRouter) Register(rs []yarpc.TransportProcedure) {
+func (m MapRouter) register(rs []yarpc.TransportProcedure) {
 	for _, r := range rs {
 		if r.Service == "" {
 			r.Service = m.defaultService


### PR DESCRIPTION
This change prefers registering procedures in the router via the constructor, effectively making them immutable.