### PR TITLE
Release peer list lock after stale subscriber removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Fixed
+- Fixed pending heap deadlock that occured when attempting to remove a peer that
+  was already removed.
 
 ## [1.37.2] - 2019-04-08
 ### Removed

--- a/peer/pendingheap/heap.go
+++ b/peer/pendingheap/heap.go
@@ -97,6 +97,7 @@ func (ph *pendingHeap) notifyStatusChanged(ps *peerScore) {
 	// heap. This may occur when calling a peer and simultaneously removing it
 	// from the heap.
 	if ps.index < 0 {
+		ph.Unlock()
 		return
 	}
 

--- a/peer/pendingheap/heap_test.go
+++ b/peer/pendingheap/heap_test.go
@@ -279,9 +279,6 @@ func TestReleaseLockWithStaleSubscriber(t *testing.T) {
 		cancel()
 	}()
 
-	select {
-	case <-ctx.Done():
-	}
-
+	<-ctx.Done()
 	assert.Equal(t, context.Canceled, ctx.Err(), "expected context to be canceled")
 }


### PR DESCRIPTION
In #1729, we introduced a change to remove panics some services were seeing,
specifically, when calling with a peer at the same time as a removing it. Within
that fix, we do not release the peer list lock when attempting to remove a stale
subscriber. This cases a deadlock, preventing any further outgoing calls to a
service.

Similar to #1729, this is the same small edge case, which is why it was left
uncovered for this time.

Related T2831133.