### PR TITLE
Add peer list benchmarks

### DIFF
--- a/peer/bench_test.go
+++ b/peer/bench_test.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package peer_test
+
+import (
+	"fmt"
+	"testing"
+
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/peer/pendingheap"
+	"go.uber.org/yarpc/peer/randpeer"
+	"go.uber.org/yarpc/peer/roundrobin"
+	"go.uber.org/yarpc/peer/tworandomchoices"
+	"go.uber.org/yarpc/yarpctest"
+)
+
+func newHeap(trans peer.Transport) peer.ChooserList   { return pendingheap.New(trans) }
+func newTRC(trans peer.Transport) peer.ChooserList    { return tworandomchoices.New(trans) }
+func newRR(trans peer.Transport) peer.ChooserList     { return roundrobin.New(trans) }
+func newRandom(trans peer.Transport) peer.ChooserList { return randpeer.New(trans) }
+
+var listFuncs = []struct {
+	name    string
+	newList func(peer.Transport) peer.ChooserList
+}{
+	{"roundrobin", newRR},
+	{"random", newRandom},
+	{"tworandom", newTRC},
+	{"heap", newHeap},
+}
+
+func BenchmarkChooseFinish(t *testing.B) {
+	variances := []int{
+		1,
+		1024,
+	}
+
+	sizes := []int{
+		1,
+		2,
+		4,
+		8,
+		16,
+		32,
+		64,
+		128,
+		256,
+		512,
+		1024,
+	}
+
+	for _, lf := range listFuncs {
+		for _, size := range sizes {
+			for _, variance := range variances {
+				t.Run(fmt.Sprintf("%s-%dpeers-%dvariance", lf.name, size, variance), func(t *testing.B) {
+					yarpctest.BenchmarkPeerListChooseFinish(t, size, variance, lf.newList)
+				})
+			}
+		}
+	}
+}
+
+func BenchmarkUpdate(t *testing.B) {
+	for _, status := range []peer.ConnectionStatus{
+		peer.Unavailable,
+		peer.Available,
+	} {
+		for _, lf := range listFuncs {
+			t.Run(fmt.Sprintf("%s-%s", lf.name, status), func(t *testing.B) {
+				yarpctest.BenchmarkPeerListUpdate(t, status, lf.newList)
+			})
+		}
+	}
+}
+
+func BenchmarkNotifyStateChange(t *testing.B) {
+	for _, lf := range listFuncs {
+		t.Run(lf.name, func(t *testing.B) {
+			yarpctest.BenchmarkPeerListNotifyStatusChanged(t, lf.newList)
+		})
+	}
+}

