### PR TITLE
Add EncodeError to InboundErrorCodec

### DIFF
--- a/v2/encoding.go
+++ b/v2/encoding.go
@@ -70,7 +70,7 @@ func (u *unaryTransportHandler) Handle(ctx context.Context, req *Request, reqBuf
 
 	decodedBody, err := codec.Decode(reqBuf)
 	if err != nil {
-		return res, nil, err
+		return nil, nil, err
 	}
 
 	body, appErr := u.h.HandlerSpec.Unary().Handle(ctx, decodedBody)
@@ -78,13 +78,13 @@ func (u *unaryTransportHandler) Handle(ctx context.Context, req *Request, reqBuf
 
 	encodedBody, err := codec.Encode(body)
 	if err != nil {
-		return res, nil, err
+		return nil, nil, err
 	}
 
 	if appErr != nil {
 		encodedError, err := codec.EncodeError(appErr)
 		if err != nil {
-			return res, nil, err
+			return nil, nil, err
 		}
 
 		errorInfo := yarpcerror.ExtractInfo(appErr)

--- a/v2/encoding.go
+++ b/v2/encoding.go
@@ -82,13 +82,14 @@ func (u *unaryTransportHandler) Handle(ctx context.Context, req *Request, reqBuf
 	}
 
 	if appErr != nil {
-		// TODO: This is a bit odd; we set the error in response AND return it.
-		// However, to preserve the current behavior of YARPC, this is
-		// necessary. This is most likely where the error details will be added,
-		// so we expect this to change.
+		encodedError, err := codec.EncodeError(appErr)
+		if err != nil {
+			return res, nil, err
+		}
+
 		errorInfo := yarpcerror.ExtractInfo(appErr)
 		res.ApplicationErrorInfo = &errorInfo
-		return res, encodedBody, appErr
+		return res, encodedError, nil
 	}
 
 	return res, encodedBody, nil

--- a/v2/router.go
+++ b/v2/router.go
@@ -107,6 +107,8 @@ type InboundCodec interface {
 	Decode(req *Buffer) (interface{}, error)
 
 	Encode(res interface{}) (*Buffer, error)
+
+	EncodeError(res error) (*Buffer, error)
 }
 
 // Router maintains and provides access to a collection of procedures

--- a/v2/yarpcjson/codec.go
+++ b/v2/yarpcjson/codec.go
@@ -25,6 +25,7 @@ import (
 	"reflect"
 
 	"go.uber.org/yarpc/v2"
+	"go.uber.org/yarpc/v2/yarpcerror"
 )
 
 var (
@@ -66,6 +67,19 @@ func (c jsonCodec) Decode(res *yarpc.Buffer) (interface{}, error) {
 func (c jsonCodec) Encode(res interface{}) (*yarpc.Buffer, error) {
 	resBuf := &yarpc.Buffer{}
 	if err := json.NewEncoder(resBuf).Encode(res); err != nil {
+		return nil, err
+	}
+
+	return resBuf, nil
+}
+
+func (c jsonCodec) EncodeError(err error) (*yarpc.Buffer, error) {
+	details := yarpcerror.ExtractDetails(err)
+	if details == nil {
+		return nil, nil
+	}
+	resBuf := &yarpc.Buffer{}
+	if err := json.NewEncoder(resBuf).Encode(details); err != nil {
 		return nil, err
 	}
 

--- a/v2/yarpcthrift/codec.go
+++ b/v2/yarpcthrift/codec.go
@@ -98,11 +98,23 @@ func (c *thriftCodec) Decode(req *yarpc.Buffer) (interface{}, error) {
 	return reqValue, nil
 }
 
-func (c *thriftCodec) Encode(res interface{}) (*yarpc.Buffer, error) {
+func (c *thriftCodec) encode(res interface{}) (*yarpc.Buffer, error) {
 	resBuf := &yarpc.Buffer{}
 	if resValue, ok := res.(wire.Value); ok {
 		err := c.responder.EncodeResponse(resValue, wire.Reply, resBuf)
 		return resBuf, err
 	}
 	return nil, yarpcerror.InternalErrorf("tried to encode a non-wire.Value in thrift codec")
+}
+
+func (c *thriftCodec) Encode(res interface{}) (*yarpc.Buffer, error) {
+	return c.encode(res)
+}
+
+func (c *thriftCodec) EncodeError(err error) (*yarpc.Buffer, error) {
+	details := yarpcerror.ExtractDetails(err)
+	if details == nil {
+		return nil, nil
+	}
+	return c.encode(details)
 }


### PR DESCRIPTION
Initial diff for adding and ErrorCodec to EncodingProcedure for serializing error objects into bytes that transports can put on the wire. This is branched off Minho's errors refactor for the api's to access the error details. Just the implementation for now as there are some open questions as a result of implementing this.

What's tricky in the case of proto is that the upstream implementations don't just expect just details but the whole status as a [`google.rpc.Status`](https://github.com/grpc/grpc/blob/master/src/proto/grpc/status/status.proto) object. This object contains a code, message and details, but in our design we've treated the error details to be separate from the error info. It is unclear if the JSON endpoints we create from the proto specs should respond with encoding just the error details or if they should encode the error details into a `google.rpc.Status`. This should really be a transport level decision as the usage of `google.rpc.Status` is a grpc specific concept. However, I don't see how we can encode proto.Messages in the encoding layer if depending on the transport we have to wrap the bytes in a `google.rpc.Status` or not.