### PR TITLE
Prioritized buffering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   This peer selection strategy uses the `ShardKey` call option to
   pin traffic to an arbitrary peer that is relatively stable as the peer list
   membership changes.
+- Prioritization for graceful degradation of quality of service.
+  The `api/priority` module introduces the notion of a prioritizer.
+  The `yarpcpriority` module is an implementation that takes tier, headers, and
+  time into account to produce broad spectrum priorities for requests and
+  coordinates those priorities with other load shedders through a "priority"
+  trace header.
+  The `middleware/inboundbuffermiddleware` module introduces an inbound unary
+  middleware that will buffer requests and limit concurrent handlers, shedding
+  unservable load based on priority.
 - Observability middleware now emits metrics for panics that occur on the stack
   of an inbound call handler.
 - The `transporttest` package now provides a `Pipe` constructor, which creates

--- a/api/priority/priority.go
+++ b/api/priority/priority.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package priority is an API for determining the priority of requests.
+package priority
+
+import (
+	"context"
+	"strconv"
+
+	"go.uber.org/yarpc/api/transport"
+)
+
+// Priority indicates a request's priority.
+//
+// Small numbers indicate priority over larger numbers.
+type Priority int8
+
+// Priority returns the string representation of a priority from "0%" to
+// "100%".
+func (p Priority) String() string {
+	return strconv.Itoa(int(p)) + "%"
+}
+
+const (
+	// Lowest priority (all other priorities will be served first)
+	Lowest = Priority(0)
+	// Highest priority (all other priorities will be served later)
+	Highest = Priority(100)
+)
+
+// Prioritizer extracts or assigns priority for an inbound request context.
+type Prioritizer interface {
+	// Priority returns the priority of the request in context.
+	Priority(context.Context, *transport.RequestMeta) (priority Priority, fortune Priority)
+}
+
+type nopPrioritizer struct{}
+
+// Priority returns the lowest priority.
+func (nopPrioritizer) Priority(context.Context, *transport.RequestMeta) (Priority, Priority) {
+	return Lowest, Lowest
+}
+
+// NopPrioritizer assigns the lowest priority to all requests.
+var NopPrioritizer Prioritizer = nopPrioritizer{}

--- a/middleware/x/inboundbuffermiddleware/buffer.go
+++ b/middleware/x/inboundbuffermiddleware/buffer.go
@@ -1,0 +1,207 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package inboundbuffermiddleware
+
+// buffer is the internal data structure of the QOS buffer.
+// The buffer assigns entity indexes for any accepted request, which the outer
+// buffer uses to track RPC specific details like context, request, response
+// writer, and the error return channel.
+// The inner buffer indexes all received requests by deadline and priority and
+// implements eviction policies.
+//
+// Instead of using reflection, the internal representation of a heap
+// is a pair of arrays that track all of the entitiy indexes, the graph and
+// co-graph.
+// For example, the minDeadlines and coMinDeadlines arrays track every entity
+// by its corresponding deadline (the deadlines array).
+//
+// The minDeadlines array is a heap of entity indexes with the
+// index of the nearest approaching deadline on top.
+// The coMinDeadliens array is the inverse: it tracks the index in the
+// minDeadlines array for every entity.
+//
+// This approach allows us to use the same integer heap implementation three
+// times without specialized types and without reflection.
+//
+// At any moment, only the values left of the `length` in any of these arrays
+// corresponds to a scheduled entity (a request).
+// The free list contains the index of every possible entity in the bounded
+// queue.
+// Those to the left of `length` are scheduled and those to the right are free.
+type buffer struct {
+	capacity int
+	length   int
+
+	// All of the following are parallel.
+	// Each index corresponds to the same entity.
+	deadlines       []uint64 // maxint indicates an unallocated entity
+	priorities      []uint64 // maxint indicates an unallocated entity
+	coFree          []int    // free[coFree[i]] == i
+	coMinDeadlines  []int    // minDeadlines[coMinDeadlines[i]] == i
+	coMinPriorities []int    // minPriorities[coMinPriorities[i]] == i
+	coMaxPriorities []int    // maxPriorities[coMaxPriorities[i]] == i
+
+	// Indexes
+	free          []int // list of unused entities
+	minDeadlines  []int // min heap by deadline
+	minPriorities []int // min heap by priority
+	maxPriorities []int // max heap by priority
+}
+
+// Init initializes the buffer.
+// The outer buffer allocates the inner buffer inline,
+// so this serves as a initailizer and no constructor is useful.
+func (b *buffer) Init(capacity int) {
+	b.capacity = capacity
+	b.deadlines = makeMaxSliceUint64(capacity)
+	b.priorities = makeMaxSliceUint64(capacity)
+	b.free = jot(capacity)
+	b.coFree = jot(capacity)
+	b.minDeadlines = jot(capacity)
+	b.coMinDeadlines = jot(capacity)
+	b.minPriorities = jot(capacity)
+	b.coMinPriorities = jot(capacity)
+	b.maxPriorities = jot(capacity)
+	b.coMaxPriorities = jot(capacity)
+}
+
+// Full indicates that no further entities can be added to the buffer until one
+// is removed.
+func (b *buffer) Full() bool {
+	return b.length >= b.capacity
+}
+
+// Adds an entity with the given deadline and priority (lower priorities have
+// precedence), returns the allocated entity index, or -1 if the buffer is
+// full.
+func (b *buffer) Put(deadline uint64, priority uint64) int {
+	if b.length >= b.capacity {
+		return -1
+	}
+
+	// Choose an entity index directly on the partition of the free entity
+	// index.
+	i := b.free[b.length]
+	b.deadlines[i] = deadline
+	b.priorities[i] = priority
+
+	// Move the entity to the partition on all corresponding indexes.
+	swap(b.maxPriorities, b.coMaxPriorities, b.coMaxPriorities[i], b.length)
+	swap(b.minPriorities, b.coMinPriorities, b.coMinPriorities[i], b.length)
+	swap(b.minDeadlines, b.coMinDeadlines, b.coMinDeadlines[i], b.length)
+	// Shift the partition, introducing the entity to every index.
+	b.length++
+
+	// Adjust indexes:
+
+	// Assuming all deadlines are positive in the Unix epoch.
+	// Time travellers, please do not use this algorithm before 1970.
+	fixHeapTowardRoot(minHeap, b.deadlines, b.minDeadlines, b.coMinDeadlines, i)
+	fixHeapTowardRoot(minHeap, b.priorities, b.minPriorities, b.coMinPriorities, i)
+	fixHeapTowardRoot(maxHeap, b.priorities, b.maxPriorities, b.coMaxPriorities, i)
+
+	return i
+}
+
+// Pop removes and returns the index for the highest priority entity in the
+// buffer.
+func (b *buffer) Pop() int {
+	if b.length == 0 {
+		return -1
+	}
+
+	// Index of highest priority entity.
+	i := b.maxPriorities[0]
+
+	b.evict(i)
+
+	return i
+}
+
+// Evict removes and returns the index of the entity with the earliest expired
+// deadline, or -1 if no entity has expired.
+func (b *buffer) EvictExpired(now uint64) int {
+	if b.length == 0 {
+		return -1
+	}
+
+	// Index of next entity to expire.
+	i := b.minDeadlines[0]
+
+	if b.deadlines[i] > now {
+		return -1
+	}
+
+	b.evict(i)
+
+	return i
+}
+
+// EvictLowerPriority removes and returns the index of the entity in the buffer
+// that has a lower priority (lower priorities are numerically higher).
+func (b *buffer) EvictLowerPriority(priority uint64) int {
+	if b.length == 0 {
+		return -1
+	}
+
+	// Index of of lowest priority entity.
+	i := b.minPriorities[0]
+
+	// Favor keeping an entity over replacing with an equivalent, for the sake
+	// of churn.
+	if b.priorities[i] >= priority {
+		return -1
+	}
+
+	b.evict(i)
+
+	return i
+}
+
+// evict removes an entity from the buffer, frees its index for a future
+// entity, and adjusts the internal heaps.
+func (b *buffer) evict(i int) {
+	// Reset values
+	b.deadlines[i] = maxUint64
+	b.priorities[i] = maxUint64
+
+	// One less entity.
+	// Move partition first, so we can use the new length as the destination
+	// index for swaps.
+	b.length--
+
+	// Move the selected entity out beyond the horizon.
+	swap(b.free, b.coFree, b.coFree[i], b.length)
+
+	// Similarly, swap entities in each index, then fix the heaps.
+	heapEvict(minHeap, b.length, b.deadlines, b.minDeadlines, b.coMinDeadlines, i)
+	heapEvict(minHeap, b.length, b.priorities, b.minPriorities, b.coMinPriorities, i)
+	heapEvict(maxHeap, b.length, b.priorities, b.maxPriorities, b.coMaxPriorities, i)
+}
+
+func heapEvict(dir heapDir, length int, values []uint64, heap, coHeap []int, i int) {
+	j := coHeap[i]
+	if j != length {
+		k := heap[length]
+		swap(heap, coHeap, j, length)
+		fixHeap(dir, length, values, heap, coHeap, k)
+	}
+}

