### PR TITLE
Relax service name constraints on dispatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Changed
+- Relaxed service name validation to allow e-mail addresses.
 
 ## [1.40.0] - 2019-09-19
 ### Added

--- a/internal/servicename.go
+++ b/internal/servicename.go
@@ -32,9 +32,12 @@ import (
 var _uuidRegexp = regexp.MustCompile("[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}")
 
 // ValidateServiceName returns an error if the given servive name is invalid.
-// Valid names are at least two characters long, start with [a-z], contain only
-// [0-9a-z] and non-consecutive hyphens, and end in [0-9a-z]. Furthermore,
-// names may not contain UUIDs.
+// Valid names are
+//  - at least two characters long
+//  - start with [a-z]
+//  - contain only [0-9a-z@.] and non-consecutive hyphens
+//  - end in [0-9a-z]
+//  - not UUIDs
 func ValidateServiceName(name string) error {
 	if len(name) < 2 {
 		// Short names aren't safe to check any further.
@@ -45,6 +48,7 @@ func ValidateServiceName(name string) error {
 		checkFirstCharacter(name),
 		checkForbiddenCharacters(name),
 		checkUUIDs(name),
+		checkLastCharacter(name),
 	)
 }
 
@@ -53,9 +57,6 @@ func checkHyphens(name string) error {
 		if name[i-1] == '-' && name[i] == '-' {
 			return fmt.Errorf("service name %q contains consecutive hyphens", name)
 		}
-	}
-	if name[len(name)-1] == '-' {
-		return fmt.Errorf("service name %q ends with a hyphen", name)
 	}
 	return nil
 }
@@ -67,6 +68,14 @@ func checkFirstCharacter(name string) error {
 	return nil
 }
 
+func checkLastCharacter(name string) error {
+	last := name[len(name)-1]
+	if ('a' <= last && last <= 'z') || ('0' <= last && last <= '9') {
+		return nil
+	}
+	return fmt.Errorf("service name %q doesn't end with a lowercase ASCII letter or number", name)
+}
+
 func checkForbiddenCharacters(name string) error {
 	for _, c := range name {
 		switch {
@@ -76,8 +85,10 @@ func checkForbiddenCharacters(name string) error {
 			continue
 		case c == '-':
 			continue
+		case c == '@', c == '.': // allow email addresses for CLIs
+			continue
 		default:
-			return fmt.Errorf("service name %q contains characters other than [0-9a-z] and hyphens", name)
+			return fmt.Errorf("service name %q contains characters other than [0-9a-z@.] and hyphens, found %q", name, c)
 		}
 	}
 	return nil

--- a/internal/servicename_test.go
+++ b/internal/servicename_test.go
@@ -36,6 +36,7 @@ func TestValidServiceNames(t *testing.T) {
 		"a77ab7g4-51cb-4808-a9ef-875568bde54a", // not valid UUID
 		"eviluuid26695g10-a384-48e7-8867-6d48b7fae80a", // not valid UUID
 		"a77gb7e4-51cb-4808-a9ef-875568bde54aeviluuid", // not valid UUID
+		"apb@uber.com",
 	}
 	for _, n := range tests {
 		assert.NoError(t, ValidateServiceName(n), "Expected %q to be a valid service name.", n)
@@ -67,6 +68,8 @@ func TestInvalidServiceNames(t *testing.T) {
 		"endswithadash-",
 		"endswithasterisk*",
 		"internal*-asterisk",
+		"apb@",
+		"@",
 	}
 	for _, n := range tests {
 		assert.Error(t, ValidateServiceName(n), "Expected %q to be an invalid service name", n)


### PR DESCRIPTION
This relaxes the service name constraint on the dispatcher. This
enables users developing a CLI, for example, to use an e-mail address.
