### PR TITLE
Move HTTP peer status notifications into connection management loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   purposes of debugging, instead of its own name.
 - Metrics emit `CodeResourceExhausted` as a client error and `CodeUnimplemented`
   as a server error.
+- Simplified the flow of status change notifications for the HTTP transport to
+  reduce the liklihood of deadlocks.
 
 ## [1.41.0] - 2019-10-01
 ### Fixed

--- a/peer/abstractpeer/peer_test.go
+++ b/peer/abstractpeer/peer_test.go
@@ -1,0 +1,311 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package abstractpeer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/yarpc/api/peer"
+	. "go.uber.org/yarpc/api/peer/peertest"
+)
+
+func TestPeerIdentifier(t *testing.T) {
+	tests := []struct {
+		hostport           string
+		expectedIdentifier string
+	}{
+		{
+			"localhost:12345",
+			"localhost:12345",
+		},
+		{
+			"123.123.123.123:12345",
+			"123.123.123.123:12345",
+		},
+	}
+
+	for _, tt := range tests {
+		pi := PeerIdentifier(tt.hostport)
+
+		assert.Equal(t, tt.expectedIdentifier, pi.Identifier())
+	}
+}
+
+func TestPeer(t *testing.T) {
+	type testStruct struct {
+		msg string
+
+		// PeerID for all the hostport.Peer initialization
+		inputPeerID string
+
+		// List of "Subscribers" that we can define beforehand and reference in our PeerActions
+		// using the "ID" field in the subscriber definition, the "ExpectedNotifyCount" is the
+		// expected number of times the subscriber will be notified
+		SubDefinitions []SubscriberDefinition
+
+		// List of actions to be applied to the peer
+		actions []PeerAction
+
+		// Expected result from running Identifier() on the peer after the actions have been applied
+		expectedIdentifier string
+
+		// Expected result from running HostPort() on the peer after the actions have been applied
+		expectedHostPort string
+
+		// Expected result from running Status() on the peer after the actions have been applied
+		expectedStatus peer.Status
+
+		// Expected subscribers in the Peer's "subscribers" map after the actions have been applied
+		expectedSubscribers []string
+	}
+	tests := []testStruct{
+		{
+			msg:                "create",
+			inputPeerID:        "localhost:12345",
+			expectedIdentifier: "localhost:12345",
+			expectedHostPort:   "localhost:12345",
+			expectedStatus: peer.Status{
+				PendingRequestCount: 0,
+				ConnectionStatus:    peer.Unavailable,
+			},
+		},
+		{
+			msg:            "start request",
+			SubDefinitions: []SubscriberDefinition{{ID: "1", ExpectedNotifyCount: 1}},
+			actions: []PeerAction{
+				SubscribeAction{SubscriberID: "1", ExpectedSubCount: 1},
+				StartStopReqAction{Stop: false},
+			},
+			expectedSubscribers: []string{"1"},
+			expectedStatus: peer.Status{
+				PendingRequestCount: 1,
+				ConnectionStatus:    peer.Unavailable,
+			},
+		},
+		{
+			msg:            "start request stop request",
+			SubDefinitions: []SubscriberDefinition{{ID: "1", ExpectedNotifyCount: 2}},
+			actions: []PeerAction{
+				SubscribeAction{SubscriberID: "1", ExpectedSubCount: 1},
+				StartStopReqAction{Stop: true},
+			},
+			expectedSubscribers: []string{"1"},
+			expectedStatus: peer.Status{
+				PendingRequestCount: 0,
+				ConnectionStatus:    peer.Unavailable,
+			},
+		},
+		{
+			msg:            "start 5 stop 2",
+			SubDefinitions: []SubscriberDefinition{{ID: "1", ExpectedNotifyCount: 7}},
+			actions: []PeerAction{
+				SubscribeAction{SubscriberID: "1", ExpectedSubCount: 1},
+				StartStopReqAction{Stop: true},
+				StartStopReqAction{Stop: false},
+				StartStopReqAction{Stop: false},
+				StartStopReqAction{Stop: true},
+				StartStopReqAction{Stop: false},
+			},
+			expectedSubscribers: []string{"1"},
+			expectedStatus: peer.Status{
+				PendingRequestCount: 3,
+				ConnectionStatus:    peer.Unavailable,
+			},
+		},
+		{
+			msg:            "start 5 stop 5",
+			SubDefinitions: []SubscriberDefinition{{ID: "1", ExpectedNotifyCount: 10}},
+			actions: []PeerAction{
+				SubscribeAction{SubscriberID: "1", ExpectedSubCount: 1},
+				StartStopReqAction{Stop: true},
+				StartStopReqAction{Stop: true},
+				StartStopReqAction{Stop: true},
+				StartStopReqAction{Stop: true},
+				StartStopReqAction{Stop: true},
+			},
+			expectedSubscribers: []string{"1"},
+			expectedStatus: peer.Status{
+
+				ConnectionStatus: peer.Unavailable,
+			},
+		},
+		{
+			msg: "set status",
+			SubDefinitions: []SubscriberDefinition{
+				{ID: "1", ExpectedNotifyCount: 1},
+				{ID: "2", ExpectedNotifyCount: 1},
+				{ID: "3", ExpectedNotifyCount: 1},
+			},
+			actions: []PeerAction{
+				SubscribeAction{SubscriberID: "1", ExpectedSubCount: 1},
+				SubscribeAction{SubscriberID: "2", ExpectedSubCount: 2},
+				SubscribeAction{SubscriberID: "3", ExpectedSubCount: 3},
+				SetStatusAction{InputStatus: peer.Available},
+			},
+			expectedSubscribers: []string{"1", "2", "3"},
+			expectedStatus: peer.Status{
+				PendingRequestCount: 0,
+				ConnectionStatus:    peer.Available,
+			},
+		},
+		{
+			msg: "incremental subscribe",
+			SubDefinitions: []SubscriberDefinition{
+				{ID: "1", ExpectedNotifyCount: 3},
+				{ID: "2", ExpectedNotifyCount: 2},
+				{ID: "3", ExpectedNotifyCount: 1},
+			},
+			actions: []PeerAction{
+				SubscribeAction{SubscriberID: "1", ExpectedSubCount: 1},
+				SetStatusAction{InputStatus: peer.Available},
+				SubscribeAction{SubscriberID: "2", ExpectedSubCount: 2},
+				SetStatusAction{InputStatus: peer.Available},
+				SubscribeAction{SubscriberID: "3", ExpectedSubCount: 3},
+				SetStatusAction{InputStatus: peer.Available},
+			},
+			expectedSubscribers: []string{"1", "2", "3"},
+			expectedStatus: peer.Status{
+				PendingRequestCount: 0,
+				ConnectionStatus:    peer.Available,
+			},
+		},
+		{
+			msg: "subscribe unsubscribe",
+			SubDefinitions: []SubscriberDefinition{
+				{ID: "1", ExpectedNotifyCount: 1},
+			},
+			actions: []PeerAction{
+				SubscribeAction{SubscriberID: "1", ExpectedSubCount: 1},
+				SetStatusAction{InputStatus: peer.Available},
+				UnsubscribeAction{SubscriberID: "1", ExpectedSubCount: 0},
+				SetStatusAction{InputStatus: peer.Available},
+			},
+			expectedStatus: peer.Status{
+				PendingRequestCount: 0,
+				ConnectionStatus:    peer.Available,
+			},
+		},
+		{
+			msg: "incremental subscribe unsubscribe",
+			SubDefinitions: []SubscriberDefinition{
+				{ID: "1", ExpectedNotifyCount: 5},
+				{ID: "2", ExpectedNotifyCount: 3},
+				{ID: "3", ExpectedNotifyCount: 1},
+			},
+			actions: []PeerAction{
+				SubscribeAction{SubscriberID: "1", ExpectedSubCount: 1},
+				SetStatusAction{InputStatus: peer.Available},
+				SubscribeAction{SubscriberID: "2", ExpectedSubCount: 2},
+				SetStatusAction{InputStatus: peer.Available},
+				SubscribeAction{SubscriberID: "3", ExpectedSubCount: 3},
+				SetStatusAction{InputStatus: peer.Available},
+				UnsubscribeAction{SubscriberID: "3", ExpectedSubCount: 2},
+				SetStatusAction{InputStatus: peer.Available},
+				UnsubscribeAction{SubscriberID: "2", ExpectedSubCount: 1},
+				SetStatusAction{InputStatus: peer.Available},
+				UnsubscribeAction{SubscriberID: "1", ExpectedSubCount: 0},
+				SetStatusAction{InputStatus: peer.Available},
+			},
+			expectedStatus: peer.Status{
+				PendingRequestCount: 0,
+				ConnectionStatus:    peer.Available,
+			},
+		},
+		{
+			msg: "unsubscribe error",
+			SubDefinitions: []SubscriberDefinition{
+				{ID: "1", ExpectedNotifyCount: 0},
+			},
+			actions: []PeerAction{
+				UnsubscribeAction{
+					SubscriberID:     "1",
+					ExpectedErrType:  peer.ErrPeerHasNoReferenceToSubscriber{},
+					ExpectedSubCount: 0,
+				},
+			},
+			expectedStatus: peer.Status{
+				PendingRequestCount: 0,
+				ConnectionStatus:    peer.Unavailable,
+			},
+		},
+		{
+			msg: "concurrent update and subscribe",
+			SubDefinitions: []SubscriberDefinition{
+				{ID: "1", ExpectedNotifyCount: 2},
+			},
+			actions: []PeerAction{
+				PeerConcurrentAction{
+					Actions: []PeerAction{
+						SubscribeAction{SubscriberID: "1", ExpectedSubCount: 1},
+						SetStatusAction{InputStatus: peer.Available},
+						SetStatusAction{InputStatus: peer.Available},
+					},
+					Wait: time.Millisecond * 70,
+				},
+			},
+			expectedSubscribers: []string{"1"},
+			expectedStatus: peer.Status{
+				PendingRequestCount: 0,
+				ConnectionStatus:    peer.Available,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			if tt.inputPeerID == "" {
+				tt.inputPeerID = "localhost:12345"
+				tt.expectedIdentifier = "localhost:12345"
+				tt.expectedHostPort = "localhost:12345"
+			}
+
+			transport := NewMockTransport(mockCtrl)
+
+			peer := NewPeer(PeerIdentifier(tt.inputPeerID), transport)
+
+			deps := &Dependencies{
+				Subscribers: CreateSubscriberMap(mockCtrl, tt.SubDefinitions),
+			}
+
+			ApplyPeerActions(t, peer, tt.actions, deps)
+
+			assert.Equal(t, tt.expectedIdentifier, peer.Identifier())
+			assert.Equal(t, tt.expectedHostPort, peer.HostPort())
+			assert.Equal(t, transport, peer.Transport())
+			assert.Equal(t, tt.expectedStatus, peer.Status())
+
+			assert.Len(t, peer.subscribers, len(tt.expectedSubscribers))
+			for _, subID := range tt.expectedSubscribers {
+				sub, ok := deps.Subscribers[subID]
+				assert.True(t, ok, "referenced subscriber id that does not exist %s", sub)
+
+				_, ok = peer.subscribers[sub]
+				assert.True(t, ok, "peer did not have reference to subscriber %v", sub)
+			}
+		})
+	}
+}

