### PR TITLE
Do not synchronize gRPC update and status monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   as a server error.
 - Simplified the flow of status change notifications for the HTTP transport to
   reduce the liklihood of deadlocks.
+- Removed a bug from the gRPC transport that would cause a very rare deadlock
+  during production deploys and restarts.
+  The gRPC peer release method would synchronize with the connection status
+  change monitor loop, waiting for it to exit.
+  This would wait forever since retain was called while holding a lock on the
+  list.
 
 ## [1.41.0] - 2019-10-01
 ### Fixed

--- a/api/peer/transport.go
+++ b/api/peer/transport.go
@@ -22,12 +22,23 @@ package peer
 
 // Subscriber listens to changes of a Peer over time.
 type Subscriber interface {
-	// The Peer Notifies the Subscriber when its status changes (e.g. connections status, pending requests)
+	// The Peer Notifies the Subscriber when its status changes (e.g.
+	// connections status, pending requests)
+	//
+	// NotifyStatusChanged may call methods of the corresponding Peer,
+	// particularly Status.
+	// So, subscriber methods must not be called while holding a lock on the
+	// Transport.
 	NotifyStatusChanged(Identifier)
 }
 
-// Transport manages Peers across different Subscribers.  A Subscriber will request a Peer for a specific
-// PeerIdentifier and the Transport has the ability to create a new Peer or return an existing one.
+// Transport manages Peers across different Subscribers.
+//
+// A Subscriber will request a Peer for a specific PeerIdentifier and the
+// Transport has the ability to create a new Peer or return an existing one.
+//
+// RetainPeer and ReleasePeer must not call or synchronize with goroutines that
+// call methods of the Subscriber.
 type Transport interface {
 	// Get or create a Peer for the Subscriber
 	RetainPeer(Identifier, Subscriber) (Peer, error)

--- a/transport/grpc/transport.go
+++ b/transport/grpc/transport.go
@@ -144,7 +144,6 @@ func (t *Transport) ReleasePeer(pid peer.Identifier, ps peer.Subscriber) error {
 	if p.NumSubscribers() == 0 {
 		delete(t.addressToPeer, address)
 		p.stop()
-		p.wait()
 	}
 	return nil
 }


### PR DESCRIPTION
This addresses a deadlock that occurs in gRPC because the connection status monitor goroutine gets synchronized with peer list updates when they release a peer.

Further work planned to eliminate this class of flaw by also desynchronizing peer list updates.