### PR TITLE
Add thrift procedures under second Fx value group

### DIFF
--- a/encoding/thrift/thriftrw-plugin-yarpc/fx.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/fx.go
@@ -134,6 +134,7 @@ type ServerResult struct {
 	<$fx>.Out
 
 	Procedures []<$transport>.Procedure ` + "`group:\"yarpcfx\"`" + `
+	ThriftProcedures []<$transport>.Procedure ` + "`group:\"thrift\"`" + `
 }
 
 // Server provides procedures for <.Name> to an Fx application. It expects a
@@ -148,7 +149,10 @@ type ServerResult struct {
 func Server(opts ...<$thrift>.RegisterOption) interface{} {
 	return func(p ServerParams) ServerResult {
 		procedures := <$server>.New(p.Handler, opts...)
-		return ServerResult{Procedures: procedures}
+		return ServerResult{
+			Procedures: procedures,
+			ThriftProcedures: procedures,
+		}
 	}
 }
 `

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/readonlystorefx/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/readonlystorefx/server.go
@@ -25,7 +25,8 @@ type ServerParams struct {
 type ServerResult struct {
 	fx.Out
 
-	Procedures []transport.Procedure `group:"yarpcfx"`
+	Procedures       []transport.Procedure `group:"yarpcfx"`
+	ThriftProcedures []transport.Procedure `group:"thrift"`
 }
 
 // Server provides procedures for ReadOnlyStore to an Fx application. It expects a
@@ -40,6 +41,9 @@ type ServerResult struct {
 func Server(opts ...thrift.RegisterOption) interface{} {
 	return func(p ServerParams) ServerResult {
 		procedures := readonlystoreserver.New(p.Handler, opts...)
-		return ServerResult{Procedures: procedures}
+		return ServerResult{
+			Procedures:       procedures,
+			ThriftProcedures: procedures,
+		}
 	}
 }

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storefx/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storefx/server.go
@@ -25,7 +25,8 @@ type ServerParams struct {
 type ServerResult struct {
 	fx.Out
 
-	Procedures []transport.Procedure `group:"yarpcfx"`
+	Procedures       []transport.Procedure `group:"yarpcfx"`
+	ThriftProcedures []transport.Procedure `group:"thrift"`
 }
 
 // Server provides procedures for Store to an Fx application. It expects a
@@ -40,6 +41,9 @@ type ServerResult struct {
 func Server(opts ...thrift.RegisterOption) interface{} {
 	return func(p ServerParams) ServerResult {
 		procedures := storeserver.New(p.Handler, opts...)
-		return ServerResult{Procedures: procedures}
+		return ServerResult{
+			Procedures:       procedures,
+			ThriftProcedures: procedures,
+		}
 	}
 }

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/baseservicefx/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/baseservicefx/server.go
@@ -25,7 +25,8 @@ type ServerParams struct {
 type ServerResult struct {
 	fx.Out
 
-	Procedures []transport.Procedure `group:"yarpcfx"`
+	Procedures       []transport.Procedure `group:"yarpcfx"`
+	ThriftProcedures []transport.Procedure `group:"thrift"`
 }
 
 // Server provides procedures for BaseService to an Fx application. It expects a
@@ -40,6 +41,9 @@ type ServerResult struct {
 func Server(opts ...thrift.RegisterOption) interface{} {
 	return func(p ServerParams) ServerResult {
 		procedures := baseserviceserver.New(p.Handler, opts...)
-		return ServerResult{Procedures: procedures}
+		return ServerResult{
+			Procedures:       procedures,
+			ThriftProcedures: procedures,
+		}
 	}
 }

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/emptyservicefx/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/emptyservicefx/server.go
@@ -25,7 +25,8 @@ type ServerParams struct {
 type ServerResult struct {
 	fx.Out
 
-	Procedures []transport.Procedure `group:"yarpcfx"`
+	Procedures       []transport.Procedure `group:"yarpcfx"`
+	ThriftProcedures []transport.Procedure `group:"thrift"`
 }
 
 // Server provides procedures for EmptyService to an Fx application. It expects a
@@ -40,6 +41,9 @@ type ServerResult struct {
 func Server(opts ...thrift.RegisterOption) interface{} {
 	return func(p ServerParams) ServerResult {
 		procedures := emptyserviceserver.New(p.Handler, opts...)
-		return ServerResult{Procedures: procedures}
+		return ServerResult{
+			Procedures:       procedures,
+			ThriftProcedures: procedures,
+		}
 	}
 }

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendemptyfx/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendemptyfx/server.go
@@ -25,7 +25,8 @@ type ServerParams struct {
 type ServerResult struct {
 	fx.Out
 
-	Procedures []transport.Procedure `group:"yarpcfx"`
+	Procedures       []transport.Procedure `group:"yarpcfx"`
+	ThriftProcedures []transport.Procedure `group:"thrift"`
 }
 
 // Server provides procedures for ExtendEmpty to an Fx application. It expects a
@@ -40,6 +41,9 @@ type ServerResult struct {
 func Server(opts ...thrift.RegisterOption) interface{} {
 	return func(p ServerParams) ServerResult {
 		procedures := extendemptyserver.New(p.Handler, opts...)
-		return ServerResult{Procedures: procedures}
+		return ServerResult{
+			Procedures:       procedures,
+			ThriftProcedures: procedures,
+		}
 	}
 }

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendonlyfx/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendonlyfx/server.go
@@ -25,7 +25,8 @@ type ServerParams struct {
 type ServerResult struct {
 	fx.Out
 
-	Procedures []transport.Procedure `group:"yarpcfx"`
+	Procedures       []transport.Procedure `group:"yarpcfx"`
+	ThriftProcedures []transport.Procedure `group:"thrift"`
 }
 
 // Server provides procedures for ExtendOnly to an Fx application. It expects a
@@ -40,6 +41,9 @@ type ServerResult struct {
 func Server(opts ...thrift.RegisterOption) interface{} {
 	return func(p ServerParams) ServerResult {
 		procedures := extendonlyserver.New(p.Handler, opts...)
-		return ServerResult{Procedures: procedures}
+		return ServerResult{
+			Procedures:       procedures,
+			ThriftProcedures: procedures,
+		}
 	}
 }

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/barfx/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/barfx/server.go
@@ -25,7 +25,8 @@ type ServerParams struct {
 type ServerResult struct {
 	fx.Out
 
-	Procedures []transport.Procedure `group:"yarpcfx"`
+	Procedures       []transport.Procedure `group:"yarpcfx"`
+	ThriftProcedures []transport.Procedure `group:"thrift"`
 }
 
 // Server provides procedures for Bar to an Fx application. It expects a
@@ -40,6 +41,9 @@ type ServerResult struct {
 func Server(opts ...thrift.RegisterOption) interface{} {
 	return func(p ServerParams) ServerResult {
 		procedures := barserver.New(p.Handler, opts...)
-		return ServerResult{Procedures: procedures}
+		return ServerResult{
+			Procedures:       procedures,
+			ThriftProcedures: procedures,
+		}
 	}
 }

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/foofx/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/foofx/server.go
@@ -25,7 +25,8 @@ type ServerParams struct {
 type ServerResult struct {
 	fx.Out
 
-	Procedures []transport.Procedure `group:"yarpcfx"`
+	Procedures       []transport.Procedure `group:"yarpcfx"`
+	ThriftProcedures []transport.Procedure `group:"thrift"`
 }
 
 // Server provides procedures for Foo to an Fx application. It expects a
@@ -40,6 +41,9 @@ type ServerResult struct {
 func Server(opts ...thrift.RegisterOption) interface{} {
 	return func(p ServerParams) ServerResult {
 		procedures := fooserver.New(p.Handler, opts...)
-		return ServerResult{Procedures: procedures}
+		return ServerResult{
+			Procedures:       procedures,
+			ThriftProcedures: procedures,
+		}
 	}
 }

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/namefx/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/namefx/server.go
@@ -25,7 +25,8 @@ type ServerParams struct {
 type ServerResult struct {
 	fx.Out
 
-	Procedures []transport.Procedure `group:"yarpcfx"`
+	Procedures       []transport.Procedure `group:"yarpcfx"`
+	ThriftProcedures []transport.Procedure `group:"thrift"`
 }
 
 // Server provides procedures for Name to an Fx application. It expects a
@@ -40,6 +41,9 @@ type ServerResult struct {
 func Server(opts ...thrift.RegisterOption) interface{} {
 	return func(p ServerParams) ServerResult {
 		procedures := nameserver.New(p.Handler, opts...)
-		return ServerResult{Procedures: procedures}
+		return ServerResult{
+			Procedures:       procedures,
+			ThriftProcedures: procedures,
+		}
 	}
 }

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/weather/weatherfx/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/weather/weatherfx/server.go
@@ -25,7 +25,8 @@ type ServerParams struct {
 type ServerResult struct {
 	fx.Out
 
-	Procedures []transport.Procedure `group:"yarpcfx"`
+	Procedures       []transport.Procedure `group:"yarpcfx"`
+	ThriftProcedures []transport.Procedure `group:"thrift"`
 }
 
 // Server provides procedures for Weather to an Fx application. It expects a
@@ -40,6 +41,9 @@ type ServerResult struct {
 func Server(opts ...thrift.RegisterOption) interface{} {
 	return func(p ServerParams) ServerResult {
 		procedures := weatherserver.New(p.Handler, opts...)
-		return ServerResult{Procedures: procedures}
+		return ServerResult{
+			Procedures:       procedures,
+			ThriftProcedures: procedures,
+		}
 	}
 }

--- a/internal/crossdock/thrift/echo/echofx/server.go
+++ b/internal/crossdock/thrift/echo/echofx/server.go
@@ -45,7 +45,8 @@ type ServerParams struct {
 type ServerResult struct {
 	fx.Out
 
-	Procedures []transport.Procedure `group:"yarpcfx"`
+	Procedures       []transport.Procedure `group:"yarpcfx"`
+	ThriftProcedures []transport.Procedure `group:"thrift"`
 }
 
 // Server provides procedures for Echo to an Fx application. It expects a
@@ -60,6 +61,9 @@ type ServerResult struct {
 func Server(opts ...thrift.RegisterOption) interface{} {
 	return func(p ServerParams) ServerResult {
 		procedures := echoserver.New(p.Handler, opts...)
-		return ServerResult{Procedures: procedures}
+		return ServerResult{
+			Procedures:       procedures,
+			ThriftProcedures: procedures,
+		}
 	}
 }

--- a/internal/crossdock/thrift/gauntlet/secondservicefx/server.go
+++ b/internal/crossdock/thrift/gauntlet/secondservicefx/server.go
@@ -45,7 +45,8 @@ type ServerParams struct {
 type ServerResult struct {
 	fx.Out
 
-	Procedures []transport.Procedure `group:"yarpcfx"`
+	Procedures       []transport.Procedure `group:"yarpcfx"`
+	ThriftProcedures []transport.Procedure `group:"thrift"`
 }
 
 // Server provides procedures for SecondService to an Fx application. It expects a
@@ -60,6 +61,9 @@ type ServerResult struct {
 func Server(opts ...thrift.RegisterOption) interface{} {
 	return func(p ServerParams) ServerResult {
 		procedures := secondserviceserver.New(p.Handler, opts...)
-		return ServerResult{Procedures: procedures}
+		return ServerResult{
+			Procedures:       procedures,
+			ThriftProcedures: procedures,
+		}
 	}
 }

--- a/internal/crossdock/thrift/gauntlet/thrifttestfx/server.go
+++ b/internal/crossdock/thrift/gauntlet/thrifttestfx/server.go
@@ -45,7 +45,8 @@ type ServerParams struct {
 type ServerResult struct {
 	fx.Out
 
-	Procedures []transport.Procedure `group:"yarpcfx"`
+	Procedures       []transport.Procedure `group:"yarpcfx"`
+	ThriftProcedures []transport.Procedure `group:"thrift"`
 }
 
 // Server provides procedures for ThriftTest to an Fx application. It expects a
@@ -60,6 +61,9 @@ type ServerResult struct {
 func Server(opts ...thrift.RegisterOption) interface{} {
 	return func(p ServerParams) ServerResult {
 		procedures := thrifttestserver.New(p.Handler, opts...)
-		return ServerResult{Procedures: procedures}
+		return ServerResult{
+			Procedures:       procedures,
+			ThriftProcedures: procedures,
+		}
 	}
 }

--- a/internal/crossdock/thrift/oneway/onewayfx/server.go
+++ b/internal/crossdock/thrift/oneway/onewayfx/server.go
@@ -45,7 +45,8 @@ type ServerParams struct {
 type ServerResult struct {
 	fx.Out
 
-	Procedures []transport.Procedure `group:"yarpcfx"`
+	Procedures       []transport.Procedure `group:"yarpcfx"`
+	ThriftProcedures []transport.Procedure `group:"thrift"`
 }
 
 // Server provides procedures for Oneway to an Fx application. It expects a
@@ -60,6 +61,9 @@ type ServerResult struct {
 func Server(opts ...thrift.RegisterOption) interface{} {
 	return func(p ServerParams) ServerResult {
 		procedures := onewayserver.New(p.Handler, opts...)
-		return ServerResult{Procedures: procedures}
+		return ServerResult{
+			Procedures:       procedures,
+			ThriftProcedures: procedures,
+		}
 	}
 }

--- a/internal/examples/thrift-hello/hello/echo/hellofx/server.go
+++ b/internal/examples/thrift-hello/hello/echo/hellofx/server.go
@@ -45,7 +45,8 @@ type ServerParams struct {
 type ServerResult struct {
 	fx.Out
 
-	Procedures []transport.Procedure `group:"yarpcfx"`
+	Procedures       []transport.Procedure `group:"yarpcfx"`
+	ThriftProcedures []transport.Procedure `group:"thrift"`
 }
 
 // Server provides procedures for Hello to an Fx application. It expects a
@@ -60,6 +61,9 @@ type ServerResult struct {
 func Server(opts ...thrift.RegisterOption) interface{} {
 	return func(p ServerParams) ServerResult {
 		procedures := helloserver.New(p.Handler, opts...)
-		return ServerResult{Procedures: procedures}
+		return ServerResult{
+			Procedures:       procedures,
+			ThriftProcedures: procedures,
+		}
 	}
 }

--- a/internal/examples/thrift-keyvalue/keyvalue/kv/keyvaluefx/server.go
+++ b/internal/examples/thrift-keyvalue/keyvalue/kv/keyvaluefx/server.go
@@ -45,7 +45,8 @@ type ServerParams struct {
 type ServerResult struct {
 	fx.Out
 
-	Procedures []transport.Procedure `group:"yarpcfx"`
+	Procedures       []transport.Procedure `group:"yarpcfx"`
+	ThriftProcedures []transport.Procedure `group:"thrift"`
 }
 
 // Server provides procedures for KeyValue to an Fx application. It expects a
@@ -60,6 +61,9 @@ type ServerResult struct {
 func Server(opts ...thrift.RegisterOption) interface{} {
 	return func(p ServerParams) ServerResult {
 		procedures := keyvalueserver.New(p.Handler, opts...)
-		return ServerResult{Procedures: procedures}
+		return ServerResult{
+			Procedures:       procedures,
+			ThriftProcedures: procedures,
+		}
 	}
 }

--- a/internal/examples/thrift-oneway/sink/hellofx/server.go
+++ b/internal/examples/thrift-oneway/sink/hellofx/server.go
@@ -45,7 +45,8 @@ type ServerParams struct {
 type ServerResult struct {
 	fx.Out
 
-	Procedures []transport.Procedure `group:"yarpcfx"`
+	Procedures       []transport.Procedure `group:"yarpcfx"`
+	ThriftProcedures []transport.Procedure `group:"thrift"`
 }
 
 // Server provides procedures for Hello to an Fx application. It expects a
@@ -60,6 +61,9 @@ type ServerResult struct {
 func Server(opts ...thrift.RegisterOption) interface{} {
 	return func(p ServerParams) ServerResult {
 		procedures := helloserver.New(p.Handler, opts...)
-		return ServerResult{Procedures: procedures}
+		return ServerResult{
+			Procedures:       procedures,
+			ThriftProcedures: procedures,
+		}
 	}
 }


### PR DESCRIPTION
This adds thrift procedures under a second Fx value group. This could
for example, support an aggressive Thrift to Protobuf migration; we
may need to automatically generate Protobuf procedures based on the
output of the already existing generated procedures.

This would enable us to depend on thrift generated procedures and
provide new ones in the `yarpcfx` value group.

I intentionally, skipped the CHANGELOG update since this is not
intended to be a user facing feature.