### PR TITLE
Pivot grpc to use abstractpeer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Fixed
+- Simplified the flow of status change notifications for the gRPC transport to
+  reduce the liklihood of deadlocks.
 
 ## [1.42.0] - 2019-10-31 (Spooky)
 ### Added


### PR DESCRIPTION
This change moves pending request count notifications into a separate goroutine to break potential deadlocks:

- peer list informs transport of start/end request
- trasport informs peer list of pending request count change