### PR TITLE
Use go mod for license updates

### DIFF
--- a/etc/bin/.gitignore
+++ b/etc/bin/.gitignore
@@ -1,0 +1,1 @@
+update-license

--- a/etc/bin/update-licenses.sh
+++ b/etc/bin/update-licenses.sh
@@ -5,9 +5,12 @@ set -e
 DIR="$(cd "$(dirname "${0}")/../.." && pwd)"
 cd "${DIR}"
 
+export GOBIN=$DIR/etc/bin
+go install go.uber.org/tools/update-license
+
 # We need to ignore internal/tests for licenses so that the golden test for
 # thriftrw-plugin-yarpc can verify the contents of the generated code without
 # running updateLicenses on it.
-update-license $(find . -name '*.go' \
+$GOBIN/update-license $(find . -name '*.go' \
 	| grep -v '^\./vendor' \
 	| grep -v '/thriftrw-plugin-yarpc/internal/tests/')


### PR DESCRIPTION
This makes a minor adjustment to how the update-licenses script installs its binary component, now to use go modules instead of depending on the binaries on the GOPATH.