### PR TITLE
http: fix idleConnTimeout not propagated 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - gRPC inbounds correctly convert all YARPC error codes to gRPC error codes,
   outside of handler errors. Previously, well-defined YARPC errors were wrapped
   with an `Unknown` gRPC code for unimplemented procedures.
+- Fixes `idleConnTimeout` not propgated to the underlying http transport.
 
 ## [1.44.0] - 2020-02-27
 ### Added

--- a/transport/http/config.go
+++ b/transport/http/config.go
@@ -83,6 +83,7 @@ func (ts *transportSpec) Spec() yarpcconfig.TransportSpec {
 //      keepAlive: 30s
 //      maxIdleConns: 2
 //      maxIdleConnsPerHost: 2
+//      idleConnTimeout: 90s
 //      disableKeepAlives: false
 //      disableCompression: false
 //      responseHeaderTimeout: 0s
@@ -123,6 +124,9 @@ func (ts *transportSpec) buildTransport(tc *TransportConfig, k *yarpcconfig.Kit)
 	}
 	if tc.MaxIdleConnsPerHost > 0 {
 		options.maxIdleConnsPerHost = tc.MaxIdleConnsPerHost
+	}
+	if tc.IdleConnTimeout > 0 {
+		options.idleConnTimeout = tc.IdleConnTimeout
 	}
 	if tc.DisableKeepAlives {
 		options.disableKeepAlives = true

--- a/transport/http/config_test.go
+++ b/transport/http/config_test.go
@@ -490,8 +490,7 @@ func useFakeBuildClient(t *testing.T, want *wantHTTPClient) TransportOption {
 		assert.Equal(t, want.KeepAlive, options.keepAlive, "http.Client: KeepAlive should match")
 		assert.Equal(t, want.MaxIdleConns, options.maxIdleConns, "http.Client: MaxIdleConns should match")
 		assert.Equal(t, want.MaxIdleConnsPerHost, options.maxIdleConnsPerHost, "http.Client: MaxIdleConnsPerHost should match")
-		// TODO(kris): not sure why the default is not zero.
-		// assert.Equal(t, want.IdleConnTimeout, options.idleConnTimeout, "http.Client: IdleConnTimeout should match")
+		assert.Equal(t, want.IdleConnTimeout, options.idleConnTimeout, "http.Client: IdleConnTimeout should match")
 		assert.Equal(t, want.DisableKeepAlives, options.disableKeepAlives, "http.Client: DisableKeepAlives should match")
 		assert.Equal(t, want.DisableCompression, options.disableCompression, "http.Client: DisableCompression should match")
 		assert.Equal(t, want.ResponseHeaderTimeout, options.responseHeaderTimeout, "http.Client: ResponseHeaderTimeout should match")


### PR DESCRIPTION
`idleConnTimeout` was added as a configurable parameter for http transport but it's not actually
propagated to the underlying http transport correctly --- effectively an no-op. 

This fixes that. 
