### PR TITLE
Add support for HTTP fallback handler through configurator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Added
+- Configurator can now be constructed with an fallback HTTP handler.
+  All HTTP transports will divert non-RPC requests (those lacking an encoding
+  header) to this HTTP handler.
 
 ## [1.39.0] - 2019-06-25
 ### Fixed

--- a/transport/http/config.go
+++ b/transport/http/config.go
@@ -143,6 +143,8 @@ func (ts *transportSpec) buildTransport(tc *TransportConfig, k *yarpcconfig.Kit)
 	}
 	options.connBackoffStrategy = strategy
 
+	options.fallbackHandler = k.HTTPFallbackHandler
+
 	return options.newTransport(), nil
 }
 

--- a/transport/http/config.go
+++ b/transport/http/config.go
@@ -143,7 +143,7 @@ func (ts *transportSpec) buildTransport(tc *TransportConfig, k *yarpcconfig.Kit)
 	}
 	options.connBackoffStrategy = strategy
 
-	options.fallbackHandler = k.HTTPFallbackHandler
+	options.fallbackHandler = k.HTTPFallbackHandler()
 
 	return options.newTransport(), nil
 }

--- a/transport/http/config_test.go
+++ b/transport/http/config_test.go
@@ -503,6 +503,8 @@ func useFakeBuildClient(t *testing.T, want *wantHTTPClient) TransportOption {
 }
 
 func TestFallbackHandler(t *testing.T) {
+	type attrs map[string]interface{}
+
 	env := map[string]string{}
 
 	fourZeroFour := http.HandlerFunc(func(resWriter http.ResponseWriter, req *http.Request) {
@@ -514,9 +516,9 @@ func TestFallbackHandler(t *testing.T) {
 		yarpcconfig.HTTPFallbackHandler(fourZeroFour),
 	)
 
-	cfgData := map[string]interface{}{
-		"inbounds": map[string]interface{}{
-			"http": map[string]interface{}{
+	cfgData := attrs{
+		"inbounds": attrs{
+			"http": attrs{
 				"address": "127.0.0.1:8080",
 			},
 		},
@@ -530,8 +532,10 @@ func TestFallbackHandler(t *testing.T) {
 
 	dis := yarpc.NewDispatcher(cfg)
 
-	dis.Start()
-	defer dis.Stop()
+	require.NoError(t, dis.Start())
+	defer func() {
+		require.NoError(t, dis.Stop())
+	}()
 
 	res, err := http.Get("http://127.0.0.1:8080")
 	require.NoError(t, err)

--- a/transport/http/config_test.go
+++ b/transport/http/config_test.go
@@ -534,7 +534,7 @@ func TestFallbackHandler(t *testing.T) {
 
 	require.NoError(t, dis.Start())
 	defer func() {
-		require.NoError(t, dis.Stop())
+		assert.NoError(t, dis.Stop())
 	}()
 
 	res, err := http.Get("http://127.0.0.1:8080")

--- a/transport/http/inbound.go
+++ b/transport/http/inbound.go
@@ -104,6 +104,7 @@ func (t *Transport) NewInbound(addr string, opts ...InboundOption) *Inbound {
 		shutdownTimeout:   defaultShutdownTimeout,
 		tracer:            t.tracer,
 		logger:            t.logger,
+		fallbackHandler:   t.fallbackHandler,
 		transport:         t,
 		grabHeaders:       make(map[string]struct{}),
 		bothResponseError: true,
@@ -128,6 +129,7 @@ type Inbound struct {
 	transport       *Transport
 	grabHeaders     map[string]struct{}
 	interceptor     func(http.Handler) http.Handler
+	fallbackHandler http.Handler
 
 	once *lifecycle.Once
 
@@ -174,6 +176,7 @@ func (i *Inbound) start() error {
 		tracer:            i.tracer,
 		grabHeaders:       i.grabHeaders,
 		bothResponseError: i.bothResponseError,
+		fallbackHandler:   i.fallbackHandler,
 		logger:            i.logger,
 	}
 	if i.interceptor != nil {

--- a/transport/http/transport.go
+++ b/transport/http/transport.go
@@ -49,6 +49,7 @@ type transportOptions struct {
 	innocenceWindow       time.Duration
 	jitter                func(int64) int64
 	tracer                opentracing.Tracer
+	fallbackHandler       http.Handler
 	buildClient           func(*transportOptions) *http.Client
 	logger                *zap.Logger
 }
@@ -229,6 +230,7 @@ func (o *transportOptions) newTransport() *Transport {
 		connBackoffStrategy: o.connBackoffStrategy,
 		innocenceWindow:     o.innocenceWindow,
 		jitter:              o.jitter,
+		fallbackHandler:     o.fallbackHandler,
 		peers:               make(map[string]*httpPeer),
 		tracer:              o.tracer,
 		logger:              logger,
@@ -271,6 +273,7 @@ type Transport struct {
 	connectorsGroup     sync.WaitGroup
 	innocenceWindow     time.Duration
 	jitter              func(int64) int64
+	fallbackHandler     http.Handler
 
 	tracer opentracing.Tracer
 	logger *zap.Logger

--- a/yarpcconfig/configurator.go
+++ b/yarpcconfig/configurator.go
@@ -256,10 +256,10 @@ func (c *Configurator) NewDispatcher(serviceName string, data interface{}) (*yar
 
 func (c *Configurator) load(serviceName string, cfg *yarpcConfig) (_ yarpc.Config, err error) {
 	kit := &Kit{
-		HTTPFallbackHandler: c.fallbackHandler,
-		name:                serviceName,
-		c:                   c,
-		resolver:            c.resolver,
+		name:            serviceName,
+		c:               c,
+		resolver:        c.resolver,
+		fallbackHandler: c.fallbackHandler,
 	}
 	b := newBuilder(serviceName, kit)
 

--- a/yarpcconfig/kit.go
+++ b/yarpcconfig/kit.go
@@ -23,6 +23,7 @@ package yarpcconfig
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"reflect"
 	"sort"
 	"strings"
@@ -33,6 +34,8 @@ import (
 // Kit is an opaque object that carries context for the Configurator. Build
 // functions that receive this object MUST NOT modify it.
 type Kit struct {
+	HTTPFallbackHandler http.Handler
+
 	c *Configurator
 
 	name string

--- a/yarpcconfig/kit.go
+++ b/yarpcconfig/kit.go
@@ -34,8 +34,6 @@ import (
 // Kit is an opaque object that carries context for the Configurator. Build
 // functions that receive this object MUST NOT modify it.
 type Kit struct {
-	HTTPFallbackHandler http.Handler
-
 	c *Configurator
 
 	name string
@@ -43,8 +41,18 @@ type Kit struct {
 	// Used to resolve interpolated variables.
 	resolver interpolate.VariableResolver
 
+	// Any HTTP transports may use this to forward non-RPC traffic to a non-RPC
+	// HTTP handler.
+	fallbackHandler http.Handler
+
 	// TransportSpec currently being used. This may or may not be set.
 	transportSpec *compiledTransportSpec
+}
+
+// HTTPFallbackHandler carries the configured HTTP handler for non–RPC
+// requests.
+func (k *Kit) HTTPFallbackHandler() http.Handler {
+	return k.fallbackHandler
 }
 
 // Returns a shallow copy of this Kit with spec set to the given value.

--- a/yarpcconfig/option.go
+++ b/yarpcconfig/option.go
@@ -20,6 +20,8 @@
 
 package yarpcconfig
 
+import "net/http"
+
 // Option customizes a Configurator.
 type Option func(*Configurator)
 
@@ -42,5 +44,15 @@ type Option func(*Configurator)
 func InterpolationResolver(f func(k string) (v string, ok bool)) Option {
 	return func(c *Configurator) {
 		c.resolver = f
+	}
+}
+
+// HTTPFallbackHandler introduces an optional HTTP fallback handler for HTTP
+// transports.
+// Any HTTP transports constructed by this configurator may forward non-RPC
+// requests to this handler.
+func HTTPFallbackHandler(h http.Handler) Option {
+	return func(c *Configurator) {
+		c.fallbackHandler = h
 	}
 }


### PR DESCRIPTION
This change introduces a YARPC Configurator option for an HTTP-specific fallback handler. Any YARPC HTTP inbounds constructed with this configurator option will send any non-RPC requests (those that lack an Rpc-Encoding header) to that HTTP handler.

The configurator option allows us to inject a fallback handler in an Fx module. This is useful for realizing Fx HTTP debug pages on an RPC port.

This change supersedes the interceptor option which did the reverse: allowed an interceptor to capture non-RPC traffic before it was seen by the HTTP transport.

- [x] CHANGELOG entry.