### PR TITLE
Avoid "SendSystemError failed" in case of caller timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added fail-fast option to peer lists.  With this option enabled, a peer list
   will return an error if no peers are connected at the time of a call, instead
   of waiting for an available peer or the context to time out.
-- Avoid "SendSystemError failed" and "responseWriter failed to close" for caller timeout
 ### Fixed
 - Previously, every peer list reported itself as a "single" peer list for
   purposes of debugging, instead of its own name.
 - Metrics emit `CodeResourceExhausted` as a client error and `CodeUnimplemented`
   as a server error.
+- Avoid "SendSystemError failed" and "responseWriter failed to close" server
+  logs when TChannel callers time out.
 
 ## [1.41.0] - 2019-10-01
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added fail-fast option to peer lists.  With this option enabled, a peer list
   will return an error if no peers are connected at the time of a call, instead
   of waiting for an available peer or the context to time out.
+- Avoid "SendSystemError failed" and "responseWriter failed to close" for caller timeout
 ### Fixed
 - Previously, every peer list reported itself as a "single" peer list for
   purposes of debugging, instead of its own name.

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -335,12 +335,7 @@ func getSystemError(err error) error {
 }
 
 func isTChannelTimeoutError(err error) bool {
-	if tchannelerr, ok := getSystemError(err).(tchannel.SystemError); ok {
-		if tchannelerr.Code() == tchannel.ErrCodeTimeout {
-			return true
-		}
-	}
-	return false
+	return tchannel.GetSystemErrorCode(err) == tchannel.ErrCodeTimeout
 }
 
 func appendError(left error, right error) error {

--- a/transport/tchannel/handler_test.go
+++ b/transport/tchannel/handler_test.go
@@ -671,23 +671,23 @@ func TestIsTChannelTimeoutError(t *testing.T) {
 		wantResult bool
 	}{
 		{
-			name: "plain error",
+			name:       "plain error",
 			giveErr:    errors.New("test"),
 			wantResult: false,
 		},
 		{
-			name: "none timeout tchannel error",
-			giveErr:  tchannel.NewSystemError(tchannel.ErrCodeBusy, "test"),
+			name:       "no timeout tchannel error",
+			giveErr:    tchannel.NewSystemError(tchannel.ErrCodeBusy, "test"),
 			wantResult: false,
 		},
 		{
-			name: "yarpc timeout error",
-			giveErr:  yarpcerrors.Newf(_tchannelCodeToCode[tchannel.ErrCodeTimeout], "time out"),
+			name:       "yarpc timeout error",
+			giveErr:    yarpcerrors.Newf(_tchannelCodeToCode[tchannel.ErrCodeTimeout], "time out"),
 			wantResult: true,
 		},
 		{
-			name: "tchannel timeout error",
-			giveErr:  tchannel.NewSystemError(tchannel.ErrCodeTimeout, "time out"),
+			name:       "tchannel timeout error",
+			giveErr:    tchannel.NewSystemError(tchannel.ErrCodeTimeout, "time out"),
 			wantResult: true,
 		},
 	}

--- a/transport/tchannel/handler_test.go
+++ b/transport/tchannel/handler_test.go
@@ -681,11 +681,6 @@ func TestIsTChannelTimeoutError(t *testing.T) {
 			wantResult: false,
 		},
 		{
-			name:       "yarpc timeout error",
-			giveErr:    yarpcerrors.Newf(_tchannelCodeToCode[tchannel.ErrCodeTimeout], "time out"),
-			wantResult: true,
-		},
-		{
 			name:       "tchannel timeout error",
 			giveErr:    tchannel.NewSystemError(tchannel.ErrCodeTimeout, "time out"),
 			wantResult: true,


### PR DESCRIPTION
In the last step of handling inbound request, the handler tried to close response writer for caller. However, if the caller has timed out, the close action would fail since the channel has been closed. In addition, the handler would try to write error message to the writer, which would certainly fail because again, it's closed.
The message is clueless and not very meaningful for engineers.
This PR would not send the redundant error messages (failed to send system error etc.) in case of caller timeout.

<img width="272" alt="Screen Shot 2019-10-03 at 2 38 07 PM" src="https://user-images.githubusercontent.com/37088484/66166180-708ee900-e5eb-11e9-807b-18f8c89722a6.png">

