### PR TITLE
Compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- gRPC now supports compression.
+  The packages `compressor/gzip` and `compressor/snappy` provide
+  compressors accepted by the gRPC `Compressor` dialer option.
 - Observability middleware now emits metrics for panics that occur on the stack
   of an inbound call handler.
 - The `transporttest` package now provides a `Pipe` constructor, which creates

--- a/api/transport/compression.go
+++ b/api/transport/compression.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package transport
+
+import "io"
+
+// Compressor represents a compression strategy and supports creating new
+// compression and decompression streams for that strategy.
+//
+// This interface is equivalent to the compressor API proposed by grpc-go.
+// https://godoc.org/google.golang.org/grpc/encoding#Compressor
+type Compressor interface {
+	Name() string
+	Compress(w io.Writer) (io.WriteCloser, error)
+	Decompress(r io.Reader) (io.Reader, error)
+}

--- a/compressor/gzip/gzip.go
+++ b/compressor/gzip/gzip.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package gzip provides a YARPC binding for gzip compression.
+package gzip
+
+import (
+	"compress/gzip"
+	"io"
+
+	"go.uber.org/yarpc/api/transport"
+)
+
+// Compressor represents the gzip compression strategy.
+type Compressor struct{}
+
+var _ transport.Compressor = Compressor{}
+
+// Name is gzip.
+func (Compressor) Name() string {
+	return "gzip"
+}
+
+// Compress creates a gzip compressor.
+func (Compressor) Compress(w io.Writer) (io.WriteCloser, error) {
+	return gzip.NewWriter(w), nil
+}
+
+// Decompress creates a gzip decompressor.
+func (Compressor) Decompress(r io.Reader) (io.Reader, error) {
+	return gzip.NewReader(r)
+}

--- a/compressor/gzip/gzip_test.go
+++ b/compressor/gzip/gzip_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package gzip_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/compressor/gzip"
+)
+
+func TestGzip(t *testing.T) {
+	input := []byte("Now is the time for all good men to come to the aid of their country")
+
+	buf := bytes.NewBuffer(nil)
+	writer, err := gzip.Compressor{}.Compress(buf)
+	require.NoError(t, err)
+
+	_, err = writer.Write(input)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	str, err := gzip.Compressor{}.Decompress(buf)
+	require.NoError(t, err)
+
+	output, err := ioutil.ReadAll(str)
+	require.NoError(t, err)
+
+	assert.Equal(t, input, output)
+}
+
+func TestGzipName(t *testing.T) {
+	assert.Equal(t, "gzip", gzip.Compressor{}.Name())
+}

--- a/compressor/snappy/snappy.go
+++ b/compressor/snappy/snappy.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package snappy provides a YARPC binding for snappy compression.
+//
+// To use snappy with gzip in particular, you will need to
+// register the Compressor with grpc-go, the underlying implementation
+// of gRPC which makes extensive use of global variables for
+// depencencies.
+//
+//  import (
+//      "google.golang.org/grpc/encoding"
+//      "go.uber.org/yarpc/compressor/snappy"
+//  )
+//  encoding.RegisterCompressor(snappy.Compressor)
+//
+// If you are constructing your YARPC clients directly through the API,
+// create a gRPC dialer with the Compressor option.
+//
+//  trans := grpc.NewTransport()
+//  dialer := trans.NewDialer(grpc.Compressor(snappy.Compressor))
+//  peers := roundrobin.New(dialer)
+//  outbound := trans.NewOutbound(peers)
+//
+// If you are using the YARPC configurator to create YARPC objects
+// using config files, you will also need to register the compressor
+// with your configurator.
+//
+//  configurator := yarpcconfig.New()
+//  configurator.MustRegisterCompressor(snappy.Compressor)
+//
+// Then, using the compression strategy for outbound requests
+// on a particular client, just set the compressor to snappy.
+//
+//  outbounds:
+//    theirsecureservice:
+//      grpc:
+//        address: ":443"
+//        tls:
+//          enabled: true
+//        compressor: snappy
+package snappy
+
+import (
+	"io"
+
+	"github.com/golang/snappy"
+	"go.uber.org/yarpc/api/transport"
+)
+
+// Compressor represents the snappy streaming compression strategy.
+type Compressor struct{}
+
+var _ transport.Compressor = Compressor{}
+
+// Name is snappy.
+func (Compressor) Name() string {
+	return "snappy"
+}
+
+// Compress creates a snappy compressor.
+func (Compressor) Compress(w io.Writer) (io.WriteCloser, error) {
+	return snappy.NewBufferedWriter(w), nil
+}
+
+// Decompress creates a snappy decompressor.
+func (Compressor) Decompress(r io.Reader) (io.Reader, error) {
+	return snappy.NewReader(r), nil
+}

