### PR TITLE
[v2] Add yarpcpendingheapfx package

### DIFF
--- a/v2/internal/internalgauntlettest/gauntlet_test.go
+++ b/v2/internal/internalgauntlettest/gauntlet_test.go
@@ -95,7 +95,7 @@ func newChooser(t *testing.T, chooser string, dialer yarpc.Dialer, id yarpc.Iden
 		return pl
 
 	case _pendingheap:
-		pl := yarpcpendingheap.New(dialer)
+		pl := yarpcpendingheap.New("pending-heap", dialer)
 		pl.Update(update)
 		return pl
 

--- a/v2/yarpcpendingheap/heap.go
+++ b/v2/yarpcpendingheap/heap.go
@@ -207,15 +207,3 @@ func (ph *pendingHeap) popPeer() (*peerScore, bool) {
 func (ph *pendingHeap) update(i int) {
 	heap.Fix(ph, i)
 }
-
-func (ph *pendingHeap) Start() error {
-	return nil
-}
-
-func (ph *pendingHeap) Stop() error {
-	return nil
-}
-
-func (ph *pendingHeap) IsRunning() bool {
-	return true
-}

--- a/v2/yarpcpendingheap/heap_test.go
+++ b/v2/yarpcpendingheap/heap_test.go
@@ -28,11 +28,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPeerHeapRunning(t *testing.T) {
-	var ph pendingHeap
-	assert.True(t, (&ph).IsRunning(), "Always running. Nothing stops the peer heap.")
-}
-
 func TestPeerHeapEmpty(t *testing.T) {
 	var ph pendingHeap
 	assert.Zero(t, ph.Len(), "New peer heap should be empty")

--- a/v2/yarpcpendingheap/list.go
+++ b/v2/yarpcpendingheap/list.go
@@ -70,7 +70,7 @@ func Seed(seed int64) ListOption {
 }
 
 // New creates a new pending heap.
-func New(dialer yarpc.Dialer, opts ...ListOption) *List {
+func New(name string, dialer yarpc.Dialer, opts ...ListOption) *List {
 	cfg := defaultListOptions
 	for _, o := range opts {
 		o.apply(&cfg)
@@ -90,7 +90,7 @@ func New(dialer yarpc.Dialer, opts ...ListOption) *List {
 	}
 	return &List{
 		List: yarpcpeerlist.New(
-			"fewest-pending-requests",
+			name,
 			dialer,
 			&pendingHeap{
 				nextRand: nextRandFn,

--- a/v2/yarpcpendingheap/list_test.go
+++ b/v2/yarpcpendingheap/list_test.go
@@ -404,7 +404,7 @@ func TestPeerHeapList(t *testing.T) {
 			}
 			opts := []ListOption{Capacity(0), noShuffle(), randOption}
 
-			pl := New(dialer, opts...)
+			pl := New("fewest-pending-requests", dialer, opts...)
 
 			deps := yarpctest.ListActionDeps{
 				Peers: peerMap,

--- a/v2/yarpcpendingheapfx/doc.go
+++ b/v2/yarpcpendingheapfx/doc.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package yarpcpendingheapfx provides a fewest-pending heap peer.List
+// implementation into the Fx application.
+package yarpcpendingheapfx

--- a/v2/yarpcpendingheapfx/yarpcpendingheapfx.go
+++ b/v2/yarpcpendingheapfx/yarpcpendingheapfx.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpcpendingheapfx
+
+import (
+	"fmt"
+
+	"go.uber.org/config"
+	"go.uber.org/fx"
+	yarpc "go.uber.org/yarpc/v2"
+	"go.uber.org/yarpc/v2/yarpcpendingheap"
+)
+
+const (
+	_name             = "yarpcpendingheapfx"
+	_configurationKey = "yarpc.choosers.fewest-pending-requests"
+)
+
+// Module produces a yarpcpendingheap peer list.
+var Module = fx.Options(
+	fx.Provide(NewConfig),
+	fx.Provide(NewList),
+)
+
+// Config is the configuration for constructing a set of fewest pending peer.Choosers.
+type Config struct {
+	Choosers map[string]PendingHeapConfig `yaml:",inline"`
+}
+
+// PendingHeapConfig is the configuration for constructing a specific fewest pending peer.Chooser.
+type PendingHeapConfig struct {
+	Dialer   string `yaml:"dialer"`
+	Capacity int    `yaml:"capacity"`
+}
+
+// ConfigParams defines the dependencies of this module.
+type ConfigParams struct {
+	fx.In
+
+	Provider config.Provider
+}
+
+// ConfigResult defines the values produced by this module.
+type ConfigResult struct {
+	fx.Out
+
+	Config Config
+}
+
+// NewConfig produces a Config.
+func NewConfig(p ConfigParams) (ConfigResult, error) {
+	c := Config{}
+	if err := p.Provider.Get(_configurationKey).Populate(&c); err != nil {
+		return ConfigResult{}, err
+	}
+	return ConfigResult{Config: c}, nil
+}
+
+// ListParams defines the dependencies of this module.
+type ListParams struct {
+	fx.In
+
+	Config   Config
+	Provider yarpc.DialerProvider
+}
+
+// ListResult defines the values produced by this module.
+type ListResult struct {
+	fx.Out
+
+	Choosers []yarpc.Chooser `group:"yarpcfx"`
+	Lists    []yarpc.List    `group:"yarpcfx"`
+}
+
+// NewList produces `yarpcpendingheap.List`s as `yarpc.Chooser`s and
+// `yarpc.List`s.
+func NewList(p ListParams) (ListResult, error) {
+	var (
+		choosers []yarpc.Chooser
+		lists    []yarpc.List
+	)
+	for name, c := range p.Config.Choosers {
+		dialer, ok := p.Provider.Dialer(c.Dialer)
+		if !ok {
+			return ListResult{}, fmt.Errorf("failed to resolve dialer %q", c.Dialer)
+		}
+
+		var opts []yarpcpendingheap.ListOption
+		if c.Capacity > 0 {
+			opts = append(opts, yarpcpendingheap.Capacity(c.Capacity))
+		}
+
+		list := yarpcpendingheap.New(name, dialer, opts...)
+
+		choosers = append(choosers, list)
+		lists = append(lists, list)
+	}
+	return ListResult{
+		Choosers: choosers,
+		Lists:    lists,
+	}, nil
+}

--- a/v2/yarpcpendingheapfx/yarpcpendingheapfx_test.go
+++ b/v2/yarpcpendingheapfx/yarpcpendingheapfx_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpcpendingheapfx
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/config"
+	yarpc "go.uber.org/yarpc/v2"
+	"go.uber.org/yarpc/v2/yarpcdialer"
+	"go.uber.org/yarpc/v2/yarpctest"
+)
+
+func newDialerProvider(t *testing.T) yarpc.DialerProvider {
+	p, err := yarpcdialer.NewProvider(yarpctest.NewFakeDialer("http"))
+	require.NoError(t, err)
+	return p
+}
+
+func TestNewConfig(t *testing.T) {
+	cfg := strings.NewReader("yarpc: {choosers: {fewest-pending-requests: {bar: {dialer: http, capacity: 100}}}}")
+	provider, err := config.NewYAML(config.Source(cfg))
+	require.NoError(t, err)
+
+	res, err := NewConfig(ConfigParams{
+		Provider: provider,
+	})
+	require.NoError(t, err)
+	assert.Equal(t,
+		Config{
+			Choosers: map[string]PendingHeapConfig{
+				"bar": {Dialer: "http", Capacity: 100},
+			},
+		},
+		res.Config)
+}
+
+func TestNewList(t *testing.T) {
+	t.Run("unknown dialer", func(t *testing.T) {
+		_, err := NewList(ListParams{
+			Config: Config{
+				Choosers: map[string]PendingHeapConfig{
+					"bar": {Dialer: "dne", Capacity: 100},
+				},
+			},
+			Provider: newDialerProvider(t),
+		})
+		assert.EqualError(t, err, `failed to resolve dialer "dne"`)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		res, err := NewList(ListParams{
+			Config: Config{
+				Choosers: map[string]PendingHeapConfig{
+					"bar": {Dialer: "http", Capacity: 100},
+				},
+			},
+			Provider: newDialerProvider(t),
+		})
+		require.NoError(t, err)
+
+		require.Len(t, res.Choosers, 1)
+		assert.Equal(t, "bar", res.Choosers[0].Name())
+		require.Len(t, res.Lists, 1)
+		assert.Equal(t, "bar", res.Lists[0].Name())
+	})
+}


### PR DESCRIPTION
This introduces the Fx layer for `yarpcpendingheap` is largely copied
from `yarpcroundrobinfx`.

Commits are individually reviewable.