### PR TITLE
[WIP Optional Review] Per message metrics for streaming

### DIFF
--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -62,11 +62,11 @@ func (c call) End(err error) {
 
 func (c call) EndWithAppError(err error, isApplicationError bool) {
 	elapsed := _timeNow().Sub(c.started)
-	c.endLogs(elapsed, err, isApplicationError)
+	c.log(elapsed, err, isApplicationError)
 	c.endStats(elapsed, err, isApplicationError)
 }
 
-func (c call) endLogs(elapsed time.Duration, err error, isApplicationError bool) {
+func (c call) log(elapsed time.Duration, err error, isApplicationError bool) {
 	var ce *zapcore.CheckedEntry
 	if err == nil && !isApplicationError {
 		msg := _successfulInbound

--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -161,3 +161,14 @@ func (c call) endStats(elapsed time.Duration, err error, isApplicationError bool
 		}
 	}
 }
+
+func (c call) EndStream(err error) {
+	elapsed := _timeNow().Sub(c.started)
+	c.edge.streaming.streamDurations.Observe(elapsed)
+	c.log(elapsed, err, false)
+	c.endStreamStats(err)
+}
+
+func (c call) endStreamStats(err error) {
+
+}

--- a/internal/observability/codes.go
+++ b/internal/observability/codes.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package observability
+
+import (
+	"go.uber.org/yarpc/yarpcerrors"
+)
+
+// TODO(apeatsbond): This code may be worth exporting in the yarpcerrors
+// package.
+
+type fault int
+
+const (
+	indeterminateFault fault = iota
+	clientFault
+	serverFault
+)
+
+// determine whether the status code is a client, server or indeterminate fault.
+func statusFault(status *yarpcerrors.Status) fault {
+	switch status.Code() {
+	case yarpcerrors.CodeCancelled,
+		yarpcerrors.CodeInvalidArgument,
+		yarpcerrors.CodeNotFound,
+		yarpcerrors.CodeAlreadyExists,
+		yarpcerrors.CodePermissionDenied,
+		yarpcerrors.CodeFailedPrecondition,
+		yarpcerrors.CodeAborted,
+		yarpcerrors.CodeOutOfRange,
+		yarpcerrors.CodeUnimplemented,
+		yarpcerrors.CodeUnauthenticated:
+		return clientFault
+
+	case yarpcerrors.CodeUnknown,
+		yarpcerrors.CodeDeadlineExceeded,
+		yarpcerrors.CodeResourceExhausted,
+		yarpcerrors.CodeInternal,
+		yarpcerrors.CodeUnavailable,
+		yarpcerrors.CodeDataLoss:
+		return serverFault
+	}
+
+	return indeterminateFault
+}

--- a/internal/observability/graph_test.go
+++ b/internal/observability/graph_test.go
@@ -47,11 +47,11 @@ func TestEdgeNopFallbacks(t *testing.T) {
 	}
 
 	// Should succeed, covered by middleware tests.
-	_ = newEdge(zap.NewNop(), meter, req, string(_directionOutbound))
+	_ = newEdge(zap.NewNop(), meter, req, string(_directionOutbound), transport.Unary)
 
 	// Should fall back to no-op metrics.
 	// Usage of nil metrics should not panic, should not observe changes.
-	e := newEdge(zap.NewNop(), meter, req, string(_directionOutbound))
+	e := newEdge(zap.NewNop(), meter, req, string(_directionOutbound), transport.Unary)
 
 	e.calls.Inc()
 	assert.Equal(t, int64(0), e.calls.Load(), "Expected to fall back to no-op metrics.")

--- a/internal/observability/middleware.go
+++ b/internal/observability/middleware.go
@@ -152,6 +152,7 @@ func (m *Middleware) CallOneway(ctx context.Context, req *transport.Request, out
 // HandleStream implements middleware.StreamInbound.
 func (m *Middleware) HandleStream(serverStream *transport.ServerStream, h transport.StreamHandler) error {
 	call := m.graph.begin(serverStream.Context(), transport.Streaming, _directionInbound, serverStream.Request().Meta.ToRequest())
+	call.EndStreamHandshake(err) //TODO(need some way to log that the initial handshake was fine)
 
 	wrappedStream, err := transport.NewServerStream(newServerStreamWrapper(call, serverStream))
 	if err != nil {
@@ -163,8 +164,7 @@ func (m *Middleware) HandleStream(serverStream *transport.ServerStream, h transp
 	}
 
 	err = h.HandleStream(wrappedStream)
-	// TODO: end stream
-	call.End(err)
+	call.EndStream(err)
 	return err
 }
 
@@ -172,7 +172,7 @@ func (m *Middleware) HandleStream(serverStream *transport.ServerStream, h transp
 func (m *Middleware) CallStream(ctx context.Context, request *transport.StreamRequest, out transport.StreamOutbound) (*transport.ClientStream, error) {
 	call := m.graph.begin(ctx, transport.Streaming, _directionOutbound, request.Meta.ToRequest())
 	clientStream, err := out.CallStream(ctx, request)
-	call.End(err)
+	call.EndStreamHandshake(err) //TODO(need some way to log that the initial handshake was fine)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/observability/middleware.go
+++ b/internal/observability/middleware.go
@@ -152,8 +152,18 @@ func (m *Middleware) CallOneway(ctx context.Context, req *transport.Request, out
 // HandleStream implements middleware.StreamInbound.
 func (m *Middleware) HandleStream(serverStream *transport.ServerStream, h transport.StreamHandler) error {
 	call := m.graph.begin(serverStream.Context(), transport.Streaming, _directionInbound, serverStream.Request().Meta.ToRequest())
-	err := h.HandleStream(serverStream)
-	// TODO(pedge): wrap the *transport.ServerStream?
+
+	wrappedStream, err := transport.NewServerStream(newServerStreamWrapper(call, serverStream))
+	if err != nil {
+		// This will never happen since transport.NewServerStream only returns an
+		// error for nil streams. In the nearly impossible situation where we do, we
+		// fall back to using the original, unwrapped stream.
+		m.graph.logger.Error("transport.ServerStream wrapping should never fail, streaming metrics are disabled")
+		wrappedStream = serverStream
+	}
+
+	err = h.HandleStream(wrappedStream)
+	// TODO: end stream
 	call.End(err)
 	return err
 }
@@ -162,7 +172,18 @@ func (m *Middleware) HandleStream(serverStream *transport.ServerStream, h transp
 func (m *Middleware) CallStream(ctx context.Context, request *transport.StreamRequest, out transport.StreamOutbound) (*transport.ClientStream, error) {
 	call := m.graph.begin(ctx, transport.Streaming, _directionOutbound, request.Meta.ToRequest())
 	clientStream, err := out.CallStream(ctx, request)
-	// TODO(pedge): wrap the *transport.ClientStream?
 	call.End(err)
-	return clientStream, err
+	if err != nil {
+		return nil, err
+	}
+
+	wrappedStream, err := transport.NewClientStream(newClientStreamWrapper(call, clientStream))
+	if err != nil {
+		// This will never happen since transport.NewClientStream only returns an
+		// error for nil streams. In the nearly impossible situation where we do, we
+		// fall back to using the original, unwrapped stream.
+		m.graph.logger.Error("transport.ClientStream wrapping should never fail, streaming metrics are disabled")
+		wrappedStream = clientStream
+	}
+	return wrappedStream, nil
 }

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -410,8 +410,8 @@ func TestMiddlewareMetrics(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		validate := func(mw *Middleware, direction string) {
-			key, free := getKey(req, direction)
+		validate := func(mw *Middleware, direction string, rpcType transport.Type) {
+			key, free := getKey(req, direction, rpcType)
 			edge := mw.graph.getEdge(key)
 			free()
 			assert.Equal(t, int64(tt.wantCalls), edge.calls.Load())
@@ -435,7 +435,7 @@ func TestMiddlewareMetrics(t *testing.T) {
 				&transporttest.FakeResponseWriter{},
 				newHandler(tt),
 			)
-			validate(mw, string(_directionInbound))
+			validate(mw, string(_directionInbound), transport.Unary)
 		})
 		t.Run(tt.desc+", unary outbound", func(t *testing.T) {
 			mw := NewMiddleware(Config{
@@ -444,7 +444,7 @@ func TestMiddlewareMetrics(t *testing.T) {
 				ContextExtractor: NewNopContextExtractor(),
 			})
 			mw.Call(context.Background(), req, newOutbound(tt))
-			validate(mw, string(_directionOutbound))
+			validate(mw, string(_directionOutbound), transport.Unary)
 		})
 	}
 }
@@ -452,7 +452,7 @@ func TestMiddlewareMetrics(t *testing.T) {
 // getKey gets the "key" that we will use to get an edge in the graph.  We use
 // a separate function to recreate the logic because extracting it out in the
 // main code could have performance implications.
-func getKey(req *transport.Request, direction string) (key []byte, free func()) {
+func getKey(req *transport.Request, direction string, rpcType transport.Type) (key []byte, free func()) {
 	d := digester.New()
 	d.Add(req.Caller)
 	d.Add(req.Service)
@@ -462,6 +462,7 @@ func getKey(req *transport.Request, direction string) (key []byte, free func()) 
 	d.Add(req.RoutingKey)
 	d.Add(req.RoutingDelegate)
 	d.Add(direction)
+	d.Add(rpcType.String())
 	return d.Digest(), d.Free
 }
 
@@ -560,6 +561,7 @@ func TestMiddlewareSuccessSnapshot(t *testing.T) {
 		"procedure":        "procedure",
 		"routing_delegate": "rd",
 		"routing_key":      "rk",
+		"rpc_type":         transport.Unary.String(),
 		"source":           "caller",
 	}
 	want := &metrics.RootSnapshot{
@@ -621,23 +623,25 @@ func TestMiddlewareFailureSnapshot(t *testing.T) {
 	tags := metrics.Tags{
 		"dest":             "service",
 		"direction":        "inbound",
-		"transport":        "unknown",
 		"encoding":         "raw",
 		"procedure":        "procedure",
 		"routing_delegate": "rd",
 		"routing_key":      "rk",
+		"rpc_type":         transport.Unary.String(),
 		"source":           "caller",
+		"transport":        "unknown",
 	}
 	errorTags := metrics.Tags{
 		"dest":             "service",
 		"direction":        "inbound",
-		"transport":        "unknown",
 		"encoding":         "raw",
+		"error":            "unknown_internal_yarpc",
 		"procedure":        "procedure",
 		"routing_delegate": "rd",
 		"routing_key":      "rk",
+		"rpc_type":         transport.Unary.String(),
 		"source":           "caller",
-		"error":            "unknown_internal_yarpc",
+		"transport":        "unknown",
 	}
 	want := &metrics.RootSnapshot{
 		Counters: []metrics.Snapshot{
@@ -733,6 +737,7 @@ func TestApplicationErrorSnapShot(t *testing.T) {
 				"procedure":        "procedure",
 				"routing_delegate": "rd",
 				"routing_key":      "rk",
+				"rpc_type":         transport.Unary.String(),
 				"source":           "caller",
 			}
 			errorTags := metrics.Tags{
@@ -743,6 +748,7 @@ func TestApplicationErrorSnapShot(t *testing.T) {
 				"procedure":        "procedure",
 				"routing_delegate": "rd",
 				"routing_key":      "rk",
+				"rpc_type":         transport.Unary.String(),
 				"source":           "caller",
 				"error":            tt.errTag,
 			}

--- a/internal/observability/stream.go
+++ b/internal/observability/stream.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package observability
+
+import (
+	"context"
+
+	"go.uber.org/yarpc/api/transport"
+)
+
+var _ transport.StreamCloser = (*streamWrapper)(nil)
+
+type streamWrapper struct {
+	call   call
+	stream transport.StreamCloser
+}
+
+func newClientStreamWrapper(call call, stream transport.StreamCloser) transport.StreamCloser {
+	return &streamWrapper{
+		call:   call,
+		stream: stream,
+	}
+}
+
+func newServerStreamWrapper(call call, stream transport.Stream) transport.Stream {
+	return &streamWrapper{
+		call:   call,
+		stream: contextCloser{stream},
+	}
+}
+
+func (s *streamWrapper) Context() context.Context {
+	return s.stream.Context()
+}
+
+func (s *streamWrapper) Request() *transport.StreamRequest {
+	return s.stream.Request()
+}
+
+func (s *streamWrapper) SendMessage(ctx context.Context, msg *transport.StreamMessage) error {
+	return s.stream.SendMessage(ctx, msg)
+}
+
+func (s *streamWrapper) ReceiveMessage(ctx context.Context) (*transport.StreamMessage, error) {
+	return s.stream.ReceiveMessage(ctx)
+}
+
+func (s *streamWrapper) Close(ctx context.Context) error {
+	return s.stream.Close(ctx)
+}
+
+// This is a light wrapper so that we can re-use the same methods for
+// instrumenting observaiblity. The transport.ServerStream does not have a
+// Close(ctx) method, unlike the transport.ClientStream.
+type contextCloser struct {
+	transport.Stream
+}
+
+func (c contextCloser) Close(ctx context.Context) error {
+	return nil
+}


### PR DESCRIPTION
Just a work-in-progress for now, since I'm out next week.
This still needs production validation and missing a few parts.

We may need to keep the existing metrics around streaming in case anyone is using them :/

Notable parts to look at:
- `graph.go` for the additional stream metrics and definitions
- `stream.go` for stream wrapper where we emit the metrics