--- a/yarpctest/bench.go
+++ b/yarpctest/bench.go
@@ -1,0 +1,160 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpctest
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/peer/hostport"
+)
+
+// BenchmarkPeerListChooseFinish assesses the speed of choose + finish for each
+// of the YARPC peer choosers, with varying numbers of peers, and varying
+// latencies.
+// In order to remove exogenous behaviors from the simulation, each new request
+// may be finished any number of turns in the future.
+// One random request will be finished for every new peer chosen.
+// By increasing the size of the concurrency window, we can increase the
+// variance of pending requests on each individual peer.
+//
+// Size is the number of peers in the list.
+// For this benchmark, the number of peers is fixed.
+// All peers are connected.
+// Variance is the number of concurrent pending requests.
+// this number is also fixed for the benchmark.
+// Variance comes into play because the request that finishes is chosen
+// randomly from the window of previously chosen peers.
+func BenchmarkPeerListChooseFinish(t *testing.B, size int, variance int, newList func(peer.Transport) peer.ChooserList) {
+	t.ReportAllocs()
+
+	trans := NewFakeTransport()
+	list := newList(trans)
+
+	// Build a static membership for the list.
+	var ids []peer.Identifier
+	for i := 0; i < size; i++ {
+		ids = append(ids, hostport.Identify(strconv.Itoa(i)))
+	}
+	err := list.Update(peer.ListUpdates{
+		Additions: ids,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, trans.Start())
+	require.NoError(t, list.Start())
+	defer func() {
+		require.NoError(t, trans.Stop())
+		require.NoError(t, list.Stop())
+	}()
+
+	req := &transport.Request{}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Build a bank of concurrent requests.
+	finishers := make([]func(error), variance)
+	{
+		i := 0
+		for {
+			_, onFinish, _ := list.Choose(ctx, req)
+			if onFinish != nil {
+				finishers[i] = onFinish
+				i++
+				if i >= variance {
+					break
+				}
+			}
+		}
+	}
+
+	t.ResetTimer()
+	for n := 0; n < t.N; n++ {
+		_, onFinish, _ := list.Choose(ctx, req)
+		if onFinish == nil {
+			continue
+		}
+		index := rand.Intn(variance)
+		finishers[index](nil)
+		finishers[index] = onFinish
+	}
+}
+
+// BenchmarkPeerListUpdate measures the performance of peer list updates.
+func BenchmarkPeerListUpdate(t *testing.B, init peer.ConnectionStatus, newList func(peer.Transport) peer.ChooserList) {
+	trans := NewFakeTransport(InitialConnectionStatus(init))
+	list := newList(trans)
+	rng := rand.NewSource(1)
+
+	var oldBits int64
+
+	t.ResetTimer()
+	for n := 0; n < t.N; n++ {
+		newBits := rng.Int63()
+		additions := idsForBits(newBits &^ oldBits)
+		removals := idsForBits(oldBits &^ newBits)
+		err := list.Update(peer.ListUpdates{
+			Additions: additions,
+			Removals:  removals,
+		})
+		if err != nil {
+			panic(fmt.Sprintf("benchmark invalidated by update error: %v", err))
+		}
+		oldBits = newBits
+	}
+}
+
+// BenchmarkPeerListNotifyStatusChanged measures the performance of a peer list
+// in the presence of rapidly changing network conditions.
+func BenchmarkPeerListNotifyStatusChanged(t *testing.B, newList func(peer.Transport) peer.ChooserList) {
+	trans := NewFakeTransport()
+	list := newList(trans)
+	rng := rand.NewSource(1)
+
+	// Add all 63 peers.
+	err := list.Update(peer.ListUpdates{
+		Additions: bitIds[:],
+	})
+	if err != nil {
+		panic(fmt.Sprintf("benchmark invalidated by update error: %v", err))
+	}
+
+	t.ResetTimer()
+	// Divide N by numIds. Add one to round up from zero.
+	for n := 0; n < t.N/numIds+1; n++ {
+		bits := rng.Int63()
+		for i := uint(0); i < numIds; i++ {
+			bit := (1 << i) & bits
+			if bit != 0 {
+				trans.SimulateConnect(bitIds[i])
+			} else {
+				trans.SimulateDisconnect(bitIds[i])
+			}
+		}
+	}
+}


### PR DESCRIPTION
This introduces a yarpctest facility for running benchmarks on YARPC peer lists.

The benchmarks measure peer selection, list updates, and notification changes.

```
goos: darwin
goarch: amd64
pkg: go.uber.org/yarpc/peer
BenchmarkChooseFinish/roundrobin-1peers-1variance-12         	 6827647	       164 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/roundrobin-1peers-1024variance-12      	 7156023	       164 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/roundrobin-2peers-1variance-12         	 7202422	       163 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/roundrobin-2peers-1024variance-12      	 7128897	       162 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/roundrobin-4peers-1variance-12         	 7406811	       163 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/roundrobin-4peers-1024variance-12      	 7348772	       162 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/roundrobin-8peers-1variance-12         	 7127984	       164 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/roundrobin-8peers-1024variance-12      	 6820710	       163 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/roundrobin-16peers-1variance-12        	 7288510	       163 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/roundrobin-16peers-1024variance-12     	 7256950	       162 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/roundrobin-32peers-1variance-12        	 7332945	       163 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/roundrobin-32peers-1024variance-12     	 7289731	       163 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/roundrobin-64peers-1variance-12        	 7358836	       173 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/roundrobin-64peers-1024variance-12     	 7285861	       188 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/roundrobin-128peers-1variance-12       	 6005888	       184 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/roundrobin-128peers-1024variance-12    	 7018770	       191 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/roundrobin-256peers-1variance-12       	 6229946	       166 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/roundrobin-256peers-1024variance-12    	 7172715	       169 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/roundrobin-512peers-1variance-12       	 7294604	       172 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/roundrobin-512peers-1024variance-12    	 7027006	       172 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/roundrobin-1024peers-1variance-12      	 7314874	       164 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/roundrobin-1024peers-1024variance-12   	 7150450	       166 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/random-1peers-1variance-12             	 6981982	       178 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/random-1peers-1024variance-12          	 7064755	       171 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/random-2peers-1variance-12             	 6818907	       171 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/random-2peers-1024variance-12          	 7067342	       170 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/random-4peers-1variance-12             	 6952458	       170 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/random-4peers-1024variance-12          	 7027168	       182 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/random-8peers-1variance-12             	 7058355	       173 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/random-8peers-1024variance-12          	 7004074	       178 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/random-16peers-1variance-12            	 6990291	       171 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/random-16peers-1024variance-12         	 7000909	       171 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/random-32peers-1variance-12            	 6851562	       170 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/random-32peers-1024variance-12         	 6876770	       170 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/random-64peers-1variance-12            	 7037550	       171 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/random-64peers-1024variance-12         	 7071907	       181 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/random-128peers-1variance-12           	 6996903	       173 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/random-128peers-1024variance-12        	 6718285	       174 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/random-256peers-1variance-12           	 6912187	       171 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/random-256peers-1024variance-12        	 6009651	       198 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/random-512peers-1variance-12           	 6169918	       172 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/random-512peers-1024variance-12        	 6827995	       173 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/random-1024peers-1variance-12          	 6688077	       173 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/random-1024peers-1024variance-12       	 6770958	       175 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/tworandom-1peers-1variance-12          	 6904990	       165 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/tworandom-1peers-1024variance-12       	 7347864	       174 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/tworandom-2peers-1variance-12          	 5908260	       225 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/tworandom-2peers-1024variance-12       	 5966595	       195 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/tworandom-4peers-1variance-12          	 5998363	       216 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/tworandom-4peers-1024variance-12       	 4922215	       225 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/tworandom-8peers-1variance-12          	 4770422	       234 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/tworandom-8peers-1024variance-12       	 5217156	       226 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/tworandom-16peers-1variance-12         	 5727003	       213 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/tworandom-16peers-1024variance-12      	 5591354	       215 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/tworandom-32peers-1variance-12         	 5610380	       214 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/tworandom-32peers-1024variance-12      	 5753376	       207 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/tworandom-64peers-1variance-12         	 5274306	       210 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/tworandom-64peers-1024variance-12      	 5667042	       209 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/tworandom-128peers-1variance-12        	 5967524	       211 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/tworandom-128peers-1024variance-12     	 4776691	       214 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/tworandom-256peers-1variance-12        	 5710959	       209 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/tworandom-256peers-1024variance-12     	 4630358	       234 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/tworandom-512peers-1variance-12        	 4785201	       235 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/tworandom-512peers-1024variance-12     	 4627572	       239 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/tworandom-1024peers-1variance-12       	 4568142	       245 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/tworandom-1024peers-1024variance-12    	 4226528	       244 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/heap-1peers-1variance-12               	 5166764	       246 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/heap-1peers-1024variance-12            	 5144205	       239 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/heap-2peers-1variance-12               	 4764588	       242 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/heap-2peers-1024variance-12            	 4504558	       257 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/heap-4peers-1variance-12               	 3798808	       285 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/heap-4peers-1024variance-12            	 3976111	       336 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/heap-8peers-1variance-12               	 4449300	       273 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/heap-8peers-1024variance-12            	 3796497	       335 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/heap-16peers-1variance-12              	 4013424	       328 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/heap-16peers-1024variance-12           	 3384528	       396 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/heap-32peers-1variance-12              	 4236654	       286 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/heap-32peers-1024variance-12           	 2556964	       436 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/heap-64peers-1variance-12              	 4172155	       285 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/heap-64peers-1024variance-12           	 2529349	       432 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/heap-128peers-1variance-12             	 4011601	       324 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/heap-128peers-1024variance-12          	 2232954	       473 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/heap-256peers-1variance-12             	 3741055	       316 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/heap-256peers-1024variance-12          	 2504361	       474 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/heap-512peers-1variance-12             	 3713556	       326 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/heap-512peers-1024variance-12          	 2301484	       521 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/heap-1024peers-1variance-12            	 3345300	       347 ns/op	       0 B/op	       0 allocs/op
BenchmarkChooseFinish/heap-1024peers-1024variance-12         	 2161008	       556 ns/op	       0 B/op	       0 allocs/op
BenchmarkUpdate/roundrobin-Unavailable-12                    	  291108	      4152 ns/op
BenchmarkUpdate/random-Unavailable-12                        	  278569	      4079 ns/op
BenchmarkUpdate/tworandom-Unavailable-12                     	  286516	      3976 ns/op
BenchmarkUpdate/heap-Unavailable-12                          	  287503	      4074 ns/op
BenchmarkUpdate/roundrobin-Available-12                      	  280225	      4054 ns/op
BenchmarkUpdate/random-Available-12                          	  291391	      3877 ns/op
BenchmarkUpdate/tworandom-Available-12                       	  274666	      4019 ns/op
BenchmarkUpdate/heap-Available-12                            	  296634	      3998 ns/op
BenchmarkNotifyStateChange/roundrobin-12                     	 9862171	       121 ns/op
BenchmarkNotifyStateChange/random-12                         	 9623268	       140 ns/op
BenchmarkNotifyStateChange/tworandom-12                      	 8817020	       137 ns/op
BenchmarkNotifyStateChange/heap-12                           	 9410389	       128 ns/op
```