--- a/middleware/x/inboundbuffermiddleware/buffer_test.go
+++ b/middleware/x/inboundbuffermiddleware/buffer_test.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package inboundbuffermiddleware
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The buffer constructor is only needed for tests since the buffer is inlined
+// into the parent struct otherwise.
+func newBuffer(capacity int) *buffer {
+	b := new(buffer)
+	b.Init(capacity)
+	return b
+}
+
+func TestBufferDegenerate(t *testing.T) {
+	b := newBuffer(0)
+	assert.Equal(t, -1, b.Pop())
+	assert.Equal(t, -1, b.Put(0, 0))
+	assert.Equal(t, -1, b.Pop())
+	assert.Equal(t, -1, b.Put(0, 0))
+}
+
+func TestBufferTrivial(t *testing.T) {
+	b := newBuffer(1)
+	assert.Equal(t, -1, b.Pop())
+
+	assert.Equal(t, 0, b.Put(0, 0))
+	assert.Equal(t, 1, b.length)
+
+	assert.Equal(t, -1, b.Put(0, 0))
+
+	assert.Equal(t, 0, b.Pop())
+	assert.Equal(t, 0, b.length)
+	assert.Equal(t, -1, b.Pop())
+}
+
+func TestBufferFavorHigherPriorityLeft(t *testing.T) {
+	b := newBuffer(2)
+	assert.Equal(t, -1, b.Pop())
+
+	assert.Equal(t, 0, b.Put(0, 0))
+	assert.Equal(t, 1, b.Put(0, 1))
+	assert.Equal(t, -1, b.Put(0, 0))
+
+	assert.Equal(t, 1, b.Pop())
+	assert.Equal(t, 0, b.Pop())
+	assert.Equal(t, -1, b.Pop())
+}
+
+func TestBufferFavorHigherPriorityRight(t *testing.T) {
+	b := newBuffer(2)
+	assert.Equal(t, -1, b.Pop())
+
+	assert.Equal(t, 0, b.Put(0, 1))
+	assert.Equal(t, 1, b.Put(0, 0))
+	assert.Equal(t, -1, b.Put(0, 0))
+
+	assert.Equal(t, 0, b.Pop())
+	assert.Equal(t, 1, b.Pop())
+	assert.Equal(t, -1, b.Pop())
+}
+
+func TestBufferDeadlineEviction(t *testing.T) {
+	b := newBuffer(3)
+	assert.Equal(t, -1, b.Pop())
+	assert.Equal(t, -1, b.EvictExpired(0))
+
+	assert.Equal(t, 0, b.Put(0, 0))
+	assert.Equal(t, 1, b.Put(1, 0))
+	assert.Equal(t, 2, b.Put(2, 0))
+	assert.Equal(t, -1, b.Put(0, 0))
+
+	assert.Equal(t, 0, b.EvictExpired(1))
+	assert.Equal(t, 1, b.EvictExpired(1))
+
+	assert.Equal(t, -1, b.EvictExpired(1))
+
+	assert.Equal(t, 2, b.EvictExpired(2))
+	assert.Equal(t, -1, b.EvictExpired(2))
+}
+
+func TestBufferPriorityEviction(t *testing.T) {
+	b := newBuffer(3)
+	assert.Equal(t, -1, b.Pop())
+	assert.Equal(t, -1, b.EvictExpired(0))
+
+	assert.Equal(t, 0, b.Put(0, 3))
+	// {0:3}
+	assert.Equal(t, 1, b.Put(0, 1))
+	// {0:3} {1:1}
+	assert.Equal(t, 2, b.Put(0, 2))
+	// {0:3} {2:2} {1:1}
+	assert.Equal(t, -1, b.Put(0, 0))
+
+	assert.Equal(t, -1, b.EvictLowerPriority(0))
+	assert.Equal(t, -1, b.EvictLowerPriority(1))
+	assert.Equal(t, 1, b.EvictLowerPriority(2))
+	// {0:3} {2:2}
+
+	assert.Equal(t, 2, b.EvictLowerPriority(3))
+	// {0:3}
+
+	assert.Equal(t, -1, b.EvictLowerPriority(3))
+	assert.Equal(t, 0, b.Pop())
+	assert.Equal(t, -1, b.EvictLowerPriority(0))
+	assert.Equal(t, -1, b.Pop())
+}

