### PR TITLE
Fix expected/actual order in list tests

### DIFF
--- a/peer/pendingheap/list_test.go
+++ b/peer/pendingheap/list_test.go
@@ -678,8 +678,8 @@ func TestPeerHeapList(t *testing.T) {
 			sort.Strings(availablePeers)
 			sort.Strings(unavailablePeers)
 
-			assert.Equal(t, availablePeers, tt.expectedAvailablePeers, "incorrect available peers")
-			assert.Equal(t, unavailablePeers, tt.expectedUnavailablePeers, "incorrect unavailable peers")
+			assert.Equal(t, tt.expectedAvailablePeers, availablePeers, "incorrect available peers")
+			assert.Equal(t, tt.expectedUnavailablePeers, unavailablePeers, "incorrect unavailable peers")
 			assert.Equal(t, tt.expectedRunning, pl.IsRunning(), "Peer list should match expected final running state")
 		})
 	}

--- a/peer/randpeer/list_test.go
+++ b/peer/randpeer/list_test.go
@@ -593,8 +593,8 @@ func TestRandPeer(t *testing.T) {
 			sort.Strings(availablePeers)
 			sort.Strings(unavailablePeers)
 
-			assert.Equal(t, availablePeers, tt.expectedAvailablePeers, "incorrect available peers")
-			assert.Equal(t, unavailablePeers, tt.expectedUnavailablePeers, "incorrect unavailable peers")
+			assert.Equal(t, tt.expectedAvailablePeers, availablePeers, "incorrect available peers")
+			assert.Equal(t, tt.expectedUnavailablePeers, unavailablePeers, "incorrect unavailable peers")
 			assert.Equal(t, tt.expectedRunning, pl.IsRunning(), "Peer list should match expected final running state")
 		})
 	}

--- a/peer/roundrobin/list_test.go
+++ b/peer/roundrobin/list_test.go
@@ -913,19 +913,19 @@ func TestRoundRobinList(t *testing.T) {
 			}
 			ApplyPeerListActions(t, pl, tt.peerListActions, deps)
 
-			assert.Equal(t, pl.NumAvailable(), len(tt.expectedAvailablePeers), "invalid available peerlist size")
+			assert.Equal(t, len(tt.expectedAvailablePeers), pl.NumAvailable(), "invalid available peerlist size")
 			for _, expectedRingPeer := range tt.expectedAvailablePeers {
 				ok := pl.Available(hostport.PeerIdentifier(expectedRingPeer))
 				assert.True(t, ok, fmt.Sprintf("expected peer: %s was not in available peerlist", expectedRingPeer))
 			}
 
-			assert.Equal(t, pl.NumUnavailable(), len(tt.expectedUnavailablePeers), "invalid unavailable peerlist size")
+			assert.Equal(t, len(tt.expectedUnavailablePeers), pl.NumUnavailable(), "invalid unavailable peerlist size")
 			for _, expectedUnavailablePeer := range tt.expectedUnavailablePeers {
 				ok := !pl.Available(hostport.PeerIdentifier(expectedUnavailablePeer))
 				assert.True(t, ok, fmt.Sprintf("expected peer: %s was not in unavailable peerlist", expectedUnavailablePeer))
 			}
 
-			assert.Equal(t, pl.NumUninitialized(), len(tt.expectedUninitializedPeers), "invalid uninitialized peerlist size")
+			assert.Equal(t, len(tt.expectedUninitializedPeers), pl.NumUninitialized(), "invalid uninitialized peerlist size")
 			for _, expectedUninitializedPeer := range tt.expectedUninitializedPeers {
 				ok := pl.Uninitialized(hostport.PeerIdentifier(expectedUninitializedPeer))
 				assert.True(t, ok, fmt.Sprintf("expected peer: %s was not in uninitialized peerlist", expectedUninitializedPeer))

--- a/peer/tworandomchoices/list_test.go
+++ b/peer/tworandomchoices/list_test.go
@@ -593,8 +593,8 @@ func TestTwoRandomChoicesPeer(t *testing.T) {
 			sort.Strings(availablePeers)
 			sort.Strings(unavailablePeers)
 
-			assert.Equal(t, availablePeers, tt.expectedAvailablePeers, "incorrect available peers")
-			assert.Equal(t, unavailablePeers, tt.expectedUnavailablePeers, "incorrect unavailable peers")
+			assert.Equal(t, tt.expectedAvailablePeers, availablePeers, "incorrect available peers")
+			assert.Equal(t, tt.expectedUnavailablePeers, unavailablePeers, "incorrect unavailable peers")
 			assert.Equal(t, tt.expectedRunning, pl.IsRunning(), "Peer list should match expected final running state")
 		})
 	}


### PR DESCRIPTION
While fixing a failing test, I noticed that expected and actual values were in places inverted.