### PR TITLE
thrift: Return invalid argument error when `FromWire` fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `yarpcerrors.FromError`, support wrapped errors, and `yarpcerrors.Status`
   implements `Unwrap() error`.
 ### Changed
+- Inbound Thrift requests that fail during `wire.Value#FromWire` are returned as
+  `yarpcerrors.CodeInvalidArgument`, to indicate a client error.
 - Dropped library dependency on development tools.
 ### Fixed
 - gRPC inbounds correctly convert all YARPC error codes to gRPC error codes,

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic.thrift
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic.thrift
@@ -28,3 +28,15 @@ service Store extends ReadOnlyStore {
     oneway void forget(1: string key)
 }
 
+
+// this struct intentionally has the same shape as the `CompareAndSwap` wrapper
+// `Store_CompareAndSwap_Args`, except all fields are optional.
+struct OptionalCompareAndSwapWrapper {
+    1: optional OptionalCompareAndSwap cas
+}
+
+struct OptionalCompareAndSwap {
+    1: optional string key
+    2: optional i64 currentValue
+    3: optional i64 newValue
+}

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic.thrift
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic.thrift
@@ -29,8 +29,10 @@ service Store extends ReadOnlyStore {
 }
 
 
-// this struct intentionally has the same shape as the `CompareAndSwap` wrapper
+// This struct intentionally has the same shape as the `CompareAndSwap` wrapper
 // `Store_CompareAndSwap_Args`, except all fields are optional.
+
+// We use this to generate an invalid payload for testing.
 struct OptionalCompareAndSwapWrapper {
     1: optional OptionalCompareAndSwap cas
 }

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/atomic.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/atomic.go
@@ -933,14 +933,14 @@ var ThriftModule = &thriftreflect.ThriftModule{
 	Name:     "atomic",
 	Package:  "go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic",
 	FilePath: "atomic.thrift",
-	SHA1:     "8ac690c0a021bad15c751f1b1209b03c3340e5e9",
+	SHA1:     "05404c365186efd5cbceb965fe5455362b9b6158",
 	Includes: []*thriftreflect.ThriftModule{
 		common.ThriftModule,
 	},
 	Raw: rawIDL,
 }
 
-const rawIDL = "include \"./common.thrift\"\n\nexception KeyDoesNotExist {\n    1: optional string key\n}\n\nexception IntegerMismatchError {\n    1: required i64 expectedValue\n    2: required i64 gotValue\n}\n\nstruct CompareAndSwap {\n    1: required string key\n    2: required i64 currentValue\n    3: required i64 newValue\n}\n\nservice ReadOnlyStore extends common.BaseService {\n    i64 integer(1: string key) throws (1: KeyDoesNotExist doesNotExist)\n}\n\nservice Store extends ReadOnlyStore {\n    void increment(1: string key, 2: i64 value)\n\n    void compareAndSwap(1: CompareAndSwap request)\n        throws (1: IntegerMismatchError mismatch)\n\n    oneway void forget(1: string key)\n}\n\n\n// this struct intentionally has the same shape as the `CompareAndSwap` wrapper\n// `Store_CompareAndSwap_Args`, except all fields are optional.\nstruct OptionalCompareAndSwapWrapper {\n    1: optional OptionalCompareAndSwap cas\n}\n\nstruct OptionalCompareAndSwap {\n    1: optional string key\n    2: optional i64 currentValue\n    3: optional i64 newValue\n}\n"
+const rawIDL = "include \"./common.thrift\"\n\nexception KeyDoesNotExist {\n    1: optional string key\n}\n\nexception IntegerMismatchError {\n    1: required i64 expectedValue\n    2: required i64 gotValue\n}\n\nstruct CompareAndSwap {\n    1: required string key\n    2: required i64 currentValue\n    3: required i64 newValue\n}\n\nservice ReadOnlyStore extends common.BaseService {\n    i64 integer(1: string key) throws (1: KeyDoesNotExist doesNotExist)\n}\n\nservice Store extends ReadOnlyStore {\n    void increment(1: string key, 2: i64 value)\n\n    void compareAndSwap(1: CompareAndSwap request)\n        throws (1: IntegerMismatchError mismatch)\n\n    oneway void forget(1: string key)\n}\n\n\n// This struct intentionally has the same shape as the `CompareAndSwap` wrapper\n// `Store_CompareAndSwap_Args`, except all fields are optional.\n\n// We use this to generate an invalid payload for testing.\nstruct OptionalCompareAndSwapWrapper {\n    1: optional OptionalCompareAndSwap cas\n}\n\nstruct OptionalCompareAndSwap {\n    1: optional string key\n    2: optional i64 currentValue\n    3: optional i64 newValue\n}\n"
 
 // ReadOnlyStore_Integer_Args represents the arguments for the ReadOnlyStore.integer function.
 //

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/atomic.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/atomic.go
@@ -550,19 +550,397 @@ func (v *KeyDoesNotExist) Error() string {
 	return v.String()
 }
 
