### PR TITLE
Add improved logging for streams and streaming messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added improved logging for streams and streaming messages.
 - Log level configuration can now be expressed specifically for every
   combination of inbound and outbound, for success, failure, and application
   error.

--- a/internal/observability/graph.go
+++ b/internal/observability/graph.go
@@ -93,7 +93,8 @@ func (g *graph) begin(ctx context.Context, rpcType transport.Type, direction dir
 	d.Add(req.RoutingKey)
 	d.Add(req.RoutingDelegate)
 	d.Add(string(direction))
-	e := g.getOrCreateEdge(d.Digest(), req, string(direction))
+	d.Add(rpcType.String())
+	e := g.getOrCreateEdge(d.Digest(), req, string(direction), rpcType)
 	d.Free()
 
 	levels := &g.inboundLevels
@@ -113,11 +114,11 @@ func (g *graph) begin(ctx context.Context, rpcType transport.Type, direction dir
 	}
 }
 
-func (g *graph) getOrCreateEdge(key []byte, req *transport.Request, direction string) *edge {
+func (g *graph) getOrCreateEdge(key []byte, req *transport.Request, direction string, rpcType transport.Type) *edge {
 	if e := g.getEdge(key); e != nil {
 		return e
 	}
-	return g.createEdge(key, req, direction)
+	return g.createEdge(key, req, direction, rpcType)
 }
 
 func (g *graph) getEdge(key []byte) *edge {
@@ -127,7 +128,7 @@ func (g *graph) getEdge(key []byte) *edge {
 	return e
 }
 
-func (g *graph) createEdge(key []byte, req *transport.Request, direction string) *edge {
+func (g *graph) createEdge(key []byte, req *transport.Request, direction string, rpcType transport.Type) *edge {
 	g.edgesMu.Lock()
 	// Since we'll rarely hit this code path, the overhead of defer is acceptable.
 	defer g.edgesMu.Unlock()
@@ -137,7 +138,7 @@ func (g *graph) createEdge(key []byte, req *transport.Request, direction string)
 		return e
 	}
 
-	e := newEdge(g.logger, g.meter, req, direction)
+	e := newEdge(g.logger, g.meter, req, direction, rpcType)
 	g.edges[string(key)] = e
 	return e
 }
@@ -159,7 +160,7 @@ type edge struct {
 
 // newEdge constructs a new edge. Since Registries enforce metric uniqueness,
 // edges should be cached and re-used for each RPC.
-func newEdge(logger *zap.Logger, meter *metrics.Scope, req *transport.Request, direction string) *edge {
+func newEdge(logger *zap.Logger, meter *metrics.Scope, req *transport.Request, direction string, rpcType transport.Type) *edge {
 	tags := metrics.Tags{
 		"source":           req.Caller,
 		"dest":             req.Service,
@@ -169,6 +170,7 @@ func newEdge(logger *zap.Logger, meter *metrics.Scope, req *transport.Request, d
 		"routing_key":      req.RoutingKey,
 		"routing_delegate": req.RoutingDelegate,
 		"direction":        direction,
+		"rpc_type":         rpcType.String(),
 	}
 	calls, err := meter.Counter(metrics.Spec{
 		Name:      "calls",
@@ -240,6 +242,7 @@ func newEdge(logger *zap.Logger, meter *metrics.Scope, req *transport.Request, d
 	if err != nil {
 		logger.Error("Failed to create server failure latency distribution.", zap.Error(err))
 	}
+
 	logger = logger.With(
 		zap.String("source", req.Caller),
 		zap.String("dest", req.Service),

--- a/internal/observability/graph_test.go
+++ b/internal/observability/graph_test.go
@@ -47,11 +47,11 @@ func TestEdgeNopFallbacks(t *testing.T) {
 	}
 
 	// Should succeed, covered by middleware tests.
-	_ = newEdge(zap.NewNop(), meter, req, string(_directionOutbound))
+	_ = newEdge(zap.NewNop(), meter, req, string(_directionOutbound), transport.Unary)
 
 	// Should fall back to no-op metrics.
 	// Usage of nil metrics should not panic, should not observe changes.
-	e := newEdge(zap.NewNop(), meter, req, string(_directionOutbound))
+	e := newEdge(zap.NewNop(), meter, req, string(_directionOutbound), transport.Unary)
 
 	e.calls.Inc()
 	assert.Equal(t, int64(0), e.calls.Load(), "Expected to fall back to no-op metrics.")

--- a/internal/observability/middleware.go
+++ b/internal/observability/middleware.go
@@ -176,8 +176,18 @@ func (m *Middleware) CallOneway(ctx context.Context, req *transport.Request, out
 // HandleStream implements middleware.StreamInbound.
 func (m *Middleware) HandleStream(serverStream *transport.ServerStream, h transport.StreamHandler) error {
 	call := m.graph.begin(serverStream.Context(), transport.Streaming, _directionInbound, serverStream.Request().Meta.ToRequest())
-	err := h.HandleStream(serverStream)
-	// TODO(pedge): wrap the *transport.ServerStream?
+
+	wrappedStream, err := transport.NewServerStream(newServerStreamWrapper(call, serverStream))
+	if err != nil {
+		// This will never happen since transport.NewServerStream only returns an
+		// error for nil streams. In the nearly impossible situation where we do, we
+		// fall back to using the original, unwrapped stream.
+		m.graph.logger.DPanic("transport.ServerStream wrapping should never fail, streaming metrics are disabled")
+		wrappedStream = serverStream
+	}
+
+	err = h.HandleStream(wrappedStream)
+	// TODO: end stream
 	call.End(err)
 	return err
 }
@@ -186,7 +196,18 @@ func (m *Middleware) HandleStream(serverStream *transport.ServerStream, h transp
 func (m *Middleware) CallStream(ctx context.Context, request *transport.StreamRequest, out transport.StreamOutbound) (*transport.ClientStream, error) {
 	call := m.graph.begin(ctx, transport.Streaming, _directionOutbound, request.Meta.ToRequest())
 	clientStream, err := out.CallStream(ctx, request)
-	// TODO(pedge): wrap the *transport.ClientStream?
 	call.End(err)
-	return clientStream, err
+	if err != nil {
+		return nil, err
+	}
+
+	wrappedStream, err := transport.NewClientStream(newClientStreamWrapper(call, clientStream))
+	if err != nil {
+		// This will never happen since transport.NewClientStream only returns an
+		// error for nil streams. In the nearly impossible situation where we do, we
+		// fall back to using the original, unwrapped stream.
+		m.graph.logger.DPanic("transport.ClientStream wrapping should never fail, streaming metrics are disabled")
+		wrappedStream = clientStream
+	}
+	return wrappedStream, nil
 }

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -268,7 +268,7 @@ func TestMiddlewareLogging(t *testing.T) {
 			},
 		})
 
-		getLog := func() observer.LoggedEntry {
+		getLog := func(t *testing.T) observer.LoggedEntry {
 			entries := logs.TakeAll()
 			require.Equal(t, 1, len(entries), "Unexpected number of logs written.")
 			e := entries[0]
@@ -305,7 +305,7 @@ func TestMiddlewareLogging(t *testing.T) {
 				},
 				Context: logContext,
 			}
-			assert.Equal(t, expected, getLog(), "Unexpected log entry written.")
+			assert.Equal(t, expected, getLog(t), "Unexpected log entry written.")
 		})
 		t.Run(tt.desc+", unary outbound", func(t *testing.T) {
 			res, err := mw.Call(context.Background(), req, newOutbound(tt))
@@ -326,7 +326,7 @@ func TestMiddlewareLogging(t *testing.T) {
 				},
 				Context: logContext,
 			}
-			assert.Equal(t, expected, getLog(), "Unexpected log entry written.")
+			assert.Equal(t, expected, getLog(t), "Unexpected log entry written.")
 		})
 
 		// Application errors aren't applicable to oneway and streaming
@@ -350,7 +350,7 @@ func TestMiddlewareLogging(t *testing.T) {
 				},
 				Context: logContext,
 			}
-			assert.Equal(t, expected, getLog(), "Unexpected log entry written.")
+			assert.Equal(t, expected, getLog(t), "Unexpected log entry written.")
 		})
 		t.Run(tt.desc+", oneway outbound", func(t *testing.T) {
 			ack, err := mw.CallOneway(context.Background(), req, newOutbound(tt))
@@ -371,7 +371,7 @@ func TestMiddlewareLogging(t *testing.T) {
 				},
 				Context: logContext,
 			}
-			assert.Equal(t, expected, getLog(), "Unexpected log entry written.")
+			assert.Equal(t, expected, getLog(t), "Unexpected log entry written.")
 		})
 		t.Run(tt.desc+", stream inbound", func(t *testing.T) {
 			stream, err := transport.NewServerStream(&fakeStream{ctx: context.Background(), request: sreq})
@@ -391,7 +391,7 @@ func TestMiddlewareLogging(t *testing.T) {
 				},
 				Context: logContext,
 			}
-			assert.Equal(t, expected, getLog(), "Unexpected log entry written.")
+			assert.Equal(t, expected, getLog(t), "Unexpected log entry written.")
 		})
 		t.Run(tt.desc+", stream outbound", func(t *testing.T) {
 			clientStream, err := mw.CallStream(context.Background(), sreq, newOutbound(tt))
@@ -412,7 +412,7 @@ func TestMiddlewareLogging(t *testing.T) {
 				},
 				Context: logContext,
 			}
-			assert.Equal(t, expected, getLog(), "Unexpected log entry written.")
+			assert.Equal(t, expected, getLog(t), "Unexpected log entry written.")
 		})
 	}
 }

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -176,7 +176,7 @@ func TestMiddlewareLogging(t *testing.T) {
 		RoutingDelegate: "routing-delegate",
 		Body:            strings.NewReader("body"),
 	}
