### PR TITLE
yarpcerrors: Support errors.Unwrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - yarpctest: Add `ContextWithCall` function to ease testing of functions that
   use `yarpc.CallFromContext`.
+- `yarpcerrors` supports the `errors.Unwrap` API.
 
 ## [1.44.0] - 2020-02-27
 ### Added

--- a/yarpcerrors/errors_test.go
+++ b/yarpcerrors/errors_test.go
@@ -164,3 +164,12 @@ func testAllErrorConstructors(
 	}
 	t.Run("Named", namedFunc)
 }
+
+func TestErrUnwrap(t *testing.T) {
+	myErr := errors.New("my custom error")
+	yErr := AbortedErrorf("wrap my custom err: %w", myErr)
+
+	assert.Equal(t, FromError(yErr).Message(), "wrap my custom err: my custom error", "unexpected message")
+	assert.Equal(t, myErr, errors.Unwrap(yErr), "expected original error")
+	assert.True(t, errors.Is(yErr, myErr), "expected original error")
+}


### PR DESCRIPTION
This change enables `yarpcerrors` to support the new `errors.Unwrap`
API. This may be useful for better introspection during error handling
and allows users to use the `%w` verb on constsruction.

- https://golang.org/pkg/fmt/#Errorf

- [x] Description and context for reviewers: one partner, one stranger
- [x] Entry in CHANGELOG.md
