### PR TITLE
observability: Log error messages from Protobuf handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - HTTP does not hold onto connections forever by default. `IdleConnTimeout`
   now defaults to 15 minutes.
 - `protobuf.GetErrorDetails` can extract error details from wrapped errors.
+- observability: errors returned from Protobuf handlers are logged with their
+  error message instead of `application_error`.
+- `encoding/protobuf` error details (`yarpcerrors.Status` with details) are
+  logged at application error log level. This matches behavior with Thrift
+  exceptions.
 
 ## [1.44.0] - 2020-02-27
 ### Added

--- a/internal/observability/common_test.go
+++ b/internal/observability/common_test.go
@@ -74,10 +74,7 @@ type fakeOutbound struct {
 }
 
 func (o fakeOutbound) Call(context.Context, *transport.Request) (*transport.Response, error) {
-	if o.err != nil {
-		return nil, o.err
-	}
-	return &transport.Response{ApplicationError: o.applicationErr}, nil
+	return &transport.Response{ApplicationError: o.applicationErr}, o.err
 }
 
 func (o fakeOutbound) CallOneway(context.Context, *transport.Request) (transport.Ack, error) {

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -207,7 +207,7 @@ func TestMiddlewareLogging(t *testing.T) {
 
 	tests := []test{
 		{
-			desc:            "sucess",
+			desc:            "success",
 			wantErrLevel:    zapcore.InfoLevel,
 			wantInboundMsg:  "Handled inbound request.",
 			wantOutboundMsg: "Made outbound call.",


### PR DESCRIPTION
This fixes an issue where all errors returned from a Protobuf handler
were logged uninformatively (identical to Thrift exceptions):

```
{ ... { ... "error": "application_error"}}
```

Unfortunately, all errors returned from Protobuf handlers are marked
as application errors and changing this behavior would be a breaking
change to HTTP/JSONpb users :(

https://github.com/yarpc/yarpc-go/blob/bd70ffbd17e635243988ba62be97eebff738204d/encoding/protobuf/inbound.go#L71

With this PR we

1. Correctly log the error using `zap.Error(err)`, by detecting if we
   observed an error in addition to the application error bit being
   set.

2. Any `yarpcerror` created with details (including
  `encoding/protobuf.WithDetails`) are logged at the application error
  log level. This aligns with Thrift exceptions and would be the least
  surprising behavior for users (perhaps auto) migrating from Thrift
  exceptions to Protobuf error details.

Note that we made a similar workaround for metrics in #1739, where
regardless of the applciation bit being set or not, we'd emit the
correct metric.

Fixes T5590765

- [x] Description and context for reviewers: one partner, one stranger
- [x] Entry in CHANGELOG.md