### PR TITLE
Pivot fewest-pending-requests to use new abstract list

### DIFF
--- a/peer/pendingheap/list.go
+++ b/peer/pendingheap/list.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"go.uber.org/yarpc/api/peer"
-	"go.uber.org/yarpc/peer/peerlist/v2"
+	"go.uber.org/yarpc/peer/abstractlist"
 )
 
 type listConfig struct {
@@ -82,14 +82,14 @@ func New(transport peer.Transport, opts ...ListOption) *List {
 		o(&cfg)
 	}
 
-	plOpts := []peerlist.ListOption{
-		peerlist.Capacity(cfg.capacity),
+	plOpts := []abstractlist.Option{
+		abstractlist.Capacity(cfg.capacity),
 	}
 	if !cfg.shuffle {
-		plOpts = append(plOpts, peerlist.NoShuffle())
+		plOpts = append(plOpts, abstractlist.NoShuffle())
 	}
 	if cfg.failFast {
-		plOpts = append(plOpts, peerlist.FailFast())
+		plOpts = append(plOpts, abstractlist.FailFast())
 	}
 
 	nextRandFn := nextRand(cfg.seed)
@@ -99,7 +99,7 @@ func New(transport peer.Transport, opts ...ListOption) *List {
 	}
 
 	return &List{
-		List: peerlist.New(
+		List: abstractlist.New(
 			"fewest-pending-requests",
 			transport,
 			&pendingHeap{
@@ -110,9 +110,9 @@ func New(transport peer.Transport, opts ...ListOption) *List {
 	}
 }
 
-// List is a PeerList which rotates which peers are to be selected in a circle
+// List is a peer list which rotates which peers are to be selected in a circle
 type List struct {
-	*peerlist.List
+	*abstractlist.List
 }
 
 // nextRand is a convenience function for creating a new rand.Rand from a given

--- a/peer/pendingheap/list_test.go
+++ b/peer/pendingheap/list_test.go
@@ -45,15 +45,15 @@ import (
 )
 
 var (
-	_noContextDeadlineError = yarpcerrors.Newf(yarpcerrors.CodeInvalidArgument, "can't wait for peer without a context deadline for a fewest-pending-requests peer list")
+	_noContextDeadlineError = yarpcerrors.Newf(yarpcerrors.CodeInvalidArgument, `"fewest-pending-requests" peer list can't wait for peer without a context deadline`)
 )
 
 func newNotRunningError(err string) error {
-	return yarpcerrors.FailedPreconditionErrorf("fewest-pending-requests peer list is not running: %s", err)
+	return yarpcerrors.FailedPreconditionErrorf(`"fewest-pending-requests" peer list is not running: %s`, err)
 }
 
 func newUnavailableError(err error) error {
-	return yarpcerrors.UnavailableErrorf("fewest-pending-requests peer list timed out waiting for peer: %s", err.Error())
+	return yarpcerrors.UnavailableErrorf(`"fewest-pending-requests" peer list timed out waiting for peer: %s`, err.Error())
 }
 
 // InsertionOrder is a test option that yields control over random insertion

--- a/peer/pendingheap/score.go
+++ b/peer/pendingheap/score.go
@@ -22,7 +22,10 @@ package pendingheap
 
 import (
 	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/peer/abstractlist"
 )
+
+var _ abstractlist.Subscriber = (*peerScore)(nil)
 
 // peerScore is a book-keeping object for each retained peer
 type peerScore struct {
@@ -30,18 +33,11 @@ type peerScore struct {
 	peer peer.StatusPeer
 	heap *pendingHeap
 	// mutable
-	status peer.Status
-	score  int64
-	index  int // index in the peer list.
-	last   int // snapshot of the heap's incrementing counter.
+	pending int
+	index   int // index in the peer list.
+	last    int // snapshot of the heap's incrementing counter.
 }
 
-func (ps *peerScore) NotifyStatusChanged(_ peer.Identifier) {
-	ps.heap.notifyStatusChanged(ps)
-}
-
-func scorePeer(p peer.StatusPeer) int64 {
-	status := p.Status()
-	score := int64(status.PendingRequestCount)
-	return score
+func (ps *peerScore) UpdatePendingRequestCount(pendingRequestCount int) {
+	ps.heap.updatePendingRequestCount(ps, pendingRequestCount)
 }


### PR DESCRIPTION
This change replaces the abstract list implementation for the pending request heap. The new abstract list tracks pending request counts itself instead of coordinating with the transport. #1828.

The most sensitive change to this implementation is that the heap no longer relies on peer.Status() at all (avoiding another potential deadlock), since the peer list sends the pending request count as an argument.

Since we’ve long since abandoned multi-dimensional peer scoring, this change also consolidates the score and pending request count into a single integer variable. At time of writing, we rely on the transport to provide relatively reliable connection statuses for each peer. Peer lists have a fail-fast mode and a wait-for-available mode, but don’t have a “here’s the best peer we’ve got, but you might not be able to connect” mode.