--- a/middleware/x/inboundbuffermiddleware/doc.go
+++ b/middleware/x/inboundbuffermiddleware/doc.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package inboundbuffermiddleware provides a quality-of-service-aware load-shedding buffer for
+// inbound unary requests.
+//
+// This takes the form of a middleware with a life cycle.
+// The buffer maintains workers so it must be started and stopped.
+//
+// The QOS-aware load shedder is a bounded buffer and worker pool.
+// The size of the worker pool (Concurrency) limits the  number
+// of concurrent requests that the service will handle.
+// The size of the bounded buffer dictates the size of the sample
+// of requests that the load shedder can select requests from.
+//
+// The load shedder will evict any expired request.
+// If the buffer is full, the load shedder will replace the
+// lowest priority request with any higher priority request it receives.
+// Workers accept the highest priority requests first.
+package inboundbuffermiddleware

--- a/middleware/x/inboundbuffermiddleware/heap.go
+++ b/middleware/x/inboundbuffermiddleware/heap.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package inboundbuffermiddleware
+
+import (
+	"fmt"
+	"os"
+)
+
+type heapDir bool
+
+const (
+	minHeap heapDir = true
+	maxHeap         = false
+)
+
+func fixHeap(dir heapDir, length int, values []uint64, heap, coHeap []int, index int) {
+	fmt.Fprintf(os.Stderr, "fix heap index %d i %d\n", index, coHeap[index])
+	fixHeapTowardRoot(dir, values, heap, coHeap, index)
+	fixHeapAwayFromRoot(dir, length, values, heap, coHeap, index)
+}
+
+func fixHeapTowardRoot(dir heapDir, values []uint64, heap, coHeap []int, index int) {
+	value := values[index]
+	i := coHeap[index]
+	for i > 0 {
+		pi := (i+1)/2 - 1
+		parent := values[heap[pi]]
+		if parent > value == dir {
+			fmt.Fprintf(os.Stderr, "fix heap toward root swap %d %d index %d\n", i, pi, index)
+			swap(heap, coHeap, i, pi)
+			i = pi
+		} else {
+			break
+		}
+	}
+}
+
+func fixHeapAwayFromRoot(dir heapDir, length int, values []uint64, heap, coHeap []int, index int) {
+	value := values[index]
+	i := coHeap[index]
+	for {
+		// i = index, ri = right index, li = left index, si = swap index.
+		// Variant: i increases, following either the left or right child
+		// index, until there are no more children.
+		ri := (i + 1) * 2
+		li := ri - 1
+		si := -1 // sentinel indicates no lesser child found.
+
+		var left uint64
+		// Consider the left child, if one exists.
+		if li < length {
+			left = values[heap[li]]
+			if left < value == dir {
+				si = li
+			}
+		}
+
+		// Independently, consider the right child, if one exists.
+		if ri < length {
+			right := values[heap[ri]]
+			// The right child will override a planned swap with the left child
+			// if the right child is less than the left.
+			if si >= 0 {
+				if right < left == dir {
+					si = ri
+				}
+			} else {
+				if right < value == dir {
+					si = ri
+				}
+			}
+		}
+
+		// Swap with either the left or right child if either were found to be
+		// less than their parent.
+		if si >= 0 {
+			fmt.Fprintf(os.Stderr, "swap child %d %d\n", i, si)
+			swap(heap, coHeap, i, si)
+			i = si
+		} else {
+			// Otherwise, we are guaranteed that either there are no children
+			// or no descendants less than the current node.
+			break
+		}
+	}
+}

--- a/middleware/x/inboundbuffermiddleware/heap_test.go
+++ b/middleware/x/inboundbuffermiddleware/heap_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package inboundbuffermiddleware
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func jotUint64(num int) []uint64 {
+	slice := make([]uint64, num)
+	for i := 0; i < num; i++ {
+		slice[i] = uint64(i)
+	}
+	return slice
+}
+
+func TestHeap(t *testing.T) {
+	size := 10
+
+	values := jotUint64(size)
+	heap := jot(size)
+	coHeap := jot(size)
+
+	t.Run("down", func(t *testing.T) {
+		for i := 0; i < size-1; i++ {
+			values[i] = maxUint64
+			fixHeap(minHeap, size, values, heap, coHeap, i)
+			assert.Equal(t, uint64(i+1), values[heap[0]])
+		}
+
+		values[size-1] = maxUint64
+		fixHeap(minHeap, size, values, heap, coHeap, size-1)
+		assert.Equal(t, maxUint64, values[heap[0]])
+	})
+
+	t.Run("up", func(t *testing.T) {
+		for i := size - 1; i > 0; i-- {
+			values[i] = uint64(i)
+			fixHeap(minHeap, size, values, heap, coHeap, i)
+			assert.Equal(t, uint64(i), values[heap[0]])
+		}
+	})
+
+	t.Run("up_with_duplicates", func(t *testing.T) {
+		for i := 0; i < size-1; i++ {
+			values[i] = maxUint64
+			fixHeap(minHeap, size, values, heap, coHeap, i)
+			assert.Equal(t, uint64(i+1), values[heap[0]])
+		}
+
+		for i := size - 1; i > 0; i-- {
+			// Dividing by half results in 0, 0, 1, 1, &c.
+			// So, the second sift runs into its doppleganger and exercises the
+			// case where the parent is not less than itself.
+			values[i] = uint64(size / 2)
+			fixHeap(minHeap, size, values, heap, coHeap, i)
+			assert.Equal(t, uint64(size/2), values[heap[0]])
+		}
+	})
+}

