### PR TITLE
[spring] Refactor response error from boolean to error type

### DIFF
--- a/v2/CHANGES
+++ b/v2/CHANGES
@@ -12,6 +12,8 @@
             could be considered fatal (T1995085). This affects transports and encodings.
             - [x] JSON encoding
             - [x] HTTP transport
+      - [ ] Revisit the ApplicationError field in *yarpc.Response and consider replacing it
+            with a strongly-typed metadata struct or interface.
 - [x] Change Request and Response body to yarpc.Buffer type
       - [ ] Accumulate request bodies at the inbound
 - [ ] yarpcrouter.Router needs to accept middleware to decorate registered

--- a/v2/CHANGES
+++ b/v2/CHANGES
@@ -7,11 +7,11 @@
             them positional, to avoid separating and embedding Meta* for the
             streaming case.
       - [ ] Incorporate implicit buffer pooling in yarpc.Buffer (using internal/bufferpool.Buffer)
-      - [ ] Now that we propogate a Response struct back, the Response should hold the actual
+      - [x] Now that we propogate a Response struct back, the Response should hold the actual
             application error. Errors returned by the handler (not through the Response)
             could be considered fatal (T1995085). This affects transports and encodings.
-            - [ ] JSON encoding
-            - [ ] HTTP transport
+            - [x] JSON encoding
+            - [x] HTTP transport
 - [x] Change Request and Response body to yarpc.Buffer type
       - [ ] Accumulate request bodies at the inbound
 - [ ] yarpcrouter.Router needs to accept middleware to decorate registered

--- a/v2/encoding.go
+++ b/v2/encoding.go
@@ -77,7 +77,11 @@ func (u *unaryTransportHandler) Handle(ctx context.Context, req *Request, reqBuf
 	}
 
 	if appErr != nil {
-		res.ApplicationError = true
+		// TODO: This is a bit odd; we set the error in response AND return it.
+		// However, to preserve the current behavior of YARPC, this is
+		// necessary. This is most likely where the error details will be added,
+		// so we expect this to change.
+		res.ApplicationError = appErr
 		return res, encodedBody, appErr
 	}
 

--- a/v2/internal/internalgauntlettest/thrift/echo/echoserver/server.go
+++ b/v2/internal/internalgauntlettest/thrift/echo/echoserver/server.go
@@ -72,14 +72,13 @@ func (h handler) Echo(ctx context.Context, body wire.Value) (yarpcthrift.Respons
 		return yarpcthrift.Response{}, err
 	}
 
-	success, err := h.impl.Echo(ctx, args.Request)
+	success, appErr := h.impl.Echo(ctx, args.Request)
 
-	appErr := err
-	result, err := echo.Echo_Echo_Helper.WrapResponse(success, err)
+	result, err := echo.Echo_Echo_Helper.WrapResponse(success, appErr)
 
 	var response yarpcthrift.Response
 	if err == nil {
-		response.ApplicationError = appErr
+		response.Exception = appErr
 		response.Body = result
 	}
 	return response, err

