### PR TITLE
[v2] Fx clean up

### DIFF
--- a/v2/CHANGES
+++ b/v2/CHANGES
@@ -18,21 +18,21 @@
       - [x] Accumulate request bodies at the inbound
 - [x] yarpcrouter.Router needs to accept middleware to decorate registered
       procedures.
-- [ ] Replace functional options in yarpcpeerlist with struct options
+- [x] Replace functional options in yarpcpeerlist with struct options
 - [ ] Consider separating the auto-observability middleware into two components: logging and metrics.
 - [ ] Integrate the configuration into a variety of Fx modules.
       - [ ] Integrate servicefx.Metadata into each of the relevant Fx packages.
             - [ ] HTTP
             - [ ] TChannel
-      - [ ] Transports
-            - [ ] HTTP
+      - [x] Transports
+            - [x] HTTP
             - [x] gRPC
             - [x] TChannel
-      - [ ] Peer lists
-            - [ ] Round-robin
-            - [ ] Two-random-choices
-            - [ ] Random-peer
-            - [ ] Pending-heap
+      - [x] Peer lists
+            - [x] Round-robin
+            - [x] Two-random-choices
+            - [x] Random-peer
+            - [x] Pending-heap
       - [ ] Middleware
 - [x] Create an API in yarpcfx to register and obtain peer lists by name.
       Use this API to configure the chooser for an outbound in their transport fx package.

--- a/v2/yarpcfx/constants.go
+++ b/v2/yarpcfx/constants.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpcfx
+
+const _name = "yarpcfx"

--- a/v2/yarpcfx/internal/internalpeerlistfx/module.go
+++ b/v2/yarpcfx/internal/internalpeerlistfx/module.go
@@ -18,28 +18,20 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package yarpcfx
+package internalpeerlistfx
 
 import (
 	"go.uber.org/fx"
-	"go.uber.org/yarpc/v2/yarpcfx/internal/internalpeerlistfx"
-	"go.uber.org/yarpc/v2/yarpcfx/internal/internaltransportfx"
-	"go.uber.org/yarpc/v2/yarpcfx/yarpcfxmiddleware"
+	"go.uber.org/yarpc/v2/yarpcpendingheapfx"
+	"go.uber.org/yarpc/v2/yarpcrandpeerfx"
+	"go.uber.org/yarpc/v2/yarpcroundrobinfx"
+	"go.uber.org/yarpc/v2/yarpctworandomchoicesfx"
 )
 
-// Module provides YARPC integration for services. The module produces a
-// yarpc.Router, yarpc.ClientProvider and configuration for transports, peer
-// lists and middleware.
+// Module provides all peer lists to an Fx application.
 var Module = fx.Options(
-	fx.Provide(
-		newClientProvider,
-		newDialerProvider,
-		newChooserProvider,
-		newListProvider,
-		newRouter,
-	),
-
-	yarpcfxmiddleware.Module,
-	internaltransportfx.Module,
-	internalpeerlistfx.Module,
+	yarpcpendingheapfx.Module,
+	yarpcroundrobinfx.Module,
+	yarpcrandpeerfx.Module,
+	yarpctworandomchoicesfx.Module,
 )

--- a/v2/yarpcfx/internal/internaltransportfx/module.go
+++ b/v2/yarpcfx/internal/internaltransportfx/module.go
@@ -18,28 +18,18 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package yarpcfx
+package internaltransportfx
 
 import (
 	"go.uber.org/fx"
-	"go.uber.org/yarpc/v2/yarpcfx/internal/internalpeerlistfx"
-	"go.uber.org/yarpc/v2/yarpcfx/internal/internaltransportfx"
-	"go.uber.org/yarpc/v2/yarpcfx/yarpcfxmiddleware"
+	"go.uber.org/yarpc/v2/yarpcgrpcfx"
+	"go.uber.org/yarpc/v2/yarpchttpfx"
+	"go.uber.org/yarpc/v2/yarpctchannelfx"
 )
 
-// Module provides YARPC integration for services. The module produces a
-// yarpc.Router, yarpc.ClientProvider and configuration for transports, peer
-// lists and middleware.
+// Module provides all transports Fx application.
 var Module = fx.Options(
-	fx.Provide(
-		newClientProvider,
-		newDialerProvider,
-		newChooserProvider,
-		newListProvider,
-		newRouter,
-	),
-
-	yarpcfxmiddleware.Module,
-	internaltransportfx.Module,
-	internalpeerlistfx.Module,
+	yarpchttpfx.Module,
+	yarpctchannelfx.Module,
+	yarpcgrpcfx.Module,
 )

--- a/v2/yarpcfx/module.go
+++ b/v2/yarpcfx/module.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpcfx
+
+import (
+	"go.uber.org/fx"
+)
+
+// Module provides YARPC integration for services. The module produces
+// a yarpc.Router and a yarpc.ClientProvider.
+var Module = fx.Options(
+	fx.Provide(NewClientProvider),
+	fx.Provide(NewDialerProvider),
+	fx.Provide(NewChooserProvider),
+	fx.Provide(NewListProvider),
+	fx.Provide(NewRouter),
+)

