### PR TITLE
Thread logger through round-robin list

### DIFF
--- a/peer/roundrobin/config.go
+++ b/peer/roundrobin/config.go
@@ -66,10 +66,17 @@ type Configuration struct {
 //    capacity: 1
 //    failFast: true
 func Spec() yarpcconfig.PeerListSpec {
+	return SpecWithOptions()
+}
+
+// SpecWithOptions accepts additional list constructor options.
+func SpecWithOptions(options ...ListOption) yarpcconfig.PeerListSpec {
 	return yarpcconfig.PeerListSpec{
 		Name: "round-robin",
 		BuildPeerList: func(cfg Configuration, t peer.Transport, k *yarpcconfig.Kit) (peer.ChooserList, error) {
-			opts := make([]ListOption, 0, 2)
+			opts := make([]ListOption, 0, len(options)+2)
+
+			opts = append(opts, options...)
 
 			if cfg.Capacity != nil {
 				if *cfg.Capacity <= 0 {

--- a/peer/roundrobin/list.go
+++ b/peer/roundrobin/list.go
@@ -25,6 +25,7 @@ import (
 
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/peer/abstractlist"
+	"go.uber.org/zap"
 )
 
 type listConfig struct {
@@ -32,6 +33,7 @@ type listConfig struct {
 	shuffle  bool
 	failFast bool
 	seed     int64
+	logger   *zap.Logger
 }
 
 var defaultListConfig = listConfig{
@@ -64,6 +66,13 @@ func FailFast() ListOption {
 	}
 }
 
+// Logger specifies a logger.
+func Logger(logger *zap.Logger) ListOption {
+	return func(c *listConfig) {
+		c.logger = logger
+	}
+}
+
 // New creates a new round robin peer list.
 func New(transport peer.Transport, opts ...ListOption) *List {
 	cfg := defaultListConfig
@@ -74,6 +83,9 @@ func New(transport peer.Transport, opts ...ListOption) *List {
 	plOpts := []abstractlist.Option{
 		abstractlist.Capacity(cfg.capacity),
 		abstractlist.Seed(cfg.seed),
+	}
+	if cfg.logger != nil {
+		plOpts = append(plOpts, abstractlist.Logger(cfg.logger))
 	}
 	if !cfg.shuffle {
 		plOpts = append(plOpts, abstractlist.NoShuffle())

--- a/peer/roundrobin/list_test.go
+++ b/peer/roundrobin/list_test.go
@@ -45,6 +45,7 @@ import (
 	"go.uber.org/yarpc/yarpcconfig"
 	"go.uber.org/yarpc/yarpcerrors"
 	"go.uber.org/yarpc/yarpctest"
+	"go.uber.org/zap/zaptest"
 )
 
 var (
@@ -901,7 +902,7 @@ func TestRoundRobinList(t *testing.T) {
 			ExpectPeerRetainsWithError(transport, tt.errRetainedPeerIDs, tt.retainErr)
 			ExpectPeerReleases(transport, tt.errReleasedPeerIDs, tt.releaseErr)
 
-			opts := []ListOption{seed(0)}
+			opts := []ListOption{seed(0), Logger(zaptest.NewLogger(t))}
 			if !tt.shuffle {
 				opts = append(opts, noShuffle)
 			}


### PR DESCRIPTION
This change threads a logger through the round robin peer list to the underlying abstract peer list.