### PR TITLE
Add codec to the ServerStream to avoid panic

### DIFF
--- a/encoding/protobuf/inbound.go
+++ b/encoding/protobuf/inbound.go
@@ -123,6 +123,7 @@ func (s *streamHandler) HandleStream(stream *transport.ServerStream) error {
 	protoStream := &ServerStream{
 		ctx:    ctx,
 		stream: stream,
+		codec:  s.codec,
 	}
 	return convertToYARPCError(transportRequest.Meta.Encoding, s.handle(protoStream), s.codec)
 }

--- a/encoding/protobuf/inbound_test.go
+++ b/encoding/protobuf/inbound_test.go
@@ -111,3 +111,31 @@ func TestInboundAnyResolver(t *testing.T) {
 		})
 	}
 }
+
+func TestNewStreamHandlerHasAllFieldsSet(t *testing.T){
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	stream := transporttest.NewMockStreamCloser(mockCtrl)
+	stream.EXPECT().Context().Return(context.Background())
+	stream.EXPECT().Request().Return(
+		&transport.StreamRequest{
+			Meta: &transport.RequestMeta{
+				Encoding: JSONEncoding,
+			},
+		},
+	)
+
+	serverStream, err := transport.NewServerStream(stream)
+
+	f := func(stream *ServerStream) error{
+		assert.NotNil(t, stream.codec)
+		assert.NotNil(t, stream.stream)
+		assert.NotNil(t, stream.ctx)
+		return nil
+	}
+	streamHandler := NewStreamHandler(StreamHandlerParams{Handle:f})
+
+	err = streamHandler.HandleStream(serverStream)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
When the HandleStream is invoked I have been getting panics from unmarshalling (line 85 in marshal.go) because no codec has been set on the ServerStream. Setting the codec on the ServerStream seems to resolve the issue.
