### PR TITLE
[v2] [WIP] Support direct and return addresses

### DIFF
--- a/v2/request.go
+++ b/v2/request.go
@@ -30,6 +30,10 @@ import (
 
 // Request is the low level request representation.
 type Request struct {
+	// Peer if present indicates the destination address for an outbound
+	// request or the return address of an inbound request.
+	Peer Identifier
+
 	// Name of the service making the request.
 	Caller string
 

--- a/v2/response.go
+++ b/v2/response.go
@@ -22,6 +22,11 @@ package yarpc
 
 // Response is the low level response representation.
 type Response struct {
-	Headers          Headers
+	// Peer if present indicates the peer that handled an outbound request.
+	Peer Identifier
+
+	// Headers are response headers or trailers.
+	Headers Headers
+
 	ApplicationError bool
 }

--- a/v2/yarpcgrpc/outbound.go
+++ b/v2/yarpcgrpc/outbound.go
@@ -32,6 +32,7 @@ import (
 	"go.uber.org/yarpc/v2/yarpcerror"
 	"go.uber.org/yarpc/v2/yarpcpeer"
 	"go.uber.org/yarpc/v2/yarpctracing"
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -63,6 +64,9 @@ type Outbound struct {
 
 	// Tracer attaches a tracer for the outbound.
 	Tracer opentracing.Tracer
+
+	// Logger writes logs for the outbound.
+	Logger *zap.Logger
 }
 
 // Call implements yarpc.UnaryOutbound#Call.
@@ -208,7 +212,6 @@ func (o *Outbound) CallStream(ctx context.Context, req *yarpc.Request) (*yarpc.C
 	if err != nil {
 		return nil, err
 	}
-	defer func() { onFinish(err) }()
 
 	_, span, err := o.getSpanForRequest(ctx, start, req, md)
 	if err != nil {
@@ -228,7 +231,7 @@ func (o *Outbound) CallStream(ctx context.Context, req *yarpc.Request) (*yarpc.C
 		span.Finish()
 		return nil, err
 	}
-	stream := newClientStream(streamCtx, req, clientStream, span)
+	stream := newClientStream(streamCtx, req, onFinish, clientStream, span)
 	tClientStream, err := yarpc.NewClientStream(stream)
 	if err != nil {
 		span.Finish()
@@ -247,30 +250,16 @@ func (o *Outbound) getPeerForRequest(ctx context.Context, req *yarpc.Request) (*
 		err      error
 	)
 
-	if o.Chooser != nil {
+	if req.Peer != nil {
+		peer, onFinish, err = o.getEphemeralPeer(req.Peer)
+	} else if o.Chooser != nil {
 		peer, onFinish, err = o.Chooser.Choose(ctx, req)
 		if err != nil {
 			return nil, nil, err
 		}
-
 	} else if o.Dialer != nil && o.URL != nil {
 		id := yarpc.Address(o.URL.Host)
-		peer, err = o.Dialer.RetainPeer(id, yarpc.NopSubscriber)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		onFinish = func(error) {
-			// Do nothing.
-			//
-			// We cannot call ReleasePeer since we only dial a single peer. If a
-			// finished request calls ReleasePeer, this will close the connection loop
-			// for all concurrent callers since they have the same subscriber.
-			// Concurrent calls would otherwise fail.
-			//
-			// This could be avoided by introducing a per request subscriber.
-		}
-
+		peer, onFinish, err = o.getEphemeralPeer(id)
 	} else {
 		return nil, nil, yarpcerror.FailedPreconditionErrorf("gRPC Outbound must have either Chooser or Dialer and URL to make a Call")
 	}
@@ -285,6 +274,21 @@ func (o *Outbound) getPeerForRequest(ctx context.Context, req *yarpc.Request) (*
 
 	return grpcPeer, onFinish, nil
 }
+
+func (o *Outbound) getEphemeralPeer(id yarpc.Identifier) (yarpc.Peer, func(error), error) {
+	peer, err := o.Dialer.RetainPeer(id, yarpc.NopSubscriber)
+	if err != nil {
+		return nil, nil, err
+	}
+	return peer, func(error) {
+		err = o.Dialer.ReleasePeer(id, yarpc.NopSubscriber)
+		if err != nil && o.Logger != nil {
+			o.Logger.Error("unable to release peer", zap.Error(err))
+		}
+	}, nil
+}
+
+func nopFinish(error) {}
 
 // getSpanForRequest returns an opentracing.Span with the given metadata
 // injected into the span.Context()

--- a/v2/yarpcgrpc/stream.go
+++ b/v2/yarpcgrpc/stream.go
@@ -77,19 +77,21 @@ func (ss *serverStream) ReceiveMessage(_ context.Context) (*yarpc.StreamMessage,
 }
 
 type clientStream struct {
-	ctx    context.Context
-	req    *yarpc.Request
-	stream grpc.ClientStream
-	span   opentracing.Span
-	closed atomic.Bool
+	ctx      context.Context
+	req      *yarpc.Request
+	onFinish func(error)
+	stream   grpc.ClientStream
+	span     opentracing.Span
+	closed   atomic.Bool
 }
 
-func newClientStream(ctx context.Context, req *yarpc.Request, stream grpc.ClientStream, span opentracing.Span) *clientStream {
+func newClientStream(ctx context.Context, req *yarpc.Request, onFinish func(error), stream grpc.ClientStream, span opentracing.Span) *clientStream {
 	return &clientStream{
-		ctx:    ctx,
-		req:    req,
-		stream: stream,
-		span:   span,
+		ctx:      ctx,
+		req:      req,
+		onFinish: onFinish,
+		stream:   stream,
+		span:     span,
 	}
 }
 

--- a/v2/yarpchttp/constants.go
+++ b/v2/yarpchttp/constants.go
@@ -31,6 +31,10 @@ var (
 
 // HTTP headers used in requests and responses to send YARPC metadata.
 const (
+	// PeerHeader is the header key for carrying the return address for a
+	// request or response.
+	PeerHeader = "Rpc-Peer"
+
 	// Name of the service sending the request. This corresponds to the
 	// Request.Caller attribute.
 	CallerHeader = "Rpc-Caller"
@@ -86,6 +90,9 @@ const (
 	// feature is supported on the server. If any non-empty value is set,
 	// this indicates true.
 	BothResponseErrorHeader = "Rpc-Both-Response-Error"
+
+	// ContentTypeHeader is the key of the HTTP Content-Type header.
+	ContentTypeHeader = "Content-Type"
 )
 
 // Valid values for the Rpc-Status header.

--- a/v2/yarpchttp/inbound.go
+++ b/v2/yarpchttp/inbound.go
@@ -120,13 +120,15 @@ func (i *Inbound) Start(_ context.Context) error {
 		logger = i.Logger
 	}
 
-	var httpHandler http.Handler = handler{
+	handler := handler{
 		router:              i.Router,
 		grabHeaders:         grabHeaders,
 		legacyResponseError: i.legacyResponseError,
 		logger:              logger,
 		tracer:              tracer,
 	}
+
+	var httpHandler http.Handler = handler
 
 	if i.Interceptor != nil {
 		httpHandler = i.Interceptor(httpHandler)
@@ -153,11 +155,12 @@ func (i *Inbound) Start(_ context.Context) error {
 		}
 	}
 
+	handler.addr = i.Listener.Addr().String()
+
 	i.server = internalhttp.NewHTTPServer(server)
 	go i.server.Run(i.Listener)
 
-	addr := i.Listener.Addr().String()
-	logger.Info("started HTTP inbound", zap.String("address", addr))
+	logger.Info("started HTTP inbound", zap.Stringer("address", i.Listener.Addr()))
 	if len(i.Router.Procedures()) == 0 {
 		logger.Warn("no procedures specified for HTTP inbound")
 	}


### PR DESCRIPTION
This change introduces a Peer property of Request and Response objects that
overrides outbound peer selection in every transport, and a return address
for outbound responses so you can follow-up with a direct request to the same
peer, possibly bypassing intermediate routers.

Incidentally also fixed a peer management leak in gRPC.
Ephemeral peers are now retained until the unary request ends or streaming
client closes.
That behavior probably ought to be separated and back-ported.

- [x] http direct address
- [x] grpc direct address
- [x] tchannel direct address
- [x] http return address
- [ ] grpc return address
- [ ] tchannel return address
- [ ] call option setter
- [ ] call option handler peer address receiver
- [ ] inbound call getter
- [ ] tests