--- a/middleware/x/inboundbuffermiddleware/middleware.go
+++ b/middleware/x/inboundbuffermiddleware/middleware.go
@@ -1,0 +1,243 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package inboundbuffermiddleware
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"go.uber.org/atomic"
+	"go.uber.org/yarpc/api/priority"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/yarpcerrors"
+	"go.uber.org/zap"
+)
+
+// Buffer is an inbound unary middleware that ensures gradual degradation in
+// the face of excess load, quality of service for higher priority requests,
+// and coordinates load shedding for dependent requests.
+type Buffer struct {
+	concurrency atomic.Int32
+
+	mx        sync.Mutex
+	pendingCh chan struct{}
+	stopCh    chan struct{}
+	doneCh    chan struct{}
+	entities  []entity
+	buffer    buffer
+
+	prioritizer priority.Prioritizer
+	logger      *zap.Logger
+	now         func() time.Time
+}
+
+type entity struct {
+	ctx   context.Context
+	req   *transport.Request
+	res   transport.ResponseWriter
+	errCh chan error
+	next  transport.UnaryHandler
+}
+
+// New creates a buffer, an inbound unary middleware.
+func New(opts ...Option) *Buffer {
+	options := defaultOptions
+	for _, opt := range opts {
+		opt.apply(&options)
+	}
+
+	logger := options.logger
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
+	prioritizer := options.prioritizer
+	if prioritizer == nil {
+		prioritizer = priority.NopPrioritizer
+	}
+
+	now := options.now
+	if now == nil {
+		now = time.Now
+	}
+
+	b := &Buffer{
+		stopCh:      make(chan struct{}),
+		doneCh:      make(chan struct{}, options.concurrency),
+		pendingCh:   make(chan struct{}, 1),
+		entities:    make([]entity, options.capacity),
+		prioritizer: prioritizer,
+		logger:      logger,
+		now:         now,
+	}
+	b.buffer.Init(options.capacity)
+	b.concurrency.Store(int32(options.concurrency))
+	return b
+}
+
+// Start spawns workers to process inbound unary requests.
+func (b *Buffer) Start(ctx context.Context) error {
+	b.logger.Debug("inbound buffer middleware: initiated startup")
+	for i := 0; i < int(b.concurrency.Load()); i++ {
+		go worker(b, i)
+	}
+	return nil
+}
+
+// Stop shuts down workers and waits for them all to gracefully exit, or
+// returns an error early if the deadline in context occurs first.
+func (b *Buffer) Stop(ctx context.Context) error {
+	b.logger.Debug("inbound buffer middleware: initiated shutdown")
+
+	close(b.stopCh)
+	for {
+		select {
+		case <-ctx.Done():
+			b.logger.Error("inbound buffer middleware: shutdown aborted", zap.Error(ctx.Err()))
+			return ctx.Err()
+		case <-b.stopCh:
+			if b.concurrency.Load() == 0 {
+				b.logger.Debug("inbound buffer middleware: completed shutdown")
+				return nil
+			}
+		}
+	}
+}
+
+// Handle receives requests and schedules them or drops them if there's no room
+// for the request in the queue.
+func (b *Buffer) Handle(ctx context.Context, req *transport.Request, res transport.ResponseWriter, next transport.UnaryHandler) error {
+	// Read or create a priority for this request.
+
+	// Put the request on the queue, if we can.
+	errCh := b.put(ctx, req, res, next)
+	if errCh == nil {
+		return yarpcerrors.Newf(yarpcerrors.CodeResourceExhausted, "too busy and insuficient priority")
+	}
+
+	// Non-blocking poke on the pending channel to wake a worker if one has not
+	// already been wakened.
+	// If the channel is already full, our poke will get ignored, but the next
+	// worker to successfully take an item off the queue will poke the channel
+	// again to keep the cycle going.
+	select {
+	case b.pendingCh <- struct{}{}:
+	default:
+	}
+
+	// Wait for response error.
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case err := <-errCh:
+		return err
+	}
+}
+
+func (b *Buffer) put(ctx context.Context, req *transport.Request, res transport.ResponseWriter, next transport.UnaryHandler) <-chan error {
+	// Get or create priority from context.
+	p, f := b.prioritizer.Priority(ctx, req.ToRequestMeta())
+	priority := uint64(p)*1000 + uint64(f)
+
+	// Extrace deadline from request context.
+	deadline := maxUint64
+	if d, ok := ctx.Deadline(); ok {
+		deadline = uint64(d.UnixNano())
+	}
+
+	// We have postponed acquiring the lock because obtaining deadline and
+	// priority did not require the buffer.
+	b.mx.Lock()
+	defer b.mx.Unlock()
+
+	// Evict expired requests.
+	now := uint64(b.now().UnixNano())
+	for b.buffer.EvictExpired(now) != -1 {
+		// Continue until empty or all expired requests evicted.
+	}
+
+	if b.buffer.Full() {
+		b.buffer.EvictLowerPriority(priority)
+	}
+
+	i := b.buffer.Put(deadline, priority)
+	if i < 0 {
+		return nil
+	}
+	// fmt.Fprintf(os.Stderr, "put %d, pending %v\n", i, b.buffer.free[:b.buffer.length])
+
+	errCh := make(chan error, 1)
+	b.entities[i] = entity{
+		ctx:   ctx,
+		req:   req,
+		res:   res,
+		errCh: errCh,
+		next:  next,
+	}
+	return errCh
+}
+
+func (b *Buffer) pop() (ctx context.Context, req *transport.Request, res transport.ResponseWriter, errCh chan error, next transport.UnaryHandler, ok bool) {
+	b.mx.Lock()
+	defer b.mx.Unlock()
+
+	i := b.buffer.Pop()
+	if i < 0 {
+		return
+	}
+
+	e := &b.entities[i]
+	ctx = e.ctx
+	req = e.req
+	res = e.res
+	errCh = e.errCh
+	next = e.next
+	ok = true
+
+	// Release garbage.
+	b.entities[i] = entity{}
+
+	return
+}
+
+func worker(b *Buffer, i int) {
+	b.logger.Debug("inbound buffer middleware: worker started", zap.Int("worker", i))
+
+	for {
+		select {
+		case <-b.stopCh:
+			b.logger.Debug("inbound buffer middleware: worker shut down", zap.Int("worker", i))
+			b.concurrency.Dec()
+			b.doneCh <- struct{}{}
+			return
+		case <-b.pendingCh:
+		}
+
+		if ctx, req, res, errCh, next, ok := b.pop(); ok {
+			// Put a token back in the notifier. There may be more pending
+			// requests for other workers.
+			b.pendingCh <- struct{}{}
+
+			errCh <- next.Handle(ctx, req, res)
+		}
+	}
+}

--- a/middleware/x/inboundbuffermiddleware/middleware_test.go
+++ b/middleware/x/inboundbuffermiddleware/middleware_test.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package inboundbuffermiddleware
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/api/transport/transporttest"
+	"go.uber.org/yarpc/internal/testtime"
+	"go.uber.org/yarpc/yarpcerrors"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestStartStop(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
+	defer cancel()
+
+	// Exercise the Time option just for the coverage.
+	buffer := New(Time(time.Now))
+	require.NoError(t, buffer.Start(ctx))
+	for i := 0; i < 8; i++ {
+		require.NoError(t, buffer.Handle(ctx, &transport.Request{Body: &bytes.Buffer{}}, &transporttest.FakeResponseWriter{}, transporttest.EchoHandler{}))
+	}
+	require.NoError(t, buffer.Stop(ctx))
+}
+
+type slowHandler struct{}
+
+func (slowHandler) Handle(ctx context.Context, req *transport.Request, resw transport.ResponseWriter) error {
+	_, err := io.Copy(resw, req.Body)
+	time.Sleep(time.Millisecond)
+	return err
+}
+
+func TestStress(t *testing.T) {
+	body := "Hello, World!\n\n"
+	// handler := transporttest.EchoHandler{}
+	var handler slowHandler
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*testtime.Second)
+	defer cancel()
+
+	buffer := New(Capacity(8), Concurrency(8), Logger(zaptest.NewLogger(t)))
+	require.NoError(t, buffer.Start(ctx))
+
+	concurrency := 64
+
+	type result struct {
+		errors  int
+		drops   int
+		corrupt int
+	}
+
+	resCh := make(chan result)
+	for client := 0; client < concurrency; client++ {
+		go func(client int) {
+			var res result
+
+			for i := 0; i < 64; i++ {
+				resw := &transporttest.FakeResponseWriter{}
+				err := buffer.Handle(ctx, &transport.Request{
+					Body: bytes.NewBufferString(body),
+				}, resw, handler)
+				if yarpcerrors.IsResourceExhausted(err) {
+					res.drops++
+				} else if err != nil {
+					res.errors++
+				} else if resw.Body.String() != body {
+					res.corrupt++
+				}
+			}
+
+			resCh <- res
+		}(client)
+	}
+
+	var res result
+	for i := 0; i < concurrency; i++ {
+		r := <-resCh
+		res.errors += r.errors
+		res.drops += r.drops
+		res.corrupt += r.corrupt
+	}
+
+	require.NoError(t, buffer.Stop(ctx))
+	assert.Zero(t, res.corrupt)
+
+	// Report
+	t.Logf("%#v\n", res)
+}

