### PR TITLE
Set minimum grpc-go version to v1.19

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -39,7 +39,7 @@ import:
   subpackages:
   - context
 - package: google.golang.org/grpc
-  version: ^1.12.0
+  version: ^1.19.0
   repo: https://github.com/grpc/grpc-go
 - package: golang.org/x/sys
   # explicitly specifying this because glide is having issues with golang.org repos


### PR DESCRIPTION
yarpc uses grpc.WithContextDialer. This method was exported first in v1.19

Changelog: https://github.com/grpc/grpc-go/releases/tag/v1.19.0

- [x] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [ ] Entry in CHANGELOG.md
