### PR TITLE
[spring] Document Listeners will be closed on Stop()

### DIFF
--- a/v2/yarpcgrpc/inbound.go
+++ b/v2/yarpcgrpc/inbound.go
@@ -46,6 +46,8 @@ var errRouterNotSet = yarpcerror.Newf(yarpcerror.CodeInternal, "gRPC router not 
 // Inbound receives YARPC requests using a gRPC server.
 type Inbound struct {
 	// Listener is an open listener for inbound gRPC requests.
+	//
+	// The listener will be closed on Stop(ctx).
 	Listener net.Listener
 
 	// Addr is a host:port on which to listen if no Listener is provided.

--- a/v2/yarpchttp/inbound.go
+++ b/v2/yarpchttp/inbound.go
@@ -37,6 +37,8 @@ import (
 // Inbound receives YARPC requests using an HTTP server.
 type Inbound struct {
 	// Listener is an open listener for inbound HTTP requests.
+	//
+	// The listener will be closed on Stop(ctx).
 	Listener net.Listener
 
 	// Addr is a host:port on which to listen if no Listener is expressly provided.


### PR DESCRIPTION
While writing an integration test I noticed that this behaviour is
undocumented. The underlying servers for the gRPC and HTTP inbound
will call `Listener.Close()` when shutting down.
