### PR TITLE
Introduce simple yarpcfx package

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: b9ce5e38613f491706af90585cf5b167b6fc8cc9137dd2df5edb4ba8333f8a1f
-updated: 2018-08-24T15:06:31.978765253Z
+hash: 32f1414d394805f5752c32b711d5e53d411947a42067b58a479b0f463ec88f43
+updated: 2018-11-01T13:25:36.31063214-07:00
 imports:
 - name: github.com/apache/thrift
   version: 53dd39833a08ce33582e5ff31fa18bb4735d6731
@@ -32,7 +32,7 @@ imports:
   subpackages:
   - gomock
 - name: github.com/golang/protobuf
-  version: b27b920f9e71b439b873b17bf99f56467623814a
+  version: e09c5db296004fbe3f74490e84dcd62c3c5ddb1b
   subpackages:
   - proto
   - ptypes
@@ -62,23 +62,23 @@ imports:
   - prometheus
   - prometheus/promhttp
 - name: github.com/prometheus/client_model
-  version: 5c3871d89910bfb32f5fcab2aa4b9ec68e65a99f
+  version: 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: c7de2306084e37d54b8be01f3541a8464345e9a5
+  version: 38c53a9f4bfcd932d1b00bfc65e256a7fba6b37a
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: 05ee40e3a273f7245e8777337fc7b46e533a9a92
+  version: 780932d4fbbe0e69b84c34c20f5c8d0981e109ea
   subpackages:
   - internal/util
   - nfs
   - xfs
 - name: github.com/stretchr/testify
-  version: f35b8ab0b5a2cef36673838d662e249dd9c94686
+  version: c679ae2cc0cb27ec3293fea7e254e47386f05d69
   subpackages:
   - assert
   - require
@@ -93,7 +93,7 @@ imports:
 - name: github.com/uber-go/tally
   version: ff17f3c43c065c3c2991f571e740eee43ea3a14a
 - name: github.com/uber/jaeger-client-go
-  version: b043381d944715b469fd6b37addfd30145ca1758
+  version: 1a782e2da844727691fef1757c72eb190c2909f0
   subpackages:
   - internal/baggage
   - internal/spanlog
@@ -124,13 +124,18 @@ imports:
   - typed
 - name: go.uber.org/atomic
   version: 1ea20fb1cbb1cc08cbd0d913a96dead89aa18289
+- name: go.uber.org/config
+  version: c9c3d11a88c1a266ced73d92e22e1d36d2bc2ed6
+  subpackages:
+  - internal/merge
+  - internal/unreachable
 - name: go.uber.org/dig
-  version: d6ba99365e475c24e8ac02392eb3f78ccab2a6f3
+  version: bc5e6a1faffe87bfc9db86098fc01725d8d2a4c0
   subpackages:
   - internal/digreflect
   - internal/dot
 - name: go.uber.org/fx
-  version: b156a883a62423b7d9ab651d1689c42c4d788787
+  version: 6244a3ed900ddd4deac96447f2c988d4722ad890
   subpackages:
   - fxtest
   - internal/fxlog
@@ -145,7 +150,7 @@ imports:
   - push
   - tallypush
 - name: go.uber.org/thriftrw
-  version: fb439a9a7f5a388d8606aae1c1ff6654b8b67fbe
+  version: f21741d67580a27b01451386c3998090905dc243
   subpackages:
   - envelope
   - internal/envelope
@@ -172,7 +177,7 @@ imports:
   - zapcore
   - zaptest/observer
 - name: golang.org/x/net
-  version: faa378e6dbaed88bd8100f8bcf09939375c6e8fa
+  version: 9b4f9f5ad5197c79fd623a3638e70d8b26cef344
   repo: https://github.com/golang/net
   subpackages:
   - bpf
@@ -189,28 +194,26 @@ imports:
   - ipv6
   - trace
 - name: golang.org/x/sys
-  version: 4910a1d54f876d7b22162a85f4d066d3ee649450
+  version: 3b87a42e500a6dc65dae1a55d0b641295971163e
   repo: https://github.com/golang/sys
-  subpackages:
-  - unix
 - name: golang.org/x/text