--- a/middleware/x/inboundbuffermiddleware/options.go
+++ b/middleware/x/inboundbuffermiddleware/options.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package inboundbuffermiddleware
+
+import (
+	"time"
+
+	"go.uber.org/yarpc/api/priority"
+	"go.uber.org/zap"
+)
+
+var defaultOptions = options{
+	capacity:    256,
+	concurrency: 8,
+}
+
+type options struct {
+	capacity    int
+	concurrency int
+	logger      *zap.Logger
+	prioritizer priority.Prioritizer
+	now         func() time.Time
+}
+
+// Option is a constructor option for the QOS Buffer (New).
+type Option interface {
+	apply(*options)
+}
+
+// Capacity overrides the size of the bounded buffer.
+//
+// The default is 256.
+func Capacity(capacity int) Option {
+	return capacityOption{capacity: capacity}
+}
+
+type capacityOption struct {
+	capacity int
+}
+
+func (o capacityOption) apply(opts *options) {
+	opts.capacity = o.capacity
+}
+
+// Concurrency overrides the number of concurrent workers will process requests
+// off the bounded buffer.
+//
+// The default is 8.
+func Concurrency(concurrency int) Option {
+	return concurrencyOption{concurrency: concurrency}
+}
+
+type concurrencyOption struct {
+	concurrency int
+}
+
+func (o concurrencyOption) apply(opts *options) {
+	opts.concurrency = o.concurrency
+}
+
+// Prioritizer specifies a prioritizer for requests.
+//
+// The default assigns an equally low priority to all requests.
+func Prioritizer(prioritizer priority.Prioritizer) Option {
+	return prioritizerOption{prioritizer: prioritizer}
+}
+
+type prioritizerOption struct {
+	prioritizer priority.Prioritizer
+}
+
+func (o prioritizerOption) apply(opts *options) {
+	opts.prioritizer = o.prioritizer
+}
+
+// Logger specifies a logger for the bounded buffer to send messages for worker
+// startup and shutdown.
+func Logger(logger *zap.Logger) Option {
+	return loggerOption{logger: logger}
+}
+
+type loggerOption struct {
+	logger *zap.Logger
+}
+
+func (o loggerOption) apply(opts *options) {
+	opts.logger = o.logger
+}
+
+// Time overrides the system clock for determining the current time.
+//
+// The buffer will decline any request that expires before a worker will
+// process it, based on the time.
+func Time(now func() time.Time) Option {
+	return timeOption{now: now}
+}
+
+type timeOption struct {
+	now func() time.Time
+}
+
+func (o timeOption) apply(opts *options) {
+	opts.now = o.now
+}

--- a/middleware/x/inboundbuffermiddleware/util.go
+++ b/middleware/x/inboundbuffermiddleware/util.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package inboundbuffermiddleware
+
+const (
+	maxUint64 = ^uint64(0)
+)
+
+func jot(num int) []int {
+	slice := make([]int, num)
+	for i := 0; i < num; i++ {
+		slice[i] = i
+	}
+	return slice
+}
+
+func swap(values, coValues []int, i, j int) {
+	a, b := values[i], values[j]
+	values[i], values[j] = values[j], values[i]
+	coValues[a], coValues[b] = j, i
+}
+
+func makeMaxSliceUint64(size int) []uint64 {
+	slice := make([]uint64, size)
+	for i := 0; i < size; i++ {
+		slice[i] = maxUint64
+	}
+	return slice
+}

--- a/middleware/x/inboundbuffermiddleware/util_test.go
+++ b/middleware/x/inboundbuffermiddleware/util_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package inboundbuffermiddleware
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJot(t *testing.T) {
+	assert.Equal(t, []int{0, 1, 2}, jot(3))
+}
+
+func TestSwap(t *testing.T) {
+	nums := []int{3, 2, 1, 0}
+	coNums := []int{3, 2, 1, 0}
+
+	swap(nums, coNums, 0, 0)
+	assert.Equal(t, []int{3, 2, 1, 0}, nums)
+	assert.Equal(t, []int{3, 2, 1, 0}, coNums)
+
+	swap(nums, coNums, 0, 1)
+	assert.Equal(t, []int{2, 3, 1, 0}, nums)
+	assert.Equal(t, []int{3, 2, 0, 1}, coNums)
+
+	swap(nums, coNums, 1, 2)
+	assert.Equal(t, []int{2, 1, 3, 0}, nums)
+	assert.Equal(t, []int{3, 1, 0, 2}, coNums)
+
+	swap(nums, coNums, 2, 3)
+	assert.Equal(t, []int{2, 1, 0, 3}, nums)
+	assert.Equal(t, []int{2, 1, 0, 3}, coNums)
+
+	swap(nums, coNums, 0, 3)
+	assert.Equal(t, []int{3, 1, 0, 2}, nums)
+	assert.Equal(t, []int{2, 1, 3, 0}, coNums)
+}

--- a/yarpcpriority/hash.go
+++ b/yarpcpriority/hash.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpcpriority
+
+import (
+	"encoding/binary"
+	"hash/crc32"
+	"time"
+)
+
+const hour = uint64(time.Second * 60 * 60)
+
+func makeDefaultTimeHash() func(key string, now time.Time) uint32 {
+	hasher := crc32.NewIEEE()
+	return func(key string, now time.Time) uint32 {
+		hasher.Reset()
+
+		hasher.Write([]byte(key))
+
+		var t [8]byte
+		binary.BigEndian.PutUint64(t[:], uint64(now.UnixNano())/hour)
+		hasher.Write(t[:])
+
+		return hasher.Sum32()
+	}
+}
+
+func makeDefaultHash() func(key string) uint32 {
+	hasher := crc32.NewIEEE()
+	return func(key string) uint32 {
+		hasher.Reset()
+
+		hasher.Write([]byte(key))
+
+		return hasher.Sum32()
+	}
+}

