### PR TITLE
Consistent hashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - gRPC now supports compression.
   The packages `compressor/gzip` and `compressor/snappy` provide
   compressors accepted by the gRPC `Compressor` dialer option.
+- The `peer/hashring32` package now provides support for consistent hashing
+  that is compatible with RingPop hash ring topologies.
+  This peer selection strategy uses the `ShardKey` call option to
+  pin traffic to an arbitrary peer that is relatively stable as the peer list
+  membership changes.
 - Observability middleware now emits metrics for panics that occur on the stack
   of an inbound call handler.
 - The `transporttest` package now provides a `Pipe` constructor, which creates

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,9 @@ go 1.13
 require (
 	github.com/apache/thrift v0.13.0 // indirect
 	github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b // indirect
+	github.com/cactus/go-statsd-client/statsd v0.0.0-20191106001114-12b4e2b38748 // indirect
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
+	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13
 	github.com/fatih/structtag v1.2.0 // indirect
 	github.com/gogo/googleapis v1.3.2
 	github.com/gogo/protobuf v1.3.1
@@ -27,10 +29,12 @@ require (
 	github.com/streadway/quantile v0.0.0-20150917103942-b0c588724d25 // indirect
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/stretchr/testify v1.4.0
+	github.com/uber-common/bark v1.2.1 // indirect
 	github.com/uber-go/mapdecode v1.0.0
 	github.com/uber-go/tally v3.3.15+incompatible
 	github.com/uber/jaeger-client-go v2.22.1+incompatible
 	github.com/uber/jaeger-lib v2.2.0+incompatible // indirect
+	github.com/uber/ringpop-go v0.8.5
 	github.com/uber/tchannel-go v1.16.0
 	go.uber.org/atomic v1.5.1
 	go.uber.org/fx v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,9 @@ github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b h1:AP/Y7sqYicnjGDfD5VcY4CIfh1hRXBUavxrvELjTiOE=
 github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b/go.mod h1:ac9efd0D1fsDb3EJvhqgXRbFx7bs2wqZ10HQPeU8U/Q=
+github.com/cactus/go-statsd-client v3.2.0+incompatible h1:ZJpQV7zHnerDzsEQS1wnI38tpR7wX3QFmL7WzTerEmY=
+github.com/cactus/go-statsd-client/statsd v0.0.0-20191106001114-12b4e2b38748 h1:bXxS5/Z3/dfc8iFniQfgogNBomo0u+1//9eP+jl8GVo=
+github.com/cactus/go-statsd-client/statsd v0.0.0-20191106001114-12b4e2b38748/go.mod h1:l/bIBLeOl9eX+wxJAzxS4TveKRtAqlyDpHjhkfO0MEI=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd h1:qMd81Ts1T2OTKmB4acZcyKaMtRnY5Y44NuXGX2GFJ1w=
@@ -18,6 +21,8 @@ github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13 h1:fAjc9m62+UWV/WAFKLNi6ZS0675eEUC9y3AlwSbQu1Y=
+github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/structtag v1.0.0/go.mod h1:IKitwq45uXL/yqi5mYghiD3w9H6eTOvI9vnk8tXMphA=
@@ -122,6 +127,7 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/samuel/go-thrift v0.0.0-20191111193933-5165175b40af h1:EiWVfh8mr40yFZEui2oF0d45KgH48PkB2H0Z0GANvSI=
 github.com/samuel/go-thrift v0.0.0-20191111193933-5165175b40af/go.mod h1:Vrkh1pnjV9Bl8c3P9zH0/D4NlOHWP5d4/hF4YTULaec=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
+github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/streadway/quantile v0.0.0-20150917103942-b0c588724d25 h1:7z3LSn867ex6VSaahyKadf4WtSsJIgne6A1WLOAGM8A=
 github.com/streadway/quantile v0.0.0-20150917103942-b0c588724d25/go.mod h1:lbP8tGiBjZ5YWIc2fzuRpTaz0b/53vT6PEs3QuAWzuU=
@@ -135,6 +141,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/uber-common/bark v1.2.1 h1:cREJ9b7CpTjwZr0/5wV82fXlitoCIEHHnt9WkQ4lIk0=
+github.com/uber-common/bark v1.2.1/go.mod h1:g0ZuPcD7XiExKHynr93Q742G/sbrdVQkghrqLGOoFuY=
 github.com/uber-go/mapdecode v1.0.0 h1:euUEFM9KnuCa1OBixz1xM+FIXmpixyay5DLymceOVrU=
 github.com/uber-go/mapdecode v1.0.0/go.mod h1:b5nP15FwXTgpjTjeA9A2uTHXV5UJCl4arwKpP0FP1Hw=
 github.com/uber-go/tally v3.3.12+incompatible/go.mod h1:YDTIBxdXyOU/sCWilKB4bgyufu1cEi0jdVnRdxvjnmU=
@@ -144,6 +152,8 @@ github.com/uber/jaeger-client-go v2.22.1+incompatible h1:NHcubEkVbahf9t3p75TOCR8
 github.com/uber/jaeger-client-go v2.22.1+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.2.0+incompatible h1:MxZXOiR2JuoANZ3J6DE/U0kSFv/eJ/GfSYVCjK7dyaw=
 github.com/uber/jaeger-lib v2.2.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
+github.com/uber/ringpop-go v0.8.5 h1:aBa/SHmmFRcAXA63k7uBheoTL8tCmH7L+OgktB1AF/o=
+github.com/uber/ringpop-go v0.8.5/go.mod h1:zVI6eGO6L7pG14GkntHsSOfmUAWQ7B4lvmzly4IT4ls=
 github.com/uber/tchannel-go v1.16.0 h1:B7dirDs15/vJJYDeoHpv3xaEUjuRZ38Rvt1qq9g7pSo=
 github.com/uber/tchannel-go v1.16.0/go.mod h1:Rrgz1eL8kMjW/nEzZos0t+Heq0O4LhnUJVA32OvWKHo=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=

--- a/peer/hashring32/config.go
+++ b/peer/hashring32/config.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package hashring32
+
+import (
+	"go.uber.org/net/metrics"
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/peer/hashring32/internal/farmhashring"
+	"go.uber.org/yarpc/yarpcconfig"
+	"go.uber.org/zap"
+)
+
+// Config is the configuration object for hashring32yarpc
+type Config struct {
+	// OffsetHeader allows clients to pass in a header to adjust to offset value
+	// in the Choose function.
+	OffsetHeader string `config:"offsetHeader"`
+
+	// PeerOverrideHeader allows clients to pass a header containing the shard
+	// identifier for a specific peer to override the destination address for
+	// the outgoing request.
+	//
+	// For example, if the peer list uses addresses to identify peers,
+	// the hash ring will have retained a peer for every known address.
+	// Specifying an address like "127.0.0.1" in the route override header will
+	// deflect the request to that exact peer.
+	// If that peer is not available, the request will continue on to the peer
+	// implied by the shard key.
+	PeerOverrideHeader string `config:"peerOverrideHeader"`
+
+	ReplicaDelimiter string `config:"replicaDelimiter"`
+}
+
+// Spec returns a configuration specification for the hashed peer list
+// implementation, making it possible to select peer based on a specified hashing
+// function.
+func Spec(logger *zap.Logger, meter *metrics.Scope) yarpcconfig.PeerListSpec {
+	// TODO thread meter thorugh list options to abstract list metrics.
+
+	return yarpcconfig.PeerListSpec{
+		Name: "hashring32",
+		BuildPeerList: func(c Config, t peer.Transport, k *yarpcconfig.Kit) (peer.ChooserList, error) {
+			return New(
+				t,
+				farmhashring.Fingerprint32,
+				OffsetHeader(c.OffsetHeader),
+				ReplicaDelimiter(c.ReplicaDelimiter),
+				PeerOverrideHeader(c.PeerOverrideHeader),
+				Logger(logger),
+			), nil
+		},
+	}
+}

--- a/peer/hashring32/config_test.go
+++ b/peer/hashring32/config_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package hashring32
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/peer/hostport"
+	"go.uber.org/yarpc/yarpcconfig"
+	"go.uber.org/yarpc/yarpctest"
+)
+
+func TestPendingHeapConfig(t *testing.T) {
+	s := Spec(nil, nil)
+	c := Config{
+		OffsetHeader:     "offsetHeader",
+		ReplicaDelimiter: "#",
+	}
+	build := s.BuildPeerList.(func(c Config, t peer.Transport, k *yarpcconfig.Kit) (peer.ChooserList, error))
+	pl, err := build(c, yarpctest.NewFakeTransport(), nil)
+	assert.NoError(t, err, "must construct a peer list")
+	pl.Update(peer.ListUpdates{Additions: []peer.Identifier{hostport.PeerIdentifier("127.0.0.1:8080")}})
+}

--- a/peer/hashring32/internal/farmhashring/fingerprint32.go
+++ b/peer/hashring32/internal/farmhashring/fingerprint32.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package farmhashring provides a Farmhash shard function.
+package farmhashring
+
+import farm "github.com/dgryski/go-farm"
+
+// Fingerprint32 returns a farmhash 32 bit fingerprint, suitable
+// for use when constructing a hashring32 HashFunc.
+func Fingerprint32(shardKey string) uint32 {
+	return farm.Fingerprint32([]byte(shardKey))
+}

--- a/peer/hashring32/internal/farmhashring/fingerprint32_test.go
+++ b/peer/hashring32/internal/farmhashring/fingerprint32_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package farmhashring
+
+import "testing"
+
+func TestFringerprint32(t *testing.T) {
+	Fingerprint32("please cover this one line of code")
+}

--- a/peer/hashring32/internal/hashring32/hashring32.go
+++ b/peer/hashring32/internal/hashring32/hashring32.go
@@ -1,0 +1,440 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package hashring32
+
+import (
+	"errors"
+	"math"
+	"math/rand"
+	"sort"
+	"strconv"
+	"sync"
+
+	"go.uber.org/yarpc/peer/hashring32/internal/radixsort32"
+)
+
+const (
+	defaultNumReplicas      = 100
+	defaultNumPeersEstimate = 1500
+)
+
+var (
+	// ErrEmptyPool is thrown when no availabel peer in pool.
+	ErrEmptyPool = errors.New("empty pool")
+	// ErrNegativeN is thrown when Shard.N is negative.
+	ErrNegativeN = errors.New("negative n")
+	// ErrUnexpected is thrown when a invalid code branch is reached and should never happen.
+	ErrUnexpected = errors.New("unexpected error")
+)
+
+// Hashring32 will implement Choose, Add, Remove, Include, Exclude, Set, and Len.
+type Hashring32 struct {
+	hash             HashFunc32
+	numReplicas      int
+	numPeersEstimate int
+	formatReplica    ReplicaFormatterFunc
+	sorter           *radixsort32.RadixSorter32
+
+	m sync.RWMutex
+
+	// Hashes in hashesArray and membersMapByHash should always be synced.
+	hashesArray      []uint32
+	membersMapByHash map[uint32](map[string]struct{})
+	membersSet       map[string]struct{}
+}
+
+// New creates a new Hashring32.
+func New(hash HashFunc32, options ...Option) *Hashring32 {
+	ring := &Hashring32{
+		hash:             hash,
+		numReplicas:      defaultNumReplicas,
+		numPeersEstimate: defaultNumPeersEstimate,
+		formatReplica:    formatSimpleReplica,
+	}
+
+	// set or override constructor options
+	for _, opt := range options {
+		opt.apply(ring)
+	}
+
+	// initialize inner fields
+	capacity := ring.numReplicas * ring.numPeersEstimate
+	ring.hashesArray = make([]uint32, 0, capacity)
+	ring.membersMapByHash = make(map[uint32](map[string]struct{}), capacity)
+	ring.membersSet = make(map[string]struct{}, ring.numPeersEstimate)
+	// TODO: Adjust parameters base on benchmarks
+	ring.sorter = radixsort32.New(
+		radixsort32.Radix(16),
+		radixsort32.MaxLen(capacity),
+		radixsort32.MinLen(1000))
+
+	return ring
+}
+
+// Option is an option for the hash ring constructor.
+type Option interface {
+	apply(*Hashring32)
+}
+
+// NumReplicas specifies the number of replicas to use for each peer.
+//
+// More replicas produces a more even distribution of entities and slower
+// membership updates.
+//
+// Changing the replica number changes the topology of the ring.
+// Do not change the replica number on a populated ring.
+// Drain any stateful service before changing the number of replicas.
+func NumReplicas(n int) Option {
+	return numReplicasOption{numReplicas: n}
+}
+
+type numReplicasOption struct {
+	numReplicas int
+}
+
+func (o numReplicasOption) apply(r *Hashring32) {
+	r.numReplicas = o.numReplicas
+}
+
+// ReplicaFormatter specifies the function the hash ring will use to construct
+// replica names from a peer identifier and a replica number.
+//
+// Replica names are hashed to find their positions within the hash ring.
+//
+// The default replica formatter simply concatenates the peer identifier and
+// the replica number as a decimal string.
+func ReplicaFormatter(formatReplica ReplicaFormatterFunc) Option {
+	return replicaFormatterOption{
+		formatReplica: formatReplica,
+	}
+}
+
+type replicaFormatterOption struct {
+	formatReplica ReplicaFormatterFunc
+}
+
+func (o replicaFormatterOption) apply(r *Hashring32) {
+	r.formatReplica = o.formatReplica
+}
+
+func formatSimpleReplica(identifier string, replicaNum int) string {
+	return identifier + strconv.Itoa(replicaNum)
+}
+
+// DelimitedReplicaFormatter joins a peer identifier and replica number with a given delimiter.
+func DelimitedReplicaFormatter(delimiter string) ReplicaFormatterFunc {
+	return func(identifier string, replicaNum int) string {
+		replica := strconv.Itoa(replicaNum)
+		identifierLen := len(identifier)
+		buffer := make([]byte, 0, identifierLen+len(replica)+len(delimiter))
+		buffer = append(buffer, []byte(identifier)...)
+		buffer = append(buffer, []byte(delimiter)...)
+		buffer = append(buffer, []byte(replica)...)
+		return string(buffer)
+	}
+}
+
+// NumPeersEstimate specifies an estimate for the nubmer of identified peers
+// the hashring will contain.
+//
+// This figure and the number of replicas determines the initial capacity of the ring slice.
+func NumPeersEstimate(numPeersEstimate int) Option {
+	return numPeersEstimateOption{
+		numPeersEstimate: numPeersEstimate,
+	}
+}
+
+type numPeersEstimateOption struct {
+	numPeersEstimate int
+}
+
+func (o numPeersEstimateOption) apply(r *Hashring32) {
+	r.numPeersEstimate = o.numPeersEstimate
+}
+
+// Choose returns first (shard.N + 1) peers within the matched range of hashed
+// shard.Key in the hash ring.
+func (r *Hashring32) Choose(shard Shard) ([]string, error) {
+	r.m.RLock()
+	defer r.m.RUnlock()
+
+	if shard.N < 0 {
+		return nil, ErrNegativeN
+	}
+
+	if len(r.membersSet) == 0 {
+		return nil, ErrEmptyPool
+	}
+
+	var ix int
+	if shard.Key == "" {
+		// Random index to get hash value
+		ix = rand.Intn(len(r.hashesArray))
+	} else {
+		// Binary search to find hash value
+		key := r.hash(shard.Key)
+		ix = indexOf(r.hashesArray, key)
+	}
+
+	res := make([]string, shard.N+1)
+	// used to remove duplicates
+	set := make(map[string]struct{}, shard.N+1)
+	for len(set) < shard.N+1 && len(set) < len(r.membersSet) {
+		hash := r.hashesArray[ix]
+		ix++
+
+		// reach end of ring , start from the beginning
+		if ix == len(r.hashesArray) {
+			ix = 0
+		}
+
+		// same hash can contains different members (collisions)
+		for member := range r.membersMapByHash[hash] {
+			// different hashes can point to same server (replicas)
+			if _, ok := set[member]; !ok {
+				res[len(set)] = member
+				set[member] = struct{}{}
+				if len(set) == shard.N+1 {
+					break
+				}
+			}
+		}
+	}
+
+	return res[:len(set)], nil
+}
+
+// ChooseNth returns (shard.N + 1)th peer within the matched range of hashed
+// shard.Key in the hash ring.
+func (r *Hashring32) ChooseNth(shard Shard) (string, error) {
+	r.m.RLock()
+	defer r.m.RUnlock()
+
+	if shard.N < 0 {
+		return "", ErrNegativeN
+	}
+
+	if len(r.membersSet) == 0 {
+		return "", ErrEmptyPool
+	}
+
+	var ix int
+	if shard.Key == "" {
+		// Random index to get hash value
+		ix = rand.Intn(len(r.hashesArray))
+	} else {
+		// Binary search to find hash value
+		key := r.hash(shard.Key)
+		ix = indexOf(r.hashesArray, key)
+	}
+
+	// use by ChooseNth
+	var last *string
+	// used to remove duplicates
+	var set map[string]struct{}
+	if shard.N > 0 {
+		set = make(map[string]struct{}, shard.N+1)
+	}
+	for set == nil || (len(set) < shard.N+1 && len(set) < len(r.membersSet)) {
+		hash := r.hashesArray[ix]
+		ix++
+
+		// reach end of ring , start from the beginning
+		if ix == len(r.hashesArray) {
+			ix = 0
+		}
+
+		// same hash can contains different members (collisions)
+		for member := range r.membersMapByHash[hash] {
+			if set == nil {
+				return member, nil
+			}
+			// different hashes can point to same server (replicas)
+			if _, ok := set[member]; !ok {
+				last = &member
+				set[member] = struct{}{}
+				if len(set) == shard.N+1 {
+					break
+				}
+			}
+		}
+	}
+
+	return *last, nil
+}
+
+// Add adds a member into the hash ring and returns whether it is a new member.
+func (r *Hashring32) Add(member string) (new bool) {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	if _, ok := r.membersSet[member]; ok {
+		return false
+	}
+
+	r.addHelper(member)
+
+	r.sorter.Sort(r.hashesArray)
+	return true
+}
+
+// Remove removes a member from the hash ring and returns whether it was an existing member.
+func (r *Hashring32) Remove(member string) (found bool) {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	if _, ok := r.membersSet[member]; !ok {
+		return false
+	}
+
+	delete(r.membersSet, member)
+
+	toBeRemoved := make(map[int]struct{}, r.numReplicas)
+	r.removeHelper(member, toBeRemoved)
+
+	for i := range toBeRemoved {
+		r.hashesArray[i] = uint32(math.MaxUint32)
+	}
+	r.sorter.Sort(r.hashesArray)
+	r.hashesArray = r.hashesArray[:len(r.hashesArray)-len(toBeRemoved)]
+	return true
+}
+
+// Include includes a group of new members into the hash ring
+func (r *Hashring32) Include(group map[string]struct{}) {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	for member := range group {
+		if _, ok := r.membersSet[member]; ok {
+			continue
+		}
+
+		r.addHelper(member)
+	}
+	r.sorter.Sort(r.hashesArray)
+}
+
+// Exclude excludes a group of new members from the hash ring
+func (r *Hashring32) Exclude(group map[string]struct{}) {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	// cannot use pre-allocated slices from buffer pool here because size is dynamic.
+	toBeRemoved := make(map[int]struct{}, len(group)*r.numReplicas)
+
+	for member := range group {
+		if _, ok := r.membersSet[member]; !ok {
+			continue
+		}
+		r.removeHelper(member, toBeRemoved)
+	}
+
+	for index := range toBeRemoved {
+		r.hashesArray[index] = uint32(math.MaxUint32)
+	}
+	r.sorter.Sort(r.hashesArray)
+	r.hashesArray = r.hashesArray[:len(r.hashesArray)-len(toBeRemoved)]
+}
+
+// Set clear the whole ring and replace with a group of new members.
+func (r *Hashring32) Set(group map[string]struct{}) {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	// cannot use pre-allocated slices from buffer pool here because size is dynamic.
+	toBeRemoved := make(map[int]struct{}, len(group)*r.numReplicas)
+
+	// remove old members
+	for member := range r.membersSet {
+		// skip intersection
+		if _, ok := group[member]; ok {
+			continue
+		}
+		r.removeHelper(member, toBeRemoved)
+	}
+	// add new members
+	for member := range group {
+		// skip intersection
+		if _, ok := r.membersSet[member]; ok {
+			continue
+		}
+		r.addHelper(member)
+	}
+	for i := range toBeRemoved {
+		r.hashesArray[i] = uint32(math.MaxUint32)
+	}
+	r.sorter.Sort(r.hashesArray)
+	r.hashesArray = r.hashesArray[:len(r.hashesArray)-len(toBeRemoved)]
+}
+
+// Len returns number of members of the hash ring.
+func (r *Hashring32) Len() int {
+	r.m.RLock()
+	defer r.m.RUnlock()
+	return len(r.membersSet)
+}
+
+// addHelper adds member into hashes array (without sorting) and map.
+func (r *Hashring32) addHelper(member string) {
+	r.membersSet[member] = struct{}{}
+	for i := 0; i < r.numReplicas; i++ {
+		hash := r.hash(r.formatReplica(member, i))
+
+		if _, ok := r.membersMapByHash[hash]; !ok {
+			r.membersMapByHash[hash] = make(map[string]struct{})
+			r.hashesArray = append(r.hashesArray, hash)
+		}
+		r.membersMapByHash[hash][member] = struct{}{}
+	}
+}
+
+// removeHelper adds a member into toBeRemoved set and removes it from map.
+func (r *Hashring32) removeHelper(member string, toBeRemoved map[int]struct{}) {
+	delete(r.membersSet, member)
+
+	for i := 0; i < r.numReplicas; i++ {
+		hash := r.hash(r.formatReplica(member, i))
+		delete(r.membersMapByHash[hash], member)
+		// no more member for this hash
+		if len(r.membersMapByHash[hash]) == 0 {
+			delete(r.membersMapByHash, hash)
+			// mark removed ones.
+			// do not remove immediately because they are needed for binary search.
+			toBeRemoved[indexOf(r.hashesArray, hash)] = struct{}{}
+		}
+	}
+}
+
+// indexOf applies binary search to get the value in an array.
+func indexOf(slice []uint32, v uint32) int {
+	if len(slice) == 0 {
+		return -1
+	}
+	// binary search
+	index := sort.Search(len(slice),
+		func(i int) bool { return slice[i] >= v })
+	// greater than all elements, returns the first
+	if index >= len(slice) {
+		return 0
+	}
+	return index
+}

--- a/peer/hashring32/internal/hashring32/hashring32_test.go
+++ b/peer/hashring32/internal/hashring32/hashring32_test.go
@@ -1,0 +1,515 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package hashring32
+
+import (
+	"sort"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/yarpc/peer/hashring32/internal/farmhashring"
+)
+
+// Unit Tests
+
+const (
+	ringpopID1 = "127.0.0.1:10000"
+	ringpopID2 = "127.0.0.1:10001"
+	ringpopID3 = "127.0.0.1:10002"
+	ringpopID4 = "127.0.0.1:10004"
+	ringpopID5 = "127.0.0.1:10005"
+
+	key1 = "123"
+	key2 = "456"
+)
+
+func makeHashring32() *Hashring32 {
+	return New(
+		farmhashring.Fingerprint32,
+		NumReplicas(100),
+		NumPeersEstimate(1500),
+	)
+}
+
+func TestAddRemove(t *testing.T) {
+	rp := makeHashring32()
+
+	b := rp.Add(ringpopID1)
+	b2 := rp.Add(ringpopID1)
+	assertRingState(t, rp)
+
+	ids, err := rp.Choose(Shard{
+		Key: key1,
+	})
+	id := ids[0]
+	assert.NoError(t, err, "Choose failed to select peer")
+	assert.True(t, b, "Choose returned false but element did not exist.")
+	assert.False(t, b2, "Choose returned true but element already exists.")
+	assert.Equal(t, ringpopID1, id, "aaa")
+	assert.Equal(t, 1, rp.Len(), "Size of members should be 1")
+
+	b = rp.Remove(ringpopID1)
+	b2 = rp.Remove(ringpopID1)
+	assertRingState(t, rp)
+
+	ids, err = rp.Choose(Shard{
+		Key: key1,
+	})
+	assert.True(t, b, "Remove returned false but element were actually removed")
+	assert.False(t, b2, "Remove returned true but element already exists.")
+	assert.Error(t, err, "Expected not to find any peer")
+	assert.Nil(t, ids, "Expected to find empty string as ID")
+	assert.Equal(t, 0, rp.Len(), "Size of members should be 1")
+}
+
+// TestMultipleChoose tests whether peer chooser
+// always selects the same peer when ring is at the same topology.
+func TestMultipleChoose(t *testing.T) {
+	rp := makeHashring32()
+	rp.Add(ringpopID1)
+	rp.Add(ringpopID2)
+	rp.Add(ringpopID3)
+	assertRingState(t, rp)
+
+	assert.Equal(t, 3, rp.Len(), "Size of members should be 1")
+	id, err := rp.Choose(Shard{
+		Key: key1,
+	})
+	assert.NoError(t, err, "Choose failed to select peer")
+	id2, err := rp.Choose(Shard{
+		Key: key1,
+	})
+	assert.NoError(t, err, "Choose failed to select peer")
+	assert.Equal(t, id, id2, "Choose selected a different peer")
+	id3, err := rp.Choose(Shard{
+		Key: key1,
+	})
+	assert.NoError(t, err, "Choose failed to select peer")
+	assert.Equal(t, id, id3, "Choose selected a different peer")
+
+	rp.Add(ringpopID4)
+	rp.Add(ringpopID5)
+	rp.Remove(ringpopID4)
+	rp.Remove(ringpopID5)
+	assertRingState(t, rp)
+
+	id2, err = rp.Choose(Shard{
+		Key: key1,
+	})
+	assert.NoError(t, err, "Choose failed to select peer")
+	assert.Equal(t, id, id2, "Choose selected a different peer")
+	id3, err = rp.Choose(Shard{
+		Key: key1,
+	})
+	assert.NoError(t, err, "Choose failed to select peer")
+	assert.Equal(t, id, id3, "Choose selected a different peer")
+}
+
+func TestNoKey(t *testing.T) {
+	rp := makeHashring32()
+	rp.Add(ringpopID1)
+	assertRingState(t, rp)
+
+	id, err := rp.Choose(Shard{Key: ""})
+	assert.NoError(t, err, "Should returns a random individual when no shard key.")
+	assert.Equal(t, ringpopID1, id[0], "Should returns a random individual.")
+}
+
+func TestRingpopIncludeExclude(t *testing.T) {
+	rp := makeHashring32()
+	peers := map[string]struct{}{
+		ringpopID1: {},
+		ringpopID2: {},
+		ringpopID3: {},
+		ringpopID4: {},
+		ringpopID5: {},
+	}
+	rp.Include(peers)
+	assert.Equal(t, 5, rp.Len(), "Load balancer pool size should be 5.")
+	rp.Include(peers)
+	assert.Equal(t, 5, rp.Len(), "Load balancer pool size should be 5.")
+
+	toBeRemoved := map[string]struct{}{
+		ringpopID2: {},
+		ringpopID3: {},
+		ringpopID4: {},
+	}
+	rp.Exclude(toBeRemoved)
+	assert.Equal(t, 2, rp.Len(), "Load balancer pool size should be 2")
+	rp.Exclude(toBeRemoved)
+	assert.Equal(t, 2, rp.Len(), "Load balancer pool size should be 2")
+}
+
+func TestHashCollision(t *testing.T) {
+	rp := makeHashring32()
+	// Add collisions
+	rp.Add("98.25.121.4:24016")
+	rp.Add("251.73.56.7:21031")
+	assertRingState(t, rp)
+
+	b := rp.Remove("98.25.121.4:24016")
+	assert.Equal(t, 1, rp.Len(), "Expects length to be 1")
+	b2 := rp.Remove("251.73.56.7:21031")
+	assertRingState(t, rp)
+	assert.Equal(t, 0, rp.Len(), "Expects length to be 1")
+	assert.True(t, b, "Element should exist")
+	assert.True(t, b2, "Element should exist")
+}
+
+func TestIndexOf(t *testing.T) {
+	var empty = []uint32{}
+	assert.Equal(t, -1, indexOf(empty, uint32(0)), "Should return -1 for empty array")
+
+	var slice = []uint32{0, 1, 2, 3, 4}
+	assert.Equal(t, 0, indexOf(slice, uint32(0)), "Should return index 0")
+	assert.Equal(t, 3, indexOf(slice, uint32(3)), "Should return index 3")
+	assert.Equal(t, 4, indexOf(slice, uint32(4)), "Should return index 4")
+	assert.Equal(t, 0, indexOf(slice, uint32(5)), "Should return index 0")
+}
+
+func TestNotEnoughPeers(t *testing.T) {
+	rp := makeHashring32()
+	rp.Add("127.0.0.1:0")
+	assertRingState(t, rp)
+
+	peers, err := rp.Choose(Shard{Key: key1, N: 1})
+	assert.Equal(t, 1, len(peers))
+	assert.Equal(t, "127.0.0.1:0", peers[0])
+	assert.NoError(t, err)
+
+	peer, err := rp.ChooseNth(Shard{Key: key1, N: 1})
+	assert.Equal(t, "127.0.0.1:0", peer)
+	assert.NoError(t, err)
+}
+
+func TestSimpleReplicaFormatter(t *testing.T) {
+	assert.Equal(t, "member10", formatSimpleReplica("member", 10))
+}
+
+func TestDelimitedReplicaFormatter(t *testing.T) {
+	PoundReplicaFormatter := DelimitedReplicaFormatter("#")
+	assert.Equal(t, "member#11", PoundReplicaFormatter("member", 11))
+
+	EmptyReplicaFormatter := DelimitedReplicaFormatter("")
+	assert.Equal(t, "member12", EmptyReplicaFormatter("member", 12))
+
+	TildaReplicaFormatter := DelimitedReplicaFormatter("~")
+	assert.Equal(t, "member~13", TildaReplicaFormatter("member", 13))
+}
+
+// Benchmarks
+func BenchmarkHashring32Adds100(b *testing.B) {
+	benchmarkAdds(b, makeHashring32(), 100)
+}
+
+func BenchmarkHashring32Adds1000(b *testing.B) {
+	benchmarkAdds(b, makeHashring32(), 1000)
+}
+
+func BenchmarkHashring32Removes100(b *testing.B) {
+	benchmarkRemoves(b, makeHashring32(), 100)
+}
+
+func BenchmarkHashring32Removes1000(b *testing.B) {
+	benchmarkRemoves(b, makeHashring32(), 1000)
+}
+
+func BenchmarkHashring32Include100(b *testing.B) {
+	benchmarkInclude(b, makeHashring32(), 100)
+}
+
+func BenchmarkHashring32Include1000(b *testing.B) {
+	benchmarkInclude(b, makeHashring32(), 1000)
+}
+
+func BenchmarkHashring32Exclude100(b *testing.B) {
+	benchmarkExclude(b, makeHashring32(), 100)
+}
+
+func BenchmarkHashring32Exclude1000(b *testing.B) {
+	benchmarkExclude(b, makeHashring32(), 1000)
+}
+
+func BenchmarkHashring32Choose100NoHint(b *testing.B) {
+	benchmarkChoose(b, makeHashring32(), 100)
+}
+
+func BenchmarkHashring32Choose1000NoHint(b *testing.B) {
+	benchmarkChoose(b, makeHashring32(), 1000)
+}
+
+func BenchmarkHashring32Set100Updates10(b *testing.B) {
+	benchmarkSet(b, makeHashring32(), 100, 10)
+}
+
+func BenchmarkHashring32Set1000Updates100(b *testing.B) {
+	benchmarkSet(b, makeHashring32(), 1000, 100)
+}
+
+func BenchmarkHashring32Set1500Updates1500(b *testing.B) {
+	benchmarkSet(b, makeHashring32(), 1000, 1000)
+}
+
+// benchmark helpers
+
+func benchmarkAdds(b *testing.B, hashring32 *Hashring32, capacity int) {
+	b.StopTimer()
+	updates := generateStringsGroup(capacity)
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		hashring32.Set(generateEmptySet())
+		b.StartTimer()
+		for member := range updates {
+			hashring32.Add(member)
+		}
+	}
+}
+
+func benchmarkRemoves(b *testing.B, hashring32 *Hashring32, capacity int) {
+	b.StopTimer()
+	updates := generateStringsGroup(capacity)
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		hashring32.Set(deepCopy(updates))
+		b.StartTimer()
+		for member := range updates {
+			hashring32.Remove(member)
+		}
+	}
+}
+
+func benchmarkInclude(b *testing.B, hashring32 *Hashring32, capacity int) {
+	b.StopTimer()
+	updates := generateStringsGroup(capacity)
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		hashring32.Set(generateEmptySet())
+		b.StartTimer()
+		hashring32.Include(updates)
+	}
+}
+
+func benchmarkExclude(b *testing.B, hashring32 *Hashring32, capacity int) {
+	b.StopTimer()
+	updates := generateStringsGroup(capacity)
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		hashring32.Set(deepCopy(updates))
+		b.StartTimer()
+		hashring32.Exclude(updates)
+	}
+}
+
+// If hints is empty use NoHint otherwise pick a hint in the array in round robin.
+func benchmarkChoose(b *testing.B, hashring32 *Hashring32, capacity int, shards ...Shard) {
+	b.StopTimer()
+	updates := generateStringsGroup(capacity)
+	hashring32.Set(updates)
+	numShards := len(shards)
+	k := 0
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < capacity; j++ {
+			if numShards == 0 {
+				hashring32.Choose(Shard{})
+			} else {
+				hashring32.Choose(shards[k])
+				k++
+				if k == numShards {
+					k = 0
+				}
+			}
+		}
+	}
+}
+
+// capacity = size of old group = size of new group
+// numUpdates is the size of members in new group but not old group
+// numUpdates has to be smaller than or equal to capacity
+func benchmarkSet(b *testing.B, hashring32 *Hashring32, capacity, numUpdates int) {
+	b.StopTimer()
+	tmp := generateStringsGroup(capacity + numUpdates)
+	old := make(map[string]struct{})
+	new := make(map[string]struct{})
+	j := 0
+	for member := range tmp {
+		if j < capacity {
+			old[member] = struct{}{}
+		}
+		if j >= numUpdates {
+			new[member] = struct{}{}
+		}
+		j++
+	}
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		hashring32.Set(old)
+		b.StartTimer()
+		hashring32.Set(new)
+	}
+}
+
+// helpers
+
+func deepCopy(set map[string]struct{}) map[string]struct{} {
+	target := make(map[string]struct{})
+	for k := range set {
+		target[k] = struct{}{}
+	}
+	return target
+}
+
+func generateEmptySet() map[string]struct{} {
+	return make(map[string]struct{})
+}
+
+// better to use capacity 0 ~ 65535
+func generateStringsGroup(capacity int) map[string]struct{} {
+	set := make(map[string]struct{})
+	for i := 0; i < capacity; i++ {
+		str := "127.0.0.1:" + strconv.Itoa(i)
+		set[str] = struct{}{}
+	}
+	return set
+}
+
+// assertRingState verifies whether the ring is in a valid state
+func assertRingState(t *testing.T, hr *Hashring32) {
+	// whether hash array is sorted
+	isSorted(t, hr)
+	// whether hash array is synced with hash map
+	arrayMapSynced(t, hr)
+	// whether choose with various N returns valid results
+	chooseCombo(t, hr, key1)
+	chooseCombo(t, hr, key2)
+}
+
+// chooseCombo provides sanity test with various N compared to the ring size.
+func chooseCombo(t *testing.T, hr *Hashring32, key string) {
+	// Choose exactly 1 peer
+	chooseN(t, hr, key, 0)
+	// Choose more than peer list size
+	chooseN(t, hr, key, hr.Len())
+	// Choose exactly peer list size
+	chooseN(t, hr, key, hr.Len()-1)
+	// Choose less peers than peer list size
+	chooseN(t, hr, key, hr.Len()-2)
+
+	// Choose the 1st (index 0) peer
+	chooseNth(t, hr, key, 0)
+	// Choose (size + 1)th peer
+	chooseNth(t, hr, key, hr.Len())
+	// Choose (size)th peer
+	chooseNth(t, hr, key, hr.Len()-1)
+	// Choose (size - 1)th peer
+	chooseNth(t, hr, key, hr.Len()-2)
+
+	if key != "randomKey" {
+		chooseCombo(t, hr, "randomKey")
+	}
+}
+
+func chooseN(t *testing.T, hr *Hashring32, key string, n int) {
+	size := hr.Len()
+
+	peers, err := hr.Choose(Shard{
+		N:   n,
+		Key: key,
+	})
+
+	if n < 0 {
+		assert.Error(t, err, "n cannot be negative integer")
+		assert.Nil(t, peers, "peers should be nil when n is negative")
+		return
+	}
+
+	if size == 0 {
+		assert.Error(t, err, "should return error for empty peer list")
+		assert.Nil(t, peers, "peers should be nil when n is negative")
+		return
+	}
+
+	// all provided peers are in members set
+	for _, peer := range peers {
+		_, ok := hr.membersSet[peer]
+		assert.True(t, ok, "returned peer not in members set")
+
+	}
+
+	if n+1 >= size {
+		assert.NoError(t, err, "should not return error even when size smaller than n")
+		assert.Len(t, peers, size, "should return all available peers when requested more than that")
+		return
+	}
+
+	// n + 1 < size
+	assert.Len(t, peers, n+1, "number of peers should equal to n + 1")
+}
+
+func chooseNth(t *testing.T, hr *Hashring32, key string, n int) {
+	size := hr.Len()
+
+	peer, err := hr.ChooseNth(Shard{
+		N:   n,
+		Key: key,
+	})
+
+	if n < 0 {
+		assert.Error(t, err, "n cannot be negative integer")
+		assert.Equal(t, peer, "", "peers should be nil when n is negative")
+		return
+	}
+
+	if size == 0 {
+		assert.Error(t, err, "should return error for empty peer list")
+		assert.Equal(t, peer, "", "peers should be empty string when no peer")
+		return
+	}
+
+	// n + 1 < size
+	assert.NotEqual(t, peer, "")
+	if _, ok := hr.membersSet[peer]; ok {
+		assert.True(t, ok, "returned peer not in members set")
+	}
+}
+
+func isSorted(t *testing.T, ring *Hashring32) {
+	assert.True(t, sort.SliceIsSorted(ring.hashesArray, func(i, j int) bool {
+		return ring.hashesArray[i] < ring.hashesArray[j]
+	}), "hashes array should be sorted")
+}
+
+func arrayMapSynced(t *testing.T, ring *Hashring32) {
+	assert.Equal(t,
+		len(ring.membersMapByHash), len(ring.hashesArray), "hashes array and map should be always synced")
+	for _, hash := range ring.hashesArray {
+		v := ring.membersMapByHash[hash]
+		{
+			assert.NotNil(t, v, "hashes array and map should be always synced")
+		}
+	}
+}

