### PR TITLE
[v2] Fx: Integrate unary outbound transport middleware

### DIFF
--- a/v2/CHANGES
+++ b/v2/CHANGES
@@ -21,7 +21,17 @@
 - [ ] Replace functional options in yarpcpeerlist with struct options
 - [ ] Integrate the configuration into a variety of Fx modules.
       - [ ] Integrate servicefx.Metadata into each of the relevant Fx packages.
-- [ ] Create an API in yarpcfx to register and obtain peer lists by name.
+      - [ ] Transports
+            - [ ] HTTP
+            - [ ] gRPC
+            - [ ] TChannel
+      - [ ] Peer lists
+            - [ ] Round-robin
+            - [ ] Two-random-choices
+            - [ ] Random-peer
+            - [ ] Pending-heap
+      - [ ] Middleware
+- [x] Create an API in yarpcfx to register and obtain peer lists by name.
       Use this API to configure the chooser for an outbound in their transport fx package.
       Use this API to send updates from a peer list updater to a peer list in the updater fx package.
 - [ ] yarpchttp needs to subsume responsibility for validating requests instead

--- a/v2/CHANGES
+++ b/v2/CHANGES
@@ -19,6 +19,7 @@
 - [ ] yarpcrouter.Router needs to accept middleware to decorate registered
       procedures.
 - [ ] Replace functional options in yarpcpeerlist with struct options
+- [ ] Consider separating the auto-observability middleware into two components: logging and metrics.
 - [ ] Integrate the configuration into a variety of Fx modules.
       - [ ] Integrate servicefx.Metadata into each of the relevant Fx packages.
       - [ ] Transports

--- a/v2/internal/internalyarpcobservability/middleware.go
+++ b/v2/internal/internalyarpcobservability/middleware.go
@@ -36,6 +36,12 @@ var (
 	_ yarpc.StreamOutboundTransportMiddleware = (*Middleware)(nil)
 )
 