--- a/yarpcpriority/options.go
+++ b/yarpcpriority/options.go
@@ -1,0 +1,166 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpcpriority
+
+import (
+	"math/rand"
+	"time"
+
+	"go.uber.org/yarpc/api/priority"
+)
+
+// Option is an argument to the Prioritizer constructor.
+type Option interface {
+	apply(*Prioritizer)
+}
+
+// Options groups options.
+func Options(opts ...Option) Option {
+	return options(opts)
+}
+
+type options []Option
+
+func (opts options) apply(p *Prioritizer) {
+	for _, opt := range opts {
+		opt.apply(p)
+	}
+}
+
+// Priority overrides the priortizier's default priority of service.
+func Priority(p priority.Priority) Option {
+	return priorityOption{priority: p}
+}
+
+type priorityOption struct {
+	priority priority.Priority
+}
+
+var _ Option = priorityOption{}
+
+func (o priorityOption) apply(p *Prioritizer) {
+	p.priority = o.priority
+}
+
+// ProcedurePriority overrides the default priority for requests for a
+// particular procedure.
+func ProcedurePriority(procedure string, priority priority.Priority) Option {
+	return procedurePriorityOption{
+		procedure: procedure,
+		priority:  priority,
+	}
+}
+
+type procedurePriorityOption struct {
+	procedure string
+	priority  priority.Priority
+}
+
+var _ Option = procedurePriorityOption{}
+
+func (o procedurePriorityOption) apply(p *Prioritizer) {
+	p.priorityRules[o.procedure] = o.priority
+}
+
+// FortuneRule is an option that adds a rule for generating a fortune for a
+// request if it has either a header or trace header (baggage).
+// The rule can be scoped to a specific procedure.
+// By default, ever rule rotates the fortune every hour to prevent perpetual
+// misfortune for the entity identified by a particular header.
+// Permanent rules stick the priority for a header or baggage value
+// permanently.
+type FortuneRule struct {
+	Header    string
+	Baggage   string
+	Procedure string
+	Permanent bool
+}
+
+var _ Option = FortuneRule{}
+
+func (r FortuneRule) apply(p *Prioritizer) {
+	p.fortuneRules = append(p.fortuneRules, r)
+}
+
+// Random overrides the default source of random numbers.
+func Random(source rand.Source) Option {
+	return randomOption{source: source}
+}
+
+type randomOption struct {
+	source rand.Source
+}
+
+var _ Option = randomOption{}
+
+func (o randomOption) apply(p *Prioritizer) {
+	p.prng = o.source
+}
+
+// Hash specifies a function from to generate a priority for a key.
+//
+// The default hash is CRC32.
+func Hash(hash func(string) uint32) Option {
+	return hashOption{hash: hash}
+}
+
+type hashOption struct {
+	hash func(string) uint32
+}
+
+var _ Option = hashOption{}
+
+func (o hashOption) apply(p *Prioritizer) {
+	p.hash = o.hash
+}
+
+// TimeHash specifies a hash function from which to generate a priority for a
+// key and time.
+//
+// The default hash incorporates CRC32 on the key and varies on the hour.
+func TimeHash(timeHash func(string, time.Time) uint32) Option {
+	return timeHashOption{timeHash: timeHash}
+}
+
+type timeHashOption struct {
+	timeHash func(string, time.Time) uint32
+}
+
+var _ Option = timeHashOption{}
+
+func (o timeHashOption) apply(p *Prioritizer) {
+	p.timeHash = o.timeHash
+}
+
+// Time specifies an alternate time source.
+func Time(now func() time.Time) Option {
+	return timeOption{now: now}
+}
+
+type timeOption struct {
+	now func() time.Time
+}
+
+var _ Option = timeOption{}
+
+func (o timeOption) apply(p *Prioritizer) {
+	p.now = o.now
+}

--- a/yarpcpriority/priority.go
+++ b/yarpcpriority/priority.go
@@ -1,0 +1,210 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpcpriority
+
+import (
+	"context"
+	"math/rand"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/opentracing/opentracing-go"
+	"go.uber.org/yarpc/api/priority"
+	"go.uber.org/yarpc/api/transport"
+)
+
+const (
+	priorityBaggageKey = "priority"
+	fortuneBaggageKey  = "fortune"
+)
+
+// Prioritizer extracts or creates priorities for requests.
+type Prioritizer struct {
+	mx sync.Mutex
+
+	priority      priority.Priority
+	priorityRules map[string]priority.Priority
+	fortuneRules  []FortuneRule
+
+	prng     rand.Source
+	hash     func(string) uint32
+	timeHash func(string, time.Time) uint32
+	now      func() time.Time
+}
+
+var _ priority.Prioritizer = (*Prioritizer)(nil)
+
+// New creates a prioritizer with the given options.
+func New(opts ...Option) *Prioritizer {
+	p := &Prioritizer{
+		priorityRules: make(map[string]priority.Priority),
+	}
+	for _, opt := range opts {
+		opt.apply(p)
+	}
+	if p.prng == nil {
+		p.prng = rand.NewSource(time.Now().UnixNano())
+	}
+	if p.hash == nil {
+		p.hash = makeDefaultHash()
+	}
+	if p.timeHash == nil {
+		p.timeHash = makeDefaultTimeHash()
+	}
+	if p.now == nil {
+		p.now = time.Now
+	}
+	return p
+}
+
+// Priority obtains or creates a priority and fortune for a context and
+// request.
+//
+// The foremost preference is to use the "priority" and "fortune" headers
+// present in context headers (trace baggge).
+//
+// In its absence, the prioritizer will create a priority and add it to the
+// trace span.
+//
+// The default priority is 0.
+// The default priority can be overridden with the Priority option or
+// ProcedurePriority options if specific procedures have different default
+// priorities.
+//
+// The default fortune is random.
+// The default fortune can be overridden by the first FortuneRule option that
+// matches the request procedure and a header or baggage.
+// The priority will be consistent for the same header or baggage value for an
+// hour at a time.
+// Permanent fortune rules will consistently generate the same priority for the
+// matched header or baggage regardless of the hour.
+func (p *Prioritizer) Priority(ctx context.Context, req *transport.RequestMeta) (priority.Priority, priority.Priority) {
+	var pn, fn priority.Priority
+	var ps, fs string
+
+	span := opentracing.SpanFromContext(ctx)
+
+	if span != nil {
+		ps = span.BaggageItem(priorityBaggageKey)
+		fs = span.BaggageItem(fortuneBaggageKey)
+	}
+
+	if ps == "" {
+		pn = p.constructPriority(req.Procedure)
+		ps = strconv.Itoa(int(pn))
+		if span != nil {
+			span.SetBaggageItem(priorityBaggageKey, ps)
+		}
+	} else {
+		if i, err := strconv.Atoi(ps); err == nil {
+			pn = clamp(i)
+		}
+	}
+
+	if fs == "" {
+		fn = p.constructFortune(span, req)
+		fs = strconv.Itoa(int(fn))
+		if span != nil {
+			span.SetBaggageItem(fortuneBaggageKey, fs)
+		}
+	} else {
+		if i, err := strconv.Atoi(fs); err == nil {
+			fn = clamp(i)
+		}
+	}
+
+	return pn, fn
+}
+
+func clamp(i int) priority.Priority {
+	if i > 100 {
+		i = 100
+	}
+	if i < 0 {
+		i = 0
+	}
+	return priority.Priority(i)
+}
+
+func (p *Prioritizer) constructPriority(procedure string) priority.Priority {
+	if pn, ok := p.priorityRules[procedure]; ok {
+		return pn
+	}
+	return p.priority
+}
+
+func (p *Prioritizer) constructFortune(span opentracing.Span, req *transport.RequestMeta) priority.Priority {
+	for _, rule := range p.fortuneRules {
+		var value string
+		if rule.Procedure != "" && rule.Procedure != req.Procedure {
+			continue
+		}
+		if rule.Baggage != "" {
+			value = span.BaggageItem(rule.Baggage)
+		}
+		if rule.Header != "" {
+			value, _ = req.Headers.Get(rule.Header)
+		}
+		if value != "" {
+			var hash uint32
+			if rule.Permanent {
+				hash = p.lockHash(value)
+			} else {
+				hash = p.lockTimeHash(value)
+			}
+			return p.constructFortuneFromEntropy(hash)
+		}
+	}
+	return p.constructRandomFortune()
+}
+
+func (p *Prioritizer) constructRandomFortune() priority.Priority {
+	return p.constructFortuneFromEntropy(p.rand())
+}
+
+func (p *Prioritizer) constructFortuneFromEntropy(entropy uint32) priority.Priority {
+	// Produce entropy in the range [1, 100] inclusive.
+	return priority.Priority(entropy % 101)
+}
+
+func (p *Prioritizer) lockHash(key string) uint32 {
+	p.mx.Lock()
+	defer p.mx.Unlock()
+
+	return p.hash(key)
+}
+
+func (p *Prioritizer) lockTimeHash(key string) uint32 {
+	now := p.now()
+
+	p.mx.Lock()
+	defer p.mx.Unlock()
+
+	return p.timeHash(key, now)
+}
+
+func (p *Prioritizer) rand() uint32 {
+	p.mx.Lock()
+	defer p.mx.Unlock()
+
+	return uint32(p.prng.Int63())
+}

