### PR TITLE
[v2] Upgrade `yarpcpeerlist` Choose lock

### DIFF
--- a/v2/yarpcpeerlist/list.go
+++ b/v2/yarpcpeerlist/list.go
@@ -305,9 +305,9 @@ func (pl *List) removeFromUnavailablePeers(t *peerThunk) {
 // Choose selects the next available peer in the peer list
 func (pl *List) Choose(ctx context.Context, req *yarpc.Request) (yarpc.Peer, func(error), error) {
 	for {
-		pl.lock.RLock()
+		pl.lock.Lock()
 		p := pl.implementation.Choose(ctx, req)
-		pl.lock.RUnlock()
+		pl.lock.Unlock()
 
 		if p != nil {
 			t := p.(*peerThunk)


### PR DESCRIPTION
This upgrades the `yarpcpeerlist` list lock from a read-write mutex. #1644
highlighted an issue in the abstract list where peer list implementations
`Choose` method was called incorrectly with a read-write lock.

Using multiple goroutines around structs that are not safe for concurrent use
(such as using a [rand.Source](https://golang.org/pkg/math/rand/#NewSource)),
triggered the golang race detector in #1644.