--- a/peer/hashring32/internal/hashring32/ringpop_test.go
+++ b/peer/hashring32/internal/hashring32/ringpop_test.go
@@ -1,0 +1,395 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// hashring32 with farmhash fingerprint32 produces a consistent hash ring that
+// is compatible with Ringpop.
+// This test verifies compatibility.
+
+package hashring32
+
+import (
+	"fmt"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dgryski/go-farm"
+	"github.com/stretchr/testify/assert"
+	"github.com/uber/ringpop-go/hashring"
+	"github.com/uber/ringpop-go/membership"
+)
+
+// Shadow tests create a real RingPop ring, and make the scheduler shadowing
+// all the ring topology updates. Ring size and look up results are compared
+// and verified to be identical after every operation.
+
+func TestRingpopShadowAddRemove(t *testing.T) {
+	ring := newRing(100, t)
+	servers := generateServers(100)
+
+	for server := range servers {
+		ring.add(server)
+		ring.sameMembers()
+	}
+	for server := range servers {
+		ring.remove(server)
+		ring.sameMembers()
+	}
+}
+
+func TestRingpopShadowIncludeExclude(t *testing.T) {
+	ring := newRing(100, t)
+	servers := generateServers(100)
+
+	ring.include(servers)
+	ring.sameMembers()
+	ring.exclude(servers)
+	ring.sameMembers()
+}
+
+func TestRingpopShadowSet(t *testing.T) {
+	ring := newRing(100, t)
+	servers := generateServers(100)
+	ring.include(servers)
+	newServers := newPopulation(10, servers)
+	ring.set(newServers)
+
+}
+
+func TestRingpopShadowChoose(t *testing.T) {
+	ring := newRing(100, t)
+	servers := generateServers(1000)
+	ring.set(servers)
+
+	for i := 0; i < 100; i++ {
+		ring.lookup(generateRandomString())
+	}
+}
+
+func TestRingpopShadowCombo(t *testing.T) {
+	ring := newRing(100, t)
+
+	s1 := generateRandomHostPort()
+	s2 := generateRandomHostPort()
+	s3 := generateRandomHostPort()
+	ring.add(s1)
+	ring.add(s2)
+	ring.add(s3)
+	for i := 0; i < 20; i++ {
+		ring.lookup(generateRandomString())
+	}
+	ring.remove(s1)
+	ring.sameMembers()
+
+	for i := 0; i < 20; i++ {
+		ring.lookup(generateRandomString())
+	}
+
+	servers := generateServers(100)
+	ring.include(servers)
+	for i := 0; i < 100; i++ {
+		ring.lookup(generateRandomString())
+	}
+
+	newServers := newPopulation(10, servers)
+	ring.set(newServers)
+	for i := 0; i < 100; i++ {
+		ring.lookup(generateRandomString())
+		ring.lookupN(generateRandomString(), 5)
+		ring.lookupNth(generateRandomString(), 5)
+	}
+}
+
+type ring struct {
+	hashring *hashring.HashRing
+	pool     map[string]*member
+
+	shadowScheduler *Hashring32
+
+	t *testing.T
+	m sync.RWMutex
+}
+
+func newRing(replica int, t *testing.T) *ring {
+	return &ring{
+		hashring:        hashring.New(farm.Fingerprint32, replica),
+		pool:            make(map[string]*member),
+		shadowScheduler: makeHashring32(),
+		t:               t,
+	}
+}
+
+type member string
+
+func newRingMember(id string) *member {
+	member := member(id)
+	return &member
+}
+
+// Label is a dummy method for implementing ringpop.Member interface.
+func (f *member) Label(key string) (string, bool) {
+	return "", false
+}
+
+// ID->Address mapping is managed by outside libraries.
+func (f *member) GetAddress() string {
+	// When GetAddress() and Identity() provides different value,
+	// Ringpop uses new format fmt.Sprintf("%s#%v", identity, replica)
+	// Use this to force ringpop library use the new format.
+	return (string)(*f)
+}
+
+func (f *member) Identity() string {
+	return (string)(*f)
+}
+
+func (r *ring) sameMembers() {
+	assert.Equal(r.t, len(r.hashring.Servers()), r.shadowScheduler.Len())
+	for s := range r.shadowScheduler.membersSet {
+		assert.True(r.t, r.hashring.HasServer(s), fmt.Sprintf("Expected not to see %s.", s))
+	}
+}
+
+func (r *ring) lookup(key string) {
+	res, ok := r.hashring.Lookup(key)
+	r.m.RLock()
+	defer r.m.RUnlock()
+
+	resSArr, errS := r.shadowScheduler.Choose(Shard{
+		Key: key,
+	})
+	resS := resSArr[0]
+
+	assert.Equal(r.t, res, resS, "Load balancer should returns the same result.")
+	if ok {
+		assert.NoError(r.t, errS, "Load balancer should returns no error.")
+	} else {
+		assert.Error(r.t, errS, "Load Balancer should returns error.")
+	}
+}
+
+func (r *ring) lookupN(key string, n int) {
+	res := r.hashring.LookupN(key, n)
+	r.m.RLock()
+	defer r.m.RUnlock()
+
+	resSArr, errS := r.shadowScheduler.Choose(Shard{
+		Key: key,
+		N:   n - 1,
+	})
+
+	assert.NoError(r.t, errS)
+	assert.Equal(r.t, res, resSArr, "Load balancer should returns the same result.")
+}
+
+func (r *ring) lookupNth(key string, n int) {
+	res := r.hashring.LookupN(key, n)
+	r.m.RLock()
+	defer r.m.RUnlock()
+
+	resSArr, errS := r.shadowScheduler.ChooseNth(Shard{
+		Key: key,
+		N:   n - 1,
+	})
+
+	assert.NoError(r.t, errS)
+	assert.Equal(r.t, res[n-1], resSArr, "Load balancer should returns the same result.")
+}
+
+func (r *ring) add(individual string) {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	newMember := r.shadowScheduler.Add(individual)
+
+	if r.pool[individual] != nil {
+		assert.False(r.t, newMember, "Load balancer doesn't find member.")
+		return
+	}
+
+	r.pool[individual] = newRingMember(individual)
+	r.hashring.ProcessMembershipChanges([]membership.MemberChange{
+		{After: r.pool[individual]},
+	})
+
+	assert.True(r.t, newMember, "Load balancer has a member that should not exist.")
+}
+
+func (r *ring) remove(individual string) {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	found := r.shadowScheduler.Remove(individual)
+
+	if r.pool[individual] == nil {
+		assert.False(r.t, found, "Ringpop loadbalancer found a member that shoould not exist.")
+		return
+	}
+	r.hashring.ProcessMembershipChanges([]membership.MemberChange{
+		{Before: r.pool[individual]},
+	})
+	delete(r.pool, individual)
+
+	assert.True(r.t, found, "Load balancer has a member that should not exist.")
+}
+
+func (r *ring) include(population map[string]struct{}) {
+	r.m.Lock()
+	membershipChanges := make([]membership.MemberChange, 0, len(population))
+	for id := range population {
+		if r.pool[id] == nil {
+			r.pool[id] = newRingMember(id)
+			membershipChanges = append(membershipChanges, membership.MemberChange{
+				After: r.pool[id],
+			})
+		}
+	}
+	r.hashring.ProcessMembershipChanges(membershipChanges)
+	r.m.Unlock()
+
+	r.shadowScheduler.Include(population)
+	assert.Equal(r.t, r.size(), r.shadowScheduler.Len(), "Sizes doesn't match the real ring.")
+}
+
+func (r *ring) exclude(population map[string]struct{}) {
+	r.m.Lock()
+	membershipChanges := make([]membership.MemberChange, 0, len(population))
+	for id := range population {
+		if r.pool[id] != nil {
+			membershipChanges = append(membershipChanges, membership.MemberChange{
+				Before: r.pool[id],
+			})
+			delete(r.pool, id)
+		}
+	}
+	r.hashring.ProcessMembershipChanges(membershipChanges)
+	r.m.Unlock()
+
+	r.shadowScheduler.Exclude(population)
+	assert.Equal(r.t, r.size(), r.shadowScheduler.Len(), "Sizes doesn't match the real ring.")
+}
+
+func (r *ring) set(population map[string]struct{}) {
+	r.m.Lock()
+
+	membershipChanges := make([]membership.MemberChange, 0, len(population))
+	newPool := make(map[string]*member)
+	for id := range population {
+		newPool[id] = newRingMember(id)
+		if r.pool[id] == nil {
+			membershipChanges = append(membershipChanges, membership.MemberChange{
+				After: newPool[id],
+			})
+		}
+	}
+	for id := range r.pool {
+		if newPool[id] == nil {
+			membershipChanges = append(membershipChanges, membership.MemberChange{
+				Before: r.pool[id],
+			})
+		}
+	}
+	r.pool = newPool
+	r.hashring.ProcessMembershipChanges(membershipChanges)
+	r.m.Unlock()
+
+	r.shadowScheduler.Set(population)
+	assert.Equal(r.t, r.size(), r.shadowScheduler.Len(), "Sizes doesn't match the real ring.")
+}
+
+func (r *ring) size() int {
+	r.m.RLock()
+	defer r.m.RUnlock()
+	return len(r.pool)
+}
+
+func generateRandomString() string {
+	rand.Seed(time.Now().UnixNano())
+	var letterRunes = []rune("1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+	b := make([]rune, 20)
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	return string(b)
+}
+
+// helpers
+const ipUpperBound = 256
+
+func generateRandomHostPort() string {
+	// Make port number exact 5 digits so no replica collisions
+	return fmt.Sprintf("%d.%d.%d.%d:%d%d%d%d%d",
+		rand.Intn(ipUpperBound),
+		rand.Intn(ipUpperBound),
+		rand.Intn(ipUpperBound),
+		rand.Intn(ipUpperBound),
+		rand.Intn(6)+1, // max port is 65535
+		rand.Intn(6),
+		rand.Intn(6),
+		rand.Intn(4),
+		rand.Intn(7))
+}
+
+func generateServers(count int) map[string]struct{} {
+	servers := make(map[string]struct{}, count)
+	for i := 0; i < count; i++ {
+		for {
+			hostport := generateRandomHostPort()
+			if _, ok := servers[hostport]; ok {
+				continue
+			}
+			servers[hostport] = struct{}{}
+			break
+		}
+	}
+	return servers
+}
+
+// newPopulation updates numUpdates individuals in the oldPopulation,
+// and keeps the size unchanged.
+func newPopulation(numUpdates int, oldPopulation map[string]struct{}) map[string]struct{} {
+	count := len(oldPopulation)
+
+	sameServersCount := count - numUpdates
+	newPopulation := make(map[string]struct{})
+
+	for server := range oldPopulation {
+		if len(newPopulation) == sameServersCount {
+			break
+		}
+		newPopulation[server] = struct{}{}
+	}
+
+	// Generate new servers so that size doesn't change
+	for {
+		if len(newPopulation) == count {
+			break
+		}
+		server := generateRandomHostPort()
+		// Avoid adding old servers
+		if _, ok := oldPopulation[server]; ok {
+			continue
+		}
+		newPopulation[server] = struct{}{}
+	}
+	return newPopulation
+}

--- a/peer/hashring32/internal/hashring32/types.go
+++ b/peer/hashring32/internal/hashring32/types.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package hashring32
+
+// HashFunc32 is the 32 bits hash function type
+type HashFunc32 func(string) uint32
+
+// ReplicaFormatterFunc defines the format to stringify member identifier and replica point.
+type ReplicaFormatterFunc func(identifier string, replicaPoint int) string
+
+// Shard includes a shard key and a number indicating a rightward linear lookup in the ring.
+type Shard struct {
+	Key string
+	N   int
+}

--- a/peer/hashring32/internal/radixsort32/radixsort.go
+++ b/peer/hashring32/internal/radixsort32/radixsort.go
@@ -1,0 +1,252 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package radixsort32
+
+import (
+	"math/bits"
+	"sort"
+	"sync"
+)
+
+const (
+	defaultRadix  = 8
+	defaultMinLen = 1000
+	defaultMaxLen = 200000
+)
+
+// RadixSorter32 is a radix sorter for sorting []uint32
+type RadixSorter32 struct {
+	// radix can be 1, 2, 4, 8, 16
+	// cannot be 32 because the size of counting buffer overflows integer
+	radix uint
+	// for slice shorter than minLength it uses regular sort algorithm
+	minLength int
+	// for slice longer than maxLength it allocate buffer dynamically
+	// which increases garbage collector's pressure =
+	maxLength int
+
+	// immutable after construction
+	mask       uint32
+	keyOffsets []uint
+
+	// buffer used to reduce memory allocation
+	buffer buf
+}
+
+// Option is an option for the radix sorter constructor.
+type Option interface {
+	apply(*RadixSorter32)
+}
+
+type noOption struct{}
+
+func (noOption) apply(*RadixSorter32) {}
+
+// Radix specifies the radix sorter's radix.
+//
+// Radix may be 1, 2, 4, 8, or 16.
+func Radix(radix int) Option {
+	for i := range validRadixes {
+		if validRadixes[i] == radix {
+			return radixOption{radix: radix}
+		}
+	}
+	// fallback to default value
+	return noOption{}
+}
+
+var validRadixes = []int{1, 2, 4, 8, 16}
+
+type radixOption struct {
+	radix int
+}
+
+func (o radixOption) apply(r *RadixSorter32) {
+	r.radix = uint(o.radix)
+}
+
+// MinLen specifies minimum length of slice to use radix sort.
+//
+// The radix sorter will use quick sort for shorter slices.
+func MinLen(minLen int) Option {
+	return minLenOption{minLen: minLen}
+}
+
+type minLenOption struct {
+	minLen int
+}
+
+func (o minLenOption) apply(r *RadixSorter32) {
+	if o.minLen < 0 {
+		o.minLen = 0
+	}
+	r.minLength = o.minLen
+	if o.minLen > r.maxLength {
+		r.maxLength = r.minLength
+	}
+}
+
+// MaxLen is maximum length of slice that can utilize buffers in pool,
+// would use dynamic buffer allocation for larger slices
+func MaxLen(maxLen int) Option {
+	return maxLenOption{maxLen: maxLen}
+}
+
+type maxLenOption struct {
+	maxLen int
+}
+
+func (o maxLenOption) apply(r *RadixSorter32) {
+	if o.maxLen >= r.minLength {
+		r.maxLength = o.maxLen
+	}
+	r.maxLength = o.maxLen
+	if o.maxLen < r.minLength {
+		r.minLength = r.maxLength
+	}
+}
+
+// New creates a radix sorter for sorting []uint32
+func New(options ...Option) *RadixSorter32 {
+	rs := &RadixSorter32{
+		radix:     defaultRadix,
+		minLength: defaultMinLen,
+		maxLength: defaultMaxLen,
+	}
+	for _, opt := range options {
+		opt.apply(rs)
+	}
+	// set key mask, e.g., 0xFF when radix is 8
+	for i := 0; i < int(rs.radix); i++ {
+		rs.mask = bits.RotateLeft32(rs.mask, 1) | 1
+	}
+
+	rs.buffer = newBuffer(rs.maxLength, int(rs.mask)+1)
+
+	iterations := 32 / rs.radix
+	rs.keyOffsets = make([]uint, iterations)
+	for i := range rs.keyOffsets {
+		rs.keyOffsets[i] = uint(i) * rs.radix
+	}
+	return rs
+}
+
+// Sort sorts a slice of type []uint32
+func (r *RadixSorter32) Sort(origin []uint32) {
+	if len(origin) <= r.minLength {
+		sort.Slice(origin, func(i, j int) bool {
+			return origin[i] < origin[j]
+		})
+		return
+	}
+
+	// Utilize buffer from pool or allocate slice when size too large
+	length := len(origin)
+	var buf, swap *[]uint32
+	if len(origin) > r.maxLength {
+		tmp := make([]uint32, length)
+		swap = &tmp
+	} else {
+		buf = r.buffer.getSwap()
+		t := (*buf)[:len(origin)]
+		swap = &t
+		defer r.buffer.putSwap(buf)
+	}
+
+	var key uint32
+
+	offset := r.buffer.getCounters()
+	defer r.buffer.putCounters(offset)
+
+	counts := r.buffer.getCounters()
+	defer r.buffer.putCounters(counts)
+
+	for _, keyOffset := range r.keyOffsets {
+		keyMask := uint32(r.mask << keyOffset)
+
+		// counting
+		for i := range *counts {
+			(*counts)[i] = 0
+		}
+
+		for _, h := range origin {
+			key = r.mask & ((h & keyMask) >> keyOffset)
+			(*counts)[key]++
+		}
+		for i := range *offset {
+			if i == 0 {
+				(*offset)[0] = 0
+				continue
+			}
+			(*offset)[i] = (*offset)[i-1] + (*counts)[i-1]
+		}
+
+		for _, h := range origin {
+			key = r.mask & ((h & keyMask) >> keyOffset)
+			(*swap)[(*offset)[key]] = h
+			(*offset)[key]++
+		}
+		*swap, origin = origin, *swap
+	}
+}
+
+// buffer
+type buf struct {
+	swapPool     sync.Pool
+	countersPool sync.Pool
+}
+
+func (b *buf) getSwap() *[]uint32 {
+	buf := *b.swapPool.Get().(*[]uint32)
+	bb := buf[:]
+	return &bb
+}
+
+func (b *buf) putSwap(buf *[]uint32) {
+	b.swapPool.Put(buf)
+}
+
+func (b *buf) getCounters() *[]int {
+	buf := *b.countersPool.Get().(*[]int)
+	bb := buf[:]
+	return &bb
+}
+
+func (b *buf) putCounters(buf *[]int) {
+	b.countersPool.Put(buf)
+}
+
+func newBuffer(swapSize, countersSize int) buf {
+	return buf{
+		swapPool: sync.Pool{
+			New: func() interface{} {
+				b := make([]uint32, swapSize)
+				return &b
+			},
+		},
+		countersPool: sync.Pool{
+			New: func() interface{} {
+				b := make([]int, countersSize)
+				return &b
+			},
+		},
+	}
+}

--- a/peer/hashring32/internal/radixsort32/radixsort_test.go
+++ b/peer/hashring32/internal/radixsort32/radixsort_test.go
@@ -1,0 +1,156 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package radixsort32
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRadixSort tests radix sort correctness
+func TestRadixSort(t *testing.T) {
+	sorter := makeSorter(16, 100, 15000)
+	// short break
+	testRadixSortReversedSlice(t, sorter, 10)
+	// radix sort with buffers in pool
+	testRadixSortReversedSlice(t, sorter, 300)
+	// radix sort with dynamically allocated buffers
+	testRadixSortReversedSlice(t, sorter, 20000)
+}
+
+// TestOptions tests options and fallbacks
+func TestOptions(t *testing.T) {
+	sorter := makeSorter(3, 500000, 100)
+	assert.Equal(t, uint(8), sorter.radix)
+	assert.Equal(t, 100, sorter.maxLength)
+	assert.Equal(t, 100, sorter.minLength)
+
+	sorter2 := makeSorter(3, -50, 100)
+	assert.Equal(t, 0, sorter2.minLength)
+	assert.Equal(t, 100, sorter2.maxLength)
+}
+
+func testRadixSortReversedSlice(t *testing.T, sorter *RadixSorter32, size int) {
+	slice := makeRevertedSlice(size)
+	sorter.Sort(slice)
+	assert.EqualValues(t, makeSortedSlice(size), slice)
+}
+
+func makeSorter(radix, minLen, maxLen int) *RadixSorter32 {
+	sorter := New(
+		Radix(radix),
+		MinLen(minLen),
+		MaxLen(maxLen))
+	return sorter
+}
+
+func makeRevertedSlice(size int) []uint32 {
+	a := make([]uint32, size)
+	for i := size - 1; i >= 0; i-- {
+		a[i] = uint32(len(a) - 1 - i)
+	}
+	return a
+}
+
+func makeSortedSlice(size int) []uint32 {
+	a := make([]uint32, size)
+	for i := 0; i < len(a); i++ {
+		a[i] = uint32(i)
+	}
+	return a
+}
+
+// Benchmarks
+
+func BenchmarkSortSize150KCompare(b *testing.B) {
+	benchmarkCompareSort(b, 150000)
+}
+
+func BenchmarkSortSize150KRadix4(b *testing.B) {
+	benchmarkRadixSort(b, 4, 150000)
+}
+
+func BenchmarkSortSize150KRadix8(b *testing.B) {
+	benchmarkRadixSort(b, 8, 150000)
+}
+
+func BenchmarkSortSize150KRadix16(b *testing.B) {
+	benchmarkRadixSort(b, 16, 150000)
+}
+
+func BenchmarkSortSize15KCompare(b *testing.B) {
+	benchmarkCompareSort(b, 15000)
+}
+
+func BenchmarkSortSize15KRadix4(b *testing.B) {
+	benchmarkRadixSort(b, 4, 15000)
+}
+
+func BenchmarkSortSize15KRadix8(b *testing.B) {
+	benchmarkRadixSort(b, 8, 15000)
+}
+
+func BenchmarkSortSize15KRadix16(b *testing.B) {
+	benchmarkRadixSort(b, 16, 15000)
+}
+
+func BenchmarkSortSize1500Compare(b *testing.B) {
+	benchmarkCompareSort(b, 1500)
+}
+
+func BenchmarkSortSize1500Radix4(b *testing.B) {
+	benchmarkRadixSort(b, 4, 1500)
+}
+
+func BenchmarkSortSize1500Radix8(b *testing.B) {
+	benchmarkRadixSort(b, 8, 1500)
+}
+
+func BenchmarkSortSize15000KRadix16(b *testing.B) {
+	benchmarkRadixSort(b, 16, 1500)
+}
+
+const par = 8
+
+func benchmarkRadixSort(b *testing.B, radix, size int) {
+	sorter := makeSorter(radix, 0, size)
+	b.SetParallelism(par)
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			sorter.Sort(makeRevertedSlice(size))
+		}
+	})
+}
+
+func benchmarkCompareSort(b *testing.B, size int) {
+	sorter := makeSorter(8, size, size)
+	b.SetParallelism(par)
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			sorter.Sort(makeRevertedSlice(size))
+		}
+	})
+}

