### PR TITLE
[v2] Fix bug for applying outbound transport middleware

### DIFF
--- a/v2/outbound_transport_middleware.go
+++ b/v2/outbound_transport_middleware.go
@@ -75,6 +75,11 @@ func applyUnaryOutboundTransportMiddleware(o UnaryOutbound, f UnaryOutboundTrans
 // UnaryOutboundTransportMiddlewareFunc adapts a function into a UnaryOutboundTransportMiddleware.
 type UnaryOutboundTransportMiddlewareFunc func(context.Context, *Request, *Buffer, UnaryOutbound) (*Response, *Buffer, error)
 
+// Name for UnaryOutboundTransportMiddlewareFunc.
+func (UnaryOutboundTransportMiddlewareFunc) Name() string {
+	return "UnaryOutboundTransportMiddlewareFunc"
+}
+
 // Call for UnaryOutboundTransportMiddlewareFunc.
 func (f UnaryOutboundTransportMiddlewareFunc) Call(
 	ctx context.Context,

--- a/v2/outbound_transport_middleware.go
+++ b/v2/outbound_transport_middleware.go
@@ -78,25 +78,25 @@ func NewUnaryOutboundTransportMiddleware(
 	name string,
 	f func(context.Context, *Request, *Buffer, UnaryOutbound) (*Response, *Buffer, error),
 ) UnaryOutboundTransportMiddleware {
-	return unaryOutboundTransportMiddlewareStruct{
+	return unaryOutboundTransportMiddleware{
 		name: name,
 		f:    f,
 	}
 }
 
-// unaryOutboundTransportMiddlewareStruct adapts a function and name into a middleware
-type unaryOutboundTransportMiddlewareStruct struct {
+// unaryOutboundTransportMiddleware adapts a function and name into a middleware
+type unaryOutboundTransportMiddleware struct {
 	name string
 	f    func(context.Context, *Request, *Buffer, UnaryOutbound) (*Response, *Buffer, error)
 }
 
-// Name for unaryOutboundTransportMiddlewareStruct.
-func (u unaryOutboundTransportMiddlewareStruct) Name() string {
+// Name for unaryOutboundTransportMiddleware.
+func (u unaryOutboundTransportMiddleware) Name() string {
 	return u.name
 }
 
-// Call for unaryOutboundTransportMiddlewareStruct.
-func (u unaryOutboundTransportMiddlewareStruct) Call(
+// Call for unaryOutboundTransportMiddleware.
+func (u unaryOutboundTransportMiddleware) Call(
 	ctx context.Context,
 	request *Request,
 	buf *Buffer,

--- a/v2/outbound_transport_middleware.go
+++ b/v2/outbound_transport_middleware.go
@@ -72,22 +72,37 @@ func applyUnaryOutboundTransportMiddleware(o UnaryOutbound, f UnaryOutboundTrans
 	return unaryOutboundWithMiddleware{o: o, f: f}
 }
 
-// UnaryOutboundTransportMiddlewareFunc adapts a function into a UnaryOutboundTransportMiddleware.
-type UnaryOutboundTransportMiddlewareFunc func(context.Context, *Request, *Buffer, UnaryOutbound) (*Response, *Buffer, error)
-
-// Name for UnaryOutboundTransportMiddlewareFunc.
-func (UnaryOutboundTransportMiddlewareFunc) Name() string {
-	return "UnaryOutboundTransportMiddlewareFunc"
+// NewUnaryOutboundTransportMiddleware is a convenience constructor for creating
+// new middleware.
+func NewUnaryOutboundTransportMiddleware(
+	name string,
+	f func(context.Context, *Request, *Buffer, UnaryOutbound) (*Response, *Buffer, error),
+) UnaryOutboundTransportMiddleware {
+	return unaryOutboundTransportMiddlewareStruct{
+		name: name,
+		f:    f,
+	}
 }
 
-// Call for UnaryOutboundTransportMiddlewareFunc.
-func (f UnaryOutboundTransportMiddlewareFunc) Call(
+// unaryOutboundTransportMiddlewareStruct adapts a function and name into a middleware
+type unaryOutboundTransportMiddlewareStruct struct {
+	name string
+	f    func(context.Context, *Request, *Buffer, UnaryOutbound) (*Response, *Buffer, error)
+}
+
+// Name for unaryOutboundTransportMiddlewareStruct.
+func (u unaryOutboundTransportMiddlewareStruct) Name() string {
+	return u.name
+}
+
+// Call for unaryOutboundTransportMiddlewareStruct.
+func (u unaryOutboundTransportMiddlewareStruct) Call(
 	ctx context.Context,
 	request *Request,
 	buf *Buffer,
 	out UnaryOutbound,
 ) (*Response, *Buffer, error) {
-	return f(ctx, request, buf, out)
+	return u.f(ctx, request, buf, out)
 }
 
 type unaryOutboundWithMiddleware struct {

--- a/v2/outbound_transport_middleware_test.go
+++ b/v2/outbound_transport_middleware_test.go
@@ -80,6 +80,26 @@ func TestOutboundMiddleware(t *testing.T) {
 	})
 }
 
+func TestUnaryOutboundTransportMiddlewareStruct(t *testing.T) {
+	t.Run("name is called", func(t *testing.T) {
+		mw := yarpc.NewUnaryOutboundTransportMiddleware("my-middleware-name", nil)
+		assert.Equal(t, "my-middleware-name", mw.Name())
+	})
+
+	t.Run("func is called", func(t *testing.T) {
+		var called bool
+
+		mw := yarpc.NewUnaryOutboundTransportMiddleware("name",
+			func(context.Context, *yarpc.Request, *yarpc.Buffer, yarpc.UnaryOutbound) (*yarpc.Response, *yarpc.Buffer, error) {
+				called = true
+				return nil, nil, nil
+			})
+
+		_, _, _ = mw.Call(context.Background(), nil, nil, nil)
+		assert.True(t, called, "middleware did not call func")
+	})
+}
+
 func TestStreamNopOutboundMiddleware(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()

--- a/v2/yarpcfx/yarpcfx.go
+++ b/v2/yarpcfx/yarpcfx.go
@@ -65,10 +65,14 @@ func NewClientProvider(p ClientProviderParams) (ClientProviderResult, error) {
 	for _, cl := range p.ClientLists {
 		clients = append(clients, cl...)
 	}
+
+	clientsWithMiddleware := make([]yarpc.Client, 0, len(clients))
 	for _, c := range clients {
 		c.Unary = yarpc.ApplyUnaryOutboundTransportMiddleware(c.Unary, p.UnaryOutboundTransportMiddleware...)
+		clientsWithMiddleware = append(clientsWithMiddleware, c)
 	}
-	provider, err := yarpcclient.NewProvider(clients...)
+
+	provider, err := yarpcclient.NewProvider(clientsWithMiddleware...)
 	if err != nil {
 		return ClientProviderResult{}, err
 	}

--- a/v2/yarpcfx/yarpcfx_test.go
+++ b/v2/yarpcfx/yarpcfx_test.go
@@ -68,7 +68,7 @@ func TestClientHasMiddleware(t *testing.T) {
 	var gotCallOrder []string
 
 	var newMiddleware = func(name string) yarpc.UnaryOutboundTransportMiddleware {
-		return yarpc.NewUnaryOutboundTransportMiddleware("foo",
+		return yarpc.NewUnaryOutboundTransportMiddleware(name,
 			func(ctx context.Context, _ *yarpc.Request, _ *yarpc.Buffer, o yarpc.UnaryOutbound) (*yarpc.Response, *yarpc.Buffer, error) {
 				gotCallOrder = append(gotCallOrder, name)
 				return o.Call(ctx, nil, nil)

--- a/v2/yarpcfx/yarpcfx_test.go
+++ b/v2/yarpcfx/yarpcfx_test.go
@@ -86,7 +86,7 @@ func TestClientHasMiddleware(t *testing.T) {
 
 	result, err := NewClientProvider(ClientProviderParams{
 		UnaryOutboundTransportMiddleware: []yarpc.UnaryOutboundTransportMiddleware{middleware},
-		Clients:                          []yarpc.Client{client},
+		Clients: []yarpc.Client{client},
 	})
 
 	require.NoError(t, err)


### PR DESCRIPTION
This fixes a bug introduced in #1643 where we were not actually applying
middleware to `yarpc.Client`s. Previously we were modifying the `Client` with
the variable scoped to that loop. That variable is out of scope after that loop
which meant that we never persisted the middleware application.

This change fixes this by adding an outer list that we append to.