### PR TITLE
Avoid listening on public interfaces and fixed ports

### DIFF
--- a/internal/integrationtest/util.go
+++ b/internal/integrationtest/util.go
@@ -24,6 +24,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net"
 	"sync"
 	"testing"
 	"time"
@@ -108,7 +109,10 @@ func (s TransportSpec) NewServer(t *testing.T, addr string) (*yarpc.Dispatcher, 
 // exercise a transport dropping connections if the transport is stopped before
 // a pending request can complete.
 func (s TransportSpec) TestConnectAndStopRoundRobin(t *testing.T) {
-	addr := "127.0.0.1:31172"
+	conn, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := conn.Addr().String()
+	conn.Close()
 
 	client, rawClient := s.NewClient(t, []string{addr})
 
@@ -133,7 +137,7 @@ func (s TransportSpec) TestConcurrentClientsRoundRobin(t *testing.T) {
 	var wg sync.WaitGroup
 	count := concurrentAttempts
 
-	server, addr := s.NewServer(t, ":0")
+	server, addr := s.NewServer(t, "127.0.0.1:0")
 	defer server.Stop()
 
 	client, rawClient := s.NewClient(t, []string{addr})


### PR DESCRIPTION
This change adjusts a couple tests to avoid listening on fixed ports and public interfaces.

The first change obtains an open port from the OS and immediately closes it to obtain an address that is very unlikely to answer. It’s not absolute, but it’s better than attempting to connect to a random but fixed port and hoping nothing is there.

The other test is the integration test helper’s self-test. The test used TChannel as an example, but this changes it to use HTTP. This relaxes a dependency on TChannel while avoiding the problem that tchannel-go has no mode for listening on localhost specifically, since it recasts localhost as the first public ip4 network interface for purposes of divining its “return address”.

