### PR TITLE
Specify capacity for the slice created in call.HeaderNames()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet
+### Fixed
+- call.HeaderNames() now creates specifies a capacity when creating a slice, 
+  which should improve the call.HeaderNames()'s performance.
 
 ## [1.38.0] - 2019-05-20
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- call.HeaderNames() now creates specifies a capacity when creating a slice, 
+- call.HeaderNames() now specifies a capacity when creating a slice, 
   which should improve the call.HeaderNames()'s performance.
 
 ## [1.38.0] - 2019-05-20

--- a/api/encoding/call.go
+++ b/api/encoding/call.go
@@ -120,8 +120,9 @@ func (c *Call) HeaderNames() []string {
 		return nil
 	}
 
-	var names []string
-	for k := range c.ic.req.Headers.Items() {
+	items := c.ic.req.Headers.Items()
+	names := make([]string, 0, len(items))
+	for k := range items {
 		names = append(names, k)
 	}
 	sort.Strings(names)


### PR DESCRIPTION
- `call.HeaderNames()` returns a slice that contains the names of every header in the internal header map. However, it does not specify a capacity; it therefore allocates a bit more than expected. This change simply adds a capacity value, which should speed things up quite a bit.
