### PR TITLE
Pivot two-random-choices to use new abstract list

### DIFF
--- a/peer/tworandomchoices/list.go
+++ b/peer/tworandomchoices/list.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"go.uber.org/yarpc/api/peer"
-	"go.uber.org/yarpc/peer/peerlist/v2"
+	"go.uber.org/yarpc/peer/abstractlist"
 )
 
 type listOptions struct {
@@ -94,17 +94,17 @@ func New(transport peer.Transport, opts ...ListOption) *List {
 		options.source = rand.NewSource(time.Now().UnixNano())
 	}
 
-	plOpts := []peerlist.ListOption{
-		peerlist.Capacity(options.capacity),
-		peerlist.NoShuffle(),
+	plOpts := []abstractlist.Option{
+		abstractlist.Capacity(options.capacity),
+		abstractlist.NoShuffle(),
 	}
 
 	if options.failFast {
-		plOpts = append(plOpts, peerlist.FailFast())
+		plOpts = append(plOpts, abstractlist.FailFast())
 	}
 
 	return &List{
-		List: peerlist.New(
+		List: abstractlist.New(
 			"two-random-choices",
 			transport,
 			newTwoRandomChoicesList(options.capacity, options.source),
@@ -115,5 +115,5 @@ func New(transport peer.Transport, opts ...ListOption) *List {
 
 // List is a PeerList that rotates which peers are to be selected randomly
 type List struct {
-	*peerlist.List
+	*abstractlist.List
 }

--- a/peer/tworandomchoices/list_test.go
+++ b/peer/tworandomchoices/list_test.go
@@ -46,15 +46,15 @@ import (
 )
 
 var (
-	_noContextDeadlineError = yarpcerrors.Newf(yarpcerrors.CodeInvalidArgument, "can't wait for peer without a context deadline for a two-random-choices peer list")
+	_noContextDeadlineError = yarpcerrors.Newf(yarpcerrors.CodeInvalidArgument, `"two-random-choices" peer list can't wait for peer without a context deadline`)
 )
 
 func newNotRunningError(err string) error {
-	return yarpcerrors.FailedPreconditionErrorf("two-random-choices peer list is not running: %s", err)
+	return yarpcerrors.FailedPreconditionErrorf(`"two-random-choices" peer list is not running: %s`, err)
 }
 
 func newUnavailableError(err error) error {
-	return yarpcerrors.UnavailableErrorf("two-random-choices peer list timed out waiting for peer: %s", err.Error())
+	return yarpcerrors.UnavailableErrorf(`"two-random-choices" peer list timed out waiting for peer: %s`, err.Error())
 }
 
 func TestTwoRandomChoicesPeer(t *testing.T) {

--- a/peer/tworandomchoices/tworandomchoices.go
+++ b/peer/tworandomchoices/tworandomchoices.go
@@ -21,12 +21,11 @@
 package tworandomchoices
 
 import (
-	"context"
 	"math/rand"
 
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
-	peerlist "go.uber.org/yarpc/peer/peerlist/v2"
+	"go.uber.org/yarpc/peer/abstractlist"
 )
 
 type twoRandomChoicesList struct {
@@ -41,9 +40,9 @@ func newTwoRandomChoicesList(cap int, source rand.Source) *twoRandomChoicesList 
 	}
 }
 
-var _ peerlist.Implementation = (*twoRandomChoicesList)(nil)
+var _ abstractlist.Implementation = (*twoRandomChoicesList)(nil)
 
-func (l *twoRandomChoicesList) Add(peer peer.StatusPeer, _ peer.Identifier) peer.Subscriber {
+func (l *twoRandomChoicesList) Add(peer peer.StatusPeer, _ peer.Identifier) abstractlist.Subscriber {
 	index := len(l.subscribers)
 	l.subscribers = append(l.subscribers, &subscriber{
 		index: index,
@@ -52,7 +51,7 @@ func (l *twoRandomChoicesList) Add(peer peer.StatusPeer, _ peer.Identifier) peer
 	return l.subscribers[index]
 }
 
-func (l *twoRandomChoicesList) Remove(peer peer.StatusPeer, _ peer.Identifier, ps peer.Subscriber) {
+func (l *twoRandomChoicesList) Remove(peer peer.StatusPeer, _ peer.Identifier, ps abstractlist.Subscriber) {
 	sub, ok := ps.(*subscriber)
 	if !ok || len(l.subscribers) == 0 {
 		return
@@ -64,7 +63,7 @@ func (l *twoRandomChoicesList) Remove(peer peer.StatusPeer, _ peer.Identifier, p
 	l.subscribers = l.subscribers[0:last]
 }
 
-func (l *twoRandomChoicesList) Choose(_ context.Context, _ *transport.Request) peer.StatusPeer {
+func (l *twoRandomChoicesList) Choose(_ *transport.Request) peer.StatusPeer {
 	numSubs := len(l.subscribers)
 	if numSubs == 0 {
 		return nil
@@ -84,26 +83,17 @@ func (l *twoRandomChoicesList) Choose(_ context.Context, _ *transport.Request) p
 }
 
 func (l *twoRandomChoicesList) pending(index int) int {
-	return l.subscribers[index].peer.Status().PendingRequestCount
-}
-
-func (l *twoRandomChoicesList) Start() error {
-	return nil
-}
-
-func (l *twoRandomChoicesList) Stop() error {
-	return nil
-}
-
-func (l *twoRandomChoicesList) IsRunning() bool {
-	return true
+	return l.subscribers[index].pending
 }
 
 type subscriber struct {
-	index int
-	peer  peer.StatusPeer
+	index   int
+	peer    peer.StatusPeer
+	pending int
 }
 
-var _ peer.Subscriber = (*subscriber)(nil)
+var _ abstractlist.Subscriber = (*subscriber)(nil)
 
-func (*subscriber) NotifyStatusChanged(peer.Identifier) {}
+func (s *subscriber) UpdatePendingRequestCount(pendingRequestCount int) {
+	s.pending = pendingRequestCount
+}


### PR DESCRIPTION
This change replaces the shared logic among peer lists with the new abstract peer list. The new abstract list tracks pending request counts itself instead of coordinating with the transport #1828. This is immaterial for random peer lists, but they still benefit from shared logic for tracking peer availability, and to decrease the breadth of liability, all peer lists share this abstraction.