### PR TITLE
Increase HTTP default timeout to > 5 seconds

### DIFF
--- a/transport/http/inbound.go
+++ b/transport/http/inbound.go
@@ -36,7 +36,13 @@ import (
 	"go.uber.org/zap"
 )
 
-const defaultShutdownTimeout = 5 * time.Second
+// We want a value that's around 5 seconds, but slightly higher than how
+// long a successful HTTP shutdown can take.
+// There's a specific path in the HTTP shutdown path that can take 5 seconds:
+// https://golang.org/src/net/http/server.go?s=83923:83977#L2710
+// This avoids timeouts in shutdown caused by new idle connections, without
+// making the timeout too large.
+const defaultShutdownTimeout = 6 * time.Second
 
 // InboundOption customizes the behavior of an HTTP Inbound constructed with
 // NewInbound.


### PR DESCRIPTION
This avoids flaky failures caused by the http Server.Shutdown taking
more than 5 seconds in the specific case of a new idle connection.

Ref: T4471621