### PR TITLE
Add fail-fast option to peer lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Added
+- Added fail-fast option to peer lists.  With this option enabled, a peer list
+  will return an error if no peers are connected at the time of a call, instead
+  of waiting.
 
 ## [1.41.0] - 2019-10-01
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Added fail-fast option to peer lists.  With this option enabled, a peer list
   will return an error if no peers are connected at the time of a call, instead
-  of waiting.
+  of waiting for an available peer or the context to time out.
 
 ## [1.41.0] - 2019-10-01
 ### Fixed

--- a/peer/peerlist/v2/list.go
+++ b/peer/peerlist/v2/list.go
@@ -444,9 +444,8 @@ func (pl *List) Choose(ctx context.Context, req *transport.Request) (peer.Peer, 
 			pl.notifyPeerAvailable()
 			t.StartRequest()
 			return t.peer, t.boundOnFinish, nil
-		}
-		if p == nil && pl.failFast {
-			return nil, nil, yarpcerrors.Newf(yarpcerrors.CodeUnavailable, "%s peer list has no peer available", pl.name)
+		} else if pl.failFast {
+			return nil, nil, yarpcerrors.Newf(yarpcerrors.CodeUnavailable, "%q peer list has no peer available", pl.name)
 		}
 		if err := pl.waitForPeerAddedEvent(ctx); err != nil {
 			return nil, nil, err

--- a/peer/pendingheap/config.go
+++ b/peer/pendingheap/config.go
@@ -31,6 +31,7 @@ import (
 // Configuration descripes how to build a fewest pending heap peer list.
 type Configuration struct {
 	Capacity *int `config:"capacity"`
+	FailFast bool `config:"failFast"`
 }
 
 // Spec returns a configuration specification for the pending heap peer list
@@ -51,20 +52,38 @@ type Configuration struct {
 //            peers:
 //              - 127.0.0.1:8080
 //              - 127.0.0.1:8081
+//
+// Other than a specific peer or peers list, use any peer list updater
+// registered with a yarpc Configurator.
+// The configuration allows for alternative initial allocation capacity and a
+// fail-fast option.
+// With fail-fast enabled, the peer list will return an error immediately if no
+// peers are available (connected) at the time the request is sent.
+//
+//  fewest-pending-requests:
+//    peers:
+//      - 127.0.0.1:8080
+//    capacity: 1
+//    failFast: true
 func Spec() yarpcconfig.PeerListSpec {
 	return yarpcconfig.PeerListSpec{
 		Name: "fewest-pending-requests",
 		BuildPeerList: func(cfg Configuration, t peer.Transport, k *yarpcconfig.Kit) (peer.ChooserList, error) {
-			if cfg.Capacity == nil {
-				return New(t), nil
+			opts := make([]ListOption, 0, 2)
+
+			if cfg.Capacity != nil {
+				if *cfg.Capacity <= 0 {
+					return nil, yarpcerrors.Newf(yarpcerrors.CodeInvalidArgument,
+						fmt.Sprintf("Capacity must be greater than 0. Got: %d.", *cfg.Capacity))
+				}
+				opts = append(opts, Capacity(*cfg.Capacity))
 			}
 
-			if *cfg.Capacity <= 0 {
-				return nil, yarpcerrors.Newf(yarpcerrors.CodeInvalidArgument,
-					fmt.Sprintf("Capacity must be greater than 0. Got: %d.", *cfg.Capacity))
+			if cfg.FailFast {
+				opts = append(opts, FailFast())
 			}
 
-			return New(t, Capacity(*cfg.Capacity)), nil
+			return New(t, opts...), nil
 		},
 	}
 }

--- a/peer/pendingheap/list_test.go
+++ b/peer/pendingheap/list_test.go
@@ -22,15 +22,25 @@ package pendingheap
 
 import (
 	"context"
+	"fmt"
+	"net"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/multierr"
+	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/peer"
 	. "go.uber.org/yarpc/api/peer/peertest"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/testtime"
+	"go.uber.org/yarpc/internal/whitespace"
+	"go.uber.org/yarpc/transport/http"
+	"go.uber.org/yarpc/yarpcconfig"
 	"go.uber.org/yarpc/yarpcerrors"
 )
 
@@ -674,4 +684,45 @@ func TestPeerHeapList(t *testing.T) {
 
 var noShuffle ListOption = func(c *listConfig) {
 	c.shuffle = false
+}
+
+func TestFailFastConfig(t *testing.T) {
+	conn, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	serviceName := "test"
+	config := whitespace.Expand(fmt.Sprintf(`
+		outbounds:
+			nowhere:
+				http:
+					fewest-pending-requests:
+						peers:
+							- %q
+						capacity: 10
+						failFast: true
+	`, conn.Addr()))
+	cfgr := yarpcconfig.New()
+	cfgr.MustRegisterTransport(http.TransportSpec())
+	cfgr.MustRegisterPeerList(Spec())
+	cfg, err := cfgr.LoadConfigFromYAML(serviceName, strings.NewReader(config))
+	require.NoError(t, err)
+
+	d := yarpc.NewDispatcher(cfg)
+	d.Start()
+	defer d.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
+	defer cancel()
+
+	client := d.MustOutboundConfig("nowhere")
+	_, err = client.Outbounds.Unary.Call(ctx, &transport.Request{
+		Service:   "service",
+		Caller:    "caller",
+		Encoding:  transport.Encoding("blank"),
+		Procedure: "bogus",
+		Body:      strings.NewReader("nada"),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no peer available")
 }

--- a/peer/roundrobin/list.go
+++ b/peer/roundrobin/list.go
@@ -30,6 +30,7 @@ import (
 type listConfig struct {
 	capacity int
 	shuffle  bool
+	failFast bool
 	seed     int64
 }
 
@@ -52,6 +53,17 @@ func Capacity(capacity int) ListOption {
 	}
 }
 
+// FailFast indicates that the peer list should not wait for a peer to become
+// available when choosing a peer.
+//
+// This option is preferrable when the better failure mode is to retry from the
+// origin, since another proxy instance might already have a connection.
+func FailFast() ListOption {
+	return func(c *listConfig) {
+		c.failFast = true
+	}
+}
+
 // New creates a new round robin peer list.
 func New(transport peer.Transport, opts ...ListOption) *List {
 	cfg := defaultListConfig
@@ -65,6 +77,9 @@ func New(transport peer.Transport, opts ...ListOption) *List {
 	}
 	if !cfg.shuffle {
 		plOpts = append(plOpts, peerlist.NoShuffle())
+	}
+	if cfg.failFast {
+		plOpts = append(plOpts, peerlist.FailFast())
 	}
 
 	return &List{

--- a/peer/roundrobin/list_test.go
+++ b/peer/roundrobin/list_test.go
@@ -23,16 +23,25 @@ package roundrobin
 import (
 	"context"
 	"fmt"
+	"net"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/multierr"
+	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/peer"
 	. "go.uber.org/yarpc/api/peer/peertest"
+	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/introspection"
+	"go.uber.org/yarpc/internal/testtime"
+	"go.uber.org/yarpc/internal/whitespace"
 	"go.uber.org/yarpc/peer/hostport"
+	"go.uber.org/yarpc/transport/http"
+	"go.uber.org/yarpc/yarpcconfig"
 	"go.uber.org/yarpc/yarpcerrors"
 )
 
@@ -1008,4 +1017,45 @@ func seed(seed int64) ListOption {
 	return func(c *listConfig) {
 		c.seed = seed
 	}
+}
+
+func TestFailFastConfig(t *testing.T) {
+	conn, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	serviceName := "test"
+	config := whitespace.Expand(fmt.Sprintf(`
+		outbounds:
+			nowhere:
+				http:
+					round-robin:
+						peers:
+							- %q
+						capacity: 10
+						failFast: true
+	`, conn.Addr()))
+	cfgr := yarpcconfig.New()
+	cfgr.MustRegisterTransport(http.TransportSpec())
+	cfgr.MustRegisterPeerList(Spec())
+	cfg, err := cfgr.LoadConfigFromYAML(serviceName, strings.NewReader(config))
+	require.NoError(t, err)
+
+	d := yarpc.NewDispatcher(cfg)
+	d.Start()
+	defer d.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
+	defer cancel()
+
+	client := d.MustOutboundConfig("nowhere")
+	_, err = client.Outbounds.Unary.Call(ctx, &transport.Request{
+		Service:   "service",
+		Caller:    "caller",
+		Encoding:  transport.Encoding("blank"),
+		Procedure: "bogus",
+		Body:      strings.NewReader("nada"),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no peer available")
 }

--- a/peer/tworandomchoices/list.go
+++ b/peer/tworandomchoices/list.go
@@ -31,6 +31,7 @@ import (
 type listOptions struct {
 	capacity int
 	source   rand.Source
+	failFast bool
 }
 
 var defaultListOptions = listOptions{
@@ -71,6 +72,17 @@ func Source(source rand.Source) ListOption {
 	})
 }
 
+// FailFast indicates that the peer list should not wait for a peer to become
+// available when choosing a peer.
+//
+// This option is preferrable when the better failure mode is to retry from the
+// origin, since another proxy instance might already have a connection.
+func FailFast() ListOption {
+	return listOptionFunc(func(options *listOptions) {
+		options.failFast = true
+	})
+}
+
 // New creates a new fewest pending requests of two random peers peer list.
 func New(transport peer.Transport, opts ...ListOption) *List {
 	options := defaultListOptions
@@ -85,6 +97,10 @@ func New(transport peer.Transport, opts ...ListOption) *List {
 	plOpts := []peerlist.ListOption{
 		peerlist.Capacity(options.capacity),
 		peerlist.NoShuffle(),
+	}
+
+	if options.failFast {
+		plOpts = append(plOpts, peerlist.FailFast())
 	}
 
 	return &List{

--- a/peer/tworandomchoices/list_test.go
+++ b/peer/tworandomchoices/list_test.go
@@ -22,16 +22,26 @@ package tworandomchoices_test
 
 import (
 	"context"
+	"fmt"
+	"net"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/multierr"
+	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/peer"
 	. "go.uber.org/yarpc/api/peer/peertest"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/testtime"
+	"go.uber.org/yarpc/internal/whitespace"
 	"go.uber.org/yarpc/peer/tworandomchoices"
+	"go.uber.org/yarpc/transport/http"
+	"go.uber.org/yarpc/yarpcconfig"
 	"go.uber.org/yarpc/yarpcerrors"
 )
 
@@ -586,4 +596,45 @@ func TestTwoRandomChoicesPeer(t *testing.T) {
 			assert.Equal(t, tt.expectedRunning, pl.IsRunning(), "Peer list should match expected final running state")
 		})
 	}
+}
+
+func TestFailFastConfig(t *testing.T) {
+	conn, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	serviceName := "test"
+	config := whitespace.Expand(fmt.Sprintf(`
+		outbounds:
+			nowhere:
+				http:
+					two-random-choices:
+						peers:
+							- %q
+						capacity: 10
+						failFast: true
+	`, conn.Addr()))
+	cfgr := yarpcconfig.New()
+	cfgr.MustRegisterTransport(http.TransportSpec())
+	cfgr.MustRegisterPeerList(tworandomchoices.Spec())
+	cfg, err := cfgr.LoadConfigFromYAML(serviceName, strings.NewReader(config))
+	require.NoError(t, err)
+
+	d := yarpc.NewDispatcher(cfg)
+	d.Start()
+	defer d.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
+	defer cancel()
+
+	client := d.MustOutboundConfig("nowhere")
+	_, err = client.Outbounds.Unary.Call(ctx, &transport.Request{
+		Service:   "service",
+		Caller:    "caller",
+		Encoding:  transport.Encoding("blank"),
+		Procedure: "bogus",
+		Body:      strings.NewReader("nada"),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no peer available")
 }


### PR DESCRIPTION
This change introduces a FailFast constructor option for the fewest-pending-requests, round-robin, random, and two-random-choices peer list implementations.