### PR TITLE
Revert service name relaxation for emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Fixed
 - Fixed TChannel memory pressure that would occur during server-side errors.
-### Changed
-- Relaxed service name validation to allow e-mail addresses.
 
 ## [1.40.0] - 2019-09-19
 ### Added

--- a/internal/servicename_test.go
+++ b/internal/servicename_test.go
@@ -36,7 +36,6 @@ func TestValidServiceNames(t *testing.T) {
 		"a77ab7g4-51cb-4808-a9ef-875568bde54a", // not valid UUID
 		"eviluuid26695g10-a384-48e7-8867-6d48b7fae80a", // not valid UUID
 		"a77gb7e4-51cb-4808-a9ef-875568bde54aeviluuid", // not valid UUID
-		"apb@uber.com",
 	}
 	for _, n := range tests {
 		assert.NoError(t, ValidateServiceName(n), "Expected %q to be a valid service name.", n)
@@ -68,8 +67,6 @@ func TestInvalidServiceNames(t *testing.T) {
 		"endswithadash-",
 		"endswithasterisk*",
 		"internal*-asterisk",
-		"apb@",
-		"@",
 	}
 	for _, n := range tests {
 		assert.Error(t, ValidateServiceName(n), "Expected %q to be an invalid service name", n)


### PR DESCRIPTION
migration. This is no longer required and relaxing this constraint
could cause more headaches for our infrastructure stack than what's
necessary. re:
https://github.com/yarpc/yarpc-go/pull/1800#discussion_r327868920

This was merged to `dev`, but unreleased, so this removes the
CHANGELOG entry entirely.