### PR TITLE
glide: Drop prometheus/client_golang constraint

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -16,12 +16,6 @@ import:
   version: '>=0.3, < 2.0'
 - package: github.com/opentracing/opentracing-go
   version: ^1
-- package: github.com/prometheus/client_golang
-  # This isn't exposed to customers, so we can depend on a pre-1.0 release.
-  version: '>=0.8, < 0.10'
-  subpackages:
-  - prometheus
-  - prometheus/promhttp
 - package: go.uber.org/fx
   version: ^1
 - package: go.uber.org/zap


### PR DESCRIPTION
We don't actually import or use prometheus/client_golang directly in
this code base so that constraint is unnecessary.

We do use it in yarpc/metrics. See yarpc/metrics#27 for constraint update
there.

Resolves #1797