### PR TITLE
Remove deadline from stream example

### DIFF
--- a/internal/examples/streaming/client/main.go
+++ b/internal/examples/streaming/client/main.go
@@ -26,7 +26,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"time"
 
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/internal/examples/streaming"
@@ -56,8 +55,11 @@ func do() error {
 	}
 	defer dispatcher.Stop()
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	// Specifying a deadline on the context affects the entire stream. As this is
+	// generally not the desired behavior, we use a cancelable context instead.
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
 	stream, err := client.HelloThere(ctx, yarpc.WithHeader("test", "testtest"))
 	if err != nil {
 		return fmt.Errorf("failed to create stream: %s", err.Error())


### PR DESCRIPTION
Previously, this example code would cause a context deadline exceeded error
since the deadline on the context applies to the entire stream. This removes the
timeout on the context, instead replacing it with a cancelable context; the
cancelable context can be used to cancel the stream as needed.

Prior to this change, running the example would fail:

*server*
```bash
$ go run ./internal/examples/streaming/server
Error reading from stream: "code:deadline-exceeded message:context deadline exceeded" # after one second
```

*client*
```
$ go run ./internal/examples/streaming/client
>>> asd
sending message: "asd"

2019/07/08 14:27:50 EOF
exit status 1
```

After this change:

*server*
```bash
$ go run ./internal/examples/streaming/server
Received a message: "test"
Sent response message: "Got your message: \"test\", thanks!"
```

*client*
```bash
$ go run ./internal/examples/streaming/client
>>> test
sending message: "test"
waiting for response...
got response: "Got your message: \"test\", thanks!"
```