### PR TITLE
[v2] Randomize insertion order for fewest-pending-heap

### DIFF
--- a/v2/yarpcpendingheap/heap_test.go
+++ b/v2/yarpcpendingheap/heap_test.go
@@ -39,7 +39,7 @@ func TestPeerHeapEmpty(t *testing.T) {
 	popAndVerifyHeap(t, &ph)
 }
 
-func TestPeerHeapOrdering(t *testing.T) {
+func TestRoundRobinHeapOrdering(t *testing.T) {
 	p1 := &peerScore{score: 1}
 	p2 := &peerScore{score: 2}
 	p3 := &peerScore{score: 3}
@@ -55,7 +55,9 @@ func TestPeerHeapOrdering(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		var h pendingHeap
+		h := pendingHeap{
+			nextRand: nextRand(0), /* irrelevant since we're not doing random insertions*/
+		}
 		for _, ps := range tt {
 			h.pushPeer(ps)
 		}
@@ -65,8 +67,63 @@ func TestPeerHeapOrdering(t *testing.T) {
 	}
 }
 
+func TestPeerHeapInsertionOrdering(t *testing.T) {
+	p1 := &peerScore{score: 1}
+	p2 := &peerScore{score: 2}
+	p3 := &peerScore{score: 3}
+	p4 := &peerScore{score: 3} // same score as p3
+
+	tests := []struct {
+		name          string
+		give          []*peerScore
+		nextRandIndex int
+		insert        *peerScore
+		want          []*peerScore
+	}{
+		{
+			name:   "p3.last < p4.last",
+			give:   []*peerScore{p1, p2, p3},
+			insert: p4,
+			// no swap since nextRandIndex+1 == len(list)
+			nextRandIndex: 3,
+			want:          []*peerScore{p1, p2, p3, p4},
+			// p1.last = 1
+			// p2.last = 2
+			// p3.last = 3
+			// p4.last = 4
+		},
+		{
+			name:          "p4.last < p3.last",
+			give:          []*peerScore{p1, p2, p3},
+			insert:        p4,
+			nextRandIndex: 0, // swap p1.last
+			want:          []*peerScore{p1, p2, p4, p3},
+			// p1.last = 4
+			// p2.last = 2
+			// p4.last = 1
+			// p3.last = 3
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := pendingHeap{nextRand: nextRandFromSlice([]int{tt.nextRandIndex})}
+			// prepare list
+			for _, ps := range tt.give {
+				h.pushPeer(ps)
+			}
+
+			// new peer added
+			h.pushPeerRandom(tt.insert)
+
+			popped := popAndVerifyHeap(t, &h)
+			assert.Equal(t, tt.want, popped, "Unexpected ordering of peers")
+		})
+	}
+}
+
 func TestPeerHeapUpdate(t *testing.T) {
-	var h pendingHeap
+	h := pendingHeap{nextRand: nextRand(0)}
 	p1 := &peerScore{score: 1}
 	p2 := &peerScore{score: 2}
 	p3 := &peerScore{score: 3}
@@ -90,7 +147,7 @@ func TestPeerHeapUpdate(t *testing.T) {
 func TestPeerHeapDelete(t *testing.T) {
 	const numPeers = 10
 
-	var h pendingHeap
+	h := pendingHeap{nextRand: nextRand(0)}
 	peers := make([]*peerScore, numPeers)
 	for i := range peers {
 		peers[i] = &peerScore{score: int64(i)}
@@ -114,7 +171,7 @@ func (ph *pendingHeap) validate(ps *peerScore) error {
 }
 
 func TestPeerHeapValidate(t *testing.T) {
-	var h pendingHeap
+	h := pendingHeap{nextRand: nextRand(0)}
 	ps := &peerScore{score: 1}
 	h.pushPeer(ps)
 	assert.Nil(t, h.validate(ps), "peer %v should validate", ps)

--- a/v2/yarpcpendingheap/list.go
+++ b/v2/yarpcpendingheap/list.go
@@ -21,6 +21,9 @@
 package yarpcpendingheap
 
 import (
+	"math/rand"
+	"time"
+
 	"go.uber.org/yarpc/v2"
 	"go.uber.org/yarpc/v2/yarpcpeerlist"
 )
@@ -28,11 +31,14 @@ import (
 type listOptions struct {
 	capacity int
 	shuffle  bool
+	seed     int64
+	nextRand func(int) int
 }
 
 var defaultListOptions = listOptions{
 	capacity: 10,
 	shuffle:  true,
+	seed:     time.Now().UnixNano(),
 }
 
 // ListOption customizes the behavior of a pending requests peer heap.
@@ -54,6 +60,15 @@ func Capacity(capacity int) ListOption {
 	})
 }
 
+// Seed specifies the random seed to use for shuffling peers.
+//
+// Defaults to time in nanoseconds.
+func Seed(seed int64) ListOption {
+	return listOptionFunc(func(c *listOptions) {
+		c.seed = seed
+	})
+}
+
 // New creates a new pending heap.
 func New(dialer yarpc.Dialer, opts ...ListOption) *List {
 	cfg := defaultListOptions
@@ -68,11 +83,18 @@ func New(dialer yarpc.Dialer, opts ...ListOption) *List {
 		plOpts = append(plOpts, yarpcpeerlist.NoShuffle())
 	}
 
+	nextRandFn := nextRand(cfg.seed)
+	if cfg.nextRand != nil {
+		// only true in tests
+		nextRandFn = cfg.nextRand
+	}
 	return &List{
 		List: yarpcpeerlist.New(
 			"fewest-pending-requests",
 			dialer,
-			&pendingHeap{},
+			&pendingHeap{
+				nextRand: nextRandFn,
+			},
 			plOpts...,
 		),
 	}
@@ -81,4 +103,17 @@ func New(dialer yarpc.Dialer, opts ...ListOption) *List {
 // List is a PeerList which rotates which peers are to be selected in a circle
 type List struct {
 	*yarpcpeerlist.List
+}
+
+// nextRand is a convenience function for creating a new rand.Rand from a given
+// seed.
+func nextRand(seed int64) func(int) int {
+	r := rand.New(rand.NewSource(seed))
+
+	return func(numPeers int) int {
+		if numPeers == 0 {
+			return 0
+		}
+		return r.Intn(numPeers)
+	}
 }


### PR DESCRIPTION
This ensures that peers are randomly inserted into the heap among
equally scored peers, by randomly swapping 'last' with another peer on
insertion.

We've observed behaviour where batch deploys 'herd' towards a select
few instances. The theory is that when the FPH degenerates to
round-robin behaviour, batches of peers being inserted into the list
get added to the end of the ring. Relates to T2152727.

Note that this is a port of (#1608)