### PR TITLE
grpc: Repro for SendMsg holding on to response writer's bytes

### DIFF
--- a/transport/grpc/response_writer.go
+++ b/transport/grpc/response_writer.go
@@ -21,15 +21,14 @@
 package grpc
 
 import (
-	"bytes"
-
 	"go.uber.org/multierr"
 	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/bufferpool"
 	"google.golang.org/grpc/metadata"
 )
 
 type responseWriter struct {
-	buffer    *bytes.Buffer
+	buffer    *bufferpool.Buffer
 	md        metadata.MD
 	headerErr error
 }
@@ -40,7 +39,7 @@ func newResponseWriter() *responseWriter {
 
 func (r *responseWriter) Write(p []byte) (int, error) {
 	if r.buffer == nil {
-		r.buffer = bytes.NewBuffer(make([]byte, 0, len(p)))
+		r.buffer = bufferpool.Get()
 	}
 	return r.buffer.Write(p)
 }
@@ -71,5 +70,8 @@ func (r *responseWriter) Bytes() []byte {
 }
 
 func (r *responseWriter) Close() {
+	if r.buffer != nil {
+		bufferpool.Put(r.buffer)
+	}
 	r.buffer = nil
 }


### PR DESCRIPTION
YARPC uses gRPC differently to other systems,
 * YARPC handles marshalling, and passes in `[]byte`
 * It uses a "pass-through" codec since the data is already marshalled

This causes some surprising behaviour with `SendMsg`. When `SendMsg` is
normally used, a proto struct is passed in, gRPC marshals this into a
byte slice, and then holds on to the byte slice even after the `SendMsg`
function returns (it's added to a queue, that is eventually written to
the wire). Since we use a pass-through codec, the byte slice we pass in
to `SendMsg` is held on to even after the method returns.

This displays the issue by swapping out the `*bytes.Buffer` to a
`*bufferpool.Buffer`.

Today, this doesn't cause issues as the response writers don't seem to
be pooled.