### PR TITLE
Use gzip and snappy compressor pools

### DIFF
--- a/compressor/grpc/grpc.go
+++ b/compressor/grpc/grpc.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package yarpcgrpccompressor provides an adapter for YARPC compressors to
+// gRPC compressors.
+//
+// The only distinction is that YARPC's Decompressor returns an io.ReadCloser
+// instead of a mere io.Reader.
+// gRPC does not call Close, so must infer the end of stream by returning the
+// reader to the reader pool when Read returns io.EOF.
+// This wrapper uses the io.EOF to trigger and automatic Close.
+package yarpcgrpccompressor
+
+import (
+	"io"
+
+	"go.uber.org/yarpc/api/transport"
+	"google.golang.org/grpc/encoding"
+)
+
+// New adapts a YARPC compressor to a gRPC compressor.
+func New(compressor transport.Compressor) encoding.Compressor {
+	return &Compressor{compressor: compressor}
+}
+
+// Compressor is a gRPC compressor that wraps a YARPC compressor.
+type Compressor struct {
+	compressor transport.Compressor
+}
+
+var _ encoding.Compressor = (*Compressor)(nil)
+
+// Name returns the name of the underlying compressor.
+func (c *Compressor) Name() string {
+	return c.compressor.Name()
+}
+
+// Compress wraps a writer with a compressing writer.
+func (c *Compressor) Compress(w io.Writer) (io.WriteCloser, error) {
+	return c.compressor.Compress(w)
+}
+
+// Decompress wraps a reader with a decompressing reader.
+func (c *Compressor) Decompress(r io.Reader) (io.Reader, error) {
+	dr, err := c.compressor.Decompress(r)
+	if err != nil {
+		return nil, err
+	}
+	return &reader{reader: dr}, nil
+}
+
+type reader struct {
+	reader io.ReadCloser
+}
+
+var _ io.Reader = (*reader)(nil)
+
+func (r *reader) Read(buf []byte) (n int, err error) {
+	n, err = r.reader.Read(buf)
+	if err == io.EOF {
+		r.reader.Close()
+	}
+	return n, err
+}

--- a/compressor/grpc/grpc_test.go
+++ b/compressor/grpc/grpc_test.go
@@ -18,17 +18,18 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package transport
+package yarpcgrpccompressor_test
 
