### PR TITLE
http: Close idle connections when transport is closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   transports to reduce the liklihood of deadlocks.
 - Increase default HTTP timeout to avoid stop timeout errors when the server
   has a new idle connection.
+- Close idle connections when the transport is closed.
 
 ## [1.42.0] - 2019-10-31 (Spooky)
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Simplified the flow of status change notifications for the gRPC and TChannel
   transports to reduce the liklihood of deadlocks.
+- Increase default HTTP timeout to avoid stop timeout errors when the server
+  has a new idle connection.
 
 ## [1.42.0] - 2019-10-31 (Spooky)
 ### Added

--- a/transport/http/close_idle_go112.go
+++ b/transport/http/close_idle_go112.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// +build go1.12
+
+package http
+
+import "net/http"
+
+// Once YARPC only supports Go1.12+, we can inline this into the callers.
+func closeIdleConnections(client *http.Client) {
+	client.CloseIdleConnections()
+}

--- a/transport/http/close_idle_pre_go112.go
+++ b/transport/http/close_idle_pre_go112.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// +build !go1.12
+
+package http
+
+import "net/http"
+
+func closeIdleConnections(client *http.Client) {}

--- a/transport/http/transport.go
+++ b/transport/http/transport.go
@@ -306,7 +306,7 @@ func (a *Transport) Start() error {
 // Stop stops the HTTP transport.
 func (a *Transport) Stop() error {
 	return a.once.Stop(func() error {
-		a.client.CloseIdleConnections()
+		closeIdleConnections(a.client)
 		a.connectorsGroup.Wait()
 		return nil
 	})

--- a/transport/http/transport.go
+++ b/transport/http/transport.go
@@ -306,6 +306,7 @@ func (a *Transport) Start() error {
 // Stop stops the HTTP transport.
 func (a *Transport) Stop() error {
 	return a.once.Stop(func() error {
+		a.client.CloseIdleConnections()
 		a.connectorsGroup.Wait()
 		return nil
 	})


### PR DESCRIPTION
http: Close idle connections when transport is closed

Even after a HTTP transport is closed, we leave idle connections around.
Closing idle connections can avoid issues that #1850 tries to avoid.

Ref: T4471621
