### PR TITLE
add AllHeader() function to get all request headers

### DIFF
--- a/api/encoding/call.go
+++ b/api/encoding/call.go
@@ -113,6 +113,17 @@ func (c *Call) Header(k string) string {
 	return ""
 }
 
+// AllHeaders returns map of request headers where
+// key is a header name in lower case
+// and value is a header value
+func (c *Call) AllHeaders() map[string]string {
+	headers := make(map[string]string)
+	for k, v := range c.ic.req.Headers.Items() {
+		headers[k] = v
+	}
+	return headers
+}
+
 // HeaderNames returns a sorted list of the names of user defined headers
 // provided with this request.
 func (c *Call) HeaderNames() []string {

--- a/api/encoding/inbound_call_test.go
+++ b/api/encoding/inbound_call_test.go
@@ -63,6 +63,13 @@ func TestInboundCallReadFromRequest(t *testing.T) {
 	assert.Equal(t, "true", call.Header("success"))
 	assert.Equal(t, "", call.Header("does-not-exist"))
 
+	expectedHeaders := map[string]string{
+		"hello":   "World",
+		"foo":     "bar",
+		"success": "true",
+	}
+	assert.Equal(t, expectedHeaders, call.AllHeaders())
+
 	headerNames := call.HeaderNames()
 	sort.Strings(headerNames)
 	assert.Equal(t, []string{"foo", "hello", "success"}, headerNames)

--- a/call.go
+++ b/call.go
@@ -140,6 +140,13 @@ func (c *Call) Header(k string) string {
 	return (*encoding.Call)(c).Header(k)
 }
 
+// AllHeaders returns map of request headers where
+// key is a header name in lower case
+// and value is a header value
+func (c *Call) AllHeaders() map[string]string {
+	return (*encoding.Call)(c).AllHeaders()
+}
+
 // HeaderNames returns a sorted list of the names of user defined headers
 // provided with this request.
 func (c *Call) HeaderNames() []string {

--- a/call_test.go
+++ b/call_test.go
@@ -58,7 +58,7 @@ func TestCallFromContext(t *testing.T) {
 			Transport:       "trans",
 			Encoding:        transport.Encoding("baz"),
 			Procedure:       "hello",
-			Headers:         transport.NewHeaders().With("foo", "bar"),
+			Headers:         transport.NewHeaders().With("foo", "bar").With("Hello", "World"),
 			ShardKey:        "one",
 			RoutingKey:      "two",
 			RoutingDelegate: "three",
@@ -72,8 +72,14 @@ func TestCallFromContext(t *testing.T) {
 	assert.Equal(t, transport.Encoding("baz"), call.Encoding())
 	assert.Equal(t, "hello", call.Procedure())
 	assert.Equal(t, "bar", call.Header("foo"))
-	assert.Equal(t, []string{"foo"}, call.HeaderNames())
+	assert.Equal(t, []string{"foo", "hello"}, call.HeaderNames())
 	assert.Equal(t, "one", call.ShardKey())
 	assert.Equal(t, "two", call.RoutingKey())
 	assert.Equal(t, "three", call.RoutingDelegate())
+
+	expectedHeaders := map[string]string{
+		"foo":   "bar",
+		"hello": "World",
+	}
+	assert.Equal(t, expectedHeaders, call.AllHeaders())
 }


### PR DESCRIPTION
This PR add _AllHeaders()_ function which returns all request headers as a map.