### PR TITLE
Specify log levels for every edge of traffic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+- Log level configuration can now be expressed specifically for every
+  combination of inbound and outbound, for success, failure, and application
+  error.
 
 ## [1.39.0] - 2019-06-25
 ### Fixed

--- a/config.go
+++ b/config.go
@@ -43,9 +43,32 @@ const (
 
 // LogLevelConfig configures the levels at which YARPC logs various things.
 type LogLevelConfig struct {
-	// Level at which application errors are logged. Note that all Thrift
-	// exceptions are considered application errors.
-	//
+	// Level at which successful requests are logged.
+	// Defaults to DebugLevel.
+	Success *zapcore.Level
+	// Level at which errors are logged.
+	// Thrift exceptions are application errors, which we log as a separate
+	// class from success and failure.
+	Failure *zapcore.Level
+	// Level at which application errors are logged.
+	// All Thrift exceptions are considered application errors.
+	// Defaults to ErrorLevel.
+	ApplicationError *zapcore.Level
+
+	// Specific overrides for inbound and outbound requests.
+	Inbound, Outbound DirectionalLogLevelConfig
+}
+
+type DirectionalLogLevelConfig struct {
+	// Level at which successful requests are logged.
+	// Defaults to DebugLevel.
+	Success *zapcore.Level
+	// Level at which errors are logged.
+	// Thrift exceptions are application errors, which we log as a separate
+	// class from success and failure.
+	Failure *zapcore.Level
+	// Level at which application errors are logged.
+	// All Thrift exceptions are considered application errors.
 	// Defaults to ErrorLevel.
 	ApplicationError *zapcore.Level
 }

--- a/config.go
+++ b/config.go
@@ -41,24 +41,8 @@ const (
 	_packageName       = "yarpc"
 )
 
-// LogLevelConfig configures the levels at which YARPC logs various things.
-type LogLevelConfig struct {
-	// Level at which successful requests are logged.
-	// Defaults to DebugLevel.
-	Success *zapcore.Level
-	// Level at which errors are logged.
-	// Thrift exceptions are application errors, which we log as a separate
-	// class from success and failure.
-	Failure *zapcore.Level
-	// Level at which application errors are logged.
-	// All Thrift exceptions are considered application errors.
-	// Defaults to ErrorLevel.
-	ApplicationError *zapcore.Level
-
-	// Specific overrides for inbound and outbound requests.
-	Inbound, Outbound DirectionalLogLevelConfig
-}
-
+// DirectionalLogLevelConfig may override the log levels for any combination of
+// successes, failures, and application errors.
 type DirectionalLogLevelConfig struct {
 	// Level at which successful requests are logged.
 	// Defaults to DebugLevel.
@@ -69,8 +53,33 @@ type DirectionalLogLevelConfig struct {
 	Failure *zapcore.Level
 	// Level at which application errors are logged.
 	// All Thrift exceptions are considered application errors.
+	// All errors from Protobuf handlers are application errors.
 	// Defaults to ErrorLevel.
 	ApplicationError *zapcore.Level
+}
+
+// LogLevelConfig configures the levels at which YARPC logs various things.
+type LogLevelConfig struct {
+	// Level at which successful requests are logged.
+	// Defaults to DebugLevel.
+	// Can be overridden by Inbound.Success or Outbound.Success for inbound or
+	// outbound requests.
+	Success *zapcore.Level
+	// Level at which errors are logged.
+	// Thrift exceptions are application errors, which we log as a separate
+	// class from success and failure.
+	// Can be overridden by Inbound.Failure or Outbound.Failure for inbound or
+	// outbound requests.
+	Failure *zapcore.Level
+	// Level at which application errors are logged.
+	// All Thrift exceptions are considered application errors.
+	// Defaults to ErrorLevel.
+	// Can be overridden by Inbound.ApplicationError or
+	// Outbound.ApplicationError for inbound or outbound requests.
+	ApplicationError *zapcore.Level
+
+	// Specific overrides for inbound and outbound requests.
+	Inbound, Outbound DirectionalLogLevelConfig
 }
 
 // LoggingConfig describes how logging should be configured.

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -101,10 +101,26 @@ func addObservingMiddleware(cfg Config, meter *metrics.Scope, logger *zap.Logger
 	}
 
 	observer := observability.NewMiddleware(observability.Config{
-		Logger:                logger,
-		Scope:                 meter,
-		ContextExtractor:      extractor,
-		ApplicationErrorLevel: cfg.Logging.Levels.ApplicationError,
+		Logger:           logger,
+		Scope:            meter,
+		ContextExtractor: extractor,
+		Levels: observability.LevelsConfig{
+			Default: observability.DirectionalLevelsConfig{
+				Success:          cfg.Logging.Levels.Success,
+				Failure:          cfg.Logging.Levels.Failure,
+				ApplicationError: cfg.Logging.Levels.ApplicationError,
+			},
+			Inbound: observability.DirectionalLevelsConfig{
+				Success:          cfg.Logging.Levels.Inbound.Success,
+				Failure:          cfg.Logging.Levels.Inbound.Failure,
+				ApplicationError: cfg.Logging.Levels.Inbound.ApplicationError,
+			},
+			Outbound: observability.DirectionalLevelsConfig{
+				Success:          cfg.Logging.Levels.Outbound.Success,
+				Failure:          cfg.Logging.Levels.Outbound.Failure,
+				ApplicationError: cfg.Logging.Levels.Outbound.ApplicationError,
+			},
+		},
 	})
 
 	cfg.InboundMiddleware.Unary = inboundmiddleware.UnaryChain(observer, cfg.InboundMiddleware.Unary)

--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -53,7 +53,11 @@ type call struct {
 	rpcType   transport.Type
 	direction directionName
 
-	succLevel, failLevel, appErrLevel zapcore.Level
+	levels *levels
+}
+
+type levels struct {
+	success, failure, applicationError zapcore.Level
 }
 
 func (c call) End(err error) {
@@ -73,16 +77,16 @@ func (c call) endLogs(elapsed time.Duration, err error, isApplicationError bool)
 		if c.direction != _directionInbound {
 			msg = _successfulOutbound
 		}
-		ce = c.edge.logger.Check(c.succLevel, msg)
+		ce = c.edge.logger.Check(c.levels.success, msg)
 	} else {
 		msg := _errorInbound
 		if c.direction != _directionInbound {
 			msg = _errorOutbound
 		}
 
-		lvl := c.failLevel
+		lvl := c.levels.failure
 		if isApplicationError {
-			lvl = c.appErrLevel
+			lvl = c.levels.applicationError
 		}
 		ce = c.edge.logger.Check(lvl, msg)
 	}

--- a/internal/observability/middleware.go
+++ b/internal/observability/middleware.go
@@ -78,12 +78,16 @@ type Config struct {
 	Levels LevelsConfig
 }
 
+// LevelsConfig specifies log level overrides for inbound traffic, outbound
+// traffic, or the defaults for either.
 type LevelsConfig struct {
 	Default  DirectionalLevelsConfig
 	Inbound  DirectionalLevelsConfig
 	Outbound DirectionalLevelsConfig
 }
 
+// DirectionalLevelsConfig may override the log levels for any combination of
+// successes, failures, and application errors.
 type DirectionalLevelsConfig struct {
 	// Log level used to log successful calls.
 	//

--- a/internal/observability/middleware.go
+++ b/internal/observability/middleware.go
@@ -74,22 +74,33 @@ type Config struct {
 	// Extracts request-scoped information from the context for logging.
 	ContextExtractor ContextExtractor
 
-	// Log level used to log successful inbound and outbound calls.
+	// Levels specify log levels for various classes of requests.
+	Levels LevelsConfig
+}
+
+type LevelsConfig struct {
+	Default  DirectionalLevelsConfig
+	Inbound  DirectionalLevelsConfig
+	Outbound DirectionalLevelsConfig
+}
+
+type DirectionalLevelsConfig struct {
+	// Log level used to log successful calls.
 	//
 	// Defaults to DebugLevel.
-	SuccessLevel *zapcore.Level
+	Success *zapcore.Level
 
-	// Log level used to log failed inbound and outbound calls. This includes
-	// low-level network errors, TChannel error frames, etc.
+	// Log level used to log failed calls.
+	// This includes low-level network errors, TChannel error frames, etc.
 	//
 	// Defaults to ErrorLevel.
-	FailureLevel *zapcore.Level
+	Failure *zapcore.Level
 
-	// Log level used to log calls that failed with an application error. All
-	// Thrift exceptions are considered application errors.
+	// Log level used to log calls that failed with an application error.
+	// All Thrift exceptions are considered application errors.
 	//
 	// Defaults to ErrorLevel.
-	ApplicationErrorLevel *zapcore.Level
+	ApplicationError *zapcore.Level
 }
 
 // NewMiddleware constructs an observability middleware with the provided
@@ -97,17 +108,26 @@ type Config struct {
 func NewMiddleware(cfg Config) *Middleware {
 	m := &Middleware{newGraph(cfg.Scope, cfg.Logger, cfg.ContextExtractor)}
 
-	if lvl := cfg.SuccessLevel; lvl != nil {
-		m.graph.succLevel = *lvl
-	}
-	if lvl := cfg.FailureLevel; lvl != nil {
-		m.graph.failLevel = *lvl
-	}
-	if lvl := cfg.ApplicationErrorLevel; lvl != nil {
-		m.graph.appErrLevel = *lvl
-	}
+	// Apply the default levels
+	applyLogLevelsConfig(&m.graph.inboundLevels, &cfg.Levels.Default)
+	applyLogLevelsConfig(&m.graph.outboundLevels, &cfg.Levels.Default)
+	// Override with direction-specific levels
+	applyLogLevelsConfig(&m.graph.inboundLevels, &cfg.Levels.Inbound)
+	applyLogLevelsConfig(&m.graph.outboundLevels, &cfg.Levels.Outbound)
 
 	return m
+}
+
+func applyLogLevelsConfig(dst *levels, src *DirectionalLevelsConfig) {
+	if level := src.Success; level != nil {
+		dst.success = *src.Success
+	}
+	if level := src.Failure; level != nil {
+		dst.failure = *src.Failure
+	}
+	if level := src.ApplicationError; level != nil {
+		dst.applicationError = *src.ApplicationError
+	}
 }
 
 // Handle implements middleware.UnaryInbound.

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -68,10 +68,10 @@ func TestNewMiddlewareLogLevels(t *testing.T) {
 				assert.Equal(t, zapcore.InfoLevel, NewMiddleware(Config{
 					Levels: LevelsConfig{
 						Default: DirectionalLevelsConfig{
-							Success: &warnLevel, // overrridden
+							Success: &warnLevel, // overridden by Inbound.Success
 						},
 						Inbound: DirectionalLevelsConfig{
-							Success: &infoLevel,
+							Success: &infoLevel, // overrides Default.Success
 						},
 					},
 				}).graph.inboundLevels.success)

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -48,39 +48,116 @@ func TestNewMiddlewareLogLevels(t *testing.T) {
 	infoLevel := zapcore.InfoLevel
 	warnLevel := zapcore.WarnLevel
 
-	t.Run("Success", func(t *testing.T) {
-		t.Run("default", func(t *testing.T) {
-			assert.Equal(t, zapcore.DebugLevel, NewMiddleware(Config{}).graph.succLevel)
+	t.Run("Inbound", func(t *testing.T) {
+		t.Run("Success", func(t *testing.T) {
+			t.Run("default", func(t *testing.T) {
+				assert.Equal(t, zapcore.DebugLevel, NewMiddleware(Config{}).graph.inboundLevels.success)
+			})
+
+			t.Run("any direction override", func(t *testing.T) {
+				assert.Equal(t, zapcore.InfoLevel, NewMiddleware(Config{
+					Levels: LevelsConfig{
+						Default: DirectionalLevelsConfig{
+							Success: &infoLevel,
+						},
+					},
+				}).graph.inboundLevels.success)
+			})
+
+			t.Run("directional override", func(t *testing.T) {
+				assert.Equal(t, zapcore.InfoLevel, NewMiddleware(Config{
+					Levels: LevelsConfig{
+						Default: DirectionalLevelsConfig{
+							Success: &warnLevel, // overrridden
+						},
+						Inbound: DirectionalLevelsConfig{
+							Success: &infoLevel,
+						},
+					},
+				}).graph.inboundLevels.success)
+			})
 		})
 
-		t.Run("override", func(t *testing.T) {
-			assert.Equal(t, zapcore.InfoLevel, NewMiddleware(Config{
-				SuccessLevel: &infoLevel,
-			}).graph.succLevel)
+		t.Run("Failure", func(t *testing.T) {
+			t.Run("default", func(t *testing.T) {
+				assert.Equal(t, zapcore.ErrorLevel, NewMiddleware(Config{}).graph.inboundLevels.failure)
+			})
+
+			t.Run("override", func(t *testing.T) {
+				assert.Equal(t, zapcore.WarnLevel, NewMiddleware(Config{
+					Levels: LevelsConfig{
+						Inbound: DirectionalLevelsConfig{
+							Failure: &warnLevel,
+						},
+					},
+				}).graph.inboundLevels.failure)
+			})
+		})
+
+		t.Run("ApplicationError", func(t *testing.T) {
+			t.Run("default", func(t *testing.T) {
+				assert.Equal(t, zapcore.ErrorLevel, NewMiddleware(Config{}).graph.inboundLevels.applicationError)
+			})
+
+			t.Run("override", func(t *testing.T) {
+				assert.Equal(t, zapcore.WarnLevel, NewMiddleware(Config{
+					Levels: LevelsConfig{
+						Inbound: DirectionalLevelsConfig{
+							ApplicationError: &warnLevel,
+						},
+					},
+				}).graph.inboundLevels.applicationError)
+			})
 		})
 	})
 
-	t.Run("Failure", func(t *testing.T) {
-		t.Run("default", func(t *testing.T) {
-			assert.Equal(t, zapcore.ErrorLevel, NewMiddleware(Config{}).graph.failLevel)
+	t.Run("Outbound", func(t *testing.T) {
+		t.Run("Success", func(t *testing.T) {
+			t.Run("default", func(t *testing.T) {
+				assert.Equal(t, zapcore.DebugLevel, NewMiddleware(Config{}).graph.outboundLevels.success)
+			})
+
+			t.Run("override", func(t *testing.T) {
+				assert.Equal(t, zapcore.InfoLevel, NewMiddleware(Config{
+					Levels: LevelsConfig{
+						Outbound: DirectionalLevelsConfig{
+							Success: &infoLevel,
+						},
+					},
+				}).graph.outboundLevels.success)
+			})
 		})
 
-		t.Run("override", func(t *testing.T) {
-			assert.Equal(t, zapcore.WarnLevel, NewMiddleware(Config{
-				FailureLevel: &warnLevel,
-			}).graph.failLevel)
-		})
-	})
+		t.Run("Failure", func(t *testing.T) {
+			t.Run("default", func(t *testing.T) {
+				assert.Equal(t, zapcore.ErrorLevel, NewMiddleware(Config{}).graph.outboundLevels.failure)
+			})
 
-	t.Run("ApplicationError", func(t *testing.T) {
-		t.Run("default", func(t *testing.T) {
-			assert.Equal(t, zapcore.ErrorLevel, NewMiddleware(Config{}).graph.appErrLevel)
+			t.Run("override", func(t *testing.T) {
+				assert.Equal(t, zapcore.WarnLevel, NewMiddleware(Config{
+					Levels: LevelsConfig{
+						Outbound: DirectionalLevelsConfig{
+							Failure: &warnLevel,
+						},
+					},
+				}).graph.outboundLevels.failure)
+			})
 		})
 
-		t.Run("override", func(t *testing.T) {
-			assert.Equal(t, zapcore.WarnLevel, NewMiddleware(Config{
-				ApplicationErrorLevel: &warnLevel,
-			}).graph.appErrLevel)
+		t.Run("ApplicationError", func(t *testing.T) {
+			t.Run("default", func(t *testing.T) {
+				assert.Equal(t, zapcore.ErrorLevel, NewMiddleware(Config{}).graph.outboundLevels.applicationError)
+			})
+
+			t.Run("override", func(t *testing.T) {
+				assert.Equal(t, zapcore.WarnLevel, NewMiddleware(Config{
+					Levels: LevelsConfig{
+						Outbound: DirectionalLevelsConfig{
+							ApplicationError: &warnLevel,
+						},
+					},
+				}).graph.outboundLevels.applicationError)
+			})
 		})
 	})
 }
@@ -179,12 +256,16 @@ func TestMiddlewareLogging(t *testing.T) {
 	for _, tt := range tests {
 		core, logs := observer.New(zapcore.DebugLevel)
 		mw := NewMiddleware(Config{
-			Logger:                zap.New(core),
-			Scope:                 metrics.New().Scope(),
-			ContextExtractor:      NewNopContextExtractor(),
-			SuccessLevel:          &infoLevel,
-			ApplicationErrorLevel: &warnLevel,
-			// Leave failure level as the default.
+			Logger:           zap.New(core),
+			Scope:            metrics.New().Scope(),
+			ContextExtractor: NewNopContextExtractor(),
+			Levels: LevelsConfig{
+				Default: DirectionalLevelsConfig{
+					Success:          &infoLevel,
+					ApplicationError: &warnLevel,
+					// Leave failure level as the default.
+				},
+			},
 		})
 
 		getLog := func() observer.LoggedEntry {

--- a/yarpcconfig/configurator_test.go
+++ b/yarpcconfig/configurator_test.go
@@ -133,6 +133,34 @@ func TestConfigurator(t *testing.T) {
 			},
 		},
 		{
+			desc: "outbound success info logging",
+			test: func(*testing.T, *gomock.Controller) (tt testCase) {
+				debugLevel := zapcore.DebugLevel
+				infoLevel := zapcore.InfoLevel
+
+				tt.serviceName = "foo"
+				tt.give = whitespace.Expand(`
+					logging:
+						levels:
+							success: debug
+							outbound:
+								success: info
+				`)
+				tt.wantConfig = yarpc.Config{
+					Name: "foo",
+					Logging: yarpc.LoggingConfig{
+						Levels: yarpc.LogLevelConfig{
+							Success: &debugLevel,
+							Outbound: yarpc.DirectionalLogLevelConfig{
+								Success: &infoLevel,
+							},
+						},
+					},
+				}
+				return
+			},
+		},
+		{
 			desc: "application error, invalid type",
 			test: func(*testing.T, *gomock.Controller) (tt testCase) {
 				tt.give = whitespace.Expand(`

--- a/yarpcconfig/decode.go
+++ b/yarpcconfig/decode.go
@@ -40,13 +40,37 @@ type yarpcConfig struct {
 // logging allows configuring the log levels from YAML.
 type logging struct {
 	Levels struct {
+		// Defaults regardless of direction.
+		Success          *zapLevel `config:"success"`
+		Failure          *zapLevel `config:"failure"`
 		ApplicationError *zapLevel `config:"applicationError"`
+
+		// Directional overrides.
+		Inbound  levels `config:"inbound"`
+		Outbound levels `config:"outbound"`
 	} `config:"levels"`
+}
+
+type levels struct {
+	Success          *zapLevel `config:"success"`
+	Failure          *zapLevel `config:"failure"`
+	ApplicationError *zapLevel `config:"applicationError"`
 }
 
 // Fills values from this object into the provided YARPC config.
 func (l *logging) fill(cfg *yarpc.Config) {
+	cfg.Logging.Levels.Success = (*zapcore.Level)(l.Levels.Success)
+	cfg.Logging.Levels.Failure = (*zapcore.Level)(l.Levels.Failure)
 	cfg.Logging.Levels.ApplicationError = (*zapcore.Level)(l.Levels.ApplicationError)
+
+	l.Levels.Inbound.fill(&cfg.Logging.Levels.Inbound)
+	l.Levels.Outbound.fill(&cfg.Logging.Levels.Outbound)
+}
+
+func (l *levels) fill(cfg *yarpc.DirectionalLogLevelConfig) {
+	cfg.Success = (*zapcore.Level)(l.Success)
+	cfg.Failure = (*zapcore.Level)(l.Failure)
+	cfg.ApplicationError = (*zapcore.Level)(l.ApplicationError)
 }
 
 type zapLevel zapcore.Level

--- a/yarpcconfig/doc.go
+++ b/yarpcconfig/doc.go
@@ -257,8 +257,8 @@
 //  success
 //    Configures the level at which successful requests are logged.
 //    Defaults to "debug".
-// 	applicationError
-// 	  Configures the level at which application errors are logged.
+//  applicationError
+//    Configures the level at which application errors are logged.
 //    All Thrift exceptions are considered application errors.
 //    Defaults to "error".
 //  failure

--- a/yarpcconfig/doc.go
+++ b/yarpcconfig/doc.go
@@ -254,9 +254,16 @@
 //
 // The following keys are supported under the 'levels' key,
 //
+//  success
+//    Configures the level at which successful requests are logged.
+//    Defaults to "debug".
 // 	applicationError
-// 	  Configures the level at which application errors are logged. All Thrift
-// 	  exceptions are considered application errors. Defaults to "error".
+// 	  Configures the level at which application errors are logged.
+//    All Thrift exceptions are considered application errors.
+//    Defaults to "error".
+//  failure
+//    Configures the level at which all other failures are logged.
+//    Default is "error".
 //
 // For example, the following configuration will have the effect of logging
 // Thrift exceptions for inbound and outbound calls ("Error handling inbound
@@ -265,6 +272,26 @@
 // 	logging:
 // 	  levels:
 // 	    applicationError: info
+//
+// The 'logging' attribute also has 'inbound' and 'outbound' sections
+// to specify log levels that depend on the traffic direction.
+// For example, the following configuration will only override the log level
+// for successful outbound requests.
+//
+//  logging:
+//    levels:
+//      inbound:
+//        success: debug
+//
+// The log levels are:
+//
+//  debug
+//  info
+//  warn
+//  error
+//  dpanic
+//  panic
+//  fatal
 //
 // Customizing Configuration
 //


### PR DESCRIPTION
This change introduces finer granularity for overriding the log level for (inbound, outbound) x (success, failure, application error) edges of traffic. Previously, it was only possible to override for application errors both inbound and outbound. With the new configuration structure, on one level you can provide an override for both inbound and outbound, and a level lower than that, override specifically inbound or outbound.