### PR TITLE
Drop "host" network mode from docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.1.10
-    network_mode: "host"
     environment:
       - TEST_TIME_SCALE=5
       - THIS_CHUNK=${BUILDKITE_PARALLEL_JOB}
@@ -27,7 +26,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.1.11
-    network_mode: "host"
     environment:
       - TEST_TIME_SCALE=5
       - THIS_CHUNK=${BUILDKITE_PARALLEL_JOB}


### PR DESCRIPTION
The auto-dependency updater and all PRs now fail with the following error:
```
Cannot create container for service yarpc-go-1.10: cannot share the host's network namespace when user namespaces are enabled
```

The Docker documentation [here](https://docs.docker.com/engine/security/userns-remap/) indicates that user namespaces conflict with when `network_mode: "host"`. We're unsure why, but user namespaces seems to have been enabled on BuildKite which directly conflicts with our `docker-compose` setup.

This drops the `network_mode` which was previously set to `"host"`. There will be no impact on current tests since no tests do not need to communicate to other containers.