### PR TITLE
Pivot tchannel to use abstractpeer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Simplified the flow of status change notifications for the gRPC transport to
-  reduce the liklihood of deadlocks.
+- Simplified the flow of status change notifications for the gRPC and TChannel
+  transports to reduce the liklihood of deadlocks.
 
 ## [1.42.0] - 2019-10-31 (Spooky)
 ### Added

--- a/transport/tchannel/peer.go
+++ b/transport/tchannel/peer.go
@@ -25,14 +25,16 @@ import (
 	"time"
 
 	"go.uber.org/yarpc/api/peer"
-	"go.uber.org/yarpc/peer/hostport"
+	"go.uber.org/yarpc/peer/abstractpeer"
 )
 
 type tchannelPeer struct {
-	*hostport.Peer
+	*abstractpeer.Peer
+
 	transport *Transport
 	addr      string
 	changed   chan struct{}
+	pending   chan struct{}
 	released  chan struct{}
 	timer     *time.Timer
 }
@@ -46,7 +48,7 @@ func newPeer(addr string, t *Transport) *tchannelPeer {
 
 	return &tchannelPeer{
 		addr:      addr,
-		Peer:      hostport.NewPeer(hostport.PeerIdentifier(addr), t),
+		Peer:      abstractpeer.NewPeer(abstractpeer.PeerIdentifier(addr), t),
 		transport: t,
 		changed:   make(chan struct{}, 1),
 		released:  make(chan struct{}),
@@ -74,7 +76,7 @@ func (p *tchannelPeer) MaintainConn() {
 
 		inbound, outbound := tp.NumConnections()
 		if inbound+outbound > 0 {
-			p.Peer.SetStatus(peer.Available)
+			p.setConnectionStatus(peer.Available)
 			// Reset on success
 			attempts = 0
 			if !p.waitForChange() {
@@ -82,7 +84,7 @@ func (p *tchannelPeer) MaintainConn() {
 			}
 
 		} else {
-			p.Peer.SetStatus(peer.Connecting)
+			p.setConnectionStatus(peer.Connecting)
 
 			// Attempt to connect
 			ctx := context.Background()
@@ -90,9 +92,9 @@ func (p *tchannelPeer) MaintainConn() {
 			_, err := tp.Connect(ctx)
 
 			if err == nil {
-				p.Peer.SetStatus(peer.Available)
+				p.setConnectionStatus(peer.Available)
 			} else {
-				p.Peer.SetStatus(peer.Unavailable)
+				p.setConnectionStatus(peer.Unavailable)
 				// Back-off on fail
 				if !p.sleep(backoff.Duration(attempts)) {
 					break
@@ -109,6 +111,11 @@ func (p *tchannelPeer) MaintainConn() {
 
 func (p *tchannelPeer) Release() {
 	close(p.released)
+}
+
+func (p *tchannelPeer) setConnectionStatus(status peer.ConnectionStatus) {
+	p.Peer.SetStatus(status)
+	p.Peer.NotifyStatusChanged()
 }
 
 func (p *tchannelPeer) OnStatusChanged() {
@@ -150,4 +157,36 @@ func (p *tchannelPeer) sleep(delay time.Duration) (completed bool) {
 		<-p.timer.C
 	}
 	return false
+}
+
+func (p *tchannelPeer) monitorPendingRequestCount() {
+	for {
+		select {
+		case <-p.released:
+			return
+		case <-p.pending:
+			p.Peer.NotifyStatusChanged()
+		}
+	}
+}
+
+func (p *tchannelPeer) notifyPendingRequestCountChanged() {
+	// kick the pending request count change channel.
+	// monitorPendingRequestCount broadcasts changes to subscribers so
+	// StartRequest() and EndRequest() don't reply to peer lists on the stack,
+	// possibly causing deadlock.
+	select {
+	case p.pending <- struct{}{}:
+	default:
+	}
+}
+
+func (p *tchannelPeer) StartRequest() {
+	p.Peer.StartRequest()
+	p.notifyPendingRequestCountChanged()
+}
+
+func (p *tchannelPeer) EndRequest() {
+	p.Peer.EndRequest()
+	p.notifyPendingRequestCountChanged()
 }

--- a/transport/tchannel/transport.go
+++ b/transport/tchannel/transport.go
@@ -142,6 +142,7 @@ func (t *Transport) getOrCreatePeer(pid peer.Identifier) *tchannelPeer {
 	// Start a peer connection loop
 	t.connectorsGroup.Add(1)
 	go p.MaintainConn()
+	go p.monitorPendingRequestCount()
 
 	return p
 }


### PR DESCRIPTION
As with #1835 does for gRPC and #1660 does for HTTP, use the abstract peer implementation to send pending request count notifications asynchronously to prevent the possibility of deadlock due to cross-talk between peer lists and transport.