### PR TITLE
Align error handling with Go 1.13 errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   outside of handler errors. Previously, well-defined YARPC errors were wrapped
   with an `Unknown` gRPC code for unimplemented procedures.
 - Fixes `idleConnTimeout` not propgated to the underlying http transport.
+- `protobuf.GetErrorDetails` can extract error details from wrapped errors.
 
 ## [1.44.0] - 2020-02-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - gRPC inbound supports introspection, suitable for debug pages.
 - yarpctest: Add `ContextWithCall` function to ease testing of functions that
   use `yarpc.CallFromContext`.
-- `yarpcerrors` supports the `errors.Unwrap` API.
+- `yarpcerrors` are aligned with the `errors` API introduced in Go 1.13
+  (https://blog.golang.org/go1.13-errors). `yarpcerrors.IsStatus`,
+  `yarpcerrors.FromError`, support wrapped errors, and `yarpcerrors.Status`
+  implements `Unwrap() error`.
 ### Fixed
 - gRPC inbounds correctly convert all YARPC error codes to gRPC error codes,
   outside of handler errors. Previously, well-defined YARPC errors were wrapped

--- a/encoding/protobuf/error.go
+++ b/encoding/protobuf/error.go
@@ -107,7 +107,8 @@ func convertToYARPCError(encoding transport.Encoding, err error, codec *codec) e
 	if err == nil {
 		return nil
 	}
-	if pberr, ok := err.(*pberror); ok {
+	var pberr *pberror
+	if errors.As(err, &pberr) {
 		// We only use this function on the inbound side, and pberrors should be
 		// constructed using the constructor above, so we can safely assume all
 		// the details are proto.Message-typed.

--- a/encoding/protobuf/error_external_test.go
+++ b/encoding/protobuf/error_external_test.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package protobuf_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gogo/protobuf/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/encoding/protobuf"
+	"go.uber.org/yarpc/yarpcerrors"
+)
+
+func TestGetDetailsFromWrappedError(t *testing.T) {
+	errDetail := &types.BytesValue{Value: []byte("err detail bytes")}
+
+	pbErr := protobuf.NewError(
+		yarpcerrors.CodeAborted,
+		"aborted",
+		protobuf.WithErrorDetails(errDetail))
+
+	wrappedErr := fmt.Errorf("wrapped err 2: %w", fmt.Errorf("wrapped err 1: %w", pbErr))
+
+	details := protobuf.GetErrorDetails(wrappedErr)
+	require.Len(t, details, 1, "expected exactly one detail")
+	assert.Equal(t, errDetail, details[0], "unexpected detail")
+}

--- a/yarpcerrors/errors_test.go
+++ b/yarpcerrors/errors_test.go
@@ -211,3 +211,27 @@ func TestFromError(t *testing.T) {
 		assert.Equal(t, "custom err", st.Message())
 	})
 }
+
+func TestIsStatus(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		assert.False(t, IsStatus(nil))
+	})
+
+	t.Run("unknown err", func(t *testing.T) {
+		err := errors.New("foo")
+		assert.False(t, IsStatus(err), "unexpected Status")
+	})
+
+	t.Run("wrapped Status", func(t *testing.T) {
+		err := fmt.Errorf("wrap 2: %w",
+			FailedPreconditionErrorf("wrap 1: %w", // yarpc error
+				errors.New("inner")))
+
+		assert.True(t, IsStatus(err), "expected YARPC error")
+	})
+
+	t.Run("wrapped Status interface", func(t *testing.T) {
+		err := fmt.Errorf("wrapped: %w", customYARPCError{err: "custom err"})
+		assert.True(t, IsStatus(err))
+	})
+}


### PR DESCRIPTION
This change aligns YARPC's error handling with the API introduced in Go 1.13.
Note that some changes can be considered breaking changes. However, aligning our
error handling behavior with Go APIs will be more idiomatic and ensure that we
have the least surprising behavior.

In this PR, `yarpcerrors.IsStatus` and `yarpcerrors.FromError` support
interacting with wrapped errors, and Protobuf error details can be extracted
from wrapped errors.

- https://blog.golang.org/go1.13-errors
- https://golang.org/pkg/errors/

Commits are individually reviewable and will be rebased to preserve commit
history.

- [x] Description and context for reviewers: one partner, one stranger
- [x] Entry in CHANGELOG.md
