### PR TITLE
Prepare release 1.42.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   as a server error.
 - Simplified the flow of status change notifications for the HTTP transport to
   reduce the liklihood of deadlocks.
+- Removed a bug from the gRPC transport that would cause a very rare deadlock
+  during production deploys and restarts.
+  The gRPC peer release method would synchronize with the connection status
+  change monitor loop, waiting for it to exit.
+  This would wait forever since retain was called while holding a lock on the
+  list.
 
 ## [1.41.0] - 2019-10-01
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added fail-fast option to peer lists.  With this option enabled, a peer list
   will return an error if no peers are connected at the time of a call, instead
   of waiting for an available peer or the context to time out.
+### Fixed
+- Previously, every peer list reported itself as a "single" peer list for
+  purposes of debugging, instead of its own name.
 
 ## [1.41.0] - 2019-10-01
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- No changes yet.
+
 ## [1.41.0] - 2019-10-01
 ### Fixed
 - Fixed TChannel memory pressure that would occur during server-side errors.
@@ -1117,6 +1120,7 @@ This release requires regeneration of ThriftRW code.
 
 - Initial release.
 
+[Unreleased]: https://github.com/yarpc/yarpc-go/compare/v1.41.0...HEAD
 [1.41.0]: https://github.com/yarpc/yarpc-go/compare/v1.40.0...v1.41.0
 [1.40.0]: https://github.com/yarpc/yarpc-go/compare/v1.39.0...v1.40.0
 [1.39.0]: https://github.com/yarpc/yarpc-go/compare/v1.38.0...v1.39.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Previously, every peer list reported itself as a "single" peer list for
   purposes of debugging, instead of its own name.
+- Metrics emit `CodeResourceExhausted` as a client error and `CodeUnimplemented`
+  as a server error.
 
 ## [1.41.0] - 2019-10-01
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Added
+- Added fail-fast option to peer lists.  With this option enabled, a peer list
+  will return an error if no peers are connected at the time of a call, instead
+  of waiting for an available peer or the context to time out.
 
 ## [1.41.0] - 2019-10-01
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.42.0] - 2019-10-31 (Spooky)
 ### Added
 - Added fail-fast option to peer lists.  With this option enabled, a peer list
   will return an error if no peers are connected at the time of a call, instead
@@ -1136,7 +1136,7 @@ This release requires regeneration of ThriftRW code.
 
 - Initial release.
 
-[Unreleased]: https://github.com/yarpc/yarpc-go/compare/v1.41.0...HEAD
+[1.42.0]: https://github.com/yarpc/yarpc-go/compare/v1.41.0...v1.42.0
 [1.41.0]: https://github.com/yarpc/yarpc-go/compare/v1.40.0...v1.41.0
 [1.40.0]: https://github.com/yarpc/yarpc-go/compare/v1.39.0...v1.40.0
 [1.39.0]: https://github.com/yarpc/yarpc-go/compare/v1.38.0...v1.39.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   purposes of debugging, instead of its own name.
 - Metrics emit `CodeResourceExhausted` as a client error and `CodeUnimplemented`
   as a server error.
+- Simplified the flow of status change notifications for the HTTP transport to
+  reduce the liklihood of deadlocks.
 
 ## [1.41.0] - 2019-10-01
 ### Fixed

--- a/api/peer/transport.go
+++ b/api/peer/transport.go
@@ -22,12 +22,23 @@ package peer
 
 // Subscriber listens to changes of a Peer over time.
 type Subscriber interface {
-	// The Peer Notifies the Subscriber when its status changes (e.g. connections status, pending requests)
+	// The Peer Notifies the Subscriber when its status changes (e.g.
+	// connections status, pending requests)
+	//
+	// NotifyStatusChanged may call methods of the corresponding Peer,
+	// particularly Status.
+	// So, subscriber methods must not be called while holding a lock on the
+	// Transport.
 	NotifyStatusChanged(Identifier)
 }
 
