### PR TITLE
[v2] Support inbound encoding middleware in Fx

### DIFF
--- a/v2/inbound_encoding_middleware.go
+++ b/v2/inbound_encoding_middleware.go
@@ -60,8 +60,17 @@ func (h unaryEncodingHandlerWithMiddleware) Handle(ctx context.Context, reqBuf i
 	return h.i.Handle(ctx, reqBuf, h.h)
 }
 
-// ApplyUnaryInboundEncodingMiddleware applies the given middleware to the given UnaryTransportHandler.
-func ApplyUnaryInboundEncodingMiddleware(handler UnaryEncodingHandler, middleware UnaryInboundEncodingMiddleware) UnaryEncodingHandler {
+// ApplyUnaryInboundEncodingMiddleware applies the middleware to the
+// UnaryInboundEncodingHandler.
+func ApplyUnaryInboundEncodingMiddleware(h UnaryEncodingHandler, middleware ...UnaryInboundEncodingMiddleware) UnaryEncodingHandler {
+	handler := h
+	for i := len(middleware) - 1; i >= 0; i-- {
+		handler = applyUnaryInboundEncodingMiddleware(handler, middleware[i])
+	}
+	return handler
+}
+
+func applyUnaryInboundEncodingMiddleware(handler UnaryEncodingHandler, middleware UnaryInboundEncodingMiddleware) UnaryEncodingHandler {
 	if middleware == nil {
 		return handler
 	}

--- a/v2/inbound_encoding_middleware.go
+++ b/v2/inbound_encoding_middleware.go
@@ -35,6 +35,7 @@ import "context"
 // UnaryInboundEncodingMiddleware is re-used across requests and MAY be called multiple
 // times for the same request.
 type UnaryInboundEncodingMiddleware interface {
+	Name() string
 	Handle(ctx context.Context, reqBuf interface{}, h UnaryEncodingHandler) (interface{}, error)
 }
 
@@ -43,6 +44,8 @@ type UnaryInboundEncodingMiddleware interface {
 var NopUnaryInboundEncodingMiddleware UnaryInboundEncodingMiddleware = nopUnaryInboundEncodingMiddleware{}
 
 type nopUnaryInboundEncodingMiddleware struct{}
+
+func (nopUnaryInboundEncodingMiddleware) Name() string { return nopName }
 
 func (nopUnaryInboundEncodingMiddleware) Handle(ctx context.Context, reqBuf interface{}, handler UnaryEncodingHandler) (interface{}, error) {
 	return handler.Handle(ctx, reqBuf)
@@ -65,10 +68,31 @@ func ApplyUnaryInboundEncodingMiddleware(handler UnaryEncodingHandler, middlewar
 	return unaryEncodingHandlerWithMiddleware{h: handler, i: middleware}
 }
 
-// UnaryInboundEncodingMiddlewareFunc adapts a function into an InboundMiddleware.
-type UnaryInboundEncodingMiddlewareFunc func(context.Context, *Request, *Buffer, UnaryTransportHandler) (*Response, *Buffer, error)
+// NewUnaryInboundEncodingMiddleware is a convenience constructor for creating
+// new middleware.
+func NewUnaryInboundEncodingMiddleware(
+	name string,
+	f func(context.Context, interface{}, UnaryEncodingHandler) (interface{}, error),
+) UnaryInboundEncodingMiddleware {
+	return unaryInboundEncodingMiddleware{
+		name: name,
+		f:    f,
+	}
+}
 
-// Handle for UnaryInboundEncodingMiddlewareFunc
-func (f UnaryInboundEncodingMiddlewareFunc) Handle(ctx context.Context, req *Request, reqBuf *Buffer, handler UnaryTransportHandler) (*Response, *Buffer, error) {
-	return f(ctx, req, reqBuf, handler)
+// unaryInboundEncodingMiddleware adapts a function and name into a
+// UnaryInboundEncodingMiddleware.
+type unaryInboundEncodingMiddleware struct {
+	name string
+	f    func(context.Context, interface{}, UnaryEncodingHandler) (interface{}, error)
+}
+
+// Name for unaryInboundEncodingMiddleware
+func (u unaryInboundEncodingMiddleware) Name() string {
+	return u.name
+}
+
+// Handle for unaryInboundEncodingMiddleware
+func (u unaryInboundEncodingMiddleware) Handle(ctx context.Context, reqBuf interface{}, handler UnaryEncodingHandler) (interface{}, error) {
+	return u.f(ctx, reqBuf, handler)
 }

--- a/v2/inbound_transport_middleware_test.go
+++ b/v2/inbound_transport_middleware_test.go
@@ -57,7 +57,7 @@ func TestUnaryNopInboundTransportMiddleware(t *testing.T) {
 	assert.Equal(t, err, handleErr)
 }
 
-func TestNilInboundMiddleware(t *testing.T) {
+func TestNilInboundTransportMiddleware(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -74,7 +74,7 @@ func TestNilInboundMiddleware(t *testing.T) {
 	})
 }
 
-func TestOrderedInboundMiddlewareAppply(t *testing.T) {
+func TestOrderedInboundTransportMiddlewareAppply(t *testing.T) {
 	gotOrder := make([]string, 0, 4)
 
 	var newMiddleware = func(name string) yarpc.UnaryInboundTransportMiddleware {
@@ -101,7 +101,7 @@ func TestOrderedInboundMiddlewareAppply(t *testing.T) {
 	assert.Equal(t, wantOrder, gotOrder, "unexpected middleware ordering")
 }
 
-func TestStreamNopInboundMiddleware(t *testing.T) {
+func TestStreamNopInboundTransportMiddleware(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 

--- a/v2/yarpcmiddlewarefx/constants.go
+++ b/v2/yarpcmiddlewarefx/constants.go
@@ -23,4 +23,5 @@ package yarpcmiddlewarefx
 const (
 	outboundTransportConfigurationKey = "yarpc.middleware.outbounds.transport"
 	inboundTransportConfigurationKey  = "yarpc.middleware.inbounds.transport"
+	inboundEncodingConfigurationKey   = "yarpc.middleware.inbounds.encoding"
 )

--- a/v2/yarpcmiddlewarefx/inbound_encoding.go
+++ b/v2/yarpcmiddlewarefx/inbound_encoding.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpcmiddlewarefx
+
+import (
+	"fmt"
+
+	"go.uber.org/config"
+	"go.uber.org/fx"
+	yarpc "go.uber.org/yarpc/v2"
+)
+
+// InboundEncodingConfig describes the configuration
+// shape for an ordered list of unary inbound encoding middleware.
+type InboundEncodingConfig struct {
+	Unary []string `yaml:"unary"`
+}
+
+// InboundEncodingConfigParams defines the dependencies of this module.
+type InboundEncodingConfigParams struct {
+	fx.In
+
+	Provider config.Provider
+}
+
+// InboundEncodingConfigResult defines the values produced by this module.
+type InboundEncodingConfigResult struct {
+	fx.Out
+
+	Config InboundEncodingConfig
+}
+
+// NewInboundEncodingConfig produces an UnaryInboundEncodingConfig.
+func NewInboundEncodingConfig(p InboundEncodingConfigParams) (InboundEncodingConfigResult, error) {
+	mc := InboundEncodingConfig{}
+	if err := p.Provider.Get(inboundEncodingConfigurationKey).Populate(&mc); err != nil {
+		return InboundEncodingConfigResult{}, err
+	}
+	return InboundEncodingConfigResult{
+		Config: mc,
+	}, nil
+}
+
+// UnaryInboundEncodingParams defines the dependencies of this module.
+type UnaryInboundEncodingParams struct {
+	fx.In
+
+	Config          InboundEncodingConfig
+	Middleware      []yarpc.UnaryInboundEncodingMiddleware   `group:"yarpcfx"`
+	MiddlewareLists [][]yarpc.UnaryInboundEncodingMiddleware `group:"yarpcfx"`
+}
+
+// UnaryInboundEncodingResult defines the values produced by this module.
+type UnaryInboundEncodingResult struct {
+	fx.Out
+
+	// An ordered slice of middleware according to the given configuration.
+	OrderedMiddleware []yarpc.UnaryInboundEncodingMiddleware `name:"yarpcfx"`
+}
+
+// NewUnaryInboundEncoding produceds an ordered slice of unary inbound encoding middleware.
+func NewUnaryInboundEncoding(
+	p UnaryInboundEncodingParams,
+) (UnaryInboundEncodingResult, error) {
+	// Collect all of the middleware into a single slice.
+	middleware := p.Middleware
+	for _, ml := range p.MiddlewareLists {
+		middleware = append(middleware, ml...)
+	}
+
+	// Compose a map of the middleware, and validate that there are not any name conflicts.
+	middlewareMap := make(map[string]yarpc.UnaryInboundEncodingMiddleware, len(middleware))
+	for _, m := range middleware {
+		name := m.Name()
+		if _, ok := middlewareMap[name]; ok {
+			return UnaryInboundEncodingResult{}, fmt.Errorf("unary inbound encoding middleware %q was registered more than once", name)
+		}
+		middlewareMap[name] = m
+	}
+
+	// Construct an ordered slice of middleware using the configured slice of names.
+	ordered := make([]yarpc.UnaryInboundEncodingMiddleware, len(p.Config.Unary))
+	for i, name := range p.Config.Unary {
+		m, ok := middlewareMap[name]
+		if !ok {
+			return UnaryInboundEncodingResult{}, fmt.Errorf("failed to resolve unary inbound encoding middleware: %q", name)
+		}
+		ordered[i] = m
+	}
+
+	return UnaryInboundEncodingResult{
+		OrderedMiddleware: ordered,
+	}, nil
+}

--- a/v2/yarpcmiddlewarefx/inbound_encoding_test.go
+++ b/v2/yarpcmiddlewarefx/inbound_encoding_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpcmiddlewarefx
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/config"
+	yarpc "go.uber.org/yarpc/v2"
+)
+
+func TestNewInboundEncodingConfig(t *testing.T) {
+	cfg := strings.NewReader(`yarpc: {middleware: {inbounds: {encoding: {unary: ["nop"]}}}}`)
+	provider, err := config.NewYAML(config.Source(cfg))
+	require.NoError(t, err)
+
+	res, err := NewInboundEncodingConfig(InboundEncodingConfigParams{
+		Provider: provider,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, InboundEncodingConfig{Unary: []string{"nop"}}, res.Config)
+}
+
+func TestNewUnaryInboundEncoding(t *testing.T) {
+	t.Run("duplicate registration error", func(t *testing.T) {
+		_, err := NewUnaryInboundEncoding(
+			UnaryInboundEncodingParams{
+				Middleware: []yarpc.UnaryInboundEncodingMiddleware{
+					yarpc.NopUnaryInboundEncodingMiddleware,
+					yarpc.NopUnaryInboundEncodingMiddleware,
+				},
+			},
+		)
+		assert.EqualError(t, err, `unary inbound encoding middleware "nop" was registered more than once`)
+	})
+
+	t.Run("configured middleware is not available", func(t *testing.T) {
+		_, err := NewUnaryInboundEncoding(
+			UnaryInboundEncodingParams{
+				Config: InboundEncodingConfig{
+					Unary: []string{"dne"},
+				},
+			},
+		)
+		assert.EqualError(t, err, `failed to resolve unary inbound encoding middleware: "dne"`)
+	})
+
+	t.Run("successful construction", func(t *testing.T) {
+		res, err := NewUnaryInboundEncoding(
+			UnaryInboundEncodingParams{
+				Config: InboundEncodingConfig{
+					Unary: []string{"nop"},
+				},
+				MiddlewareLists: [][]yarpc.UnaryInboundEncodingMiddleware{
+					{
+						yarpc.NopUnaryInboundEncodingMiddleware,
+					},
+				},
+			},
+		)
+		require.NoError(t, err)
+
+		middleware := res.OrderedMiddleware
+		require.Len(t, middleware, 1)
+		assert.Equal(t, "nop", middleware[0].Name())
+	})
+}

--- a/v2/yarpctest/mocks.go
+++ b/v2/yarpctest/mocks.go
@@ -872,6 +872,18 @@ func (mr *MockUnaryInboundEncodingMiddlewareMockRecorder) Handle(arg0, arg1, arg
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Handle", reflect.TypeOf((*MockUnaryInboundEncodingMiddleware)(nil).Handle), arg0, arg1, arg2)
 }
 
+// Name mocks base method
+func (m *MockUnaryInboundEncodingMiddleware) Name() string {
+	ret := m.ctrl.Call(m, "Name")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Name indicates an expected call of Name
+func (mr *MockUnaryInboundEncodingMiddlewareMockRecorder) Name() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockUnaryInboundEncodingMiddleware)(nil).Name))
+}
+
 // MockUnaryInboundTransportMiddleware is a mock of UnaryInboundTransportMiddleware interface
 type MockUnaryInboundTransportMiddleware struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
Similar to #1643 and #1658, this introduces support for applying inbound
encoding middleware at the Fx layer.

Commits are individually reviewable.