### PR TITLE
Pivot random peer list to use new abstract list.

### DIFF
--- a/peer/randpeer/list.go
+++ b/peer/randpeer/list.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"go.uber.org/yarpc/api/peer"
-	"go.uber.org/yarpc/peer/peerlist/v2"
+	"go.uber.org/yarpc/peer/abstractlist"
 )
 
 type listOptions struct {
@@ -93,17 +93,17 @@ func New(transport peer.Transport, opts ...ListOption) *List {
 		options.source = rand.NewSource(time.Now().UnixNano())
 	}
 
-	plOpts := []peerlist.ListOption{
-		peerlist.Capacity(options.capacity),
-		peerlist.NoShuffle(),
+	plOpts := []abstractlist.Option{
+		abstractlist.Capacity(options.capacity),
+		abstractlist.NoShuffle(),
 	}
 
 	if options.failFast {
-		plOpts = append(plOpts, peerlist.FailFast())
+		plOpts = append(plOpts, abstractlist.FailFast())
 	}
 
 	return &List{
-		List: peerlist.New(
+		List: abstractlist.New(
 			"random",
 			transport,
 			newRandomList(options.capacity, options.source),
@@ -114,5 +114,5 @@ func New(transport peer.Transport, opts ...ListOption) *List {
 
 // List is a PeerList that rotates which peers are to be selected randomly
 type List struct {
-	*peerlist.List
+	*abstractlist.List
 }

--- a/peer/randpeer/list_test.go
+++ b/peer/randpeer/list_test.go
@@ -46,15 +46,15 @@ import (
 )
 
 var (
-	_noContextDeadlineError = yarpcerrors.Newf(yarpcerrors.CodeInvalidArgument, "can't wait for peer without a context deadline for a random peer list")
+	_noContextDeadlineError = yarpcerrors.Newf(yarpcerrors.CodeInvalidArgument, `"random" peer list can't wait for peer without a context deadline`)
 )
 
 func newNotRunningError(err string) error {
-	return yarpcerrors.FailedPreconditionErrorf("random peer list is not running: %s", err)
+	return yarpcerrors.FailedPreconditionErrorf(`"random" peer list is not running: %s`, err)
 }
 
 func newUnavailableError(err error) error {
-	return yarpcerrors.UnavailableErrorf("random peer list timed out waiting for peer: %s", err.Error())
+	return yarpcerrors.UnavailableErrorf(`"random" peer list timed out waiting for peer: %s`, err.Error())
 }
 
 func TestRandPeer(t *testing.T) {


### PR DESCRIPTION
This change replaces the shared logic among peer lists with the new abstract peer list. The new abstract list tracks pending request counts itself instead of coordinating with the transport #1828. This is immaterial for random peer lists, but they still benefit from shared logic for tracking peer availability, and to decrease the breadth of liability, all peer lists share this abstraction.