### PR TITLE
Pivot round robin from peerlist/v2 to abstractlist

### DIFF
--- a/peer/roundrobin/list.go
+++ b/peer/roundrobin/list.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"go.uber.org/yarpc/api/peer"
-	"go.uber.org/yarpc/peer/peerlist/v2"
+	"go.uber.org/yarpc/peer/abstractlist"
 )
 
 type listConfig struct {
@@ -71,19 +71,19 @@ func New(transport peer.Transport, opts ...ListOption) *List {
 		o(&cfg)
 	}
 
-	plOpts := []peerlist.ListOption{
-		peerlist.Capacity(cfg.capacity),
-		peerlist.Seed(cfg.seed),
+	plOpts := []abstractlist.Option{
+		abstractlist.Capacity(cfg.capacity),
+		abstractlist.Seed(cfg.seed),
 	}
 	if !cfg.shuffle {
-		plOpts = append(plOpts, peerlist.NoShuffle())
+		plOpts = append(plOpts, abstractlist.NoShuffle())
 	}
 	if cfg.failFast {
-		plOpts = append(plOpts, peerlist.FailFast())
+		plOpts = append(plOpts, abstractlist.FailFast())
 	}
 
 	return &List{
-		List: peerlist.New(
+		List: abstractlist.New(
 			"round-robin",
 			transport,
 			newPeerRing(),
@@ -94,5 +94,5 @@ func New(transport peer.Transport, opts ...ListOption) *List {
 
 // List is a PeerList which rotates which peers are to be selected in a circle
 type List struct {
-	*peerlist.List
+	*abstractlist.List
 }

--- a/peer/roundrobin/list_test.go
+++ b/peer/roundrobin/list_test.go
@@ -39,22 +39,26 @@ import (
 	"go.uber.org/yarpc/internal/introspection"
 	"go.uber.org/yarpc/internal/testtime"
 	"go.uber.org/yarpc/internal/whitespace"
+	"go.uber.org/yarpc/peer/abstractpeer"
 	"go.uber.org/yarpc/peer/hostport"
 	"go.uber.org/yarpc/transport/http"
 	"go.uber.org/yarpc/yarpcconfig"
 	"go.uber.org/yarpc/yarpcerrors"
+	"go.uber.org/yarpc/yarpctest"
 )
 
 var (
-	_noContextDeadlineError = yarpcerrors.Newf(yarpcerrors.CodeInvalidArgument, "can't wait for peer without a context deadline for a round-robin peer list")
+	_noContextDeadlineError = yarpcerrors.Newf(yarpcerrors.CodeInvalidArgument, `"round-robin" peer list can't wait for peer without a context deadline`)
+	_notRunningErrorFormat  = `"round-robin" peer list is not running: %s`
+	_unavailableErrorFormat = `"round-robin" peer list timed out waiting for peer: %s`
 )
 
 func newNotRunningError(err string) error {
-	return yarpcerrors.FailedPreconditionErrorf("round-robin peer list is not running: %s", err)
+	return yarpcerrors.FailedPreconditionErrorf(_notRunningErrorFormat, err)
 }
 
 func newUnavailableError(err error) error {
-	return yarpcerrors.UnavailableErrorf("round-robin peer list timed out waiting for peer: %s", err.Error())
+	return yarpcerrors.UnavailableErrorf(_unavailableErrorFormat, err.Error())
 }
 
 func TestRoundRobinList(t *testing.T) {
@@ -932,15 +936,38 @@ func TestRoundRobinList(t *testing.T) {
 }
 
 func TestIntrospect(t *testing.T) {
-	pl := New(testTransport{})
-	assert.NoError(t, pl.Start())
+	trans := yarpctest.NewFakeTransport(yarpctest.InitialConnectionStatus(peer.Unavailable))
+	pl := New(trans, noShuffle)
 	assert.NoError(t, pl.Update(peer.ListUpdates{
 		Additions: []peer.Identifier{
-			newTestPeer("foo", 0, peer.Unavailable),
-			newTestPeer("bar", 1, peer.Available),
-			newTestPeer("baz", 2, peer.Available),
+			abstractpeer.Identify("foo"),
+			abstractpeer.Identify("bar"),
+			abstractpeer.Identify("baz"),
 		},
 	}))
+	require.NoError(t, pl.Start())
+
+	trans.SimulateConnect(abstractpeer.Identify("bar"))
+	trans.SimulateConnect(abstractpeer.Identify("baz"))
+
+	// Simulate some load.
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
+	defer cancel()
+	{
+		p, _, err := pl.Choose(ctx, &transport.Request{})
+		require.NoError(t, err)
+		assert.Equal(t, p.Identifier(), "bar")
+	}
+	{
+		p, _, err := pl.Choose(ctx, &transport.Request{})
+		require.NoError(t, err)
+		assert.Equal(t, p.Identifier(), "baz")
+	}
+	{
+		p, _, err := pl.Choose(ctx, &transport.Request{})
+		require.NoError(t, err)
+		assert.Equal(t, p.Identifier(), "bar")
+	}
 
 	chooserStatus := pl.Introspect()
 	assert.Equal(t, "round-robin", chooserStatus.Name)
@@ -951,8 +978,8 @@ func TestIntrospect(t *testing.T) {
 		peerIdentifierToPeerStatus[peerStatus.Identifier] = peerStatus
 	}
 	checkPeerStatus(t, peerIdentifierToPeerStatus, "foo", "Unavailable, 0 pending request(s)")
-	checkPeerStatus(t, peerIdentifierToPeerStatus, "bar", "Available, 1 pending request(s)")
-	checkPeerStatus(t, peerIdentifierToPeerStatus, "baz", "Available, 2 pending request(s)")
+	checkPeerStatus(t, peerIdentifierToPeerStatus, "bar", "Available, 2 pending request(s)")
+	checkPeerStatus(t, peerIdentifierToPeerStatus, "baz", "Available, 1 pending request(s)")
 }
 
 func checkPeerStatus(
@@ -965,49 +992,6 @@ func checkPeerStatus(
 	assert.True(t, ok)
 	assert.Equal(t, expectedState, peerStatus.State)
 }
-
-type testTransport struct{}
-
-func (testTransport) RetainPeer(peerIdentifier peer.Identifier, _ peer.Subscriber) (peer.Peer, error) {
-	return peerIdentifier.(*testPeer), nil
-}
-
-func (testTransport) ReleasePeer(peer.Identifier, peer.Subscriber) error {
-	return nil
-}
-
-type testPeer struct {
-	identifier          string
-	pendingRequestCount int
-	connectionStatus    peer.ConnectionStatus
-}
-
-func newTestPeer(
-	identifier string,
-	pendingRequestCount int,
-	connectionStatus peer.ConnectionStatus,
-) *testPeer {
-	return &testPeer{
-		identifier,
-		pendingRequestCount,
-		connectionStatus,
-	}
-}
-
-func (p *testPeer) Identifier() string {
-	return p.identifier
-}
-
-func (p *testPeer) Status() peer.Status {
-	return peer.Status{
-		PendingRequestCount: p.pendingRequestCount,
-		ConnectionStatus:    p.connectionStatus,
-	}
-}
-
-func (*testPeer) StartRequest() {}
-
-func (*testPeer) EndRequest() {}
 
 var noShuffle ListOption = func(c *listConfig) {
 	c.shuffle = false

--- a/peer/roundrobin/peerring.go
+++ b/peer/roundrobin/peerring.go
@@ -22,11 +22,10 @@ package roundrobin
 
 import (
 	"container/ring"
-	"context"
 
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
-	"go.uber.org/yarpc/peer/peerlist/v2"
+	"go.uber.org/yarpc/peer/abstractlist"
 )
 
 // newPeerRing creates a new peerRing with an initial capacity
@@ -39,8 +38,7 @@ type subscriber struct {
 	node *ring.Ring
 }
 
-func (s *subscriber) NotifyStatusChanged(pid peer.Identifier) {
-}
+func (s *subscriber) UpdatePendingRequestCount(int) {}
 
 // peerRing provides a safe way to interact (Add/Remove/Get) with a potentially
 // changing list of peer objects
@@ -49,11 +47,11 @@ type peerRing struct {
 	nextNode *ring.Ring
 }
 
-var _ peerlist.Implementation = (*peerRing)(nil)
+var _ abstractlist.Implementation = (*peerRing)(nil)
 
 // Add a peer.StatusPeer to the end of the peerRing, if the ring is empty it
 // initializes the nextNode marker
-func (pr *peerRing) Add(p peer.StatusPeer, _ peer.Identifier) peer.Subscriber {
+func (pr *peerRing) Add(p peer.StatusPeer, _ peer.Identifier) abstractlist.Subscriber {
 	sub := &subscriber{peer: p}
 	newNode := ring.New(1)
 	newNode.Value = sub
@@ -71,7 +69,7 @@ func (pr *peerRing) Add(p peer.StatusPeer, _ peer.Identifier) peer.Subscriber {
 
 // Remove the peer from the ring. Use the subscriber to address the node of the
 // ring directly.
-func (pr *peerRing) Remove(p peer.StatusPeer, _ peer.Identifier, s peer.Subscriber) {
+func (pr *peerRing) Remove(p peer.StatusPeer, _ peer.Identifier, s abstractlist.Subscriber) {
 	sub, ok := s.(*subscriber)
 	if !ok {
 		// Don't panic.
@@ -95,7 +93,7 @@ func (pr *peerRing) isNextNode(node *ring.Ring) bool {
 
 // Choose returns the next peer in the ring, or nil if there is no peer in the ring
 // after it has the next peer, it increments the nextPeer marker in the ring
-func (pr *peerRing) Choose(_ context.Context, _ *transport.Request) peer.StatusPeer {
+func (pr *peerRing) Choose(_ *transport.Request) peer.StatusPeer {
 	if pr.nextNode == nil {
 		return nil
 	}
@@ -120,16 +118,4 @@ func popNodeFromRing(rNode *ring.Ring) {
 
 func pushBeforeNode(curNode, newNode *ring.Ring) {
 	curNode.Prev().Link(newNode)
-}
-
-func (pr *peerRing) Start() error {
-	return nil
-}
-
-func (pr *peerRing) Stop() error {
-	return nil
-}
-
-func (pr *peerRing) IsRunning() bool {
-	return true
 }


### PR DESCRIPTION
This change replaces the shared logic among peer lists with the new abstract peer list. The new abstract list tracks pending request counts itself instead of coordinating with the transport #1828. This is immaterial for random peer lists, but they still benefit from shared logic for tracking peer availability, and to decrease the breadth of liability, all peer lists share this abstraction.