### PR TITLE
yarpcerrors: Support fmt verbs for errors with no args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Fixed
+- yarpcerrors: `fmt` verbs are ignored when no args are passed to error
+  constructors.
 
 ## [1.45.0] - 2020-04-21
 ### Added

--- a/yarpcerrors/errors.go
+++ b/yarpcerrors/errors.go
@@ -33,9 +33,17 @@ func Newf(code Code, format string, args ...interface{}) *Status {
 	if code == CodeOK {
 		return nil
 	}
+
+	var err error
+	if len(args) == 0 {
+		err = errors.New(format)
+	} else {
+		err = fmt.Errorf(format, args...)
+	}
+
 	return &Status{
 		code: code,
-		err:  fmt.Errorf(format, args...),
+		err:  err,
 	}
 }
 

--- a/yarpcerrors/errors_test.go
+++ b/yarpcerrors/errors_test.go
@@ -235,3 +235,8 @@ func TestIsStatus(t *testing.T) {
 		assert.True(t, IsStatus(err))
 	})
 }
+
+func TestErrorWithFmtVerbs(t *testing.T) {
+	err := errors.New(`http://foo%s: invalid URL escape "%s"`)
+	assert.EqualError(t, UnknownErrorf(err.Error()), FromError(err).Error())
+}


### PR DESCRIPTION
The last release mistakenly introduced a minor regression, which
required a changes to a handful of upgraded services:

- https://github.com/yarpc/yarpc-go/pull/1905/files#diff-5c08e10470cea3c3921307ca74147156L414

Although a minor edge case, this meant that `FromError`, which returns
a `CodeUnknown` for unknown errors, and `Newf(CodeUnknown,...)` would
produce different error messages.

Before this fix, the `Newf(CodeUnknown,...)` error in the added test
would be:

```
"code:unknown message:http://foo%!s(MISSING): invalid URL escape \"%!s(MISSING)\""
```

After this change, `Newf` now matchs the `FromError` message:

```
"code:unknown message:http://foo%s: invalid URL escape \"%s\""
```

This resets the behavior, such that the constructor acts like
`fmt.Errorf` with args and `errors.New` without.

- [x] Description and context for reviewers: one partner, one stranger
- [x] Entry in CHANGELOG.md
