### PR TITLE
Fix `Dispatcher.Register` example tests

### DIFF
--- a/dispatcher_example_test.go
+++ b/dispatcher_example_test.go
@@ -31,11 +31,12 @@ import (
 )
 
 func ExampleDispatcher_minimal() {
-	dispatcher := yarpc.NewDispatcher(yarpc.Config{Name: "myFancyService"})
+	dispatcher := yarpc.NewDispatcher(yarpc.Config{Name: "my-fancy-service"})
 	if err := dispatcher.Start(); err != nil {
 		log.Fatal(err)
 	}
 	defer dispatcher.Stop()
+	// Output:
 }
 
 // global dispatcher used in the registration examples
@@ -47,16 +48,26 @@ func ExampleDispatcher_Register_raw() {
 	}
 
 	dispatcher.Register(raw.Procedure("echo", handler))
+	// Output:
+}
+
+type Request struct {
+	key string
+}
+
+type Response struct {
+	val string
 }
 
 // Excuse the weird naming of this function. This lets is show as "JSON"
 // rather than "Json"
 
 func ExampleDispatcher_Register_jSON() {
-	handler := func(ctx context.Context, key string) (string, error) {
-		fmt.Println("key", key)
-		return "value", nil
+	handler := func(ctx context.Context, req *Request) (*Response, error) {
+		fmt.Println("key", req.key)
+		return &Response{val: "value"}, nil
 	}
 
 	dispatcher.Register(json.Procedure("get", handler))
+	// Output:
 }


### PR DESCRIPTION
Turns out that example tests won't run unless there's the following
output comment.

```
// Output:
```

This includes tests that have no output. This change runs and fixes
the broken examples.

- https://blog.golang.org/examples

Before:
```
go test -v ./... -run="ExampleDispatcher"
testing: warning: no tests to run
PASS
ok  	go.uber.org/yarpc	0.741s [no tests to run]
```
After
```
go test -v ./... -run="ExampleDispatcher"
=== RUN   ExampleDispatcher_minimal
--- PASS: ExampleDispatcher_minimal (0.00s)
=== RUN   ExampleDispatcher_Register_raw
--- PASS: ExampleDispatcher_Register_raw (0.00s)
=== RUN   ExampleDispatcher_Register_jSON
--- PASS: ExampleDispatcher_Register_jSON (0.00s)
PASS
ok  	go.uber.org/yarpc	1.501s
```

Fixes #1911