### PR TITLE
Fix client and server code faults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Previously, every peer list reported itself as a "single" peer list for
   purposes of debugging, instead of its own name.
+- Metrics emit `CodeResourceExhausted` as a client error and `CodeUnimplemented`
+  as a server error.
 
 ## [1.41.0] - 2019-10-01
 ### Fixed

--- a/internal/observability/codes.go
+++ b/internal/observability/codes.go
@@ -46,16 +46,16 @@ func statusFault(status *yarpcerrors.Status) fault {
 		yarpcerrors.CodeFailedPrecondition,
 		yarpcerrors.CodeAborted,
 		yarpcerrors.CodeOutOfRange,
-		yarpcerrors.CodeUnimplemented,
-		yarpcerrors.CodeUnauthenticated:
+		yarpcerrors.CodeUnauthenticated,
+		yarpcerrors.CodeResourceExhausted:
 		return clientFault
 
 	case yarpcerrors.CodeUnknown,
 		yarpcerrors.CodeDeadlineExceeded,
-		yarpcerrors.CodeResourceExhausted,
 		yarpcerrors.CodeInternal,
 		yarpcerrors.CodeUnavailable,
-		yarpcerrors.CodeDataLoss:
+		yarpcerrors.CodeDataLoss,
+		yarpcerrors.CodeUnimplemented:
 		return serverFault
 	}
 


### PR DESCRIPTION
Metrics were incorrectly emitting `CodeResourceExhausted` and
`CodeUnimplemented`. This changes the observability middleware to emit
`CodeResourceExhausted` as a client error and `CodeUnimplemented` as a server
error.

- [x] Entry in CHANGELOG.md