### PR TITLE
protobuf: Drop direct dependency of `golang/protobuf`

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -10,8 +10,6 @@ import:
   version: '>=1, <1.3' # T4191773 - TODO: v1.3 breaks gRPC/Protobuf tests
 - package: github.com/gogo/googleapis
   version: '>=1, <1.3' # T4191773 - not pinning to a version grabs latest master :/
-- package: github.com/golang/protobuf
-  version: ^1
 - package: github.com/mattn/go-shellwords
   version: ^1
 - package: github.com/uber-go/mapdecode

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/gogo/protobuf v1.3.1
 	github.com/gogo/status v1.1.0
 	github.com/golang/mock v1.4.0
-	github.com/golang/protobuf v1.3.3
 	github.com/golang/snappy v0.0.1
 	github.com/google/go-cmp v0.4.0 // indirect
 	github.com/kisielk/errcheck v1.2.0

--- a/transport/grpc/outbound_test.go
+++ b/transport/grpc/outbound_test.go
@@ -27,8 +27,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gogo/protobuf/types"
 	"github.com/golang/mock/gomock"
-	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc/api/peer"
@@ -241,7 +241,7 @@ func TestCallServiceMatch(t *testing.T) {
 					}
 
 					// Send the response attributes back and end the stream.
-					if sendErr := stream.SendMsg(&empty.Empty{}); sendErr != nil {
+					if sendErr := stream.SendMsg(&types.Empty{}); sendErr != nil {
 						// We couldn't send the response.
 						return sendErr
 					}


### PR DESCRIPTION
Turns out that we were relying on `golang/protobuf` in one spot which
adds an unnecessary direct dependency to YARPC. We've standardized
on `gogo/protobuf` so this diff replaces the equivalent type.
