### PR TITLE
Thread a logger into fewest-pending-requests list

### DIFF
--- a/peer/pendingheap/config.go
+++ b/peer/pendingheap/config.go
@@ -66,10 +66,17 @@ type Configuration struct {
 //    capacity: 1
 //    failFast: true
 func Spec() yarpcconfig.PeerListSpec {
+	return SpecWithOptions()
+}
+
+// SpecWithOptions accepts additional list constructor options.
+func SpecWithOptions(options ...ListOption) yarpcconfig.PeerListSpec {
 	return yarpcconfig.PeerListSpec{
 		Name: "fewest-pending-requests",
 		BuildPeerList: func(cfg Configuration, t peer.Transport, k *yarpcconfig.Kit) (peer.ChooserList, error) {
-			opts := make([]ListOption, 0, 2)
+			opts := make([]ListOption, 0, len(options)+2)
+
+			opts = append(opts, options...)
 
 			if cfg.Capacity != nil {
 				if *cfg.Capacity <= 0 {

--- a/peer/pendingheap/list.go
+++ b/peer/pendingheap/list.go
@@ -26,6 +26,7 @@ import (
 
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/peer/abstractlist"
+	"go.uber.org/zap"
 )
 
 type listConfig struct {
@@ -34,6 +35,7 @@ type listConfig struct {
 	failFast bool
 	seed     int64
 	nextRand func(int) int
+	logger   *zap.Logger
 }
 
 var defaultListConfig = listConfig{
@@ -64,6 +66,13 @@ func Seed(seed int64) ListOption {
 	}
 }
 
+// Logger provides an optional logger for the list.
+func Logger(logger *zap.Logger) ListOption {
+	return func(c *listConfig) {
+		c.logger = logger
+	}
+}
+
 // FailFast indicates that the peer list should not wait for a peer to become
 // available when choosing a peer.
 //
@@ -84,6 +93,7 @@ func New(transport peer.Transport, opts ...ListOption) *List {
 
 	plOpts := []abstractlist.Option{
 		abstractlist.Capacity(cfg.capacity),
+		abstractlist.Logger(cfg.logger),
 	}
 	if !cfg.shuffle {
 		plOpts = append(plOpts, abstractlist.NoShuffle())

--- a/peer/pendingheap/list_test.go
+++ b/peer/pendingheap/list_test.go
@@ -42,6 +42,7 @@ import (
 	"go.uber.org/yarpc/transport/http"
 	"go.uber.org/yarpc/yarpcconfig"
 	"go.uber.org/yarpc/yarpcerrors"
+	"go.uber.org/zap/zaptest"
 )
 
 var (
@@ -649,11 +650,13 @@ func TestPeerHeapList(t *testing.T) {
 			ExpectPeerRetainsWithError(transport, tt.errRetainedPeerIDs, tt.retainErr)
 			ExpectPeerReleases(transport, tt.errReleasedPeerIDs, tt.releaseErr)
 
+			logger := zaptest.NewLogger(t)
+
 			randOption := DisableRandomInsertion()
 			if tt.nextRand != nil {
 				randOption = InsertionOrder(tt.nextRand)
 			}
-			opts := []ListOption{Capacity(0), noShuffle, randOption}
+			opts := []ListOption{Capacity(0), noShuffle, randOption, Logger(logger), Seed(0)}
 
 			pl := New(transport, opts...)
 


### PR DESCRIPTION
This change threads a logger dependency through to the abstract peer list from the fewest pending requests peer list. For config driven instantiation, this requires threading dependencies through the Spec constructor. Alas that we lacked the foresight to take variadic options there, as is the pattern established by transports.