### PR TITLE
Add custom dialer function to HTTP transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   combination of inbound and outbound, for success, failure, and application
   error.
 - A peer list and transport stress tester is now in the `yarpctest` package.
+- Added custom dialer option for outbound HTTP requests.
 
 ## [1.39.0] - 2019-06-25
 ### Fixed

--- a/transport/http/transport.go
+++ b/transport/http/transport.go
@@ -186,7 +186,8 @@ func InnocenceWindow(d time.Duration) TransportOption {
 }
 
 // DialContext specifies the dial function for creating TCP connections on the
-// outbound.
+// outbound. This will override the default dial context, which has a 30 second
+// timeout and respects the KeepAlive option.
 //
 // See https://golang.org/pkg/net/http/#Transport.DialContext for details.
 func DialContext(f func(ctx context.Context, network, addr string) (net.Conn, error)) TransportOption {


### PR DESCRIPTION
This adds a custom dial function to the HTTP transport's underlying
`http.Transport`. This is a back port of an identical feature in v2
(D2681895).

Note that this option is passed in through the `Transport` since 
all `Outbound`s share the same HTTP client.

See: https://golang.org/pkg/net/http/#Transport.DialContext.