### PR TITLE
Use set instead of append for gRPC MD writer

### DIFF
--- a/transport/grpc/headers.go
+++ b/transport/grpc/headers.go
@@ -228,5 +228,5 @@ func (md mdReadWriter) ForeachKey(handler func(string, string) error) error {
 // Set implements opentracing.TextMapWriter.
 func (md mdReadWriter) Set(key string, value string) {
 	key = strings.ToLower(key)
-	md[key] = append(md[key], value)
+	md[key] = []string{value}
 }

--- a/transport/grpc/headers_test.go
+++ b/transport/grpc/headers_test.go
@@ -200,3 +200,13 @@ func TestIsReserved(t *testing.T) {
 	assert.True(t, isReserved(EncodingHeader))
 	assert.True(t, isReserved("rpc-foo"))
 }
+
+func TestMDReadWriterDuplicateKey(t *testing.T) {
+	const key = "uber-trace-id"
+	md := map[string][]string{
+		key: {"to-override"},
+	}
+	mdRW := mdReadWriter(md)
+	mdRW.Set(key, "overwritten")
+	assert.Equal(t, []string{"overwritten"}, md[key], "expected overwritten values")
+}


### PR DESCRIPTION
Use set instead of append for gRPC MD writer. Previously, this would enable
multiple values for the same key.