### PR TITLE
Add custom dialer option to TChannel transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Added
+- The TChannel Transport now supports a custom dialer function option.
 
 ## [1.43.0] - 2020-02-25
 ### Added

--- a/glide.yaml
+++ b/glide.yaml
@@ -25,7 +25,7 @@ import:
 - package: github.com/uber/jaeger-client-go
   version: '>=1, <3'
 - package: github.com/uber/tchannel-go
-  version: ^1.10.0
+  version: ^1.16.0
 - package: github.com/uber-go/tally
   version: ^3
 - package: go.uber.org/atomic

--- a/transport/tchannel/options.go
+++ b/transport/tchannel/options.go
@@ -21,6 +21,7 @@
 package tchannel
 
 import (
+	"context"
 	"net"
 	"time"
 
@@ -53,6 +54,7 @@ type transportOptions struct {
 	logger              *zap.Logger
 	addr                string
 	listener            net.Listener
+	dialer              func(ctx context.Context, network, hostPort string) (net.Conn, error)
 	name                string
 	connTimeout         time.Duration
 	connBackoffStrategy backoffapi.Strategy
@@ -129,6 +131,16 @@ func ListenAddr(addr string) TransportOption {
 func Listener(l net.Listener) TransportOption {
 	return func(t *transportOptions) {
 		t.listener = l
+	}
+}
+
+// Dialer sets a dialer function for outbound calls.
+//
+// The function signature matches the net.Dialer DialContext method.
+// https://golang.org/pkg/net/#Dialer.DialContext
+func Dialer(dialer func(ctx context.Context, network, hostPort string) (net.Conn, error)) TransportOption {
+	return func(t *transportOptions) {
+		t.dialer = dialer
 	}
 }
 


### PR DESCRIPTION
This threads through a custom TChannel dialer option to YARPC's
TChannel transport. This simply enables users to set `tchannel-go`'s
`Dialer` field.

- https://sourcegraph.com/github.com/uber/tchannel-go@71773855579843b9ff2fe1ef7ba122f0e6bc71bf/-/blob/channel.go#L119

Fixes T5298175.

- [x] Description and context for reviewers: one partner, one stranger
- [x] Entry in CHANGELOG.md
