### PR TITLE
Thread Request.Transport field through outbound request middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   gRPC.
 - The `yarpctest.FakeOutbound` can now send requests to a `transport.Router`.
   This allows end to end testing with a client and server in memory.
+- All outbounds now implement `Name` and a new `transport.Namer` interface.
+  This will allow outbound observability middleware to carry the transport name
+  in metrics properly.
 ### Changed
 - This change reduces the API surface of the peer list implementations to
   remove a previously public embedded type and replace it with implementations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   gRPC.
 - The `yarpctest.FakeOutbound` can now send requests to a `transport.Router`.
   This allows end to end testing with a client and server in memory.
+  The `OutboundCallOverride`, `OutboundCallOnewayOverride` (new), and
+  `OutboundCallStreamOverride` (new) are now a complete set that allow tests to
+  hook any of the call behaviors.
 - All outbounds now implement `Name` and a new `transport.Namer` interface.
   This will allow outbound observability middleware to carry the transport name
   in metrics properly.

--- a/api/middleware/outbound.go
+++ b/api/middleware/outbound.go
@@ -27,6 +27,12 @@ import (
 	"go.uber.org/yarpc/internal/introspection"
 )
 
+var (
+	_ transport.Namer = (*unaryOutboundWithMiddleware)(nil)
+	_ transport.Namer = (*onewayOutboundWithMiddleware)(nil)
+	_ transport.Namer = (*streamOutboundWithMiddleware)(nil)
+)
+
 // UnaryOutbound defines transport-level middleware for
 // `UnaryOutbound`s.
 //
@@ -53,7 +59,13 @@ func ApplyUnaryOutbound(o transport.UnaryOutbound, f UnaryOutbound) transport.Un
 	if f == nil {
 		return o
 	}
-	return unaryOutboundWithMiddleware{o: o, f: f}
+
+	var name string
+	if namer, ok := o.(transport.Namer); ok {
+		name = namer.Name()
+	}
+
+	return unaryOutboundWithMiddleware{o: o, f: f, name: name}
 }
 
 // UnaryOutboundFunc adapts a function into a UnaryOutbound middleware.
@@ -65,8 +77,13 @@ func (f UnaryOutboundFunc) Call(ctx context.Context, request *transport.Request,
 }
 
 type unaryOutboundWithMiddleware struct {
-	o transport.UnaryOutbound
-	f UnaryOutbound
+	name string
+	o    transport.UnaryOutbound
+	f    UnaryOutbound
+}
+
+func (fo unaryOutboundWithMiddleware) Name() string {
+	return fo.name
 }
 
 func (fo unaryOutboundWithMiddleware) Transports() []transport.Transport {
@@ -127,7 +144,13 @@ func ApplyOnewayOutbound(o transport.OnewayOutbound, f OnewayOutbound) transport
 	if f == nil {
 		return o
 	}
-	return onewayOutboundWithMiddleware{o: o, f: f}
+
+	var name string
+	if namer, ok := o.(transport.Namer); ok {
+		name = namer.Name()
+	}
+
+	return onewayOutboundWithMiddleware{o: o, f: f, name: name}
 }
 
 // OnewayOutboundFunc adapts a function into a OnewayOutbound middleware.
@@ -139,8 +162,13 @@ func (f OnewayOutboundFunc) CallOneway(ctx context.Context, request *transport.R
 }
 
 type onewayOutboundWithMiddleware struct {
-	o transport.OnewayOutbound
-	f OnewayOutbound
+	name string
+	o    transport.OnewayOutbound
+	f    OnewayOutbound
+}
+
+func (fo onewayOutboundWithMiddleware) Name() string {
+	return fo.name
 }
 
 func (fo onewayOutboundWithMiddleware) Transports() []transport.Transport {
@@ -202,7 +230,13 @@ func ApplyStreamOutbound(o transport.StreamOutbound, f StreamOutbound) transport
 	if f == nil {
 		return o
 	}
-	return streamOutboundWithMiddleware{o: o, f: f}
+
+	var name string
+	if namer, ok := o.(transport.Namer); ok {
+		name = namer.Name()
+	}
+
+	return streamOutboundWithMiddleware{o: o, f: f, name: name}
 }
 
 // StreamOutboundFunc adapts a function into a StreamOutbound middleware.