--- a/peer/abstractpeer/peeraction_test.go
+++ b/peer/abstractpeer/peeraction_test.go
@@ -1,0 +1,160 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package abstractpeer
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/internal/testtime"
+)
+
+// There are no actual tests in this file, it contains a series of helper methods
+// for testing abstractpeer.Peers
+
+// Dependences are passed through all the PeerActions in order to pass certain
+// state in between Actions
+type Dependencies struct {
+	Subscribers map[string]peer.Subscriber
+}
+
+// PeerAction defines actions that can be applied on a abstractpeer.Peer
+type PeerAction interface {
+	Apply(*testing.T, *Peer, *Dependencies)
+}
+
+// StartStopReqAction will run a StartRequest and (optionally) EndRequest
+type StartStopReqAction struct {
+	Stop bool
+}
+
+// Apply will run StartRequest and (optionally) EndRequest
+func (sa StartStopReqAction) Apply(t *testing.T, p *Peer, d *Dependencies) {
+	p.StartRequest()
+	p.NotifyStatusChanged()
+	if sa.Stop {
+		p.EndRequest()
+		p.NotifyStatusChanged()
+	}
+}
+
+// SetStatusAction will run a SetStatus on a Peer
+type SetStatusAction struct {
+	InputStatus peer.ConnectionStatus
+}
+
+// Apply will run SetStatus on the Peer
+func (sa SetStatusAction) Apply(t *testing.T, p *Peer, d *Dependencies) {
+	p.SetStatus(sa.InputStatus)
+	p.NotifyStatusChanged()
+
+	assert.Equal(t, sa.InputStatus, p.Status().ConnectionStatus)
+}
+
+// SubscribeAction will run an Subscribe on a Peer
+type SubscribeAction struct {
+	// SubscriberID is a unique identifier for a subscriber that is
+	// contained in the Dependencies object passed in Apply
+	SubscriberID string
+
+	// ExpectedSubCount is the number of subscribers on the Peer after
+	// the subscription
+	ExpectedSubCount int
+}
+
+// Apply will run Subscribe on a Peer
+func (sa SubscribeAction) Apply(t *testing.T, p *Peer, d *Dependencies) {
+	sub, ok := d.Subscribers[sa.SubscriberID]
+	assert.True(t, ok, "referenced a subscriberID that does not exist %s", sa.SubscriberID)
+
+	p.Subscribe(sub)
+
+	assert.Equal(t, sa.ExpectedSubCount, p.NumSubscribers())
+}
+
+// UnsubscribeAction will run Unsubscribe on a Peer
+type UnsubscribeAction struct {
+	// SubscriberID is a unique identifier for a subscriber that is
+	// contained in the Dependencies object passed in Apply
+	SubscriberID string
+
+	// ExpectedErrType is the type of error that is expected to be returned
+	// from Unsubscribe
+	ExpectedErrType error
+
+	// ExpectedSubCount is the number of subscribers on the Peer after
+	// the subscription
+	ExpectedSubCount int
+}
+
+// Apply will run Unsubscribe from the Peer and assert on the result
+func (ua UnsubscribeAction) Apply(t *testing.T, p *Peer, d *Dependencies) {
+	sub, ok := d.Subscribers[ua.SubscriberID]
+	assert.True(t, ok, "referenced a subscriberID that does not exist %s", ua.SubscriberID)
+
+	err := p.Unsubscribe(sub)
+
+	assert.Equal(t, ua.ExpectedSubCount, p.NumSubscribers())
+	if err != nil {
+		assert.IsType(t, ua.ExpectedErrType, err)
+	} else {
+		assert.Nil(t, ua.ExpectedErrType)
+	}
+}
+
+// PeerConcurrentAction will run a series of actions in parallel
+type PeerConcurrentAction struct {
+	Actions []PeerAction
+	Wait    time.Duration
+}
+
+// Apply runs all the ConcurrentAction's actions in goroutines with a delay of `Wait`
+// between each action. Returns when all actions have finished executing
+func (a PeerConcurrentAction) Apply(t *testing.T, p *Peer, d *Dependencies) {
+	var wg sync.WaitGroup
+
+	wg.Add(len(a.Actions))
+	for _, action := range a.Actions {
+		go func(ac PeerAction) {
+			defer wg.Done()
+			ac.Apply(t, p, d)
+		}(action)
+
+		if a.Wait > 0 {
+			testtime.Sleep(a.Wait)
+		}
+	}
+
+	wg.Wait()
+}
+
+// ApplyPeerActions runs all the PeerActions on the Peer
+func ApplyPeerActions(t *testing.T, p *Peer, actions []PeerAction, d *Dependencies) {
+	for i, action := range actions {
+		t.Run(fmt.Sprintf("action #%d: %T", i, action), func(t *testing.T) {
+			action.Apply(t, p, d)
+		})
+	}
+}

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -532,7 +532,7 @@ func (o *Outbound) doWithPeer(
 			// Note that the connection experienced a time out, which may
 			// indicate that the connection is half-open, that the destination
 			// died without sending a TCP FIN packet.
-			p.OnSuspect()
+			p.onSuspect()
 
 			end := time.Now()
 			return nil, yarpcerrors.Newf(
@@ -543,7 +543,7 @@ func (o *Outbound) doWithPeer(
 
 		// Note that the connection may have been lost so the peer connection
 		// maintenance loop resumes probing for availability.
-		p.OnDisconnected()
+		p.onDisconnected()
 
 		return nil, yarpcerrors.Newf(yarpcerrors.CodeUnknown, "unknown error from http client: %s", err.Error())
 	}


### PR DESCRIPTION
This change ensures that all status notifications emerge from the HTTP peer connection management loop, which guarantees that they will run in a stack with no locks on the peer.

To do this, I had to make a breaking change to the abstract peer list implementation used by HTTP. That is to say, I avoided making a breaking change by copying peer/hostport to peer/abstractpeer. The new abstractpeer does not send notifications when you change the status, so that responsibility moves into the HTTP transport.