### PR TITLE
Pending heap: Fix panic caused by stale subscribers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Fixed
+- Fix fewest pending heap panic that occurs when calling a peer and removing it
+  simultaneously.
 
 ## [1.37.0] - 2019-03-14
 ### Fixed

--- a/peer/pendingheap/heap_test.go
+++ b/peer/pendingheap/heap_test.go
@@ -26,6 +26,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/api/peer/peertest"
 )
 
 func TestPeerHeapRunning(t *testing.T) {
@@ -155,7 +157,7 @@ func TestPeerHeapDelete(t *testing.T) {
 	}
 
 	// The first peer is the lowest, remove it so it swaps with the last peer.
-	h.delete(0)
+	h.delete(peers[0])
 
 	// Now when we pop peers, we expect peers 1 to N.
 	want := peers[1:]
@@ -199,7 +201,7 @@ func popAndVerifyHeap(t *testing.T, h *pendingHeap) []*peerScore {
 		}
 
 		if ps.score < lastScore {
-			t.Fatalf("heap returned peer %v with lower score than %v", ps, lastScore)
+			t.Fatalf("heap returned peer %+v with lower score than %v", ps, lastScore)
 		}
 		lastScore = ps.score
 	}


### PR DESCRIPTION
During a concurrent peer call and removal of that peer from a list update, it
was possible for a subscriber to notify the fewest pending heap peer list of an
already removed peer. This caused an indexing panic when attempting to fix the
heap. This change ensures that we first validate that the subscriber is not
stale. See T2388437 for more details.

This PR adds a failing test and its corresponding fix in separate,
individually reviewable commits.