### PR TITLE
Desynchronize peer list updates from retain/release

### DIFF
--- a/peer/abstractlist/list.go
+++ b/peer/abstractlist/list.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"sort"
 	"sync"
 	"time"
 
@@ -153,7 +152,7 @@ func New(name string, transport peer.Transport, implementation Implementation, o
 		name:               name,
 		logger:             logger,
 		peers:              make(map[string]*peerFacade, options.capacity),
-		offlinePeers:       make(map[string]peer.Identifier, options.capacity),
+		plans:              make(map[string]peer.Identifier, options.capacity),
 		implementation:     implementation,
 		transport:          transport,
 		noShuffle:          options.noShuffle,
@@ -180,21 +179,39 @@ func New(name string, transport peer.Transport, implementation Implementation, o
 // the transport about choices other peer lists that share the same peers have
 // made.
 type List struct {
-	lock sync.RWMutex
-	once *lifecycle.Once
-
 	name   string
 	logger *zap.Logger
 
+	once               *lifecycle.Once
+	lock               sync.RWMutex
 	peers              map[string]*peerFacade
-	offlinePeers       map[string]peer.Identifier
 	implementation     Implementation
 	peerAvailableEvent chan struct{}
 	transport          peer.Transport
 
+	updatesLock sync.RWMutex
+	plans       map[string]peer.Identifier
+	updates     []operation
+	recycle     []operation
+	started     bool
+	stopped     bool
+
 	noShuffle bool
 	failFast  bool
 	randSrc   rand.Source
+}
+
+type opCode byte
+
+const (
+	addCode opCode = iota + 1
+	removeCode
+	stopCode
+)
+
+type operation struct {
+	Code opCode
+	ID   peer.Identifier
 }
 
 // Name returns the name of the list.
@@ -226,107 +243,132 @@ func (pl *List) Update(updates peer.ListUpdates) error {
 		return nil
 	}
 
-	pl.lock.Lock()
-	defer pl.lock.Unlock()
-
-	if !pl.once.IsRunning() {
-		return pl.updateOffline(updates)
+	if err := pl.update(updates); err != nil {
+		return err
 	}
-	return pl.updateOnline(updates)
+
+	pl.notifyFlushNeeded()
+
+	return nil
 }
 
-// updateOnline must be run under a list lock.
-func (pl *List) updateOnline(updates peer.ListUpdates) error {
+func (pl *List) update(updates peer.ListUpdates) error {
+	// We can shuffle the additions before taking on the lock, to minimize the
+	// duration we hold the lock.
+	additions := updates.Additions
+	if !pl.noShuffle {
+		additions = shuffle(pl.randSrc, additions)
+	}
+
+	pl.updatesLock.Lock()
+	defer pl.updatesLock.Unlock()
+
 	var errs error
 	for _, id := range updates.Removals {
 		errs = multierr.Append(errs, pl.remove(id))
 	}
-
-	add := updates.Additions
-	if !pl.noShuffle {
-		add = shuffle(pl.randSrc, add)
-	}
-
-	for _, id := range add {
+	for _, id := range additions {
 		errs = multierr.Append(errs, pl.add(id))
 	}
+
 	return errs
 }
 
-// updateOffline must be run under a list lock.
-func (pl *List) updateOffline(updates peer.ListUpdates) error {
-	var errs error
-	for _, id := range updates.Removals {
-		errs = multierr.Append(errs, pl.removeOffline(id))
+func (pl *List) remove(id peer.Identifier) error {
+	addr := id.Identifier()
+
+	_, ok := pl.plans[addr]
+	if !ok {
+		return peer.ErrPeerRemoveNotInList(addr)
 	}
-	for _, id := range updates.Additions {
-		errs = multierr.Append(errs, pl.addOffline(id))
-	}
-	return errs
+
+	delete(pl.plans, addr)
+
+	pl.updates = append(pl.updates, operation{
+		Code: removeCode,
+		ID:   id,
+	})
+
+	pl.logger.Debug("enqueue peer to remove", zap.String("address", addr))
+
+	return nil
 }
 
-// Start notifies the List that requests will start coming
-func (pl *List) Start() error {
-	return pl.once.Start(pl.start)
-}
-
-func (pl *List) start() error {
-	pl.lock.Lock()
-	defer pl.lock.Unlock()
-
-	all := pl.offlinePeerIdentifiers()
-
-	var err error
-	err = multierr.Append(err, pl.updateOffline(peer.ListUpdates{
-		Removals: all,
-	}))
-	err = multierr.Append(err, pl.updateOnline(peer.ListUpdates{
-		Additions: all,
-	}))
-	return err
-}
-
-// Stop notifies the List that requests will stop coming
-func (pl *List) Stop() error {
-	return pl.once.Stop(pl.stop)
-}
-
-func (pl *List) stop() error {
-	pl.lock.Lock()
-	defer pl.lock.Unlock()
-
-	all := pl.onlinePeerIdentifiers()
-
-	var err error
-	err = multierr.Append(err, pl.updateOnline(peer.ListUpdates{
-		Removals: all,
-	}))
-	err = multierr.Append(err, pl.updateOffline(peer.ListUpdates{
-		Additions: all,
-	}))
-	return err
-}
-
-// IsRunning returns whether the peer list is running.
-func (pl *List) IsRunning() bool {
-	return pl.once.IsRunning()
-}
-
-// add retains a peer and sets up a facade (a thin proxy for a peer) to receive
-// connection status notifications from the dialer and track pending request
-// counts.
-//
-// add does not add the peer to the list of peers available for choosing (the
-// Implementation).
-// The facade is responsible for adding and removing the peer from the
-// collection of available peers based on connection status notifications.
-//
-// add must be run inside a list lock.
+// addOffline must be run under a list lock.
 func (pl *List) add(id peer.Identifier) error {
 	addr := id.Identifier()
 
-	if _, ok := pl.peers[addr]; ok {
+	if _, ok := pl.plans[addr]; ok {
 		return peer.ErrPeerAddAlreadyInList(addr)
+	}
+
+	pl.plans[addr] = id
+
+	pl.updates = append(pl.updates, operation{
+		Code: addCode,
+		ID:   id,
+	})
+
+	pl.logger.Debug("enqueue peer to add", zap.String("address", addr))
+
+	return nil
+}
+
+// notifyFlushNeeded must not be called while holding the update queue lock nor the
+// list lock.
+func (pl *List) notifyFlushNeeded() {
+	// TODO or when AutoFlush is enabled for tests.
+	if pl.once.IsRunning() {
+		pl.Flush()
+	}
+}
+
+// Flush effects all enqueued updates synchronously and should only be used to
+// synchronize tests.
+func (pl *List) Flush() {
+	pl.updatesLock.Lock()
+	defer pl.updatesLock.Unlock()
+
+	pl.lock.Lock()
+	defer pl.lock.Unlock()
+
+	if pl.stopped {
+		return
+	}
+
+	for _, op := range pl.updates {
+		switch op.Code {
+		case addCode:
+			pl.doAdd(op.ID)
+		case removeCode:
+			pl.doRemove(op.ID)
+		case stopCode:
+			pl.doStop()
+			pl.stopped = true
+			return
+		}
+	}
+
+	// Clear updates, retain all prior allocated capacity.
+	pl.updates = pl.updates[0:0]
+}
+
+// doAdd retains a peer and sets up a facade (a thin proxy for a peer)
+// to receive connection status notifications from the dialer and track pending
+// request counts.
+//
+// doAdd does not add the peer to the list of peers available for
+// choosing (the Implementation).
+// The facade is responsible for adding and removing the peer from the
+// collection of available peers based on connection status notifications.
+//
+// doAdd must be run inside a list lock.
+func (pl *List) doAdd(id peer.Identifier) {
+	addr := id.Identifier()
+
+	if _, ok := pl.peers[addr]; ok {
+		pl.logger.DPanic("assertion error: adding peer that is already present", zap.String("address", addr))
+		return
 	}
 
 	pf := &peerFacade{list: pl, id: id}
@@ -335,37 +377,27 @@ func (pl *List) add(id peer.Identifier) error {
 	// The transport must not call back before returning.
 	p, err := pl.transport.RetainPeer(id, pf)
 	if err != nil {
-		return err
+		pl.logger.DPanic("error retaining peer for peer list", zap.Error(err))
+		return
 	}
 
 	pf.peer = p
 	pl.peers[addr] = pf
 	pl.notifyStatusChanged(pf)
 
-	return nil
+	pl.logger.Debug("added peer", zap.String("address", addr))
 }
 
-// addOffline must be run under a list lock.
-func (pl *List) addOffline(id peer.Identifier) error {
-	addr := id.Identifier()
-
-	if _, ok := pl.offlinePeers[addr]; ok {
-		return peer.ErrPeerAddAlreadyInList(addr)
-	}
-
-	pl.offlinePeers[addr] = id
-	return nil
-}
-
-// remove releases and forgets a peer.
+// doRemove releases and forgets a peer.
 //
-// remove must be run under a list lock.
-func (pl *List) remove(id peer.Identifier) error {
+// doRemove must be run under a list lock.
+func (pl *List) doRemove(id peer.Identifier) {
 	addr := id.Identifier()
 
 	pf, ok := pl.peers[addr]
 	if !ok {
-		return peer.ErrPeerRemoveNotInList(addr)
+		pl.logger.DPanic("assertion error: removing peer that is currently absent", zap.String("address", addr))
+		return
 	}
 
 	if pf.status.ConnectionStatus == peer.Available {
@@ -376,21 +408,63 @@ func (pl *List) remove(id peer.Identifier) error {
 
 	delete(pl.peers, addr)
 
+	pl.logger.Debug("removed peer", zap.String("address", addr))
+
 	// The transport must not call back before returning.
-	return pl.transport.ReleasePeer(id, pf)
+	if err := pl.transport.ReleasePeer(id, pf); err != nil {
+		pl.logger.DPanic("error releasing peer for peer list", zap.Error(err))
+	}
 }
 
-func (pl *List) removeOffline(id peer.Identifier) error {
-	addr := id.Identifier()
-
-	_, ok := pl.offlinePeers[addr]
-	if !ok {
-		return peer.ErrPeerRemoveNotInList(addr)
+func (pl *List) doStop() {
+	for _, peer := range pl.peers {
+		pl.doRemove(peer)
 	}
+}
 
-	delete(pl.offlinePeers, addr)
+// Start notifies the List that requests will start coming
+func (pl *List) Start() error {
+	return pl.once.Start(pl.start)
+}
 
+func (pl *List) start() error {
+	pl.logger.Debug("starting peer list")
+
+	// TODO flush in goroutine
+	pl.Flush()
+
+	pl.logger.Debug("started peer list")
 	return nil
+}
+
+// Stop notifies the List that requests will stop coming
+func (pl *List) Stop() error {
+	return pl.once.Stop(pl.stop)
+}
+
+func (pl *List) stop() error {
+	pl.logger.Debug("stopping peer list")
+	pl.stopUpdates()
+
+	// TODO flush conditionally
+	pl.Flush()
+
+	pl.logger.Debug("stopped peer list")
+	return nil
+}
+
+func (pl *List) stopUpdates() {
+	pl.updatesLock.Lock()
+	defer pl.updatesLock.Unlock()
+
+	pl.updates = append(pl.updates, operation{
+		Code: stopCode,
+	})
+}
+
+// IsRunning returns whether the peer list is running.
+func (pl *List) IsRunning() bool {
+	return pl.once.IsRunning()
 }
 
 // Choose selects the next available peer in the peer list.
@@ -575,15 +649,6 @@ func (pl *List) NumUnavailable() int {
 	return pl.countPeersWithStatus(peer.Unavailable)
 }
 
-// NumUninitialized returns how many peers are unavailable because the peer
-// list was stopped or has not yet started.
-func (pl *List) NumUninitialized() int {
-	pl.lock.RLock()
-	defer pl.lock.RUnlock()
-
-	return len(pl.offlinePeers)
-}
-
 // Available returns whether the identifier peer is available for traffic.
 func (pl *List) Available(pid peer.Identifier) bool {
 	pl.lock.RLock()
@@ -593,15 +658,6 @@ func (pl *List) Available(pid peer.Identifier) bool {
 		return pf.status.ConnectionStatus == peer.Available
 	}
 	return false
-}
-
-// Uninitialized returns whether the identifier peer is present but uninitialized.
-func (pl *List) Uninitialized(pid peer.Identifier) bool {
-	pl.lock.RLock()
-	defer pl.lock.RUnlock()
-
-	_, exists := pl.offlinePeers[pid.Identifier()]
-	return exists
 }
 
 // Peers returns a snapshot of all retained (available and unavailable) peers.
@@ -614,39 +670,6 @@ func (pl *List) Peers() []peer.StatusPeer {
 		peers = append(peers, pf.peer)
 	}
 	return peers
-}
-
-func (pl *List) onlinePeerIdentifiers() []peer.Identifier {
-	// This is not duplicate code with offlinePeerIdentifiers, as it traverses
-	// peers instead of offlinePeers.
-	addrs := make([]string, 0, len(pl.peers))
-	for addr := range pl.peers {
-		addrs = append(addrs, addr)
-	}
-	sort.Strings(addrs)
-
-	ids := make([]peer.Identifier, len(addrs))
-	for i, addr := range addrs {
-		ids[i] = pl.peers[addr].peer
-	}
-	return ids
-}
-
-func (pl *List) offlinePeerIdentifiers() []peer.Identifier {
-	// This is not duplicate code with offlinePeerIdentifiers, as it traverses
-	// offlinePeers instead of onlinePeers.
-	addrs := make([]string, 0, len(pl.offlinePeers))
-	for addr := range pl.offlinePeers {
-		addrs = append(addrs, addr)
-	}
-	sort.Strings(addrs)
-
-	ids := make([]peer.Identifier, len(addrs))
-	for i, addr := range addrs {
-		id := pl.offlinePeers[addr]
-		ids[i] = id
-	}
-	return ids
 }
 
 // Introspect returns a ChooserStatus with a summary of the Peers.

--- a/peer/abstractlist/list_test.go
+++ b/peer/abstractlist/list_test.go
@@ -139,7 +139,13 @@ func TestPeerList(t *testing.T) {
 	impl := &mraList{}
 	core, log := observer.New(zap.DebugLevel)
 	logger := zap.New(core)
-	list := New("mra", fake, impl, Capacity(1), NoShuffle(), Seed(0), Logger(logger))
+	list := New("mra", fake, impl,
+		Capacity(1),
+		AutoFlush(),
+		NoShuffle(),
+		Seed(0),
+		Logger(logger),
+	)
 
 	ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
 	defer cancel()
@@ -249,7 +255,7 @@ func TestPeerList(t *testing.T) {
 func TestFailWait(t *testing.T) {
 	fake := yarpctest.NewFakeTransport(yarpctest.InitialConnectionStatus(peer.Available))
 	impl := &mraList{}
-	list := New("mra", fake, impl)
+	list := New("mra", fake, impl, AutoFlush())
 
 	require.NoError(t, list.Start())
 
@@ -296,7 +302,7 @@ func TestFailWait(t *testing.T) {
 func TestFailFast(t *testing.T) {
 	fake := yarpctest.NewFakeTransport(yarpctest.InitialConnectionStatus(peer.Unavailable))
 	impl := &mraList{}
-	list := New("mra", fake, impl, FailFast())
+	list := New("mra", fake, impl, FailFast(), AutoFlush())
 
 	ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
 	defer cancel()
@@ -311,7 +317,7 @@ func TestFailFast(t *testing.T) {
 func TestIntrospect(t *testing.T) {
 	fake := yarpctest.NewFakeTransport(yarpctest.InitialConnectionStatus(peer.Unavailable))
 	impl := &mraList{}
-	list := New("mra", fake, impl, FailFast())
+	list := New("mra", fake, impl, FailFast(), AutoFlush())
 
 	assert.Equal(t, introspection.ChooserStatus{
 		Name:  "mra",
@@ -372,7 +378,7 @@ func TestIntrospect(t *testing.T) {
 func TestWaitForNeverStarted(t *testing.T) {
 	fake := yarpctest.NewFakeTransport(yarpctest.InitialConnectionStatus(peer.Unavailable))
 	impl := &mraList{}
-	list := New("mra", fake, impl, FailFast())
+	list := New("mra", fake, impl, FailFast(), AutoFlush())
 
 	ctx, cancel := context.WithTimeout(context.Background(), 0)
 	defer cancel()

--- a/peer/abstractlist/list_test.go
+++ b/peer/abstractlist/list_test.go
@@ -52,6 +52,7 @@ func values(m map[string]peer.Identifier) []peer.Identifier {
 	}
 	return vs
 }
+
 func TestValues(t *testing.T) {
 	vs := values(map[string]peer.Identifier{})
 	assert.Equal(t, []peer.Identifier{}, vs)
@@ -175,9 +176,7 @@ func TestPeerList(t *testing.T) {
 
 	assert.Equal(t, 0, list.NumAvailable())
 	assert.Equal(t, 0, list.NumUnavailable())
-	assert.Equal(t, 2, list.NumUninitialized())
 	assert.False(t, list.Available(abstractpeer.Identify("2.2.2.2:4040")))
-	assert.True(t, list.Uninitialized(abstractpeer.Identify("2.2.2.2:4040")))
 
 	require.NoError(t, list.Start())
 
@@ -185,9 +184,7 @@ func TestPeerList(t *testing.T) {
 	fake.SimulateConnect(abstractpeer.Identify("2.2.2.2:4040"))
 	assert.Equal(t, 1, list.NumAvailable())
 	assert.Equal(t, 1, list.NumUnavailable())
-	assert.Equal(t, 0, list.NumUninitialized())
 	assert.True(t, list.Available(abstractpeer.Identify("2.2.2.2:4040")))
-	assert.False(t, list.Uninitialized(abstractpeer.Identify("2.2.2.2:4040")))
 	peers = list.Peers()
 	assert.Len(t, peers, 2)
 	p, onFinish, err := list.Choose(ctx, &transport.Request{})
@@ -200,7 +197,6 @@ func TestPeerList(t *testing.T) {
 	fake.SimulateConnect(abstractpeer.Identify("1.1.1.1:4040"))
 	assert.Equal(t, 2, list.NumAvailable())
 	assert.Equal(t, 0, list.NumUnavailable())
-	assert.Equal(t, 0, list.NumUninitialized())
 	peers = list.Peers()
 	assert.Len(t, peers, 2)
 	p, onFinish, err = list.Choose(ctx, &transport.Request{})

--- a/peer/pendingheap/list.go
+++ b/peer/pendingheap/list.go
@@ -30,12 +30,13 @@ import (
 )
 
 type listConfig struct {
-	capacity int
-	shuffle  bool
-	failFast bool
-	seed     int64
-	nextRand func(int) int
-	logger   *zap.Logger
+	capacity  int
+	shuffle   bool
+	failFast  bool
+	autoFlush bool
+	seed      int64
+	nextRand  func(int) int
+	logger    *zap.Logger
 }
 
 var defaultListConfig = listConfig{
@@ -100,6 +101,9 @@ func New(transport peer.Transport, opts ...ListOption) *List {
 	}
 	if cfg.failFast {
 		plOpts = append(plOpts, abstractlist.FailFast())
+	}
+	if cfg.autoFlush {
+		plOpts = append(plOpts, abstractlist.AutoFlush())
 	}
 
 	nextRandFn := nextRand(cfg.seed)

--- a/peer/pendingheap/list_test.go
+++ b/peer/pendingheap/list_test.go
@@ -525,7 +525,7 @@ func TestPeerHeapList(t *testing.T) {
 			if tt.nextRand != nil {
 				randOption = InsertionOrder(tt.nextRand)
 			}
-			opts := []ListOption{Capacity(0), noShuffle, randOption, Logger(logger), Seed(0)}
+			opts := []ListOption{Capacity(0), noShuffle, autoFlush, randOption, Logger(logger), Seed(0)}
 
 			pl := New(transport, opts...)
 
@@ -556,6 +556,10 @@ func TestPeerHeapList(t *testing.T) {
 
 var noShuffle ListOption = func(c *listConfig) {
 	c.shuffle = false
+}
+
+var autoFlush ListOption = func(c *listConfig) {
+	c.autoFlush = true
 }
 
 func TestFailFastConfig(t *testing.T) {

--- a/peer/pendingheap/list_test.go
+++ b/peer/pendingheap/list_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/multierr"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/peer"
 	. "go.uber.org/yarpc/api/peer/peertest"
@@ -98,14 +97,6 @@ func TestPeerHeapList(t *testing.T) {
 
 		// PeerIDs that will be released from the transport
 		releasedPeerIDs []string
-
-		// PeerIDs that will return "retainErr" from the transport's OnRetain function
-		errRetainedPeerIDs []string
-		retainErr          error
-
-		// PeerIDs that will return "releaseErr" from the transport's OnRelease function
-		errReleasedPeerIDs []string
-		releaseErr         error
 
 		// A list of actions that will be applied on the PeerList
 		peerListActions []PeerListAction
@@ -225,87 +216,6 @@ func TestPeerHeapList(t *testing.T) {
 			expectedRunning: false,
 		},
 		{
-			msg:                "update retain error",
-			errRetainedPeerIDs: []string{"1"},
-			retainErr:          peer.ErrInvalidPeerType{},
-			peerListActions: []PeerListAction{
-				StartAction{},
-				UpdateAction{AddedPeerIDs: []string{"1"}, ExpectedErr: peer.ErrInvalidPeerType{}},
-			},
-			expectedRunning: true,
-		},
-		{
-			msg:                      "update retain multiple errors",
-			retainedAvailablePeerIDs: []string{"2"},
-			errRetainedPeerIDs:       []string{"1", "3"},
-			retainErr:                peer.ErrInvalidPeerType{},
-			peerListActions: []PeerListAction{
-				StartAction{},
-				UpdateAction{
-					AddedPeerIDs: []string{"1", "2", "3"},
-					ExpectedErr:  multierr.Combine(peer.ErrInvalidPeerType{}, peer.ErrInvalidPeerType{}),
-				},
-			},
-			expectedAvailablePeers: []string{"2"},
-			expectedRunning:        true,
-		},
-		{
-			msg:                      "start stop release error",
-			retainedAvailablePeerIDs: []string{"1"},
-			errReleasedPeerIDs:       []string{"1"},
-			releaseErr:               peer.ErrTransportHasNoReferenceToPeer{},
-			peerListActions: []PeerListAction{
-				StartAction{},
-				UpdateAction{AddedPeerIDs: []string{"1"}},
-				StopAction{
-					ExpectedErr: peer.ErrTransportHasNoReferenceToPeer{},
-				},
-			},
-			expectedRunning: false,
-		},
-		{
-			msg:                      "assure stop is idempotent",
-			retainedAvailablePeerIDs: []string{"1"},
-			errReleasedPeerIDs:       []string{"1"},
-			releaseErr:               peer.ErrTransportHasNoReferenceToPeer{},
-			peerListActions: []PeerListAction{
-				StartAction{},
-				UpdateAction{AddedPeerIDs: []string{"1"}},
-				ConcurrentAction{
-					Actions: []PeerListAction{
-						StopAction{
-							ExpectedErr: peer.ErrTransportHasNoReferenceToPeer{},
-						},
-						StopAction{
-							ExpectedErr: peer.ErrTransportHasNoReferenceToPeer{},
-						},
-						StopAction{
-							ExpectedErr: peer.ErrTransportHasNoReferenceToPeer{},
-						},
-					},
-				},
-			},
-			expectedRunning: false,
-		},
-		{
-			msg:                      "start stop release multiple errors",
-			retainedAvailablePeerIDs: []string{"1", "2", "3"},
-			releasedPeerIDs:          []string{"2"},
-			errReleasedPeerIDs:       []string{"1", "3"},
-			releaseErr:               peer.ErrTransportHasNoReferenceToPeer{},
-			peerListActions: []PeerListAction{
-				StartAction{},
-				UpdateAction{AddedPeerIDs: []string{"1", "2", "3"}},
-				StopAction{
-					ExpectedErr: multierr.Combine(
-						peer.ErrTransportHasNoReferenceToPeer{},
-						peer.ErrTransportHasNoReferenceToPeer{},
-					),
-				},
-			},
-			expectedRunning: false,
-		},
-		{
 			msg: "choose before start",
 			peerListActions: []PeerListAction{
 				ChooseAction{
@@ -395,25 +305,6 @@ func TestPeerHeapList(t *testing.T) {
 			expectedRunning: true,
 		},
 		{
-			msg:                      "add retain error",
-			retainedAvailablePeerIDs: []string{"1", "2"},
-			expectedAvailablePeers:   []string{"1", "2"},
-			errRetainedPeerIDs:       []string{"3"},
-			retainErr:                peer.ErrInvalidPeerType{},
-			peerListActions: []PeerListAction{
-				StartAction{},
-				UpdateAction{AddedPeerIDs: []string{"1", "2"}},
-				UpdateAction{
-					AddedPeerIDs: []string{"3"},
-					ExpectedErr:  peer.ErrInvalidPeerType{},
-				},
-				ChooseAction{ExpectedPeer: "1"},
-				ChooseAction{ExpectedPeer: "2"},
-				ChooseAction{ExpectedPeer: "1"},
-			},
-			expectedRunning: true,
-		},
-		{
 			msg:                      "add duplicate peer",
 			retainedAvailablePeerIDs: []string{"1", "2"},
 			expectedAvailablePeers:   []string{"1", "2"},
@@ -443,24 +334,6 @@ func TestPeerHeapList(t *testing.T) {
 				},
 				ChooseAction{ExpectedPeer: "1"},
 				ChooseAction{ExpectedPeer: "2"},
-				ChooseAction{ExpectedPeer: "1"},
-			},
-			expectedRunning: true,
-		},
-		{
-			msg:                      "remove release error",
-			retainedAvailablePeerIDs: []string{"1", "2"},
-			errReleasedPeerIDs:       []string{"2"},
-			releaseErr:               peer.ErrTransportHasNoReferenceToPeer{},
-			expectedAvailablePeers:   []string{"1"},
-			peerListActions: []PeerListAction{
-				StartAction{},
-				UpdateAction{AddedPeerIDs: []string{"1", "2"}},
-				UpdateAction{
-					RemovedPeerIDs: []string{"2"},
-					ExpectedErr:    peer.ErrTransportHasNoReferenceToPeer{},
-				},
-				ChooseAction{ExpectedPeer: "1"},
 				ChooseAction{ExpectedPeer: "1"},
 			},
 			expectedRunning: true,
@@ -645,10 +518,6 @@ func TestPeerHeapList(t *testing.T) {
 				tt.retainedUnavailablePeerIDs,
 			)
 			ExpectPeerReleases(transport, tt.releasedPeerIDs, nil)
-
-			// Unhealthy Transport Retain/Release
-			ExpectPeerRetainsWithError(transport, tt.errRetainedPeerIDs, tt.retainErr)
-			ExpectPeerReleases(transport, tt.errReleasedPeerIDs, tt.releaseErr)
 
 			logger := zaptest.NewLogger(t)
 

--- a/peer/randpeer/list.go
+++ b/peer/randpeer/list.go
@@ -30,10 +30,11 @@ import (
 )
 
 type listOptions struct {
-	capacity int
-	source   rand.Source
-	failFast bool
-	logger   *zap.Logger
+	capacity  int
+	source    rand.Source
+	failFast  bool
+	autoFlush bool
+	logger    *zap.Logger
 }
 
 var defaultListOptions = listOptions{
@@ -112,6 +113,9 @@ func New(transport peer.Transport, opts ...ListOption) *List {
 	}
 	if options.failFast {
 		plOpts = append(plOpts, abstractlist.FailFast())
+	}
+	if options.autoFlush {
+		plOpts = append(plOpts, abstractlist.AutoFlush())
 	}
 
 	return &List{

--- a/peer/randpeer/list_test.go
+++ b/peer/randpeer/list_test.go
@@ -48,6 +48,10 @@ var (
 	_noContextDeadlineError = yarpcerrors.Newf(yarpcerrors.CodeInvalidArgument, `"random" peer list can't wait for peer without a context deadline`)
 )
 
+var autoFlush ListOption = listOptionFunc(func(c *listOptions) {
+	c.autoFlush = true
+})
+
 func newNotRunningError(err string) error {
 	return yarpcerrors.FailedPreconditionErrorf(`"random" peer list is not running: %s`, err)
 }
@@ -444,7 +448,7 @@ func TestRandPeer(t *testing.T) {
 			ExpectPeerReleases(transport, tt.releasedPeerIDs, nil)
 
 			logger := zaptest.NewLogger(t)
-			pl := New(transport, Seed(0), Logger(logger))
+			pl := New(transport, Seed(0), autoFlush, Logger(logger))
 
 			deps := ListActionDeps{
 				Peers: peerMap,

--- a/peer/randpeer/list_test.go
+++ b/peer/randpeer/list_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/multierr"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/peer"
 	. "go.uber.org/yarpc/api/peer/peertest"
@@ -69,14 +68,6 @@ func TestRandPeer(t *testing.T) {
 
 		// PeerIDs that will be released from the transport
 		releasedPeerIDs []string
-
-		// PeerIDs that will return "retainErr" from the transport's OnRetain function
-		errRetainedPeerIDs []string
-		retainErr          error
-
-		// PeerIDs that will return "releaseErr" from the transport's OnRelease function
-		errReleasedPeerIDs []string
-		releaseErr         error
 
 		// A list of actions that will be applied on the PeerList
 		peerListActions []PeerListAction
@@ -196,87 +187,6 @@ func TestRandPeer(t *testing.T) {
 			expectedRunning: false,
 		},
 		{
-			msg:                "update retain error",
-			errRetainedPeerIDs: []string{"1"},
-			retainErr:          peer.ErrInvalidPeerType{},
-			peerListActions: []PeerListAction{
-				StartAction{},
-				UpdateAction{AddedPeerIDs: []string{"1"}, ExpectedErr: peer.ErrInvalidPeerType{}},
-			},
-			expectedRunning: true,
-		},
-		{
-			msg:                      "update retain multiple errors",
-			retainedAvailablePeerIDs: []string{"2"},
-			errRetainedPeerIDs:       []string{"1", "3"},
-			retainErr:                peer.ErrInvalidPeerType{},
-			peerListActions: []PeerListAction{
-				StartAction{},
-				UpdateAction{
-					AddedPeerIDs: []string{"1", "2", "3"},
-					ExpectedErr:  multierr.Combine(peer.ErrInvalidPeerType{}, peer.ErrInvalidPeerType{}),
-				},
-			},
-			expectedAvailablePeers: []string{"2"},
-			expectedRunning:        true,
-		},
-		{
-			msg:                      "start stop release error",
-			retainedAvailablePeerIDs: []string{"1"},
-			errReleasedPeerIDs:       []string{"1"},
-			releaseErr:               peer.ErrTransportHasNoReferenceToPeer{},
-			peerListActions: []PeerListAction{
-				StartAction{},
-				UpdateAction{AddedPeerIDs: []string{"1"}},
-				StopAction{
-					ExpectedErr: peer.ErrTransportHasNoReferenceToPeer{},
-				},
-			},
-			expectedRunning: false,
-		},
-		{
-			msg:                      "assure stop is idempotent",
-			retainedAvailablePeerIDs: []string{"1"},
-			errReleasedPeerIDs:       []string{"1"},
-			releaseErr:               peer.ErrTransportHasNoReferenceToPeer{},
-			peerListActions: []PeerListAction{
-				StartAction{},
-				UpdateAction{AddedPeerIDs: []string{"1"}},
-				ConcurrentAction{
-					Actions: []PeerListAction{
-						StopAction{
-							ExpectedErr: peer.ErrTransportHasNoReferenceToPeer{},
-						},
-						StopAction{
-							ExpectedErr: peer.ErrTransportHasNoReferenceToPeer{},
-						},
-						StopAction{
-							ExpectedErr: peer.ErrTransportHasNoReferenceToPeer{},
-						},
-					},
-				},
-			},
-			expectedRunning: false,
-		},
-		{
-			msg:                      "start stop release multiple errors",
-			retainedAvailablePeerIDs: []string{"1", "2", "3"},
-			releasedPeerIDs:          []string{"2"},
-			errReleasedPeerIDs:       []string{"1", "3"},
-			releaseErr:               peer.ErrTransportHasNoReferenceToPeer{},
-			peerListActions: []PeerListAction{
-				StartAction{},
-				UpdateAction{AddedPeerIDs: []string{"1", "2", "3"}},
-				StopAction{
-					ExpectedErr: multierr.Combine(
-						peer.ErrTransportHasNoReferenceToPeer{},
-						peer.ErrTransportHasNoReferenceToPeer{},
-					),
-				},
-			},
-			expectedRunning: false,
-		},
-		{
 			msg: "choose before start",
 			peerListActions: []PeerListAction{
 				ChooseAction{
@@ -344,22 +254,6 @@ func TestRandPeer(t *testing.T) {
 			expectedRunning: true,
 		},
 		{
-			msg:                      "add retain error",
-			retainedAvailablePeerIDs: []string{"1", "2"},
-			expectedAvailablePeers:   []string{"1", "2"},
-			errRetainedPeerIDs:       []string{"3"},
-			retainErr:                peer.ErrInvalidPeerType{},
-			peerListActions: []PeerListAction{
-				StartAction{},
-				UpdateAction{AddedPeerIDs: []string{"1", "2"}},
-				UpdateAction{
-					AddedPeerIDs: []string{"3"},
-					ExpectedErr:  peer.ErrInvalidPeerType{},
-				},
-			},
-			expectedRunning: true,
-		},
-		{
 			msg:                      "add duplicate peer",
 			retainedAvailablePeerIDs: []string{"1", "2"},
 			expectedAvailablePeers:   []string{"1", "2"},
@@ -390,24 +284,6 @@ func TestRandPeer(t *testing.T) {
 				ChooseAction{ExpectedPeer: "1"},
 				ChooseAction{ExpectedPeer: "1"},
 				ChooseAction{ExpectedPeer: "2"},
-			},
-			expectedRunning: true,
-		},
-		{
-			msg:                      "remove release error",
-			retainedAvailablePeerIDs: []string{"1", "2"},
-			errReleasedPeerIDs:       []string{"2"},
-			releaseErr:               peer.ErrTransportHasNoReferenceToPeer{},
-			expectedAvailablePeers:   []string{"1"},
-			peerListActions: []PeerListAction{
-				StartAction{},
-				UpdateAction{AddedPeerIDs: []string{"1", "2"}},
-				UpdateAction{
-					RemovedPeerIDs: []string{"2"},
-					ExpectedErr:    peer.ErrTransportHasNoReferenceToPeer{},
-				},
-				ChooseAction{ExpectedPeer: "1"},
-				ChooseAction{ExpectedPeer: "1"},
 			},
 			expectedRunning: true,
 		},
@@ -566,10 +442,6 @@ func TestRandPeer(t *testing.T) {
 				tt.retainedUnavailablePeerIDs,
 			)
 			ExpectPeerReleases(transport, tt.releasedPeerIDs, nil)
-
-			// Unhealthy Transport Retain/Release
-			ExpectPeerRetainsWithError(transport, tt.errRetainedPeerIDs, tt.retainErr)
-			ExpectPeerReleases(transport, tt.errReleasedPeerIDs, tt.releaseErr)
 
 			logger := zaptest.NewLogger(t)
 			pl := New(transport, Seed(0), Logger(logger))

--- a/peer/roundrobin/list.go
+++ b/peer/roundrobin/list.go
@@ -29,11 +29,12 @@ import (
 )
 
 type listConfig struct {
-	capacity int
-	shuffle  bool
-	failFast bool
-	seed     int64
-	logger   *zap.Logger
+	capacity  int
+	shuffle   bool
+	failFast  bool
+	seed      int64
+	autoFlush bool
+	logger    *zap.Logger
 }
 
 var defaultListConfig = listConfig{
@@ -92,6 +93,9 @@ func New(transport peer.Transport, opts ...ListOption) *List {
 	}
 	if cfg.failFast {
 		plOpts = append(plOpts, abstractlist.FailFast())
+	}
+	if cfg.autoFlush {
+		plOpts = append(plOpts, abstractlist.AutoFlush())
 	}
 
 	return &List{

--- a/peer/roundrobin/list_test.go
+++ b/peer/roundrobin/list_test.go
@@ -755,7 +755,7 @@ func TestRoundRobinList(t *testing.T) {
 			)
 			ExpectPeerReleases(transport, tt.releasedPeerIDs, nil)
 
-			opts := []ListOption{seed(0), Logger(zaptest.NewLogger(t))}
+			opts := []ListOption{seed(0), autoFlush, Logger(zaptest.NewLogger(t))}
 			if !tt.shuffle {
 				opts = append(opts, noShuffle)
 			}
@@ -843,6 +843,10 @@ func checkPeerStatus(
 
 var noShuffle ListOption = func(c *listConfig) {
 	c.shuffle = false
+}
+
+var autoFlush ListOption = func(c *listConfig) {
+	c.autoFlush = true
 }
 
 func seed(seed int64) ListOption {

--- a/peer/tworandomchoices/list.go
+++ b/peer/tworandomchoices/list.go
@@ -30,10 +30,11 @@ import (
 )
 
 type listOptions struct {
-	capacity int
-	source   rand.Source
-	failFast bool
-	logger   *zap.Logger
+	capacity  int
+	source    rand.Source
+	failFast  bool
+	autoFlush bool
+	logger    *zap.Logger
 }
 
 var defaultListOptions = listOptions{
@@ -113,6 +114,9 @@ func New(transport peer.Transport, opts ...ListOption) *List {
 	}
 	if options.failFast {
 		plOpts = append(plOpts, abstractlist.FailFast())
+	}
+	if options.autoFlush {
+		plOpts = append(plOpts, abstractlist.AutoFlush())
 	}
 
 	return &List{

--- a/peer/tworandomchoices/list_test.go
+++ b/peer/tworandomchoices/list_test.go
@@ -44,6 +44,10 @@ import (
 	"go.uber.org/zap/zaptest"
 )
 
+var autoFlush ListOption = listOptionFunc(func(c *listOptions) {
+	c.autoFlush = true
+})
+
 var (
 	_noContextDeadlineError = yarpcerrors.Newf(yarpcerrors.CodeInvalidArgument, `"two-random-choices" peer list can't wait for peer without a context deadline`)
 )
@@ -444,7 +448,7 @@ func TestTwoRandomChoicesPeer(t *testing.T) {
 			ExpectPeerReleases(transport, tt.releasedPeerIDs, nil)
 
 			logger := zaptest.NewLogger(t)
-			pl := New(transport, Seed(0), Logger(logger))
+			pl := New(transport, Seed(0), autoFlush, Logger(logger))
 
 			deps := ListActionDeps{
 				Peers: peerMap,


### PR DESCRIPTION
This is a change in two commits.

1. Alter the abstract peer list such that the Update method creates a plan of changes to the list. A new Flush method executes the plan. Because planning changes is now decoupled from executing changes, the Update method can no longer propagate Retain/Release Peer errors, so these are logged.
2. The second change introduces a flusher goroutine and de-synchronizes Update from Flush. Operations accumulate until the flusher executes them in batches.

If there is a transport or list bug that causes a deadlock, the old failure mode was that Update would block. The new failure mode is that the peer list will accumulate pending operations until the instance runs out of memory. Choices still can’t be executed.

This change is proposed for consideration. The alternative approach to mitigating the consequences of deadlock would be to asynchronously debounce updates before they arrive at the peer list. This requires some further consideration since the differential updater is not part of the OSS YARPC and conflates concerns about what constitutes a change in a logical peer, including health state changes, which at this time do not surface in the YARPC API. We may need to consider both how to extend the YARPC API to differentiate healthy from unhealthy logical peers, allow for the possibility of trying unhealthy peers if healthy peers are not available, and also how to debounce updates. Alternately, we can try to be satisfied with a debouncer that is not possible to open the source for.