### PR TITLE
Fix peer list lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Fixed
+- Upgrade a read-lock to a read-write lock around peer selection.
+  This addresses a data race observed in production that results in broken peer
+  list invariants.
 
 ## [1.35.2] - 2018-11-06
 ### Removed

--- a/peer/peerlist/doc.go
+++ b/peer/peerlist/doc.go
@@ -47,4 +47,10 @@
 //   	}
 //   }
 //
+// The abstract peer list is designed to take responsibility for concurrently
+// communicating with three parties: the outbound (which sees it as a
+// peer.Chooser), the peer list updater (which see it as a peer.List), and the
+// transport (which sees it as a bank of peer.Subscriber).
+// By taking care of concurrency, the abstract peer list frees the
+// Implementation from the concern of thread safety.
 package peerlist

--- a/peer/peerlist/v2/doc.go
+++ b/peer/peerlist/v2/doc.go
@@ -42,4 +42,10 @@
 //   	}
 //   }
 //
+// The abstract peer list is designed to take responsibility for concurrently
+// communicating with three parties: the outbound (which sees it as a
+// peer.Chooser), the peer list updater (which see it as a peer.List), and the
+// transport (which sees it as a bank of peer.Subscriber).
+// By taking care of concurrency, the abstract peer list frees the
+// Implementation from the concern of thread safety.
 package peerlist

--- a/peer/peerlist/v2/list.go
+++ b/peer/peerlist/v2/list.go
@@ -416,11 +416,17 @@ func (pl *List) Choose(ctx context.Context, req *transport.Request) (peer.Peer, 
 	}
 
 	for {
-		pl.lock.RLock()
+		pl.lock.Lock()
 		p := pl.availableChooser.Choose(ctx, req)
-		pl.lock.RUnlock()
+		pl.lock.Unlock()
 
 		if p != nil {
+			// A nil peer is an indication that there are no more peers
+			// available for pending choices.
+			// A non-nil peer indicates that we have drained the waiting
+			// channel but there may be other peer lists waiting for a peer.
+			// We re-fill the channel enabling those choices to proceed
+			// concurrently.
 			t := p.(*peerThunk)
 			pl.notifyPeerAvailable()
 			t.StartRequest()


### PR DESCRIPTION
This addresses a data race observed in production that would invalidate peer
list invariants.
All peer lists mutate internal structures during peer selection.