### PR TITLE
gRPC transport supports streaming

### DIFF
--- a/transport/grpc/doc.go
+++ b/transport/grpc/doc.go
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 // Package grpc implements a YARPC transport based on the gRPC protocol.
-// The gRPC transport provides support for Unary RPCs only.
+// The gRPC transport provides support for unary and streaming RPCs.
 //
 // Usage
 //


### PR DESCRIPTION
This change addresses a stale comment in the gRPC transport package doc.