--- a/peer/hashring32/list.go
+++ b/peer/hashring32/list.go
@@ -1,0 +1,210 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package hashring32
+
+// package harshing32yarpc provides peerlist bindings for hashring32 in YARPC.
+
+import (
+	"context"
+
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/introspection"
+	"go.uber.org/yarpc/peer/abstractlist"
+	"go.uber.org/yarpc/peer/hashring32/internal/hashring32"
+	"go.uber.org/zap"
+)
+
+type options struct {
+	offsetHeader       string
+	peerOverrideHeader string
+	peerRingOptions    []hashring32.Option
+	logger             *zap.Logger
+}
+
+// Option customizes the behavior of hashring32 implementation.
+type Option interface {
+	apply(*options)
+}
+
+// OffsetHeader is the option function that allows a user to pass a header
+// key to the hashring to adjust to N value in the hashring choose function.
+func OffsetHeader(offsetHeader string) Option {
+	return offsetHeaderOption{offsetHeader: offsetHeader}
+}
+
+type offsetHeaderOption struct {
+	offsetHeader string
+}
+
+func (o offsetHeaderOption) apply(opts *options) {
+	opts.offsetHeader = o.offsetHeader
+}
+
+// PeerOverrideHeader allows clients to pass a header containing the shard
+// identifier for a specific peer to override the destination address for the
+// outgoing request.
+//
+// For example, if the peer list uses addresses to identify peers, the hash
+// ring will have retained a peer for every known address.
+// Specifying an address like "127.0.0.1" in the route override header will
+// deflect the request to that exact peer.
+// If that peer is not available, the request will continue on to the peer
+// implied by the shard key.
+func PeerOverrideHeader(peerOverrideHeader string) Option {
+	return peerOverrideHeaderOption{peerOverrideHeader: peerOverrideHeader}
+}
+
+type peerOverrideHeaderOption struct {
+	peerOverrideHeader string
+}
+
+func (o peerOverrideHeaderOption) apply(opts *options) {
+	opts.peerOverrideHeader = o.peerOverrideHeader
+}
+
+// ReplicaDelimiter overrides the the delimiter the hash ring uses to construct
+// replica identifiers from peer identifiers and replica numbers.
+//
+// The default delimiter is an empty string.
+func ReplicaDelimiter(delimiter string) Option {
+	return replicaDelimiterOption{delimiter: delimiter}
+}
+
+type replicaDelimiterOption struct {
+	delimiter string
+}
+
+func (o replicaDelimiterOption) apply(opts *options) {
+	opts.peerRingOptions = append(
+		opts.peerRingOptions,
+		hashring32.ReplicaFormatter(
+			hashring32.DelimitedReplicaFormatter(o.delimiter),
+		),
+	)
+}
+
+// Logger threads a logger into the hash ring constructor.
+func Logger(logger *zap.Logger) Option {
+	return loggerOption{logger: logger}
+}
+
+type loggerOption struct {
+	logger *zap.Logger
+}
+
+func (o loggerOption) apply(opts *options) {
+	opts.logger = o.logger
+}
+
+// New creates a new hashring32 peer list.
+func New(transport peer.Transport, hashFunc hashring32.HashFunc32, opts ...Option) *List {
+	var options options
+	for _, o := range opts {
+		o.apply(&options)
+	}
+
+	logger := options.logger
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
+	ring := newPeerRing(hashFunc, options.offsetHeader, options.peerOverrideHeader, logger, options.peerRingOptions...)
+
+	return &List{
+		list: abstractlist.New("hashring32", transport, ring, abstractlist.Logger(logger)),
+	}
+}
+
+// List is a PeerList which chooses peers based on a hashing function.
+type List struct {
+	list *abstractlist.List
+}
+
+// Start causes the peer list to start.
+//
+// Starting will retain all peers that have been added but not removed
+// the first time it is called.
+//
+// Start may be called any number of times and in any order in relation to Stop
+// but will only cause the list to start the first time, and only if it has not
+// already been stopped.
+func (l *List) Start() error {
+	return l.list.Start()
+}
+
+// Stop causes the peer list to stop.
+//
+// Stopping will release all retained peers to the underlying transport.
+//
+// Stop may be called any number of times and in order in relation to Start but
+// will only cause the list to stop the first time, and only if it has
+// previously been started.
+func (l *List) Stop() error {
+	return l.list.Stop()
+}
+
+// IsRunning returns whether the list has started and not yet stopped.
+func (l *List) IsRunning() bool {
+	return l.list.IsRunning()
+}
+
+// Choose returns a peer, suitable for sending a request.
+//
+// The peer is not guaranteed to be connected and available, but the peer list
+// makes every attempt to ensure this and minimize the probability that a
+// chosen peer will fail to carry a request.
+func (l *List) Choose(ctx context.Context, req *transport.Request) (peer peer.Peer, onFinish func(error), err error) {
+	return l.list.Choose(ctx, req)
+}
+
+// Update may add and remove logical peers in the list.
+//
+// The peer list uses a transport to obtain a physical peer for each logical
+// peer.
+// The transport is responsible for informing the peer list whether the peer is
+// available or unavailable, but cannot guarantee that the peer will still be
+// available after it is chosen.
+func (l *List) Update(updates peer.ListUpdates) error {
+	return l.list.Update(updates)
+}
+
+// NotifyStatusChanged forwards a status change notification to an individual
+// peer in the list.
+//
+// This satisfies the peer.Subscriber interface and should only be used to
+// send notifications in tests.
+// The list's RetainPeer and ReleasePeer methods deal with an individual
+// peer.Subscriber instance for each peer in the list, avoiding a map lookup.
+func (l *List) NotifyStatusChanged(pid peer.Identifier) {
+	l.list.NotifyStatusChanged(pid)
+}
+
+// Introspect reveals information about the list to the internal YARPC
+// introspection system.
+func (l *List) Introspect() introspection.ChooserStatus {
+	return l.list.Introspect()
+}
+
+// Peers produces a slice of all retained peers.
+func (l *List) Peers() []peer.StatusPeer {
+	return l.list.Peers()
+}

