### PR TITLE
[v2] Add yarpcrandpeerfx package

### DIFF
--- a/v2/internal/internalgauntlettest/gauntlet_test.go
+++ b/v2/internal/internalgauntlettest/gauntlet_test.go
@@ -85,7 +85,7 @@ func newChooser(t *testing.T, chooser string, dialer yarpc.Dialer, id yarpc.Iden
 
 	switch chooser {
 	case _random:
-		pl := yarpcrandpeer.New(dialer)
+		pl := yarpcrandpeer.New("random", dialer)
 		pl.Update(update)
 		return pl
 

--- a/v2/yarpcrandpeer/list.go
+++ b/v2/yarpcrandpeer/list.go
@@ -71,7 +71,7 @@ func Source(source rand.Source) ListOption {
 }
 
 // New creates a new random peer list.
-func New(transport yarpc.Dialer, opts ...ListOption) *List {
+func New(name string, dialer yarpc.Dialer, opts ...ListOption) *List {
 	options := defaultListOptions
 	for _, opt := range opts {
 		opt.apply(&options)
@@ -88,8 +88,8 @@ func New(transport yarpc.Dialer, opts ...ListOption) *List {
 
 	return &List{
 		List: yarpcpeerlist.New(
-			"random",
-			transport,
+			name,
+			dialer,
 			newRandomList(options.capacity, options.source),
 			plOpts...,
 		),

--- a/v2/yarpcrandpeer/list_test.go
+++ b/v2/yarpcrandpeer/list_test.go
@@ -323,7 +323,7 @@ func TestRandPeer(t *testing.T) {
 			yarpctest.ExpectPeerRetainsWithError(transport, tt.errRetainedPeerIDs, tt.retainErr)
 			yarpctest.ExpectPeerReleases(transport, tt.errReleasedPeerIDs, tt.releaseErr)
 
-			pl := New(transport, Seed(0))
+			pl := New("random", transport, Seed(0))
 
 			deps := yarpctest.ListActionDeps{
 				Peers: peerMap,

--- a/v2/yarpcrandpeer/random.go
+++ b/v2/yarpcrandpeer/random.go
@@ -71,18 +71,6 @@ func (r *randomList) Choose(_ context.Context, _ *yarpc.Request) yarpc.StatusPee
 	return r.subscribers[index].peer
 }
 
-func (r *randomList) Start() error {
-	return nil
-}
-
-func (r *randomList) Stop() error {
-	return nil
-}
-
-func (r *randomList) IsRunning() bool {
-	return true
-}
-
 type subscriber struct {
 	index int
 	peer  yarpc.StatusPeer

--- a/v2/yarpcrandpeerfx/doc.go
+++ b/v2/yarpcrandpeerfx/doc.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package yarpcrandpeerfx provides a random peer.List implementation into the
+// Fx application.
+package yarpcrandpeerfx

--- a/v2/yarpcrandpeerfx/yarpcrandpeerfx.go
+++ b/v2/yarpcrandpeerfx/yarpcrandpeerfx.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpcrandpeerfx
+
+import (
+	"fmt"
+
+	"go.uber.org/config"
+	"go.uber.org/fx"
+	yarpc "go.uber.org/yarpc/v2"
+	"go.uber.org/yarpc/v2/yarpcrandpeer"
+)
+
+const (
+	_name             = "yarpcrandpeerfx"
+	_configurationKey = "yarpc.choosers.random"
+)
+
+// Module produces a yarpcrandpeer peer list.
+var Module = fx.Options(
+	fx.Provide(NewConfig),
+	fx.Provide(NewList),
+)
+
+// Config is the configuration for constructing a set of random peer.Choosers.
+type Config struct {
+	Choosers map[string]RandomConfig `yaml:",inline"`
+}
+
+// RandomConfig is the configuration for constructing a specific random peer.Chooser.
+type RandomConfig struct {
+	Dialer   string `yaml:"dialer"`
+	Capacity int    `yaml:"capacity"`
+}
+
+// ConfigParams defines the dependencies of this module.
+type ConfigParams struct {
+	fx.In
+
+	Provider config.Provider
+}
+
+// ConfigResult defines the values produced by this module.
+type ConfigResult struct {
+	fx.Out
+
+	Config Config
+}
+
+// NewConfig produces a Config.
+func NewConfig(p ConfigParams) (ConfigResult, error) {
+	c := Config{}
+	if err := p.Provider.Get(_configurationKey).Populate(&c); err != nil {
+		return ConfigResult{}, err
+	}
+	return ConfigResult{Config: c}, nil
+}
+
+// ListParams defines the dependencies of this module.
+type ListParams struct {
+	fx.In
+
+	Config   Config
+	Provider yarpc.DialerProvider
+}
+
+// ListResult defines the values produced by this module.
+type ListResult struct {
+	fx.Out
+
+	Choosers []yarpc.Chooser `group:"yarpcfx"`
+	Lists    []yarpc.List    `group:"yarpcfx"`
+}
+
+// NewList produces `yarpcrandpeer.List`s as `yarpc.Chooser`s and `yarpc.List`s.
+func NewList(p ListParams) (ListResult, error) {
+	var (
+		choosers []yarpc.Chooser
+		lists    []yarpc.List
+	)
+	for name, c := range p.Config.Choosers {
+		dialer, ok := p.Provider.Dialer(c.Dialer)
+		if !ok {
+			return ListResult{}, fmt.Errorf("failed to resolve dialer %q", c.Dialer)
+		}
+
+		var opts []yarpcrandpeer.ListOption
+		if c.Capacity > 0 {
+			opts = append(opts, yarpcrandpeer.Capacity(c.Capacity))
+		}
+
+		list := yarpcrandpeer.New(name, dialer, opts...)
+
+		choosers = append(choosers, list)
+		lists = append(lists, list)
+	}
+	return ListResult{
+		Choosers: choosers,
+		Lists:    lists,
+	}, nil
+}

--- a/v2/yarpcrandpeerfx/yarpcrandpeerfx_test.go
+++ b/v2/yarpcrandpeerfx/yarpcrandpeerfx_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpcrandpeerfx
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/config"
+	yarpc "go.uber.org/yarpc/v2"
+	"go.uber.org/yarpc/v2/yarpcdialer"
+	"go.uber.org/yarpc/v2/yarpctest"
+)
+
+func newDialerProvider(t *testing.T) yarpc.DialerProvider {
+	p, err := yarpcdialer.NewProvider(yarpctest.NewFakeDialer("http"))
+	require.NoError(t, err)
+	return p
+}
+
+func TestNewConfig(t *testing.T) {
+	cfg := strings.NewReader("yarpc: {choosers: {random: {bar: {dialer: http, capacity: 100}}}}")
+	provider, err := config.NewYAML(config.Source(cfg))
+	require.NoError(t, err)
+
+	res, err := NewConfig(ConfigParams{
+		Provider: provider,
+	})
+	require.NoError(t, err)
+	assert.Equal(t,
+		Config{
+			Choosers: map[string]RandomConfig{
+				"bar": {Dialer: "http", Capacity: 100},
+			},
+		},
+		res.Config)
+}
+
+func TestNewList(t *testing.T) {
+	t.Run("unknown dialer", func(t *testing.T) {
+		_, err := NewList(ListParams{
+			Config: Config{
+				Choosers: map[string]RandomConfig{
+					"bar": {Dialer: "dne", Capacity: 100},
+				},
+			},
+			Provider: newDialerProvider(t),
+		})
+		assert.EqualError(t, err, `failed to resolve dialer "dne"`)
+	})
+
+	t.Run("successfully create chooser and list", func(t *testing.T) {
+		res, err := NewList(ListParams{
+			Config: Config{
+				Choosers: map[string]RandomConfig{
+					"bar": {Dialer: "http", Capacity: 100},
+				},
+			},
+			Provider: newDialerProvider(t),
+		})
+		require.NoError(t, err)
+
+		require.Len(t, res.Choosers, 1)
+		assert.Equal(t, "bar", res.Choosers[0].Name())
+		require.Len(t, res.Lists, 1)
+		assert.Equal(t, "bar", res.Lists[0].Name())
+	})
+}


### PR DESCRIPTION
This introduces the Fx layer for `yarpcrandpeer`. This is largely
copied from `yarpcroundrobin`.

Commits are individually reviewable.