### PR TITLE
[spring] Add nil error checks to gRPC

### DIFF
--- a/v2/yarpcgrpc/handler.go
+++ b/v2/yarpcgrpc/handler.go
@@ -194,10 +194,12 @@ func (h *handler) handleUnary(
 
 	err = handlerErrorToGRPCError(err, mdWriter)
 
-	// Send the response attributes back and end the stream.
-	if sendErr := serverStream.SendMsg(resBuf.Bytes()); sendErr != nil {
-		// We couldn't send the response.
-		return sendErr
+	if resBuf != nil {
+		// Send the response attributes back and end the stream.
+		if sendErr := serverStream.SendMsg(resBuf.Bytes()); sendErr != nil {
+			// We couldn't send the response.
+			return sendErr
+		}
 	}
 
 	mdWriter.SetResponse(res)

--- a/v2/yarpcgrpc/metadata_writer.go
+++ b/v2/yarpcgrpc/metadata_writer.go
@@ -38,6 +38,10 @@ func newMetadataWriter() *metadataWriter {
 }
 
 func (r *metadataWriter) SetResponse(res *yarpc.Response) {
+	if res == nil {
+		return
+	}
+
 	r.headerErr = multierr.Combine(r.headerErr, addApplicationHeaders(r.md, res.Headers))
 
 	if res.ApplicationError {


### PR DESCRIPTION
Depending on encoding behaviour, it was previously possible for the
gRPC transport to panic since it always expected a non-nil
`yarpc.Buffer`, even on errors.

This ensures that we check the `yarpc.Request` and `yarpc.Buffer`
before sending information back over the wire.

Although this block of code was previously unidiomatic for go, this
preserves the behaviour of sending an error message _and_ body. Error
handling will be refactored in a follow up.