-import "io"
+import (
+	"testing"
 
-// Compressor represents a compression strategy and supports creating new
-// compression and decompression streams for that strategy.
-//
-// This interface is equivalent to the compressor API proposed by grpc-go.
-// https://godoc.org/google.golang.org/grpc/encoding#Compressor
-type Compressor interface {
-	Name() string
-	Compress(w io.Writer) (io.WriteCloser, error)
-	Decompress(r io.Reader) (io.ReadCloser, error)
+	"go.uber.org/yarpc/compressor/grpc"
+	"go.uber.org/yarpc/compressor/gzip"
+	"google.golang.org/grpc/encoding"
+)
+
+func TestCompressorRegistration(t *testing.T) {
+	gz := yarpcgzip.New()
+	gg := yarpcgrpccompressor.New(gz)
+	encoding.RegisterCompressor(gg)
 }

--- a/compressor/gzip/gzip.go
+++ b/compressor/gzip/gzip.go
@@ -18,32 +18,197 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Package gzip provides a YARPC binding for gzip compression.
-package gzip
+// Package yarpcgzip provides a YARPC binding for GZIP compression.
+package yarpcgzip
 
 import (
 	"compress/gzip"
+	"encoding/binary"
 	"io"
+	"sync"
 
 	"go.uber.org/yarpc/api/transport"
 )
 
-// Compressor represents the gzip compression strategy.
-type Compressor struct{}
+const name = "gzip"
 
-var _ transport.Compressor = Compressor{}
+// Option is an option argument for the Gzip compressor constructor, New.
+type Option interface {
+	apply(*Compressor)
+}
+
+// Level sets the compression level for the compressor.
+func Level(level int) Option {
+	return levelOption{level: level}
+}
+
+type levelOption struct {
+	level int
+}
+
+func (o levelOption) apply(opts *Compressor) {
+	opts.level = o.level
+}
+
+// New returns a GZIP compression strategy, suitable for configuring an
+// outbound dialer.
+//
+// The compressor is compatible with the gRPC experimental compressor system.
+// However, since gRPC requires global registration of compressors,
+// you must arrange for the compressor to be registered in your
+// application initialization.
+//
+//  import (
+//      "compress/gzip"
+//
+//      "google.golang.org/grpc/encoding"
+//      "go.uber.org/yarpc/compressor/gzip"
+//  )
+//
+//  var GZIPCompressor = yarpcgzip.New(yarpcgzip.Level(gzip.BestCompression))
+//
+//  func init()
+//      encoding.RegisterCompressor(GZIPCompressor)
+//  }
+//
+// If you are constructing your YARPC clients directly through the API,
+// create a gRPC dialer with the Compressor option.
+//
+//  trans := grpc.NewTransport()
+//  dialer := trans.NewDialer(GZIPCompressor)
+//  peers := roundrobin.New(dialer)
+//  outbound := trans.NewOutbound(peers)
+//
+// If you are using the YARPC configurator to create YARPC objects
+// using config files, you will also need to register the compressor
+// with your configurator.
+//
+//  configurator := yarpcconfig.New()
+//  configurator.MustRegisterCompressor(GZIPCompressor)
+//
+// Then, using the compression strategy for outbound requests
+// on a particular client, just set the compressor to gzip.
+//
+//  outbounds:
+//    theirsecureservice:
+//      grpc:
+//        address: ":443"
+//        tls:
+//          enabled: true
+//        compressor: gzip
+//
+func New(opts ...Option) *Compressor {
+	c := &Compressor{
+		level: gzip.DefaultCompression,
+	}
+	for _, opt := range opts {
+		opt.apply(c)
+	}
+	return c
+}
+
+// Compressor represents the gzip compression strategy.
+type Compressor struct {
+	level         int
+	compressors   sync.Pool
+	decompressors sync.Pool
+}
+
+var _ transport.Compressor = (*Compressor)(nil)
 
 // Name is gzip.
-func (Compressor) Name() string {
-	return "gzip"
+func (*Compressor) Name() string {
+	return name
 }
 
 // Compress creates a gzip compressor.
-func (Compressor) Compress(w io.Writer) (io.WriteCloser, error) {
-	return gzip.NewWriter(w), nil
+func (c *Compressor) Compress(w io.Writer) (io.WriteCloser, error) {
+	if cw, got := c.compressors.Get().(*writer); got {
+		cw.writer.Reset(w)
+		return cw, nil
+	}
+
+	cw, err := gzip.NewWriterLevel(w, c.level)
+	if err != nil {
+		return nil, err
+	}
+
+	return &writer{
+		writer: cw,
+		pool:   &c.compressors,
+	}, nil
 }
 
-// Decompress creates a gzip decompressor.
-func (Compressor) Decompress(r io.Reader) (io.Reader, error) {
-	return gzip.NewReader(r)
+type writer struct {
+	writer *gzip.Writer
+	pool   *sync.Pool
+}
+
+var _ io.WriteCloser = (*writer)(nil)
+
+func (w *writer) Write(buf []byte) (int, error) {
+	return w.writer.Write(buf)
+}
+
+func (w *writer) Close() error {
+	defer w.pool.Put(w)
+	return w.writer.Close()
+}
+
+// Decompress obtains a gzip decompressor.
+func (c *Compressor) Decompress(r io.Reader) (io.Reader, error) {
+	if dr, got := c.decompressors.Get().(*reader); got {
+		if err := dr.reader.Reset(r); err != nil {
+			c.decompressors.Put(r)
+			return nil, err
+		}
+
+		return dr, nil
+	}
+
+	dr, err := gzip.NewReader(r)
+	if err != nil {
+		return nil, err
+	}
+
+	return &reader{
+		reader: dr,
+		pool:   &c.decompressors,
+	}, nil
+}
+
+type reader struct {
+	reader *gzip.Reader
+	pool   *sync.Pool
+}
+
+var _ io.Reader = (*reader)(nil)
+
+func (r *reader) Read(buf []byte) (n int, err error) {
+	n, err = r.reader.Read(buf)
+	if err == io.EOF {
+		r.pool.Put(r)
+	}
+	return n, err
+}
+
+// DecompressedSize returns the decompressed size of the given GZIP compressed
+// bytes.
+//
+// gRPC specifically casts the compressor to a DecompressedSizer
+// to pre-check message length.
+//
+// Per gRPC-go, on which this is based:
+// https://github.com/grpc/grpc-go/blob/master/encoding/gzip/gzip.go
+//
+// RFC1952 specifies that the last four bytes "contains the size of
+// the original (uncompressed) input data modulo 2^32."
+// gRPC has a max message size of 2GB so we don't need to worry about
+// wraparound for that transport protocol.
+func (c *Compressor) DecompressedSize(buf []byte) int {
+	last := len(buf)
+	if last < 4 {
+		return -1
+	}
+	return int(binary.LittleEndian.Uint32(buf[last-4 : last]))
 }

--- a/compressor/gzip/gzip_test.go
+++ b/compressor/gzip/gzip_test.go
@@ -37,7 +37,6 @@ var quote = "Now is the time for all good men to come to the aid of their countr
 var input = []byte(quote + quote + quote)
 
 func TestGzip(t *testing.T) {
-
 	buf := bytes.NewBuffer(nil)
 	writer, err := yarpcgzip.New().Compress(buf)
 	require.NoError(t, err)
@@ -51,6 +50,7 @@ func TestGzip(t *testing.T) {
 
 	output, err := ioutil.ReadAll(str)
 	require.NoError(t, err)
+	require.NoError(t, str.Close())
 
 	assert.Equal(t, input, output)
 }
@@ -71,6 +71,7 @@ func TestCompressionPooling(t *testing.T) {
 
 		output, err := ioutil.ReadAll(str)
 		require.NoError(t, err)
+		require.NoError(t, str.Close())
 
 		assert.Equal(t, input, output)
 	}
@@ -102,6 +103,7 @@ func TestEveryCompressionLevel(t *testing.T) {
 
 			output, err := ioutil.ReadAll(str)
 			require.NoError(t, err)
+			require.NoError(t, str.Close())
 
 			assert.Equal(t, input, output)
 		})

--- a/compressor/gzip/gzip_test.go
+++ b/compressor/gzip/gzip_test.go
@@ -18,11 +18,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package gzip_test
+package yarpcgzip_test
 
 import (
 	"bytes"
+	"compress/gzip"
 	"io/ioutil"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,18 +32,21 @@ import (
 	"go.uber.org/yarpc/compressor/gzip"
 )
 
+// This should be compressible:
+var quote = "Now is the time for all good men to come to the aid of their country"
+var input = []byte(quote + quote + quote)
+
 func TestGzip(t *testing.T) {
-	input := []byte("Now is the time for all good men to come to the aid of their country")
 
 	buf := bytes.NewBuffer(nil)
-	writer, err := gzip.Compressor{}.Compress(buf)
+	writer, err := yarpcgzip.New().Compress(buf)
 	require.NoError(t, err)
 
 	_, err = writer.Write(input)
 	require.NoError(t, err)
 	require.NoError(t, writer.Close())
 
-	str, err := gzip.Compressor{}.Decompress(buf)
+	str, err := yarpcgzip.New().Decompress(buf)
 	require.NoError(t, err)
 
 	output, err := ioutil.ReadAll(str)
@@ -50,6 +55,83 @@ func TestGzip(t *testing.T) {
 	assert.Equal(t, input, output)
 }
 
+func TestCompressionPooling(t *testing.T) {
+	compressor := yarpcgzip.New()
+	for i := 0; i < 128; i++ {
+		buf := bytes.NewBuffer(nil)
+		writer, err := compressor.Compress(buf)
+		require.NoError(t, err)
+
+		_, err = writer.Write(input)
+		require.NoError(t, err)
+		require.NoError(t, writer.Close())
+
+		str, err := compressor.Decompress(buf)
+		require.NoError(t, err)
+
+		output, err := ioutil.ReadAll(str)
+		require.NoError(t, err)
+
+		assert.Equal(t, input, output)
+	}
+}
+
+func TestEveryCompressionLevel(t *testing.T) {
+	levels := []int{
+		gzip.NoCompression,
+		gzip.BestSpeed,
+		gzip.BestCompression,
+		gzip.DefaultCompression,
+		gzip.HuffmanOnly,
+	}
+
+	for _, level := range levels {
+		t.Run(strconv.Itoa(level), func(t *testing.T) {
+			compressor := yarpcgzip.New(yarpcgzip.Level(level))
+
+			buf := bytes.NewBuffer(nil)
+			writer, err := compressor.Compress(buf)
+			require.NoError(t, err)
+
+			_, err = writer.Write(input)
+			require.NoError(t, err)
+			require.NoError(t, writer.Close())
+
+			str, err := compressor.Decompress(buf)
+			require.NoError(t, err)
+
+			output, err := ioutil.ReadAll(str)
+			require.NoError(t, err)
+
+			assert.Equal(t, input, output)
+		})
+	}
+}
+
 func TestGzipName(t *testing.T) {
-	assert.Equal(t, "gzip", gzip.Compressor{}.Name())
+	assert.Equal(t, "gzip", yarpcgzip.New().Name())
+}
+
+func TestDecompressedSize(t *testing.T) {
+	compressor := yarpcgzip.New(yarpcgzip.Level(gzip.BestCompression))
+
+	buf := bytes.NewBuffer(nil)
+	writer, err := compressor.Compress(buf)
+	require.NoError(t, err)
+
+	_, err = writer.Write(input)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	assert.Equal(t, len(input), compressor.DecompressedSize(buf.Bytes()))
+
+	// Sanity check
+	assert.True(t, buf.Len() < len(input), "one would think the compressed data would be smaller")
+	t.Logf("decompress: %d\n", len(input))
+	t.Logf("compressed: %d\n", buf.Len())
+}
+
+func TestDecompressedSizeError(t *testing.T) {
+	compressor := yarpcgzip.New(yarpcgzip.Level(gzip.BestCompression))
+	assert.Equal(t, -1, compressor.DecompressedSize([]byte{}))
 }

--- a/compressor/snappy/snappy.go
+++ b/compressor/snappy/snappy.go
@@ -18,24 +18,46 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Package snappy provides a YARPC binding for snappy compression.
+// Package yarpcsnappy provides a YARPC binding for snappy compression.
+package yarpcsnappy
+
+import (
+	"io"
+	"sync"
+
+	"github.com/golang/snappy"
+	"go.uber.org/yarpc/api/transport"
+)
+
+// Option is an option argument for the Snappy compressor constructor, New.
+type Option interface {
+	apply(*Compressor)
+}
+
+// New returns a Snappy compression strategy, suitable for configuring
+// an outbound dialer.
 //
-// To use snappy with gzip in particular, you will need to
-// register the Compressor with grpc-go, the underlying implementation
-// of gRPC which makes extensive use of global variables for
-// depencencies.
+// The compressor is compatible with the gRPC experimental compressor system.
+// However, since gRPC requires global registration of compressors,
+// you must arrange for the compressor to be registered in your
+// application initialization.
 //
 //  import (
 //      "google.golang.org/grpc/encoding"
 //      "go.uber.org/yarpc/compressor/snappy"
 //  )
-//  encoding.RegisterCompressor(snappy.Compressor)
+//
+//  var SnappyCompressor = yarpcsnappy.New()
+//
+//  func init()
+//      encoding.RegisterCompressor(SnappyCompressor)
+//  }
 //
 // If you are constructing your YARPC clients directly through the API,
 // create a gRPC dialer with the Compressor option.
 //
 //  trans := grpc.NewTransport()
-//  dialer := trans.NewDialer(grpc.Compressor(snappy.Compressor))
+//  dialer := trans.NewDialer(grpc.Compressor(SnappyCompressor))
 //  peers := roundrobin.New(dialer)
 //  outbound := trans.NewOutbound(peers)
 //
@@ -44,7 +66,7 @@
 // with your configurator.
 //
 //  configurator := yarpcconfig.New()
-//  configurator.MustRegisterCompressor(snappy.Compressor)
+//  configurator.MustRegisterCompressor(SnappyCompressor)
 //
 // Then, using the compression strategy for outbound requests
 // on a particular client, just set the compressor to snappy.
@@ -56,31 +78,76 @@
 //        tls:
 //          enabled: true
 //        compressor: snappy
-package snappy
-
-import (
-	"io"
-
-	"github.com/golang/snappy"
-	"go.uber.org/yarpc/api/transport"
-)
+//
+func New(...Option) *Compressor {
+	return &Compressor{}
+}
 
 // Compressor represents the snappy streaming compression strategy.
-type Compressor struct{}
+type Compressor struct {
+	compressors   sync.Pool
+	decompressors sync.Pool
+}
 
-var _ transport.Compressor = Compressor{}
+var _ transport.Compressor = (*Compressor)(nil)
 
 // Name is snappy.
-func (Compressor) Name() string {
+func (*Compressor) Name() string {
 	return "snappy"
 }
 
 // Compress creates a snappy compressor.
-func (Compressor) Compress(w io.Writer) (io.WriteCloser, error) {
-	return snappy.NewBufferedWriter(w), nil
+func (c *Compressor) Compress(w io.Writer) (io.WriteCloser, error) {
+	if cw, got := c.compressors.Get().(*writer); got {
+		cw.writer.Reset(w)
+		return cw, nil
+	}
+	return &writer{
+		writer: snappy.NewBufferedWriter(w),
+		pool:   &c.compressors,
+	}, nil
+}
+
+type writer struct {
+	writer *snappy.Writer
+	pool   *sync.Pool
+}
+
+var _ io.WriteCloser = (*writer)(nil)
+
+func (w *writer) Write(buf []byte) (int, error) {
+	return w.writer.Write(buf)
+}
+
+func (w *writer) Close() error {
+	defer w.pool.Put(w)
+	return w.writer.Close()
 }
 
 // Decompress creates a snappy decompressor.
-func (Compressor) Decompress(r io.Reader) (io.Reader, error) {
-	return snappy.NewReader(r), nil
+func (c *Compressor) Decompress(r io.Reader) (io.Reader, error) {
+	dr, got := c.decompressors.Get().(*reader)
+	if got {
+		dr.reader.Reset(r)
+		return dr, nil
+	}
+	return &reader{
+		reader: snappy.NewReader(r),
+		pool:   &c.decompressors,
+	}, nil
+}
+
+type reader struct {
+	reader *snappy.Reader
+	pool   *sync.Pool
+}
+
+var _ io.Reader = (*reader)(nil)
+
+func (r *reader) Read(buf []byte) (n int, err error) {
+	n, err = r.reader.Read(buf)
+	if err == io.EOF {
+		r.pool.Put(r)
+	}
+	return n, err
 }

--- a/compressor/snappy/snappy_test.go
+++ b/compressor/snappy/snappy_test.go
@@ -48,6 +48,7 @@ func TestSnappy(t *testing.T) {
 
 	output, err := ioutil.ReadAll(str)
 	require.NoError(t, err)
+	require.NoError(t, str.Close())
 
 	assert.Equal(t, input, output)
 }
@@ -68,6 +69,7 @@ func TestCompressionPooling(t *testing.T) {
 
 		output, err := ioutil.ReadAll(str)
 		require.NoError(t, err)
+		require.NoError(t, str.Close())
 
 		assert.Equal(t, input, output)
 	}

--- a/compressor/snappy/snappy_test.go
+++ b/compressor/snappy/snappy_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package snappy_test
+package yarpcsnappy_test
 
 import (
 	"bytes"
@@ -30,18 +30,20 @@ import (
 	"go.uber.org/yarpc/compressor/snappy"
 )
 
-func TestSnappy(t *testing.T) {
-	input := []byte("Now is the time for all good men to come to the aid of their country")
+// This should be compressible:
+var quote = "Now is the time for all good men to come to the aid of their country"
+var input = []byte(quote + quote + quote)
 
+func TestSnappy(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
-	writer, err := snappy.Compressor{}.Compress(buf)
+	writer, err := yarpcsnappy.New().Compress(buf)
 	require.NoError(t, err)
 
 	_, err = writer.Write(input)
 	require.NoError(t, err)
 	require.NoError(t, writer.Close())
 
-	str, err := snappy.Compressor{}.Decompress(buf)
+	str, err := yarpcsnappy.New().Decompress(buf)
 	require.NoError(t, err)
 
 	output, err := ioutil.ReadAll(str)
@@ -50,6 +52,44 @@ func TestSnappy(t *testing.T) {
 	assert.Equal(t, input, output)
 }
 
+func TestCompressionPooling(t *testing.T) {
+	compressor := yarpcsnappy.New()
+	for i := 0; i < 128; i++ {
+		buf := bytes.NewBuffer(nil)
+		writer, err := compressor.Compress(buf)
+		require.NoError(t, err)
+
+		_, err = writer.Write(input)
+		require.NoError(t, err)
+		require.NoError(t, writer.Close())
+
+		str, err := compressor.Decompress(buf)
+		require.NoError(t, err)
+
+		output, err := ioutil.ReadAll(str)
+		require.NoError(t, err)
+
+		assert.Equal(t, input, output)
+	}
+}
+
 func TestSnappyName(t *testing.T) {
-	assert.Equal(t, "snappy", snappy.Compressor{}.Name())
+	assert.Equal(t, "snappy", yarpcsnappy.New().Name())
+}
+
+func TestSnappyCompression(t *testing.T) {
+	compressor := yarpcsnappy.New()
+
+	buf := bytes.NewBuffer(nil)
+	writer, err := compressor.Compress(buf)
+	require.NoError(t, err)
+
+	_, err = writer.Write(input)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	// Sanity check
+	assert.True(t, buf.Len() < len(input), "one would think the compressed data would be smaller")
+	t.Logf("decompress: %d\n", len(input))
+	t.Logf("compressed: %d\n", buf.Len())
 }

--- a/transport/grpc/globals_for_test.go
+++ b/transport/grpc/globals_for_test.go
@@ -21,6 +21,7 @@
 package grpc
 
 import (
+	"go.uber.org/yarpc/compressor/grpc"
 	"go.uber.org/yarpc/yarpcconfig"
 	"google.golang.org/grpc/encoding"
 )
@@ -49,6 +50,7 @@ func init() {
 		_gzipCompressor,
 	}
 	for _, compressor := range compressors {
-		encoding.RegisterCompressor(compressor)
+		adapter := yarpcgrpccompressor.New(compressor)
+		encoding.RegisterCompressor(adapter)
 	}
 }

--- a/transport/grpc/integration_test.go
+++ b/transport/grpc/integration_test.go
@@ -505,7 +505,7 @@ func (c *testCompressor) Compress(w io.Writer) (io.WriteCloser, error) {
 	return &metered, c.comperr
 }
 
-func (c *testCompressor) Decompress(r io.Reader) (io.Reader, error) {
+func (c *testCompressor) Decompress(r io.Reader) (io.ReadCloser, error) {
 	metered := byteMeter{
 		Reader:  r,
 		counter: c.metrics.new("decompress", c.name),


### PR DESCRIPTION
This change anticipates performance problems with compression by pooling readers and writers.

The implementation follows the form but not the letter of the corresponding GZIP compressor from gRPC-go.

https://github.com/grpc/grpc-go/blob/master/encoding/gzip/gzip.go

- Notably, we do not interact with the gRPC global registry.
- The compression level is determined once at time of construction.
- We do not use a closure to populate the pool. We consequently can see coverage for both creation and reuse of pool readers and writers.
- Nonzero tests.