--- a/v2/yarpcfx/module.go
+++ b/v2/yarpcfx/module.go
@@ -27,9 +27,10 @@ import (
 // Module provides YARPC integration for services. The module produces
 // a yarpc.Router and a yarpc.ClientProvider.
 var Module = fx.Options(
-	fx.Provide(NewClientProvider),
-	fx.Provide(NewDialerProvider),
-	fx.Provide(NewChooserProvider),
-	fx.Provide(NewListProvider),
-	fx.Provide(NewRouter),
+	// yarpcfx
+	fx.Provide(newClientProvider),
+	fx.Provide(newDialerProvider),
+	fx.Provide(newChooserProvider),
+	fx.Provide(newListProvider),
+	fx.Provide(newRouter),
 )

--- a/v2/yarpcfx/module.go
+++ b/v2/yarpcfx/module.go
@@ -22,15 +22,41 @@ package yarpcfx
 
 import (
 	"go.uber.org/fx"
+	"go.uber.org/yarpc/v2/yarpcfx/yarpcfxmiddleware"
+	"go.uber.org/yarpc/v2/yarpchttpfx"
+	"go.uber.org/yarpc/v2/yarpcpendingheapfx"
+	"go.uber.org/yarpc/v2/yarpcrandpeerfx"
+	"go.uber.org/yarpc/v2/yarpcroundrobinfx"
+	"go.uber.org/yarpc/v2/yarpctchannelfx"
+	"go.uber.org/yarpc/v2/yarpctworandomchoicesfx"
 )
 
 // Module provides YARPC integration for services. The module produces
 // a yarpc.Router and a yarpc.ClientProvider.
 var Module = fx.Options(
-	// yarpcfx
-	fx.Provide(newClientProvider),
-	fx.Provide(newDialerProvider),
-	fx.Provide(newChooserProvider),
-	fx.Provide(newListProvider),
-	fx.Provide(newRouter),
+
+	fx.Provide( // yarpcfx
+		newClientProvider,
+		newDialerProvider,
+		newChooserProvider,
+		newListProvider,
+		newRouter,
+	),
+
+	fx.Provide( // transports
+		yarpchttpfx.Module,
+		yarpctchannelfx.Module,
+		// TODO(apeatsbond): grpcfx when #1652 lands
+	),
+
+	fx.Provide( // peer lists
+		yarpcpendingheapfx.Module,
+		yarpcroundrobinfx.Module,
+		yarpcrandpeerfx.Module,
+		yarpctworandomchoicesfx.Module,
+	),
+
+	fx.Provide( // middleware
+		yarpcfxmiddleware.Module,
+	),
 )

--- a/v2/yarpcfx/yarpcfx.go
+++ b/v2/yarpcfx/yarpcfx.go
@@ -30,18 +30,6 @@ import (
 	"go.uber.org/yarpc/v2/yarpcrouter"
 )
 
-const _name = "yarpcfx"
-
-// Module provides YARPC integration for services. The module produces
-// a yarpc.Router and a yarpc.ClientProvider.
-var Module = fx.Options(
-	fx.Provide(NewClientProvider),
-	fx.Provide(NewDialerProvider),
-	fx.Provide(NewChooserProvider),
-	fx.Provide(NewListProvider),
-	fx.Provide(NewRouter),
-)
-
 // ClientProviderParams defines the dependencies of this module.
 type ClientProviderParams struct {
 	fx.In

--- a/v2/yarpcfx/yarpcfx.go
+++ b/v2/yarpcfx/yarpcfx.go
@@ -47,8 +47,8 @@ type ClientProviderResult struct {
 	Provider yarpc.ClientProvider
 }
 
-// NewClientProvider provides a yarpc.ClientProvider to the Fx application.
-func NewClientProvider(p ClientProviderParams) (ClientProviderResult, error) {
+// newClientProvider provides a yarpc.ClientProvider to the Fx application.
+func newClientProvider(p ClientProviderParams) (ClientProviderResult, error) {
 	clients := p.Clients
 	for _, cl := range p.ClientLists {
 		clients = append(clients, cl...)
@@ -84,8 +84,8 @@ type DialerProviderResult struct {
 	Provider yarpc.DialerProvider
 }
 
-// NewDialerProvider provides a yarpc.DialerProvider to the Fx application.
-func NewDialerProvider(p DialerProviderParams) (DialerProviderResult, error) {
+// newDialerProvider provides a yarpc.DialerProvider to the Fx application.
+func newDialerProvider(p DialerProviderParams) (DialerProviderResult, error) {
 	dialers := p.Dialers
 	for _, dl := range p.DialerLists {
 		dialers = append(dialers, dl...)
@@ -114,8 +114,8 @@ type ChooserProviderResult struct {
 	Provider yarpc.ChooserProvider
 }
 
-// NewChooserProvider provides a yarpc.ChooserProvider to the Fx application.
-func NewChooserProvider(p ChooserProviderParams) (ChooserProviderResult, error) {
+// newChooserProvider provides a yarpc.ChooserProvider to the Fx application.
+func newChooserProvider(p ChooserProviderParams) (ChooserProviderResult, error) {
 	choosers := p.Choosers
 	for _, cl := range p.ChooserLists {
 		choosers = append(choosers, cl...)
@@ -144,8 +144,8 @@ type ListProviderResult struct {
 	Provider yarpc.ListProvider
 }
 
-// NewListProvider provides a yarpc.ListProvider to the Fx application.
-func NewListProvider(p ListProviderParams) (ListProviderResult, error) {
+// newListProvider provides a yarpc.ListProvider to the Fx application.
+func newListProvider(p ListProviderParams) (ListProviderResult, error) {
 	lists := p.Lists
 	for _, ll := range p.ListLists {
 		lists = append(lists, ll...)
@@ -178,9 +178,9 @@ type RouterResult struct {
 	Router yarpc.Router
 }
 
-// NewRouter registers procedures with a router, and produces it so
+// newRouter registers procedures with a router, and produces it so
 // that specific transport inbounds can depend upon it.
-func NewRouter(p RouterParams) (RouterResult, error) {
+func newRouter(p RouterParams) (RouterResult, error) {
 	procedures := p.Procedures
 	for _, pl := range p.ProcedureLists {
 		procedures = append(procedures, pl...)

--- a/v2/yarpcfx/yarpcfx_test.go
+++ b/v2/yarpcfx/yarpcfx_test.go
@@ -33,7 +33,7 @@ import (
 func TestNewClientProvider(t *testing.T) {
 	t.Run("duplicate registration error", func(t *testing.T) {
 		foo := yarpc.Client{Name: "foo"}
-		_, err := NewClientProvider(ClientProviderParams{
+		_, err := newClientProvider(ClientProviderParams{
 			Clients: []yarpc.Client{foo, foo},
 		})
 		assert.EqualError(t, err, `client "foo" was registered more than once`)
@@ -42,7 +42,7 @@ func TestNewClientProvider(t *testing.T) {
 		foo := yarpc.Client{Name: "foo", Caller: "foo-caller", Service: "foo-service"}
 		bar := yarpc.Client{Name: "bar", Caller: "bar-caller", Service: "bar-service"}
 
-		res, err := NewClientProvider(ClientProviderParams{
+		res, err := newClientProvider(ClientProviderParams{
 			Clients:     []yarpc.Client{foo},
 			ClientLists: [][]yarpc.Client{{bar}},
 		})
@@ -89,7 +89,7 @@ func TestClientHasMiddleware(t *testing.T) {
 		Unary: trans.NewOutbound(nil, yarpctest.OutboundCallOverride(out)),
 	}
 
-	result, err := NewClientProvider(ClientProviderParams{
+	result, err := newClientProvider(ClientProviderParams{
 		UnaryOutboundTransportMiddleware: []yarpc.UnaryOutboundTransportMiddleware{mw1, mw2},
 		Clients: []yarpc.Client{client},
 	})
@@ -107,7 +107,7 @@ func TestClientHasMiddleware(t *testing.T) {
 func TestNewDialerProvider(t *testing.T) {
 	t.Run("duplicate registration error", func(t *testing.T) {
 		foo := yarpctest.NewFakeDialer("foo")
-		_, err := NewDialerProvider(DialerProviderParams{
+		_, err := newDialerProvider(DialerProviderParams{
 			Dialers: []yarpc.Dialer{foo, foo},
 		})
 		assert.EqualError(t, err, `dialer "foo" was registered more than once`)
@@ -116,7 +116,7 @@ func TestNewDialerProvider(t *testing.T) {
 		foo := yarpctest.NewFakeDialer("foo")
 		bar := yarpctest.NewFakeDialer("bar")
 
-		res, err := NewDialerProvider(DialerProviderParams{
+		res, err := newDialerProvider(DialerProviderParams{
 			Dialers:     []yarpc.Dialer{foo},
 			DialerLists: [][]yarpc.Dialer{{bar}},
 		})
@@ -137,7 +137,7 @@ func TestNewDialerProvider(t *testing.T) {
 func TestNewChooserProvider(t *testing.T) {
 	t.Run("duplicate registration error", func(t *testing.T) {
 		foo := yarpctest.NewFakePeerChooser("foo")
-		_, err := NewChooserProvider(ChooserProviderParams{
+		_, err := newChooserProvider(ChooserProviderParams{
 			Choosers: []yarpc.Chooser{foo, foo},
 		})
 		assert.EqualError(t, err, `chooser "foo" was registered more than once`)
@@ -146,7 +146,7 @@ func TestNewChooserProvider(t *testing.T) {
 		foo := yarpctest.NewFakePeerChooser("foo")
 		bar := yarpctest.NewFakePeerChooser("bar")
 
-		res, err := NewChooserProvider(ChooserProviderParams{
+		res, err := newChooserProvider(ChooserProviderParams{
 			Choosers:     []yarpc.Chooser{foo},
 			ChooserLists: [][]yarpc.Chooser{{bar}},
 		})
@@ -167,7 +167,7 @@ func TestNewChooserProvider(t *testing.T) {
 func TestNewListProvider(t *testing.T) {
 	t.Run("duplicate registration error", func(t *testing.T) {
 		foo := yarpctest.NewFakePeerList("foo")
-		_, err := NewListProvider(ListProviderParams{
+		_, err := newListProvider(ListProviderParams{
 			Lists: []yarpc.List{foo, foo},
 		})
 		assert.EqualError(t, err, `list "foo" was registered more than once`)
@@ -176,7 +176,7 @@ func TestNewListProvider(t *testing.T) {
 		foo := yarpctest.NewFakePeerList("foo")
 		bar := yarpctest.NewFakePeerList("bar")
 
-		res, err := NewListProvider(ListProviderParams{
+		res, err := newListProvider(ListProviderParams{
 			Lists:     []yarpc.List{foo},
 			ListLists: [][]yarpc.List{{bar}},
 		})
@@ -201,7 +201,7 @@ func TestNewRouter(t *testing.T) {
 		{Name: "Hello::SecondList"},
 	}
 
-	res, err := NewRouter(RouterParams{
+	res, err := newRouter(RouterParams{
 		Procedures:     []yarpc.TransportProcedure{single},
 		ProcedureLists: [][]yarpc.TransportProcedure{list},
 	})
@@ -233,7 +233,7 @@ func TestNewRouterWithInboundMiddleware(t *testing.T) {
 		},
 	}
 
-	result, err := NewRouter(RouterParams{
+	result, err := newRouter(RouterParams{
 		Procedures:               procedures,
 		UnaryTransportMiddleware: unaryMiddleware,
 	})

--- a/v2/yarpcfx/yarpcfxmiddleware/constants.go
+++ b/v2/yarpcfx/yarpcfxmiddleware/constants.go
@@ -18,21 +18,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package yarpcmiddlewarefx
+package yarpcfxmiddleware
 
-import (
-	"go.uber.org/fx"
-)
-
-// Module produces ordered slices of middleware according to
-// the middleware configuration.
-var Module = fx.Provide(
-	NewOutboundTransportConfig,
-	NewUnaryOutboundTransport,
-
-	NewInboundTransportConfig,
-	NewUnaryInboundTransport,
-
-	NewInboundEncodingConfig,
-	NewUnaryInboundEncoding,
+const (
+	outboundTransportConfigurationKey = "yarpc.middleware.outbounds.transport"
+	inboundTransportConfigurationKey  = "yarpc.middleware.inbounds.transport"
+	inboundEncodingConfigurationKey   = "yarpc.middleware.inbounds.encoding"
 )

--- a/v2/yarpcfx/yarpcfxmiddleware/inbound_encoding.go
+++ b/v2/yarpcfx/yarpcfxmiddleware/inbound_encoding.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package yarpcmiddlewarefx
+package yarpcfxmiddleware
 
 import (
 	"fmt"

--- a/v2/yarpcfx/yarpcfxmiddleware/inbound_encoding.go
+++ b/v2/yarpcfx/yarpcfxmiddleware/inbound_encoding.go
@@ -48,8 +48,8 @@ type InboundEncodingConfigResult struct {
 	Config InboundEncodingConfig
 }
 
-// NewInboundEncodingConfig produces an UnaryInboundEncodingConfig.
-func NewInboundEncodingConfig(p InboundEncodingConfigParams) (InboundEncodingConfigResult, error) {
+// newInboundEncodingConfig produces an UnaryInboundEncodingConfig.
+func newInboundEncodingConfig(p InboundEncodingConfigParams) (InboundEncodingConfigResult, error) {
 	mc := InboundEncodingConfig{}
 	if err := p.Provider.Get(inboundEncodingConfigurationKey).Populate(&mc); err != nil {
 		return InboundEncodingConfigResult{}, err
@@ -76,8 +76,8 @@ type UnaryInboundEncodingResult struct {
 	OrderedMiddleware []yarpc.UnaryInboundEncodingMiddleware `name:"yarpcfx"`
 }
 
-// NewUnaryInboundEncoding produces an ordered slice of unary inbound encoding middleware.
-func NewUnaryInboundEncoding(
+// newUnaryInboundEncoding produces an ordered slice of unary inbound encoding middleware.
+func newUnaryInboundEncoding(
 	p UnaryInboundEncodingParams,
 ) (UnaryInboundEncodingResult, error) {
 	// Collect all of the middleware into a single slice.

--- a/v2/yarpcfx/yarpcfxmiddleware/inbound_encoding_test.go
+++ b/v2/yarpcfx/yarpcfxmiddleware/inbound_encoding_test.go
@@ -35,7 +35,7 @@ func TestNewInboundEncodingConfig(t *testing.T) {
 	provider, err := config.NewYAML(config.Source(cfg))
 	require.NoError(t, err)
 
-	res, err := NewInboundEncodingConfig(InboundEncodingConfigParams{
+	res, err := newInboundEncodingConfig(InboundEncodingConfigParams{
 		Provider: provider,
 	})
 	require.NoError(t, err)
@@ -44,7 +44,7 @@ func TestNewInboundEncodingConfig(t *testing.T) {
 
 func TestNewUnaryInboundEncoding(t *testing.T) {
 	t.Run("duplicate registration error", func(t *testing.T) {
-		_, err := NewUnaryInboundEncoding(
+		_, err := newUnaryInboundEncoding(
 			UnaryInboundEncodingParams{
 				Middleware: []yarpc.UnaryInboundEncodingMiddleware{
 					yarpc.NopUnaryInboundEncodingMiddleware,
@@ -56,7 +56,7 @@ func TestNewUnaryInboundEncoding(t *testing.T) {
 	})
 
 	t.Run("configured middleware is not available", func(t *testing.T) {
-		_, err := NewUnaryInboundEncoding(
+		_, err := newUnaryInboundEncoding(
 			UnaryInboundEncodingParams{
 				Config: InboundEncodingConfig{
 					Unary: []string{"dne"},
@@ -67,7 +67,7 @@ func TestNewUnaryInboundEncoding(t *testing.T) {
 	})
 
 	t.Run("successful construction", func(t *testing.T) {
-		res, err := NewUnaryInboundEncoding(
+		res, err := newUnaryInboundEncoding(
 			UnaryInboundEncodingParams{
 				Config: InboundEncodingConfig{
 					Unary: []string{"nop"},

--- a/v2/yarpcfx/yarpcfxmiddleware/inbound_encoding_test.go
+++ b/v2/yarpcfx/yarpcfxmiddleware/inbound_encoding_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package yarpcmiddlewarefx
+package yarpcfxmiddleware
 
 import (
 	"strings"
@@ -30,51 +30,51 @@ import (
 	yarpc "go.uber.org/yarpc/v2"
 )
 
-func TestNewInboundTransportConfig(t *testing.T) {
-	cfg := strings.NewReader(`yarpc: {middleware: {inbounds: {transport: {unary: ["nop"]}}}}`)
+func TestNewInboundEncodingConfig(t *testing.T) {
+	cfg := strings.NewReader(`yarpc: {middleware: {inbounds: {encoding: {unary: ["nop"]}}}}`)
 	provider, err := config.NewYAML(config.Source(cfg))
 	require.NoError(t, err)
 
-	res, err := NewInboundTransportConfig(InboundTransportConfigParams{
+	res, err := NewInboundEncodingConfig(InboundEncodingConfigParams{
 		Provider: provider,
 	})
 	require.NoError(t, err)
-	assert.Equal(t, InboundTransportConfig{Unary: []string{"nop"}}, res.Config)
+	assert.Equal(t, InboundEncodingConfig{Unary: []string{"nop"}}, res.Config)
 }
 
-func TestNewUnaryInboundTransport(t *testing.T) {
+func TestNewUnaryInboundEncoding(t *testing.T) {
 	t.Run("duplicate registration error", func(t *testing.T) {
-		_, err := NewUnaryInboundTransport(
-			UnaryInboundTransportParams{
-				Middleware: []yarpc.UnaryInboundTransportMiddleware{
-					yarpc.NopUnaryInboundTransportMiddleware,
-					yarpc.NopUnaryInboundTransportMiddleware,
+		_, err := NewUnaryInboundEncoding(
+			UnaryInboundEncodingParams{
+				Middleware: []yarpc.UnaryInboundEncodingMiddleware{
+					yarpc.NopUnaryInboundEncodingMiddleware,
+					yarpc.NopUnaryInboundEncodingMiddleware,
 				},
 			},
 		)
-		assert.EqualError(t, err, `unary inbound transport middleware "nop" was registered more than once`)
+		assert.EqualError(t, err, `unary inbound encoding middleware "nop" was registered more than once`)
 	})
 
 	t.Run("configured middleware is not available", func(t *testing.T) {
-		_, err := NewUnaryInboundTransport(
-			UnaryInboundTransportParams{
-				Config: InboundTransportConfig{
+		_, err := NewUnaryInboundEncoding(
+			UnaryInboundEncodingParams{
+				Config: InboundEncodingConfig{
 					Unary: []string{"dne"},
 				},
 			},
 		)
-		assert.EqualError(t, err, `failed to resolve unary inbound transport middleware: "dne"`)
+		assert.EqualError(t, err, `failed to resolve unary inbound encoding middleware: "dne"`)
 	})
 
 	t.Run("successful construction", func(t *testing.T) {
-		res, err := NewUnaryInboundTransport(
-			UnaryInboundTransportParams{
-				Config: InboundTransportConfig{
+		res, err := NewUnaryInboundEncoding(
+			UnaryInboundEncodingParams{
+				Config: InboundEncodingConfig{
 					Unary: []string{"nop"},
 				},
-				MiddlewareLists: [][]yarpc.UnaryInboundTransportMiddleware{
+				MiddlewareLists: [][]yarpc.UnaryInboundEncodingMiddleware{
 					{
-						yarpc.NopUnaryInboundTransportMiddleware,
+						yarpc.NopUnaryInboundEncodingMiddleware,
 					},
 				},
 			},

--- a/v2/yarpcfx/yarpcfxmiddleware/inbound_transport.go
+++ b/v2/yarpcfx/yarpcfxmiddleware/inbound_transport.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package yarpcmiddlewarefx
+package yarpcfxmiddleware
 
 import (
 	"fmt"

--- a/v2/yarpcfx/yarpcfxmiddleware/inbound_transport.go
+++ b/v2/yarpcfx/yarpcfxmiddleware/inbound_transport.go
@@ -48,8 +48,8 @@ type InboundTransportConfigResult struct {
 	Config InboundTransportConfig
 }
 
-// NewInboundTransportConfig produces an UnaryInboundTransportConfig.
-func NewInboundTransportConfig(p InboundTransportConfigParams) (InboundTransportConfigResult, error) {
+// newInboundTransportConfig produces an UnaryInboundTransportConfig.
+func newInboundTransportConfig(p InboundTransportConfigParams) (InboundTransportConfigResult, error) {
 	mc := InboundTransportConfig{}
 	if err := p.Provider.Get(inboundTransportConfigurationKey).Populate(&mc); err != nil {
 		return InboundTransportConfigResult{}, err
@@ -76,8 +76,8 @@ type UnaryInboundTransportResult struct {
 	OrderedMiddleware []yarpc.UnaryInboundTransportMiddleware `name:"yarpcfx"`
 }
 
-// NewUnaryInboundTransport produces an ordered slice of unary inbound transport middleware.
-func NewUnaryInboundTransport(
+// newUnaryInboundTransport produces an ordered slice of unary inbound transport middleware.
+func newUnaryInboundTransport(
 	p UnaryInboundTransportParams,
 ) (UnaryInboundTransportResult, error) {
 	// Collect all of the middleware into a single slice.

--- a/v2/yarpcfx/yarpcfxmiddleware/inbound_transport_test.go
+++ b/v2/yarpcfx/yarpcfxmiddleware/inbound_transport_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package yarpcmiddlewarefx
+package yarpcfxmiddleware
 
 import (
 	"strings"
@@ -30,51 +30,51 @@ import (
 	yarpc "go.uber.org/yarpc/v2"
 )
 
-func TestNewOutboundTransportConfig(t *testing.T) {
-	cfg := strings.NewReader(`yarpc: {middleware: {outbounds: {transport: {unary: ["nop"]}}}}`)
+func TestNewInboundTransportConfig(t *testing.T) {
+	cfg := strings.NewReader(`yarpc: {middleware: {inbounds: {transport: {unary: ["nop"]}}}}`)
 	provider, err := config.NewYAML(config.Source(cfg))
 	require.NoError(t, err)
 
-	res, err := NewOutboundTransportConfig(OutboundTransportConfigParams{
+	res, err := NewInboundTransportConfig(InboundTransportConfigParams{
 		Provider: provider,
 	})
 	require.NoError(t, err)
-	assert.Equal(t, OutboundTransportConfig{Unary: []string{"nop"}}, res.Config)
+	assert.Equal(t, InboundTransportConfig{Unary: []string{"nop"}}, res.Config)
 }
 
-func TestNewUnaryOutboundTransport(t *testing.T) {
+func TestNewUnaryInboundTransport(t *testing.T) {
 	t.Run("duplicate registration error", func(t *testing.T) {
-		_, err := NewUnaryOutboundTransport(
-			UnaryOutboundTransportParams{
-				Middleware: []yarpc.UnaryOutboundTransportMiddleware{
-					yarpc.NopUnaryOutboundTransportMiddleware,
-					yarpc.NopUnaryOutboundTransportMiddleware,
+		_, err := NewUnaryInboundTransport(
+			UnaryInboundTransportParams{
+				Middleware: []yarpc.UnaryInboundTransportMiddleware{
+					yarpc.NopUnaryInboundTransportMiddleware,
+					yarpc.NopUnaryInboundTransportMiddleware,
 				},
 			},
 		)
-		assert.EqualError(t, err, `unary outbound transport middleware "nop" was registered more than once`)
+		assert.EqualError(t, err, `unary inbound transport middleware "nop" was registered more than once`)
 	})
 
 	t.Run("configured middleware is not available", func(t *testing.T) {
-		_, err := NewUnaryOutboundTransport(
-			UnaryOutboundTransportParams{
-				Config: OutboundTransportConfig{
+		_, err := NewUnaryInboundTransport(
+			UnaryInboundTransportParams{
+				Config: InboundTransportConfig{
 					Unary: []string{"dne"},
 				},
 			},
 		)
-		assert.EqualError(t, err, `failed to resolve unary outbound transport middleware: "dne"`)
+		assert.EqualError(t, err, `failed to resolve unary inbound transport middleware: "dne"`)
 	})
 
 	t.Run("successful construction", func(t *testing.T) {
-		res, err := NewUnaryOutboundTransport(
-			UnaryOutboundTransportParams{
-				Config: OutboundTransportConfig{
+		res, err := NewUnaryInboundTransport(
+			UnaryInboundTransportParams{
+				Config: InboundTransportConfig{
 					Unary: []string{"nop"},
 				},
-				MiddlewareLists: [][]yarpc.UnaryOutboundTransportMiddleware{
+				MiddlewareLists: [][]yarpc.UnaryInboundTransportMiddleware{
 					{
-						yarpc.NopUnaryOutboundTransportMiddleware,
+						yarpc.NopUnaryInboundTransportMiddleware,
 					},
 				},
 			},

--- a/v2/yarpcfx/yarpcfxmiddleware/inbound_transport_test.go
+++ b/v2/yarpcfx/yarpcfxmiddleware/inbound_transport_test.go
@@ -35,7 +35,7 @@ func TestNewInboundTransportConfig(t *testing.T) {
 	provider, err := config.NewYAML(config.Source(cfg))
 	require.NoError(t, err)
 
-	res, err := NewInboundTransportConfig(InboundTransportConfigParams{
+	res, err := newInboundTransportConfig(InboundTransportConfigParams{
 		Provider: provider,
 	})
 	require.NoError(t, err)
@@ -44,7 +44,7 @@ func TestNewInboundTransportConfig(t *testing.T) {
 
 func TestNewUnaryInboundTransport(t *testing.T) {
 	t.Run("duplicate registration error", func(t *testing.T) {
-		_, err := NewUnaryInboundTransport(
+		_, err := newUnaryInboundTransport(
 			UnaryInboundTransportParams{
 				Middleware: []yarpc.UnaryInboundTransportMiddleware{
 					yarpc.NopUnaryInboundTransportMiddleware,
@@ -56,7 +56,7 @@ func TestNewUnaryInboundTransport(t *testing.T) {
 	})
 
 	t.Run("configured middleware is not available", func(t *testing.T) {
-		_, err := NewUnaryInboundTransport(
+		_, err := newUnaryInboundTransport(
 			UnaryInboundTransportParams{
 				Config: InboundTransportConfig{
 					Unary: []string{"dne"},
@@ -67,7 +67,7 @@ func TestNewUnaryInboundTransport(t *testing.T) {
 	})
 
 	t.Run("successful construction", func(t *testing.T) {
-		res, err := NewUnaryInboundTransport(
+		res, err := newUnaryInboundTransport(
 			UnaryInboundTransportParams{
 				Config: InboundTransportConfig{
 					Unary: []string{"nop"},

--- a/v2/yarpcfx/yarpcfxmiddleware/module.go
+++ b/v2/yarpcfx/yarpcfxmiddleware/module.go
@@ -27,12 +27,12 @@ import (
 // Module produces ordered slices of middleware according to
 // the middleware configuration.
 var Module = fx.Provide(
-	NewOutboundTransportConfig,
-	NewUnaryOutboundTransport,
+	newOutboundTransportConfig,
+	newUnaryOutboundTransport,
 
-	NewInboundTransportConfig,
-	NewUnaryInboundTransport,
+	newInboundTransportConfig,
+	newUnaryInboundTransport,
 
-	NewInboundEncodingConfig,
-	NewUnaryInboundEncoding,
+	newInboundEncodingConfig,
+	newUnaryInboundEncoding,
 )

--- a/v2/yarpcfx/yarpcfxmiddleware/module.go
+++ b/v2/yarpcfx/yarpcfxmiddleware/module.go
@@ -18,10 +18,21 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package yarpcmiddlewarefx
+package yarpcfxmiddleware
 
-const (
-	outboundTransportConfigurationKey = "yarpc.middleware.outbounds.transport"
-	inboundTransportConfigurationKey  = "yarpc.middleware.inbounds.transport"
-	inboundEncodingConfigurationKey   = "yarpc.middleware.inbounds.encoding"
+import (
+	"go.uber.org/fx"
+)
+
+// Module produces ordered slices of middleware according to
+// the middleware configuration.
+var Module = fx.Provide(
+	NewOutboundTransportConfig,
+	NewUnaryOutboundTransport,
+
+	NewInboundTransportConfig,
+	NewUnaryInboundTransport,
+
+	NewInboundEncodingConfig,
+	NewUnaryInboundEncoding,
 )

--- a/v2/yarpcfx/yarpcfxmiddleware/outbound_transport.go
+++ b/v2/yarpcfx/yarpcfxmiddleware/outbound_transport.go
@@ -48,8 +48,8 @@ type OutboundTransportConfigResult struct {
 	Config OutboundTransportConfig
 }
 
-// NewOutboundTransportConfig produces an UnaryOutboundTransportConfig.
-func NewOutboundTransportConfig(p OutboundTransportConfigParams) (OutboundTransportConfigResult, error) {
+// newOutboundTransportConfig produces an UnaryOutboundTransportConfig.
+func newOutboundTransportConfig(p OutboundTransportConfigParams) (OutboundTransportConfigResult, error) {
 	mc := OutboundTransportConfig{}
 	if err := p.Provider.Get(outboundTransportConfigurationKey).Populate(&mc); err != nil {
 		return OutboundTransportConfigResult{}, err
@@ -76,8 +76,8 @@ type UnaryOutboundTransportResult struct {
 	OrderedMiddleware []yarpc.UnaryOutboundTransportMiddleware `name:"yarpcfx"`
 }
 
-// NewUnaryOutboundTransport produces an ordered slice of unary outbound transport middleware.
-func NewUnaryOutboundTransport(
+// newUnaryOutboundTransport produces an ordered slice of unary outbound transport middleware.
+func newUnaryOutboundTransport(
 	p UnaryOutboundTransportParams,
 ) (UnaryOutboundTransportResult, error) {
 	// Collect all of the middleware into a single slice.

--- a/v2/yarpcfx/yarpcfxmiddleware/outbound_transport.go
+++ b/v2/yarpcfx/yarpcfxmiddleware/outbound_transport.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package yarpcmiddlewarefx
+package yarpcfxmiddleware
 
 import (
 	"fmt"

--- a/v2/yarpcfx/yarpcfxmiddleware/outbound_transport_test.go
+++ b/v2/yarpcfx/yarpcfxmiddleware/outbound_transport_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package yarpcmiddlewarefx
+package yarpcfxmiddleware
 
 import (
 	"strings"
@@ -30,51 +30,51 @@ import (
 	yarpc "go.uber.org/yarpc/v2"
 )
 
-func TestNewInboundEncodingConfig(t *testing.T) {
-	cfg := strings.NewReader(`yarpc: {middleware: {inbounds: {encoding: {unary: ["nop"]}}}}`)
+func TestNewOutboundTransportConfig(t *testing.T) {
+	cfg := strings.NewReader(`yarpc: {middleware: {outbounds: {transport: {unary: ["nop"]}}}}`)
 	provider, err := config.NewYAML(config.Source(cfg))
 	require.NoError(t, err)
 
-	res, err := NewInboundEncodingConfig(InboundEncodingConfigParams{
+	res, err := NewOutboundTransportConfig(OutboundTransportConfigParams{
 		Provider: provider,
 	})
 	require.NoError(t, err)
-	assert.Equal(t, InboundEncodingConfig{Unary: []string{"nop"}}, res.Config)
+	assert.Equal(t, OutboundTransportConfig{Unary: []string{"nop"}}, res.Config)
 }
 
-func TestNewUnaryInboundEncoding(t *testing.T) {
+func TestNewUnaryOutboundTransport(t *testing.T) {
 	t.Run("duplicate registration error", func(t *testing.T) {
-		_, err := NewUnaryInboundEncoding(
-			UnaryInboundEncodingParams{
-				Middleware: []yarpc.UnaryInboundEncodingMiddleware{
-					yarpc.NopUnaryInboundEncodingMiddleware,
-					yarpc.NopUnaryInboundEncodingMiddleware,
+		_, err := NewUnaryOutboundTransport(
+			UnaryOutboundTransportParams{
+				Middleware: []yarpc.UnaryOutboundTransportMiddleware{
+					yarpc.NopUnaryOutboundTransportMiddleware,
+					yarpc.NopUnaryOutboundTransportMiddleware,
 				},
 			},
 		)
-		assert.EqualError(t, err, `unary inbound encoding middleware "nop" was registered more than once`)
+		assert.EqualError(t, err, `unary outbound transport middleware "nop" was registered more than once`)
 	})
 
 	t.Run("configured middleware is not available", func(t *testing.T) {
-		_, err := NewUnaryInboundEncoding(
-			UnaryInboundEncodingParams{
-				Config: InboundEncodingConfig{
+		_, err := NewUnaryOutboundTransport(
+			UnaryOutboundTransportParams{
+				Config: OutboundTransportConfig{
 					Unary: []string{"dne"},
 				},
 			},
 		)
-		assert.EqualError(t, err, `failed to resolve unary inbound encoding middleware: "dne"`)
+		assert.EqualError(t, err, `failed to resolve unary outbound transport middleware: "dne"`)
 	})
 
 	t.Run("successful construction", func(t *testing.T) {
-		res, err := NewUnaryInboundEncoding(
-			UnaryInboundEncodingParams{
-				Config: InboundEncodingConfig{
+		res, err := NewUnaryOutboundTransport(
+			UnaryOutboundTransportParams{
+				Config: OutboundTransportConfig{
 					Unary: []string{"nop"},
 				},
-				MiddlewareLists: [][]yarpc.UnaryInboundEncodingMiddleware{
+				MiddlewareLists: [][]yarpc.UnaryOutboundTransportMiddleware{
 					{
-						yarpc.NopUnaryInboundEncodingMiddleware,
+						yarpc.NopUnaryOutboundTransportMiddleware,
 					},
 				},
 			},

--- a/v2/yarpcfx/yarpcfxmiddleware/outbound_transport_test.go
+++ b/v2/yarpcfx/yarpcfxmiddleware/outbound_transport_test.go
@@ -35,7 +35,7 @@ func TestNewOutboundTransportConfig(t *testing.T) {
 	provider, err := config.NewYAML(config.Source(cfg))
 	require.NoError(t, err)
 
-	res, err := NewOutboundTransportConfig(OutboundTransportConfigParams{
+	res, err := newOutboundTransportConfig(OutboundTransportConfigParams{
 		Provider: provider,
 	})
 	require.NoError(t, err)
@@ -44,7 +44,7 @@ func TestNewOutboundTransportConfig(t *testing.T) {
 
 func TestNewUnaryOutboundTransport(t *testing.T) {
 	t.Run("duplicate registration error", func(t *testing.T) {
-		_, err := NewUnaryOutboundTransport(
+		_, err := newUnaryOutboundTransport(
 			UnaryOutboundTransportParams{
 				Middleware: []yarpc.UnaryOutboundTransportMiddleware{
 					yarpc.NopUnaryOutboundTransportMiddleware,
@@ -56,7 +56,7 @@ func TestNewUnaryOutboundTransport(t *testing.T) {
 	})
 
 	t.Run("configured middleware is not available", func(t *testing.T) {
-		_, err := NewUnaryOutboundTransport(
+		_, err := newUnaryOutboundTransport(
 			UnaryOutboundTransportParams{
 				Config: OutboundTransportConfig{
 					Unary: []string{"dne"},
@@ -67,7 +67,7 @@ func TestNewUnaryOutboundTransport(t *testing.T) {
 	})
 
 	t.Run("successful construction", func(t *testing.T) {
-		res, err := NewUnaryOutboundTransport(
+		res, err := newUnaryOutboundTransport(
 			UnaryOutboundTransportParams{
 				Config: OutboundTransportConfig{
 					Unary: []string{"nop"},

--- a/v2/yarpcrouter/router.go
+++ b/v2/yarpcrouter/router.go
@@ -46,14 +46,12 @@ type MapRouter struct {
 	serviceNames              map[string]struct{}
 }
 
-// NewMapRouter builds a new MapRouter that uses the given name as the
-// default service name and registers the given procedures.
+// NewMapRouter builds a new MapRouter that uses the given name as the default
+// service name and registers the given procedures.
 //
-// If a provided procedure does not specify its service name, it will
-// inherit the default service name. Multiple procedures with the
-// same name and service name may exist if they handle different encodings.
-// If a procedure does not specify an encoding, it can only support one handler.
-// The router will select that handler regardless of the encoding.
+// If a provided procedure does not specify its service name, it will inherit
+// the default service name. Multiple procedures with the same name and service
+// name may exist if they handle different encodings.
 func NewMapRouter(defaultService string, rs []yarpc.TransportProcedure) MapRouter {
 	router := MapRouter{
 		defaultService:            defaultService,


### PR DESCRIPTION
This cleans up a variety of Fx changes
- moves `yarpcmiddlewarefx` within the `yarpcfx` package
- makes the constructors in yarpcfx all private
- adds a `yarpcfx.Module` for users to add to their service

Commits are individually reviewable.