### PR TITLE
Peer list stress test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Log level configuration can now be expressed specifically for every
   combination of inbound and outbound, for success, failure, and application
   error.
+- A peer list and transport stress tester is now in the `yarpctest` package.
 
 ## [1.39.0] - 2019-06-25
 ### Fixed

--- a/internal/stresstest/main.go
+++ b/internal/stresstest/main.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package main runs a stress test on each peer list implementation,
+// concurrently adding, removing, connecting, disconnecting, and choosing
+// peers.
+//
+// Output:
+//
+//  name                     stress  workers  min       max         mean       choices  updates
+//  round-robin              true    1        245       8770915     146851     5253     46150
+//  round-robin              false   1        207       418011      291        971224   1
+//  round-robin              true    10       233       16849329    387306     19074    50669
+//  round-robin              false   10       223       1578697     5346       1194757  1
+//  round-robin              true    100      230       27465221    908544     75258    46810
+//  round-robin              false   100      226       7461220     67418      1032094  1
+//  round-robin              true    1000     233       22398858    2024969    330804   4576
+//  round-robin              false   1000     229       21501281    802412     839121   1
+//  round-robin              true    10000    233       92130003    19808992   346389   297
+//  round-robin              false   10000    276       64225586    21145554   314307   1
+//  round-robin              true    100000   230       938109206   206172150  420222   8
+//  round-robin              false   100000   234       752404056   162852049  555573   1
+//  random                   true    1        290       9613482     147458     5411     51211
+//  random                   false   1        218       4010623     320        945794   1
+//  random                   true    10       251       13586138    292117     25511    51602
+//  random                   false   10       234       6359156     6460       945427   1
+//  random                   true    100      245       22698254    635979     106915   41375
+//  random                   false   100      245       11036988    90960      740277   1
+//  random                   true    1000     248       16201139    1991433    335656   8817
+//  random                   false   1000     241       20870812    1309373    510240   1
+//  random                   true    10000    289       78923469    23178028   288479   125
+//  random                   false   10000    297       80162200    24015477   278955   1
+//  random                   true    100000   241       765837860   237899834  351979   25
+//  random                   false   100000   289       694941549   212820591  365262   1
+//  fewest-pending-requests  true    1        390       4419885     224512     3200     45697
+//  fewest-pending-requests  false   1        313       1388333     437        811476   1
+//  fewest-pending-requests  true    10       341       15878684    238641     29821    38477
+//  fewest-pending-requests  false   10       328       5097597     8860       719393   1
+//  fewest-pending-requests  true    100      338       12701474    452931     150094   35696
+//  fewest-pending-requests  false   100      339       9182151     96564      705745   1
+//  fewest-pending-requests  true    1000     329       13381772    2351399    285263   1816
+//  fewest-pending-requests  false   1000     312       16021295    1546288    430947   1
+//  fewest-pending-requests  true    10000    421       85027409    29813414   227209   135
+//  fewest-pending-requests  false   10000    404       86757606    27587847   244877   1
+//  fewest-pending-requests  true    100000   381       969925927   278125286  320719   11
+//  fewest-pending-requests  false   100000   342       759484399   256068224  351255   1
+//  two-random-choices       true    1        296       12530130    167011     4873     56520
+//  two-random-choices       false   1        234       2157414     331        973400   1
+//  two-random-choices       true    10       257       14773053    264627     27980    49152
+//  two-random-choices       false   10       254       6038348     6769       896344   1
+//  two-random-choices       true    100      264       16509807    566482     120169   47062
+//  two-random-choices       false   100      265       8954712     78887      840535   1
+//  two-random-choices       true    1000     262       16153194    1959869    341938   6304
+//  two-random-choices       false   1000     257       14265730    1299014    512357   1
+//  two-random-choices       true    10000    312       65980563    25155737   263431   75
+//  two-random-choices       false   10000    315       68347456    23842068   282351   1
+//  two-random-choices       true    100000   259       1164075075  114441088  663750   31
+//  two-random-choices       false   100000   269       836529911   164734573  545225   1
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/peer/pendingheap"
+	"go.uber.org/yarpc/peer/randpeer"
+	"go.uber.org/yarpc/peer/roundrobin"
+	"go.uber.org/yarpc/peer/tworandomchoices"
+	"go.uber.org/yarpc/yarpctest"
+)
+
+func main() {
+	fmt.Printf("name,stress,workers,min,max,mean,choices,updates\n")
+	log := logger{}
+	for _, c := range []struct {
+		name    string
+		newFunc func(peer.Transport) peer.ChooserList
+	}{
+		{
+			name: "round-robin",
+			newFunc: func(trans peer.Transport) peer.ChooserList {
+				return roundrobin.New(trans)
+			},
+		},
+		{
+			name: "random",
+			newFunc: func(trans peer.Transport) peer.ChooserList {
+				return randpeer.New(trans)
+			},
+		},
+		{
+			name: "fewest-pending-requests",
+			newFunc: func(trans peer.Transport) peer.ChooserList {
+				return pendingheap.New(trans)
+			},
+		},
+		{
+			name: "two-random-choices",
+			newFunc: func(trans peer.Transport) peer.ChooserList {
+				return tworandomchoices.New(trans)
+			},
+		},
+	} {
+		for i := 1; i <= 100000; i *= 10 {
+			for _, lowStress := range []bool{false, true} {
+				report := yarpctest.ListStressTest{
+					Workers:   i,
+					Duration:  time.Second,
+					Timeout:   time.Millisecond * time.Duration(i),
+					LowStress: lowStress,
+					New:       c.newFunc,
+				}.Run(log)
+				if report.Choices != 0 {
+					fmt.Printf("%s,%v,%d,%d,%d,%d,%d,%d\n",
+						c.name,
+						!lowStress,
+						uint64(i),
+						uint64(report.Min),
+						uint64(report.Max),
+						uint64(report.Total/time.Duration(report.Choices)),
+						report.Choices,
+						report.Updates,
+					)
+				}
+			}
+		}
+	}
+}
+
+type logger struct{}
+
+func (logger) Logf(format string, args ...interface{}) {
+	fmt.Printf(format, args...)
+}

