### PR TITLE
Add custom dialer function to gRPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   combination of inbound and outbound, for success, failure, and application
   error.
 - A peer list and transport stress tester is now in the `yarpctest` package.
+- Added custom dialer option for gRPC.
 
 ## [1.39.0] - 2019-06-25
 ### Fixed

--- a/transport/grpc/transport.go
+++ b/transport/grpc/transport.go
@@ -29,6 +29,8 @@ import (
 	"go.uber.org/yarpc/pkg/lifecycle"
 )
 
+var emptyDialOpts = &dialOptions{}
+
 // Transport is a grpc transport.Transport.
 //
 // This currently does not have any additional functionality over creating
@@ -101,7 +103,7 @@ func (t *Transport) NewOutbound(peerChooser peer.Chooser, options ...OutboundOpt
 // peer.Transport that supports custom DialOptions instead of using the
 // grpc.Transport as a peer.Transport.
 func (t *Transport) RetainPeer(pid peer.Identifier, ps peer.Subscriber) (peer.Peer, error) {
-	return t.retainPeer(pid, nil, ps)
+	return t.retainPeer(pid, emptyDialOpts, ps)
 }
 
 func (t *Transport) retainPeer(pid peer.Identifier, options *dialOptions, ps peer.Subscriber) (peer.Peer, error) {


### PR DESCRIPTION
This adds a custom dial function to the gRPC transport. This is a back
port of an identical feature in v2 (D2679617).

See https://godoc.org/google.golang.org/grpc#WithContextDialer for
more details.