-// Transport manages Peers across different Subscribers.  A Subscriber will request a Peer for a specific
-// PeerIdentifier and the Transport has the ability to create a new Peer or return an existing one.
+// Transport manages Peers across different Subscribers.
+//
+// A Subscriber will request a Peer for a specific PeerIdentifier and the
+// Transport has the ability to create a new Peer or return an existing one.
+//
+// RetainPeer and ReleasePeer must not call or synchronize with goroutines that
+// call methods of the Subscriber.
 type Transport interface {
 	// Get or create a Peer for the Subscriber
 	RetainPeer(Identifier, Subscriber) (Peer, error)

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 0e5fe0feec3ddf53987a3a9750da5fac22dc7bc7710369eecc35d90c188c0d73
-updated: 2019-08-30T15:04:26.507937675Z
+hash: b96c4d16c667159550719c15c63cffb65bfc610754a5c04e9c1d0bbfd8ec7d9f
+updated: 2019-10-10T10:37:07.205506-07:00
 imports:
 - name: github.com/anmitsu/go-shlex
   version: 648efa622239a2f6ff949fed78ee37b48d499ba4
@@ -23,7 +23,7 @@ imports:
   subpackages:
   - spew
 - name: github.com/fatih/structtag
-  version: 76ae1d6d2117609598c7d4e8f3e938145f204e8f
+  version: 3878f9fb88e63e26ea1e6c97ab985cb55452fee5
 - name: github.com/gogo/googleapis
   version: d31c731455cb061f42baff3bda55bad0118b126b
   subpackages:
@@ -100,7 +100,7 @@ imports:
   subpackages:
   - difflib
 - name: github.com/prometheus/client_golang
-  version: 2641b987480bca71fb39738eb8c8b0d577cb1d76
+  version: 170205fb58decfd011f1550d4cfb737230d7ae4f
   subpackages:
   - prometheus
   - prometheus/internal
@@ -136,7 +136,7 @@ imports:
 - name: github.com/uber-go/tally
   version: 3332297784e46cd346ab6d9894fd4ea027dc9368
 - name: github.com/uber/jaeger-client-go
-  version: 85825f3f682a6fb24b12a4604be2a101432c7534
+  version: d4d621cd6ed9aa5f1fc91eb0d0211d336bd6b79d
   subpackages:
   - internal/baggage
   - internal/spanlog
@@ -183,9 +183,9 @@ imports:
   - internal/fxreflect
   - internal/lifecycle
 - name: go.uber.org/multierr
-  version: 3c4937480c32f4c13a875a1829af76c98ca3d40a
+  version: 71e610a0e48dbda460d9c18adca8b5f2de04a7c1
 - name: go.uber.org/net/metrics
-  version: 0327310766f9da183152db859680ae0345c31957
+  version: 05a053b545cba614bf12635803f4749dab7bd0d0
   subpackages:
   - bucket
   - push
@@ -230,14 +230,16 @@ imports:
   - internal/bufferpool
   - internal/color
   - internal/exit
+  - internal/ztest
   - zapcore
+  - zaptest
   - zaptest/observer
 - name: golang.org/x/lint
   version: 959b441ac422379a43da2230f62be024250818b0
   subpackages:
   - golint
 - name: golang.org/x/net
-  version: ba9fcec4b297b415637633c5a6e8fa592e4a16c3
+  version: 3b0461eec859c4b73bb64fdc8285971fd33e3938
   subpackages:
   - bpf
   - context
@@ -255,9 +257,6 @@ imports:
 - name: golang.org/x/sys
   version: 1e83adbbebd0f5dc971915fd7e5db032c3d2b731
   repo: https://github.com/golang/sys
-  subpackages:
-  - unix
-  - windows
 - name: golang.org/x/text
   version: 3d0f7978add91030e5e8976ff65ccdd828286cba
   subpackages:
@@ -289,7 +288,7 @@ imports:
   subpackages:
   - googleapis/rpc/status
 - name: google.golang.org/grpc
-  version: 6eaf6f47437a6b4e2153a190160ef39a92c7eceb
+  version: f6d0f9ee430895e87ef1ceb5ac8f39725bafceef
   repo: https://github.com/grpc/grpc-go
   subpackages:
   - balancer
@@ -358,6 +357,6 @@ imports:
   - version
 testImports:
 - name: github.com/uber/jaeger-lib
-  version: 0e30338a695636fe5bcf7301e8030ce8dd2a8530
+  version: a87ae9d84fb038a8d79266298970720be7c80fcd
   subpackages:
   - metrics

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: eae06dc9789023809cfc6e99aec4ed41f2ef5ef40e08e7d9067a3bdea1455b5a
-updated: 2019-10-11T14:10:56.731699-07:00
+updated: 2019-10-14T15:04:12.552609178Z
 imports:
 - name: github.com/anmitsu/go-shlex
   version: 648efa622239a2f6ff949fed78ee37b48d499ba4
@@ -110,13 +110,13 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 9b359b28d22bbf656f14e4adac914ed64a6850a4
+  version: 287d3e634a1e550c9e463dd7e5a75a422c614505
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: 00ec24a6a2d86e7074629c8384715dbb05adccd8
+  version: aee14273b394209f45977b2d7a6b730071adf5e2
   subpackages:
   - internal/fs
   - internal/util
@@ -125,7 +125,7 @@ imports:
   subpackages:
   - parser
 - name: github.com/stretchr/testify
-  version: 221dbe5ed46703ee255b1da0dec05086f5035f62
+  version: 85f2b59c4459e5bf57488796be8c3667cb8246d6
   subpackages:
   - assert
   - require
@@ -235,11 +235,11 @@ imports:
   - zaptest
   - zaptest/observer
 - name: golang.org/x/lint
-  version: 959b441ac422379a43da2230f62be024250818b0
+  version: 16217165b5de779cb6a5e4fc81fa9c1166fda457
   subpackages:
   - golint
 - name: golang.org/x/net
-  version: d66e71096ffb9f08f36d9aefcae80ce319de6d68
+  version: 491137f692577e390404f177a0515c9f86f79754
   subpackages:
   - bpf
   - context
@@ -255,8 +255,11 @@ imports:
   - ipv6
   - trace
 - name: golang.org/x/sys
-  version: 1e83adbbebd0f5dc971915fd7e5db032c3d2b731
+  version: b09406accb4736d857a32bf9444cd7edae2ffa79
   repo: https://github.com/golang/sys
+  subpackages:
+  - unix
+  - windows
 - name: golang.org/x/text
   version: 3d0f7978add91030e5e8976ff65ccdd828286cba
   subpackages:
@@ -265,7 +268,7 @@ imports:
   - unicode/bidi
   - unicode/norm
 - name: golang.org/x/tools
-  version: f340ed3ae274cf744edc12c671194b31a12fe4ac
+  version: 5fa5b1782b2c597541464a432bc01e7ff6de2c19
   repo: https://github.com/golang/tools
   subpackages:
   - cmd/stringer
@@ -275,8 +278,10 @@ imports:
   - go/ast/inspector
   - go/buildutil
   - go/gcexportdata
+  - go/internal/cgo
   - go/internal/gcimporter
   - go/internal/packagesdriver
+  - go/loader
   - go/packages
   - go/types/objectpath
   - go/types/typeutil
@@ -284,7 +289,7 @@ imports:
   - internal/gopathwalk
   - internal/semver
 - name: google.golang.org/genproto
-  version: 24fa4b261c55da65468f2abfdae2b024eef27dfb
+  version: 548a555dbc03994223efbaba0090152849259498
   subpackages:
   - googleapis/rpc/status
 - name: google.golang.org/grpc
@@ -324,14 +329,16 @@ imports:
   - status
   - tap
 - name: gopkg.in/yaml.v2
-  version: 51d6538a90f86fe93ac480b35f37b2be17fef232
+  version: f221b8435cfb71e54062f6c6e99e9ade30b124d5
 - name: honnef.co/go/tools
-  version: 00664db7fdb567f0b2efbbcdb7d9ed23f7135468
+  version: a2fc4037bf9fb9a7662bf915cde585ccc17c1c2b
   subpackages:
   - arg
   - cmd/staticcheck
+  - code
   - config
   - deprecated
+  - edit
   - facts
   - functions
   - go/types/typeutil
@@ -347,9 +354,10 @@ imports:
   - loader
   - pattern
   - printf
+  - report
   - simple
   - ssa
-  - ssautil
+  - ssa/ssautil
   - staticcheck
   - staticcheck/vrp
   - stylecheck

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: eae06dc9789023809cfc6e99aec4ed41f2ef5ef40e08e7d9067a3bdea1455b5a
-updated: 2019-10-14T15:04:12.552609178Z
+updated: 2019-10-15T15:04:38.689148954Z
 imports:
 - name: github.com/anmitsu/go-shlex
   version: 648efa622239a2f6ff949fed78ee37b48d499ba4
@@ -149,7 +149,7 @@ imports:
   - thrift-gen/zipkincore
   - utils
 - name: github.com/uber/tchannel-go
-  version: 5ee9e351d45f66dc690528cbf014fe5b64b23bc9
+  version: e6bc214d794a9d6062045dd672de210cf211994d
   subpackages:
   - internal/argreader
   - json
@@ -239,7 +239,7 @@ imports:
   subpackages:
   - golint
 - name: golang.org/x/net
-  version: 491137f692577e390404f177a0515c9f86f79754
+  version: da9a3fd4c5820e74b24a6cb7fb438dc9b0dd377c
   subpackages:
   - bpf
   - context
@@ -268,7 +268,7 @@ imports:
   - unicode/bidi
   - unicode/norm
 - name: golang.org/x/tools
-  version: 5fa5b1782b2c597541464a432bc01e7ff6de2c19
+  version: 18e3458ac98b4126ac324c8056a0f2d826c6688a
   repo: https://github.com/golang/tools
   subpackages:
   - cmd/stringer

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: b96c4d16c667159550719c15c63cffb65bfc610754a5c04e9c1d0bbfd8ec7d9f
-updated: 2019-10-10T10:37:07.205506-07:00
+hash: eae06dc9789023809cfc6e99aec4ed41f2ef5ef40e08e7d9067a3bdea1455b5a
+updated: 2019-10-11T14:10:56.731699-07:00
 imports:
 - name: github.com/anmitsu/go-shlex
   version: 648efa622239a2f6ff949fed78ee37b48d499ba4
@@ -239,7 +239,7 @@ imports:
   subpackages:
   - golint
 - name: golang.org/x/net
-  version: 3b0461eec859c4b73bb64fdc8285971fd33e3938
+  version: d66e71096ffb9f08f36d9aefcae80ce319de6d68
   subpackages:
   - bpf
   - context

--- a/glide.yaml
+++ b/glide.yaml
@@ -39,7 +39,7 @@ import:
   subpackages:
   - context
 - package: google.golang.org/grpc
-  version: ^1.12.0
+  version: ^1.19.0
   repo: https://github.com/grpc/grpc-go
 - package: golang.org/x/sys
   # explicitly specifying this because glide is having issues with golang.org repos

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,6 +8,8 @@ import:
   version: master
 - package: github.com/gogo/protobuf
   version: '>=1, <1.3' # T4191773 - TODO: v1.3 breaks gRPC/Protobuf tests
+- package: github.com/gogo/googleapis
+  version: '>=1, <1.3' # T4191773 - not pinning to a version grabs latest master :/
 - package: github.com/golang/protobuf
   version: ^1
 - package: github.com/mattn/go-shellwords

--- a/glide.yaml
+++ b/glide.yaml
@@ -7,7 +7,7 @@ import:
 - package: github.com/crossdock/crossdock-go
   version: master
 - package: github.com/gogo/protobuf
-  version: ^1
+  version: '>=1, <1.3' # T4191773 - TODO: v1.3 breaks gRPC/Protobuf tests
 - package: github.com/golang/protobuf
   version: ^1
 - package: github.com/mattn/go-shellwords

--- a/internal/integrationtest/util.go
+++ b/internal/integrationtest/util.go
@@ -24,6 +24,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net"
 	"sync"
 	"testing"
 	"time"
@@ -40,8 +41,9 @@ import (
 )
 
 const (
-	maxAttempts        = 1000
-	concurrentAttempts = 100
+	_maxAttempts        = 1000
+	_concurrentAttempts = 100
+	_unconnectableAddr  = "0.0.0.1:1"
 )
 
 // TransportSpec specifies how to create test clients and servers for a transport.
@@ -108,7 +110,7 @@ func (s TransportSpec) NewServer(t *testing.T, addr string) (*yarpc.Dispatcher, 
 // exercise a transport dropping connections if the transport is stopped before
 // a pending request can complete.
 func (s TransportSpec) TestConnectAndStopRoundRobin(t *testing.T) {
-	addr := "127.0.0.1:31172"
+	addr := _unconnectableAddr
 
 	client, rawClient := s.NewClient(t, []string{addr})
 
@@ -131,9 +133,9 @@ func (s TransportSpec) TestConnectAndStopRoundRobin(t *testing.T) {
 // apply to cover connection reuse.
 func (s TransportSpec) TestConcurrentClientsRoundRobin(t *testing.T) {
 	var wg sync.WaitGroup
-	count := concurrentAttempts
+	count := _concurrentAttempts
 
-	server, addr := s.NewServer(t, ":0")
+	server, addr := s.NewServer(t, "127.0.0.1:0")
 	defer server.Stop()
 
 	client, rawClient := s.NewClient(t, []string{addr})
@@ -158,7 +160,10 @@ func (s TransportSpec) TestConcurrentClientsRoundRobin(t *testing.T) {
 // TestBackoffConnRoundRobin is a reusable test that any transport can apply to
 // cover connection management backoff.
 func (s TransportSpec) TestBackoffConnRoundRobin(t *testing.T) {
-	addr := "127.0.0.1:31782"
+	conn, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := conn.Addr().String()
+	conn.Close()
 
 	done := make(chan struct{})
 	go func() {
@@ -193,7 +198,7 @@ func Blast(ctx context.Context, t *testing.T, rawClient raw.Client) {
 
 // CallUntilSuccess sends a request until it succeeds.
 func CallUntilSuccess(t *testing.T, rawClient raw.Client, interval time.Duration) {
-	for i := 0; i < maxAttempts; i++ {
+	for i := 0; i < _maxAttempts; i++ {
 		ctx := context.Background()
 		ctx, cancel := context.WithTimeout(ctx, interval)
 		err := Call(ctx, rawClient)

--- a/internal/observability/codes.go
+++ b/internal/observability/codes.go
@@ -46,16 +46,16 @@ func statusFault(status *yarpcerrors.Status) fault {
 		yarpcerrors.CodeFailedPrecondition,
 		yarpcerrors.CodeAborted,
 		yarpcerrors.CodeOutOfRange,
-		yarpcerrors.CodeUnimplemented,
-		yarpcerrors.CodeUnauthenticated:
+		yarpcerrors.CodeUnauthenticated,
+		yarpcerrors.CodeResourceExhausted:
 		return clientFault
 
 	case yarpcerrors.CodeUnknown,
 		yarpcerrors.CodeDeadlineExceeded,
-		yarpcerrors.CodeResourceExhausted,
 		yarpcerrors.CodeInternal,
 		yarpcerrors.CodeUnavailable,
-		yarpcerrors.CodeDataLoss:
+		yarpcerrors.CodeDataLoss,
+		yarpcerrors.CodeUnimplemented:
 		return serverFault
 	}
 

--- a/internal/stresstest/main.go
+++ b/internal/stresstest/main.go
@@ -119,7 +119,7 @@ func main() {
 			},
 		},
 	} {
-		for i := 1; i <= 100000; i *= 10 {
+		for i := 1; i <= 1000; i *= 10 {
 			for _, lowStress := range []bool{false, true} {
 				report := yarpctest.ListStressTest{
 					Workers:   i,

--- a/peer/abstractpeer/peer_test.go
+++ b/peer/abstractpeer/peer_test.go
@@ -1,0 +1,311 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package abstractpeer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/yarpc/api/peer"
+	. "go.uber.org/yarpc/api/peer/peertest"
+)
+
+func TestPeerIdentifier(t *testing.T) {
+	tests := []struct {
+		hostport           string
+		expectedIdentifier string
+	}{
+		{
+			"localhost:12345",
+			"localhost:12345",
+		},
+		{
+			"123.123.123.123:12345",
+			"123.123.123.123:12345",
+		},
+	}
+
+	for _, tt := range tests {
+		pi := PeerIdentifier(tt.hostport)
+
+		assert.Equal(t, tt.expectedIdentifier, pi.Identifier())
+	}
+}
+
+func TestPeer(t *testing.T) {
+	type testStruct struct {
+		msg string
+
+		// PeerID for all the hostport.Peer initialization
+		inputPeerID string
+
+		// List of "Subscribers" that we can define beforehand and reference in our PeerActions
+		// using the "ID" field in the subscriber definition, the "ExpectedNotifyCount" is the
+		// expected number of times the subscriber will be notified
+		SubDefinitions []SubscriberDefinition
+
+		// List of actions to be applied to the peer
+		actions []PeerAction
+
+		// Expected result from running Identifier() on the peer after the actions have been applied
+		expectedIdentifier string
+
+		// Expected result from running HostPort() on the peer after the actions have been applied
+		expectedHostPort string
+
+		// Expected result from running Status() on the peer after the actions have been applied
+		expectedStatus peer.Status
+
+		// Expected subscribers in the Peer's "subscribers" map after the actions have been applied
+		expectedSubscribers []string
+	}
+	tests := []testStruct{
+		{
+			msg:                "create",
+			inputPeerID:        "localhost:12345",
+			expectedIdentifier: "localhost:12345",
+			expectedHostPort:   "localhost:12345",
+			expectedStatus: peer.Status{
+				PendingRequestCount: 0,
+				ConnectionStatus:    peer.Unavailable,
+			},
+		},
+		{
+			msg:            "start request",
+			SubDefinitions: []SubscriberDefinition{{ID: "1", ExpectedNotifyCount: 1}},
+			actions: []PeerAction{
+				SubscribeAction{SubscriberID: "1", ExpectedSubCount: 1},
+				StartStopReqAction{Stop: false},
+			},
+			expectedSubscribers: []string{"1"},
+			expectedStatus: peer.Status{
+				PendingRequestCount: 1,
+				ConnectionStatus:    peer.Unavailable,
+			},
+		},
+		{
+			msg:            "start request stop request",
+			SubDefinitions: []SubscriberDefinition{{ID: "1", ExpectedNotifyCount: 2}},
+			actions: []PeerAction{
+				SubscribeAction{SubscriberID: "1", ExpectedSubCount: 1},
+				StartStopReqAction{Stop: true},
+			},
+			expectedSubscribers: []string{"1"},
+			expectedStatus: peer.Status{
+				PendingRequestCount: 0,
+				ConnectionStatus:    peer.Unavailable,
+			},
+		},
+		{
+			msg:            "start 5 stop 2",
+			SubDefinitions: []SubscriberDefinition{{ID: "1", ExpectedNotifyCount: 7}},
+			actions: []PeerAction{
+				SubscribeAction{SubscriberID: "1", ExpectedSubCount: 1},
+				StartStopReqAction{Stop: true},
+				StartStopReqAction{Stop: false},
+				StartStopReqAction{Stop: false},
+				StartStopReqAction{Stop: true},
+				StartStopReqAction{Stop: false},
+			},
+			expectedSubscribers: []string{"1"},
+			expectedStatus: peer.Status{
+				PendingRequestCount: 3,
+				ConnectionStatus:    peer.Unavailable,
+			},
+		},
+		{
+			msg:            "start 5 stop 5",
+			SubDefinitions: []SubscriberDefinition{{ID: "1", ExpectedNotifyCount: 10}},
+			actions: []PeerAction{
+				SubscribeAction{SubscriberID: "1", ExpectedSubCount: 1},
+				StartStopReqAction{Stop: true},
+				StartStopReqAction{Stop: true},
+				StartStopReqAction{Stop: true},
+				StartStopReqAction{Stop: true},
+				StartStopReqAction{Stop: true},
+			},
+			expectedSubscribers: []string{"1"},
+			expectedStatus: peer.Status{
+
+				ConnectionStatus: peer.Unavailable,
+			},
+		},
+		{
+			msg: "set status",
+			SubDefinitions: []SubscriberDefinition{
+				{ID: "1", ExpectedNotifyCount: 1},
+				{ID: "2", ExpectedNotifyCount: 1},
+				{ID: "3", ExpectedNotifyCount: 1},
+			},
+			actions: []PeerAction{
+				SubscribeAction{SubscriberID: "1", ExpectedSubCount: 1},
+				SubscribeAction{SubscriberID: "2", ExpectedSubCount: 2},
+				SubscribeAction{SubscriberID: "3", ExpectedSubCount: 3},
+				SetStatusAction{InputStatus: peer.Available},
+			},
+			expectedSubscribers: []string{"1", "2", "3"},
+			expectedStatus: peer.Status{
+				PendingRequestCount: 0,
+				ConnectionStatus:    peer.Available,
+			},
+		},
+		{
+			msg: "incremental subscribe",
+			SubDefinitions: []SubscriberDefinition{
+				{ID: "1", ExpectedNotifyCount: 3},
+				{ID: "2", ExpectedNotifyCount: 2},
+				{ID: "3", ExpectedNotifyCount: 1},
+			},
+			actions: []PeerAction{
+				SubscribeAction{SubscriberID: "1", ExpectedSubCount: 1},
+				SetStatusAction{InputStatus: peer.Available},
+				SubscribeAction{SubscriberID: "2", ExpectedSubCount: 2},
+				SetStatusAction{InputStatus: peer.Available},
+				SubscribeAction{SubscriberID: "3", ExpectedSubCount: 3},
+				SetStatusAction{InputStatus: peer.Available},
+			},
+			expectedSubscribers: []string{"1", "2", "3"},
+			expectedStatus: peer.Status{
+				PendingRequestCount: 0,
+				ConnectionStatus:    peer.Available,
+			},
+		},
+		{
+			msg: "subscribe unsubscribe",
+			SubDefinitions: []SubscriberDefinition{
+				{ID: "1", ExpectedNotifyCount: 1},
+			},
+			actions: []PeerAction{
+				SubscribeAction{SubscriberID: "1", ExpectedSubCount: 1},
+				SetStatusAction{InputStatus: peer.Available},
+				UnsubscribeAction{SubscriberID: "1", ExpectedSubCount: 0},
+				SetStatusAction{InputStatus: peer.Available},
+			},
+			expectedStatus: peer.Status{
+				PendingRequestCount: 0,
+				ConnectionStatus:    peer.Available,
+			},
+		},
+		{
+			msg: "incremental subscribe unsubscribe",
+			SubDefinitions: []SubscriberDefinition{
+				{ID: "1", ExpectedNotifyCount: 5},
+				{ID: "2", ExpectedNotifyCount: 3},
+				{ID: "3", ExpectedNotifyCount: 1},
+			},
+			actions: []PeerAction{
+				SubscribeAction{SubscriberID: "1", ExpectedSubCount: 1},
+				SetStatusAction{InputStatus: peer.Available},
+				SubscribeAction{SubscriberID: "2", ExpectedSubCount: 2},
+				SetStatusAction{InputStatus: peer.Available},
+				SubscribeAction{SubscriberID: "3", ExpectedSubCount: 3},
+				SetStatusAction{InputStatus: peer.Available},
+				UnsubscribeAction{SubscriberID: "3", ExpectedSubCount: 2},
+				SetStatusAction{InputStatus: peer.Available},
+				UnsubscribeAction{SubscriberID: "2", ExpectedSubCount: 1},
+				SetStatusAction{InputStatus: peer.Available},
+				UnsubscribeAction{SubscriberID: "1", ExpectedSubCount: 0},
+				SetStatusAction{InputStatus: peer.Available},
+			},
+			expectedStatus: peer.Status{
+				PendingRequestCount: 0,
+				ConnectionStatus:    peer.Available,
+			},
+		},
+		{
+			msg: "unsubscribe error",
+			SubDefinitions: []SubscriberDefinition{
+				{ID: "1", ExpectedNotifyCount: 0},
+			},
+			actions: []PeerAction{
+				UnsubscribeAction{
+					SubscriberID:     "1",
+					ExpectedErrType:  peer.ErrPeerHasNoReferenceToSubscriber{},
+					ExpectedSubCount: 0,
+				},
+			},
+			expectedStatus: peer.Status{
+				PendingRequestCount: 0,
+				ConnectionStatus:    peer.Unavailable,
+			},
+		},
+		{
+			msg: "concurrent update and subscribe",
+			SubDefinitions: []SubscriberDefinition{
+				{ID: "1", ExpectedNotifyCount: 2},
+			},
+			actions: []PeerAction{
+				PeerConcurrentAction{
+					Actions: []PeerAction{
+						SubscribeAction{SubscriberID: "1", ExpectedSubCount: 1},
+						SetStatusAction{InputStatus: peer.Available},
+						SetStatusAction{InputStatus: peer.Available},
+					},
+					Wait: time.Millisecond * 70,
+				},
+			},
+			expectedSubscribers: []string{"1"},
+			expectedStatus: peer.Status{
+				PendingRequestCount: 0,
+				ConnectionStatus:    peer.Available,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			if tt.inputPeerID == "" {
+				tt.inputPeerID = "localhost:12345"
+				tt.expectedIdentifier = "localhost:12345"
+				tt.expectedHostPort = "localhost:12345"
+			}
+
+			transport := NewMockTransport(mockCtrl)
+
+			peer := NewPeer(PeerIdentifier(tt.inputPeerID), transport)
+
+			deps := &Dependencies{
+				Subscribers: CreateSubscriberMap(mockCtrl, tt.SubDefinitions),
+			}
+
+			ApplyPeerActions(t, peer, tt.actions, deps)
+
+			assert.Equal(t, tt.expectedIdentifier, peer.Identifier())
+			assert.Equal(t, tt.expectedHostPort, peer.HostPort())
+			assert.Equal(t, transport, peer.Transport())
+			assert.Equal(t, tt.expectedStatus, peer.Status())
+
+			assert.Len(t, peer.subscribers, len(tt.expectedSubscribers))
+			for _, subID := range tt.expectedSubscribers {
+				sub, ok := deps.Subscribers[subID]
+				assert.True(t, ok, "referenced subscriber id that does not exist %s", sub)
+
+				_, ok = peer.subscribers[sub]
+				assert.True(t, ok, "peer did not have reference to subscriber %v", sub)
+			}
+		})
+	}
+}

--- a/peer/abstractpeer/peeraction_test.go
+++ b/peer/abstractpeer/peeraction_test.go
@@ -1,0 +1,160 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package abstractpeer
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/internal/testtime"
+)
+
+// There are no actual tests in this file, it contains a series of helper methods
+// for testing abstractpeer.Peers
+
+// Dependences are passed through all the PeerActions in order to pass certain
+// state in between Actions
+type Dependencies struct {
+	Subscribers map[string]peer.Subscriber
+}
+
+// PeerAction defines actions that can be applied on a abstractpeer.Peer
+type PeerAction interface {
+	Apply(*testing.T, *Peer, *Dependencies)
+}
+
+// StartStopReqAction will run a StartRequest and (optionally) EndRequest
+type StartStopReqAction struct {
+	Stop bool
+}
+
+// Apply will run StartRequest and (optionally) EndRequest
+func (sa StartStopReqAction) Apply(t *testing.T, p *Peer, d *Dependencies) {
+	p.StartRequest()
+	p.NotifyStatusChanged()
+	if sa.Stop {
+		p.EndRequest()
+		p.NotifyStatusChanged()
+	}
+}
+
+// SetStatusAction will run a SetStatus on a Peer
+type SetStatusAction struct {
+	InputStatus peer.ConnectionStatus
+}
+
+// Apply will run SetStatus on the Peer
+func (sa SetStatusAction) Apply(t *testing.T, p *Peer, d *Dependencies) {
+	p.SetStatus(sa.InputStatus)
+	p.NotifyStatusChanged()
+
+	assert.Equal(t, sa.InputStatus, p.Status().ConnectionStatus)
+}
+
+// SubscribeAction will run an Subscribe on a Peer
+type SubscribeAction struct {
+	// SubscriberID is a unique identifier for a subscriber that is
+	// contained in the Dependencies object passed in Apply
+	SubscriberID string
+
+	// ExpectedSubCount is the number of subscribers on the Peer after
+	// the subscription
+	ExpectedSubCount int
+}
+
+// Apply will run Subscribe on a Peer
+func (sa SubscribeAction) Apply(t *testing.T, p *Peer, d *Dependencies) {
+	sub, ok := d.Subscribers[sa.SubscriberID]
+	assert.True(t, ok, "referenced a subscriberID that does not exist %s", sa.SubscriberID)
+
+	p.Subscribe(sub)
+
+	assert.Equal(t, sa.ExpectedSubCount, p.NumSubscribers())
+}
+
+// UnsubscribeAction will run Unsubscribe on a Peer
+type UnsubscribeAction struct {
+	// SubscriberID is a unique identifier for a subscriber that is
+	// contained in the Dependencies object passed in Apply
+	SubscriberID string
+
+	// ExpectedErrType is the type of error that is expected to be returned
+	// from Unsubscribe
+	ExpectedErrType error
+
+	// ExpectedSubCount is the number of subscribers on the Peer after
+	// the subscription
+	ExpectedSubCount int
+}
+
+// Apply will run Unsubscribe from the Peer and assert on the result
+func (ua UnsubscribeAction) Apply(t *testing.T, p *Peer, d *Dependencies) {
+	sub, ok := d.Subscribers[ua.SubscriberID]
+	assert.True(t, ok, "referenced a subscriberID that does not exist %s", ua.SubscriberID)
+
+	err := p.Unsubscribe(sub)
+
+	assert.Equal(t, ua.ExpectedSubCount, p.NumSubscribers())
+	if err != nil {
+		assert.IsType(t, ua.ExpectedErrType, err)
+	} else {
+		assert.Nil(t, ua.ExpectedErrType)
+	}
+}
+
+// PeerConcurrentAction will run a series of actions in parallel
+type PeerConcurrentAction struct {
+	Actions []PeerAction
+	Wait    time.Duration
+}
+
+// Apply runs all the ConcurrentAction's actions in goroutines with a delay of `Wait`
+// between each action. Returns when all actions have finished executing
+func (a PeerConcurrentAction) Apply(t *testing.T, p *Peer, d *Dependencies) {
+	var wg sync.WaitGroup
+
+	wg.Add(len(a.Actions))
+	for _, action := range a.Actions {
+		go func(ac PeerAction) {
+			defer wg.Done()
+			ac.Apply(t, p, d)
+		}(action)
+
+		if a.Wait > 0 {
+			testtime.Sleep(a.Wait)
+		}
+	}
+
+	wg.Wait()
+}
+
+// ApplyPeerActions runs all the PeerActions on the Peer
+func ApplyPeerActions(t *testing.T, p *Peer, actions []PeerAction, d *Dependencies) {
+	for i, action := range actions {
+		t.Run(fmt.Sprintf("action #%d: %T", i, action), func(t *testing.T) {
+			action.Apply(t, p, d)
+		})
+	}
+}

--- a/peer/peerlist/v2/list.go
+++ b/peer/peerlist/v2/list.go
@@ -67,6 +67,7 @@ type Implementation interface {
 type listOptions struct {
 	capacity  int
 	noShuffle bool
+	failFast  bool
 	seed      int64
 }
 
@@ -101,6 +102,16 @@ func NoShuffle() ListOption {
 	})
 }
 
+// FailFast indicates that the peer list should not wait for peers to be added,
+// when choosing a peer.
+//
+// This option is particularly useful for proxies.
+func FailFast() ListOption {
+	return listOptionFunc(func(options *listOptions) {
+		options.failFast = true
+	})
+}
+
 // Seed specifies the random seed to use for shuffling peers
 //
 // Defaults to approximately the process start time in nanoseconds.
@@ -126,6 +137,7 @@ func New(name string, transport peer.Transport, availableChooser Implementation,
 		availableChooser:   availableChooser,
 		transport:          transport,
 		noShuffle:          options.noShuffle,
+		failFast:           options.failFast,
 		randSrc:            rand.NewSource(options.seed),
 		peerAvailableEvent: make(chan struct{}, 1),
 	}
@@ -155,6 +167,7 @@ type List struct {
 	transport          peer.Transport
 
 	noShuffle bool
+	failFast  bool
 	randSrc   rand.Source
 
 	once *lifecycle.Once
@@ -431,6 +444,8 @@ func (pl *List) Choose(ctx context.Context, req *transport.Request) (peer.Peer, 
 			pl.notifyPeerAvailable()
 			t.StartRequest()
 			return t.peer, t.boundOnFinish, nil
+		} else if pl.failFast {
+			return nil, nil, yarpcerrors.Newf(yarpcerrors.CodeUnavailable, "%q peer list has no peer available", pl.name)
 		}
 		if err := pl.waitForPeerAddedEvent(ctx); err != nil {
 			return nil, nil, err

--- a/peer/peerlist/v2/list.go
+++ b/peer/peerlist/v2/list.go
@@ -643,7 +643,7 @@ func (pl *List) Introspect() introspection.ChooserStatus {
 	}
 
 	return introspection.ChooserStatus{
-		Name: "Single",
+		Name: pl.name,
 		State: fmt.Sprintf("%s (%d/%d available)", state, len(availables),
 			len(availables)+len(unavailables)),
 		Peers: peersStatus,

--- a/peer/pendingheap/config.go
+++ b/peer/pendingheap/config.go
@@ -31,6 +31,7 @@ import (
 // Configuration descripes how to build a fewest pending heap peer list.
 type Configuration struct {
 	Capacity *int `config:"capacity"`
+	FailFast bool `config:"failFast"`
 }
 
 // Spec returns a configuration specification for the pending heap peer list
@@ -51,20 +52,38 @@ type Configuration struct {
 //            peers:
 //              - 127.0.0.1:8080
 //              - 127.0.0.1:8081
+//
+// Other than a specific peer or peers list, use any peer list updater
+// registered with a yarpc Configurator.
+// The configuration allows for alternative initial allocation capacity and a
+// fail-fast option.
+// With fail-fast enabled, the peer list will return an error immediately if no
+// peers are available (connected) at the time the request is sent.
+//
+//  fewest-pending-requests:
+//    peers:
+//      - 127.0.0.1:8080
+//    capacity: 1
+//    failFast: true
 func Spec() yarpcconfig.PeerListSpec {
 	return yarpcconfig.PeerListSpec{
 		Name: "fewest-pending-requests",
 		BuildPeerList: func(cfg Configuration, t peer.Transport, k *yarpcconfig.Kit) (peer.ChooserList, error) {
-			if cfg.Capacity == nil {
-				return New(t), nil
+			opts := make([]ListOption, 0, 2)
+
+			if cfg.Capacity != nil {
+				if *cfg.Capacity <= 0 {
+					return nil, yarpcerrors.Newf(yarpcerrors.CodeInvalidArgument,
+						fmt.Sprintf("Capacity must be greater than 0. Got: %d.", *cfg.Capacity))
+				}
+				opts = append(opts, Capacity(*cfg.Capacity))
 			}
 
-			if *cfg.Capacity <= 0 {
-				return nil, yarpcerrors.Newf(yarpcerrors.CodeInvalidArgument,
-					fmt.Sprintf("Capacity must be greater than 0. Got: %d.", *cfg.Capacity))
+			if cfg.FailFast {
+				opts = append(opts, FailFast())
 			}
 
-			return New(t, Capacity(*cfg.Capacity)), nil
+			return New(t, opts...), nil
 		},
 	}
 }

--- a/peer/pendingheap/list_test.go
+++ b/peer/pendingheap/list_test.go
@@ -22,15 +22,25 @@ package pendingheap
 
 import (
 	"context"
+	"fmt"
+	"net"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/multierr"
+	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/peer"
 	. "go.uber.org/yarpc/api/peer/peertest"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/testtime"
+	"go.uber.org/yarpc/internal/whitespace"
+	"go.uber.org/yarpc/transport/http"
+	"go.uber.org/yarpc/yarpcconfig"
 	"go.uber.org/yarpc/yarpcerrors"
 )
 
@@ -674,4 +684,45 @@ func TestPeerHeapList(t *testing.T) {
 
 var noShuffle ListOption = func(c *listConfig) {
 	c.shuffle = false
+}
+
+func TestFailFastConfig(t *testing.T) {
+	conn, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	serviceName := "test"
+	config := whitespace.Expand(fmt.Sprintf(`
+		outbounds:
+			nowhere:
+				http:
+					fewest-pending-requests:
+						peers:
+							- %q
+						capacity: 10
+						failFast: true
+	`, conn.Addr()))
+	cfgr := yarpcconfig.New()
+	cfgr.MustRegisterTransport(http.TransportSpec())
+	cfgr.MustRegisterPeerList(Spec())
+	cfg, err := cfgr.LoadConfigFromYAML(serviceName, strings.NewReader(config))
+	require.NoError(t, err)
+
+	d := yarpc.NewDispatcher(cfg)
+	d.Start()
+	defer d.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
+	defer cancel()
+
+	client := d.MustOutboundConfig("nowhere")
+	_, err = client.Outbounds.Unary.Call(ctx, &transport.Request{
+		Service:   "service",
+		Caller:    "caller",
+		Encoding:  transport.Encoding("blank"),
+		Procedure: "bogus",
+		Body:      strings.NewReader("nada"),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no peer available")
 }

--- a/peer/roundrobin/list.go
+++ b/peer/roundrobin/list.go
@@ -30,6 +30,7 @@ import (
 type listConfig struct {
 	capacity int
 	shuffle  bool
+	failFast bool
 	seed     int64
 }
 
@@ -52,6 +53,17 @@ func Capacity(capacity int) ListOption {
 	}
 }
 
+// FailFast indicates that the peer list should not wait for a peer to become
+// available when choosing a peer.
+//
+// This option is preferrable when the better failure mode is to retry from the
+// origin, since another proxy instance might already have a connection.
+func FailFast() ListOption {
+	return func(c *listConfig) {
+		c.failFast = true
+	}
+}
+
 // New creates a new round robin peer list.
 func New(transport peer.Transport, opts ...ListOption) *List {
 	cfg := defaultListConfig
@@ -65,6 +77,9 @@ func New(transport peer.Transport, opts ...ListOption) *List {
 	}
 	if !cfg.shuffle {
 		plOpts = append(plOpts, peerlist.NoShuffle())
+	}
+	if cfg.failFast {
+		plOpts = append(plOpts, peerlist.FailFast())
 	}
 
 	return &List{

--- a/peer/roundrobin/list.go
+++ b/peer/roundrobin/list.go
@@ -84,7 +84,7 @@ func New(transport peer.Transport, opts ...ListOption) *List {
 
 	return &List{
 		List: peerlist.New(
-			"roundrobin",
+			"round-robin",
 			transport,
 			newPeerRing(),
 			plOpts...,

--- a/peer/roundrobin/list_test.go
+++ b/peer/roundrobin/list_test.go
@@ -23,16 +23,25 @@ package roundrobin
 import (
 	"context"
 	"fmt"
+	"net"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/multierr"
+	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/peer"
 	. "go.uber.org/yarpc/api/peer/peertest"
+	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/introspection"
+	"go.uber.org/yarpc/internal/testtime"
+	"go.uber.org/yarpc/internal/whitespace"
 	"go.uber.org/yarpc/peer/hostport"
+	"go.uber.org/yarpc/transport/http"
+	"go.uber.org/yarpc/yarpcconfig"
 	"go.uber.org/yarpc/yarpcerrors"
 )
 
@@ -1008,4 +1017,45 @@ func seed(seed int64) ListOption {
 	return func(c *listConfig) {
 		c.seed = seed
 	}
+}
+
+func TestFailFastConfig(t *testing.T) {
+	conn, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	serviceName := "test"
+	config := whitespace.Expand(fmt.Sprintf(`
+		outbounds:
+			nowhere:
+				http:
+					round-robin:
+						peers:
+							- %q
+						capacity: 10
+						failFast: true
+	`, conn.Addr()))
+	cfgr := yarpcconfig.New()
+	cfgr.MustRegisterTransport(http.TransportSpec())
+	cfgr.MustRegisterPeerList(Spec())
+	cfg, err := cfgr.LoadConfigFromYAML(serviceName, strings.NewReader(config))
+	require.NoError(t, err)
+
+	d := yarpc.NewDispatcher(cfg)
+	d.Start()
+	defer d.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
+	defer cancel()
+
+	client := d.MustOutboundConfig("nowhere")
+	_, err = client.Outbounds.Unary.Call(ctx, &transport.Request{
+		Service:   "service",
+		Caller:    "caller",
+		Encoding:  transport.Encoding("blank"),
+		Procedure: "bogus",
+		Body:      strings.NewReader("nada"),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no peer available")
 }

--- a/peer/roundrobin/list_test.go
+++ b/peer/roundrobin/list_test.go
@@ -46,15 +46,15 @@ import (
 )
 
 var (
-	_noContextDeadlineError = yarpcerrors.Newf(yarpcerrors.CodeInvalidArgument, "can't wait for peer without a context deadline for a roundrobin peer list")
+	_noContextDeadlineError = yarpcerrors.Newf(yarpcerrors.CodeInvalidArgument, "can't wait for peer without a context deadline for a round-robin peer list")
 )
 
 func newNotRunningError(err string) error {
-	return yarpcerrors.FailedPreconditionErrorf("roundrobin peer list is not running: %s", err)
+	return yarpcerrors.FailedPreconditionErrorf("round-robin peer list is not running: %s", err)
 }
 
 func newUnavailableError(err error) error {
-	return yarpcerrors.UnavailableErrorf("roundrobin peer list timed out waiting for peer: %s", err.Error())
+	return yarpcerrors.UnavailableErrorf("round-robin peer list timed out waiting for peer: %s", err.Error())
 }
 
 func TestRoundRobinList(t *testing.T) {
@@ -943,7 +943,7 @@ func TestIntrospect(t *testing.T) {
 	}))
 
 	chooserStatus := pl.Introspect()
-	assert.Equal(t, "Single", chooserStatus.Name)
+	assert.Equal(t, "round-robin", chooserStatus.Name)
 	assert.Equal(t, "Running (2/3 available)", chooserStatus.State)
 
 	peerIdentifierToPeerStatus := make(map[string]introspection.PeerStatus, len(chooserStatus.Peers))

--- a/peer/tworandomchoices/list.go
+++ b/peer/tworandomchoices/list.go
@@ -31,6 +31,7 @@ import (
 type listOptions struct {
 	capacity int
 	source   rand.Source
+	failFast bool
 }
 
 var defaultListOptions = listOptions{
@@ -71,6 +72,17 @@ func Source(source rand.Source) ListOption {
 	})
 }
 
+// FailFast indicates that the peer list should not wait for a peer to become
+// available when choosing a peer.
+//
+// This option is preferrable when the better failure mode is to retry from the
+// origin, since another proxy instance might already have a connection.
+func FailFast() ListOption {
+	return listOptionFunc(func(options *listOptions) {
+		options.failFast = true
+	})
+}
+
 // New creates a new fewest pending requests of two random peers peer list.
 func New(transport peer.Transport, opts ...ListOption) *List {
 	options := defaultListOptions
@@ -85,6 +97,10 @@ func New(transport peer.Transport, opts ...ListOption) *List {
 	plOpts := []peerlist.ListOption{
 		peerlist.Capacity(options.capacity),
 		peerlist.NoShuffle(),
+	}
+
+	if options.failFast {
+		plOpts = append(plOpts, peerlist.FailFast())
 	}
 
 	return &List{

--- a/peer/tworandomchoices/list_test.go
+++ b/peer/tworandomchoices/list_test.go
@@ -22,16 +22,26 @@ package tworandomchoices_test
 
 import (
 	"context"
+	"fmt"
+	"net"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/multierr"
+	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/peer"
 	. "go.uber.org/yarpc/api/peer/peertest"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/testtime"
+	"go.uber.org/yarpc/internal/whitespace"
 	"go.uber.org/yarpc/peer/tworandomchoices"
+	"go.uber.org/yarpc/transport/http"
+	"go.uber.org/yarpc/yarpcconfig"
 	"go.uber.org/yarpc/yarpcerrors"
 )
 
@@ -586,4 +596,45 @@ func TestTwoRandomChoicesPeer(t *testing.T) {
 			assert.Equal(t, tt.expectedRunning, pl.IsRunning(), "Peer list should match expected final running state")
 		})
 	}
+}
+
+func TestFailFastConfig(t *testing.T) {
+	conn, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	serviceName := "test"
+	config := whitespace.Expand(fmt.Sprintf(`
+		outbounds:
+			nowhere:
+				http:
+					two-random-choices:
+						peers:
+							- %q
+						capacity: 10
+						failFast: true
+	`, conn.Addr()))
+	cfgr := yarpcconfig.New()
+	cfgr.MustRegisterTransport(http.TransportSpec())
+	cfgr.MustRegisterPeerList(tworandomchoices.Spec())
+	cfg, err := cfgr.LoadConfigFromYAML(serviceName, strings.NewReader(config))
+	require.NoError(t, err)
+
+	d := yarpc.NewDispatcher(cfg)
+	d.Start()
+	defer d.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
+	defer cancel()
+
+	client := d.MustOutboundConfig("nowhere")
+	_, err = client.Outbounds.Unary.Call(ctx, &transport.Request{
+		Service:   "service",
+		Caller:    "caller",
+		Encoding:  transport.Encoding("blank"),
+		Procedure: "bogus",
+		Body:      strings.NewReader("nada"),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no peer available")
 }

--- a/transport/grpc/transport.go
+++ b/transport/grpc/transport.go
@@ -24,7 +24,6 @@ import (
 	"net"
 	"sync"
 
-	"go.uber.org/multierr"
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/pkg/lifecycle"
 )
@@ -65,14 +64,14 @@ func (t *Transport) Stop() error {
 	return t.once.Stop(func() error {
 		t.lock.Lock()
 		defer t.lock.Unlock()
+
 		for _, grpcPeer := range t.addressToPeer {
 			grpcPeer.stop()
 		}
-		var err error
 		for _, grpcPeer := range t.addressToPeer {
-			err = multierr.Append(err, grpcPeer.wait())
+			grpcPeer.wait()
 		}
-		return err
+		return nil
 	})
 }
 
@@ -145,7 +144,7 @@ func (t *Transport) ReleasePeer(pid peer.Identifier, ps peer.Subscriber) error {
 	if p.NumSubscribers() == 0 {
 		delete(t.addressToPeer, address)
 		p.stop()
-		return p.wait()
+		p.wait()
 	}
 	return nil
 }

--- a/transport/grpc/transport.go
+++ b/transport/grpc/transport.go
@@ -144,7 +144,6 @@ func (t *Transport) ReleasePeer(pid peer.Identifier, ps peer.Subscriber) error {
 	if p.NumSubscribers() == 0 {
 		delete(t.addressToPeer, address)
 		p.stop()
-		p.wait()
 	}
 	return nil
 }

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -532,7 +532,7 @@ func (o *Outbound) doWithPeer(
 			// Note that the connection experienced a time out, which may
 			// indicate that the connection is half-open, that the destination
 			// died without sending a TCP FIN packet.
-			p.OnSuspect()
+			p.onSuspect()
 
 			end := time.Now()
 			return nil, yarpcerrors.Newf(
@@ -543,7 +543,7 @@ func (o *Outbound) doWithPeer(
 
 		// Note that the connection may have been lost so the peer connection
 		// maintenance loop resumes probing for availability.
-		p.OnDisconnected()
+		p.onDisconnected()
 
 		return nil, yarpcerrors.Newf(yarpcerrors.CodeUnknown, "unknown error from http client: %s", err.Error())
 	}

--- a/transport/http/peer_test.go
+++ b/transport/http/peer_test.go
@@ -32,7 +32,6 @@ import (
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/integrationtest"
 	"go.uber.org/yarpc/internal/testtime"
-	"go.uber.org/yarpc/internal/yarpctest"
 	"go.uber.org/yarpc/peer/hostport"
 	"go.uber.org/yarpc/transport/http"
 )
@@ -63,7 +62,7 @@ var spec = integrationtest.TransportSpec{
 		return x.(*http.Transport).NewInbound(addr)
 	},
 	Addr: func(x peer.Transport, ib transport.Inbound) string {
-		return yarpctest.ZeroAddrToHostPort(ib.(*http.Inbound).Addr())
+		return ib.(*http.Inbound).Addr().String()
 	},
 }
 
@@ -72,10 +71,10 @@ func TestHTTPWithRoundRobin(t *testing.T) {
 	ctx, cancel := context.WithTimeout(ctx, testtime.Second)
 	defer cancel()
 
-	permanent, permanentAddr := spec.NewServer(t, ":0")
+	permanent, permanentAddr := spec.NewServer(t, "127.0.0.1:0")
 	defer permanent.Stop()
 
-	temporary, temporaryAddr := spec.NewServer(t, ":0")
+	temporary, temporaryAddr := spec.NewServer(t, "127.0.0.1:0")
 	defer temporary.Stop()
 
 	// Construct a client with a bank of peers. We will keep one running all
@@ -107,7 +106,7 @@ func TestHTTPWithRoundRobin(t *testing.T) {
 }
 
 func TestHTTPOnSuspect(t *testing.T) {
-	server, serverAddr := spec.NewServer(t, ":0")
+	server, serverAddr := spec.NewServer(t, "127.0.0.1:0")
 
 	client, c := spec.NewClient(t, []string{serverAddr})
 	defer client.Stop()

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package yarpc // import "go.uber.org/yarpc"
 
 // Version is the current version of YARPC.
-const Version = "1.41.0"
+const Version = "1.42.0-dev"

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package yarpc // import "go.uber.org/yarpc"
 
 // Version is the current version of YARPC.
-const Version = "1.42.0-dev"
+const Version = "1.42.0"


### PR DESCRIPTION
### Added
- Added fail-fast option to peer lists.  With this option enabled, a peer list
  will return an error if no peers are connected at the time of a call, instead
  of waiting for an available peer or the context to time out.

### Fixed
- Previously, every peer list reported itself as a "single" peer list for
  purposes of debugging, instead of its own name.
- Metrics emit `CodeResourceExhausted` as a client error and `CodeUnimplemented`
  as a server error.
- Simplified the flow of status change notifications for the HTTP transport to
  reduce the liklihood of deadlocks.
- Removed a bug from the gRPC transport that would cause a very rare deadlock
  during production deploys and restarts.
  The gRPC peer release method would synchronize with the connection status
  change monitor loop, waiting for it to exit.
  This would wait forever since retain was called while holding a lock on the
  list.