### PR TITLE
Adding a counter for application errors reflected type name as seen by the middleware

### DIFF
--- a/api/transport/response.go
+++ b/api/transport/response.go
@@ -24,9 +24,10 @@ import "io"
 
 // Response is the low level response representation.
 type Response struct {
-	Headers          Headers
-	Body             io.ReadCloser
-	ApplicationError bool
+	Headers                  Headers
+	Body                     io.ReadCloser
+	ApplicationError         bool
+	SpecificApplicationError error
 }
 
 // ResponseWriter allows Handlers to write responses in a streaming fashion.
@@ -46,4 +47,13 @@ type ResponseWriter interface {
 	// application error. If called, this MUST be called before any invocation
 	// of Write().
 	SetApplicationError()
+}
+
+// ResponseWriterV2 allows Handlers to write responses in a streaming fashion
+// and also specify an application error that might have happened in the call
+type ResponseWriterV2 interface {
+	ResponseWriter
+
+	// SpecifyApplicationError specifies the application error that happened on the call.
+	SpecifyApplicationError(error)
 }

--- a/api/transport/transporttest/reqres.go
+++ b/api/transport/transporttest/reqres.go
@@ -211,6 +211,7 @@ func (m ResponseMatcher) Matches(got interface{}) bool {
 // written to it.
 type FakeResponseWriter struct {
 	IsApplicationError bool
+	ApplicationError   error
 	Headers            transport.Headers
 	Body               bytes.Buffer
 }
@@ -218,6 +219,11 @@ type FakeResponseWriter struct {
 // SetApplicationError for FakeResponseWriter.
 func (fw *FakeResponseWriter) SetApplicationError() {
 	fw.IsApplicationError = true
+}
+
+// SpecifyApplicationError for FakeResponseWriter.
+func (fw *FakeResponseWriter) SpecifyApplicationError(err error) {
+	fw.ApplicationError = err
 }
 
 // AddHeaders for FakeResponseWriter.

--- a/encoding/thrift/inbound.go
+++ b/encoding/thrift/inbound.go
@@ -74,6 +74,10 @@ func (t thriftUnaryHandler) Handle(ctx context.Context, treq *transport.Request,
 
 	if res.IsApplicationError {
 		rw.SetApplicationError()
+
+		if responseWriterV2, ok := rw.(transport.ResponseWriterV2); ok {
+			responseWriterV2.SpecifyApplicationError(res.ApplicationError)
+		}
 	}
 
 	if err := call.WriteToResponse(rw); err != nil {

--- a/encoding/thrift/response.go
+++ b/encoding/thrift/response.go
@@ -27,4 +27,6 @@ type Response struct {
 	Body envelope.Enveloper
 
 	IsApplicationError bool
+
+	ApplicationError error
 }

--- a/internal/observability/common_test.go
+++ b/internal/observability/common_test.go
@@ -32,13 +32,21 @@ type fakeAck struct{}
 func (a fakeAck) String() string { return "" }
 
 type fakeHandler struct {
-	err            error
-	applicationErr bool
+	err              error
+	isApplicationErr bool
+	applicationError error
 }
 
 func (h fakeHandler) Handle(_ context.Context, _ *transport.Request, rw transport.ResponseWriter) error {
-	if h.applicationErr {
+	if h.isApplicationErr {
 		rw.SetApplicationError()
+
+		if h.applicationError != nil {
+			if rwV2, ok := rw.(transport.ResponseWriterV2); ok {
+				rwV2.SpecifyApplicationError(h.applicationError)
+			}
+		}
+
 		return nil
 	}
 	return h.err


### PR DESCRIPTION
This adds a _caller_failure_ counter with a specific _error_ reflected name for every inbound _caller_failure_ error.

This is specially important for teams using YARPC and Thrift because it allows for tailored monitoring and alerting.

One can compare this with HTTP status code: for a given endpoint, we might want to have a specific alert or dashboard for Internal Server Errors (500) and another one for Bad Requests (400) or a given specific Thrift error. 
Having a generic availability alert adds the overhead to the on-call engineer to investigate logs in the middle of an incident, to confirm they are not Bad Requests, for example. The alternative is to emit these stats from inside the service itself, which is error prone as it would require code to be added on the last return statement of every endpoint in the service.