### PR TITLE
buildkite: Use 1.13 build for auto-update dependencies

### DIFF
--- a/.buildkite/pipeline-update-deps.yml
+++ b/.buildkite/pipeline-update-deps.yml
@@ -1,17 +1,17 @@
 steps:
-  - name: ":docker: :package: 1.12"
+  - name: ":docker: :package: 1.13"
     plugins:
       docker-compose#v2.0.0:
-        build: yarpc-go-1.12
+        build: yarpc-go-1.13
         image-repository: 027047743804.dkr.ecr.us-east-2.amazonaws.com/uber
     agents:
       queue: builders
   - wait
-  - name: ":go: 1.12 update-deps"
+  - name: ":go: 1.13 update-deps"
     command: "etc/bin/update-deps.sh"
     plugins:
       docker-compose#v2.0.0:
-        run: yarpc-go-1.12
+        run: yarpc-go-1.13
         env:
           # The script needs the following environment variables in addition
           # to those provided by the docker-compose.


### PR DESCRIPTION
In #1900, we didn't update the `pipeline-update-deps.yml` file, so the
auto-dependency updater is pointing to an invalid image causing the
following error:

```
Pulling yarpc-go-1.12 ... error

ERROR: for yarpc-go-1.12  manifest for 027047743804.dkr.ecr.us-east-2.amazonaws.com/uber:yarpc-go-yarpc-go-1.12-build-2848 not found: manifest unknown: Requested image not found
ERROR: manifest for 027047743804.dkr.ecr.us-east-2.amazonaws.com/uber:yarpc-go-yarpc-go-1.12-build-2848 not found: manifest unknown: Requested image not found
Exited with 1
```

https://buildkite.com/uberopensource/yarpc-go/builds/2848#7b985c92-4e0f-47f7-a6e1-6541b4e03987

This modifies the updater to use the 1.13 image.