### PR TITLE
Rename transport.Namer.Name() to TransportNamer()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   The `OutboundCallOverride`, `OutboundCallOnewayOverride` (new), and
   `OutboundCallStreamOverride` (new) are now a complete set that allow tests to
   hook any of the call behaviors.
-- All outbounds now implement `Name` and a new `transport.Namer` interface.
+- All outbounds now implement `TransportName` and a new `transport.Namer`
+  interface.
   This will allow outbound observability middleware to carry the transport name
   in metrics properly.
 ### Changed

--- a/api/middleware/outbound.go
+++ b/api/middleware/outbound.go
@@ -62,7 +62,7 @@ func ApplyUnaryOutbound(o transport.UnaryOutbound, f UnaryOutbound) transport.Un
 
 	var name string
 	if namer, ok := o.(transport.Namer); ok {
-		name = namer.Name()
+		name = namer.TransportName()
 	}
 
 	return unaryOutboundWithMiddleware{o: o, f: f, name: name}
@@ -82,7 +82,7 @@ type unaryOutboundWithMiddleware struct {
 	f    UnaryOutbound
 }
 
-func (fo unaryOutboundWithMiddleware) Name() string {
+func (fo unaryOutboundWithMiddleware) TransportName() string {
 	return fo.name
 }
 
@@ -147,7 +147,7 @@ func ApplyOnewayOutbound(o transport.OnewayOutbound, f OnewayOutbound) transport
 
 	var name string
 	if namer, ok := o.(transport.Namer); ok {
-		name = namer.Name()
+		name = namer.TransportName()
 	}
 
 	return onewayOutboundWithMiddleware{o: o, f: f, name: name}
@@ -167,7 +167,7 @@ type onewayOutboundWithMiddleware struct {
 	f    OnewayOutbound
 }
 
-func (fo onewayOutboundWithMiddleware) Name() string {
+func (fo onewayOutboundWithMiddleware) TransportName() string {
 	return fo.name
 }
 
@@ -233,7 +233,7 @@ func ApplyStreamOutbound(o transport.StreamOutbound, f StreamOutbound) transport
 
 	var name string
 	if namer, ok := o.(transport.Namer); ok {
-		name = namer.Name()
+		name = namer.TransportName()
 	}
 
 	return streamOutboundWithMiddleware{o: o, f: f, name: name}
@@ -253,7 +253,7 @@ type streamOutboundWithMiddleware struct {
 	f    StreamOutbound
 }
 
-func (fo streamOutboundWithMiddleware) Name() string {
+func (fo streamOutboundWithMiddleware) TransportName() string {
 	return fo.name
 }
 

--- a/api/transport/outbound.go
+++ b/api/transport/outbound.go
@@ -45,7 +45,7 @@ type Outbound interface {
 // This interface is not embeded into Outbound to preserve backwards
 // compatiblity.
 type Namer interface {
-	Name() string
+	TransportName() string
 }
 
 // UnaryOutbound is a transport that knows how to send unary requests for procedure

--- a/internal/firstoutboundmiddleware/middleware.go
+++ b/internal/firstoutboundmiddleware/middleware.go
@@ -71,7 +71,7 @@ func update(req *transport.Request, out transport.Outbound) {
 	// Request forwarding in transport layer proxies needs this when copying
 	// requests to a different outbound type.
 	if namer, ok := out.(transport.Namer); ok {
-		req.Transport = namer.Name()
+		req.Transport = namer.TransportName()
 	}
 }
 
@@ -83,6 +83,6 @@ func updateStream(req *transport.StreamRequest, out transport.Outbound) {
 	// Request forwarding in transport layer proxies needs this when copying
 	// requests to a different outbound type.
 	if namer, ok := out.(transport.Namer); ok {
-		req.Meta.Transport = namer.Name()
+		req.Meta.Transport = namer.TransportName()
 	}
 }

--- a/internal/firstoutboundmiddleware/middleware_test.go
+++ b/internal/firstoutboundmiddleware/middleware_test.go
@@ -33,10 +33,7 @@ import (
 )
 
 func TestFirstOutboundMidleware(t *testing.T) {
-	const overrideName = "override"
-
 	out := yarpctest.NewFakeTransport().NewOutbound(nil,
-		yarpctest.OutboundName(overrideName),
 		yarpctest.OutboundCallOverride(
 			func(context.Context, *transport.Request) (*transport.Response, error) { return nil, nil },
 		),
@@ -55,7 +52,7 @@ func TestFirstOutboundMidleware(t *testing.T) {
 		_, err := outWithMiddleware.Call(context.Background(), req)
 		require.NoError(t, err)
 
-		assert.Equal(t, overrideName, string(req.Transport))
+		assert.Equal(t, "fake", string(req.Transport))
 	})
 
 	t.Run("oneway", func(t *testing.T) {
@@ -65,7 +62,7 @@ func TestFirstOutboundMidleware(t *testing.T) {
 		_, err := outWithMiddleware.CallOneway(context.Background(), req)
 		require.NoError(t, err)
 
-		assert.Equal(t, overrideName, string(req.Transport))
+		assert.Equal(t, "fake", string(req.Transport))
 	})
 
 	t.Run("stream", func(t *testing.T) {
@@ -75,6 +72,6 @@ func TestFirstOutboundMidleware(t *testing.T) {
 		_, err := outWithMiddleware.CallStream(context.Background(), streamReq)
 		require.NoError(t, err)
 
-		assert.Equal(t, overrideName, string(streamReq.Meta.Transport))
+		assert.Equal(t, "fake", string(streamReq.Meta.Transport))
 	})
 }

--- a/internal/outboundmiddleware/chain.go
+++ b/internal/outboundmiddleware/chain.go
@@ -74,10 +74,10 @@ type unaryChainExec struct {
 	Final transport.UnaryOutbound
 }
 
-func (x unaryChainExec) Name() string {
+func (x unaryChainExec) TransportName() string {
 	var name string
 	if namer, ok := x.Final.(transport.Namer); ok {
-		name = namer.Name()
+		name = namer.TransportName()
 	}
 	return name
 }
@@ -154,10 +154,10 @@ type onewayChainExec struct {
 	Final transport.OnewayOutbound
 }
 
-func (x onewayChainExec) Name() string {
+func (x onewayChainExec) TransportName() string {
 	var name string
 	if namer, ok := x.Final.(transport.Namer); ok {
-		name = namer.Name()
+		name = namer.TransportName()
 	}
 	return name
 }
@@ -234,10 +234,10 @@ type streamChainExec struct {
 	Final transport.StreamOutbound
 }
 
-func (x streamChainExec) Name() string {
+func (x streamChainExec) TransportName() string {
 	var name string
 	if namer, ok := x.Final.(transport.Namer); ok {
-		name = namer.Name()
+		name = namer.TransportName()
 	}
 	return name
 }

--- a/transport/grpc/outbound.go
+++ b/transport/grpc/outbound.go
@@ -69,8 +69,9 @@ func newOutbound(t *Transport, peerChooser peer.Chooser, options ...OutboundOpti
 	}
 }
 
-// Name is the transport name that will be set on `transport.Request` struct.
-func (o *Outbound) Name() string {
+// TransportName is the transport name that will be set on `transport.Request`
+// struct.
+func (o *Outbound) TransportName() string {
 	return transportName
 }
 

--- a/transport/grpc/outbound_test.go
+++ b/transport/grpc/outbound_test.go
@@ -38,8 +38,8 @@ import (
 	"google.golang.org/grpc"
 )
 
-func TestNamer(t *testing.T) {
-	assert.Equal(t, transportName, NewTransport().NewOutbound(nil).Name())
+func TestTransportNamer(t *testing.T) {
+	assert.Equal(t, transportName, NewTransport().NewOutbound(nil).TransportName())
 }
 
 func TestNoRequest(t *testing.T) {

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -169,8 +169,8 @@ type Outbound struct {
 	bothResponseError bool
 }
 
-// Name is the transport name that will be set on `transport.Request` struct.
-func (o *Outbound) Name() string {
+// TransportName is the transport name that will be set on `transport.Request` struct.
+func (o *Outbound) TransportName() string {
 	return transportName
 }
 

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -51,8 +51,8 @@ func TestNewOutbound(t *testing.T) {
 	assert.Equal(t, chooser, out.Chooser())
 }
 
-func TestNamer(t *testing.T) {
-	assert.Equal(t, transportName, NewOutbound(nil).Name())
+func TestTransportNamer(t *testing.T) {
+	assert.Equal(t, transportName, NewOutbound(nil).TransportName())
 }
 
 func TestNewSingleOutboundPanic(t *testing.T) {

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -68,8 +68,8 @@ func (t *Transport) NewSingleOutbound(addr string) *Outbound {
 	return t.NewOutbound(chooser)
 }
 
-// Name is the transport name that will be set on `transport.Request` struct.
-func (o *Outbound) Name() string {
+// TransportName is the transport name that will be set on `transport.Request` struct.
+func (o *Outbound) TransportName() string {
 	return transportName
 }
 

--- a/transport/tchannel/outbound_test.go
+++ b/transport/tchannel/outbound_test.go
@@ -38,10 +38,10 @@ import (
 	"golang.org/x/net/context"
 )
 
-func TestNamer(t *testing.T) {
+func TestTransportNamer(t *testing.T) {
 	trans, err := NewTransport()
 	require.NoError(t, err)
-	assert.Equal(t, transportName, trans.NewOutbound(nil).Name())
+	assert.Equal(t, transportName, trans.NewOutbound(nil).TransportName())
 }
 
 func TestOutboundHeaders(t *testing.T) {

--- a/transport/transports_test.go
+++ b/transport/transports_test.go
@@ -38,13 +38,12 @@ func TestFirstOutboundMiddleware(t *testing.T) {
 	// should see the name of the transport, instead of an empty string.
 
 	const (
-		transportName = "transport-name"
+		transportName = "fake"
 		serviceName   = "service-name"
 	)
 
 	newOutboundConfig := func(outboundMiddleware yarpc.OutboundMiddleware) *transport.OutboundConfig {
-		outbound := yarpctest.NewFakeTransport().
-			NewOutbound(nil, yarpctest.OutboundName(transportName))
+		outbound := yarpctest.NewFakeTransport().NewOutbound(nil)
 
 		dispatcher := yarpc.NewDispatcher(yarpc.Config{
 			Name: serviceName,

--- a/yarpctest/fake_outbound.go
+++ b/yarpctest/fake_outbound.go
@@ -140,9 +140,9 @@ type FakeOutbound struct {
 	callStreamOverride OutboundStreamCallable
 }
 
-// Name is the transport of the outbound.
-func (o *FakeOutbound) Name() string {
-	return o.name
+// TransportName is "fake".
+func (o *FakeOutbound) TransportName() string {
+	return "fake"
 }
 
 // Chooser returns theis FakeOutbound's peer chooser.


### PR DESCRIPTION
oubound.Name() and outboundMiddleware.Name() both evoke the name of the configured client, the callee service name. This change renames these methods TransportName() to disambiguate their
meaning. The fake transport name is "fake" and the outbound name does not override this property. If necessary, a future revision could add a transport name override option to the fake transport, but for the time being, "fake" appears to be sufficient for all existing tests.

- [x] Description and context for reviewers: one partner, one stranger
- [x] Docs (package doc)
- [x] Entry in CHANGELOG.md