-  version: 6e3c4e7365ddcc329f090f96e4348398f6310088
+  version: f21a4dfb5e38f5895301dc265a8def02365cc3d0
   subpackages:
   - secure/bidirule
   - transform
   - unicode/bidi
   - unicode/norm
 - name: golang.org/x/tools
-  version: ff6c8c104af2168da09d225428803f855a80b1ce
+  version: ac136b6c2db7c4d43955e4bc7174db36dc0539c0
   repo: https://github.com/golang/tools
   subpackages:
   - go/ast/astutil
 - name: google.golang.org/genproto
-  version: c66870c02cf823ceb633bcd05be3c7cda29976f4
+  version: aae13d27a44d62f039eeeb93e74e893886673932
   subpackages:
   - googleapis/rpc/status
 - name: google.golang.org/grpc
-  version: 32fb0ac620c32ba40a4626ddf94d90d12cce3455
+  version: 2e463a05d100327ca47ac218281906921038fd95
   repo: https://github.com/grpc/grpc-go
   subpackages:
   - balancer
@@ -256,11 +259,11 @@ testImports:
   subpackages:
   - update-license
 - name: golang.org/x/lint
-  version: 06c8688daad7faa9da5a0c2f163a3d14aac986ca
+  version: c67002cb31c3a748b7688c27f20d8358b4193582
   repo: https://github.com/golang/lint
   subpackages:
   - golint
 - name: honnef.co/go/tools
-  version: 88497007e8588ea5b6baee991f74a1607e809487
+  version: e3ad64cb4ed3e25a30bf42def711f9cb5b004f72
   subpackages:
   - cmd/staticcheck

--- a/glide.lock
+++ b/glide.lock
@@ -150,7 +150,7 @@ imports:
   - push
   - tallypush
 - name: go.uber.org/thriftrw
-  version: f21741d67580a27b01451386c3998090905dc243
+  version: fb439a9a7f5a388d8606aae1c1ff6654b8b67fbe
   subpackages:
   - envelope
   - internal/envelope

--- a/glide.yaml
+++ b/glide.yaml
@@ -20,6 +20,8 @@ import:
   subpackages:
   - prometheus
   - prometheus/promhttp
+- package: go.uber.org/config
+  version: ^1.3
 - package: go.uber.org/fx
   version: ^1
 - package: go.uber.org/zap

