### PR TITLE
Revert: Use separate context for grpc streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Removed
+- Revert: Use separate context for grpc streams once dial has been completed.
 
 ## [1.37.1] - 2019-03-25
 ### Fixed

--- a/transport/grpc/outbound.go
+++ b/transport/grpc/outbound.go
@@ -289,7 +289,7 @@ func (o *Outbound) stream(
 		return nil, err
 	}
 
-	streamCtx := metadata.NewOutgoingContext(context.Background(), md)
+	streamCtx := metadata.NewOutgoingContext(ctx, md)
 	clientStream, err := grpcPeer.clientConn.NewStream(
 		streamCtx,
 		&grpc.StreamDesc{
@@ -302,7 +302,7 @@ func (o *Outbound) stream(
 		span.Finish()
 		return nil, err
 	}
-	stream := newClientStream(clientStream.Context(), req, clientStream, span)
+	stream := newClientStream(streamCtx, req, clientStream, span)
 	tClientStream, err := transport.NewClientStream(stream)
 	if err != nil {
 		span.Finish()


### PR DESCRIPTION
This changed introduced a bug where closing a stream on the client
would not signal the server to also close the stream, potentially
leaking resources.