+type OptionalCompareAndSwap struct {
+	Key          *string `json:"key,omitempty"`
+	CurrentValue *int64  `json:"currentValue,omitempty"`
+	NewValue     *int64  `json:"newValue,omitempty"`
+}
+
+// ToWire translates a OptionalCompareAndSwap struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
+func (v *OptionalCompareAndSwap) ToWire() (wire.Value, error) {
+	var (
+		fields [3]wire.Field
+		i      int = 0
+		w      wire.Value
+		err    error
+	)
+
+	if v.Key != nil {
+		w, err = wire.NewValueString(*(v.Key)), error(nil)
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 1, Value: w}
+		i++
+	}
+	if v.CurrentValue != nil {
+		w, err = wire.NewValueI64(*(v.CurrentValue)), error(nil)
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 2, Value: w}
+		i++
+	}
+	if v.NewValue != nil {
+		w, err = wire.NewValueI64(*(v.NewValue)), error(nil)
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 3, Value: w}
+		i++
+	}
+
+	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+}
+
+// FromWire deserializes a OptionalCompareAndSwap struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a OptionalCompareAndSwap struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v OptionalCompareAndSwap
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
+func (v *OptionalCompareAndSwap) FromWire(w wire.Value) error {
+	var err error
+
+	for _, field := range w.GetStruct().Fields {
+		switch field.ID {
+		case 1:
+			if field.Value.Type() == wire.TBinary {
+				var x string
+				x, err = field.Value.GetString(), error(nil)
+				v.Key = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 2:
+			if field.Value.Type() == wire.TI64 {
+				var x int64
+				x, err = field.Value.GetI64(), error(nil)
+				v.CurrentValue = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 3:
+			if field.Value.Type() == wire.TI64 {
+				var x int64
+				x, err = field.Value.GetI64(), error(nil)
+				v.NewValue = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+	}
+
+	return nil
+}
+
+// String returns a readable string representation of a OptionalCompareAndSwap
+// struct.
+func (v *OptionalCompareAndSwap) String() string {
+	if v == nil {
+		return "<nil>"
+	}
+
+	var fields [3]string
+	i := 0
+	if v.Key != nil {
+		fields[i] = fmt.Sprintf("Key: %v", *(v.Key))
+		i++
+	}
+	if v.CurrentValue != nil {
+		fields[i] = fmt.Sprintf("CurrentValue: %v", *(v.CurrentValue))
+		i++
+	}
+	if v.NewValue != nil {
+		fields[i] = fmt.Sprintf("NewValue: %v", *(v.NewValue))
+		i++
+	}
+
+	return fmt.Sprintf("OptionalCompareAndSwap{%v}", strings.Join(fields[:i], ", "))
+}
+
+func _I64_EqualsPtr(lhs, rhs *int64) bool {
+	if lhs != nil && rhs != nil {
+
+		x := *lhs
+		y := *rhs
+		return (x == y)
+	}
+	return lhs == nil && rhs == nil
+}
+
+// Equals returns true if all the fields of this OptionalCompareAndSwap match the
+// provided OptionalCompareAndSwap.
+//
+// This function performs a deep comparison.
+func (v *OptionalCompareAndSwap) Equals(rhs *OptionalCompareAndSwap) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
+	if !_String_EqualsPtr(v.Key, rhs.Key) {
+		return false
+	}
+	if !_I64_EqualsPtr(v.CurrentValue, rhs.CurrentValue) {
+		return false
+	}
+	if !_I64_EqualsPtr(v.NewValue, rhs.NewValue) {
+		return false
+	}
+
+	return true
+}
+
+// MarshalLogObject implements zapcore.ObjectMarshaler, enabling
+// fast logging of OptionalCompareAndSwap.
+func (v *OptionalCompareAndSwap) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
+	if v.Key != nil {
+		enc.AddString("key", *v.Key)
+	}
+	if v.CurrentValue != nil {
+		enc.AddInt64("currentValue", *v.CurrentValue)
+	}
+	if v.NewValue != nil {
+		enc.AddInt64("newValue", *v.NewValue)
+	}
+	return err
+}
+
+// GetKey returns the value of Key if it is set or its
+// zero value if it is unset.
+func (v *OptionalCompareAndSwap) GetKey() (o string) {
+	if v != nil && v.Key != nil {
+		return *v.Key
+	}
+
+	return
+}
+
+// IsSetKey returns true if Key is not nil.
+func (v *OptionalCompareAndSwap) IsSetKey() bool {
+	return v != nil && v.Key != nil
+}
+
+// GetCurrentValue returns the value of CurrentValue if it is set or its
+// zero value if it is unset.
+func (v *OptionalCompareAndSwap) GetCurrentValue() (o int64) {
+	if v != nil && v.CurrentValue != nil {
+		return *v.CurrentValue
+	}
+
+	return
+}
+
+// IsSetCurrentValue returns true if CurrentValue is not nil.
+func (v *OptionalCompareAndSwap) IsSetCurrentValue() bool {
+	return v != nil && v.CurrentValue != nil
+}
+
+// GetNewValue returns the value of NewValue if it is set or its
+// zero value if it is unset.
+func (v *OptionalCompareAndSwap) GetNewValue() (o int64) {
+	if v != nil && v.NewValue != nil {
+		return *v.NewValue
+	}
+
+	return
+}
+
+// IsSetNewValue returns true if NewValue is not nil.
+func (v *OptionalCompareAndSwap) IsSetNewValue() bool {
+	return v != nil && v.NewValue != nil
+}
+
+type OptionalCompareAndSwapWrapper struct {
+	Cas *OptionalCompareAndSwap `json:"cas,omitempty"`
+}
+
+// ToWire translates a OptionalCompareAndSwapWrapper struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
+func (v *OptionalCompareAndSwapWrapper) ToWire() (wire.Value, error) {
+	var (
+		fields [1]wire.Field
+		i      int = 0
+		w      wire.Value
+		err    error
+	)
+
+	if v.Cas != nil {
+		w, err = v.Cas.ToWire()
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 1, Value: w}
+		i++
+	}
+
+	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+}
+
+func _OptionalCompareAndSwap_Read(w wire.Value) (*OptionalCompareAndSwap, error) {
+	var v OptionalCompareAndSwap
+	err := v.FromWire(w)
+	return &v, err
+}
+
+// FromWire deserializes a OptionalCompareAndSwapWrapper struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a OptionalCompareAndSwapWrapper struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v OptionalCompareAndSwapWrapper
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
+func (v *OptionalCompareAndSwapWrapper) FromWire(w wire.Value) error {
+	var err error
+
+	for _, field := range w.GetStruct().Fields {
+		switch field.ID {
+		case 1:
+			if field.Value.Type() == wire.TStruct {
+				v.Cas, err = _OptionalCompareAndSwap_Read(field.Value)
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+	}
+
+	return nil
+}
+
+// String returns a readable string representation of a OptionalCompareAndSwapWrapper
+// struct.
+func (v *OptionalCompareAndSwapWrapper) String() string {
+	if v == nil {
+		return "<nil>"
+	}
+
+	var fields [1]string
+	i := 0
+	if v.Cas != nil {
+		fields[i] = fmt.Sprintf("Cas: %v", v.Cas)
+		i++
+	}
+
+	return fmt.Sprintf("OptionalCompareAndSwapWrapper{%v}", strings.Join(fields[:i], ", "))
+}
+
+// Equals returns true if all the fields of this OptionalCompareAndSwapWrapper match the
+// provided OptionalCompareAndSwapWrapper.
+//
+// This function performs a deep comparison.
+func (v *OptionalCompareAndSwapWrapper) Equals(rhs *OptionalCompareAndSwapWrapper) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
+	if !((v.Cas == nil && rhs.Cas == nil) || (v.Cas != nil && rhs.Cas != nil && v.Cas.Equals(rhs.Cas))) {
+		return false
+	}
+
+	return true
+}
+
+// MarshalLogObject implements zapcore.ObjectMarshaler, enabling
+// fast logging of OptionalCompareAndSwapWrapper.
+func (v *OptionalCompareAndSwapWrapper) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
+	if v.Cas != nil {
+		err = multierr.Append(err, enc.AddObject("cas", v.Cas))
+	}
+	return err
+}
+
+// GetCas returns the value of Cas if it is set or its
+// zero value if it is unset.
+func (v *OptionalCompareAndSwapWrapper) GetCas() (o *OptionalCompareAndSwap) {
+	if v != nil && v.Cas != nil {
+		return v.Cas
+	}
+
+	return
+}
+
+// IsSetCas returns true if Cas is not nil.
+func (v *OptionalCompareAndSwapWrapper) IsSetCas() bool {
+	return v != nil && v.Cas != nil
+}
+
 // ThriftModule represents the IDL file used to generate this package.
 var ThriftModule = &thriftreflect.ThriftModule{
 	Name:     "atomic",
 	Package:  "go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic",
 	FilePath: "atomic.thrift",
-	SHA1:     "2bc145384bb2472af911bf797c7c23331111638a",
+	SHA1:     "8ac690c0a021bad15c751f1b1209b03c3340e5e9",
 	Includes: []*thriftreflect.ThriftModule{
 		common.ThriftModule,
 	},
 	Raw: rawIDL,
 }
 
-const rawIDL = "include \"./common.thrift\"\n\nexception KeyDoesNotExist {\n    1: optional string key\n}\n\nexception IntegerMismatchError {\n    1: required i64 expectedValue\n    2: required i64 gotValue\n}\n\nstruct CompareAndSwap {\n    1: required string key\n    2: required i64 currentValue\n    3: required i64 newValue\n}\n\nservice ReadOnlyStore extends common.BaseService {\n    i64 integer(1: string key) throws (1: KeyDoesNotExist doesNotExist)\n}\n\nservice Store extends ReadOnlyStore {\n    void increment(1: string key, 2: i64 value)\n\n    void compareAndSwap(1: CompareAndSwap request)\n        throws (1: IntegerMismatchError mismatch)\n\n    oneway void forget(1: string key)\n}\n\n"
+const rawIDL = "include \"./common.thrift\"\n\nexception KeyDoesNotExist {\n    1: optional string key\n}\n\nexception IntegerMismatchError {\n    1: required i64 expectedValue\n    2: required i64 gotValue\n}\n\nstruct CompareAndSwap {\n    1: required string key\n    2: required i64 currentValue\n    3: required i64 newValue\n}\n\nservice ReadOnlyStore extends common.BaseService {\n    i64 integer(1: string key) throws (1: KeyDoesNotExist doesNotExist)\n}\n\nservice Store extends ReadOnlyStore {\n    void increment(1: string key, 2: i64 value)\n\n    void compareAndSwap(1: CompareAndSwap request)\n        throws (1: IntegerMismatchError mismatch)\n\n    oneway void forget(1: string key)\n}\n\n\n// this struct intentionally has the same shape as the `CompareAndSwap` wrapper\n// `Store_CompareAndSwap_Args`, except all fields are optional.\nstruct OptionalCompareAndSwapWrapper {\n    1: optional OptionalCompareAndSwap cas\n}\n\nstruct OptionalCompareAndSwap {\n    1: optional string key\n    2: optional i64 currentValue\n    3: optional i64 newValue\n}\n"
 
 // ReadOnlyStore_Integer_Args represents the arguments for the ReadOnlyStore.integer function.
 //
@@ -955,16 +1333,6 @@ func (v *ReadOnlyStore_Integer_Result) String() string {
 	}
 
 	return fmt.Sprintf("ReadOnlyStore_Integer_Result{%v}", strings.Join(fields[:i], ", "))
-}
-
-func _I64_EqualsPtr(lhs, rhs *int64) bool {
-	if lhs != nil && rhs != nil {
-
-		x := *lhs
-		y := *rhs
-		return (x == y)
-	}
-	return lhs == nil && rhs == nil
 }
 
 // Equals returns true if all the fields of this ReadOnlyStore_Integer_Result match the

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/readonlystoreserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/readonlystoreserver/server.go
@@ -10,6 +10,7 @@ import (
 	thrift "go.uber.org/yarpc/encoding/thrift"
 	atomic "go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic"
 	baseserviceserver "go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/baseserviceserver"
+	yarpcerrors "go.uber.org/yarpc/yarpcerrors"
 )
 
 // Interface is the server-side interface for the ReadOnlyStore service.