--- a/v2/yarpcfx/yarpcfx.go
+++ b/v2/yarpcfx/yarpcfx.go
@@ -37,7 +37,6 @@ func NewClientProvider(p ClientProviderParams) (ClientProviderResult, error) {
 	for _, cl := range p.ClientLists {
 		clients = append(clients, cl...)
 	}
-
 	provider := yarpcclient.NewProvider()
 	for _, c := range clients {
 		provider.Register(c.Service, c)
@@ -71,7 +70,6 @@ func NewRouter(p RouterParams) (RouterResult, error) {
 	for _, pl := range p.ProcedureLists {
 		procedures = append(procedures, pl...)
 	}
-
 	router := yarpcrouter.NewMapRouter("foo" /* Derive from servicefx. */, procedures)
 	return RouterResult{
 		Router: yarpc.ApplyRouter(router, p.RouterMiddleware),

--- a/v2/yarpcfx/yarpcfx.go
+++ b/v2/yarpcfx/yarpcfx.go
@@ -1,0 +1,72 @@
+package yarpcfx
+
+import (
+	"go.uber.org/fx"
+	yarpc "go.uber.org/yarpc/v2"
+	"go.uber.org/yarpc/v2/yarpcclient"
+	"go.uber.org/yarpc/v2/yarpcrouter"
+)
+
+const _name = "yarpcfx"
+
+// Module provides YARPC integration for services. The module produces
+// a yarpc.Router and a yarpc.ClientProvider.
+var Module = fx.Options(
+	fx.Provide(NewClientProvider),
+	fx.Provide(NewRouter),
+)
+
+// ClientProviderParams defines the dependencies of this module.
+type ClientProviderParams struct {
+	fx.In
+
+	Clients []yarpc.Client `group:"yarpcfx"`
+}
+
+// ClientProviderResult defines the values produced by this module.
+type ClientProviderResult struct {
+	fx.Out
+
+	Provider yarpc.ClientProvider
+}
+
+// NewClientProvider provides a yarpc.ClientProvider to the Fx application.
+func NewClientProvider(p ClientProviderParams) (ClientProviderResult, error) {
+	provider := yarpcclient.NewProvider()
+	for _, c := range p.Clients {
+		provider.Register(c.Service, c)
+	}
+	return ClientProviderResult{
+		Provider: provider,
+	}, nil
+}
+
+// RouterParams defines the parameters for procedure registration and
+// router construction.
+type RouterParams struct {
+	fx.In
+
+	RouterMiddleware yarpc.RouterMiddleware       `optional:"true"`
+	SingleProcedures []yarpc.TransportProcedure   `group:"yarpcfx"`
+	ProcedureLists   [][]yarpc.TransportProcedure `group:"yarpcfx"`
+}
+
+// RouterResult defines the values produced by this module.
+type RouterResult struct {
+	fx.Out
+
+	Router yarpc.Router
+}
+
+// NewRouter registers procedures with a router, and produces it so
+// that specific transport inbounds can depend upon it.
+func NewRouter(p RouterParams) (RouterResult, error) {
+	procedures := p.SingleProcedures
+	for _, pl := range p.ProcedureLists {
+		procedures = append(procedures, pl...)
+	}
+	router := yarpcrouter.NewMapRouter("foo" /* Derive from servicefx. */, procedures)
+	return RouterResult{
+		Router: yarpc.ApplyRouter(router, p.RouterMiddleware),
+	}, nil
+}

--- a/v2/yarpcfx/yarpcfx.go
+++ b/v2/yarpcfx/yarpcfx.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package yarpcfx
 
 import (

--- a/v2/yarpcfx/yarpcfx_test.go
+++ b/v2/yarpcfx/yarpcfx_test.go
@@ -13,8 +13,8 @@ func TestNewClientProvider(t *testing.T) {
 	bar := yarpc.Client{Caller: "bar-caller", Service: "bar-service"}
 
 	res, err := NewClientProvider(ClientProviderParams{
-		SingleClients: []yarpc.Client{foo},
-		ClientLists:   [][]yarpc.Client{{bar}},
+		Clients:     []yarpc.Client{foo},
+		ClientLists: [][]yarpc.Client{{bar}},
 	})
 	require.NoError(t, err)
 	provider := res.Provider
@@ -41,8 +41,8 @@ func TestNewRouter(t *testing.T) {
 	}
 
 	res, err := NewRouter(RouterParams{
-		SingleProcedures: []yarpc.TransportProcedure{single},
-		ProcedureLists:   [][]yarpc.TransportProcedure{list},
+		Procedures:     []yarpc.TransportProcedure{single},
+		ProcedureLists: [][]yarpc.TransportProcedure{list},
 	})
 	require.NoError(t, err)
 	assert.Len(t, res.Router.Procedures(), 3)

--- a/v2/yarpcfx/yarpcfx_test.go
+++ b/v2/yarpcfx/yarpcfx_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package yarpcfx
 
 import (

--- a/v2/yarpcfx/yarpcfx_test.go
+++ b/v2/yarpcfx/yarpcfx_test.go
@@ -1,0 +1,42 @@
+package yarpcfx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	yarpc "go.uber.org/yarpc/v2"
+)
+
+func TestNewClientProvider(t *testing.T) {
+	foo := yarpc.Client{Caller: "foo-caller", Service: "foo-service"}
+
+	res, err := NewClientProvider(ClientProviderParams{
+		Clients: []yarpc.Client{foo},
+	})
+	require.NoError(t, err)
+	provider := res.Provider
+
+	client, ok := provider.Client("foo-service")
+	assert.True(t, ok)
+	assert.Equal(t, client.Caller, "foo-caller")
+	assert.Equal(t, client.Service, "foo-service")
+
+	_, ok = provider.Client("unknown")
+	assert.False(t, ok)
+}
+
+func TestNewRouter(t *testing.T) {
+	single := yarpc.TransportProcedure{Name: "Hello::HelloWorld"}
+	list := []yarpc.TransportProcedure{
+		{Name: "Hello::FirstList"},
+		{Name: "Hello::SecondList"},
+	}
+
+	res, err := NewRouter(RouterParams{
+		SingleProcedures: []yarpc.TransportProcedure{single},
+		ProcedureLists:   [][]yarpc.TransportProcedure{list},
+	})
+	require.NoError(t, err)
+	assert.Len(t, res.Router.Procedures(), 3)
+}

--- a/v2/yarpcfx/yarpcfx_test.go
+++ b/v2/yarpcfx/yarpcfx_test.go
@@ -10,9 +10,11 @@ import (
 
 func TestNewClientProvider(t *testing.T) {
 	foo := yarpc.Client{Caller: "foo-caller", Service: "foo-service"}
+	bar := yarpc.Client{Caller: "bar-caller", Service: "bar-service"}
 
 	res, err := NewClientProvider(ClientProviderParams{
-		Clients: []yarpc.Client{foo},
+		SingleClients: []yarpc.Client{foo},
+		ClientLists:   [][]yarpc.Client{{bar}},
 	})
 	require.NoError(t, err)
 	provider := res.Provider
@@ -21,6 +23,11 @@ func TestNewClientProvider(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, client.Caller, "foo-caller")
 	assert.Equal(t, client.Service, "foo-service")
+
+	client, ok = provider.Client("bar-service")
+	assert.True(t, ok)
+	assert.Equal(t, client.Caller, "bar-caller")
+	assert.Equal(t, client.Service, "bar-service")
 
 	_, ok = provider.Client("unknown")
 	assert.False(t, ok)

--- a/v2/yarpchttp/yarpchttpfx/yarpchttpfx.go
+++ b/v2/yarpchttp/yarpchttpfx/yarpchttpfx.go
@@ -113,7 +113,6 @@ type OutboundsConfig struct {
 
 // OutboundConfig is the configuration for constructing a specific outbound.
 type OutboundConfig struct {
-	Service string `yaml:"service"`
 	Address string `yaml:"address"`
 }
 
@@ -162,7 +161,7 @@ type ClientResult struct {
 // NewClients produces yarpc.Clients.
 func NewClients(p ClientParams) (ClientResult, error) {
 	var clients []yarpc.Client
-	for name, o := range p.Config.Clients {
+	for service, o := range p.Config.Clients {
 		url, err := url.Parse(o.Address)
 		if err != nil {
 			return ClientResult{}, err
@@ -184,13 +183,6 @@ func NewClients(p ClientParams) (ClientResult, error) {
 				return dialer.Stop(ctx)
 			},
 		})
-		// If the service name is explicitly set,
-		// use it. Otherwise, default to the key
-		// used to configure this outbound.
-		service := o.Service
-		if service == "" {
-			service = name
-		}
 		clients = append(
 			clients,
 			yarpc.Client{

--- a/v2/yarpchttp/yarpchttpfx/yarpchttpfx.go
+++ b/v2/yarpchttp/yarpchttpfx/yarpchttpfx.go
@@ -1,0 +1,136 @@
+package yarpchttpfx
+
+import (
+	"context"
+	"net/url"
+
+	opentracing "github.com/opentracing/opentracing-go"
+	"go.uber.org/config"
+	"go.uber.org/fx"
+	yarpc "go.uber.org/yarpc/v2"
+	"go.uber.org/yarpc/v2/yarpchttp"
+	"go.uber.org/zap"
+)
+
+const (
+	_name                     = "yarpchttpfx"
+	_inboundConfigurationKey  = "yarpchttp.inbounds"
+	_outboundConfigurationKey = "yarpchttp.outbounds"
+)
+
+// Module produces yarpchttp clients and starts yarpchttp inbounds.
+var Module = fx.Options(
+	fx.Provide(NewClients),
+	fx.Invoke(StartInbounds),
+)
+
+// InboundConfig is the configuration for starting yarpchttp inbounds.
+type InboundConfig struct {
+	Address string `yaml:"address"`
+}
+
+// StartInboundsParams defines the dependencies of this module.
+type StartInboundsParams struct {
+	fx.In
+
+	Lifecycle fx.Lifecycle
+	Router    yarpc.Router
+	Provider  config.Provider
+	Logger    *zap.Logger        `optional:"true"`
+	Tracer    opentracing.Tracer `optional:"true"`
+}
+
+// StartInbounds constructs and starts yarpchttp inbounds.
+func StartInbounds(p StartInboundsParams) error {
+	ic := InboundConfig{}
+	if err := p.Provider.Get(_inboundConfigurationKey).Populate(&ic); err != nil {
+		return err
+	}
+	inbound := yarpchttp.Inbound{
+		Addr:   ic.Address,
+		Router: p.Router,
+		Logger: p.Logger,
+		Tracer: p.Tracer,
+	}
+	p.Lifecycle.Append(fx.Hook{
+		OnStart: func(ctx context.Context) error {
+			return inbound.Start(ctx)
+		},
+		OnStop: func(ctx context.Context) error {
+			return inbound.Stop(ctx)
+		},
+	})
+	return nil
+}
+
+// Outbounds is the configuration for constructing a set of yarpchttp
+// outbounds.
+type Outbounds struct {
+	Clients map[string]OutboundConfig `yaml:",inline"`
+}
+
+// OutboundConfig is the configuration for constructing a specific
+// yarpchttp outbound.
+type OutboundConfig struct {
+	Address string `yaml:"address"`
+}
+
+// ClientParams defines the dependencies of this module.
+type ClientParams struct {
+	fx.In
+
+	Lifecycle fx.Lifecycle
+	Provider  config.Provider
+	Logger    *zap.Logger        `optional:"true"`
+	Tracer    opentracing.Tracer `optional:"true"`
+}
+
+// ClientResult defines the values produced by this module.
+type ClientResult struct {
+	fx.Out
+
+	Clients []yarpc.Client `group:"yarpcfx"`
+}
+
+// NewClients produces yarpchttp yarpc.Clients.
+func NewClients(p ClientParams) (ClientResult, error) {
+	oc := Outbounds{}
+	if err := p.Provider.Get(_outboundConfigurationKey).Populate(&oc); err != nil {
+		return ClientResult{}, err
+	}
+	var clients []yarpc.Client
+	for name, o := range oc.Clients {
+		url, err := url.Parse(o.Address)
+		if err != nil {
+			return ClientResult{}, err
+		}
+		dialer := &yarpchttp.Dialer{
+			Tracer: p.Tracer,
+			Logger: p.Logger,
+		}
+		outbound := &yarpchttp.Outbound{
+			Dialer: dialer,
+			URL:    url,
+			Tracer: p.Tracer,
+		}
+		p.Lifecycle.Append(fx.Hook{
+			OnStart: func(ctx context.Context) error {
+				return dialer.Start(ctx)
+			},
+			OnStop: func(ctx context.Context) error {
+				return dialer.Stop(ctx)
+			},
+		})
+		clients = append(
+			clients,
+			yarpc.Client{
+				Caller:  "foo", // TODO(amckinney): Derive from servicefx.
+				Service: name,
+				Unary:   outbound,
+			},
+		)
+	}
+	return ClientResult{
+		Clients: clients,
+	}, nil
+}

--- a/v2/yarpchttp/yarpchttpfx/yarpchttpfx.go
+++ b/v2/yarpchttp/yarpchttpfx/yarpchttpfx.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package yarpchttpfx
 
 import (

--- a/v2/yarpchttp/yarpchttpfx/yarpchttpfx.go
+++ b/v2/yarpchttp/yarpchttpfx/yarpchttpfx.go
@@ -93,6 +93,7 @@ type OutboundsConfig struct {
 
 // OutboundConfig is the configuration for constructing a specific outbound.
 type OutboundConfig struct {
+	Service string `yaml:"service"`
 	Address string `yaml:"address"`
 }
 
@@ -163,11 +164,18 @@ func NewClients(p ClientParams) (ClientResult, error) {
 				return dialer.Stop(ctx)
 			},
 		})
+		// If the service name is explicitly set,
+		// use it. Otherwise, default to the key
+		// used to configure this outbound.
+		service := o.Service
+		if service == "" {
+			service = name
+		}
 		clients = append(
 			clients,
 			yarpc.Client{
 				Caller:  "foo", // TODO(amckinney): Derive from servicefx.
-				Service: name,
+				Service: service,
 				Unary:   outbound,
 			},
 		)

--- a/v2/yarpchttp/yarpchttpfx/yarpchttpfx.go
+++ b/v2/yarpchttp/yarpchttpfx/yarpchttpfx.go
@@ -132,12 +132,12 @@ type OutboundsConfigResult struct {
 
 // NewOutboundsConfig produces an OutboundsConfig.
 func NewOutboundsConfig(p OutboundsConfigParams) (OutboundsConfigResult, error) {
-	ic := OutboundsConfig{}
-	if err := p.Provider.Get(_outboundConfigurationKey).Populate(&ic); err != nil {
+	oc := OutboundsConfig{}
+	if err := p.Provider.Get(_outboundConfigurationKey).Populate(&oc); err != nil {
 		return OutboundsConfigResult{}, err
 	}
 	return OutboundsConfigResult{
-		Config: ic,
+		Config: oc,
 	}, nil
 }
 

--- a/v2/yarpchttp/yarpchttpfx/yarpchttpfx_test.go
+++ b/v2/yarpchttp/yarpchttpfx/yarpchttpfx_test.go
@@ -52,7 +52,7 @@ func TestStartInbounds(t *testing.T) {
 }
 
 func TestNewOutboundsConfig(t *testing.T) {
-	cfg := strings.NewReader("yarpc: {http: {outbounds: {bar: {address: http://127.0.0.1:0, service: baz}}}}")
+	cfg := strings.NewReader("yarpc: {http: {outbounds: {bar: {address: http://127.0.0.1:0}}}}")
 	provider, err := config.NewYAML(config.Source(cfg))
 	require.NoError(t, err)
 
@@ -63,7 +63,7 @@ func TestNewOutboundsConfig(t *testing.T) {
 	assert.Equal(t,
 		OutboundsConfig{
 			Clients: map[string]OutboundConfig{
-				"bar": {Address: "http://127.0.0.1:0", Service: "baz"},
+				"bar": {Address: "http://127.0.0.1:0"},
 			},
 		},
 		res.Config,

--- a/v2/yarpchttp/yarpchttpfx/yarpchttpfx_test.go
+++ b/v2/yarpchttp/yarpchttpfx/yarpchttpfx_test.go
@@ -11,26 +11,53 @@ import (
 	"go.uber.org/yarpc/v2/yarpctest"
 )
 
-func TestStartInbounds(t *testing.T) {
-	cfg := strings.NewReader("yarpchttp: {inbounds: {address: http://127.0.0.1:0}}")
+func TestNewInboundConfig(t *testing.T) {
+	cfg := strings.NewReader("yarpc: {http: {inbounds: {address: http://127.0.0.1:0}}}")
 	provider, err := config.NewYAML(config.Source(cfg))
 	require.NoError(t, err)
 
+	res, err := NewInboundConfig(InboundConfigParams{
+		Provider: provider,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, InboundConfig{Address: "http://127.0.0.1:0"}, res.Config)
+}
+
+func TestStartInbounds(t *testing.T) {
 	assert.NoError(t, StartInbounds(StartInboundsParams{
 		Lifecycle: fxtest.NewLifecycle(t),
 		Router:    yarpctest.NewFakeRouter(nil),
-		Provider:  provider,
+		Config:    InboundConfig{Address: "http://127.0.0.1:0"},
 	}))
 }
 
-func TestNewClients(t *testing.T) {
-	cfg := strings.NewReader("yarpchttp: {outbounds: {bar: {address: http://127.0.0.1:0}}}")
+func TestNewOutboundsConfig(t *testing.T) {
+	cfg := strings.NewReader("yarpc: {http: {outbounds: {bar: {address: http://127.0.0.1:0}}}}")
 	provider, err := config.NewYAML(config.Source(cfg))
 	require.NoError(t, err)
 
+	res, err := NewOutboundsConfig(OutboundsConfigParams{
+		Provider: provider,
+	})
+	require.NoError(t, err)
+	assert.Equal(t,
+		OutboundsConfig{
+			Clients: map[string]OutboundConfig{
+				"bar": {Address: "http://127.0.0.1:0"},
+			},
+		},
+		res.Config,
+	)
+}
+
+func TestNewClients(t *testing.T) {
 	res, err := NewClients(ClientParams{
 		Lifecycle: fxtest.NewLifecycle(t),
-		Provider:  provider,
+		Config: OutboundsConfig{
+			Clients: map[string]OutboundConfig{
+				"bar": {Address: "http://127.0.0.1:0"},
+			},
+		},
 	})
 	require.NoError(t, err)
 

--- a/v2/yarpchttp/yarpchttpfx/yarpchttpfx_test.go
+++ b/v2/yarpchttp/yarpchttpfx/yarpchttpfx_test.go
@@ -60,7 +60,6 @@ func TestNewClients(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-
 	assert.Len(t, res.Clients, 1)
 	assert.Equal(t, res.Clients[0].Caller, "foo")
 }

--- a/v2/yarpchttp/yarpchttpfx/yarpchttpfx_test.go
+++ b/v2/yarpchttp/yarpchttpfx/yarpchttpfx_test.go
@@ -1,0 +1,39 @@
+package yarpchttpfx
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/config"
+	"go.uber.org/fx/fxtest"
+	"go.uber.org/yarpc/v2/yarpctest"
+)
+
+func TestStartInbounds(t *testing.T) {
+	cfg := strings.NewReader("yarpchttp: {inbounds: {address: http://127.0.0.1:0}}")
+	provider, err := config.NewYAML(config.Source(cfg))
+	require.NoError(t, err)
+
+	assert.NoError(t, StartInbounds(StartInboundsParams{
+		Lifecycle: fxtest.NewLifecycle(t),
+		Router:    yarpctest.NewFakeRouter(nil),
+		Provider:  provider,
+	}))
+}
+
+func TestNewClients(t *testing.T) {
+	cfg := strings.NewReader("yarpchttp: {outbounds: {bar: {address: http://127.0.0.1:0}}}")
+	provider, err := config.NewYAML(config.Source(cfg))
+	require.NoError(t, err)
+
+	res, err := NewClients(ClientParams{
+		Lifecycle: fxtest.NewLifecycle(t),
+		Provider:  provider,
+	})
+	require.NoError(t, err)
+
+	assert.Len(t, res.Clients, 1)
+	assert.Equal(t, res.Clients[0].Caller, "foo")
+}

--- a/v2/yarpchttp/yarpchttpfx/yarpchttpfx_test.go
+++ b/v2/yarpchttp/yarpchttpfx/yarpchttpfx_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package yarpchttpfx
 
 import (

--- a/v2/yarpchttp/yarpchttpfx/yarpchttpfx_test.go
+++ b/v2/yarpchttp/yarpchttpfx/yarpchttpfx_test.go
@@ -32,7 +32,7 @@ func TestStartInbounds(t *testing.T) {
 }
 
 func TestNewOutboundsConfig(t *testing.T) {
-	cfg := strings.NewReader("yarpc: {http: {outbounds: {bar: {address: http://127.0.0.1:0}}}}")
+	cfg := strings.NewReader("yarpc: {http: {outbounds: {bar: {address: http://127.0.0.1:0, service: baz}}}}")
 	provider, err := config.NewYAML(config.Source(cfg))
 	require.NoError(t, err)
 
@@ -43,7 +43,7 @@ func TestNewOutboundsConfig(t *testing.T) {
 	assert.Equal(t,
 		OutboundsConfig{
 			Clients: map[string]OutboundConfig{
-				"bar": {Address: "http://127.0.0.1:0"},
+				"bar": {Address: "http://127.0.0.1:0", Service: "baz"},
 			},
 		},
 		res.Config,


### PR DESCRIPTION
This proposes the initial scaffold for the `yarpcfx` and `yarpchttpfx` packages which coordinate with the v2 APIs.

Each of the transports will define their own `<transport>fx` package (`yarpchttpfx` in this case) that consumes the `yarpc.Router` in order to construct and start their inbounds. Similarly, the module will produce `yarpc.Client`s that are consumed by the core `yarpcfx.Module` so that they are retrievable from the `yarpc.ClientProvider`.

Note that this also introduces the `go.uber.org/config` dependency so that we can effectively load configuration for each of these modules. There are a few notes left in the implementation with respect to missing features, like the service name resolution. This will be resolved once the package is moved into our internal space where `servicefx` can be accessed.