### PR TITLE
[v2] Replace StreamMessage with yarpc.Buffer

### DIFF
--- a/v2/CHANGES
+++ b/v2/CHANGES
@@ -69,7 +69,7 @@
       should do something more specific once yarpc/yarpc.io#2 is resolved.
 - [ ] Consider teaching abstract peer list to prefer the req.Peer if it is
       present and the corresponding peer is immediately available.
-- [ ] Revisit StreamMessage, which should probably be a yarpc.Buffer now,
+- [x] Revisit StreamMessage, which should probably be a yarpc.Buffer now,
       simplifying the gRPC binding.
 - [x] Add support for yarpc.To and yarpc.ResponseFrom call options.
 

--- a/v2/internal/internalyarpcobservability/common_test.go
+++ b/v2/internal/internalyarpcobservability/common_test.go
@@ -66,6 +66,8 @@ func (o fakeOutbound) CallStream(ctx context.Context, request *yarpc.Request) (*
 	})
 }
 
+var _ yarpc.Stream = (*fakeStream)(nil)
+
 type fakeStream struct {
 	ctx     context.Context
 	request *yarpc.Request
@@ -79,11 +81,11 @@ func (s *fakeStream) Request() *yarpc.Request {
 	return s.request
 }
 
-func (s *fakeStream) SendMessage(context.Context, *yarpc.StreamMessage) error {
+func (s *fakeStream) SendMessage(context.Context, *yarpc.Buffer) error {
 	return nil
 }
 
-func (s *fakeStream) ReceiveMessage(context.Context) (*yarpc.StreamMessage, error) {
+func (s *fakeStream) ReceiveMessage(context.Context) (*yarpc.Buffer, error) {
 	return nil, nil
 }
 

--- a/v2/stream.go
+++ b/v2/stream.go
@@ -22,7 +22,6 @@ package yarpc
 
 import (
 	"context"
-	"io"
 
 	"go.uber.org/yarpc/v2/yarpcerror"
 )
@@ -58,13 +57,13 @@ func (s *ServerStream) Request() *Request {
 // SendMessage sends a request over the stream. It blocks until the message
 // has been sent.  In certain implementations, the timeout on the context
 // will be used to timeout the request.
-func (s *ServerStream) SendMessage(ctx context.Context, msg *StreamMessage) error {
+func (s *ServerStream) SendMessage(ctx context.Context, msg *Buffer) error {
 	return s.stream.SendMessage(ctx, msg)
 }
 
 // ReceiveMessage blocks until a message is received from the connection. It
 // returns an io.Reader with the contents of the message.
-func (s *ServerStream) ReceiveMessage(ctx context.Context) (*StreamMessage, error) {
+func (s *ServerStream) ReceiveMessage(ctx context.Context) (*Buffer, error) {
 	return s.stream.ReceiveMessage(ctx)
 }
 
@@ -99,13 +98,13 @@ func (s *ClientStream) Request() *Request {
 // SendMessage sends a request over the stream. It blocks until the message
 // has been sent.  In certain implementations, the timeout on the context
 // will be used to timeout the request.
-func (s *ClientStream) SendMessage(ctx context.Context, msg *StreamMessage) error {
+func (s *ClientStream) SendMessage(ctx context.Context, msg *Buffer) error {
 	return s.stream.SendMessage(ctx, msg)
 }
 
 // ReceiveMessage blocks until a message is received from the connection. It
 // returns an io.Reader with the contents of the message.
-func (s *ClientStream) ReceiveMessage(ctx context.Context) (*StreamMessage, error) {
+func (s *ClientStream) ReceiveMessage(ctx context.Context) (*Buffer, error) {
 	return s.stream.ReceiveMessage(ctx)
 }
 
@@ -134,17 +133,11 @@ type Stream interface {
 	// SendMessage sends a request over the stream. It blocks until the message
 	// has been sent.  In certain implementations, the timeout on the context
 	// will be used to timeout the request.
-	SendMessage(context.Context, *StreamMessage) error
+	SendMessage(context.Context, *Buffer) error
 
 	// ReceiveMessage blocks until a message is received from the connection. It
-	// returns an io.Reader with the contents of the message.
-	ReceiveMessage(context.Context) (*StreamMessage, error)
-}
-
-// StreamMessage represents information that can be read off of an individual
-// message in the stream.
-type StreamMessage struct {
-	Body io.ReadCloser
+	// returns a yarpc.Buffer with the contents of the message.
+	ReceiveMessage(context.Context) (*Buffer, error)
 }
 
 // StreamCloser represents an API of interacting with a Stream that is

--- a/v2/yarpcgrpc/stream_test.go
+++ b/v2/yarpcgrpc/stream_test.go
@@ -42,10 +42,7 @@ func newTestEchoStreamHandler(name string, numTimes int) []yarpc.TransportProced
 				return err
 			}
 
-			err = ss.SendMessage(context.Background(), &yarpc.StreamMessage{
-				Body: msg.Body,
-			})
-			if err != nil {
+			if err := ss.SendMessage(context.Background(), msg); err != nil {
 				return err
 			}
 		}
@@ -102,9 +99,7 @@ func TestStream(t *testing.T) {
 	// send and receive data
 	for i := 0; i < numSends; i++ {
 		sendMsg := fmt.Sprintf("hello world! %d", i)
-		sendStreamMsg := &yarpc.StreamMessage{
-			Body: ioutil.NopCloser(yarpc.NewBufferString(sendMsg)),
-		}
+		sendStreamMsg := yarpc.NewBufferString(sendMsg)
 
 		err := clientStream.SendMessage(context.Background(), sendStreamMsg)
 		require.NoError(t, err, "could not send message")
@@ -112,7 +107,7 @@ func TestStream(t *testing.T) {
 		recvMsg, err := clientStream.ReceiveMessage(context.Background())
 		require.NoError(t, err)
 
-		recvBytes, err := ioutil.ReadAll(recvMsg.Body)
+		recvBytes, err := ioutil.ReadAll(recvMsg)
 		require.NoError(t, err)
 		assert.Equal(t, sendMsg, string(recvBytes))
 	}

--- a/v2/yarpcprotobuf/marshal_test.go
+++ b/v2/yarpcprotobuf/marshal_test.go
@@ -21,7 +21,6 @@
 package yarpcprotobuf
 
 import (
-	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,7 +30,7 @@ import (
 
 func TestUnhandledEncoding(t *testing.T) {
 	t.Run("unmarshal: internal error", func(t *testing.T) {
-		err := unmarshal(yarpc.Encoding("foo"), bytes.NewReader([]byte("foo")), nil)
+		err := unmarshal(yarpc.Encoding("foo"), yarpc.NewBufferString("foo"), nil)
 		assert.Equal(t, yarpcerror.CodeInternal, yarpcerror.FromError(err).Code())
 	})
 

--- a/v2/yarpctest/mocks.go
+++ b/v2/yarpctest/mocks.go
@@ -470,9 +470,9 @@ func (mr *MockStreamMockRecorder) Context() *gomock.Call {
 }
 
 // ReceiveMessage mocks base method
-func (m *MockStream) ReceiveMessage(arg0 context.Context) (*v2.StreamMessage, error) {
+func (m *MockStream) ReceiveMessage(arg0 context.Context) (*v2.Buffer, error) {
 	ret := m.ctrl.Call(m, "ReceiveMessage", arg0)
-	ret0, _ := ret[0].(*v2.StreamMessage)
+	ret0, _ := ret[0].(*v2.Buffer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -495,7 +495,7 @@ func (mr *MockStreamMockRecorder) Request() *gomock.Call {
 }
 
 // SendMessage mocks base method
-func (m *MockStream) SendMessage(arg0 context.Context, arg1 *v2.StreamMessage) error {
+func (m *MockStream) SendMessage(arg0 context.Context, arg1 *v2.Buffer) error {
 	ret := m.ctrl.Call(m, "SendMessage", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -554,9 +554,9 @@ func (mr *MockStreamCloserMockRecorder) Context() *gomock.Call {
 }
 
 // ReceiveMessage mocks base method
-func (m *MockStreamCloser) ReceiveMessage(arg0 context.Context) (*v2.StreamMessage, error) {
+func (m *MockStreamCloser) ReceiveMessage(arg0 context.Context) (*v2.Buffer, error) {
 	ret := m.ctrl.Call(m, "ReceiveMessage", arg0)
-	ret0, _ := ret[0].(*v2.StreamMessage)
+	ret0, _ := ret[0].(*v2.Buffer)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -579,7 +579,7 @@ func (mr *MockStreamCloserMockRecorder) Request() *gomock.Call {
 }
 
 // SendMessage mocks base method
-func (m *MockStreamCloser) SendMessage(arg0 context.Context, arg1 *v2.StreamMessage) error {
+func (m *MockStreamCloser) SendMessage(arg0 context.Context, arg1 *v2.Buffer) error {
 	ret := m.ctrl.Call(m, "SendMessage", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0


### PR DESCRIPTION
This removes `yarpc.StreamMessage` in favour of using a `yarpc.Buffer` directly.