### PR TITLE
[peerlist/v2] Fix introspection name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added fail-fast option to peer lists.  With this option enabled, a peer list
   will return an error if no peers are connected at the time of a call, instead
   of waiting for an available peer or the context to time out.
+### Fixed
+- Previously, every peer list reported itself as a "single" peer list for
+  purposes of debugging, instead of its own name.
 
 ## [1.41.0] - 2019-10-01
 ### Fixed

--- a/peer/peerlist/v2/list.go
+++ b/peer/peerlist/v2/list.go
@@ -643,7 +643,7 @@ func (pl *List) Introspect() introspection.ChooserStatus {
 	}
 
 	return introspection.ChooserStatus{
-		Name: "Single",
+		Name: pl.name,
 		State: fmt.Sprintf("%s (%d/%d available)", state, len(availables),
 			len(availables)+len(unavailables)),
 		Peers: peersStatus,

--- a/peer/roundrobin/list.go
+++ b/peer/roundrobin/list.go
@@ -84,7 +84,7 @@ func New(transport peer.Transport, opts ...ListOption) *List {
 
 	return &List{
 		List: peerlist.New(
-			"roundrobin",
+			"round-robin",
 			transport,
 			newPeerRing(),
 			plOpts...,

--- a/peer/roundrobin/list_test.go
+++ b/peer/roundrobin/list_test.go
@@ -46,15 +46,15 @@ import (
 )
 
 var (
-	_noContextDeadlineError = yarpcerrors.Newf(yarpcerrors.CodeInvalidArgument, "can't wait for peer without a context deadline for a roundrobin peer list")
+	_noContextDeadlineError = yarpcerrors.Newf(yarpcerrors.CodeInvalidArgument, "can't wait for peer without a context deadline for a round-robin peer list")
 )
 
 func newNotRunningError(err string) error {
-	return yarpcerrors.FailedPreconditionErrorf("roundrobin peer list is not running: %s", err)
+	return yarpcerrors.FailedPreconditionErrorf("round-robin peer list is not running: %s", err)
 }
 
 func newUnavailableError(err error) error {
-	return yarpcerrors.UnavailableErrorf("roundrobin peer list timed out waiting for peer: %s", err.Error())
+	return yarpcerrors.UnavailableErrorf("round-robin peer list timed out waiting for peer: %s", err.Error())
 }
 
 func TestRoundRobinList(t *testing.T) {
@@ -943,7 +943,7 @@ func TestIntrospect(t *testing.T) {
 	}))
 
 	chooserStatus := pl.Introspect()
-	assert.Equal(t, "Single", chooserStatus.Name)
+	assert.Equal(t, "round-robin", chooserStatus.Name)
 	assert.Equal(t, "Running (2/3 available)", chooserStatus.State)
 
 	peerIdentifierToPeerStatus := make(map[string]introspection.PeerStatus, len(chooserStatus.Peers))


### PR DESCRIPTION
Previously, every peer list reported itself as a "single" peer list instead of its own name.