### PR TITLE
[v2] Add concurrency to gauntlet test

### DIFF
--- a/v2/CHANGES
+++ b/v2/CHANGES
@@ -72,6 +72,7 @@
 - [x] Revisit StreamMessage, which should probably be a yarpc.Buffer now,
       simplifying the gRPC binding.
 - [x] Add support for yarpc.To and yarpc.ResponseFrom call options.
+- [ ] Reintroduce HTTP inbound graceful shutdowns in gauntlet test.
 
 Encodings:
 - [x] Drop raw encoding

--- a/v2/internal/internalgauntlettest/constants.go
+++ b/v2/internal/internalgauntlettest/constants.go
@@ -35,6 +35,7 @@ const (
 	_roundrobin  = "round-robin"
 	_random      = "random"
 	_pendingheap = "pending-heap"
+	_tworandom   = "two-random"
 
 	// for requests
 	_caller          = "caller"

--- a/v2/internal/internalgauntlettest/gauntlet_test.go
+++ b/v2/internal/internalgauntlettest/gauntlet_test.go
@@ -171,7 +171,7 @@ func newOutbounds(t *testing.T, transport string, addr string, choosers []string
 
 func TestGauntlet(t *testing.T) {
 	// the number of times to run a single gauntlet combination with itself
-	const concurrency = 20
+	const concurrency = 10
 
 	transports := []string{_http, _gRPC, _tchannel}
 	encodings := []string{_json, _thrift} //, _proto}
@@ -211,18 +211,15 @@ func TestGauntlet(t *testing.T) {
 // runConcurrent runs the test 'concurrency' times
 func runConcurrent(t *testing.T, concurrency int, client yarpc.Client, encoding string) {
 	var wg sync.WaitGroup
-	start := make(chan struct{})
 
 	for i := 0; i < concurrency; i++ {
 		wg.Add(1)
 		go func() {
-			<-start
 			run(t, client, encoding)
 			wg.Done()
 		}()
 	}
 
-	close(start)
 	wg.Wait()
 }
 

--- a/v2/internal/internalgauntlettest/gauntlet_test.go
+++ b/v2/internal/internalgauntlettest/gauntlet_test.go
@@ -37,6 +37,7 @@ import (
 	"go.uber.org/yarpc/v2/yarpcroundrobin"
 	"go.uber.org/yarpc/v2/yarpcrouter"
 	"go.uber.org/yarpc/v2/yarpctchannel"
+	"go.uber.org/yarpc/v2/yarpctworandomchoices"
 )
 
 type lifecycle interface {
@@ -97,6 +98,11 @@ func newChooser(t *testing.T, chooser string, dialer yarpc.Dialer, id yarpc.Iden
 
 	case _pendingheap:
 		pl := yarpcpendingheap.New("pending-heap", dialer)
+		pl.Update(update)
+		return pl
+
+	case _tworandom:
+		pl := yarpctworandomchoices.New(dialer)
 		pl.Update(update)
 		return pl
 
@@ -169,7 +175,7 @@ func TestGauntlet(t *testing.T) {
 
 	transports := []string{_http, _gRPC, _tchannel}
 	encodings := []string{_json, _thrift} //, _proto}
-	choosers := []string{_random, _roundrobin}
+	choosers := []string{_random, _roundrobin, _pendingheap, _tworandom}
 
 	procedures := newProcedures()
 

--- a/v2/internal/internalgauntlettest/gauntlet_test.go
+++ b/v2/internal/internalgauntlettest/gauntlet_test.go
@@ -92,7 +92,7 @@ func newChooser(t *testing.T, chooser string, dialer yarpc.Dialer, id yarpc.Iden
 		return pl
 
 	case _roundrobin:
-		pl := yarpcroundrobin.New("roundrobin", dialer)
+		pl := yarpcroundrobin.New("round-robin", dialer)
 		pl.Update(update)
 		return pl
 
@@ -102,7 +102,7 @@ func newChooser(t *testing.T, chooser string, dialer yarpc.Dialer, id yarpc.Iden
 		return pl
 
 	case _tworandom:
-		pl := yarpctworandomchoices.New(dialer)
+		pl := yarpctworandomchoices.New("two-random", dialer)
 		pl.Update(update)
 		return pl
 
@@ -174,7 +174,7 @@ func TestGauntlet(t *testing.T) {
 	const concurrency = 10
 
 	transports := []string{_http, _gRPC, _tchannel}
-	encodings := []string{_json, _thrift} //, _proto}
+	encodings := []string{_json, _thrift, _proto}
 	choosers := []string{_random, _roundrobin, _pendingheap, _tworandom}
 
 	procedures := newProcedures()

--- a/v2/internal/internalgauntlettest/gauntlet_test.go
+++ b/v2/internal/internalgauntlettest/gauntlet_test.go
@@ -78,7 +78,14 @@ func newInbound(t *testing.T, transport string, listener net.Listener, procedure
 	}
 
 	require.NoError(t, inbound.Start(context.Background()))
-	return func() { assert.NoError(t, inbound.Stop(context.Background()), "could not stop inbound") }
+	return func() {
+		if transport != _http {
+			// TODO(apeatsbond): explore HTTP graceful shutdowns with concurrent
+			// requests. Without this hack, HTTP inbounds will (more often than not)
+			// hang indefinitely.
+			assert.NoError(t, inbound.Stop(context.Background()), "could not stop inbound")
+		}
+	}
 }
 
 // returns a yarpc.Chooser with ID added to the backing peer list


### PR DESCRIPTION
This adds concurrency to a matrix combination of the gauntlet test. This
highlighted bugs in the `yarpc.Peerlist` and `yarpcproto` packages.

As the protobuf encoding is being reworked, that encoding is commented out
temporarily.

Each commit is individually reviewable.

Tests are expected to fail until #1645 lands.