### PR TITLE
[WIP] observability: Protobuf error details are logged at application error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - gRPC inbounds correctly convert all YARPC error codes to gRPC error codes,
   outside of handler errors. Previously, well-defined YARPC errors were wrapped
   with an `Unknown` gRPC code for unimplemented procedures.
+- observability: Only Thrift exceptions and Protobuf error details are logged at
+  application error log level.
 
 ## [1.44.0] - 2020-02-27
 ### Added

--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -83,6 +83,8 @@ func (c call) EndWithPanic(err error) {
 }
 
 func (c call) endLogs(elapsed time.Duration, err error, isApplicationError bool) {
+	isThriftException := isApplicationError && err == nil
+
 	var ce *zapcore.CheckedEntry
 	if err == nil && !isApplicationError {
 		msg := _successfulInbound
@@ -97,7 +99,16 @@ func (c call) endLogs(elapsed time.Duration, err error, isApplicationError bool)
 		}
 
 		lvl := c.levels.failure
-		if isApplicationError {
+
+		// Application errors are
+		//  - Thrift exceptions
+		//  - `yarpcerror`s with error details
+		//
+		// Any error returned from a Protobuf handler is marked as an application
+		// error (unlike Thrift). Therefore, we distinguish an application error
+		// from a regular error by inspecting if an error detail was set.
+		isProtoErrDetail := isApplicationError && len(yarpcerrors.FromError(err).Details()) > 0
+		if isThriftException || isProtoErrDetail {
 			lvl = c.levels.applicationError
 		}
 		ce = c.edge.logger.Check(lvl, msg)
@@ -112,7 +123,7 @@ func (c call) endLogs(elapsed time.Duration, err error, isApplicationError bool)
 	fields = append(fields, zap.Duration("latency", elapsed))
 	fields = append(fields, zap.Bool("successful", err == nil && !isApplicationError))
 	fields = append(fields, c.extract(c.ctx))
-	if isApplicationError {
+	if isThriftException {
 		fields = append(fields, zap.String(_error, "application_error"))
 	} else {
 		fields = append(fields, zap.Error(err))

--- a/internal/observability/common_test.go
+++ b/internal/observability/common_test.go
@@ -74,10 +74,7 @@ type fakeOutbound struct {
 }
 
 func (o fakeOutbound) Call(context.Context, *transport.Request) (*transport.Response, error) {
-	if o.err != nil {
-		return nil, o.err
-	}
-	return &transport.Response{ApplicationError: o.applicationErr}, nil
+	return &transport.Response{ApplicationError: o.applicationErr}, o.err
 }
 
 func (o fakeOutbound) CallOneway(context.Context, *transport.Request) (transport.Ack, error) {


### PR DESCRIPTION
Fixes a an API oddity, where all `yarpcerrors` returned from a Protobuf handler are logged as `Error handling inbound request`, with the actual error hidden. This is the same behaviour as Thrift exceptions since all errors returned from a Protobuf handler are marked application errors.

Fixes T5590765