--- a/v2/internal/internalgauntlettest/thrift/echo/echoserver/server.go
+++ b/v2/internal/internalgauntlettest/thrift/echo/echoserver/server.go
@@ -74,12 +74,12 @@ func (h handler) Echo(ctx context.Context, body wire.Value) (yarpcthrift.Respons
 
 	success, err := h.impl.Echo(ctx, args.Request)
 
-	hadError := err != nil
+	appErr := err
 	result, err := echo.Echo_Echo_Helper.WrapResponse(success, err)
 
 	var response yarpcthrift.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err

--- a/v2/internal/internalyarpcobservability/common_test.go
+++ b/v2/internal/internalyarpcobservability/common_test.go
@@ -29,12 +29,12 @@ import (
 
 type fakeHandler struct {
 	err            error
-	applicationErr bool
+	applicationErr error
 }
 
 func (h fakeHandler) Handle(context.Context, *yarpc.Request, *yarpc.Buffer) (*yarpc.Response, *yarpc.Buffer, error) {
 	res := &yarpc.Response{ApplicationError: h.applicationErr}
-	if h.applicationErr {
+	if h.applicationErr != nil {
 		return res, nil, nil
 	}
 	return res, nil, h.err
@@ -46,7 +46,7 @@ func (h fakeHandler) HandleStream(*yarpc.ServerStream) error {
 
 type fakeOutbound struct {
 	err            error
-	applicationErr bool
+	applicationErr error
 }
 
 func (o fakeOutbound) Call(context.Context, *yarpc.Request, *yarpc.Buffer) (*yarpc.Response, *yarpc.Buffer, error) {

--- a/v2/internal/internalyarpcobservability/middleware.go
+++ b/v2/internal/internalyarpcobservability/middleware.go
@@ -55,6 +55,10 @@ func (m *Middleware) Handle(ctx context.Context, req *yarpc.Request, reqBuf *yar
 	if res != nil {
 		isApplicationError = res.ApplicationError != nil
 	}
+	// TODO(mhp): Now that we are including the application error into the
+	// response, we can log with much more detail. The error in the response
+	// struct will be changing soon; the logging behavior in this middleware
+	// should be revisited after that.
 	call.EndWithAppError(err, isApplicationError)
 	return res, resBuf, err
 }

--- a/v2/internal/internalyarpcobservability/middleware.go
+++ b/v2/internal/internalyarpcobservability/middleware.go
@@ -53,7 +53,7 @@ func (m *Middleware) Handle(ctx context.Context, req *yarpc.Request, reqBuf *yar
 
 	isApplicationError := false
 	if res != nil {
-		isApplicationError = res.ApplicationError
+		isApplicationError = res.ApplicationError != nil
 	}
 	call.EndWithAppError(err, isApplicationError)
 	return res, resBuf, err
@@ -66,7 +66,7 @@ func (m *Middleware) Call(ctx context.Context, req *yarpc.Request, reqBuf *yarpc
 
 	isApplicationError := false
 	if res != nil {
-		isApplicationError = res.ApplicationError
+		isApplicationError = res.ApplicationError != nil
 	}
 	call.EndWithAppError(err, isApplicationError)
 	return res, resBuf, err

--- a/v2/response.go
+++ b/v2/response.go
@@ -23,5 +23,5 @@ package yarpc
 // Response is the low level response representation.
 type Response struct {
 	Headers          Headers
-	ApplicationError bool
+	ApplicationError error
 }

--- a/v2/yarpcgrpc/handler.go
+++ b/v2/yarpcgrpc/handler.go
@@ -191,9 +191,6 @@ func (h *handler) handleUnary(
 		Handler:   handler,
 		Logger:    h.i.Logger,
 	})
-	if res.ApplicationError != nil {
-		err = res.ApplicationError
-	}
 
 	err = handlerErrorToGRPCError(err, mdWriter)
 

--- a/v2/yarpcgrpc/handler.go
+++ b/v2/yarpcgrpc/handler.go
@@ -191,6 +191,9 @@ func (h *handler) handleUnary(
 		Handler:   handler,
 		Logger:    h.i.Logger,
 	})
+	if res.ApplicationError != nil {
+		err = res.ApplicationError
+	}
 
 	err = handlerErrorToGRPCError(err, mdWriter)
 

--- a/v2/yarpcgrpc/metadata_writer.go
+++ b/v2/yarpcgrpc/metadata_writer.go
@@ -44,7 +44,7 @@ func (r *metadataWriter) SetResponse(res *yarpc.Response) {
 
 	r.headerErr = multierr.Combine(r.headerErr, addApplicationHeaders(r.md, res.Headers))
 
-	if res.ApplicationError {
+	if res.ApplicationError != nil {
 		r.AddSystemHeader(ApplicationErrorHeader, ApplicationErrorHeaderValue)
 	}
 }

--- a/v2/yarpcgrpc/outbound.go
+++ b/v2/yarpcgrpc/outbound.go
@@ -152,8 +152,8 @@ func metadataToApplicationError(invokeErr error, responseMD metadata.MD) error {
 	if responseMD == nil {
 		return nil
 	}
-	_, ok := responseMD[ApplicationErrorHeader]
-	if ok {
+
+	if _, ok := responseMD[ApplicationErrorHeader]; ok {
 		return invokeErr
 	}
 	return nil

--- a/v2/yarpchttp/outbound.go
+++ b/v2/yarpchttp/outbound.go
@@ -141,6 +141,10 @@ func (o *Outbound) call(ctx context.Context, req *yarpc.Request, reqBuf *yarpc.B
 	botResponseError := httpRes.Header.Get(BothResponseErrorHeader) == AcceptTrue
 	if botResponseError && !o.legacyResponseError {
 		if httpRes.StatusCode >= 300 {
+			// TODO: This is a bit odd; we set the error in response AND return it.
+			// However, to preserve the current behavior of YARPC, this is
+			// necessary. This is most likely where the error details will be added,
+			// so we expect this to change.
 			return res, resBuf, res.ApplicationError
 		}
 		return res, resBuf, nil

--- a/v2/yarpchttp/outbound_test.go
+++ b/v2/yarpchttp/outbound_test.go
@@ -255,7 +255,11 @@ func TestOutboundApplicationError(t *testing.T) {
 				Procedure: "hello",
 			}, yarpc.NewBufferString("world"))
 
-			assert.Equal(t, response.ApplicationError, tt.appError, "%v: application status", tt.desc)
+			if tt.appError {
+				assert.Error(t, response.ApplicationError, "%v: application status", tt.desc)
+			} else {
+				assert.NoError(t, response.ApplicationError, "%v: application status", tt.desc)
+			}
 			assert.NoError(t, err, "%v: call failed", tt.desc)
 		})
 	}

--- a/v2/yarpcprotobuf/inbound.go
+++ b/v2/yarpcprotobuf/inbound.go
@@ -87,7 +87,11 @@ func (u *unaryHandler) Handle(ctx context.Context, req *yarpc.Request, buf *yarp
 	// early so that we don't attempt to marshal a nil
 	// object.
 	if appErr != nil {
-		res.ApplicationError = true
+		// TODO: This is a bit odd; we set the error in response AND return it.
+		// However, to preserve the current behavior of YARPC, this is
+		// necessary. This is most likely where the error details will be added,
+		// so we expect this to change.
+		res.ApplicationError = appErr
 		return res, resBuf, appErr
 	}
 
@@ -100,12 +104,6 @@ func (u *unaryHandler) Handle(ctx context.Context, req *yarpc.Request, buf *yarp
 	}
 	if _, err := resBuf.Write(body); err != nil {
 		return res, resBuf, err
-	}
-	if appErr != nil {
-		// TODO(apeatsbond): now that we propogate a Response struct back, the
-		// Response should hold the actual application error. Errors returned by the
-		// handler (not through the Response) could be considered fatal.
-		res.ApplicationError = true
 	}
 	return res, resBuf, appErr
 }

--- a/v2/yarpctchannel/handler.go
+++ b/v2/yarpctchannel/handler.go
@@ -166,11 +166,11 @@ func (h handler) writeResponse(ctx context.Context, call inboundCall, res *yarpc
 		// Nothing to see here. Move along.
 		return nil
 	}
-	if retErr != nil && (res == nil || !res.ApplicationError) {
+	if retErr != nil && (res == nil || res.ApplicationError == nil) {
 		// System error.
 		return retErr
 	}
-	if retErr != nil && res != nil && res.ApplicationError {
+	if retErr != nil && res != nil && res.ApplicationError != nil {
 		// We have an error, so we're going to propagate it as a yarpc error,
 		// regardless of whether or not it is a system error.
 		status := yarpcerror.FromError(yarpcerror.WrapHandlerError(retErr, call.ServiceName(), call.MethodString()))
@@ -190,7 +190,7 @@ func (h handler) writeResponse(ctx context.Context, call inboundCall, res *yarpc
 	// This is the point of no return. We have committed to sending a call
 	// response. Hereafter, all failures while sending the error must be logged
 	// and the response aborted.
-	if res.ApplicationError {
+	if res.ApplicationError != nil {
 		if err := call.Response().SetApplicationError(); err != nil {
 			retErr = appendError(retErr, fmt.Errorf("SetApplicationError() failed: %v", err))
 		}

--- a/v2/yarpctchannel/inbound_test.go
+++ b/v2/yarpctchannel/inbound_test.go
@@ -133,7 +133,7 @@ func TestInboundSubServices(t *testing.T) {
 		if !assert.NoError(t, err, "failed to make call") {
 			continue
 		}
-		if !assert.Equal(t, false, res.ApplicationError, "not application error") {
+		if !assert.NoError(t, res.ApplicationError, "not application error") {
 			continue
 		}
 		assert.Equal(t, resBody, yarpc.NewBufferString(tt.service))

--- a/v2/yarpctchannel/outbound.go
+++ b/v2/yarpctchannel/outbound.go
@@ -22,6 +22,7 @@ package yarpctchannel
 
 import (
 	"context"
+	"errors"
 	"io"
 
 	"github.com/uber/tchannel-go"
@@ -163,9 +164,15 @@ func callWithPeer(ctx context.Context, req *yarpc.Request, reqBody *yarpc.Buffer
 			"does not match the service name received in the response: sent %q, got: %q", req.Service, resSvcName)
 	}
 
+	var appErr error
+	if res.ApplicationError() {
+		// TODO(mhp): this is a filler error for now to preserve current yarpc
+		// error behavior. This should later be more well-defined.
+		appErr = errors.New("application error")
+	}
 	return &yarpc.Response{
 		Headers:          headers,
-		ApplicationError: res.ApplicationError(),
+		ApplicationError: appErr,
 	}, resBody, getResponseErrorAndDeleteHeaderKeys(headers)
 }
 

--- a/v2/yarpctchannel/outbound_test.go
+++ b/v2/yarpctchannel/outbound_test.go
@@ -213,7 +213,7 @@ func TestCallSuccess(t *testing.T) {
 			}
 
 			require.NotNil(t, res)
-			assert.Equal(t, false, res.ApplicationError, "not application error")
+			assert.NoError(t, res.ApplicationError, "not application error")
 
 			foo, ok := res.Headers.Get("foo")
 			assert.True(t, ok, "value for foo expected")
@@ -364,7 +364,7 @@ func TestCallError(t *testing.T) {
 		return
 	}
 
-	assert.True(t, res.ApplicationError, "application error")
+	assert.Error(t, res.ApplicationError, "application error")
 	assert.Equal(t, resBody, yarpc.NewBufferString("such fail"))
 }
 

--- a/v2/yarpcthrift/inbound.go
+++ b/v2/yarpcthrift/inbound.go
@@ -65,8 +65,8 @@ func (t unaryTransportHandler) Handle(ctx context.Context, req *yarpc.Request, r
 
 	res, resBuf := &yarpc.Response{}, &yarpc.Buffer{}
 
-	if thriftRes.ApplicationError != nil {
-		res.ApplicationError = thriftRes.ApplicationError
+	if thriftRes.Exception != nil {
+		res.ApplicationError = thriftRes.Exception
 	}
 
 	call.WriteToResponse(res)

--- a/v2/yarpcthrift/inbound.go
+++ b/v2/yarpcthrift/inbound.go
@@ -65,8 +65,8 @@ func (t unaryTransportHandler) Handle(ctx context.Context, req *yarpc.Request, r
 
 	res, resBuf := &yarpc.Response{}, &yarpc.Buffer{}
 
-	if thriftRes.IsApplicationError {
-		res.ApplicationError = true
+	if thriftRes.ApplicationError != nil {
+		res.ApplicationError = thriftRes.ApplicationError
 	}
 
 	call.WriteToResponse(res)

--- a/v2/yarpcthrift/inbound_test.go
+++ b/v2/yarpcthrift/inbound_test.go
@@ -101,7 +101,7 @@ func TestDecodeRequestApplicationError(t *testing.T) {
 
 	handler := func(ctx context.Context, w wire.Value) (Response, error) {
 		// XXX setting application error bit
-		return Response{Body: fakeEnveloper(wire.Reply), ApplicationError: errors.New("decode application error")}, nil
+		return Response{Body: fakeEnveloper(wire.Reply), Exception: errors.New("decode application error")}, nil
 	}
 	h := unaryTransportHandler{Protocol: proto, ThriftHandler: handler}
 

--- a/v2/yarpcthrift/inbound_test.go
+++ b/v2/yarpcthrift/inbound_test.go
@@ -22,6 +22,7 @@ package yarpcthrift
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -54,7 +55,7 @@ func TestDecodeRequest(t *testing.T) {
 	res, _, err := h.Handle(ctx, request(), requestBody())
 
 	assert.NoError(t, err, "unexpected error")
-	assert.False(t, res.ApplicationError, "application error bit set")
+	assert.NoError(t, res.ApplicationError, "application error set")
 }
 
 func TestDecodeEnveloped(t *testing.T) {
@@ -100,7 +101,7 @@ func TestDecodeRequestApplicationError(t *testing.T) {
 
 	handler := func(ctx context.Context, w wire.Value) (Response, error) {
 		// XXX setting application error bit
-		return Response{Body: fakeEnveloper(wire.Reply), IsApplicationError: true}, nil
+		return Response{Body: fakeEnveloper(wire.Reply), ApplicationError: errors.New("decode application error")}, nil
 	}
 	h := unaryTransportHandler{Protocol: proto, ThriftHandler: handler}
 
@@ -108,7 +109,7 @@ func TestDecodeRequestApplicationError(t *testing.T) {
 	res, resBody, err := h.Handle(ctx, request(), requestBody())
 	assert.NotNil(t, res)
 	assert.NotNil(t, resBody)
-	assert.True(t, res.ApplicationError, "application error bit unset")
+	assert.Error(t, res.ApplicationError, "application error unset")
 	assert.NoError(t, err, "unexpected error")
 }
 

--- a/v2/yarpcthrift/response.go
+++ b/v2/yarpcthrift/response.go
@@ -26,5 +26,5 @@ import "go.uber.org/thriftrw/envelope"
 type Response struct {
 	Body envelope.Enveloper
 
-	ApplicationError error
+	Exception error
 }

--- a/v2/yarpcthrift/response.go
+++ b/v2/yarpcthrift/response.go
@@ -26,5 +26,5 @@ import "go.uber.org/thriftrw/envelope"
 type Response struct {
 	Body envelope.Enveloper
 
-	IsApplicationError bool
+	ApplicationError error
 }

--- a/v2/yarpcthrift/thriftrw-plugin-yarpc2/internal/tests/atomic/readonlystoreserver/server.go
+++ b/v2/yarpcthrift/thriftrw-plugin-yarpc2/internal/tests/atomic/readonlystoreserver/server.go
@@ -56,14 +56,13 @@ func (h handler) Integer(ctx context.Context, body wire.Value) (yarpcthrift.Resp
 		return yarpcthrift.Response{}, err
 	}
 
-	success, err := h.impl.Integer(ctx, args.Key)
+	success, appErr := h.impl.Integer(ctx, args.Key)
 
-	appErr := err
-	result, err := atomic.ReadOnlyStore_Integer_Helper.WrapResponse(success, err)
+	result, err := atomic.ReadOnlyStore_Integer_Helper.WrapResponse(success, appErr)
 
 	var response yarpcthrift.Response
 	if err == nil {
-		response.ApplicationError = appErr
+		response.Exception = appErr
 		response.Body = result
 	}
 	return response, err

--- a/v2/yarpcthrift/thriftrw-plugin-yarpc2/internal/tests/atomic/readonlystoreserver/server.go
+++ b/v2/yarpcthrift/thriftrw-plugin-yarpc2/internal/tests/atomic/readonlystoreserver/server.go
@@ -58,12 +58,12 @@ func (h handler) Integer(ctx context.Context, body wire.Value) (yarpcthrift.Resp
 
 	success, err := h.impl.Integer(ctx, args.Key)
 
-	hadError := err != nil
+	appErr := err
 	result, err := atomic.ReadOnlyStore_Integer_Helper.WrapResponse(success, err)
 
 	var response yarpcthrift.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err

--- a/v2/yarpcthrift/thriftrw-plugin-yarpc2/internal/tests/atomic/storeserver/server.go
+++ b/v2/yarpcthrift/thriftrw-plugin-yarpc2/internal/tests/atomic/storeserver/server.go
@@ -71,12 +71,12 @@ func (h handler) CompareAndSwap(ctx context.Context, body wire.Value) (yarpcthri
 
 	err := h.impl.CompareAndSwap(ctx, args.Request)
 
-	hadError := err != nil
+	appErr := err
 	result, err := atomic.Store_CompareAndSwap_Helper.WrapResponse(err)
 
 	var response yarpcthrift.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err
@@ -90,12 +90,12 @@ func (h handler) Increment(ctx context.Context, body wire.Value) (yarpcthrift.Re
 
 	err := h.impl.Increment(ctx, args.Key, args.Value)
 
-	hadError := err != nil
+	appErr := err
 	result, err := atomic.Store_Increment_Helper.WrapResponse(err)
 
 	var response yarpcthrift.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err

--- a/v2/yarpcthrift/thriftrw-plugin-yarpc2/internal/tests/atomic/storeserver/server.go
+++ b/v2/yarpcthrift/thriftrw-plugin-yarpc2/internal/tests/atomic/storeserver/server.go
@@ -69,14 +69,13 @@ func (h handler) CompareAndSwap(ctx context.Context, body wire.Value) (yarpcthri
 		return yarpcthrift.Response{}, err
 	}
 
-	err := h.impl.CompareAndSwap(ctx, args.Request)
+	appErr := h.impl.CompareAndSwap(ctx, args.Request)
 
-	appErr := err
-	result, err := atomic.Store_CompareAndSwap_Helper.WrapResponse(err)
+	result, err := atomic.Store_CompareAndSwap_Helper.WrapResponse(appErr)
 
 	var response yarpcthrift.Response
 	if err == nil {
-		response.ApplicationError = appErr
+		response.Exception = appErr
 		response.Body = result
 	}
 	return response, err
@@ -88,14 +87,13 @@ func (h handler) Increment(ctx context.Context, body wire.Value) (yarpcthrift.Re
 		return yarpcthrift.Response{}, err
 	}
 
-	err := h.impl.Increment(ctx, args.Key, args.Value)
+	appErr := h.impl.Increment(ctx, args.Key, args.Value)
 
-	appErr := err
-	result, err := atomic.Store_Increment_Helper.WrapResponse(err)
+	result, err := atomic.Store_Increment_Helper.WrapResponse(appErr)
 
 	var response yarpcthrift.Response
 	if err == nil {
-		response.ApplicationError = appErr
+		response.Exception = appErr
 		response.Body = result
 	}
 	return response, err

--- a/v2/yarpcthrift/thriftrw-plugin-yarpc2/internal/tests/common/baseserviceserver/server.go
+++ b/v2/yarpcthrift/thriftrw-plugin-yarpc2/internal/tests/common/baseserviceserver/server.go
@@ -51,14 +51,13 @@ func (h handler) Healthy(ctx context.Context, body wire.Value) (yarpcthrift.Resp
 		return yarpcthrift.Response{}, err
 	}
 
-	success, err := h.impl.Healthy(ctx)
+	success, appErr := h.impl.Healthy(ctx)
 
-	appErr := err
-	result, err := common.BaseService_Healthy_Helper.WrapResponse(success, err)
+	result, err := common.BaseService_Healthy_Helper.WrapResponse(success, appErr)
 
 	var response yarpcthrift.Response
 	if err == nil {
-		response.ApplicationError = appErr
+		response.Exception = appErr
 		response.Body = result
 	}
 	return response, err

--- a/v2/yarpcthrift/thriftrw-plugin-yarpc2/internal/tests/common/baseserviceserver/server.go
+++ b/v2/yarpcthrift/thriftrw-plugin-yarpc2/internal/tests/common/baseserviceserver/server.go
@@ -53,12 +53,12 @@ func (h handler) Healthy(ctx context.Context, body wire.Value) (yarpcthrift.Resp
 
 	success, err := h.impl.Healthy(ctx)
 
-	hadError := err != nil
+	appErr := err
 	result, err := common.BaseService_Healthy_Helper.WrapResponse(success, err)
 
 	var response yarpcthrift.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err

--- a/v2/yarpcthrift/thriftrw-plugin-yarpc2/internal/tests/common/extendemptyserver/server.go
+++ b/v2/yarpcthrift/thriftrw-plugin-yarpc2/internal/tests/common/extendemptyserver/server.go
@@ -55,14 +55,13 @@ func (h handler) Hello(ctx context.Context, body wire.Value) (yarpcthrift.Respon
 		return yarpcthrift.Response{}, err
 	}
 
-	err := h.impl.Hello(ctx)
+	appErr := h.impl.Hello(ctx)
 
-	appErr := err
-	result, err := common.ExtendEmpty_Hello_Helper.WrapResponse(err)
+	result, err := common.ExtendEmpty_Hello_Helper.WrapResponse(appErr)
 
 	var response yarpcthrift.Response
 	if err == nil {
-		response.ApplicationError = appErr
+		response.Exception = appErr
 		response.Body = result
 	}
 	return response, err

--- a/v2/yarpcthrift/thriftrw-plugin-yarpc2/internal/tests/common/extendemptyserver/server.go
+++ b/v2/yarpcthrift/thriftrw-plugin-yarpc2/internal/tests/common/extendemptyserver/server.go
@@ -57,12 +57,12 @@ func (h handler) Hello(ctx context.Context, body wire.Value) (yarpcthrift.Respon
 
 	err := h.impl.Hello(ctx)
 
-	hadError := err != nil
+	appErr := err
 	result, err := common.ExtendEmpty_Hello_Helper.WrapResponse(err)
 
 	var response yarpcthrift.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err

--- a/v2/yarpcthrift/thriftrw-plugin-yarpc2/internal/tests/weather/weatherserver/server.go
+++ b/v2/yarpcthrift/thriftrw-plugin-yarpc2/internal/tests/weather/weatherserver/server.go
@@ -53,12 +53,12 @@ func (h handler) Check(ctx context.Context, body wire.Value) (yarpcthrift.Respon
 
 	success, err := h.impl.Check(ctx)
 
-	hadError := err != nil
+	appErr := err
 	result, err := weather.Weather_Check_Helper.WrapResponse(success, err)
 
 	var response yarpcthrift.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err

--- a/v2/yarpcthrift/thriftrw-plugin-yarpc2/internal/tests/weather/weatherserver/server.go
+++ b/v2/yarpcthrift/thriftrw-plugin-yarpc2/internal/tests/weather/weatherserver/server.go
@@ -51,14 +51,13 @@ func (h handler) Check(ctx context.Context, body wire.Value) (yarpcthrift.Respon
 		return yarpcthrift.Response{}, err
 	}
 
-	success, err := h.impl.Check(ctx)
+	success, appErr := h.impl.Check(ctx)
 
-	appErr := err
-	result, err := weather.Weather_Check_Helper.WrapResponse(success, err)
+	result, err := weather.Weather_Check_Helper.WrapResponse(success, appErr)
 
 	var response yarpcthrift.Response
 	if err == nil {
-		response.ApplicationError = appErr
+		response.Exception = appErr
 		response.Body = result
 	}
 	return response, err

--- a/v2/yarpcthrift/thriftrw-plugin-yarpc2/server.go
+++ b/v2/yarpcthrift/thriftrw-plugin-yarpc2/server.go
@@ -105,17 +105,16 @@ func (h handler) <.Name>(ctx <$context>.Context, body <$wire>.Value) (<$yarpcthr
 	}
 
 	<if .ReturnType>
-		success, err := h.impl.<.Name>(ctx, <range .Arguments>args.<.Name>,<end>)
+		success, appErr := h.impl.<.Name>(ctx, <range .Arguments>args.<.Name>,<end>)
 	<else>
-		err := h.impl.<.Name>(ctx, <range .Arguments>args.<.Name>,<end>)
+		appErr := h.impl.<.Name>(ctx, <range .Arguments>args.<.Name>,<end>)
 	<end>
 
-	appErr := err
-	result, err := <$prefix>Helper.WrapResponse(<if .ReturnType>success,<end> err)
+	result, err := <$prefix>Helper.WrapResponse(<if .ReturnType>success,<end> appErr)
 
 	var response <$yarpcthrift>.Response
 	if err == nil {
-		response.ApplicationError = appErr
+		response.Exception = appErr
 		response.Body = result
 	}
 	return response, err

--- a/v2/yarpcthrift/thriftrw-plugin-yarpc2/server.go
+++ b/v2/yarpcthrift/thriftrw-plugin-yarpc2/server.go
@@ -110,12 +110,12 @@ func (h handler) <.Name>(ctx <$context>.Context, body <$wire>.Value) (<$yarpcthr
 		err := h.impl.<.Name>(ctx, <range .Arguments>args.<.Name>,<end>)
 	<end>
 
-	hadError := err != nil
+	appErr := err
 	result, err := <$prefix>Helper.WrapResponse(<if .ReturnType>success,<end> err)
 
 	var response <$yarpcthrift>.Response
 	if err == nil {
-		response.IsApplicationError = hadError
+		response.ApplicationError = appErr
 		response.Body = result
 	}
 	return response, err


### PR DESCRIPTION
While there were some efforts to make behavioral changes, I've realized that any logic I try to change will break something :(. So, this change completely preserves the previous behavior of YARPC error handling and only changes the error boolean in the response struct to an error type. This means that in some cases, we currently have filler errors (notably in `yarpctchannel`) to denote that there was an application error. 

This also means that in some cases, the handler will store the application error in the response AND also return it as an error. While it was briefly discussed offline that an error should not be returned by the handler function if an application error set in the response struct, this will be done in a later commit and there are some issues with this. Specifically, a Thrift handler returning a Thrift exception was considered an application error, but this was sent through the body and returned no error, while JSON/Protobuf set the application error bit and returned the error as well. This discrepancy made it difficult to consolidate the behavior at the transport level without some information from the encoding level. Once we have support for Thrift annotations to convert Thrift exceptions to YARPC errors and the error details API, I'll tackle this again.

Each commit is individually reviewable.