### PR TITLE
[v2] Revisit Fx packages and address outstanding concerns

### DIFF
--- a/v2/CHANGES
+++ b/v2/CHANGES
@@ -19,6 +19,8 @@
 - [ ] yarpcrouter.Router needs to accept middleware to decorate registered
       procedures.
 - [ ] Replace functional options in yarpcpeerlist with struct options
+- [ ] Integrate the configuration into a variety of Fx modules.
+      - [ ] Integrate servicefx.Metadata into each of the relevant Fx packages.
 - [ ] Create an API in yarpcfx to register and obtain peer lists by name.
       Use this API to configure the chooser for an outbound in their transport fx package.
       Use this API to send updates from a peer list updater to a peer list in the updater fx package.

--- a/v2/yarpchttpfx/yarpchttpfx.go
+++ b/v2/yarpchttpfx/yarpchttpfx.go
@@ -115,6 +115,11 @@ type OutboundsConfig struct {
 
 // OutboundConfig is the configuration for constructing a specific outbound.
 type OutboundConfig struct {
+	// Specifies the outbound's registered name.
+	//
+	// If not set, defaults to the configured outbound key.
+	Name string `yaml:"name"`
+
 	// Specifies the address to use for this Outbound.
 	Address string `yaml:"address"`
 
@@ -196,11 +201,17 @@ func NewClients(p ClientParams) (ClientResult, error) {
 			URL:     url,
 			Tracer:  p.Tracer,
 		}
+		// If the outbound's name is configured, use it.
+		// Otherwise, default to the outbound key.
+		name := o.Name
+		if name == "" {
+			name = service
+		}
 		clients = append(
 			clients,
 			yarpc.Client{
-				Name:    service, // TODO(amckinney): Make the client name configurable, default to service name.
-				Caller:  "foo",   // TODO(amckinney): Derive from servicefx.
+				Name:    name,
+				Caller:  "foo", // TODO(amckinney): Derive from servicefx.
 				Service: service,
 				Unary:   outbound,
 			},

--- a/v2/yarpchttpfx/yarpchttpfx.go
+++ b/v2/yarpchttpfx/yarpchttpfx.go
@@ -115,10 +115,10 @@ type OutboundsConfig struct {
 
 // OutboundConfig is the configuration for constructing a specific outbound.
 type OutboundConfig struct {
-	// Specifies the outbound's registered name.
+	// Specifies the outbound's service name.
 	//
 	// If not set, defaults to the configured outbound key.
-	Name string `yaml:"name"`
+	Service string `yaml:"name"`
 
 	// Specifies the address to use for this Outbound.
 	Address string `yaml:"address"`
@@ -177,7 +177,7 @@ type ClientResult struct {
 // NewClients produces yarpc.Clients.
 func NewClients(p ClientParams) (ClientResult, error) {
 	var clients []yarpc.Client
-	for service, o := range p.Config.Outbounds {
+	for name, o := range p.Config.Outbounds {
 		var (
 			chooser yarpc.Chooser
 			url     *url.URL
@@ -203,9 +203,9 @@ func NewClients(p ClientParams) (ClientResult, error) {
 		}
 		// If the outbound's name is configured, use it.
 		// Otherwise, default to the outbound key.
-		name := o.Name
+		service := o.Service
 		if name == "" {
-			name = service
+			service = name
 		}
 		clients = append(
 			clients,

--- a/v2/yarpchttpfx/yarpchttpfx.go
+++ b/v2/yarpchttpfx/yarpchttpfx.go
@@ -118,10 +118,10 @@ type OutboundConfig struct {
 	// Specifies the address to use for this Outbound.
 	Address string `yaml:"address"`
 
-	// Specifies the peer list policy to use for this Outbound.
+	// Specifies the peer list chooser to use for this Outbound.
 	//
 	// If set, an address does not need to be configured.
-	Policy string `yaml:"policy"`
+	Chooser string `yaml:"chooser"`
 }
 
 // OutboundsConfigParams defines the dependencies of this module.
@@ -177,11 +177,11 @@ func NewClients(p ClientParams) (ClientResult, error) {
 			chooser yarpc.Chooser
 			url     *url.URL
 		)
-		if o.Policy != "" {
+		if o.Chooser != "" {
 			var ok bool
-			chooser, ok = p.ChooserProvider.Chooser(o.Policy)
+			chooser, ok = p.ChooserProvider.Chooser(o.Chooser)
 			if !ok {
-				return ClientResult{}, fmt.Errorf("failed to resolve outbound peer list policy: %q", o.Policy)
+				return ClientResult{}, fmt.Errorf("failed to resolve outbound peer list chooser: %q", o.Chooser)
 			}
 		} else {
 			var err error

--- a/v2/yarpchttpfx/yarpchttpfx.go
+++ b/v2/yarpchttpfx/yarpchttpfx.go
@@ -204,7 +204,7 @@ func NewClients(p ClientParams) (ClientResult, error) {
 		// If the outbound's name is configured, use it.
 		// Otherwise, default to the outbound key.
 		service := o.Service
-		if name == "" {
+		if service == "" {
 			service = name
 		}
 		clients = append(

--- a/v2/yarpchttpfx/yarpchttpfx.go
+++ b/v2/yarpchttpfx/yarpchttpfx.go
@@ -201,7 +201,7 @@ func NewClients(p ClientParams) (ClientResult, error) {
 			URL:     url,
 			Tracer:  p.Tracer,
 		}
-		// If the outbound's name is configured, use it.
+		// If the outbound's service is configured, use it.
 		// Otherwise, default to the outbound key.
 		service := o.Service
 		if service == "" {

--- a/v2/yarpchttpfx/yarpchttpfx_test.go
+++ b/v2/yarpchttpfx/yarpchttpfx_test.go
@@ -111,6 +111,13 @@ func TestNewClients(t *testing.T) {
 			giveCfg: OutboundConfig{Address: "127:0"},
 			wantErr: "parse 127:0: first path segment in URL cannot contain colon",
 		},
+		{
+			desc:        "with configured name",
+			giveCfg:     OutboundConfig{Address: "http://127.0.0.1:0", Name: "baz"},
+			wantCaller:  "foo",
+			wantName:    "baz",
+			wantService: "bar",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {

--- a/v2/yarpchttpfx/yarpchttpfx_test.go
+++ b/v2/yarpchttpfx/yarpchttpfx_test.go
@@ -113,10 +113,10 @@ func TestNewClients(t *testing.T) {
 		},
 		{
 			desc:        "with configured name",
-			giveCfg:     OutboundConfig{Address: "http://127.0.0.1:0", Name: "baz"},
+			giveCfg:     OutboundConfig{Address: "http://127.0.0.1:0", Service: "baz"},
 			wantCaller:  "foo",
-			wantName:    "baz",
-			wantService: "bar",
+			wantName:    "bar",
+			wantService: "baz",
 		},
 	}
 	for _, tt := range tests {

--- a/v2/yarpchttpfx/yarpchttpfx_test.go
+++ b/v2/yarpchttpfx/yarpchttpfx_test.go
@@ -88,16 +88,16 @@ func TestNewClients(t *testing.T) {
 		wantErr     string
 	}{
 		{
-			desc:        "policy successfully configured",
-			giveCfg:     OutboundConfig{Policy: "roundrobin"},
+			desc:        "chooser successfully configured",
+			giveCfg:     OutboundConfig{Chooser: "roundrobin"},
 			wantCaller:  "foo",
 			wantName:    "bar",
 			wantService: "bar",
 		},
 		{
-			desc:    "policy does not exist",
-			giveCfg: OutboundConfig{Policy: "dne"},
-			wantErr: `failed to resolve outbound peer list policy: "dne"`,
+			desc:    "chooser does not exist",
+			giveCfg: OutboundConfig{Chooser: "dne"},
+			wantErr: `failed to resolve outbound peer list chooser: "dne"`,
 		},
 		{
 			desc:        "address successfully configured",

--- a/v2/yarpchttpfx/yarpchttpfx_test.go
+++ b/v2/yarpchttpfx/yarpchttpfx_test.go
@@ -29,15 +29,9 @@ import (
 	"go.uber.org/fx/fxtest"
 	yarpc "go.uber.org/yarpc/v2"
 	"go.uber.org/yarpc/v2/yarpcchooser"
-	"go.uber.org/yarpc/v2/yarpcdialer"
+	"go.uber.org/yarpc/v2/yarpchttp"
 	"go.uber.org/yarpc/v2/yarpctest"
 )
-
-func newDialerProvider(t *testing.T) yarpc.DialerProvider {
-	p, err := yarpcdialer.NewProvider(yarpctest.NewFakeDialer("http"))
-	require.NoError(t, err)
-	return p
-}
 
 func newChooserProvider(t *testing.T) yarpc.ChooserProvider {
 	p, err := yarpcchooser.NewProvider(yarpctest.NewFakePeerChooser("roundrobin"))
@@ -127,7 +121,7 @@ func TestNewClients(t *testing.T) {
 						"bar": tt.giveCfg,
 					},
 				},
-				DialerProvider:  newDialerProvider(t),
+				Dialer:          &yarpchttp.Dialer{},
 				ChooserProvider: newChooserProvider(t),
 			})
 			if tt.wantErr != "" {

--- a/v2/yarpcroundrobinfx/yarpcroundrobinfx.go
+++ b/v2/yarpcroundrobinfx/yarpcroundrobinfx.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	_name             = "yarpcroundrobinfx"
-	_configurationKey = "yarpc.peers.roundrobin"
+	_configurationKey = "yarpc.choosers.roundrobin"
 )
 
 // Module produces a yarpcroundrobin peer list.
@@ -42,7 +42,7 @@ var Module = fx.Options(
 
 // Config is the configuration for constructing a set of round-robin peer.Choosers.
 type Config struct {
-	Peers map[string]RoundRobinConfig `yaml:",inline"`
+	Choosers map[string]RoundRobinConfig `yaml:",inline"`
 }
 
 // RoundRobinConfig is the configuration for constructing a specific round-robin peer.Chooser.
@@ -99,7 +99,7 @@ func NewList(p ListParams) (ListResult, error) {
 		choosers []yarpc.Chooser
 		lists    []yarpc.List
 	)
-	for name, c := range p.Config.Peers {
+	for name, c := range p.Config.Choosers {
 		dialer, ok := p.Provider.Dialer(c.Dialer)
 		if !ok {
 			return ListResult{}, fmt.Errorf("failed to resolve dialer %q", c.Dialer)

--- a/v2/yarpcroundrobinfx/yarpcroundrobinfx_test.go
+++ b/v2/yarpcroundrobinfx/yarpcroundrobinfx_test.go
@@ -39,7 +39,7 @@ func newDialerProvider(t *testing.T) yarpc.DialerProvider {
 }
 
 func TestNewConfig(t *testing.T) {
-	cfg := strings.NewReader("yarpc: {peers: {roundrobin: {bar: {dialer: http, capacity: 100}}}}")
+	cfg := strings.NewReader("yarpc: {choosers: {roundrobin: {bar: {dialer: http, capacity: 100}}}}")
 	provider, err := config.NewYAML(config.Source(cfg))
 	require.NoError(t, err)
 
@@ -49,7 +49,7 @@ func TestNewConfig(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t,
 		Config{
-			Peers: map[string]RoundRobinConfig{
+			Choosers: map[string]RoundRobinConfig{
 				"bar": {Dialer: "http", Capacity: 100},
 			},
 		},
@@ -60,7 +60,7 @@ func TestNewList(t *testing.T) {
 	t.Run("unknown dialer", func(t *testing.T) {
 		_, err := NewList(ListParams{
 			Config: Config{
-				Peers: map[string]RoundRobinConfig{
+				Choosers: map[string]RoundRobinConfig{
 					"bar": {Dialer: "dne", Capacity: 100},
 				},
 			},
@@ -72,7 +72,7 @@ func TestNewList(t *testing.T) {
 	t.Run("successfully create chooser and list", func(t *testing.T) {
 		res, err := NewList(ListParams{
 			Config: Config{
-				Peers: map[string]RoundRobinConfig{
+				Choosers: map[string]RoundRobinConfig{
 					"bar": {Dialer: "http", Capacity: 100},
 				},
 			},


### PR DESCRIPTION
Re: https://github.com/yarpc/yarpc-go/pull/1634

This revisits all of the current `*fx` packages to address the outstanding concerns and/or suggestions to clean up the implementation, e.g. configuration naming. This also adds a simple note to the `CHANGES` file for future plans. Note that a more thorough sub-section for the Fx integration is introduced in https://github.com/yarpc/yarpc-go/pull/1643. Each of the commits are individually reviewable. 