### PR TITLE
Improve release checkout instructions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -36,7 +36,7 @@ Releasing
     it.
 
     ```
-    get fetch origin
+    git fetch origin master
     git checkout origin/master
     git checkout -B $(whoami)/release
     ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -36,9 +36,9 @@ Releasing
     it.
 
     ```
-    git checkout master
-    git pull
-    git checkout -b $(whoami)/release
+    get fetch origin
+    git checkout origin/master
+    git checkout -B $(whoami)/release
     ```
 
 3.  Merge the branch with the changes being released into the newly created


### PR DESCRIPTION
The release instructions currently assume that master can fast-forward to origin/master.  This change provides instructions that do not depend on a pristine local master branch.