### PR TITLE
Assert protobuf handler implements handler interface

### DIFF
--- a/v2/yarpcprotobuf/inbound.go
+++ b/v2/yarpcprotobuf/inbound.go
@@ -28,6 +28,9 @@ import (
 	"go.uber.org/yarpc/v2/yarpcerror"
 )
 
+var _ yarpc.UnaryEncodingHandler = (*unaryHandler)(nil)
+var _ yarpc.StreamTransportHandler = (*streamHandler)(nil)
+
 // StreamHandlerParams contains the parameters for creating a new StreamTransportHandler.
 type StreamHandlerParams struct {
 	Handle func(*ServerStream) error


### PR DESCRIPTION
We assert handler implementations for JSON, Thrift. This adds an assertion for protobuf.