--- a/yarpcpriority/priority_test.go
+++ b/yarpcpriority/priority_test.go
@@ -1,0 +1,337 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpcpriority
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/mocktracer"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/yarpc/api/priority"
+	"go.uber.org/yarpc/api/transport"
+)
+
+func TestRandomFortune(t *testing.T) {
+	p := New(Time(func() time.Time { return time.Unix(0, 0) }))
+	ctx := context.Background()
+	var p1, p2 priority.Priority
+	var f1, f2 priority.Priority
+
+	{
+		tracer := mocktracer.New()
+		span := tracer.StartSpan("prioritized")
+		ctx = opentracing.ContextWithSpan(ctx, span)
+		p1, f1 = p.Priority(ctx, &transport.RequestMeta{})
+	}
+
+	{
+		tracer := mocktracer.New()
+		span := tracer.StartSpan("prioritized")
+		ctx = opentracing.ContextWithSpan(ctx, span)
+		p2, f2 = p.Priority(ctx, &transport.RequestMeta{})
+	}
+
+	assert.Equal(t, p1, p2)
+	assert.NotEqual(t, f1, f2)
+}
+
+func TestPriorityDifferentiation(t *testing.T) {
+	var p1, p2 priority.Priority
+
+	{
+		p := New(
+			Priority(1),
+			Time(func() time.Time { return time.Unix(0, 0) }),
+		)
+		ctx := context.Background()
+		tracer := mocktracer.New()
+		span := tracer.StartSpan("prioritized")
+		ctx = opentracing.ContextWithSpan(ctx, span)
+		p1, _ = p.Priority(ctx, &transport.RequestMeta{})
+	}
+
+	{
+		p := New(
+			Priority(2),
+			Time(func() time.Time { return time.Unix(0, 0) }),
+		)
+		ctx := context.Background()
+		tracer := mocktracer.New()
+		span := tracer.StartSpan("prioritized")
+		ctx = opentracing.ContextWithSpan(ctx, span)
+		p2, _ = p.Priority(ctx, &transport.RequestMeta{})
+	}
+
+	assert.Less(t, uint8(p1), uint8(p2))
+}
+
+func TestConsistentHeaderFortune(t *testing.T) {
+	p := New(
+		FortuneRule{Header: "user"},
+		Time(func() time.Time { return time.Unix(0, 0) }),
+	)
+	tracer := mocktracer.New()
+
+	ctx := context.Background()
+	span := tracer.StartSpan("prioritized")
+	ctx = opentracing.ContextWithSpan(ctx, span)
+
+	var p1, p2, p3 priority.Priority
+	var f1, f2, f3 priority.Priority
+
+	{
+		p1, f1 = p.Priority(ctx, &transport.RequestMeta{
+			Headers: transport.NewHeaders().With("user", "dk"),
+		})
+	}
+
+	{
+		p2, f2 = p.Priority(ctx, &transport.RequestMeta{
+			Headers: transport.NewHeaders().With("user", "dk"),
+		})
+
+		// Verify that the priority was captured on the span.
+		p3, f3 = p.Priority(ctx, &transport.RequestMeta{})
+	}
+
+	assert.Equal(t, p1, p2)
+	assert.Equal(t, p1, p3)
+	assert.Equal(t, f1, f2)
+	assert.Equal(t, f1, f3)
+	assert.NotEqual(t, priority.Lowest, f1)
+}
+
+func TestPermanentHeaderFortune(t *testing.T) {
+	p := New(
+		FortuneRule{Header: "user", Permanent: true},
+	)
+	tracer := mocktracer.New()
+
+	ctx := context.Background()
+	span := tracer.StartSpan("prioritized")
+	ctx = opentracing.ContextWithSpan(ctx, span)
+
+	var p1, p2, p3 priority.Priority
+	var f1, f2, f3 priority.Priority
+
+	{
+		p1, f1 = p.Priority(ctx, &transport.RequestMeta{
+			Headers: transport.NewHeaders().With("user", "tk"),
+		})
+	}
+
+	{
+		p2, f2 = p.Priority(ctx, &transport.RequestMeta{
+			Headers: transport.NewHeaders().With("user", "tk"),
+		})
+
+		// Verify that the priority was captured on the span.
+		p3, f3 = p.Priority(ctx, &transport.RequestMeta{})
+	}
+
+	assert.Equal(t, p1, p2)
+	assert.Equal(t, p1, p3)
+	assert.Equal(t, f1, f2)
+	assert.Equal(t, f1, f3)
+	assert.NotEqual(t, priority.Lowest, f1)
+}
+
+func TestProcedureFortune(t *testing.T) {
+	p := New(
+		Options(
+			FortuneRule{Header: "user", Procedure: "foo", Permanent: true},
+			FortuneRule{Header: "owner", Permanent: true},
+		),
+	)
+
+	var p1, p2, p3 priority.Priority
+	var f1, f2, f3 priority.Priority
+
+	{
+		tracer := mocktracer.New()
+		ctx := context.Background()
+		span := tracer.StartSpan("prioritized")
+		ctx = opentracing.ContextWithSpan(ctx, span)
+		p1, f1 = p.Priority(ctx, &transport.RequestMeta{
+			Procedure: "foo",
+			Headers:   transport.NewHeaders().With("user", "tk"),
+		})
+	}
+
+	{
+		tracer := mocktracer.New()
+		ctx := context.Background()
+		span := tracer.StartSpan("prioritized")
+		ctx = opentracing.ContextWithSpan(ctx, span)
+		p2, f2 = p.Priority(ctx, &transport.RequestMeta{
+			Procedure: "bar",
+			Headers:   transport.NewHeaders().With("owner", "tk"),
+		})
+
+		// Verify that the priority was captured on the span.
+		p3, f3 = p.Priority(ctx, &transport.RequestMeta{})
+	}
+
+	assert.Equal(t, p1, p2)
+	assert.Equal(t, p1, p3)
+	assert.Equal(t, f1, f2)
+	assert.Equal(t, f1, f3)
+	assert.NotEqual(t, priority.Lowest, f1)
+}
+
+func TestProcedurePriority(t *testing.T) {
+	p := New(
+		ProcedurePriority("foo", 1),
+		ProcedurePriority("bar", 2),
+	)
+
+	{
+		ctx := context.Background()
+		p, _ := p.Priority(ctx, &transport.RequestMeta{
+			Procedure: "foo",
+		})
+		assert.Equal(t, uint(p), uint(1))
+	}
+
+	{
+		ctx := context.Background()
+		p, _ := p.Priority(ctx, &transport.RequestMeta{
+			Procedure: "bar",
+		})
+		assert.Equal(t, uint(p), uint(2))
+	}
+
+}
+
+func TestConsistentBaggageFortune(t *testing.T) {
+	p := New(
+		FortuneRule{Baggage: "user"},
+		Time(func() time.Time { return time.Unix(0, 0) }),
+	)
+	ctx := context.Background()
+	var p1, p2, p3 priority.Priority
+	var f1, f2, f3 priority.Priority
+
+	{
+		tracer := mocktracer.New()
+		span := tracer.StartSpan("prioritized")
+		span.SetBaggageItem("user", "dk")
+		ctx = opentracing.ContextWithSpan(ctx, span)
+		p1, f1 = p.Priority(ctx, &transport.RequestMeta{})
+	}
+
+	{
+		tracer := mocktracer.New()
+		span := tracer.StartSpan("prioritized")
+		span.SetBaggageItem("user", "dk")
+		ctx = opentracing.ContextWithSpan(ctx, span)
+		p2, f2 = p.Priority(ctx, &transport.RequestMeta{})
+
+		// Verify that the priority was captured on the span.
+		p3, f3 = p.Priority(ctx, &transport.RequestMeta{})
+	}
+
+	assert.Equal(t, p1, p2)
+	assert.Equal(t, p1, p3)
+	assert.Equal(t, f1, f2)
+	assert.Equal(t, f1, f3)
+	assert.NotEqual(t, priority.Lowest, f1)
+}
+
+func TestConsistentFortuneVaries(t *testing.T) {
+	var now = time.Unix(0, 0)
+	p := New(
+		FortuneRule{Baggage: "user"},
+		Time(func() time.Time { return now }),
+	)
+	ctx := context.Background()
+	var p1, p2, p3 priority.Priority
+	var f1, f2, f3 priority.Priority
+
+	{
+		tracer := mocktracer.New()
+		span := tracer.StartSpan("prioritized")
+		span.SetBaggageItem("user", "dk")
+		ctx = opentracing.ContextWithSpan(ctx, span)
+		p1, f1 = p.Priority(ctx, &transport.RequestMeta{})
+	}
+
+	// Almost one hour later.
+	now = time.Unix(60*60-1, 0)
+
+	{
+		tracer := mocktracer.New()
+		span := tracer.StartSpan("prioritized")
+		span.SetBaggageItem("user", "dk")
+		ctx = opentracing.ContextWithSpan(ctx, span)
+		p2, f2 = p.Priority(ctx, &transport.RequestMeta{})
+	}
+
+	// A full hour later.
+	now = time.Unix(60*60, 0)
+
+	{
+		tracer := mocktracer.New()
+		span := tracer.StartSpan("prioritized")
+		span.SetBaggageItem("user", "dk")
+		ctx = opentracing.ContextWithSpan(ctx, span)
+		p3, f3 = p.Priority(ctx, &transport.RequestMeta{})
+	}
+
+	assert.Equal(t, p1, p2)
+	assert.Equal(t, p2, p3)
+
+	assert.Equal(t, f1, f2)
+	assert.NotEqual(t, f2, f3)
+}
+
+func TestExaggerationsAboutPriority(t *testing.T) {
+	prioritizer := New()
+	tracer := mocktracer.New()
+
+	ctx := context.Background()
+	span := tracer.StartSpan("prioritized")
+	span.SetBaggageItem("priority", "200")
+	span.SetBaggageItem("fortune", "200")
+	ctx = opentracing.ContextWithSpan(ctx, span)
+	p, f := prioritizer.Priority(ctx, &transport.RequestMeta{})
+
+	assert.Equal(t, priority.Highest, p)
+	assert.Equal(t, priority.Highest, f)
+}
+
+func TestLiesAboutPriority(t *testing.T) {
+	prioritizer := New()
+	tracer := mocktracer.New()
+
+	ctx := context.Background()
+	span := tracer.StartSpan("prioritized")
+	span.SetBaggageItem("priority", "-200")
+	span.SetBaggageItem("fortune", "-200")
+	ctx = opentracing.ContextWithSpan(ctx, span)
+	p, f := prioritizer.Priority(ctx, &transport.RequestMeta{})
+
+	assert.Equal(t, priority.Lowest, p)
+	assert.Equal(t, priority.Lowest, f)
+}


### PR DESCRIPTION
Commits are individually reviewable.

This change introduces a notion of priority to the YARPC API. A prioritizer returns a 64 bit priority for a given context and request metadata.

The second commit introduces an implementation of a prioritizer, which provides treatments for cases including random priority, tier priority, and consistent priority for particular context baggage like a UUID, by default rotating hashes on the hour.

The third commit introduces a bounded buffer middleware that indexes all incoming requests by deadline and priority. The buffer evicts expired requests and requests arriving at a full buffer either replace the lowest priority request still in the buffer or are dropped with a resource exhausted error.

- [x] wire spec
- [x] change log