-	sreq := &transport.StreamRequest{Meta: req.ToRequestMeta()}
+
 	failed := errors.New("fail")
 
 	baseFields := func() []zapcore.Field {
@@ -363,47 +363,6 @@ func TestMiddlewareLogging(t *testing.T) {
 			logContext = append(logContext, tt.wantFields...)
 			if tt.err == nil {
 				assert.NotNil(t, ack, "Expected non-nil ack if call is successful.")
-			}
-			expected := observer.LoggedEntry{
-				Entry: zapcore.Entry{
-					Level:   tt.wantErrLevel,
-					Message: tt.wantOutboundMsg,
-				},
-				Context: logContext,
-			}
-			assert.Equal(t, expected, getLog(t), "Unexpected log entry written.")
-		})
-		t.Run(tt.desc+", stream inbound", func(t *testing.T) {
-			stream, err := transport.NewServerStream(&fakeStream{ctx: context.Background(), request: sreq})
-			require.NoError(t, err)
-			err = mw.HandleStream(stream, newHandler(tt))
-			checkErr(err)
-			logContext := append(
-				baseFields(),
-				zap.String("direction", string(_directionInbound)),
-				zap.String("rpcType", "Streaming"),
-			)
-			logContext = append(logContext, tt.wantFields...)
-			expected := observer.LoggedEntry{
-				Entry: zapcore.Entry{
-					Level:   tt.wantErrLevel,
-					Message: tt.wantInboundMsg,
-				},
-				Context: logContext,
-			}
-			assert.Equal(t, expected, getLog(t), "Unexpected log entry written.")
-		})
-		t.Run(tt.desc+", stream outbound", func(t *testing.T) {
-			clientStream, err := mw.CallStream(context.Background(), sreq, newOutbound(tt))
-			checkErr(err)
-			logContext := append(
-				baseFields(),
-				zap.String("direction", string(_directionOutbound)),
-				zap.String("rpcType", "Streaming"),
-			)
-			logContext = append(logContext, tt.wantFields...)
-			if tt.err == nil {
-				assert.NotNil(t, clientStream, "Expected non-nil clientStream if call is successful.")
 			}
 			expected := observer.LoggedEntry{
 				Entry: zapcore.Entry{

--- a/internal/observability/stream.go
+++ b/internal/observability/stream.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package observability
+
+import (
+	"context"
+
+	"go.uber.org/yarpc/api/transport"
+)
+
+var _ transport.StreamCloser = (*streamWrapper)(nil)
+
+type streamWrapper struct {
+	transport.StreamCloser
+	call call
+}
+
+func newClientStreamWrapper(call call, stream transport.StreamCloser) transport.StreamCloser {
+	return &streamWrapper{
+		StreamCloser: stream,
+		call:         call,
+	}
+}
+
+func newServerStreamWrapper(call call, stream transport.Stream) transport.Stream {
+	return &streamWrapper{
+		StreamCloser: nopCloser{stream},
+		call:         call,
+	}
+}
+
+func (s *streamWrapper) SendMessage(ctx context.Context, msg *transport.StreamMessage) error {
+	return s.StreamCloser.SendMessage(ctx, msg)
+}
+
+func (s *streamWrapper) ReceiveMessage(ctx context.Context) (*transport.StreamMessage, error) {
+	return s.StreamCloser.ReceiveMessage(ctx)
+}
+
+func (s *streamWrapper) Close(ctx context.Context) error {
+	return s.StreamCloser.Close(ctx)
+}
+
+// This is a light wrapper so that we can re-use the same methods for
+// instrumenting observability. The transport.ClientStream has an additional
+// Close(ctx) method, unlike the transport.ServerStream.
+type nopCloser struct {
+	transport.Stream
+}
+
+func (c nopCloser) Close(ctx context.Context) error {
+	return nil
+}


### PR DESCRIPTION
This introduces improved logging for opening, closing, sending and receiving
messages through streams. A similar metrics pull request is added as a follow up
in #1770. T3395799.

Each commit should be individually reviewed.
- Fix `testing.T` scoping issue
- Add RPC type through observability graph
- Add passthrough wrapper for client and server streams
- Implement stream logging
- Remove previous logging tests
- Add new logging tests
- Update CHANGELOG