--- a/peer/hashring32/list_test.go
+++ b/peer/hashring32/list_test.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package hashring32
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/peer/hashring32/internal/farmhashring"
+	"go.uber.org/yarpc/yarpctest"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestAddRemoveAndChoose(t *testing.T) {
+	trans := yarpctest.NewFakeTransport(yarpctest.InitialConnectionStatus(peer.Available))
+	pl := New(
+		trans,
+		farmhashring.Fingerprint32,
+		OffsetHeader("test"),
+		PeerOverrideHeader("poTest"),
+		ReplicaDelimiter("#"),
+		Logger(zaptest.NewLogger(t)),
+	)
+
+	pl.Start()
+
+	pl.Update(
+		peer.ListUpdates{
+			Additions: []peer.Identifier{
+				&FakeShardIdentifier{id: "id1", shard: "shard-1"},
+				&FakeShardIdentifier{id: "id2", shard: "shard-2"},
+			},
+		},
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	r, _, err := pl.Choose(ctx, &transport.Request{ShardKey: "foo1"})
+	require.NoError(t, err)
+	assert.Equal(t, "id1", r.Identifier())
+
+	r, _, err = pl.Choose(ctx, &transport.Request{ShardKey: "foo2"})
+	require.NoError(t, err)
+	assert.Equal(t, "id2", r.Identifier())
+
+	pl.Update(
+		peer.ListUpdates{
+			Removals: []peer.Identifier{
+				&FakeShardIdentifier{id: "id2", shard: "shard2"},
+			},
+		},
+	)
+
+	r, _, _ = pl.Choose(ctx, &transport.Request{ShardKey: "foo1"})
+	assert.Equal(t, "id1", r.Identifier())
+
+	r, _, _ = pl.Choose(ctx, &transport.Request{ShardKey: "foo2"})
+	assert.Equal(t, "id1", r.Identifier())
+
+}
+
+func TestOverrideChooseAndRemoveOverrideChoose(t *testing.T) {
+	var headers transport.Headers
+	trans := yarpctest.NewFakeTransport(yarpctest.InitialConnectionStatus(peer.Available))
+	pl := New(
+		trans,
+		farmhashring.Fingerprint32,
+		OffsetHeader("test"),
+		PeerOverrideHeader("poTest"),
+		ReplicaDelimiter("#"),
+	)
+
+	pl.Start()
+	t.Log("started")
+
+	pl.Update(
+		peer.ListUpdates{
+			Additions: []peer.Identifier{
+				&FakeShardIdentifier{id: "id1", shard: "shard-1"},
+				&FakeShardIdentifier{id: "id2", shard: "shard-2"},
+			},
+		},
+	)
+	t.Log("updated")
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	// Test overriden by header.
+	headers = headers.With("poTest", "shard-2")
+	r, _, _ := pl.Choose(ctx, &transport.Request{ShardKey: "foo1", Headers: headers})
+	assert.Equal(t, "id2", r.Identifier())
+	t.Log("chose once")
+
+	// Test invalid override header.
+	headers = headers.With("poTest", "shard-3")
+	r, _, _ = pl.Choose(ctx, &transport.Request{ShardKey: "foo1", Headers: headers})
+	assert.Equal(t, "id1", r.Identifier())
+	t.Log("chose twice")
+
+	pl.Update(
+		peer.ListUpdates{
+			Removals: []peer.Identifier{
+				&FakeShardIdentifier{id: "id2", shard: "shard2"},
+			},
+		},
+	)
+	t.Log("updated again")
+
+	// Test removed key in override header.
+	headers = headers.With("poTest", "shard-2")
+	r, _, _ = pl.Choose(ctx, &transport.Request{ShardKey: "foo2", Headers: headers})
+	assert.Equal(t, "id1", r.Identifier())
+	t.Log("chose a third time")
+
+}

--- a/peer/hashring32/ring.go
+++ b/peer/hashring32/ring.go
@@ -1,0 +1,162 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package hashring32
+
+import (
+	"strconv"
+
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/peer/abstractlist"
+	"go.uber.org/yarpc/peer/hashring32/internal/hashring32"
+	"go.uber.org/zap"
+)
+
+// newPeerRing creates a new peerRing with an initial capacity
+func newPeerRing(hashFunc hashring32.HashFunc32, offsetHeader, peerOverrideHeader string, logger *zap.Logger, option ...hashring32.Option) *peerRing {
+	return &peerRing{
+		ring:               hashring32.New(hashFunc, option...),
+		subscribers:        make(map[string]*subscriber),
+		offsetHeader:       offsetHeader,
+		peerOverrideHeader: peerOverrideHeader,
+		logger:             logger,
+	}
+}
+
+type subscriber struct {
+	peer peer.StatusPeer
+}
+
+func (s *subscriber) UpdatePendingRequestCount(int) {}
+
+// peerRing provides a safe way to interact (Add/Remove/Get) with a potentially
+// changing list of peer objects
+// peerRing is NOT Thread-safe, make sure to only call peerRing functions with a lock
+type peerRing struct {
+	ring               *hashring32.Hashring32
+	subscribers        map[string]*subscriber
+	offsetHeader       string
+	peerOverrideHeader string
+	logger             *zap.Logger
+}
+
+var _ abstractlist.Implementation = (*peerRing)(nil)
+
+// shardIdentifier is the interface for an identifier that have a shard property
+type shardIdentifier interface {
+	Identifier() string
+	Shard() string
+}
+
+// Add a string to the end of the peerRing, if the ring is empty
+// it initializes the ring marker
+func (pr *peerRing) Add(p peer.StatusPeer, pid peer.Identifier) abstractlist.Subscriber {
+	sub := &subscriber{peer: p}
+	shardID := getShardID(pid)
+	pr.ring.Add(shardID)
+	pr.subscribers[shardID] = sub
+
+	return sub
+}
+
+// Remove the peer from the ring. Use the subscriber to address the node of the
+// ring directly.
+func (pr *peerRing) Remove(p peer.StatusPeer, pid peer.Identifier, s abstractlist.Subscriber) {
+	sub, ok := s.(*subscriber)
+	if !ok {
+		// Don't panic.
+		return
+	}
+	// Peerlist's responsibility to make sure this never happens.
+	if sub.peer.Identifier() != p.Identifier() {
+		return
+	}
+
+	shardID := getShardID(pid)
+	pr.ring.Add(shardID)
+	pr.subscribers[shardID] = sub
+
+	// validate that given peer is already in the subscriber
+	pr.ring.Remove(shardID)
+	// Peerlist's responsibility to make sure this is thread-safe.
+	delete(pr.subscribers, shardID)
+}
+
+func (pr *peerRing) getPeerOverride(req *transport.Request) peer.StatusPeer {
+	dest, ok := req.Headers.Get(pr.peerOverrideHeader)
+	if !ok {
+		return nil
+	}
+	sub, ok := pr.subscribers[dest]
+	if !ok {
+		return nil
+	}
+	return sub.peer
+}
+
+// Choose returns the assigned peer in the ring
+func (pr *peerRing) Choose(req *transport.Request) peer.StatusPeer {
+	// Client may want this request to go to a specific destination.
+	overridePeer := pr.getPeerOverride(req)
+	if overridePeer != nil {
+		return overridePeer
+	}
+
+	// Hashring choose can return an error eg if there are no peer available.
+	var n int
+	var err error
+	key, ok := req.Headers.Get(pr.offsetHeader)
+	if ok {
+		n, err = strconv.Atoi(key)
+		if err != nil {
+			pr.logger.Error("yarpc/hashring32: offset header is not a valid integer", zap.String("offsetHeader", key), zap.Error(err))
+		}
+	}
+
+	ids, err := pr.ring.Choose(hashring32.Shard{
+		Key: req.ShardKey,
+		N:   n,
+	})
+	if err != nil {
+		return nil
+	}
+	if len(ids) <= n {
+		return nil
+	}
+	sub, ok := pr.subscribers[ids[n]]
+	if !ok {
+		return nil
+	}
+
+	return sub.peer
+}
+
+// getShardID returns the shardID from a StatusPeer.
+func getShardID(p peer.Identifier) string {
+	sp, ok := p.(shardIdentifier)
+	var id string
+	if !ok {
+		id = p.Identifier()
+	} else {
+		id = sp.Shard()
+	}
+	return id
+}

--- a/peer/hashring32/utils_for_test.go
+++ b/peer/hashring32/utils_for_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package hashring32
+
+// FakeShardIdentifier implements the shardIdentifier and is used for tests
+type FakeShardIdentifier struct {
+	id    string
+	shard string
+}
+
+// Identifier returns the id of the FakeShardIdentifier
+func (p *FakeShardIdentifier) Identifier() string {
+	return p.id
+}
+
+// Shard returns the shard of the FakeShardIdentifier
+func (p *FakeShardIdentifier) Shard() string {
+	return p.shard
+}


### PR DESCRIPTION
This change brings a consistent hashing peer selection strategy.

The strategy is compatible with Ringpop topologies so this can be introduced in a gateway to relieve a Ringpop cluster of most forwarding noise and even relieve the worker of forwarding responsibility entirely. This creates a path to replacing Ringpop services with YARPC services.

The configuration spec calls the strategy "hashring32".

This varies from a previous internal version in a few small ways.

- The previous version was named `x-hashring32`. The internal version can coexist with the external to avoid breaking changes in the future.
- I’ve renamed the `RouteOverrideHeader` to `PeerOverrideHeader` and clarified its meaning in the documentation. The new documentation discusses the feature in terms of IP addresses.
- The new version uses option pattern in way that is consistent with the most recent style guide.
- Many modules that were public are now internal to avoid API creep. Some of these could sensibly be in third-party packages if they’re otherwise useful, or just `go.uber.org/yarpc/pkg`.

Commits are individually reviewable.