### PR TITLE
yarpctest: Add ContextWithCall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Added
+- yarpctest: Add `ContextWithCall` function to ease testing of functions that
+  use `yarpc.CallFromContext`.
 
 ## [1.44.0] - 2020-02-27
 ### Added

--- a/call.go
+++ b/call.go
@@ -100,6 +100,11 @@ type Call encoding.Call
 // context.
 //
 // The object is valid only as long as the request is ongoing.
+//
+// Testing
+//
+// To test functions which use CallFromContext, use yarpctest.ContextWithCall
+// to build contexts compatible with this function.
 func CallFromContext(ctx context.Context) *Call {
 	return (*Call)(encoding.CallFromContext(ctx))
 }

--- a/internal/inboundcall/metadata.go
+++ b/internal/inboundcall/metadata.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package inboundcall
+
+import (
+	"context"
+
+	"go.uber.org/yarpc/api/transport"
+)
+
+// Metadata holds metadata for an incoming request. This includes metadata
+// about the inbound request as well as response metadata.
+//
+// This drives the behavior of yarpc.Call and encoding.Call.
+type Metadata interface {
+	WriteResponseHeader(k, v string) error
+	Caller() string
+	Service() string
+	Transport() string
+	Procedure() string
+	Encoding() transport.Encoding
+	Headers() transport.Headers
+	ShardKey() string
+	RoutingKey() string
+	RoutingDelegate() string
+}
+
+type metadataKey struct{} // context key for Metadata
+
+// WithMetadata places the provided metadata on the context.
+func WithMetadata(ctx context.Context, md Metadata) context.Context {
+	return context.WithValue(ctx, metadataKey{}, md)
+}
+
+// GetMetadata retrieves inbound call metadata from a context.
+func GetMetadata(ctx context.Context) (Metadata, bool) {
+	md, ok := ctx.Value(metadataKey{}).(Metadata)
+	return md, ok
+}

--- a/internal/inboundcall/metadata_test.go
+++ b/internal/inboundcall/metadata_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package inboundcall
+
+import (
+	"context"
+	"testing"
+)
+
+func TestRoundTrip(t *testing.T) {
+	give := md{}
+	got, ok := GetMetadata(WithMetadata(context.Background(), give))
+	if !ok || got != give {
+		t.Errorf("could not round trip metadata")
+	}
+}
+
+type md struct{ Metadata }

--- a/yarpctest/context.go
+++ b/yarpctest/context.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpctest
+
+import (
+	"context"
+
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/inboundcall"
+)
+
+// Call specifies metadata for ContextWithCall.
+type Call struct {
+	Caller          string
+	Service         string
+	Transport       string
+	Procedure       string
+	Encoding        transport.Encoding
+	Headers         map[string]string
+	ShardKey        string
+	RoutingKey      string
+	RoutingDelegate string
+
+	// If set, this map will be filled with response headers written to
+	// yarpc.Call.
+	ResponseHeaders map[string]string
+}
+
+// ContextWithCall builds a Context which will yield the provided request
+// metadata when used with yarpc.CallFromContext.
+//
+//  ctx := yarpctest.ContextWithCall(ctx, &Call{..})
+//  handler.GetValue(ctx, &Request{...})
+//
+func ContextWithCall(ctx context.Context, call *Call) context.Context {
+	if call == nil {
+		return ctx // no-op
+	}
+
+	return inboundcall.WithMetadata(ctx, callMetadata{call})
+}
+
+type callMetadata struct{ c *Call }
+
+func (c callMetadata) WriteResponseHeader(k string, v string) error {
+	if c.c.ResponseHeaders != nil {
+		c.c.ResponseHeaders[k] = v
+	}
+	return nil
+}
+
+func (c callMetadata) Caller() string               { return c.c.Caller }
+func (c callMetadata) Service() string              { return c.c.Service }
+func (c callMetadata) Transport() string            { return c.c.Transport }
+func (c callMetadata) Procedure() string            { return c.c.Procedure }
+func (c callMetadata) Encoding() transport.Encoding { return c.c.Encoding }
+
+func (c callMetadata) Headers() transport.Headers {
+	return transport.HeadersFromMap(c.c.Headers)
+}
+
+func (c callMetadata) ShardKey() string        { return c.c.ShardKey }
+func (c callMetadata) RoutingKey() string      { return c.c.RoutingKey }
+func (c callMetadata) RoutingDelegate() string { return c.c.RoutingDelegate }

--- a/yarpctest/context_test.go
+++ b/yarpctest/context_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpctest_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/yarpctest"
+)
+
+func TestContextWithCallNil(t *testing.T) {
+	ctx := yarpctest.ContextWithCall(context.Background(), nil)
+	assert.Nil(t, yarpc.CallFromContext(ctx))
+}
+
+func TestContextWithCall(t *testing.T) {
+	tests := []struct {
+		desc           string
+		resHeaders     map[string]string
+		wantResHeaders map[string]string
+	}{
+		{
+			desc:           "with response headers",
+			resHeaders:     make(map[string]string),
+			wantResHeaders: map[string]string{"baz": "qux"},
+		},
+		{
+			desc:           "without response headers",
+			resHeaders:     nil,
+			wantResHeaders: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			ctx := yarpctest.ContextWithCall(context.Background(), &yarpctest.Call{
+				Caller:          "caller",
+				Service:         "service",
+				Transport:       "transport",
+				Procedure:       "procedure",
+				Encoding:        "encoding",
+				Headers:         map[string]string{"foo": "bar"},
+				ShardKey:        "shardkey",
+				RoutingKey:      "routingkey",
+				RoutingDelegate: "routingdelegate",
+				ResponseHeaders: tt.resHeaders,
+			})
+			call := yarpc.CallFromContext(ctx)
+
+			assert.Equal(t, "caller", call.Caller())
+			assert.Equal(t, "service", call.Service())
+			assert.Equal(t, "transport", call.Transport())
+			assert.Equal(t, "procedure", call.Procedure())
+			assert.Equal(t, transport.Encoding("encoding"), call.Encoding())
+			assert.Equal(t, []string{"foo"}, call.HeaderNames())
+			assert.Equal(t, "bar", call.Header("foo"))
+			assert.Equal(t, "shardkey", call.ShardKey())
+			assert.Equal(t, "routingkey", call.RoutingKey())
+			assert.Equal(t, "routingdelegate", call.RoutingDelegate())
+
+			assert.NoError(t, call.WriteResponseHeader("baz", "qux"))
+			assert.Equal(t, tt.wantResHeaders, tt.resHeaders)
+		})
+	}
+
+}


### PR DESCRIPTION
This adds a `yarpc.ContextWithCall` function to help test users of
`yarpc.CallFromContext`.

To make this possible, `encoding.Call` was refactored to rely on an internal
interface which is implemented around both, `InboundCall` and
`yarpctest.Call`.

Commits are individually reviewable.