### PR TITLE
Listen on 127.0.0.1 to suppress local firewall warnings in tests

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -169,7 +169,7 @@ func Benchmark_HTTP_YARPCToYARPC(b *testing.B) {
 	httpTransport := yhttp.NewTransport()
 	serverCfg := yarpc.Config{
 		Name:     "server",
-		Inbounds: yarpc.Inbounds{httpTransport.NewInbound(":8999")},
+		Inbounds: yarpc.Inbounds{httpTransport.NewInbound("127.0.0.1:8999")},
 	}
 
 	clientCfg := yarpc.Config{
@@ -216,7 +216,7 @@ func Benchmark_HTTP_NetHTTPToYARPC(b *testing.B) {
 	httpTransport := yhttp.NewTransport()
 	serverCfg := yarpc.Config{
 		Name:     "server",
-		Inbounds: yarpc.Inbounds{httpTransport.NewInbound(":8996")},
+		Inbounds: yarpc.Inbounds{httpTransport.NewInbound("127.0.0.1:8996")},
 	}
 
 	withDispatcher(
@@ -275,7 +275,7 @@ func Benchmark_TChannel_YARPCToTChannel(b *testing.B) {
 	defer serverCh.Close()
 
 	serverCh.Register(traw.Wrap(tchannelEcho{t: b}), "echo")
-	require.NoError(b, serverCh.ListenAndServe(":0"), "failed to start up TChannel")
+	require.NoError(b, serverCh.ListenAndServe("127.0.0.1:0"), "failed to start up TChannel")
 
 	clientTChannel, err := ytchannel.NewChannelTransport(ytchannel.ServiceName("client"))
 	require.NoError(b, err)
@@ -324,7 +324,7 @@ func Benchmark_TChannel_TChannelToTChannel(b *testing.B) {
 	defer serverCh.Close()
 
 	serverCh.Register(traw.Wrap(tchannelEcho{t: b}), "echo")
-	require.NoError(b, serverCh.ListenAndServe(":0"), "failed to start up TChannel")
+	require.NoError(b, serverCh.ListenAndServe("127.0.0.1:0"), "failed to start up TChannel")
 
 	clientCh, err := tchannel.NewChannel("client", nil)
 	require.NoError(b, err, "failed to build client TChannel")

--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -59,7 +59,7 @@ func basicConfig(t testing.TB) Config {
 		Name: "test",
 		Inbounds: Inbounds{
 			tchannelTransport.NewInbound(),
-			httpTransport.NewInbound(":0"),
+			httpTransport.NewInbound("127.0.0.1:0"),
 		},
 	}
 }
@@ -823,16 +823,16 @@ func TestObservabilityConfig(t *testing.T) {
 
 func TestIntrospect(t *testing.T) {
 	httpTransport := http.NewTransport()
-	tchannelChannelTransport, err := tchannel.NewChannelTransport(tchannel.ServiceName("test"), tchannel.ListenAddr(":4040"))
+	tchannelChannelTransport, err := tchannel.NewChannelTransport(tchannel.ServiceName("test"), tchannel.ListenAddr("127.0.0.1:4040"))
 	require.NoError(t, err)
-	tchannelTransport, err := tchannel.NewTransport(tchannel.ServiceName("test"), tchannel.ListenAddr(":5050"))
+	tchannelTransport, err := tchannel.NewTransport(tchannel.ServiceName("test"), tchannel.ListenAddr("127.0.0.1:5050"))
 	require.NoError(t, err)
 	httpOutbound := httpTransport.NewSingleOutbound("http://127.0.0.1:1234")
 
 	config := Config{
 		Name: "test",
 		Inbounds: Inbounds{
-			httpTransport.NewInbound(":0"),
+			httpTransport.NewInbound("127.0.0.1:0"),
 			tchannelChannelTransport.NewInbound(),
 			tchannelTransport.NewInbound(),
 		},
@@ -861,9 +861,9 @@ func TestIntrospect(t *testing.T) {
 
 	inboundStatus := getInboundStatus(t, dispatcherStatus.Inbounds, "http", "")
 	assert.Equal(t, "Stopped", inboundStatus.State)
-	inboundStatus = getInboundStatus(t, dispatcherStatus.Inbounds, "tchannel", ":4040")
+	inboundStatus = getInboundStatus(t, dispatcherStatus.Inbounds, "tchannel", "127.0.0.1:4040")
 	assert.Equal(t, "ChannelClient", inboundStatus.State)
-	inboundStatus = getInboundStatus(t, dispatcherStatus.Inbounds, "tchannel", ":5050")
+	inboundStatus = getInboundStatus(t, dispatcherStatus.Inbounds, "tchannel", "127.0.0.1:5050")
 	assert.Equal(t, "", inboundStatus.State)
 
 	outboundStatus := getOutboundStatus(t, dispatcherStatus.Outbounds, "test-client-http", "unary")

--- a/encoding/thrift/thriftrw-plugin-yarpc/extends_test.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/extends_test.go
@@ -42,7 +42,7 @@ import (
 )
 
 func setupTest(t *testing.T, p []transport.Procedure) (*yarpc.Dispatcher, func()) {
-	httpInbound := http.NewTransport().NewInbound(":0")
+	httpInbound := http.NewTransport().NewInbound("127.0.0.1:0")
 
 	server := yarpc.NewDispatcher(yarpc.Config{
 		Name:     "server",

--- a/encoding/thrift/thriftrw-plugin-yarpc/roundtrip_test.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/roundtrip_test.go
@@ -220,7 +220,7 @@ func testRoundTrip(t *testing.T, enveloped, multiplexed bool) {
 	ctx := context.Background()
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			httpInbound := http.NewTransport().NewInbound(":0")
+			httpInbound := http.NewTransport().NewInbound("127.0.0.1:0")
 
 			server := yarpc.NewDispatcher(yarpc.Config{
 				Name:     "roundtrip-server",

--- a/internal/crossdock/client/ctxpropagation/behavior.go
+++ b/internal/crossdock/client/ctxpropagation/behavior.go
@@ -346,7 +346,7 @@ func buildDispatcher(t crossdock.T) (dispatcher *yarpc.Dispatcher, tconfig serve
 	nextHop := nextHopTransport(t)
 
 	httpTransport := http.NewTransport()
-	tchannelTransport, err := tch.NewChannelTransport(tch.ListenAddr(":8087"), tch.ServiceName("ctxclient"))
+	tchannelTransport, err := tch.NewChannelTransport(tch.ListenAddr("127.0.0.1:8087"), tch.ServiceName("ctxclient"))
 	fatals.NoError(err, "Failed to build ChannelTransport")
 
 	// Outbound to use for this hop.
@@ -379,7 +379,7 @@ func buildDispatcher(t crossdock.T) (dispatcher *yarpc.Dispatcher, tconfig serve
 		Name: "ctxclient",
 		Inbounds: yarpc.Inbounds{
 			tchannelTransport.NewInbound(),
-			httpTransport.NewInbound(":8086"),
+			httpTransport.NewInbound("127.0.0.1:8086"),
 		},
 		Outbounds: yarpc.Outbounds{
 			"yarpc-test": {

--- a/internal/crossdock/server/oneway/server.go
+++ b/internal/crossdock/server/oneway/server.go
@@ -37,7 +37,7 @@ var dispatcher *yarpc.Dispatcher
 // Start starts the test server that clients will make requests to
 func Start() {
 	httpTransport := http.NewTransport()
-	inbounds := []transport.Inbound{httpTransport.NewInbound(":8084")}
+	inbounds := []transport.Inbound{httpTransport.NewInbound("127.0.0.1:8084")}
 
 	dispatcher = yarpc.NewDispatcher(yarpc.Config{
 		Name:     "oneway-server",

--- a/internal/crossdock/server/yarpc/server.go
+++ b/internal/crossdock/server/yarpc/server.go
@@ -42,7 +42,7 @@ var dispatcher *yarpc.Dispatcher
 // Start starts the test server that clients will make requests to
 func Start() {
 	tchannelTransport, err := tchannel.NewChannelTransport(
-		tchannel.ListenAddr(":8082"),
+		tchannel.ListenAddr("127.0.0.1:8082"),
 		tchannel.ServiceName("yarpc-test"),
 	)
 	if err != nil {
@@ -58,7 +58,7 @@ func Start() {
 		Name: "yarpc-test",
 		Inbounds: yarpc.Inbounds{
 			tchannelTransport.NewInbound(),
-			httpTransport.NewInbound(":8081"),
+			httpTransport.NewInbound("127.0.0.1:8081"),
 			grpc.NewTransport().NewInbound(grpcListener),
 		},
 	})

--- a/internal/examples/thrift-hello/hello/main.go
+++ b/internal/examples/thrift-hello/hello/main.go
@@ -83,7 +83,7 @@ func do() error {
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name: "hello",
 		Inbounds: yarpc.Inbounds{
-			http.NewInbound(":8086"),
+			http.NewInbound("127.0.0.1:8086"),
 		},
 		Outbounds: yarpc.Outbounds{
 			"hello": {

--- a/internal/examples/thrift-keyvalue/keyvalue/server/main.go
+++ b/internal/examples/thrift-keyvalue/keyvalue/server/main.go
@@ -89,7 +89,7 @@ func do() error {
 	case "http":
 		inbound = http.NewTransport(http.Logger(logger)).NewInbound("127.0.0.1:24042")
 		go func() {
-			if err := gohttp.ListenAndServe(":3242", nil); err != nil {
+			if err := gohttp.ListenAndServe("127.0.0.1:3242", nil); err != nil {
 				log.Fatal(err)
 			}
 		}()
@@ -104,7 +104,7 @@ func do() error {
 		}
 		inbound = tchannelTransport.NewInbound()
 		go func() {
-			if err := gohttp.ListenAndServe(":3243", nil); err != nil {
+			if err := gohttp.ListenAndServe("127.0.0.1:3243", nil); err != nil {
 				log.Fatal(err)
 			}
 		}()
@@ -115,7 +115,7 @@ func do() error {
 		}
 		inbound = grpc.NewTransport(grpc.Logger(logger)).NewInbound(listener)
 		go func() {
-			if err := gohttp.ListenAndServe(":3244", nil); err != nil {
+			if err := gohttp.ListenAndServe("127.0.0.1:3244", nil); err != nil {
 				log.Fatal(err)
 			}
 		}()

--- a/internal/examples/thrift-oneway/main.go
+++ b/internal/examples/thrift-oneway/main.go
@@ -46,7 +46,7 @@ func do() error {
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name: "hello",
 		Inbounds: yarpc.Inbounds{
-			httpTransport.NewInbound(":8888"),
+			httpTransport.NewInbound("127.0.0.1:8888"),
 		},
 		Outbounds: yarpc.Outbounds{
 			"hello": {

--- a/internal/net/httpserver_test.go
+++ b/internal/net/httpserver_test.go
@@ -69,26 +69,26 @@ func TestStartAddrInUse(t *testing.T) {
 	}
 }
 func TestShutdownAndListen(t *testing.T) {
-	server := NewHTTPServer(&http.Server{Addr: ":0"})
+	server := NewHTTPServer(&http.Server{Addr: "127.0.0.1:0"})
 	require.NoError(t, server.ListenAndServe())
 	require.NoError(t, server.Shutdown(context.Background()))
 	require.Error(t, server.ListenAndServe())
 }
 
 func TestShutdownWithoutStart(t *testing.T) {
-	server := NewHTTPServer(&http.Server{Addr: ":0"})
+	server := NewHTTPServer(&http.Server{Addr: "127.0.0.1:0"})
 	require.NoError(t, server.Shutdown(context.Background()))
 }
 
 func TestStartTwice(t *testing.T) {
-	server := NewHTTPServer(&http.Server{Addr: ":0"})
+	server := NewHTTPServer(&http.Server{Addr: "127.0.0.1:0"})
 	require.NoError(t, server.ListenAndServe())
 	require.Error(t, server.ListenAndServe())
 	require.NoError(t, server.Shutdown(context.Background()))
 }
 
 func TestShutdownTwice(t *testing.T) {
-	server := NewHTTPServer(&http.Server{Addr: ":0"})
+	server := NewHTTPServer(&http.Server{Addr: "127.0.0.1:0"})
 	require.NoError(t, server.ListenAndServe())
 	require.NoError(t, server.Shutdown(context.Background()))
 	require.NoError(t, server.Shutdown(context.Background()))
@@ -100,7 +100,7 @@ func TestListenFail(t *testing.T) {
 }
 
 func TestShutdownError(t *testing.T) {
-	server := NewHTTPServer(&http.Server{Addr: ":0"})
+	server := NewHTTPServer(&http.Server{Addr: "127.0.0.1:0"})
 	require.NoError(t, server.ListenAndServe())
 	require.NoError(t, server.Listener().Close())
 	time.Sleep(5 * testtime.Millisecond)

--- a/internal/yarpctest/hostport_test.go
+++ b/internal/yarpctest/hostport_test.go
@@ -32,7 +32,7 @@ var regex = regexp.MustCompile(`127\.0\.0\.1:[0-9]+`)
 
 func TestZeroAddrToHostPort(t *testing.T) {
 	for i := 0; i < 10; i++ {
-		listener, err := net.Listen("tcp", ":0")
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
 		require.NoError(t, err)
 		require.True(t, regex.MatchString(ZeroAddrToHostPort(listener.Addr())))
 		require.NoError(t, listener.Close())

--- a/transport/grpc/inbound_test.go
+++ b/transport/grpc/inbound_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestInboundMechanics(t *testing.T) {
-	listener, err := net.Listen("tcp", ":0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	inbound := NewTransport().NewInbound(listener)
 

--- a/transport/grpc/outbound_test.go
+++ b/transport/grpc/outbound_test.go
@@ -251,7 +251,7 @@ func TestCallServiceMatch(t *testing.T) {
 					return nil
 				}),
 			)
-			listener, err := net.Listen("tcp", ":0")
+			listener, err := net.Listen("tcp", "127.0.0.1:0")
 			require.NoError(t, err)
 			go func() {
 				err := server.Serve(listener)

--- a/transport/grpc/peer_test.go
+++ b/transport/grpc/peer_test.go
@@ -62,10 +62,10 @@ func TestPeerWithRoundRobin(t *testing.T) {
 	ctx, cancel := context.WithTimeout(ctx, time.Second)
 	defer cancel()
 
-	permanent, permanentAddr := spec.NewServer(t, ":0")
+	permanent, permanentAddr := spec.NewServer(t, "127.0.0.1:0")
 	defer permanent.Stop()
 
-	temporary, temporaryAddr := spec.NewServer(t, ":0")
+	temporary, temporaryAddr := spec.NewServer(t, "127.0.0.1:0")
 	defer temporary.Stop()
 
 	// Construct a client with a bank of peers. We will keep one running all

--- a/transport/http/inbound_example_test.go
+++ b/transport/http/inbound_example_test.go
@@ -33,7 +33,7 @@ import (
 
 func ExampleInbound() {
 	transport := http.NewTransport()
-	inbound := transport.NewInbound(":8888")
+	inbound := transport.NewInbound("127.0.0.1:8888")
 
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name:     "myservice",
@@ -59,7 +59,7 @@ func ExampleMux() {
 	// This inbound will serve the YARPC service on the path /yarpc.  The
 	// /health endpoint on the Mux will be left alone.
 	transport := http.NewTransport()
-	inbound := transport.NewInbound(":8888", http.Mux("/yarpc", mux))
+	inbound := transport.NewInbound("127.0.0.1:8888", http.Mux("/yarpc", mux))
 
 	// Fire up a dispatcher with the new inbound.
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
@@ -107,7 +107,7 @@ func ExampleInterceptor() {
 
 	// Create a new inbound, attaching the interceptor
 	transport := http.NewTransport()
-	inbound := transport.NewInbound(":8889", http.Interceptor(intercept))
+	inbound := transport.NewInbound("127.0.0.1:8889", http.Interceptor(intercept))
 
 	// Fire up a dispatcher with the new inbound.
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{

--- a/transport/http/inbound_test.go
+++ b/transport/http/inbound_test.go
@@ -47,7 +47,7 @@ import (
 
 func TestStartAddrInUse(t *testing.T) {
 	t1 := NewTransport()
-	i1 := t1.NewInbound(":0")
+	i1 := t1.NewInbound("127.0.0.1:0")
 
 	assert.Len(t, i1.Transports(), 1, "transports must contain the transport")
 	// we use == instead of assert.Equal because we want to do a pointer
@@ -74,10 +74,10 @@ func TestStartAddrInUse(t *testing.T) {
 
 func TestNilAddrAfterStop(t *testing.T) {
 	x := NewTransport()
-	i := x.NewInbound(":0")
+	i := x.NewInbound("127.0.0.1:0")
 	i.SetRouter(newTestRouter(nil))
 	require.NoError(t, i.Start())
-	assert.NotEqual(t, ":0", i.Addr().String())
+	assert.NotEqual(t, "127.0.0.1:0", i.Addr().String())
 	assert.NotNil(t, i.Addr())
 	assert.NoError(t, i.Stop())
 	assert.Nil(t, i.Addr())
@@ -85,10 +85,10 @@ func TestNilAddrAfterStop(t *testing.T) {
 
 func TestInboundStartAndStop(t *testing.T) {
 	x := NewTransport()
-	i := x.NewInbound(":0")
+	i := x.NewInbound("127.0.0.1:0")
 	i.SetRouter(newTestRouter(nil))
 	require.NoError(t, i.Start())
-	assert.NotEqual(t, ":0", i.Addr().String())
+	assert.NotEqual(t, "127.0.0.1:0", i.Addr().String())
 	assert.NoError(t, i.Stop())
 }
 
@@ -102,14 +102,14 @@ func TestInboundStartError(t *testing.T) {
 
 func TestInboundStartErrorBadGrabHeader(t *testing.T) {
 	x := NewTransport()
-	i := x.NewInbound(":0", GrabHeaders("x-valid", "y-invalid"))
+	i := x.NewInbound("127.0.0.1:0", GrabHeaders("x-valid", "y-invalid"))
 	i.SetRouter(new(transporttest.MockRouter))
 	assert.Equal(t, yarpcerrors.CodeInvalidArgument, yarpcerrors.FromError(i.Start()).Code())
 }
 
 func TestInboundStopWithoutStarting(t *testing.T) {
 	x := NewTransport()
-	i := x.NewInbound(":8000")
+	i := x.NewInbound("127.0.0.1:8000")
 	assert.Nil(t, i.Addr())
 	assert.NoError(t, i.Stop())
 }
@@ -126,7 +126,7 @@ func TestInboundMux(t *testing.T) {
 		w.Write([]byte("healthy"))
 	})
 
-	i := httpTransport.NewInbound(":0", Mux("/rpc/v1", mux))
+	i := httpTransport.NewInbound("127.0.0.1:0", Mux("/rpc/v1", mux))
 	h := transporttest.NewMockUnaryHandler(mockCtrl)
 	reg := transporttest.NewMockRouter(mockCtrl)
 	reg.EXPECT().Procedures()

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -58,7 +58,7 @@ func TestTransportNamer(t *testing.T) {
 func TestNewSingleOutboundPanic(t *testing.T) {
 	require.Panics(t, func() {
 		// invalid url should cause panic
-		NewTransport().NewSingleOutbound(":")
+		NewTransport().NewSingleOutbound("127.0.0.1:")
 	},
 		"expected to panic")
 }

--- a/transport/tchannel/channel_inbound_test.go
+++ b/transport/tchannel/channel_inbound_test.go
@@ -64,7 +64,7 @@ func TestChannelInboundStartAlreadyListening(t *testing.T) {
 	ch, err := tchannel.NewChannel("foo", nil)
 	require.NoError(t, err)
 
-	require.NoError(t, ch.ListenAndServe(":0"))
+	require.NoError(t, ch.ListenAndServe("127.0.0.1:0"))
 	assert.Equal(t, tchannel.ChannelListening, ch.State())
 
 	x, err := NewChannelTransport(WithChannel(ch))

--- a/transport/tchannel/peer_test.go
+++ b/transport/tchannel/peer_test.go
@@ -84,7 +84,7 @@ func TestWithRoundRobin(t *testing.T) {
 	temporary, temporaryAddr := spec.NewServer(t, "")
 	defer temporary.Stop()
 
-	l, err := net.Listen("tcp", ":0")
+	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err, "listen for bogus server")
 	invalidAddr := l.Addr().String()
 	defer l.Close()

--- a/transport/tracer_test.go
+++ b/transport/tracer_test.go
@@ -90,7 +90,7 @@ func (h handler) assertBaggage(ctx context.Context) {
 }
 
 func createGRPCDispatcher(t *testing.T, tracer opentracing.Tracer) *yarpc.Dispatcher {
-	listener, err := net.Listen("tcp", ":0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	grpcTransport := grpc.NewTransport(grpc.Tracer(tracer))
 	return yarpc.NewDispatcher(yarpc.Config{
@@ -114,7 +114,7 @@ func createHTTPDispatcher(tracer opentracing.Tracer) *yarpc.Dispatcher {
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name: "yarpc-test",
 		Inbounds: yarpc.Inbounds{
-			httpTransport.NewInbound(":18080"),
+			httpTransport.NewInbound("127.0.0.1:18080"),
 		},
 		Outbounds: yarpc.Outbounds{
 			"yarpc-test": {

--- a/x/debug/debug_test.go
+++ b/x/debug/debug_test.go
@@ -81,7 +81,7 @@ func newTestDispatcher() *yarpc.Dispatcher {
 	return yarpc.NewDispatcher(yarpc.Config{
 		Name: "test",
 		Inbounds: yarpc.Inbounds{
-			httpTransport.NewInbound(":0"),
+			httpTransport.NewInbound("127.0.0.1:0"),
 		},
 		Outbounds: yarpc.Outbounds{
 			"test-client": {

--- a/yarpctest/recorder/recorder_test.go
+++ b/yarpctest/recorder/recorder_test.go
@@ -202,7 +202,7 @@ func withDisconnectedClient(t *testing.T, recorder *Recorder, f func(raw.Client)
 
 func withConnectedClient(t *testing.T, recorder *Recorder, f func(raw.Client)) {
 	httpTransport := http.NewTransport()
-	serverHTTP := httpTransport.NewInbound(":0")
+	serverHTTP := httpTransport.NewInbound("127.0.0.1:0")
 	serverDisp := yarpc.NewDispatcher(yarpc.Config{
 		Name:     "server",
 		Inbounds: yarpc.Inbounds{serverHTTP},


### PR DESCRIPTION
Small change to listen on `127.0.0.1:0` instead of `:0`. The latter
bound to all interfaces, causing many firewall pop-ups when testing
locally without docker `SUPPRESS_DOCKER=1 make test`.

No functionality has changed, this only touches tests and examples.