### PR TITLE
Add improved metrics for streams and streaming messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Added improved logging for streams and streaming messages.
+- Added improved logging and metrics for streams and streaming messages.
 - Log level configuration can now be expressed specifically for every
   combination of inbound and outbound, for success, failure, and application
   error.

--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -146,40 +146,29 @@ func (c call) endStats(elapsed time.Duration, err error, isApplicationError bool
 	}
 
 	// Emit finer grained metrics since the error is a yarpcerrors.Status.
-	errCode := yarpcerrors.FromError(err).Code()
-	switch errCode {
-	case yarpcerrors.CodeCancelled,
-		yarpcerrors.CodeInvalidArgument,
-		yarpcerrors.CodeNotFound,
-		yarpcerrors.CodeAlreadyExists,
-		yarpcerrors.CodePermissionDenied,
-		yarpcerrors.CodeFailedPrecondition,
-		yarpcerrors.CodeAborted,
-		yarpcerrors.CodeOutOfRange,
-		yarpcerrors.CodeUnimplemented,
-		yarpcerrors.CodeUnauthenticated:
+	status := yarpcerrors.FromError(err)
+	errCode := status.Code()
+
+	switch statusFault(status) {
+	case clientFault:
 		c.edge.callerErrLatencies.Observe(elapsed)
 		if counter, err := c.edge.callerFailures.Get(_error, errCode.String()); err == nil {
 			counter.Inc()
 		}
-		return
-	case yarpcerrors.CodeUnknown,
-		yarpcerrors.CodeDeadlineExceeded,
-		yarpcerrors.CodeResourceExhausted,
-		yarpcerrors.CodeInternal,
-		yarpcerrors.CodeUnavailable,
-		yarpcerrors.CodeDataLoss:
+
+	case serverFault:
 		c.edge.serverErrLatencies.Observe(elapsed)
 		if counter, err := c.edge.serverFailures.Get(_error, errCode.String()); err == nil {
 			counter.Inc()
 		}
-		return
-	}
-	// If this code is executed we've hit an error code outside the usual error
-	// code range, so we'll just log the string representation of that code.
-	c.edge.serverErrLatencies.Observe(elapsed)
-	if counter, err := c.edge.serverFailures.Get(_error, errCode.String()); err == nil {
-		counter.Inc()
+
+	default:
+		// If this code is executed we've hit an error code outside the usual error
+		// code range, so we'll just log the string representation of that code.
+		c.edge.serverErrLatencies.Observe(elapsed)
+		if counter, err := c.edge.serverFailures.Get(_error, errCode.String()); err == nil {
+			counter.Inc()
+		}
 	}
 }
 

