### PR TITLE
[spring] gRPC peer retention scope fix

### DIFF
--- a/v2/yarpcgrpc/stream.go
+++ b/v2/yarpcgrpc/stream.go
@@ -77,19 +77,21 @@ func (ss *serverStream) ReceiveMessage(_ context.Context) (*yarpc.StreamMessage,
 }
 
 type clientStream struct {
-	ctx    context.Context
-	req    *yarpc.Request
-	stream grpc.ClientStream
-	span   opentracing.Span
-	closed atomic.Bool
+	ctx      context.Context
+	req      *yarpc.Request
+	onFinish func(error)
+	stream   grpc.ClientStream
+	span     opentracing.Span
+	closed   atomic.Bool
 }
 
-func newClientStream(ctx context.Context, req *yarpc.Request, stream grpc.ClientStream, span opentracing.Span) *clientStream {
+func newClientStream(ctx context.Context, req *yarpc.Request, onFinish func(error), stream grpc.ClientStream, span opentracing.Span) *clientStream {
 	return &clientStream{
-		ctx:    ctx,
-		req:    req,
-		stream: stream,
-		span:   span,
+		ctx:      ctx,
+		req:      req,
+		onFinish: onFinish,
+		stream:   stream,
+		span:     span,
 	}
 }
 


### PR DESCRIPTION
This change addresses a bug in gRPC’s peer retention scope and a related bug in the abstract peer implementation. The abstract peer needs to track a reference count for each peer, since the subscriber might not be unique. Fixing this allows us to release a gRPC peer when we’re done using it. The scope for unary is defined on the stack. The scope for streaming concludes when the stream closes, so we need to thread onFinish through the client.