@@ -67,7 +68,8 @@ type handler struct{ impl Interface }
 func (h handler) Integer(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args atomic.ReadOnlyStore_Integer_Args
 	if err := args.FromWire(body); err != nil {
-		return thrift.Response{}, err
+		return thrift.Response{}, yarpcerrors.InvalidArgumentErrorf(
+			"could not decode Thrift request for service 'ReadOnlyStore' procedure 'Integer': %w", err)
 	}
 
 	success, err := h.impl.Integer(ctx, args.Key)

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storeserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storeserver/server.go
@@ -10,6 +10,7 @@ import (
 	thrift "go.uber.org/yarpc/encoding/thrift"
 	atomic "go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic"
 	readonlystoreserver "go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/readonlystoreserver"
+	yarpcerrors "go.uber.org/yarpc/yarpcerrors"
 )
 
 // Interface is the server-side interface for the Store service.
@@ -100,7 +101,8 @@ type handler struct{ impl Interface }
 func (h handler) CompareAndSwap(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args atomic.Store_CompareAndSwap_Args
 	if err := args.FromWire(body); err != nil {
-		return thrift.Response{}, err
+		return thrift.Response{}, yarpcerrors.InvalidArgumentErrorf(
+			"could not decode Thrift request for service 'Store' procedure 'CompareAndSwap': %w", err)
 	}
 
 	err := h.impl.CompareAndSwap(ctx, args.Request)
@@ -128,7 +130,8 @@ func (h handler) Forget(ctx context.Context, body wire.Value) error {
 func (h handler) Increment(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args atomic.Store_Increment_Args
 	if err := args.FromWire(body); err != nil {
-		return thrift.Response{}, err
+		return thrift.Response{}, yarpcerrors.InvalidArgumentErrorf(
+			"could not decode Thrift request for service 'Store' procedure 'Increment': %w", err)
 	}
 
 	err := h.impl.Increment(ctx, args.Key, args.Value)

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/baseserviceserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/baseserviceserver/server.go
@@ -9,6 +9,7 @@ import (
 	transport "go.uber.org/yarpc/api/transport"
 	thrift "go.uber.org/yarpc/encoding/thrift"
 	common "go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common"
+	yarpcerrors "go.uber.org/yarpc/yarpcerrors"
 )
 
 // Interface is the server-side interface for the BaseService service.
@@ -52,7 +53,8 @@ type handler struct{ impl Interface }
 func (h handler) Healthy(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args common.BaseService_Healthy_Args
 	if err := args.FromWire(body); err != nil {
-		return thrift.Response{}, err
+		return thrift.Response{}, yarpcerrors.InvalidArgumentErrorf(
+			"could not decode Thrift request for service 'BaseService' procedure 'Healthy': %w", err)
 	}
 
 	success, err := h.impl.Healthy(ctx)

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendemptyserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendemptyserver/server.go
@@ -10,6 +10,7 @@ import (
 	thrift "go.uber.org/yarpc/encoding/thrift"
 	common "go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common"
 	emptyserviceserver "go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/emptyserviceserver"
+	yarpcerrors "go.uber.org/yarpc/yarpcerrors"
 )
 
 // Interface is the server-side interface for the ExtendEmpty service.
@@ -66,7 +67,8 @@ type handler struct{ impl Interface }
 func (h handler) Hello(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args common.ExtendEmpty_Hello_Args
 	if err := args.FromWire(body); err != nil {
-		return thrift.Response{}, err
+		return thrift.Response{}, yarpcerrors.InvalidArgumentErrorf(
+			"could not decode Thrift request for service 'ExtendEmpty' procedure 'Hello': %w", err)
 	}
 
 	err := h.impl.Hello(ctx)

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/nameserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/nameserver/server.go
@@ -9,6 +9,7 @@ import (
 	transport "go.uber.org/yarpc/api/transport"
 	thrift "go.uber.org/yarpc/encoding/thrift"
 	extends "go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends"
+	yarpcerrors "go.uber.org/yarpc/yarpcerrors"
 )
 
 // Interface is the server-side interface for the Name service.
@@ -52,7 +53,8 @@ type handler struct{ impl Interface }
 func (h handler) Name(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args extends.Name_Name_Args
 	if err := args.FromWire(body); err != nil {
-		return thrift.Response{}, err
+		return thrift.Response{}, yarpcerrors.InvalidArgumentErrorf(
+			"could not decode Thrift request for service 'Name' procedure 'Name': %w", err)
 	}
 
 	success, err := h.impl.Name(ctx)

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/weather/weatherserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/weather/weatherserver/server.go
@@ -9,6 +9,7 @@ import (
 	transport "go.uber.org/yarpc/api/transport"
 	thrift "go.uber.org/yarpc/encoding/thrift"
 	weather "go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/weather"
+	yarpcerrors "go.uber.org/yarpc/yarpcerrors"
 )
 
 // Interface is the server-side interface for the Weather service.
@@ -52,7 +53,8 @@ type handler struct{ impl Interface }
 func (h handler) Check(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args weather.Weather_Check_Args
 	if err := args.FromWire(body); err != nil {
-		return thrift.Response{}, err
+		return thrift.Response{}, yarpcerrors.InvalidArgumentErrorf(
+			"could not decode Thrift request for service 'Weather' procedure 'Check': %w", err)
 	}
 
 	success, err := h.impl.Check(ctx)

--- a/encoding/thrift/thriftrw-plugin-yarpc/roundtrip_test.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/roundtrip_test.go
@@ -378,11 +378,12 @@ func TestFromWireInvalidArg(t *testing.T) {
 	require.Equal(t, "Store::compareAndSwap", procedure.Name)
 	require.Equal(t, transport.Unary, procedure.HandlerSpec.Type())
 
-	// this struct has the same shape as the `CompareAndSwap` wrapper
-	// `Store_CompareAndSwap_Args`, except all fields are optional.
+	// This struct is identical to the `CompareAndSwap` wrapper
+	// `Store_CompareAndSwap_Args`, except all fields are optional. This will
+	// allow us to produce an invalid payload.
 	//
-	// The handler will fail to unmarshal the identical it into
-	// 'Store_CompareAndSwap_Args'.
+	// The handler will fail to unmarshal this type as it is missing required
+	// fields.
 	request := &atomic.OptionalCompareAndSwapWrapper{Cas: &atomic.OptionalCompareAndSwap{}}
 	val, err := request.ToWire()
 	require.NoError(t, err, "unable to covert type to wire.Value")

--- a/encoding/thrift/thriftrw-plugin-yarpc/roundtrip_test.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/roundtrip_test.go
@@ -20,6 +20,7 @@
 package main_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -29,6 +30,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/thriftrw/protocol"
 	"go.uber.org/thriftrw/ptr"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
@@ -49,6 +51,7 @@ import (
 	"go.uber.org/yarpc/internal/testtime"
 	"go.uber.org/yarpc/internal/yarpctest"
 	"go.uber.org/yarpc/transport/http"
+	"go.uber.org/yarpc/yarpcerrors"
 )
 
 func TestRoundTrip(t *testing.T) {
@@ -365,4 +368,37 @@ func (extendEmptyHandler) Hello(ctx context.Context) error {
 
 func (extendEmptyHandler) Healthy(ctx context.Context) (bool, error) {
 	return true, nil
+}
+
+func TestFromWireInvalidArg(t *testing.T) {
+	procedures := storeserver.New(nil /*server impl*/)
+	require.Len(t, procedures, 5, "unexpected number of procedures")
+
+	procedure := procedures[2]
+	require.Equal(t, "Store::compareAndSwap", procedure.Name)
+	require.Equal(t, transport.Unary, procedure.HandlerSpec.Type())
+
+	// this struct has the same shape as the `CompareAndSwap` wrapper
+	// `Store_CompareAndSwap_Args`, except all fields are optional.
+	//
+	// The handler will fail to unmarshal the identical it into
+	// 'Store_CompareAndSwap_Args'.
+	request := &atomic.OptionalCompareAndSwapWrapper{Cas: &atomic.OptionalCompareAndSwap{}}
+	val, err := request.ToWire()
+	require.NoError(t, err, "unable to covert type to wire.Value")
+
+	var body bytes.Buffer
+	err = (protocol.Binary).Encode(val, &body)
+	require.NoError(t, err, "could not marshal message to bytes")
+
+	err = procedure.HandlerSpec.Unary().Handle(context.Background(), &transport.Request{
+		Encoding: thrift.Encoding,
+		Body:     &body,
+	}, nil /*response writer*/)
+
+	require.Error(t, err, "expected handler error")
+	assert.True(t, yarpcerrors.IsStatus(err), "unkown error")
+	assert.Equal(t, yarpcerrors.CodeInvalidArgument, yarpcerrors.FromError(err).Code(), "unexpected code")
+	assert.Contains(t, yarpcerrors.FromError(err).Message(), "Store", "expected Thrift service name in message")
+	assert.Contains(t, yarpcerrors.FromError(err).Message(), "CompareAndSwap", "expected Thrift procedure name in message")
 }

--- a/encoding/thrift/thriftrw-plugin-yarpc/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/server.go
@@ -33,8 +33,8 @@ const serverTemplate = `
 <$pkgname := printf "%sserver" (lower .Name)>
 package <$pkgname>
 
-<$thrift    := import "go.uber.org/yarpc/encoding/thrift">
-<$transport := import "go.uber.org/yarpc/api/transport">
+<$thrift      := import "go.uber.org/yarpc/encoding/thrift">
+<$transport   := import "go.uber.org/yarpc/api/transport">
 
 <$contextImportPath   := .ContextImportPath>
 <$onewayWrapperImport := .OnewayWrapperImport>
@@ -130,10 +130,12 @@ func (h handler) <.Name>(ctx <$context>.Context, body <$wire>.Value) error {
 	return h.impl.<.Name>(ctx, <range .Arguments>args.<.Name>,<end>)
 }
 <else>
+<$yarpcerrors := import "go.uber.org/yarpc/yarpcerrors">
 func (h handler) <.Name>(ctx <$context>.Context, body <$wire>.Value) (<$thrift>.Response, error) {
 	var args <$prefix>Args
 	if err := args.FromWire(body); err != nil {
-		return <$thrift>.Response{}, err
+		return <$thrift>.Response{}, <$yarpcerrors>.InvalidArgumentErrorf(
+			"could not decode Thrift request for service '<$service.Name>' procedure '<.Name>': %w", err)
 	}
 
 	<if .ReturnType>

--- a/internal/crossdock/thrift/echo/echoserver/server.go
+++ b/internal/crossdock/thrift/echo/echoserver/server.go
@@ -29,6 +29,7 @@ import (
 	transport "go.uber.org/yarpc/api/transport"
 	thrift "go.uber.org/yarpc/encoding/thrift"
 	echo "go.uber.org/yarpc/internal/crossdock/thrift/echo"
+	yarpcerrors "go.uber.org/yarpc/yarpcerrors"
 )
 
 // Interface is the server-side interface for the Echo service.
@@ -73,7 +74,8 @@ type handler struct{ impl Interface }
 func (h handler) Echo(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args echo.Echo_Echo_Args
 	if err := args.FromWire(body); err != nil {
-		return thrift.Response{}, err
+		return thrift.Response{}, yarpcerrors.InvalidArgumentErrorf(
+			"could not decode Thrift request for service 'Echo' procedure 'Echo': %w", err)
 	}
 
 	success, err := h.impl.Echo(ctx, args.Ping)

--- a/internal/crossdock/thrift/gauntlet/secondserviceserver/server.go
+++ b/internal/crossdock/thrift/gauntlet/secondserviceserver/server.go
@@ -29,6 +29,7 @@ import (
 	transport "go.uber.org/yarpc/api/transport"
 	thrift "go.uber.org/yarpc/encoding/thrift"
 	gauntlet "go.uber.org/yarpc/internal/crossdock/thrift/gauntlet"
+	yarpcerrors "go.uber.org/yarpc/yarpcerrors"
 )
 
 // Interface is the server-side interface for the SecondService service.
@@ -88,7 +89,8 @@ type handler struct{ impl Interface }
 func (h handler) BlahBlah(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args gauntlet.SecondService_BlahBlah_Args
 	if err := args.FromWire(body); err != nil {
-		return thrift.Response{}, err
+		return thrift.Response{}, yarpcerrors.InvalidArgumentErrorf(
+			"could not decode Thrift request for service 'SecondService' procedure 'BlahBlah': %w", err)
 	}
 
 	err := h.impl.BlahBlah(ctx)
@@ -107,7 +109,8 @@ func (h handler) BlahBlah(ctx context.Context, body wire.Value) (thrift.Response
 func (h handler) SecondtestString(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args gauntlet.SecondService_SecondtestString_Args
 	if err := args.FromWire(body); err != nil {
-		return thrift.Response{}, err
+		return thrift.Response{}, yarpcerrors.InvalidArgumentErrorf(
+			"could not decode Thrift request for service 'SecondService' procedure 'SecondtestString': %w", err)
 	}
 
 	success, err := h.impl.SecondtestString(ctx, args.Thing)

--- a/internal/crossdock/thrift/gauntlet/thrifttestserver/server.go
+++ b/internal/crossdock/thrift/gauntlet/thrifttestserver/server.go
@@ -29,6 +29,7 @@ import (
 	transport "go.uber.org/yarpc/api/transport"
 	thrift "go.uber.org/yarpc/encoding/thrift"
 	gauntlet "go.uber.org/yarpc/internal/crossdock/thrift/gauntlet"
+	yarpcerrors "go.uber.org/yarpc/yarpcerrors"
 )
 
 // Interface is the server-side interface for the ThriftTest service.
@@ -398,7 +399,8 @@ type handler struct{ impl Interface }
 func (h handler) TestBinary(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args gauntlet.ThriftTest_TestBinary_Args
 	if err := args.FromWire(body); err != nil {
-		return thrift.Response{}, err
+		return thrift.Response{}, yarpcerrors.InvalidArgumentErrorf(
+			"could not decode Thrift request for service 'ThriftTest' procedure 'TestBinary': %w", err)
 	}
 
 	success, err := h.impl.TestBinary(ctx, args.Thing)
@@ -417,7 +419,8 @@ func (h handler) TestBinary(ctx context.Context, body wire.Value) (thrift.Respon
 func (h handler) TestByte(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args gauntlet.ThriftTest_TestByte_Args
 	if err := args.FromWire(body); err != nil {
-		return thrift.Response{}, err
+		return thrift.Response{}, yarpcerrors.InvalidArgumentErrorf(
+			"could not decode Thrift request for service 'ThriftTest' procedure 'TestByte': %w", err)
 	}
 
 	success, err := h.impl.TestByte(ctx, args.Thing)
@@ -436,7 +439,8 @@ func (h handler) TestByte(ctx context.Context, body wire.Value) (thrift.Response
 func (h handler) TestDouble(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args gauntlet.ThriftTest_TestDouble_Args
 	if err := args.FromWire(body); err != nil {
-		return thrift.Response{}, err
+		return thrift.Response{}, yarpcerrors.InvalidArgumentErrorf(
+			"could not decode Thrift request for service 'ThriftTest' procedure 'TestDouble': %w", err)
 	}
 
 	success, err := h.impl.TestDouble(ctx, args.Thing)
@@ -455,7 +459,8 @@ func (h handler) TestDouble(ctx context.Context, body wire.Value) (thrift.Respon
 func (h handler) TestEnum(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args gauntlet.ThriftTest_TestEnum_Args
 	if err := args.FromWire(body); err != nil {
-		return thrift.Response{}, err
+		return thrift.Response{}, yarpcerrors.InvalidArgumentErrorf(
+			"could not decode Thrift request for service 'ThriftTest' procedure 'TestEnum': %w", err)
 	}
 
 	success, err := h.impl.TestEnum(ctx, args.Thing)
@@ -474,7 +479,8 @@ func (h handler) TestEnum(ctx context.Context, body wire.Value) (thrift.Response
 func (h handler) TestException(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args gauntlet.ThriftTest_TestException_Args
 	if err := args.FromWire(body); err != nil {
-		return thrift.Response{}, err
+		return thrift.Response{}, yarpcerrors.InvalidArgumentErrorf(
+			"could not decode Thrift request for service 'ThriftTest' procedure 'TestException': %w", err)
 	}
 
 	err := h.impl.TestException(ctx, args.Arg)
@@ -493,7 +499,8 @@ func (h handler) TestException(ctx context.Context, body wire.Value) (thrift.Res
 func (h handler) TestI32(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args gauntlet.ThriftTest_TestI32_Args
 	if err := args.FromWire(body); err != nil {
-		return thrift.Response{}, err
+		return thrift.Response{}, yarpcerrors.InvalidArgumentErrorf(
+			"could not decode Thrift request for service 'ThriftTest' procedure 'TestI32': %w", err)
 	}
 
 	success, err := h.impl.TestI32(ctx, args.Thing)
@@ -512,7 +519,8 @@ func (h handler) TestI32(ctx context.Context, body wire.Value) (thrift.Response,
 func (h handler) TestI64(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args gauntlet.ThriftTest_TestI64_Args
 	if err := args.FromWire(body); err != nil {
-		return thrift.Response{}, err
+		return thrift.Response{}, yarpcerrors.InvalidArgumentErrorf(
+			"could not decode Thrift request for service 'ThriftTest' procedure 'TestI64': %w", err)
 	}
 
 	success, err := h.impl.TestI64(ctx, args.Thing)
@@ -531,7 +539,8 @@ func (h handler) TestI64(ctx context.Context, body wire.Value) (thrift.Response,
 func (h handler) TestInsanity(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args gauntlet.ThriftTest_TestInsanity_Args
 	if err := args.FromWire(body); err != nil {
-		return thrift.Response{}, err
+		return thrift.Response{}, yarpcerrors.InvalidArgumentErrorf(
+			"could not decode Thrift request for service 'ThriftTest' procedure 'TestInsanity': %w", err)
 	}
 
 	success, err := h.impl.TestInsanity(ctx, args.Argument)
@@ -550,7 +559,8 @@ func (h handler) TestInsanity(ctx context.Context, body wire.Value) (thrift.Resp
 func (h handler) TestList(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args gauntlet.ThriftTest_TestList_Args
 	if err := args.FromWire(body); err != nil {
-		return thrift.Response{}, err
+		return thrift.Response{}, yarpcerrors.InvalidArgumentErrorf(
+			"could not decode Thrift request for service 'ThriftTest' procedure 'TestList': %w", err)
 	}
 
 	success, err := h.impl.TestList(ctx, args.Thing)
@@ -569,7 +579,8 @@ func (h handler) TestList(ctx context.Context, body wire.Value) (thrift.Response
 func (h handler) TestMap(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args gauntlet.ThriftTest_TestMap_Args
 	if err := args.FromWire(body); err != nil {
-		return thrift.Response{}, err
+		return thrift.Response{}, yarpcerrors.InvalidArgumentErrorf(
+			"could not decode Thrift request for service 'ThriftTest' procedure 'TestMap': %w", err)
 	}
 
 	success, err := h.impl.TestMap(ctx, args.Thing)
@@ -588,7 +599,8 @@ func (h handler) TestMap(ctx context.Context, body wire.Value) (thrift.Response,
 func (h handler) TestMapMap(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args gauntlet.ThriftTest_TestMapMap_Args
 	if err := args.FromWire(body); err != nil {
-		return thrift.Response{}, err
+		return thrift.Response{}, yarpcerrors.InvalidArgumentErrorf(
+			"could not decode Thrift request for service 'ThriftTest' procedure 'TestMapMap': %w", err)
 	}
 
 	success, err := h.impl.TestMapMap(ctx, args.Hello)
@@ -607,7 +619,8 @@ func (h handler) TestMapMap(ctx context.Context, body wire.Value) (thrift.Respon
 func (h handler) TestMulti(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args gauntlet.ThriftTest_TestMulti_Args
 	if err := args.FromWire(body); err != nil {
-		return thrift.Response{}, err
+		return thrift.Response{}, yarpcerrors.InvalidArgumentErrorf(
+			"could not decode Thrift request for service 'ThriftTest' procedure 'TestMulti': %w", err)
 	}
 
 	success, err := h.impl.TestMulti(ctx, args.Arg0, args.Arg1, args.Arg2, args.Arg3, args.Arg4, args.Arg5)
@@ -626,7 +639,8 @@ func (h handler) TestMulti(ctx context.Context, body wire.Value) (thrift.Respons
 func (h handler) TestMultiException(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args gauntlet.ThriftTest_TestMultiException_Args
 	if err := args.FromWire(body); err != nil {
-		return thrift.Response{}, err
+		return thrift.Response{}, yarpcerrors.InvalidArgumentErrorf(
+			"could not decode Thrift request for service 'ThriftTest' procedure 'TestMultiException': %w", err)
 	}
 
 	success, err := h.impl.TestMultiException(ctx, args.Arg0, args.Arg1)
@@ -645,7 +659,8 @@ func (h handler) TestMultiException(ctx context.Context, body wire.Value) (thrif
 func (h handler) TestNest(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args gauntlet.ThriftTest_TestNest_Args
 	if err := args.FromWire(body); err != nil {
-		return thrift.Response{}, err
+		return thrift.Response{}, yarpcerrors.InvalidArgumentErrorf(
+			"could not decode Thrift request for service 'ThriftTest' procedure 'TestNest': %w", err)
 	}
 
 	success, err := h.impl.TestNest(ctx, args.Thing)
@@ -673,7 +688,8 @@ func (h handler) TestOneway(ctx context.Context, body wire.Value) error {
 func (h handler) TestSet(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args gauntlet.ThriftTest_TestSet_Args
 	if err := args.FromWire(body); err != nil {
-		return thrift.Response{}, err
+		return thrift.Response{}, yarpcerrors.InvalidArgumentErrorf(
+			"could not decode Thrift request for service 'ThriftTest' procedure 'TestSet': %w", err)
 	}
 
 	success, err := h.impl.TestSet(ctx, args.Thing)
@@ -692,7 +708,8 @@ func (h handler) TestSet(ctx context.Context, body wire.Value) (thrift.Response,
 func (h handler) TestString(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args gauntlet.ThriftTest_TestString_Args
 	if err := args.FromWire(body); err != nil {
-		return thrift.Response{}, err
+		return thrift.Response{}, yarpcerrors.InvalidArgumentErrorf(
+			"could not decode Thrift request for service 'ThriftTest' procedure 'TestString': %w", err)
 	}
 
 	success, err := h.impl.TestString(ctx, args.Thing)
@@ -711,7 +728,8 @@ func (h handler) TestString(ctx context.Context, body wire.Value) (thrift.Respon
 func (h handler) TestStringMap(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args gauntlet.ThriftTest_TestStringMap_Args
 	if err := args.FromWire(body); err != nil {
-		return thrift.Response{}, err
+		return thrift.Response{}, yarpcerrors.InvalidArgumentErrorf(
+			"could not decode Thrift request for service 'ThriftTest' procedure 'TestStringMap': %w", err)
 	}
 
 	success, err := h.impl.TestStringMap(ctx, args.Thing)
@@ -730,7 +748,8 @@ func (h handler) TestStringMap(ctx context.Context, body wire.Value) (thrift.Res
 func (h handler) TestStruct(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args gauntlet.ThriftTest_TestStruct_Args
 	if err := args.FromWire(body); err != nil {
-		return thrift.Response{}, err
+		return thrift.Response{}, yarpcerrors.InvalidArgumentErrorf(
+			"could not decode Thrift request for service 'ThriftTest' procedure 'TestStruct': %w", err)
 	}
 
 	success, err := h.impl.TestStruct(ctx, args.Thing)
@@ -749,7 +768,8 @@ func (h handler) TestStruct(ctx context.Context, body wire.Value) (thrift.Respon
 func (h handler) TestTypedef(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args gauntlet.ThriftTest_TestTypedef_Args
 	if err := args.FromWire(body); err != nil {
-		return thrift.Response{}, err
+		return thrift.Response{}, yarpcerrors.InvalidArgumentErrorf(
+			"could not decode Thrift request for service 'ThriftTest' procedure 'TestTypedef': %w", err)
 	}
 
 	success, err := h.impl.TestTypedef(ctx, args.Thing)
@@ -768,7 +788,8 @@ func (h handler) TestTypedef(ctx context.Context, body wire.Value) (thrift.Respo
 func (h handler) TestVoid(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args gauntlet.ThriftTest_TestVoid_Args
 	if err := args.FromWire(body); err != nil {
-		return thrift.Response{}, err
+		return thrift.Response{}, yarpcerrors.InvalidArgumentErrorf(
+			"could not decode Thrift request for service 'ThriftTest' procedure 'TestVoid': %w", err)
 	}
 
 	err := h.impl.TestVoid(ctx)

--- a/internal/examples/thrift-hello/hello/echo/helloserver/server.go
+++ b/internal/examples/thrift-hello/hello/echo/helloserver/server.go
@@ -29,6 +29,7 @@ import (
 	transport "go.uber.org/yarpc/api/transport"
 	thrift "go.uber.org/yarpc/encoding/thrift"
 	echo "go.uber.org/yarpc/internal/examples/thrift-hello/hello/echo"
+	yarpcerrors "go.uber.org/yarpc/yarpcerrors"
 )
 
 // Interface is the server-side interface for the Hello service.
@@ -73,7 +74,8 @@ type handler struct{ impl Interface }
 func (h handler) Echo(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args echo.Hello_Echo_Args
 	if err := args.FromWire(body); err != nil {
-		return thrift.Response{}, err
+		return thrift.Response{}, yarpcerrors.InvalidArgumentErrorf(
+			"could not decode Thrift request for service 'Hello' procedure 'Echo': %w", err)
 	}
 
 	success, err := h.impl.Echo(ctx, args.Echo)

--- a/internal/examples/thrift-keyvalue/keyvalue/kv/keyvalueserver/server.go
+++ b/internal/examples/thrift-keyvalue/keyvalue/kv/keyvalueserver/server.go
@@ -29,6 +29,7 @@ import (
 	transport "go.uber.org/yarpc/api/transport"
 	thrift "go.uber.org/yarpc/encoding/thrift"
 	kv "go.uber.org/yarpc/internal/examples/thrift-keyvalue/keyvalue/kv"
+	yarpcerrors "go.uber.org/yarpc/yarpcerrors"
 )
 
 // Interface is the server-side interface for the KeyValue service.
@@ -90,7 +91,8 @@ type handler struct{ impl Interface }
 func (h handler) GetValue(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args kv.KeyValue_GetValue_Args
 	if err := args.FromWire(body); err != nil {
-		return thrift.Response{}, err
+		return thrift.Response{}, yarpcerrors.InvalidArgumentErrorf(
+			"could not decode Thrift request for service 'KeyValue' procedure 'GetValue': %w", err)
 	}
 
 	success, err := h.impl.GetValue(ctx, args.Key)
@@ -109,7 +111,8 @@ func (h handler) GetValue(ctx context.Context, body wire.Value) (thrift.Response
 func (h handler) SetValue(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args kv.KeyValue_SetValue_Args
 	if err := args.FromWire(body); err != nil {
-		return thrift.Response{}, err
+		return thrift.Response{}, yarpcerrors.InvalidArgumentErrorf(
+			"could not decode Thrift request for service 'KeyValue' procedure 'SetValue': %w", err)
 	}
 
 	err := h.impl.SetValue(ctx, args.Key, args.Value)


### PR DESCRIPTION
This fixes a small edge case that came up with an internal tool that does not
guarantee sending valid requests :/

After an inbound request was unmarshaled, we would call `footype.FromWire(w)`.
If this call failed, we'd return the raw non-`yarpcerror` error. That behavior
reflects poorly on server metrics as it's deemed an unknown server error.

This change wraps the error in a `yarpcerror` using `CodeInvalidArgument`. This
aligns with the other errors returned from the Thrift and Protobuf encoding
layers.

Fixes #1909

For the majority of RPC use-cases, this should never be an issue. 
- [x] Description and context for reviewers: one partner, one stranger
- [x] Entry in CHANGELOG.md
