### PR TITLE
Privatize TChannel internal methods

### DIFF
--- a/transport/tchannel/peer.go
+++ b/transport/tchannel/peer.go
@@ -56,7 +56,7 @@ func newPeer(addr string, t *Transport) *tchannelPeer {
 	}
 }
 
-func (p *tchannelPeer) MaintainConn() {
+func (p *tchannelPeer) maintainConnection() {
 	cancel := func() {}
 
 	backoff := p.transport.connBackoffStrategy.Backoff()
@@ -109,7 +109,7 @@ func (p *tchannelPeer) MaintainConn() {
 	cancel()
 }
 
-func (p *tchannelPeer) Release() {
+func (p *tchannelPeer) release() {
 	close(p.released)
 }
 
@@ -118,7 +118,7 @@ func (p *tchannelPeer) setConnectionStatus(status peer.ConnectionStatus) {
 	p.Peer.NotifyStatusChanged()
 }
 
-func (p *tchannelPeer) OnStatusChanged() {
+func (p *tchannelPeer) notifyConnectionStatusChanged() {
 	select {
 	case p.changed <- struct{}{}:
 	default:

--- a/transport/tchannel/transport.go
+++ b/transport/tchannel/transport.go
@@ -141,7 +141,7 @@ func (t *Transport) getOrCreatePeer(pid peer.Identifier) *tchannelPeer {
 	t.peers[addr] = p
 	// Start a peer connection loop
 	t.connectorsGroup.Add(1)
-	go p.MaintainConn()
+	go p.maintainConnection()
 	go p.monitorPendingRequestCount()
 
 	return p
@@ -167,7 +167,7 @@ func (t *Transport) ReleasePeer(pid peer.Identifier, sub peer.Subscriber) error 
 
 	if p.NumSubscribers() == 0 {
 		// Release the peer so that the connection retention loop stops.
-		p.Release()
+		p.release()
 		delete(t.peers, pid.Identifier())
 	}
 
@@ -271,5 +271,5 @@ func (t *Transport) onPeerStatusChanged(tp *tchannel.Peer) {
 	if !ok {
 		return
 	}
-	p.OnStatusChanged()
+	p.notifyConnectionStatusChanged()
 }


### PR DESCRIPTION
The TChannel private peer type has some public methods.  These peers are provided to any peer list that retains or releases the peer for a given identifier, creating an API surface available to anyone who can cast the instance to an interface with the desired public method.  This change converts unnecessarily public methods to private to reduce the potential unintended API surface.