### PR TITLE
Add comment to never pool the gRPC response writer

### DIFF
--- a/transport/grpc/handler.go
+++ b/transport/grpc/handler.go
@@ -186,6 +186,11 @@ func (h *handler) handleUnary(
 	err = handlerErrorToGRPCError(err, responseWriter)
 
 	// Send the response attributes back and end the stream.
+	//
+	// Warning: SendMsg() holds onto these bytes after returning. Therefore, we
+	// cannot pool this responseWriter.
+	//
+	// See https://github.com/yarpc/yarpc-go/pull/1738 for details.
 	if sendErr := serverStream.SendMsg(responseWriter.Bytes()); sendErr != nil {
 		// We couldn't send the response.
 		return sendErr

--- a/transport/grpc/response_writer.go
+++ b/transport/grpc/response_writer.go
@@ -40,6 +40,10 @@ func newResponseWriter() *responseWriter {
 
 func (r *responseWriter) Write(p []byte) (int, error) {
 	if r.buffer == nil {
+		// Response writer bytes must not be pooled since calls to SendMsg hold on
+		// to the bytes after the the function returns.
+		//
+		// See https://github.com/yarpc/yarpc-go/pull/1738 for details.
 		r.buffer = bytes.NewBuffer(make([]byte, 0, len(p)))
 	}
 	return r.buffer.Write(p)


### PR DESCRIPTION
In https://github.com/yarpc/yarpc-go/pull/1738, we established that
calls to `ServerStream.SendMsg()`, for unary requests, hold onto the
byte slice even after returning.

This adds a few comments to ensure that we don't run into a buffer
issue again, as we did in https://github.com/yarpc/yarpc-go/pull/1416.