+// TODO(amckinney): Consider splitting this out into two middleware:
+// one for logging, and the other for metrics.
+
+// Name is the name of the YARPC observability middleware.
+const Name = "observability"
+
 // Middleware is logging and metrics middleware for all RPC types.
 type Middleware struct {
 	graph graph
@@ -44,6 +50,11 @@ type Middleware struct {
 // NewMiddleware constructs a Middleware.
 func NewMiddleware(logger *zap.Logger, scope *metrics.Scope, extract ContextExtractor) *Middleware {
 	return &Middleware{newGraph(scope, logger, extract)}
+}
+
+// Name returns the Middleware's name.
+func (m *Middleware) Name() string {
+	return Name
 }
 
 // Handle implements yarpc.UnaryInbound.

--- a/v2/outbound_transport_middleware.go
+++ b/v2/outbound_transport_middleware.go
@@ -24,6 +24,8 @@ import (
 	"context"
 )
 
+const nopName = "nop"
+
 // UnaryOutboundTransportMiddleware defines transport-level middleware for
 // `UnaryOutbound`s.
 //
@@ -37,6 +39,7 @@ import (
 // UnaryOutboundTransportMiddleware is re-used across requests and MAY be called
 // multiple times on the same request.
 type UnaryOutboundTransportMiddleware interface {
+	Name() string
 	Call(
 		ctx context.Context,
 		request *Request,
@@ -51,7 +54,18 @@ var NopUnaryOutboundTransportMiddleware UnaryOutboundTransportMiddleware = nopUn
 
 // ApplyUnaryOutboundTransportMiddleware applies the given UnaryOutboundTransportMiddleware to
 // the given UnaryOutbound transport.
-func ApplyUnaryOutboundTransportMiddleware(o UnaryOutbound, f UnaryOutboundTransportMiddleware) UnaryOutbound {
+func ApplyUnaryOutboundTransportMiddleware(o UnaryOutbound, f ...UnaryOutboundTransportMiddleware) UnaryOutbound {
+	if f == nil {
+		return o
+	}
+	outbound := o
+	for i := len(f) - 1; i >= 0; i-- {
+		outbound = applyUnaryOutboundTransportMiddleware(outbound, f[i])
+	}
+	return outbound
+}
+
+func applyUnaryOutboundTransportMiddleware(o UnaryOutbound, f UnaryOutboundTransportMiddleware) UnaryOutbound {
 	if f == nil {
 		return o
 	}
@@ -85,6 +99,10 @@ func (fo unaryOutboundWithMiddleware) Call(
 }
 
 type nopUnaryOutboundTransportMiddleware struct{}
+
+func (nopUnaryOutboundTransportMiddleware) Name() string {
+	return nopName
+}
 
 func (nopUnaryOutboundTransportMiddleware) Call(
 	ctx context.Context,

--- a/v2/yarpcfx/yarpcfx.go
+++ b/v2/yarpcfx/yarpcfx.go
@@ -46,6 +46,8 @@ var Module = fx.Options(
 type ClientProviderParams struct {
 	fx.In
 
+	UnaryOutboundTransportMiddleware []yarpc.UnaryOutboundTransportMiddleware `name:"yarpcfx" optional:"true"`
+
 	Clients     []yarpc.Client   `group:"yarpcfx"`
 	ClientLists [][]yarpc.Client `group:"yarpcfx"`
 }
@@ -62,6 +64,9 @@ func NewClientProvider(p ClientProviderParams) (ClientProviderResult, error) {
 	clients := p.Clients
 	for _, cl := range p.ClientLists {
 		clients = append(clients, cl...)
+	}
+	for _, c := range clients {
+		c.Unary = yarpc.ApplyUnaryOutboundTransportMiddleware(c.Unary, p.UnaryOutboundTransportMiddleware...)
 	}
 	provider, err := yarpcclient.NewProvider(clients...)
 	if err != nil {

--- a/v2/yarpchttpfx/yarpchttpfx.go
+++ b/v2/yarpchttpfx/yarpchttpfx.go
@@ -196,8 +196,7 @@ func NewClients(p ClientParams) (ClientResult, error) {
 				return ClientResult{}, err
 			}
 		}
-		var outbound yarpc.UnaryOutbound
-		outbound = &yarpchttp.Outbound{
+		outbound := &yarpchttp.Outbound{
 			Chooser: chooser,
 			Dialer:  p.Dialer,
 			URL:     url,

--- a/v2/yarpchttpfx/yarpchttpfx.go
+++ b/v2/yarpchttpfx/yarpchttpfx.go
@@ -162,7 +162,6 @@ type ClientParams struct {
 	Config          OutboundsConfig
 	Dialer          *yarpchttp.Dialer
 	ChooserProvider yarpc.ChooserProvider
-	Middleware      []yarpc.UnaryOutboundTransportMiddleware `name:"yarpcfx"`
 
 	Lifecycle fx.Lifecycle
 	Logger    *zap.Logger        `optional:"true"`
@@ -216,7 +215,7 @@ func NewClients(p ClientParams) (ClientResult, error) {
 				Name:    name,
 				Caller:  "foo", // TODO(amckinney): Derive from servicefx.
 				Service: service,
-				Unary:   yarpc.ApplyUnaryOutboundTransportMiddleware(outbound, p.Middleware...),
+				Unary:   outbound,
 			},
 		)
 	}

--- a/v2/yarpcmiddlewarefx/yarpcmiddlewarefx.go
+++ b/v2/yarpcmiddlewarefx/yarpcmiddlewarefx.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpcmiddlewarefx
+
+import (
+	"fmt"
+
+	"go.uber.org/config"
+	"go.uber.org/fx"
+	yarpc "go.uber.org/yarpc/v2"
+)
+
+const outboundTransportMiddlewareConfigurationKey = "yarpc.middleware.outbounds.transport"
+
+// Module produces ordered slices of middleware according to
+// the middleware configuration.
+var Module = fx.Provide(
+	NewOutboundTransportMiddlewareConfig,
+	NewUnaryOutboundTransportMiddleware,
+)
+
+// OutboundTransportMiddlewareConfig describes the configuration
+// shape for an ordered list of unary outbound transport middleware.
+type OutboundTransportMiddlewareConfig struct {
+	Unary []string `yaml:"unary"`
+}
+
+// OutboundTransportMiddlewareConfigParams defines the dependencies of this module.
+type OutboundTransportMiddlewareConfigParams struct {
+	fx.In
+
+	Provider config.Provider
+}
+
+// OutboundTransportMiddlewareConfigResult defines the values produced by this module.
+type OutboundTransportMiddlewareConfigResult struct {
+	fx.Out
+
+	Config OutboundTransportMiddlewareConfig
+}
+
+// NewOutboundTransportMiddlewareConfig produces an UnaryOutboundTransportMiddlewareConfig.
+func NewOutboundTransportMiddlewareConfig(p OutboundTransportMiddlewareConfigParams) (OutboundTransportMiddlewareConfigResult, error) {
+	mc := OutboundTransportMiddlewareConfig{}
+	if err := p.Provider.Get(outboundTransportMiddlewareConfigurationKey).Populate(&mc); err != nil {
+		return OutboundTransportMiddlewareConfigResult{}, err
+	}
+	return OutboundTransportMiddlewareConfigResult{
+		Config: mc,
+	}, nil
+}
+
+// UnaryOutboundTransportMiddlewareParams defines the dependencies of this module.
+type UnaryOutboundTransportMiddlewareParams struct {
+	fx.In
+
+	Config          OutboundTransportMiddlewareConfig
+	Middleware      []yarpc.UnaryOutboundTransportMiddleware   `group:"yarpcfx"`
+	MiddlewareLists [][]yarpc.UnaryOutboundTransportMiddleware `group:"yarpcfx"`
+}
+
+// UnaryOutboundTransportMiddlewareResult defines the values produced by this module.
+type UnaryOutboundTransportMiddlewareResult struct {
+	fx.Out
+
+	Middleware []yarpc.UnaryOutboundTransportMiddleware `name:"yarpcfx"`
+}
+
+// NewUnaryOutboundTransportMiddleware produceds an ordered slice of unary outbound transport middleware.
+func NewUnaryOutboundTransportMiddleware(
+	p UnaryOutboundTransportMiddlewareParams,
+) (UnaryOutboundTransportMiddlewareResult, error) {
+	// Collect all of the middleware into a single slice.
+	middleware := p.Middleware
+	for _, ml := range p.MiddlewareLists {
+		middleware = append(middleware, ml...)
+	}
+
+	// Compose a map of the middleware, and validate that there are not any name conflicts.
+	middlewareMap := make(map[string]yarpc.UnaryOutboundTransportMiddleware, len(middleware))
+	for _, m := range middleware {
+		name := m.Name()
+		if _, ok := middlewareMap[name]; ok {
+			return UnaryOutboundTransportMiddlewareResult{}, fmt.Errorf("unary outbound transport middleware %q was registered more than once", name)
+		}
+		middlewareMap[name] = m
+	}
+
+	// Construct an ordered slice of middleware using the configured slice of names.
+	ordered := make([]yarpc.UnaryOutboundTransportMiddleware, len(p.Config.Unary))
+	for i, name := range p.Config.Unary {
+		m, ok := middlewareMap[name]
+		if !ok {
+			return UnaryOutboundTransportMiddlewareResult{}, fmt.Errorf("failed to resolve unary outbound transport middleware: %q", name)
+		}
+		ordered[i] = m
+	}
+
+	return UnaryOutboundTransportMiddlewareResult{
+		Middleware: ordered,
+	}, nil
+}

--- a/v2/yarpcmiddlewarefx/yarpcmiddlewarefx_test.go
+++ b/v2/yarpcmiddlewarefx/yarpcmiddlewarefx_test.go
@@ -30,22 +30,22 @@ import (
 	yarpc "go.uber.org/yarpc/v2"
 )
 
-func TestNewOutboundTransportMiddlewareConfig(t *testing.T) {
+func TestNewOutboundTransportConfig(t *testing.T) {
 	cfg := strings.NewReader(`yarpc: {middleware: {outbounds: {transport: {unary: ["nop"]}}}}`)
 	provider, err := config.NewYAML(config.Source(cfg))
 	require.NoError(t, err)
 
-	res, err := NewOutboundTransportMiddlewareConfig(OutboundTransportMiddlewareConfigParams{
+	res, err := NewOutboundTransportConfig(OutboundTransportConfigParams{
 		Provider: provider,
 	})
 	require.NoError(t, err)
-	assert.Equal(t, OutboundTransportMiddlewareConfig{Unary: []string{"nop"}}, res.Config)
+	assert.Equal(t, OutboundTransportConfig{Unary: []string{"nop"}}, res.Config)
 }
 
-func TestNewUnaryOutboundTransportMiddleware(t *testing.T) {
+func TestNewUnaryOutboundTransport(t *testing.T) {
 	t.Run("duplicate registration error", func(t *testing.T) {
-		_, err := NewUnaryOutboundTransportMiddleware(
-			UnaryOutboundTransportMiddlewareParams{
+		_, err := NewUnaryOutboundTransport(
+			UnaryOutboundTransportParams{
 				Middleware: []yarpc.UnaryOutboundTransportMiddleware{
 					yarpc.NopUnaryOutboundTransportMiddleware,
 					yarpc.NopUnaryOutboundTransportMiddleware,
@@ -56,9 +56,9 @@ func TestNewUnaryOutboundTransportMiddleware(t *testing.T) {
 	})
 
 	t.Run("configured middleware is not available", func(t *testing.T) {
-		_, err := NewUnaryOutboundTransportMiddleware(
-			UnaryOutboundTransportMiddlewareParams{
-				Config: OutboundTransportMiddlewareConfig{
+		_, err := NewUnaryOutboundTransport(
+			UnaryOutboundTransportParams{
+				Config: OutboundTransportConfig{
 					Unary: []string{"dne"},
 				},
 			},
@@ -67,9 +67,9 @@ func TestNewUnaryOutboundTransportMiddleware(t *testing.T) {
 	})
 
 	t.Run("successful construction", func(t *testing.T) {
-		res, err := NewUnaryOutboundTransportMiddleware(
-			UnaryOutboundTransportMiddlewareParams{
-				Config: OutboundTransportMiddlewareConfig{
+		res, err := NewUnaryOutboundTransport(
+			UnaryOutboundTransportParams{
+				Config: OutboundTransportConfig{
 					Unary: []string{"nop"},
 				},
 				MiddlewareLists: [][]yarpc.UnaryOutboundTransportMiddleware{
@@ -81,7 +81,7 @@ func TestNewUnaryOutboundTransportMiddleware(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		middleware := res.Middleware
+		middleware := res.OrderedMiddleware
 		require.Len(t, middleware, 1)
 		assert.Equal(t, "nop", middleware[0].Name())
 	})

--- a/v2/yarpcmiddlewarefx/yarpcmiddlewarefx_test.go
+++ b/v2/yarpcmiddlewarefx/yarpcmiddlewarefx_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpcmiddlewarefx
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/config"
+	yarpc "go.uber.org/yarpc/v2"
+)
+
+func TestNewOutboundTransportMiddlewareConfig(t *testing.T) {
+	cfg := strings.NewReader(`yarpc: {middleware: {outbounds: {transport: {unary: ["nop"]}}}}`)
+	provider, err := config.NewYAML(config.Source(cfg))
+	require.NoError(t, err)
+
+	res, err := NewOutboundTransportMiddlewareConfig(OutboundTransportMiddlewareConfigParams{
+		Provider: provider,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, OutboundTransportMiddlewareConfig{Unary: []string{"nop"}}, res.Config)
+}
+
+func TestNewUnaryOutboundTransportMiddleware(t *testing.T) {
+	t.Run("duplicate registration error", func(t *testing.T) {
+		_, err := NewUnaryOutboundTransportMiddleware(
+			UnaryOutboundTransportMiddlewareParams{
+				Middleware: []yarpc.UnaryOutboundTransportMiddleware{
+					yarpc.NopUnaryOutboundTransportMiddleware,
+					yarpc.NopUnaryOutboundTransportMiddleware,
+				},
+			},
+		)
+		assert.EqualError(t, err, `unary outbound transport middleware "nop" was registered more than once`)
+	})
+
+	t.Run("configured middleware is not available", func(t *testing.T) {
+		_, err := NewUnaryOutboundTransportMiddleware(
+			UnaryOutboundTransportMiddlewareParams{
+				Config: OutboundTransportMiddlewareConfig{
+					Unary: []string{"dne"},
+				},
+			},
+		)
+		assert.EqualError(t, err, `failed to resolve unary outbound transport middleware: "dne"`)
+	})
+
+	t.Run("successful construction", func(t *testing.T) {
+		res, err := NewUnaryOutboundTransportMiddleware(
+			UnaryOutboundTransportMiddlewareParams{
+				Config: OutboundTransportMiddlewareConfig{
+					Unary: []string{"nop"},
+				},
+				MiddlewareLists: [][]yarpc.UnaryOutboundTransportMiddleware{
+					{
+						yarpc.NopUnaryOutboundTransportMiddleware,
+					},
+				},
+			},
+		)
+		require.NoError(t, err)
+
+		middleware := res.Middleware
+		require.Len(t, middleware, 1)
+		assert.Equal(t, "nop", middleware[0].Name())
+	})
+}

--- a/v2/yarpctest/mocks.go
+++ b/v2/yarpctest/mocks.go
@@ -983,6 +983,18 @@ func (mr *MockUnaryOutboundTransportMiddlewareMockRecorder) Call(arg0, arg1, arg
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Call", reflect.TypeOf((*MockUnaryOutboundTransportMiddleware)(nil).Call), arg0, arg1, arg2, arg3)
 }
 
+// Name mocks base method
+func (m *MockUnaryOutboundTransportMiddleware) Name() string {
+	ret := m.ctrl.Call(m, "Name")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Name indicates an expected call of Name
+func (mr *MockUnaryOutboundTransportMiddlewareMockRecorder) Name() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockUnaryOutboundTransportMiddleware)(nil).Name))
+}
+
 // MockUnaryTransportHandler is a mock of UnaryTransportHandler interface
 type MockUnaryTransportHandler struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
This builds upon the work in the previous Fx PRs and integrates outbound middleware into the set of configurable dependencies in the transport layer. Unlike the previous Fx configurations, the middleware respects a specific ordering, so the `Provider` pattern doesn't quite fit. If we were to use a `Provider` for middleware, it would end up looking similar to a global, flat structure which conflicts with the Fx-way of doing things, i.e. providing something along the lines of
```
type Middleware struct {
  UnaryTransport []yarpc.UnaryOutboundTransportMiddleware
  UnaryEncoding []yarpc.UnaryOutboundEncodingMiddleware
}
```

Instead, we take advantage of Fx-named types to provide an ordered list of middleware. With this, users will provide into the `yarpcfx` group for each of their middleware, and each transport module, e.g. `yarpchttpfx` will consume the namd `yarpcfx` slice. If users accidentally produce a named `yarpcfx` type (as opposed to providing into the group), then we will encounter an error because a type will be produced more than once (as desired).
