### PR TITLE
observe: Support changing app error log level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- The log level for application errors is now configurable with yarpcconfig and
+  with yarpc.NewDispatcher.
+
 ### Fixed
 - Upgrade a read-lock to a read-write lock around peer selection.
   This addresses a data race observed in production that results in broken peer

--- a/config.go
+++ b/config.go
@@ -41,14 +41,27 @@ const (
 	_packageName       = "yarpc"
 )
 
+// LogLevelConfig configures the levels at which YARPC logs various things.
+type LogLevelConfig struct {
+	// Level at which application errors are logged. Note that all Thrift
+	// exceptions are considered application errors.
+	//
+	// Defaults to ErrorLevel.
+	ApplicationError *zapcore.Level
+}
+
 // LoggingConfig describes how logging should be configured.
 type LoggingConfig struct {
 	// Supplies a logger for the dispatcher. By default, no logs are
 	// emitted.
 	Zap *zap.Logger
+
 	// If supplied, ExtractContext is used to log request-scoped
 	// information carried on the context (e.g., trace and span IDs).
 	ContextExtractor func(context.Context) zapcore.Field
+
+	// Levels configures the levels at which YARPC logs various messages.
+	Levels LogLevelConfig
 }
 
 func (c LoggingConfig) logger(name string) *zap.Logger {

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -100,7 +100,11 @@ func addObservingMiddleware(cfg Config, meter *metrics.Scope, logger *zap.Logger
 		return cfg
 	}
 
-	observer := observability.NewMiddleware(logger, meter, extractor)
+	observer := observability.NewMiddleware(observability.Config{
+		Logger:           logger,
+		Scope:            meter,
+		ContextExtractor: extractor,
+	})
 
 	cfg.InboundMiddleware.Unary = inboundmiddleware.UnaryChain(observer, cfg.InboundMiddleware.Unary)
 	cfg.InboundMiddleware.Oneway = inboundmiddleware.OnewayChain(observer, cfg.InboundMiddleware.Oneway)

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -101,9 +101,10 @@ func addObservingMiddleware(cfg Config, meter *metrics.Scope, logger *zap.Logger
 	}
 
 	observer := observability.NewMiddleware(observability.Config{
-		Logger:           logger,
-		Scope:            meter,
-		ContextExtractor: extractor,
+		Logger:                logger,
+		Scope:                 meter,
+		ContextExtractor:      extractor,
+		ApplicationErrorLevel: cfg.Logging.Levels.ApplicationError,
 	})
 
 	cfg.InboundMiddleware.Unary = inboundmiddleware.UnaryChain(observer, cfg.InboundMiddleware.Unary)

--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -708,6 +708,52 @@ func TestEnableObservabilityMiddleware(t *testing.T) {
 	assert.Equal(t, 1, logs.Len())
 }
 
+func TestObservabilityMiddlewareApplicationErrorLevel(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	req := &transport.Request{
+		Service:   "test",
+		Caller:    "test",
+		Procedure: "test",
+		Encoding:  transport.Encoding("test"),
+	}
+	out := transporttest.NewMockUnaryOutbound(mockCtrl)
+	out.EXPECT().Transports().AnyTimes()
+	out.EXPECT().Call(ctx, req).Return(&transport.Response{ApplicationError: true}, nil)
+
+	core, logs := observer.New(zapcore.DebugLevel)
+
+	infoLevel := zapcore.InfoLevel
+	dispatcher := NewDispatcher(Config{
+		Name: "test",
+		Outbounds: Outbounds{
+			"my-test-service": {
+				ServiceName: "my-real-service",
+				Unary:       out,
+			},
+		},
+		Logging: LoggingConfig{
+			Zap: zap.New(core),
+			Levels: LogLevelConfig{
+				ApplicationError: &infoLevel,
+			},
+		},
+	})
+
+	cc := dispatcher.MustOutboundConfig("my-test-service")
+	_, err := cc.Outbounds.Unary.Call(ctx, req)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, logs.Len())
+	e := logs.TakeAll()[0]
+	assert.Equal(t, zapcore.InfoLevel, e.Level)
+	assert.Equal(t, "Error making outbound call.", e.Message)
+
+}
+
 func TestDisableObservabilityMiddleware(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()

--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -52,6 +52,8 @@ type call struct {
 	req       *transport.Request
 	rpcType   transport.Type
 	direction directionName
+
+	succLevel, failLevel, appErrLevel zapcore.Level
 }
 
 func (c call) End(err error) {
@@ -71,13 +73,18 @@ func (c call) endLogs(elapsed time.Duration, err error, isApplicationError bool)
 		if c.direction != _directionInbound {
 			msg = _successfulOutbound
 		}
-		ce = c.edge.logger.Check(zap.DebugLevel, msg)
+		ce = c.edge.logger.Check(c.succLevel, msg)
 	} else {
 		msg := _errorInbound
 		if c.direction != _directionInbound {
 			msg = _errorOutbound
 		}
-		ce = c.edge.logger.Check(zap.ErrorLevel, msg)
+
+		lvl := c.failLevel
+		if isApplicationError {
+			lvl = c.appErrLevel
+		}
+		ce = c.edge.logger.Check(lvl, msg)
 	}
 
 	if ce == nil {

--- a/internal/observability/middleware.go
+++ b/internal/observability/middleware.go
@@ -62,9 +62,22 @@ type Middleware struct {
 	graph graph
 }
 
-// NewMiddleware constructs a Middleware.
-func NewMiddleware(logger *zap.Logger, scope *metrics.Scope, extract ContextExtractor) *Middleware {
-	return &Middleware{newGraph(scope, logger, extract)}
+// Config configures the observability middleware.
+type Config struct {
+	// Logger to which messages will be logged.
+	Logger *zap.Logger
+
+	// Scope to which metrics are emitted.
+	Scope *metrics.Scope
+
+	// Extracts request-scoped information from the context for logging.
+	ContextExtractor ContextExtractor
+}
+
+// NewMiddleware constructs an observability middleware with the provided
+// configuration.
+func NewMiddleware(cfg Config) *Middleware {
+	return &Middleware{newGraph(cfg.Scope, cfg.Logger, cfg.ContextExtractor)}
 }
 
 // Handle implements middleware.UnaryInbound.

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -130,7 +130,11 @@ func TestMiddlewareLogging(t *testing.T) {
 
 	for _, tt := range tests {
 		core, logs := observer.New(zapcore.DebugLevel)
-		mw := NewMiddleware(zap.New(core), metrics.New().Scope(), NewNopContextExtractor())
+		mw := NewMiddleware(Config{
+			Logger:           zap.New(core),
+			Scope:            metrics.New().Scope(),
+			ContextExtractor: NewNopContextExtractor(),
+		})
 
 		getLog := func() observer.LoggedEntry {
 			entries := logs.TakeAll()
@@ -369,7 +373,11 @@ func TestMiddlewareMetrics(t *testing.T) {
 			}
 		}
 		t.Run(tt.desc+", unary inbound", func(t *testing.T) {
-			mw := NewMiddleware(zap.NewNop(), metrics.New().Scope(), NewNopContextExtractor())
+			mw := NewMiddleware(Config{
+				Logger:           zap.NewNop(),
+				Scope:            metrics.New().Scope(),
+				ContextExtractor: NewNopContextExtractor(),
+			})
 			mw.Handle(
 				context.Background(),
 				req,
@@ -379,7 +387,11 @@ func TestMiddlewareMetrics(t *testing.T) {
 			validate(mw, string(_directionInbound))
 		})
 		t.Run(tt.desc+", unary outbound", func(t *testing.T) {
-			mw := NewMiddleware(zap.NewNop(), metrics.New().Scope(), NewNopContextExtractor())
+			mw := NewMiddleware(Config{
+				Logger:           zap.NewNop(),
+				Scope:            metrics.New().Scope(),
+				ContextExtractor: NewNopContextExtractor(),
+			})
 			mw.Call(context.Background(), req, newOutbound(tt))
 			validate(mw, string(_directionOutbound))
 		})
@@ -433,7 +445,11 @@ func TestUnaryInboundApplicationErrors(t *testing.T) {
 	}
 
 	core, logs := observer.New(zap.DebugLevel)
-	mw := NewMiddleware(zap.New(core), metrics.New().Scope(), NewNopContextExtractor())
+	mw := NewMiddleware(Config{
+		Logger:           zap.New(core),
+		Scope:            metrics.New().Scope(),
+		ContextExtractor: NewNopContextExtractor(),
+	})
 
 	assert.NoError(t, mw.Handle(
 		context.Background(),
@@ -460,7 +476,11 @@ func TestMiddlewareSuccessSnapshot(t *testing.T) {
 	defer stubTime()()
 	root := metrics.New()
 	meter := root.Scope()
-	mw := NewMiddleware(zap.NewNop(), meter, NewNopContextExtractor())
+	mw := NewMiddleware(Config{
+		Logger:           zap.NewNop(),
+		Scope:            meter,
+		ContextExtractor: NewNopContextExtractor(),
+	})
 
 	err := mw.Handle(
 		context.Background(),
@@ -522,7 +542,11 @@ func TestMiddlewareFailureSnapshot(t *testing.T) {
 	defer stubTime()()
 	root := metrics.New()
 	meter := root.Scope()
-	mw := NewMiddleware(zap.NewNop(), meter, NewNopContextExtractor())
+	mw := NewMiddleware(Config{
+		Logger:           zap.NewNop(),
+		Scope:            meter,
+		ContextExtractor: NewNopContextExtractor(),
+	})
 
 	err := mw.Handle(
 		context.Background(),

--- a/yarpcconfig/configurator.go
+++ b/yarpcconfig/configurator.go
@@ -277,7 +277,13 @@ func (c *Configurator) load(serviceName string, cfg *yarpcConfig) (_ yarpc.Confi
 		return yarpc.Config{}, err
 	}
 
-	return b.Build()
+	yc, err := b.Build()
+	if err != nil {
+		return yc, err
+	}
+
+	cfg.Logging.fill(&yc)
+	return yc, nil
 }
 
 func (c *Configurator) loadInboundInto(b *builder, i inbound) error {


### PR DESCRIPTION
This adds support for changing the log level at which application errors
are logged by the observability middleware.

Users of `yarpc.NewDispatcher` will be able to change this by using the
newly adding `yarpc.Config.Logging.Levels` field.

Users of `yarpcconfig` will be able to change this by using the new
`logging.levels` configuration field.

    yarpc:
     logging:
       levels:
         applicationError: debug

Ref: T1923451

Each commit is individually reviewable.