@@ -214,8 +248,13 @@ func (f StreamOutboundFunc) CallStream(ctx context.Context, request *transport.S
 }
 
 type streamOutboundWithMiddleware struct {
-	o transport.StreamOutbound
-	f StreamOutbound
+	name string
+	o    transport.StreamOutbound
+	f    StreamOutbound
+}
+
+func (fo streamOutboundWithMiddleware) Name() string {
+	return fo.name
 }
 
 func (fo streamOutboundWithMiddleware) Transports() []transport.Transport {

--- a/api/transport/outbound.go
+++ b/api/transport/outbound.go
@@ -22,7 +22,10 @@ package transport
 
 import "context"
 
-// Outbound is the common interface for all outbounds
+// Outbound is the common interface for all outbounds.
+//
+// Outbounds should also implement the Namer interface so that YARPC can
+// properly update the Request.Transport field.
 type Outbound interface {
 	Lifecycle
 
@@ -34,6 +37,15 @@ type Outbound interface {
 	// across multiple transport protocols during a transport protocol
 	// migration.
 	Transports() []Transport
+}
+
+// Namer is an additional interface that Outbounds may implement in order
+// properly set the transport.Request#Transport field.
+//
+// This interface is not embeded into Outbound to preserve backwards
+// compatiblity.
+type Namer interface {
+	Name() string
 }
 
 // UnaryOutbound is a transport that knows how to send unary requests for procedure

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -151,19 +151,20 @@ func convertOutbounds(outbounds Outbounds, mw OutboundMiddleware) Outbounds {
 		serviceName := outboundKey
 
 		// apply outbound middleware and create ValidatorOutbounds
+
 		if outs.Unary != nil {
 			unaryOutbound = middleware.ApplyUnaryOutbound(outs.Unary, mw.Unary)
-			unaryOutbound = request.UnaryValidatorOutbound{UnaryOutbound: unaryOutbound}
+			unaryOutbound = request.UnaryValidatorOutbound{UnaryOutbound: unaryOutbound, Namer: namerOrNil(unaryOutbound)}
 		}
 
 		if outs.Oneway != nil {
 			onewayOutbound = middleware.ApplyOnewayOutbound(outs.Oneway, mw.Oneway)
-			onewayOutbound = request.OnewayValidatorOutbound{OnewayOutbound: onewayOutbound}
+			onewayOutbound = request.OnewayValidatorOutbound{OnewayOutbound: onewayOutbound, Namer: namerOrNil(onewayOutbound)}
 		}
 
 		if outs.Stream != nil {
 			streamOutbound = middleware.ApplyStreamOutbound(outs.Stream, mw.Stream)
-			streamOutbound = request.StreamValidatorOutbound{StreamOutbound: streamOutbound}
+			streamOutbound = request.StreamValidatorOutbound{StreamOutbound: streamOutbound, Namer: namerOrNil(streamOutbound)}
 		}
 
 		if outs.ServiceName != "" {
@@ -179,6 +180,13 @@ func convertOutbounds(outbounds Outbounds, mw OutboundMiddleware) Outbounds {
 	}
 
 	return outboundSpecs
+}
+
+func namerOrNil(o transport.Outbound) (namer transport.Namer) {
+	if n, ok := o.(transport.Namer); ok {
+		namer = n
+	}
+	return
 }
 
 // collectTransports iterates over all inbounds and outbounds and collects all

--- a/internal/firstoutboundmiddleware/middleware.go
+++ b/internal/firstoutboundmiddleware/middleware.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package firstoutboundmiddleware annotates every outbound request with
+// metadata like the request transport protocol.
+// These metadata must be avilable to all subsequent middleware.
+package firstoutboundmiddleware
+
+import (
+	"context"
+
+	"go.uber.org/yarpc/api/middleware"
+	"go.uber.org/yarpc/api/transport"
+)
+
+var (
+	_ middleware.UnaryOutbound  = (*Middleware)(nil)
+	_ middleware.StreamOutbound = (*Middleware)(nil)
+	_ middleware.OnewayOutbound = (*Middleware)(nil)
+)
+
+// Middleware is the first middleware that MUST be executed in the chain of
+// TransportOutboundMiddleware.
+type Middleware struct{}
+
+// New returns middleware to begin any YARPC outbound middleware chain.
+func New() *Middleware {
+	return &Middleware{}
+}
+
+// Call implements middleware.UnaryOutbound.
+func (m *Middleware) Call(ctx context.Context, req *transport.Request, next transport.UnaryOutbound) (*transport.Response, error) {
+	update(req, next)
+	return next.Call(ctx, req)
+}
+
+// CallOneway implements middleware.OnewayOutbound.
+func (m *Middleware) CallOneway(ctx context.Context, req *transport.Request, next transport.OnewayOutbound) (transport.Ack, error) {
+	update(req, next)
+	return next.CallOneway(ctx, req)
+}
+
+// CallStream implements middleware.StreamOutbound.
+func (m *Middleware) CallStream(ctx context.Context, req *transport.StreamRequest, next transport.StreamOutbound) (*transport.ClientStream, error) {
+	updateStream(req, next)
+	return next.CallStream(ctx, req)
+}
+
+func update(req *transport.Request, out transport.Outbound) {
+	// TODO(apeatsbond): Setting environment headers and unique IDs should live
+	// here too (T1860945).
+
+	// Reset the transport field to the current outbound transport.
+	// Request forwarding in transport layer proxies needs this when copying
+	// requests to a different outbound type.
+	if namer, ok := out.(transport.Namer); ok {
+		req.Transport = namer.Name()
+	}
+}
+
+func updateStream(req *transport.StreamRequest, out transport.Outbound) {
+	// TODO(apeatsbond): Setting environment headers and unique IDs should live
+	// here too (T1860945).
+
+	// Reset the transport field to the current outbound transport.
+	// Request forwarding in transport layer proxies needs this when copying
+	// requests to a different outbound type.
+	if namer, ok := out.(transport.Namer); ok {
+		req.Meta.Transport = namer.Name()
+	}
+}

--- a/internal/firstoutboundmiddleware/middleware_test.go
+++ b/internal/firstoutboundmiddleware/middleware_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package firstoutboundmiddleware_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/api/middleware"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/firstoutboundmiddleware"
+	"go.uber.org/yarpc/yarpctest"
+)
+
+func TestFirstOutboundMidleware(t *testing.T) {
+	const overrideName = "override"
+
+	out := yarpctest.NewFakeTransport().NewOutbound(nil,
+		yarpctest.OutboundName(overrideName),
+		yarpctest.OutboundCallOverride(
+			func(context.Context, *transport.Request) (*transport.Response, error) { return nil, nil },
+		),
+		yarpctest.OutboundCallStreamOverride(
+			func(context.Context, *transport.StreamRequest) (*transport.ClientStream, error) { return nil, nil },
+		),
+		yarpctest.OutboundCallOnewayOverride(
+			func(context.Context, *transport.Request) (transport.Ack, error) { return nil, nil },
+		),
+	)
+
+	t.Run("unary", func(t *testing.T) {
+		req := &transport.Request{Transport: "" /* not set */}
+
+		outWithMiddleware := middleware.ApplyUnaryOutbound(out, firstoutboundmiddleware.New())
+		_, err := outWithMiddleware.Call(context.Background(), req)
+		require.NoError(t, err)
+
+		assert.Equal(t, overrideName, string(req.Transport))
+	})
+
+	t.Run("oneway", func(t *testing.T) {
+		req := &transport.Request{Transport: "" /* not set */}
+
+		outWithMiddleware := middleware.ApplyOnewayOutbound(out, firstoutboundmiddleware.New())
+		_, err := outWithMiddleware.CallOneway(context.Background(), req)
+		require.NoError(t, err)
+
+		assert.Equal(t, overrideName, string(req.Transport))
+	})
+
+	t.Run("stream", func(t *testing.T) {
+		streamReq := &transport.StreamRequest{Meta: &transport.RequestMeta{Transport: "" /* not set */}}
+
+		outWithMiddleware := middleware.ApplyStreamOutbound(out, firstoutboundmiddleware.New())
+		_, err := outWithMiddleware.CallStream(context.Background(), streamReq)
+		require.NoError(t, err)
+
+		assert.Equal(t, overrideName, string(streamReq.Meta.Transport))
+	})
+}

--- a/internal/outboundmiddleware/chain.go
+++ b/internal/outboundmiddleware/chain.go
@@ -28,6 +28,12 @@ import (
 	"go.uber.org/yarpc/internal/introspection"
 )
 
+var (
+	_ transport.Namer = (*unaryChainExec)(nil)
+	_ transport.Namer = (*onewayChainExec)(nil)
+	_ transport.Namer = (*streamChainExec)(nil)
+)
+
 // UnaryChain combines a series of `UnaryOutbound`s into a single `UnaryOutbound`.
 func UnaryChain(mw ...middleware.UnaryOutbound) middleware.UnaryOutbound {
 	unchained := make([]middleware.UnaryOutbound, 0, len(mw))
@@ -66,6 +72,14 @@ func (c unaryChain) Call(ctx context.Context, request *transport.Request, out tr
 type unaryChainExec struct {
 	Chain []middleware.UnaryOutbound
 	Final transport.UnaryOutbound
+}
+
+func (x unaryChainExec) Name() string {
+	var name string
+	if namer, ok := x.Final.(transport.Namer); ok {
+		name = namer.Name()
+	}
+	return name
 }
 
 func (x unaryChainExec) Transports() []transport.Transport {
@@ -140,6 +154,14 @@ type onewayChainExec struct {
 	Final transport.OnewayOutbound
 }
 
+func (x onewayChainExec) Name() string {
+	var name string
+	if namer, ok := x.Final.(transport.Namer); ok {
+		name = namer.Name()
+	}
+	return name
+}
+
 func (x onewayChainExec) Transports() []transport.Transport {
 	return x.Final.Transports()
 }
@@ -210,6 +232,14 @@ func (c streamChain) CallStream(ctx context.Context, request *transport.StreamRe
 type streamChainExec struct {
 	Chain []middleware.StreamOutbound
 	Final transport.StreamOutbound
+}
+
+func (x streamChainExec) Name() string {
+	var name string
+	if namer, ok := x.Final.(transport.Namer); ok {
+		name = namer.Name()
+	}
+	return name
 }
 
 func (x streamChainExec) Transports() []transport.Transport {

--- a/internal/request/validator_outbound.go
+++ b/internal/request/validator_outbound.go
@@ -28,7 +28,10 @@ import (
 )
 
 // UnaryValidatorOutbound wraps an Outbound to validate all outgoing unary requests.
-type UnaryValidatorOutbound struct{ transport.UnaryOutbound }
+type UnaryValidatorOutbound struct {
+	transport.UnaryOutbound
+	transport.Namer
+}
 
 // Call performs the given request, failing early if the request is invalid.
 func (o UnaryValidatorOutbound) Call(ctx context.Context, request *transport.Request) (*transport.Response, error) {
@@ -52,7 +55,10 @@ func (o UnaryValidatorOutbound) Introspect() introspection.OutboundStatus {
 }
 
 // OnewayValidatorOutbound wraps an Outbound to validate all outgoing oneway requests.
-type OnewayValidatorOutbound struct{ transport.OnewayOutbound }
+type OnewayValidatorOutbound struct {
+	transport.OnewayOutbound
+	transport.Namer
+}
 
 // CallOneway performs the given request, failing early if the request is invalid.
 func (o OnewayValidatorOutbound) CallOneway(ctx context.Context, request *transport.Request) (transport.Ack, error) {
@@ -76,7 +82,10 @@ func (o OnewayValidatorOutbound) Introspect() introspection.OutboundStatus {
 }
 
 // StreamValidatorOutbound wraps an Outbound to validate all outgoing oneway requests.
-type StreamValidatorOutbound struct{ transport.StreamOutbound }
+type StreamValidatorOutbound struct {
+	transport.Namer
+	transport.StreamOutbound
+}
 
 // CallStream performs the given request, failing early if the request is invalid.
 func (o StreamValidatorOutbound) CallStream(ctx context.Context, request *transport.StreamRequest) (*transport.ClientStream, error) {
@@ -85,4 +94,12 @@ func (o StreamValidatorOutbound) CallStream(ctx context.Context, request *transp
 	}
 
 	return o.StreamOutbound.CallStream(ctx, request)
+}
+
+// Introspect returns the introspection status of the underlying outbound.
+func (o StreamValidatorOutbound) Introspect() introspection.OutboundStatus {
+	if o, ok := o.StreamOutbound.(introspection.IntrospectableOutbound); ok {
+		return o.Introspect()
+	}
+	return introspection.OutboundStatusNotSupported
 }

--- a/transport/grpc/outbound.go
+++ b/transport/grpc/outbound.go
@@ -69,6 +69,11 @@ func newOutbound(t *Transport, peerChooser peer.Chooser, options ...OutboundOpti
 	}
 }
 
+// Name is the transport name that will be set on `transport.Request` struct.
+func (o *Outbound) Name() string {
+	return transportName
+}
+
 // Start implements transport.Lifecycle#Start.
 func (o *Outbound) Start() error {
 	return o.once.Start(o.peerChooser.Start)

--- a/transport/grpc/outbound_test.go
+++ b/transport/grpc/outbound_test.go
@@ -38,6 +38,10 @@ import (
 	"google.golang.org/grpc"
 )
 
+func TestNamer(t *testing.T) {
+	assert.Equal(t, transportName, NewTransport().NewOutbound(nil).Name())
+}
+
 func TestNoRequest(t *testing.T) {
 	tran := NewTransport()
 	out := tran.NewSingleOutbound("localhost:0")

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -46,6 +46,7 @@ import (
 
 // this ensures the HTTP outbound implements both transport.Outbound interfaces
 var (
+	_ transport.Namer                      = (*Outbound)(nil)
 	_ transport.UnaryOutbound              = (*Outbound)(nil)
 	_ transport.OnewayOutbound             = (*Outbound)(nil)
 	_ introspection.IntrospectableOutbound = (*Outbound)(nil)
@@ -166,6 +167,11 @@ type Outbound struct {
 
 	// should only be false in testing
 	bothResponseError bool
+}
+
+// Name is the transport name that will be set on `transport.Request` struct.
+func (o *Outbound) Name() string {
+	return transportName
 }
 
 // setURLTemplate configures an alternate URL template.

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -51,6 +51,10 @@ func TestNewOutbound(t *testing.T) {
 	assert.Equal(t, chooser, out.Chooser())
 }
 
+func TestNamer(t *testing.T) {
+	assert.Equal(t, transportName, NewOutbound(nil).Name())
+}
+
 func TestNewSingleOutboundPanic(t *testing.T) {
 	require.Panics(t, func() {
 		// invalid url should cause panic

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -68,6 +68,11 @@ func (t *Transport) NewSingleOutbound(addr string) *Outbound {
 	return t.NewOutbound(chooser)
 }
 
+// Name is the transport name that will be set on `transport.Request` struct.
+func (o *Outbound) Name() string {
+	return transportName
+}
+
 // Chooser returns the outbound's peer chooser.
 func (o *Outbound) Chooser() peer.Chooser {
 	return o.chooser

--- a/transport/tchannel/outbound_test.go
+++ b/transport/tchannel/outbound_test.go
@@ -38,6 +38,12 @@ import (
 	"golang.org/x/net/context"
 )
 
+func TestNamer(t *testing.T) {
+	trans, err := NewTransport()
+	require.NoError(t, err)
+	assert.Equal(t, transportName, trans.NewOutbound(nil).Name())
+}
+
 func TestOutboundHeaders(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/transport/transports_test.go
+++ b/transport/transports_test.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package transport_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/api/middleware"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/yarpctest"
+)
+
+func TestFirstOutboundMiddleware(t *testing.T) {
+	// This ensures that the meta middleware is applied before all user specified
+	// middleware. If the meta middleware is installed properly, user middleware
+	// should see the name of the transport, instead of an empty string.
+
+	const (
+		transportName = "transport-name"
+		serviceName   = "service-name"
+	)
+
+	newOutboundConfig := func(outboundMiddleware yarpc.OutboundMiddleware) *transport.OutboundConfig {
+		outbound := yarpctest.NewFakeTransport().
+			NewOutbound(nil, yarpctest.OutboundName(transportName))
+
+		dispatcher := yarpc.NewDispatcher(yarpc.Config{
+			Name: serviceName,
+			Outbounds: yarpc.Outbounds{
+				serviceName: {
+					ServiceName: serviceName,
+					Unary:       outbound,
+					Oneway:      outbound,
+					Stream:      outbound,
+				},
+			},
+			OutboundMiddleware: outboundMiddleware,
+		})
+		return dispatcher.MustOutboundConfig(serviceName)
+	}
+
+	t.Run("unary", func(t *testing.T) {
+		var gotTransportName string
+
+		out := newOutboundConfig(yarpc.OutboundMiddleware{
+			Unary: middleware.UnaryOutboundFunc(func(ctx context.Context, req *transport.Request, next transport.UnaryOutbound) (*transport.Response, error) {
+				gotTransportName = req.Transport
+				return next.Call(ctx, req)
+			}),
+		}).GetUnaryOutbound()
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		// fields required to satisfy validator outbound
+		req := &transport.Request{
+			Service:   "foo",
+			Caller:    "foo",
+			Procedure: "foo",
+			Encoding:  transport.Encoding("foo"),
+			Transport: "", // unset
+		}
+
+		_, _ = out.Call(ctx, req)
+		assert.Equal(t, transportName, gotTransportName)
+	})
+
+	t.Run("oneway", func(t *testing.T) {
+		var gotTransportName string
+
+		out := newOutboundConfig(yarpc.OutboundMiddleware{
+			Oneway: middleware.OnewayOutboundFunc(func(ctx context.Context, req *transport.Request, next transport.OnewayOutbound) (transport.Ack, error) {
+				gotTransportName = req.Transport
+				return next.CallOneway(ctx, req)
+			}),
+		}).GetOnewayOutbound()
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		// fields required to satisfy validator outbound
+		req := &transport.Request{
+			Service:   "foo",
+			Caller:    "foo",
+			Procedure: "foo",
+			Encoding:  transport.Encoding("foo"),
+			Transport: "", // unset
+		}
+
+		_, _ = out.CallOneway(ctx, req)
+		assert.Equal(t, transportName, gotTransportName)
+	})
+
+	t.Run("stream", func(t *testing.T) {
+		var gotTransportName string
+
+		out := newOutboundConfig(yarpc.OutboundMiddleware{
+			Stream: middleware.StreamOutboundFunc(func(ctx context.Context, req *transport.StreamRequest, next transport.StreamOutbound) (*transport.ClientStream, error) {
+				gotTransportName = req.Meta.Transport
+				return next.CallStream(ctx, req)
+			}),
+		}).Outbounds.Stream
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		// fields required to satisfy validator outbound
+		req := &transport.StreamRequest{
+			Meta: &transport.RequestMeta{
+				Service:   "foo",
+				Caller:    "foo",
+				Procedure: "foo",
+				Encoding:  transport.Encoding("foo"),
+				Transport: "", // unset
+			},
+		}
+
+		_, _ = out.CallStream(ctx, req)
+		assert.Equal(t, transportName, gotTransportName)
+	})
+}

--- a/yarpctest/fake_outbound.go
+++ b/yarpctest/fake_outbound.go
@@ -32,6 +32,13 @@ import (
 	"go.uber.org/yarpc/pkg/lifecycle"
 )
 
+var (
+	_ transport.Namer          = (*FakeOutbound)(nil)
+	_ transport.UnaryOutbound  = (*FakeOutbound)(nil)
+	_ transport.OnewayOutbound = (*FakeOutbound)(nil)
+	_ transport.StreamOutbound = (*FakeOutbound)(nil)
+)
+
 // FakeOutboundOption is an option for FakeTransport.NewOutbound.
 type FakeOutboundOption func(*FakeOutbound)
 
@@ -42,6 +49,13 @@ type FakeOutboundOption func(*FakeOutbound)
 func NopOutboundOption(nopOption string) FakeOutboundOption {
 	return func(o *FakeOutbound) {
 		o.nopOption = nopOption
+	}
+}
+
+// OutboundName sets the name of the "fake" outbound.
+func OutboundName(name string) FakeOutboundOption {
+	return func(o *FakeOutbound) {
+		o.name = name
 	}
 }
 
@@ -71,6 +85,7 @@ func OutboundRouter(router transport.Router) FakeOutboundOption {
 // NewOutbound returns a FakeOutbound with a given peer chooser and options.
 func (t *FakeTransport) NewOutbound(c peer.Chooser, opts ...FakeOutboundOption) *FakeOutbound {
 	o := &FakeOutbound{
+		name:      "fake",
 		once:      lifecycle.NewOnce(),
 		transport: t,
 		chooser:   c,
@@ -83,12 +98,18 @@ func (t *FakeTransport) NewOutbound(c peer.Chooser, opts ...FakeOutboundOption) 
 
 // FakeOutbound is a unary outbound for the FakeTransport. It is fake.
 type FakeOutbound struct {
+	name         string
 	once         *lifecycle.Once
 	transport    *FakeTransport
 	chooser      peer.Chooser
 	nopOption    string
 	callOverride OutboundCallable
 	router       transport.Router
+}
+
+// Name is the transport of the outbound.
+func (o *FakeOutbound) Name() string {
+	return o.name
 }
 
 // Chooser returns theis FakeOutbound's peer chooser.

--- a/yarpctest/fake_outbound.go
+++ b/yarpctest/fake_outbound.go
@@ -63,6 +63,23 @@ func OutboundName(name string) FakeOutboundOption {
 // `Call` method.
 type OutboundCallable func(ctx context.Context, req *transport.Request) (*transport.Response, error)
 
+// OutboundOnewayCallable is a function that will be called for for an outbound's
+// `Call` method.
+type OutboundOnewayCallable func(context.Context, *transport.Request) (transport.Ack, error)
+
+// OutboundStreamCallable is a function that will be called for for an outbound's
+// `Call` method.
+type OutboundStreamCallable func(context.Context, *transport.StreamRequest) (*transport.ClientStream, error)
+
+// OutboundRouter returns an option to set the router for outbound requests.
+// This connects the outbound to the inbound side of a handler for testing
+// purposes.
+func OutboundRouter(router transport.Router) FakeOutboundOption {
+	return func(o *FakeOutbound) {
+		o.router = router
+	}
+}
+
 // OutboundCallOverride returns an option to set the "callOverride" for a
 // FakeTransport.NewOutbound.
 // This can be used to set the functionality for the FakeOutbound's `Call`
@@ -73,12 +90,25 @@ func OutboundCallOverride(callable OutboundCallable) FakeOutboundOption {
 	}
 }
 
-// OutboundRouter returns an option to set the router for outbound requests.
-// This connects the outbound to the inbound side of a handler for testing
-// purposes.
-func OutboundRouter(router transport.Router) FakeOutboundOption {
+// OutboundCallOnewayOverride returns an option to set the "callOverride" for a
+// FakeTransport.NewOutbound.
+//
+// This can be used to set the functionality for the FakeOutbound's `CallOneway`
+// function.
+func OutboundCallOnewayOverride(callable OutboundOnewayCallable) FakeOutboundOption {
 	return func(o *FakeOutbound) {
-		o.router = router
+		o.callOnewayOverride = callable
+	}
+}
+
+// OutboundCallStreamOverride returns an option to set the "callOverride" for a
+// FakeTransport.NewOutbound.
+//
+// This can be used to set the functionality for the FakeOutbound's `CallStream`
+// function.
+func OutboundCallStreamOverride(callable OutboundStreamCallable) FakeOutboundOption {
+	return func(o *FakeOutbound) {
+		o.callStreamOverride = callable
 	}
 }
 
@@ -98,13 +128,16 @@ func (t *FakeTransport) NewOutbound(c peer.Chooser, opts ...FakeOutboundOption) 
 
 // FakeOutbound is a unary outbound for the FakeTransport. It is fake.
 type FakeOutbound struct {
-	name         string
-	once         *lifecycle.Once
-	transport    *FakeTransport
-	chooser      peer.Chooser
-	nopOption    string
-	callOverride OutboundCallable
-	router       transport.Router
+	name      string
+	once      *lifecycle.Once
+	transport *FakeTransport
+	chooser   peer.Chooser
+	nopOption string
+	router    transport.Router
+
+	callOverride       OutboundCallable
+	callOnewayOverride OutboundOnewayCallable
+	callStreamOverride OutboundStreamCallable
 }
 
 // Name is the transport of the outbound.
@@ -142,7 +175,12 @@ func (o *FakeOutbound) Transports() []transport.Transport {
 	return []transport.Transport{o.transport}
 }
 
-// Call pretends to send a unary RPC, but actually just returns an error.
+// Call mimicks sending a oneway RPC.
+//
+// By default, this returns a error.
+// The OutboundCallOverride option supplies an alternate implementation.
+// Alternately, the OutboundRouter option may allow this function to route a
+// unary request to a unary handler.
 func (o *FakeOutbound) Call(ctx context.Context, req *transport.Request) (*transport.Response, error) {
 	if o.callOverride != nil {
 		return o.callOverride(ctx, req)
@@ -173,8 +211,17 @@ func (o *FakeOutbound) Call(ctx context.Context, req *transport.Request) (*trans
 	}, nil
 }
 
-// CallOneway pretends to send a oneway RPC, but actually just returns an error.
+// CallOneway mimicks sending a oneway RPC.
+//
+// By default, this returns an error.
+// The OutboundCallOnewayOverride supplies an alternate implementation.
+// Atlernately, the OutboundRouter options may route the request through to a
+// oneway handler.
 func (o *FakeOutbound) CallOneway(ctx context.Context, req *transport.Request) (transport.Ack, error) {
+	if o.callOnewayOverride != nil {
+		return o.callOnewayOverride(ctx, req)
+	}
+
 	if o.router == nil {
 		return nil, errors.New(`fake outbound does not support call oneway`)
 	}
@@ -192,8 +239,17 @@ func (o *FakeOutbound) CallOneway(ctx context.Context, req *transport.Request) (
 	return nil, onewayHandler.HandleOneway(ctx, req)
 }
 
-// CallStream pretends to send a Stream RPC, but actually just returns an error.
+// CallStream mimicks sending a streaming RPC.
+//
+// By default, this returns an error.
+// The OutboundCallStreamOverride option provides a hook to change the behavior.
+// Alternately, the OutboundRouter option may route the request through to a
+// streaming handler.
 func (o *FakeOutbound) CallStream(ctx context.Context, streamReq *transport.StreamRequest) (*transport.ClientStream, error) {
+	if o.callStreamOverride != nil {
+		return o.callStreamOverride(ctx, streamReq)
+	}
+
 	if o.router == nil {
 		return nil, errors.New(`fake outbound does not support call stream`)
 	}


### PR DESCRIPTION
This change introduces a "first outbound middleware" similar to D2680639 and fixes T2737017. The middleware is responsible for priming the request metadata with the correct transport name and potentially filling out other headers in the future.

To do this, it was necessary for outbounds and outbound middleware to implement a Name() method that threads the name of the outbound (which is the transport name) through the entire chain.

For testing, this change also completes the set of overrides available for outbound calls on fake transports.