### PR TITLE
[spring] Fix response headers for proto

### DIFF
--- a/v2/yarpcprotobuf/inbound.go
+++ b/v2/yarpcprotobuf/inbound.go
@@ -79,9 +79,9 @@ func (u *unaryHandler) Handle(ctx context.Context, req *yarpc.Request, buf *yarp
 
 	res := &yarpc.Response{}
 	resBuf := &yarpc.Buffer{}
-	call.WriteToResponse(res)
 
 	protoRes, appErr := u.handle(ctx, protoReq)
+	call.WriteToResponse(res)
 
 	// If the application error is not nil, return
 	// early so that we don't attempt to marshal a nil

--- a/v2/yarpcprotobuf/inbound_test.go
+++ b/v2/yarpcprotobuf/inbound_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpcprotobuf
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/v2"
+)
+
+func TestResponseHeaders(t *testing.T) {
+	h := NewUnaryHandler(UnaryHandlerParams{
+		Handle: func(ctx context.Context, _ proto.Message) (proto.Message, error) {
+			err := yarpc.CallFromContext(ctx).WriteResponseHeader("foo-key", "bar-val")
+			require.NoError(t, err)
+
+			// currently, we still expect to get response headers when a handler returns an error
+			return nil, errors.New("")
+		},
+	})
+
+	ctx := context.Background()
+	res, _, err := h.Handle(ctx, &yarpc.Request{Encoding: Encoding}, &yarpc.Buffer{})
+	require.Error(t, err)
+
+	headers := res.Headers.Items()
+	assert.Len(t, headers, 1)
+
+	got, ok := headers["foo-key"]
+	require.True(t, ok, "header not found")
+	assert.Equal(t, "bar-val", got)
+}


### PR DESCRIPTION
Previously, we were calling `InboundCall.WriteToResponse` before
executing the user's handler. This prevented response headers from
propagating across the wire.

This small change ensures that we write to the response, after the
user handler is called.