--- a/compressor/snappy/snappy_test.go
+++ b/compressor/snappy/snappy_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package snappy_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/compressor/snappy"
+)
+
+func TestSnappy(t *testing.T) {
+	input := []byte("Now is the time for all good men to come to the aid of their country")
+
+	buf := bytes.NewBuffer(nil)
+	writer, err := snappy.Compressor{}.Compress(buf)
+	require.NoError(t, err)
+
+	_, err = writer.Write(input)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	str, err := snappy.Compressor{}.Decompress(buf)
+	require.NoError(t, err)
+
+	output, err := ioutil.ReadAll(str)
+	require.NoError(t, err)
+
+	assert.Equal(t, input, output)
+}
+
+func TestSnappyName(t *testing.T) {
+	assert.Equal(t, "snappy", snappy.Compressor{}.Name())
+}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/gogo/status v1.1.0
 	github.com/golang/mock v1.4.0
 	github.com/golang/protobuf v1.3.3
+	github.com/golang/snappy v0.0.1
 	github.com/google/go-cmp v0.4.0 // indirect
 	github.com/kisielk/errcheck v1.2.0
 	github.com/kr/pretty v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/golang/protobuf v1.3.3-0.20190920234318-1680a479a2cf h1:NOIjU7Y++Ccl6
 github.com/golang/protobuf v1.3.3-0.20190920234318-1680a479a2cf/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/golang/protobuf v1.3.3 h1:gyjaxf+svBWX08ZjK86iN9geUJF0H6gp2IRKX6Nf6/I=
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
+github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
+github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=

