### PR TITLE
gRPC: Ensure all `yarpcerrors` are converted to gRPC errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - yarpctest: Add `ContextWithCall` function to ease testing of functions that
   use `yarpc.CallFromContext`.
+### Fixed
+- gRPC inbounds correctly convert YARPC error codes to gRPC error codes, outside
+  of handler errors. Previously, well-defined YARPC errors were wrapped with an
+  `Unknown` gRPC code for unimplemneted procedures.
 
 ## [1.44.0] - 2020-02-27
 ### Added

--- a/transport/grpc/stream.go
+++ b/transport/grpc/stream.go
@@ -32,7 +32,6 @@ import (
 	"go.uber.org/yarpc/internal/grpcerrorcodes"
 	"go.uber.org/yarpc/yarpcerrors"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
@@ -160,25 +159,4 @@ func toYARPCStreamError(err error) error {
 		code = yarpcerrors.CodeUnknown
 	}
 	return yarpcerrors.Newf(code, status.Message())
-}
-
-func toGRPCStreamError(err error) error {
-	if err == nil {
-		return nil
-	}
-
-	// if this is not a yarpc error, return the error
-	// this will result in the error being a grpc-go error with codes.Unknown
-	if !yarpcerrors.IsStatus(err) {
-		return err
-	}
-	// we now know we have a yarpc error
-	yarpcStatus := yarpcerrors.FromError(err)
-	message := yarpcStatus.Message()
-	grpcCode, ok := grpcerrorcodes.YARPCCodeToGRPCCode[yarpcStatus.Code()]
-	// should only happen if grpcerrorcodes.YARPCCodeToGRPCCode does not cover all codes
-	if !ok {
-		grpcCode = codes.Unknown
-	}
-	return status.Error(grpcCode, message)
 }


### PR DESCRIPTION
This PR ensures that all `yarpcerrors` correctly convert to the
corresponding gRPC error and code. Previously, some errors were not
being converted, causing a gRPC `unknown` error, wrapping a well
defined YARPC error.

`toGRPCStreamError` is renamed `toGRPCError` and moved into
`handler.go` as it is not strictly for streaming errors.

For example, in logs we've seen:

```
Status{code=UNKNOWN, description=code:unimplemented message:unrecognized service name .. }
```

When we should really be seeing

```
Status{code=UNIMPLEMENTED, description=message:unrecognized service name ... }
```

- [x] Description and context for reviewers: one partner, one stranger
- [x] Entry in CHANGELOG.md
