### PR TITLE
Fix log level for EOF stream messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   peer.Chooser, or for the private introspection interface.
 ### Fixed
 - Fixed Streaming Protobuf-flavored-JSON nil pointer panic.
+- Log entries for EOF stream messages are now considered successes to avoid
+  setting off false alarms.
+  The successful log entries still carry the "error" field, which will reflect
+  the EOF error.
 
 ## [1.42.1] - 2019-11-27 (Gobble)
 ### Fixed

--- a/internal/observability/stream.go
+++ b/internal/observability/stream.go
@@ -22,6 +22,7 @@ package observability
 
 import (
 	"context"
+	"io"
 
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/zap"
@@ -80,7 +81,7 @@ func (c call) WrapServerStream(stream *transport.ServerStream) *transport.Server
 
 func (s *streamWrapper) SendMessage(ctx context.Context, msg *transport.StreamMessage) error {
 	err := s.StreamCloser.SendMessage(ctx, msg)
-	s.call.logStreamEvent(err, _successfulStreamSend, _errorStreamSend)
+	s.call.logStreamEvent(err, err == nil, _successfulStreamSend, _errorStreamSend)
 
 	s.edge.sends.Inc()
 	if err == nil {
@@ -98,7 +99,11 @@ func (s *streamWrapper) SendMessage(ctx context.Context, msg *transport.StreamMe
 
 func (s *streamWrapper) ReceiveMessage(ctx context.Context) (*transport.StreamMessage, error) {
 	msg, err := s.StreamCloser.ReceiveMessage(ctx)
-	s.call.logStreamEvent(err, _successfulStreamReceive, _errorStreamReceive)
+	// Receiving EOF does not constitute an error for the purposes of metrics and alerts.
+	// This is the only special case.
+	// All other log events treat EOF as an error, including when sending a
+	// message or concluding a handshake.
+	s.call.logStreamEvent(err, err == nil || err == io.EOF, _successfulStreamReceive, _errorStreamReceive)
 
 	s.edge.receives.Inc()
 	if err == nil {


### PR DESCRIPTION
Previously, EOF messages would get logged as errors.  These EOF errors are now treated as successes for the purposes of logging, to avoid setting off false alarms.  However, the log message will still carry the "error" field so users can see the EOF.

- [x] Entry in CHANGELOG.md