--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -182,12 +182,69 @@ func (c call) EndStreamHandshake() {
 // create a stream.
 func (c call) EndStreamHandshakeWithError(err error) {
 	c.logStreamEvent(err, _successStreamOpen, _errorStreamOpen)
+
+	c.edge.calls.Inc()
+	if err == nil {
+		c.edge.successes.Inc()
+		c.edge.streaming.streamsActive.Inc()
+		return
+	}
+
+	c.emitStreamError(err)
 }
 
 // EndStream should be invoked immediately after a stream closes.
 func (c call) EndStream(err error) {
 	elapsed := _timeNow().Sub(c.started)
 	c.logStreamEvent(err, _successStreamClose, _errorStreamClose, zap.Duration("duration", elapsed))
+
+	c.edge.streaming.streamsActive.Dec()
+	c.edge.streaming.streamDurations.Observe(elapsed)
+	c.emitStreamError(err)
+}
+
+// This function resembles EndStats for unary calls. However, we do not special
+// case application errors and it does not measure failure latencies as those
+// measurements are irrelevant for streams.
+func (c call) emitStreamError(err error) {
+	if err == nil {
+		return
+	}
+
+	if !yarpcerrors.IsStatus(err) {
+		if counter, err := c.edge.serverFailures.Get(_error, "unknown_internal_yarpc"); err == nil {
+			counter.Inc()
+		}
+		return
+	}
+
+	// Emit finer grained metrics since the error is a yarpcerrors.Status.
+	errCode := yarpcerrors.FromError(err).Code()
+
+	switch statusFault(yarpcerrors.FromError(err)) {
+	case clientFault:
+		if counter, err2 := c.edge.callerFailures.Get(_error, errCode.String()); err2 != nil {
+			c.edge.logger.DPanic("could not retrieve caller failures counter", zap.Error(err2))
+		} else {
+			counter.Inc()
+		}
+
+	case serverFault:
+		if counter, err2 := c.edge.serverFailures.Get(_error, errCode.String()); err2 != nil {
+			c.edge.logger.DPanic("could not retrieve server failures counter", zap.Error(err2))
+		} else {
+			counter.Inc()
+		}
+
+	default:
+		// If this code is executed we've hit an error code outside the usual error
+		// code range, so we'll just log the string representation of that code.
+		if counter, err2 := c.edge.serverFailures.Get(_error, errCode.String()); err2 != nil {
+			c.edge.logger.DPanic("could not retrieve server failures counter", zap.Error(err2))
+		} else {
+			counter.Inc()
+		}
+	}
 }
 
 // logStreamEvent is a generic logging function useful for logging stream
@@ -209,4 +266,13 @@ func (c call) logStreamEvent(err error, succMsg, errMsg string, extraFields ...z
 	fields = append(fields, extraFields...)
 
 	ce.Write(fields...)
+}
+
+// inteded for metric tags, this returns the yarpcerrors.Status error code name
+// or "unknown_internal_yarpc"
+func errToMetricString(err error) string {
+	if yarpcerrors.IsStatus(err) {
+		return yarpcerrors.FromError(err).Code().String()
+	}
+	return "unknown_internal_yarpc"
 }

--- a/internal/observability/codes.go
+++ b/internal/observability/codes.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package observability
+
+import (
+	"go.uber.org/yarpc/yarpcerrors"
+)
+
+// TODO(apeatsbond): This code may be worth exporting in the yarpcerrors
+// package.
+
+type fault int
+
+const (
+	unknownFault fault = iota
+	clientFault
+	serverFault
+)
+
+// determine whether the status code is a client, server or indeterminate fault.
+func statusFault(status *yarpcerrors.Status) fault {
+	switch status.Code() {
+	case yarpcerrors.CodeCancelled,
+		yarpcerrors.CodeInvalidArgument,
+		yarpcerrors.CodeNotFound,
+		yarpcerrors.CodeAlreadyExists,
+		yarpcerrors.CodePermissionDenied,
+		yarpcerrors.CodeFailedPrecondition,
+		yarpcerrors.CodeAborted,
+		yarpcerrors.CodeOutOfRange,
+		yarpcerrors.CodeUnimplemented,
+		yarpcerrors.CodeUnauthenticated:
+		return clientFault
+
+	case yarpcerrors.CodeUnknown,
+		yarpcerrors.CodeDeadlineExceeded,
+		yarpcerrors.CodeResourceExhausted,
+		yarpcerrors.CodeInternal,
+		yarpcerrors.CodeUnavailable,
+		yarpcerrors.CodeDataLoss:
+		return serverFault
+	}
+
+	return unknownFault
+}

--- a/internal/observability/graph.go
+++ b/internal/observability/graph.go
@@ -156,6 +156,22 @@ type edge struct {
 	latencies          *metrics.Histogram
 	callerErrLatencies *metrics.Histogram
 	serverErrLatencies *metrics.Histogram
+
+	streaming *streamEdge
+}
+
+// streamEdge metrics should only be used for streaming requests.
+type streamEdge struct {
+	sends         *metrics.Counter
+	sendSuccesses *metrics.Counter
+	sendFailures  *metrics.CounterVector
+
+	receives         *metrics.Counter
+	receiveSuccesses *metrics.Counter
+	receiveFailures  *metrics.CounterVector
+
+	streamDurations *metrics.Histogram
+	streamsActive   *metrics.Gauge
 }
 
 // newEdge constructs a new edge. Since Registries enforce metric uniqueness,
@@ -172,6 +188,8 @@ func newEdge(logger *zap.Logger, meter *metrics.Scope, req *transport.Request, d
 		"direction":        direction,
 		"rpc_type":         rpcType.String(),
 	}
+
+	// metrics for all RPCs
 	calls, err := meter.Counter(metrics.Spec{
 		Name:      "calls",
 		Help:      "Total number of RPCs.",
@@ -206,41 +224,137 @@ func newEdge(logger *zap.Logger, meter *metrics.Scope, req *transport.Request, d
 	if err != nil {
 		logger.Error("Failed to create server failures vector.", zap.Error(err))
 	}
-	latencies, err := meter.Histogram(metrics.HistogramSpec{
-		Spec: metrics.Spec{
-			Name:      "success_latency_ms",
-			Help:      "Latency distribution of successful RPCs.",
-			ConstTags: tags,
-		},
-		Unit:    time.Millisecond,
-		Buckets: _bucketsMs,
-	})
-	if err != nil {
-		logger.Error("Failed to create success latency distribution.", zap.Error(err))
+
+	// metrics for only unary and oneway
+	var latencies, callerErrLatencies, serverErrLatencies *metrics.Histogram
+	if rpcType == transport.Unary || rpcType == transport.Oneway {
+		latencies, err = meter.Histogram(metrics.HistogramSpec{
+			Spec: metrics.Spec{
+				Name:      "success_latency_ms",
+				Help:      "Latency distribution of successful RPCs.",
+				ConstTags: tags,
+			},
+			Unit:    time.Millisecond,
+			Buckets: _bucketsMs,
+		})
+		if err != nil {
+			logger.Error("Failed to create success latency distribution.", zap.Error(err))
+		}
+		callerErrLatencies, err = meter.Histogram(metrics.HistogramSpec{
+			Spec: metrics.Spec{
+				Name:      "caller_failure_latency_ms",
+				Help:      "Latency distribution of RPCs failed because of caller error.",
+				ConstTags: tags,
+			},
+			Unit:    time.Millisecond,
+			Buckets: _bucketsMs,
+		})
+		if err != nil {
+			logger.Error("Failed to create caller failure latency distribution.", zap.Error(err))
+		}
+		serverErrLatencies, err = meter.Histogram(metrics.HistogramSpec{
+			Spec: metrics.Spec{
+				Name:      "server_failure_latency_ms",
+				Help:      "Latency distribution of RPCs failed because of server error.",
+				ConstTags: tags,
+			},
+			Unit:    time.Millisecond,
+			Buckets: _bucketsMs,
+		})
+		if err != nil {
+			logger.Error("Failed to create server failure latency distribution.", zap.Error(err))
+		}
 	}
-	callerErrLatencies, err := meter.Histogram(metrics.HistogramSpec{
-		Spec: metrics.Spec{
-			Name:      "caller_failure_latency_ms",
-			Help:      "Latency distribution of RPCs failed because of caller error.",
+
+	// metrics for only streams
+	var streaming *streamEdge
+	if rpcType == transport.Streaming {
+		// sends
+		sends, err := meter.Counter(metrics.Spec{
+			Name:      "stream_sends",
+			Help:      "Total number of streaming messages sent.",
 			ConstTags: tags,
-		},
-		Unit:    time.Millisecond,
-		Buckets: _bucketsMs,
-	})
-	if err != nil {
-		logger.Error("Failed to create caller failure latency distribution.", zap.Error(err))
-	}
-	serverErrLatencies, err := meter.Histogram(metrics.HistogramSpec{
-		Spec: metrics.Spec{
-			Name:      "server_failure_latency_ms",
-			Help:      "Latency distribution of RPCs failed because of server error.",
+		})
+		if err != nil {
+			logger.DPanic("Failed to create streaming sends counter.", zap.Error(err))
+		}
+		sendSuccesses, err := meter.Counter(metrics.Spec{
+			Name:      "stream_send_successes",
+			Help:      "Number of successful streaming messages sent.",
 			ConstTags: tags,
-		},
-		Unit:    time.Millisecond,
-		Buckets: _bucketsMs,
-	})
-	if err != nil {
-		logger.Error("Failed to create server failure latency distribution.", zap.Error(err))
+		})
+		if err != nil {
+			logger.DPanic("Failed to create streaming sends successes counter.", zap.Error(err))
+		}
+		sendFailures, err := meter.CounterVector(metrics.Spec{
+			Name:      "stream_send_failures",
+			Help:      "Number streaming messages that failed to send.",
+			ConstTags: tags,
+			VarTags:   []string{_error},
+		})
+		if err != nil {
+			logger.DPanic("Failed to create streaming sends failure counter.", zap.Error(err))
+		}
+
+		// receives
+		receives, err := meter.Counter(metrics.Spec{
+			Name:      "stream_receives",
+			Help:      "Total number of streaming messages recevied.",
+			ConstTags: tags,
+		})
+		if err != nil {
+			logger.DPanic("Failed to create streaming receives counter.", zap.Error(err))
+		}
+		receiveSuccesses, err := meter.Counter(metrics.Spec{
+			Name:      "stream_receive_successes",
+			Help:      "Number of successful streaming messages received.",
+			ConstTags: tags,
+		})
+		if err != nil {
+			logger.DPanic("Failed to create streaming receives successes counter.", zap.Error(err))
+		}
+		receiveFailures, err := meter.CounterVector(metrics.Spec{
+			Name:      "stream_receive_failures",
+			Help:      "Number streaming messages failed to be recieved.",
+			ConstTags: tags,
+			VarTags:   []string{_error},
+		})
+		if err != nil {
+			logger.DPanic("Failed to create streaming receives failure counter.", zap.Error(err))
+		}
+
+		// entire stream
+		streamDurations, err := meter.Histogram(metrics.HistogramSpec{
+			Spec: metrics.Spec{
+				Name:      "stream_duration_ms",
+				Help:      "Latency distribution of total stream duration.",
+				ConstTags: tags,
+			},
+			Unit:    time.Millisecond,
+			Buckets: _bucketsMs,
+		})
+		if err != nil {
+			logger.DPanic("Failed to create stream duration histogram.", zap.Error(err))
+		}
+		streamsActive, err := meter.Gauge(metrics.Spec{
+			Name:      "streams_active",
+			Help:      "Number of active streams.",
+			ConstTags: tags,
+		})
+		if err != nil {
+			logger.DPanic("Failed to create active stream gauge.", zap.Error(err))
+		}
+
+		streaming = &streamEdge{
+			sends:            sends,
+			sendSuccesses:    sendSuccesses,
+			sendFailures:     sendFailures,
+			receives:         receives,
+			receiveSuccesses: receiveSuccesses,
+			receiveFailures:  receiveFailures,
+			streamDurations:  streamDurations,
+			streamsActive:    streamsActive,
+		}
 	}
 
 	logger = logger.With(
@@ -262,6 +376,7 @@ func newEdge(logger *zap.Logger, meter *metrics.Scope, req *transport.Request, d
 		latencies:          latencies,
 		callerErrLatencies: callerErrLatencies,
 		serverErrLatencies: serverErrLatencies,
+		streaming:          streaming,
 	}
 }
 

--- a/internal/observability/stream.go
+++ b/internal/observability/stream.go
@@ -85,15 +85,14 @@ func (s *streamWrapper) SendMessage(ctx context.Context, msg *transport.StreamMe
 	s.edge.sends.Inc()
 	if err == nil {
 		s.edge.sendSuccesses.Inc()
-
-	} else {
-		if sendFailuresCounter, err2 := s.edge.sendFailures.Get(_error, errToMetricString(err)); err2 != nil {
-			s.logger.DPanic("could not retrieve send failure counter", zap.Error(err2))
-		} else {
-			sendFailuresCounter.Inc()
-		}
+		return nil
 	}
 
+	if sendFailuresCounter, err2 := s.edge.sendFailures.Get(_error, errToMetricString(err)); err2 != nil {
+		s.logger.DPanic("could not retrieve send failure counter", zap.Error(err2))
+	} else {
+		sendFailuresCounter.Inc()
+	}
 	return err
 }
 
@@ -104,13 +103,13 @@ func (s *streamWrapper) ReceiveMessage(ctx context.Context) (*transport.StreamMe
 	s.edge.receives.Inc()
 	if err == nil {
 		s.edge.receiveSuccesses.Inc()
+		return msg, nil
+	}
 
+	if recvFailureCounter, err2 := s.edge.receiveFailures.Get(_error, errToMetricString(err)); err2 != nil {
+		s.logger.DPanic("could not retrieve receive failure counter", zap.Error(err2))
 	} else {
-		if recvFailureCounter, err2 := s.edge.receiveFailures.Get(_error, errToMetricString(err)); err2 != nil {
-			s.logger.DPanic("could not retrieve receive failure counter", zap.Error(err2))
-		} else {
-			recvFailureCounter.Inc()
-		}
+		recvFailureCounter.Inc()
 	}
 
 	return msg, err


### PR DESCRIPTION
Augmenting #1769, this introduces introduces improved metrics for opening,
closing, sending and receiving messages through streams. T3395799.

Here we, piggyback on these existing metrics for streams:
- `calls` for initiating the RPC stream
- `successes` for successfully creating the stream
- `caller_failures` and `server_failures` for any errors

We also introduce the following metrics, exclusively for streams:
- `stream_duration_ms` for the duration of the stream
- `streams_active` gauge for number of active streams
- `stream_sends` for the number of messages sent on the stream (similar to `calls` for unary)
- `stream_send_failures` for the number messages failed to send on the stream (similar to caller/server failures for unary)
- `stream_receives` for the number of messages received on the stream
- `stream_receive_failures` for the number of receives that failed 

Each commit should be individually reviewed.
- Add streaming counters, histograms and gauges
- Extract code faults
- Instrument streaming metrics
- CHANGELOG