--- a/transport/grpc/config.go
+++ b/transport/grpc/config.go
@@ -150,6 +150,7 @@ func (c InboundTLSConfig) newInboundCredentials() (credentials.TransportCredenti
 //        address: ":443"
 //        tls:
 //          enabled: true
+//        compressor: gzip
 //
 type OutboundConfig struct {
 	yarpcconfig.PeerChooser
@@ -157,10 +158,12 @@ type OutboundConfig struct {
 	// Address to connect to if no peer options set.
 	Address string            `config:"address,interpolate"`
 	TLS     OutboundTLSConfig `config:"tls"`
+	// Compressor to use by default if the server side supports it
+	Compressor string `config:"compressor"`
 }
 
 func (c OutboundConfig) dialOptions() []DialOption {
-	return c.TLS.dialOptions()
+	return append(c.TLS.dialOptions(), Compressor(c.Compressor))
 }
 
 // OutboundTLSConfig configures TLS for a gRPC outbound.

--- a/transport/grpc/config.go
+++ b/transport/grpc/config.go
@@ -162,8 +162,10 @@ type OutboundConfig struct {
 	Compressor string `config:"compressor"`
 }
 
-func (c OutboundConfig) dialOptions() []DialOption {
-	return append(c.TLS.dialOptions(), Compressor(c.Compressor))
+func (c OutboundConfig) dialOptions(kit *yarpcconfig.Kit) []DialOption {
+	opts := c.TLS.dialOptions()
+	opts = append(opts, Compressor(kit.Compressor(c.Compressor)))
+	return opts
 }
 
 // OutboundTLSConfig configures TLS for a gRPC outbound.
@@ -258,7 +260,7 @@ func (t *transportSpec) buildOutbound(outboundConfig *OutboundConfig, tr transpo
 		return nil, newTransportCastError(tr)
 	}
 
-	dialer := trans.NewDialer(outboundConfig.dialOptions()...)
+	dialer := trans.NewDialer(outboundConfig.dialOptions(kit)...)
 
 	var chooser peer.Chooser
 	if outboundConfig.Empty() {

--- a/transport/grpc/config_test.go
+++ b/transport/grpc/config_test.go
@@ -44,37 +44,37 @@ func TestNewTransportSpecOptions(t *testing.T) {
 
 func TestConfigBuildInboundOtherTransport(t *testing.T) {
 	transportSpec := &transportSpec{}
-	_, err := transportSpec.buildInbound(&InboundConfig{}, testTransport{}, nil)
+	_, err := transportSpec.buildInbound(&InboundConfig{}, testTransport{}, _kit)
 	require.Equal(t, newTransportCastError(testTransport{}), err)
 }
 
 func TestConfigBuildInboundRequiredAddress(t *testing.T) {
 	transportSpec := &transportSpec{}
-	_, err := transportSpec.buildInbound(&InboundConfig{}, NewTransport(), nil)
+	_, err := transportSpec.buildInbound(&InboundConfig{}, NewTransport(), _kit)
 	require.Equal(t, newRequiredFieldMissingError("address"), err)
 }
 
 func TestConfigBuildUnaryOutboundOtherTransport(t *testing.T) {
 	transportSpec := &transportSpec{}
-	_, err := transportSpec.buildUnaryOutbound(&OutboundConfig{}, testTransport{}, nil)
+	_, err := transportSpec.buildUnaryOutbound(&OutboundConfig{}, testTransport{}, _kit)
 	require.Equal(t, newTransportCastError(testTransport{}), err)
 }
 
 func TestConfigBuildUnaryOutboundRequiredAddress(t *testing.T) {
 	transportSpec := &transportSpec{}
-	_, err := transportSpec.buildUnaryOutbound(&OutboundConfig{}, NewTransport(), nil)
+	_, err := transportSpec.buildUnaryOutbound(&OutboundConfig{}, NewTransport(), _kit)
 	require.Equal(t, newRequiredFieldMissingError("address"), err)
 }
 
 func TestConfigBuildStreamOutboundOtherTransport(t *testing.T) {
 	transportSpec := &transportSpec{}
-	_, err := transportSpec.buildStreamOutbound(&OutboundConfig{}, testTransport{}, nil)
+	_, err := transportSpec.buildStreamOutbound(&OutboundConfig{}, testTransport{}, _kit)
 	require.Equal(t, newTransportCastError(testTransport{}), err)
 }
 
 func TestConfigBuildStreamOutboundRequiredAddress(t *testing.T) {
 	transportSpec := &transportSpec{}
-	_, err := transportSpec.buildStreamOutbound(&OutboundConfig{}, NewTransport(), nil)
+	_, err := transportSpec.buildStreamOutbound(&OutboundConfig{}, NewTransport(), _kit)
 	require.Equal(t, newRequiredFieldMissingError("address"), err)
 }
 

--- a/transport/grpc/config_test.go
+++ b/transport/grpc/config_test.go
@@ -95,8 +95,9 @@ func TestTransportSpec(t *testing.T) {
 	}
 
 	type wantOutbound struct {
-		Address string
-		TLS     bool
+		Address    string
+		TLS        bool
+		Compressor string
 	}
 
 	type test struct {
@@ -139,6 +140,23 @@ func TestTransportSpec(t *testing.T) {
 			wantOutbounds: map[string]wantOutbound{
 				"myservice": {
 					Address: "localhost:54569",
+				},
+			},
+		},
+		{
+			desc: "simple outbound with compressor",
+			outboundCfg: attrs{
+				"myservice": attrs{
+					transportName: attrs{
+						"address":    "localhost:54569",
+						"compressor": "gzip",
+					},
+				},
+			},
+			wantOutbounds: map[string]wantOutbound{
+				"myservice": {
+					Address:    "localhost:54569",
+					Compressor: "gzip",
 				},
 			},
 		},

--- a/transport/grpc/globals_for_test.go
+++ b/transport/grpc/globals_for_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package grpc
+
+import (
+	"go.uber.org/yarpc/yarpcconfig"
+	"google.golang.org/grpc/encoding"
+)
+
+// Shared global state for tests, because sadly grpc-go uses global state for
+// compressor registration.
+
+var _metrics = newMetrics(nil, nil)
+
+var (
+	_goodCompressor  = newCompressor("test-good", testCompressorOk, _metrics)
+	_badCompressor   = newCompressor("test-fail-comp", testCompressorFailToCompress, _metrics)
+	_badDecompressor = newCompressor("test-fail-decomp", testCompressorFailToDecompress, _metrics)
+	_gzipCompressor  = newCompressor("test-gzip", testCompressorGzip, _metrics)
+)
+
+var _configurator = yarpcconfig.New()
+
+var _kit = _configurator.Kit("test")
+
+func init() {
+	compressors := []*testCompressor{
+		_goodCompressor,
+		_badCompressor,
+		_badDecompressor,
+		_gzipCompressor,
+	}
+	for _, compressor := range compressors {
+		encoding.RegisterCompressor(compressor)
+	}
+}

--- a/transport/grpc/integration_test.go
+++ b/transport/grpc/integration_test.go
@@ -41,6 +41,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	gogostatus "github.com/gogo/status"
+	"github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/multierr"
@@ -64,7 +65,11 @@ import (
 
 func TestYARPCBasic(t *testing.T) {
 	t.Parallel()
-	te := testEnvOptions{}
+	te := testEnvOptions{
+		TransportOptions: []TransportOption{
+			Tracer(opentracing.NoopTracer{}),
+		},
+	}
 	te.do(t, func(t *testing.T, e *testEnv) {
 		_, err := e.GetValueYARPC(context.Background(), "foo")
 		assert.Equal(t, yarpcerrors.Newf(yarpcerrors.CodeNotFound, "foo"), err)

--- a/transport/grpc/options.go
+++ b/transport/grpc/options.go
@@ -205,9 +205,6 @@ func newTransportOptions(options []TransportOption) *transportOptions {
 	if transportOptions.tracer == nil {
 		transportOptions.tracer = opentracing.GlobalTracer()
 	}
-	if transportOptions.tracer == nil {
-		transportOptions.tracer = opentracing.NoopTracer{}
-	}
 	return transportOptions
 }
 

--- a/transport/grpc/options.go
+++ b/transport/grpc/options.go
@@ -27,6 +27,7 @@ import (
 
 	opentracing "github.com/opentracing/opentracing-go"
 	"go.uber.org/yarpc/api/backoff"
+	"go.uber.org/yarpc/api/transport"
 	intbackoff "go.uber.org/yarpc/internal/backoff"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -166,9 +167,14 @@ func ContextDialer(f func(context.Context, string) (net.Conn, error)) DialOption
 }
 
 // Compressor sets the compressor to be used by default for gRPC connections
-func Compressor(compressor string) DialOption {
+func Compressor(compressor transport.Compressor) DialOption {
 	return func(dialOptions *dialOptions) {
-		dialOptions.defaultCompressor = compressor
+		if compressor != nil {
+			// We assume that the grpc-go compressor was also globally
+			// registered and just use the name.
+			// Future implementations may elect to actually use the compressor.
+			dialOptions.defaultCompressor = compressor.Name()
+		}
 	}
 }
 

--- a/yarpcconfig/configurator.go
+++ b/yarpcconfig/configurator.go
@@ -29,6 +29,7 @@ import (
 
 	"go.uber.org/multierr"
 	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/config"
 	"go.uber.org/yarpc/internal/interpolate"
 	"gopkg.in/yaml.v2"
@@ -45,6 +46,7 @@ type Configurator struct {
 	knownPeerChoosers     map[string]*compiledPeerChooserSpec
 	knownPeerLists        map[string]*compiledPeerListSpec
 	knownPeerListUpdaters map[string]*compiledPeerListUpdaterSpec
+	knownCompressors      map[string]transport.Compressor
 	resolver              interpolate.VariableResolver
 }
 
@@ -56,6 +58,7 @@ func New(opts ...Option) *Configurator {
 		knownPeerChoosers:     make(map[string]*compiledPeerChooserSpec),
 		knownPeerLists:        make(map[string]*compiledPeerListSpec),
 		knownPeerListUpdaters: make(map[string]*compiledPeerListUpdaterSpec),
+		knownCompressors:      make(map[string]transport.Compressor),
 		resolver:              os.LookupEnv,
 	}
 
@@ -204,6 +207,23 @@ func (c *Configurator) MustRegisterPeerListUpdater(s PeerListUpdaterSpec) {
 	}
 }
 
+// RegisterCompressor registers the given Compressor for the configurator, so
+// any transport can use the given compression strategy.
+func (c *Configurator) RegisterCompressor(z transport.Compressor) error {
+	if c.knownCompressors[z.Name()] != nil {
+		return fmt.Errorf("compressor already registered on configurator for name %q", z.Name())
+	}
+	c.knownCompressors[z.Name()] = z
+	return nil
+}
+
+// MustRegisterCompressor registers the given compressor or panics.
+func (c *Configurator) MustRegisterCompressor(z transport.Compressor) {
+	if err := c.RegisterCompressor(z); err != nil {
+		panic(err)
+	}
+}
+
 // LoadConfigFromYAML loads a yarpc.Config from YAML data. Use LoadConfig if
 // you have already parsed a map[string]interface{} or
 // map[interface{}]interface{}.
@@ -252,8 +272,18 @@ func (c *Configurator) NewDispatcher(serviceName string, data interface{}) (*yar
 	return yarpc.NewDispatcher(cfg), nil
 }
 
+// Kit creates a dependency kit for the configurator, suitable for passing to
+// spec builder functions.
+func (c *Configurator) Kit(serviceName string) *Kit {
+	return &Kit{
+		name:     serviceName,
+		c:        c,
+		resolver: c.resolver,
+	}
+}
+
 func (c *Configurator) load(serviceName string, cfg *yarpcConfig) (_ yarpc.Config, err error) {
-	b := newBuilder(serviceName, &Kit{name: serviceName, c: c, resolver: c.resolver})
+	b := newBuilder(serviceName, c.Kit(serviceName))
 
 	for _, inbound := range cfg.Inbounds {
 		if e := c.loadInboundInto(b, inbound); e != nil {

--- a/yarpcconfig/kit.go
+++ b/yarpcconfig/kit.go
@@ -27,6 +27,7 @@ import (
 	"sort"
 	"strings"
 
+	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/interpolate"
 )
 
@@ -119,4 +120,10 @@ func (k *Kit) peerListUpdaterSpecNames() (names []string) {
 	}
 	sort.Strings(names)
 	return
+}
+
+// Compressor returns the known compressor for the given name or nil if the
+// named compressor is not known.
+func (k *Kit) Compressor(name string) transport.Compressor {
+	return k.c.knownCompressors[name]
 }


### PR DESCRIPTION
This introduces compression schemes generally, and implements them specifically for the gRPC transport. The change includes a compressor for both snappy and gzip, a gRPC dialer option, and a gRPC compressor configuration field.

Supersedes #1825, so that @abhinav and @AlexAPB can also modify the contents of the branch.