### PR TITLE
Release responseWriter buffer in error condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Fixed
+- Release responseWriter buffer during error condition
 
 ## [1.40.0] - 2019-09-19
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Added ReleaseBuffer() function and call it with "defer". Also removed
-  "defer bufferpool.Put(hw.buffer)" from Close() function. This ensures that
-  responseWriter buffer will be put back to buffer pool from single location.
-  This change addresses the issue in which responseWriter buffer was not put
-  back to buffer pool under error conditions.
+- Fixed TChannel memory pressure that would occur during server-side errors.
 ### Changed
 - Relaxed service name validation to allow e-mail addresses.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Release responseWriter buffer during error condition.
+- Added ReleaseBuffer() function and call it with "defer". Also removed
+  "defer bufferpool.Put(hw.buffer)" from Close() function. This ensures that
+  responseWriter buffer will be put back to buffer pool from single location.
+  This change addresses the issue in which responseWriter buffer was not put
+  back to buffer pool under error conditions.
 ### Changed
 - Relaxed service name validation to allow e-mail addresses.
 

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -313,6 +313,7 @@ func (hw *handlerWriter) Close() error {
 func (hw *handlerWriter) ReleaseBuffer() {
 	if hw.buffer != nil {
 		bufferpool.Put(hw.buffer)
+		hw.buffer = nil
 	}
 }
 


### PR DESCRIPTION
It seems that the buffer used by responseWriter object is not put back into bufferpool during error conditions. As a result, we have see large memory consumed by the process