--- a/yarpctest/fake_peer.go
+++ b/yarpctest/fake_peer.go
@@ -21,12 +21,17 @@
 package yarpctest
 
 import (
+	"sync"
+
 	"go.uber.org/yarpc/api/peer"
 )
 
 // FakePeer is a fake peer with an identifier.
 type FakePeer struct {
 	id peer.Identifier
+
+	// mutable
+	lock sync.RWMutex
 	// subscribers needs to be modified under lock in FakeTransport
 	subscribers []peer.Subscriber
 	status      peer.Status
@@ -37,33 +42,87 @@ func (p *FakePeer) Identifier() string {
 	return p.id.Identifier()
 }
 
+// String returns a humane representation of the peer and its status for debugging.
+func (p *FakePeer) String() string {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	return p.id.Identifier() + ":" + p.status.String()
+}
+
 // Status returns the fake peer status.
 func (p *FakePeer) Status() peer.Status {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
 	return p.status
 }
 
 // StartRequest increments pending request count.
 func (p *FakePeer) StartRequest() {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
 	p.status.PendingRequestCount++
 }
 
 // EndRequest decrements pending request count.
 func (p *FakePeer) EndRequest() {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
 	p.status.PendingRequestCount--
 }
 
 func (p *FakePeer) simulateConnect() {
-	p.status.ConnectionStatus = peer.Available
-	p.broadcast()
+	p.simulateStatusChange(peer.Available)
 }
 
 func (p *FakePeer) simulateDisconnect() {
-	p.status.ConnectionStatus = peer.Unavailable
-	p.broadcast()
+	p.simulateStatusChange(peer.Unavailable)
 }
 
-func (p *FakePeer) broadcast() {
-	for _, sub := range p.subscribers {
+func (p *FakePeer) simulateStatusChange(status peer.ConnectionStatus) {
+	for _, sub := range p.prepareStatusChange(status) {
 		sub.NotifyStatusChanged(p.id)
 	}
+}
+
+func (p *FakePeer) prepareStatusChange(status peer.ConnectionStatus) []peer.Subscriber {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	p.status.ConnectionStatus = status
+	subscribers := make([]peer.Subscriber, len(p.subscribers))
+	copy(subscribers, p.subscribers)
+	return subscribers
+}
+
+func (p *FakePeer) subscribe(ps peer.Subscriber) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	p.subscribers = append(p.subscribers, ps)
+}
+
+func (p *FakePeer) unsubscribe(ps peer.Subscriber) int {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	subscribers, count := filterSubscriber(p.subscribers, ps)
+	p.subscribers = subscribers
+	return count
+}
+
+func filterSubscriber(subs []peer.Subscriber, ps peer.Subscriber) ([]peer.Subscriber, int) {
+	res := make([]peer.Subscriber, 0, len(subs))
+	count := 0
+	for _, sub := range subs {
+		if sub != ps {
+			res = append(res, sub)
+		} else {
+			count++
+		}
+	}
+	return res, count
 }

--- a/yarpctest/fake_transport.go
+++ b/yarpctest/fake_transport.go
@@ -25,8 +25,7 @@ import (
 	"sync"
 
 	"go.uber.org/yarpc/api/peer"
-	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/pkg/lifecycletest"
+	"go.uber.org/yarpc/pkg/lifecycle"
 )
 
 // FakeTransportOption is an option for NewFakeTransport.
@@ -50,13 +49,38 @@ func InitialConnectionStatus(s peer.ConnectionStatus) FakeTransportOption {
 	}
 }
 
+// RetainErrors specifies an error for RetainPeer to return for the given
+// addresses.
+func RetainErrors(err error, addrs []string) FakeTransportOption {
+	return func(t *FakeTransport) {
+		for _, addr := range addrs {
+			t.retainErrors[addr] = err
+		}
+	}
+}
+
+// ReleaseErrors specifies an error for ReleasePeer to return for the given
+// addresses.
+func ReleaseErrors(err error, addrs []string) FakeTransportOption {
+	return func(t *FakeTransport) {
+		for _, addr := range addrs {
+			t.releaseErrors[addr] = err
+		}
+	}
+}
+
 // NewFakeTransport returns a fake transport.
 func NewFakeTransport(opts ...FakeTransportOption) *FakeTransport {
 	t := &FakeTransport{
-		Lifecycle:               lifecycletest.NewNop(),
-		initialConnectionStatus: peer.Available,
-		peers:                   make(map[string]*FakePeer),
-		mu:                      &sync.Mutex{},
+		once:                          lifecycle.NewOnce(),
+		initialConnectionStatus:       peer.Available,
+		initialPeerConnectionStatuses: make(map[string]peer.ConnectionStatus),
+
+		peers:                make(map[string]*FakePeer),
+		retainErrors:         make(map[string]error),
+		releaseErrors:        make(map[string]error),
+		pendingStatusChanges: make(chan struct{}, 1),
+		done:                 make(chan struct{}),
 	}
 	for _, opt := range opts {
 		opt(t)
@@ -66,16 +90,41 @@ func NewFakeTransport(opts ...FakeTransportOption) *FakeTransport {
 
 // FakeTransport is a fake transport.
 type FakeTransport struct {
-	transport.Lifecycle
-	nopOption               string
-	initialConnectionStatus peer.ConnectionStatus
-	peers                   map[string]*FakePeer
-	mu                      *sync.Mutex
+	nopOption                     string
+	initialConnectionStatus       peer.ConnectionStatus
+	initialPeerConnectionStatuses map[string]peer.ConnectionStatus
+	retainErrors                  map[string]error
+	releaseErrors                 map[string]error
+
+	once                 *lifecycle.Once
+	mu                   sync.RWMutex
+	peers                map[string]*FakePeer
+	changesQueue         []statusChange
+	pendingStatusChanges chan struct{}
+	done                 chan struct{}
 }
 
 // NopOption returns the configured nopOption. It's fake.
 func (t *FakeTransport) NopOption() string {
 	return t.nopOption
+}
+
+// SimulateRetainError leaves a note that any subsequent Retain for a
+// particular address should return an error.
+func (t *FakeTransport) SimulateRetainError(id peer.Identifier, err error) {
+	t.retainErrors[id.Identifier()] = err
+}
+
+// SimulateReleaseError leaves a note that any subsequent Release for a particular
+// address should return an error.
+func (t *FakeTransport) SimulateReleaseError(id peer.Identifier, err error) {
+	t.releaseErrors[id.Identifier()] = err
+}
+
+// SimulateStatusChange simulates a connection or disconnection to the peer,
+// marking the peer connection status and notifying all subscribers.
+func (t *FakeTransport) SimulateStatusChange(id peer.Identifier, status peer.ConnectionStatus) {
+	t.Peer(id).simulateStatusChange(status)
 }
 
 // SimulateConnect simulates a connection to the peer, marking the peer as
@@ -111,37 +160,123 @@ func (t *FakeTransport) Peer(id peer.Identifier) *FakePeer {
 
 // RetainPeer returns a fake peer.
 func (t *FakeTransport) RetainPeer(id peer.Identifier, ps peer.Subscriber) (peer.Peer, error) {
+	if err := t.retainErrors[id.Identifier()]; err != nil {
+		return nil, err
+	}
 	peer := t.Peer(id)
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	peer.subscribers = append(peer.subscribers, ps)
+	peer.subscribe(ps)
+	t.enqueue(statusChange{
+		Peer:   peer,
+		Status: t.getInitialStatus(id.Identifier()),
+	})
+
+	t.scheduleFlush()
 	return peer, nil
+}
+
+func (t *FakeTransport) getInitialStatus(addr string) peer.ConnectionStatus {
+	if status, ok := t.initialPeerConnectionStatuses[addr]; ok {
+		return status
+	}
+	return t.initialConnectionStatus
 }
 
 // ReleasePeer does nothing.
 func (t *FakeTransport) ReleasePeer(id peer.Identifier, ps peer.Subscriber) error {
 	peer := t.Peer(id)
+
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	if subscribers, count := filterSubscriber(peer.subscribers, ps); count == 0 {
+
+	if err := t.releaseErrors[id.Identifier()]; err != nil {
+		return err
+	}
+
+	if count := peer.unsubscribe(ps); count == 0 {
 		return fmt.Errorf("no such subscriber")
 	} else if count > 1 {
 		return fmt.Errorf("extra subscribers: %d", count-1)
-	} else {
-		peer.subscribers = subscribers
 	}
+
+	t.scheduleFlush()
 	return nil
 }
 
-func filterSubscriber(subs []peer.Subscriber, ps peer.Subscriber) ([]peer.Subscriber, int) {
-	res := make([]peer.Subscriber, 0, len(subs))
-	count := 0
-	for _, sub := range subs {
-		if sub != ps {
-			res = append(res, sub)
-		} else {
-			count++
+// Start spins up a goroutine to asynchronously flush status change notifications.
+//
+// If you do not start a fake dialer, you must call Flush explicitly.
+func (t *FakeTransport) Start() error {
+	return t.once.Start(func() error {
+		go t.monitor()
+		return nil
+	})
+}
+
+// Stop shuts down the fake dialer, allowing its status change notification
+// loop to exit.
+func (t *FakeTransport) Stop() error {
+	return t.once.Stop(func() error {
+		close(t.done)
+		return nil
+	})
+}
+
+// IsRunning returns whether the fake transport is running.
+func (t *FakeTransport) IsRunning() bool {
+	return t.once.IsRunning()
+}
+
+func (t *FakeTransport) scheduleFlush() {
+	select {
+	case t.pendingStatusChanges <- struct{}{}:
+	default:
+	}
+}
+
+func (t *FakeTransport) monitor() {
+Loop:
+	for {
+		select {
+		case <-t.done:
+			break Loop
+		case <-t.pendingStatusChanges:
+			t.Flush()
 		}
 	}
-	return res, count
+}
+
+type statusChange struct {
+	Peer   *FakePeer
+	Status peer.ConnectionStatus
+}
+
+// Flush effects all queued status changes from retaining or releasing peers.
+//
+// Calling RetainPeer and ReleasePeer schedules a peer status change and its
+// notifications.
+// Concrete dialer implementations dispatch these notifications from a
+// goroutine and subscribers may obtain a lock on the peer status.
+// For testability, the fake transport queues these changes and calling Flush
+// dispatches the notifications synchronously, but still off the RetainPeer and
+// ReleasePeer stacks.
+func (t *FakeTransport) Flush() {
+	for _, change := range t.dequeue() {
+		change.Peer.simulateStatusChange(change.Status)
+	}
+}
+
+func (t *FakeTransport) enqueue(change statusChange) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.changesQueue = append(t.changesQueue, change)
+}
+
+func (t *FakeTransport) dequeue() []statusChange {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	queue := t.changesQueue
+	t.changesQueue = make([]statusChange, 0)
+	return queue
 }

--- a/yarpctest/stress.go
+++ b/yarpctest/stress.go
@@ -1,0 +1,389 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpctest
+
+import (
+	"context"
+	"math/rand"
+	"strconv"
+	"time"
+
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/peer/hostport"
+)
+
+// ListStressTest describes the parameters of a stress test for a peer list implementation.
+type ListStressTest struct {
+	Workers   int
+	Duration  time.Duration
+	Timeout   time.Duration
+	LowStress bool
+	New       func(peer.Transport) peer.ChooserList
+}
+
+// Logger is the interface needed by reports to log results.
+// The testing.T is an example of a logger.
+type Logger interface {
+	Logf(format string, args ...interface{})
+}
+
+// Log writes the parameters for a stress test.
+func (t ListStressTest) Log(logger Logger) {
+	logger.Logf("choosers: %d\n", t.Workers)
+	logger.Logf("duration: %s\n", t.Duration)
+	logger.Logf("timeout:  %s\n", t.Timeout)
+}
+
+// Run runs a stress test on a peer list.
+//
+// The stress test creates a fake transport and a vector of fake peers.
+// The test concurrently chooses peers from the list with some number of workers
+// while simultaneously adding and removing peers from the peer list and
+// simulating connection and disconnection with those peers.
+func (t ListStressTest) Run(logger Logger) *ListStressTestReport {
+	transport := NewFakeTransport()
+	list := t.New(transport)
+	report := newStressReport(0)
+
+	s := stressor{
+		stop:      make(chan struct{}),
+		reports:   make(chan *ListStressTestReport),
+		timeout:   t.Timeout,
+		transport: transport,
+		list:      list,
+		logger:    logger,
+	}
+
+	if err := s.list.Start(); err != nil {
+		s.logger.Logf("list start error: %s\n", err.Error())
+	}
+
+	var stressors int
+	if t.LowStress {
+		for i := uint(0); i < numIds; i++ {
+			s.transport.SimulateConnect(bitIds[i])
+		}
+		err := s.list.Update(peer.ListUpdates{
+			Additions: idsForBits(allIdsMask),
+		})
+		if err != nil {
+			s.logger.Logf("list update error: %s\n", err.Error())
+			report.Errors++
+		}
+		report.Updates++
+	} else {
+		go s.stressTransport(s.reports)
+		go s.stressList(s.reports)
+		stressors = 2
+	}
+	for i := 0; i < t.Workers; i++ {
+		go s.stressChooser(i)
+	}
+
+	time.Sleep(t.Duration)
+
+	close(s.stop)
+
+	for i := 0; i < t.Workers+stressors; i++ {
+		report.merge(<-s.reports)
+	}
+
+	if err := s.list.Stop(); err != nil {
+		s.logger.Logf("list stop error: %s\n", err.Error())
+	}
+
+	return report
+}
+
+// ListStressTestReport catalogs the results of a peer list stress test.
+//
+// Each worker keeps track of its own statistics then sends them through
+// a channel to the test runner.
+// This allows each worker to have independent memory for its log reports and
+// reduces the need for synchronization across threads, which could interfere
+// with the test.
+// The reports get merged into a final report.
+type ListStressTestReport struct {
+	Workers int
+	Errors  int
+	Choices int
+	Updates int
+	Min     time.Duration
+	Max     time.Duration
+	Total   time.Duration
+}
+
+func newStressReport(numWorkers int) *ListStressTestReport {
+	return &ListStressTestReport{
+		Workers: numWorkers,
+		Min:     1000 * time.Second,
+	}
+}
+
+// Log writes the vital statistics for a stress test.
+func (r *ListStressTestReport) Log(logger Logger) {
+	logger.Logf("choices:  %d\n", r.Choices)
+	logger.Logf("updates:  %d\n", r.Updates)
+	logger.Logf("errors:   %d\n", r.Errors)
+	logger.Logf("min:      %s\n", r.Min)
+	if r.Choices != 0 {
+		logger.Logf("mean:     %s\n", r.Total/time.Duration(r.Choices))
+	}
+	logger.Logf("max:      %s\n", r.Max)
+}
+
+// add tracks the latency for a choice of a particular peer.
+// the idIndex refers to the peer that was selected.
+// in a future version of this test, we can use this id index to show which
+// peers were favored by a peer list’s strategy over time.
+func (r *ListStressTestReport) add(idIndex int, dur time.Duration) {
+	r.Choices++
+	r.Min = min(r.Min, dur)
+	r.Max = max(r.Max, dur)
+	r.Total += dur
+}
+
+// merge merges test reports from independent workers.
+func (r *ListStressTestReport) merge(s *ListStressTestReport) {
+	r.Workers += s.Workers
+	r.Errors += s.Errors
+	r.Choices += s.Choices
+	r.Updates += s.Updates
+	r.Min = min(r.Min, s.Min)
+	r.Max = max(r.Max, s.Max)
+	r.Total += s.Total
+}
+
+// stressor tracks the parameters and state for a single stress test worker.
+type stressor struct {
+	// stop closed to signal all workers to stop.
+	stop chan struct{}
+	// reports is the channel to which the final report must be sent to singal
+	// that the worker goroutine is done and transfer ownership of the report
+	// memory to the test for merging.
+	reports   chan *ListStressTestReport
+	timeout   time.Duration
+	transport *FakeTransport
+	list      peer.ChooserList
+	logger    Logger
+}
+
+// stressTransport randomly connects and disconnects each of the 63 known peers.
+// These peers may or may not be retained by the peer list at the time the
+// connection status changes.
+func (s *stressor) stressTransport(reports chan<- *ListStressTestReport) {
+	report := newStressReport(0)
+	rng := rand.NewSource(0)
+
+	_ = s.transport.Start()
+	defer func() {
+		_ = s.transport.Stop()
+	}()
+
+	// Until we receive a signal to stop...
+Loop:
+	for {
+		select {
+		case <-s.stop:
+			break Loop
+		default:
+		}
+
+		// Construt a random bit vector, where each bit signifies whether the
+		// peer for that index should be connected or disconnected.
+		bits := rng.Int63()
+		// A consequence of this is that we may send connected notifications to
+		// peers that are already connected, etc.
+		// These are valid cases to exercise in a stress test, even if they are
+		// not desirable behaviors of a real transport.
+		for i := uint(0); i < numIds; i++ {
+			bit := (1 << i) & bits
+			if bit != 0 {
+				s.transport.SimulateConnect(bitIds[i])
+			} else {
+				s.transport.SimulateDisconnect(bitIds[i])
+			}
+		}
+	}
+
+	reports <- report
+}
+
+// stressList sends membership changes to a peer list, using a random subset of all 63 peers every time.
+// Each change will tend to include half of the peers, tend to remove a quarter
+// from the previous round and add a quarter of the peers for the next round.
+// As above, we track whether the peer list has each peer using a bit vector,
+// so we can easily use bitwise operations for set differences (&^) and all of
+// the identifiers are interned up front to avoid allocations.
+// This allows us to send peer list updates very quickly.
+func (s *stressor) stressList(reports chan<- *ListStressTestReport) {
+	report := newStressReport(0)
+	rng := rand.NewSource(1)
+	var oldBits int64
+
+	// Until we are asked to stop...
+Loop:
+	for {
+		select {
+		case <-s.stop:
+			break Loop
+		default:
+		}
+
+		// Construct peer list updates by giving every peer a 50/50 chance of
+		// being included in each round.
+		// Use set difference bitwise operations to construct the lists of
+		// identifiers to add and remove from the current and previous bit
+		// vectors.
+		newBits := rng.Int63()
+		additions := idsForBits(newBits &^ oldBits)
+		removals := idsForBits(oldBits &^ newBits)
+		err := s.list.Update(peer.ListUpdates{
+			Additions: additions,
+			Removals:  removals,
+		})
+		if err != nil {
+			s.logger.Logf("list update error: %s\n", err.Error())
+			report.Errors++
+			break Loop
+		}
+		report.Updates++
+		oldBits = newBits
+	}
+
+	// Clean up.
+	err := s.list.Update(peer.ListUpdates{
+		Removals: idsForBits(oldBits),
+	})
+	if err != nil {
+		s.logger.Logf("final list update error: %s\n", err.Error())
+		report.Errors++
+	}
+
+	reports <- report
+}
+
+// stressChooser rapidly
+func (s *stressor) stressChooser(i int) {
+	rng := rand.NewSource(int64(i))
+	report := newStressReport(1)
+
+	// Until we are asked to stop...
+Loop:
+	for {
+		// We check for the stop signal before choosing instead of after
+		// because the continue statement in the error case bypasses the end of
+		// the loop to return here and could cause a deadlock if the other
+		// stressors exit first.
+		select {
+		case <-s.stop:
+			break Loop
+		default:
+		}
+
+		// Request a peer from the peer list.
+		// We use a random pre-allocated shard key to exercise the hashring in
+		// particular, but this is harmless for all other choosers.
+		shardKey := shardKeys[rng.Int63()&shardKeysMask]
+		ctx, cancel := context.WithTimeout(context.Background(), s.timeout)
+		defer cancel()
+		start := time.Now()
+		peer, onFinish, err := s.list.Choose(ctx, &transport.Request{ShardKey: shardKey})
+		stop := time.Now()
+		if err != nil {
+			s.logger.Logf("choose error: %s\n", err.Error())
+			report.Errors++
+			continue
+		}
+		// This is a good point for a future version to inject varying load
+		// based on the identifier of the peer that was selected, to show how
+		// each list behaves in the face of variations in speed of individual
+		// instances.
+		onFinish(nil)
+		cancel()
+
+		// Report the latency and identifier of the selected peer.
+		id := peer.Identifier()
+		index := idIndexes[id]
+		report.add(index, stop.Sub(start))
+	}
+
+	s.reports <- report
+}
+
+// Accessories hereafter.
+
+const (
+	// We use a 64 bit vector for peer identifiers, but only get to use 63 bits
+	// since the Go random number generator only offers 63 bits of entropy.
+	numIds     = 63
+	allIdsMask = 1<<numIds - 1
+	// We will use 256 unique shard keys.
+	shardKeysWidth = 8
+	numShardKeys   = 1 << shardKeysWidth
+	shardKeysMask  = numShardKeys - 1
+)
+
+// pre-allocated vectors for identifiers and shard keys.
+var (
+	// Each identifier is a string: the name of its own index.
+	bitIds [numIds]peer.Identifier
+	// Reverse lookeup.
+	idIndexes map[string]int
+	shardKeys [numShardKeys]string
+)
+
+func init() {
+	idIndexes = make(map[string]int, numIds)
+	for i := 0; i < numIds; i++ {
+		name := strconv.Itoa(i)
+		bitIds[i] = hostport.PeerIdentifier(name)
+		idIndexes[name] = i
+	}
+	for i := 0; i < numShardKeys; i++ {
+		shardKeys[i] = strconv.Itoa(i)
+	}
+}
+
+func idsForBits(bits int64) []peer.Identifier {
+	var ids []peer.Identifier
+	for i := uint(0); i < numIds; i++ {
+		if (1<<i)&bits != 0 {
+			ids = append(ids, bitIds[i])
+		}
+	}
+	return ids
+}
+
+func min(a, b time.Duration) time.Duration {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func max(a, b time.Duration) time.Duration {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/yarpctest/stress.go
+++ b/yarpctest/stress.go
@@ -33,9 +33,11 @@ import (
 
 // ListStressTest describes the parameters of a stress test for a peer list implementation.
 type ListStressTest struct {
-	Workers   int
-	Duration  time.Duration
-	Timeout   time.Duration
+	Workers  int
+	Duration time.Duration
+	Timeout  time.Duration
+	// LowStress disables membership and connection churn, measuring peer
+	// selection baseline performance without interference.
 	LowStress bool
 	New       func(peer.Transport) peer.ChooserList
 }
@@ -347,7 +349,7 @@ const (
 var (
 	// Each identifier is a string: the name of its own index.
 	bitIds [numIds]peer.Identifier
-	// Reverse lookeup.
+	// Reverse lookup.
 	idIndexes map[string]int
 	shardKeys [numShardKeys]string
 )

--- a/yarpctest/stress_test.go
+++ b/yarpctest/stress_test.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpctest
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/api/transport"
+)
+
+func TestStress(t *testing.T) {
+	test := ListStressTest{
+		Workers:  1,
+		Duration: time.Second,
+		Timeout:  10 * time.Millisecond,
+		New: func(t peer.Transport) peer.ChooserList {
+			return newMRUList(t)
+		},
+	}
+	report := test.Run(t)
+	report.Log(t)
+	test.Log(t)
+}
+
+var _ peer.ChooserList = (*mruList)(nil)
+
+type mruList struct {
+	transport peer.Transport
+	peer      peer.Peer
+	mu        sync.Mutex
+}
+
+func newMRUList(t peer.Transport) *mruList {
+	return &mruList{transport: t}
+}
+
+func (l *mruList) Start() error {
+	return nil
+}
+
+func (l *mruList) Stop() error {
+	return nil
+}
+
+func (l *mruList) IsRunning() bool {
+	return true
+}
+
+func (l *mruList) Choose(context.Context, *transport.Request) (peer peer.Peer, onFinish func(error), err error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.peer == nil {
+		return nil, nil, fmt.Errorf("no peer available")
+	}
+
+	return l.peer, func(error) {}, nil
+}
+
+func (l *mruList) Update(updates peer.ListUpdates) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	for _, pid := range updates.Additions {
+		l.update(pid)
+	}
+
+	if (len(updates.Additions)+len(updates.Removals))%2 == 0 {
+		return fmt.Errorf("can you handle this")
+	}
+	if len(updates.Additions) == 0 {
+		return fmt.Errorf("parting is such sweet sorrow")
+	}
+	return nil
+}
+
+func (l *mruList) update(id peer.Identifier) {
+	if peer, err := l.transport.RetainPeer(id, nopSub); err == nil {
+		if l.peer != nil {
+			_ = l.transport.ReleasePeer(id, nopSub)
+		}
+		l.peer = peer
+	}
+}
+
+type _nopSub struct{}
+
+func (_nopSub) NotifyStatusChanged(peer.Identifier) {}
+
+var nopSub = _nopSub{}


### PR DESCRIPTION
This set of changes introduces a stress test for peer lists, with concurrent updates, connection status changes, and workers selecting peers.

The change has three parts:
1. Add features to the fake transport such that it can emulate connection status changes and is concurrency safe.
2. Introduce a stress test scaffold to the YARPC test library.
3. Introduce a stress test binary that benchmarks all of the peer list implementations provided by YARPC proper.