### PR TITLE
[spring] Refactor EncodingProcedure codec to a codec generator

### DIFF
--- a/v2/encoding.go
+++ b/v2/encoding.go
@@ -63,7 +63,9 @@ func (u *unaryTransportHandler) Handle(ctx context.Context, req *Request, reqBuf
 		return nil, nil, err
 	}
 
-	decodedBody, err := u.h.Codec.Decode(reqBuf)
+	codec := u.h.Codec()
+
+	decodedBody, err := codec.Decode(reqBuf)
 	if err != nil {
 		return res, nil, err
 	}
@@ -71,7 +73,7 @@ func (u *unaryTransportHandler) Handle(ctx context.Context, req *Request, reqBuf
 	body, appErr := u.h.HandlerSpec.Unary().Handle(ctx, decodedBody)
 	call.WriteToResponse(res)
 
-	encodedBody, err := u.h.Codec.Encode(body)
+	encodedBody, err := codec.Encode(body)
 	if err != nil {
 		return res, nil, err
 	}

--- a/v2/router.go
+++ b/v2/router.go
@@ -88,7 +88,7 @@ type EncodingProcedure struct {
 	Signature string
 
 	// Codec to assist mapping the encoding-level handler to transport-level handler
-	Codec InboundCodec
+	Codec func() InboundCodec
 }
 
 // MarshalLogObject implements zap.ObjectMarshaler.

--- a/v2/yarpcjson/register.go
+++ b/v2/yarpcjson/register.go
@@ -43,6 +43,7 @@ var (
 // struct pointers. If the handler's signature is not valid, Procedure will panic.
 func Procedure(name string, handler interface{}) []yarpc.EncodingProcedure {
 	verifyUnarySignature(name, reflect.TypeOf(handler))
+	jsonCodec := newCodec(handler)
 	return []yarpc.EncodingProcedure{
 		{
 			Name: name,
@@ -50,7 +51,7 @@ func Procedure(name string, handler interface{}) []yarpc.EncodingProcedure {
 				wrapUnaryHandler(name, handler),
 			),
 			Encoding: Encoding,
-			Codec:    newCodec(handler),
+			Codec:    func() yarpc.InboundCodec { return jsonCodec },
 		},
 	}
 }

--- a/v2/yarpcrouter/router_test.go
+++ b/v2/yarpcrouter/router_test.go
@@ -118,7 +118,7 @@ func TestNewMapRouterWithEncodingProceduresHappyCase(t *testing.T) {
 		{
 			Name:        "happy_case",
 			HandlerSpec: spec,
-			Codec:       codec,
+			Codec:       func() yarpc.InboundCodec { return codec },
 		},
 	}
 
@@ -144,7 +144,7 @@ func TestNewMapRouterWithEncodingProceduresDecodeError(t *testing.T) {
 		{
 			Name:        "decode_err",
 			HandlerSpec: spec,
-			Codec:       codec,
+			Codec:       func() yarpc.InboundCodec { return codec },
 		},
 	}
 	procedures, err := yarpc.EncodingToTransportProcedures(encodingProcedures)
@@ -172,7 +172,7 @@ func TestNewMapRouterWithEncodingProceduresHandlerError(t *testing.T) {
 		{
 			Name:        "handler_err",
 			HandlerSpec: spec,
-			Codec:       codec,
+			Codec:       func() yarpc.InboundCodec { return codec },
 		},
 	}
 	procedures, err := yarpc.EncodingToTransportProcedures(encodingProcedures)
@@ -199,7 +199,7 @@ func TestNewMapRouterWithEncodingProceduresEncodeError(t *testing.T) {
 		{
 			Name:        "encode_err",
 			HandlerSpec: spec,
-			Codec:       codec,
+			Codec:       func() yarpc.InboundCodec { return codec },
 		},
 	}
 	procedures, err := yarpc.EncodingToTransportProcedures(encodingProcedures)


### PR DESCRIPTION
Sadly, Thrift's encoding/decoding is stateful: We need some information
from the request decoding to encode a corresponding response. Currently,
each codec is specific to an encoding procedure, rather than per
request. This commit changes that behavior by replacing the current
Codec field to be function that generates an InboundCodec per request.

For json/protobuf, this function will return the same codec each call.
For thrift, this function should create a new instance of a codec per
request.
