### PR TITLE
Fix gRPC streaming when used with the direct peer chooser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Fix gRPC streaming when used with the direct peer chooser
+- Fix gRPC streaming when used with the direct peer chooser.
 
 ## [1.45.0] - 2020-04-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Fixed
+- Fix gRPC streaming when used with the direct peer chooser
 
 ## [1.45.0] - 2020-04-21
 ### Added

--- a/transport/grpc/outbound.go
+++ b/transport/grpc/outbound.go
@@ -279,7 +279,6 @@ func (o *Outbound) stream(
 	if err != nil {
 		return nil, err
 	}
-	defer func() { onFinish(err) }()
 
 	grpcPeer, ok := apiPeer.(*grpcPeer)
 	if !ok {
@@ -316,7 +315,7 @@ func (o *Outbound) stream(
 		span.Finish()
 		return nil, err
 	}
-	stream := newClientStream(streamCtx, req, clientStream, span)
+	stream := newClientStream(streamCtx, req, clientStream, span, onFinish)
 	tClientStream, err := transport.NewClientStream(stream)
 	if err != nil {
 		span.Finish()

--- a/transport/grpc/stream_test.go
+++ b/transport/grpc/stream_test.go
@@ -41,7 +41,6 @@ func TestStreaming(t *testing.T) {
 			return nil, fmt.Errorf("transport was not a grpc.Transport")
 		}
 		return direct.New(direct.Configuration{}, trans.NewDialer())
-		// return peerchooser.NewSingle(id, transport)
 	}
 
 	p := NewPortProvider(t)
@@ -308,7 +307,8 @@ func TestStreaming(t *testing.T) {
 		{
 			// The direct chooser is rather unique in that it releases the peer in
 			// the onFinish function. Other choosers reuse the peer across calls and
-			// only release it as part of chooser.Stop().
+			// only release it as part of chooser.Stop(). This case ensures we don't
+			// call onFinish prematurely.
 			name: "single use chooser",
 			services: Lifecycles(
 				GRPCService(

--- a/transport/grpc/stream_test.go
+++ b/transport/grpc/stream_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 func TestStreaming(t *testing.T) {
-	newChooser := func(id peer.Identifier, transport peer.Transport) (peer.Chooser, error) {
+	newDirectChooser := func(id peer.Identifier, transport peer.Transport) (peer.Chooser, error) {
 		trans, ok := transport.(*grpc.Transport)
 		if !ok {
 			return nil, fmt.Errorf("transport was not a grpc.Transport")
@@ -306,6 +306,9 @@ func TestStreaming(t *testing.T) {
 			),
 		},
 		{
+			// The direct chooser is rather unique in that it releases the peer in
+			// the onFinish function. Other choosers reuse the peer across calls and
+			// only release it as part of chooser.Stop().
 			name: "single use chooser",
 			services: Lifecycles(
 				GRPCService(
@@ -324,7 +327,7 @@ func TestStreaming(t *testing.T) {
 						Service("myservice"),
 						Procedure("proc"),
 						ShardKey(fmt.Sprintf("127.0.0.1:%d", p.NamedPort("10").Port)),
-						Chooser(newChooser),
+						Chooser(newDirectChooser),
 						ClientStreamActions(
 							SendStreamMsg("test"),
 							RecvStreamMsg("test"),

--- a/x/yarpctest/api/request_stream.go
+++ b/x/yarpctest/api/request_stream.go
@@ -23,7 +23,9 @@ package api
 import (
 	"testing"
 
+	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
+	peerchooser "go.uber.org/yarpc/peer"
 )
 
 // ClientStreamRequestOpts are configuration options for a yarpc stream request.
@@ -32,6 +34,7 @@ type ClientStreamRequestOpts struct {
 	GiveRequest   *transport.StreamRequest
 	StreamActions []ClientStreamAction
 	WantErrMsgs   []string
+	NewChooser    func(peer.Identifier, peer.Transport) (peer.Chooser, error)
 }
 
 // NewClientStreamRequestOpts initializes a ClientStreamRequestOpts struct.
@@ -42,6 +45,9 @@ func NewClientStreamRequestOpts() ClientStreamRequestOpts {
 				Caller:   "unknown",
 				Encoding: transport.Encoding("raw"),
 			},
+		},
+		NewChooser: func(id peer.Identifier, transport peer.Transport) (peer.Chooser, error) {
+			return peerchooser.NewSingle(id, transport), nil
 		},
 	}
 }

--- a/x/yarpctest/request.go
+++ b/x/yarpctest/request.go
@@ -43,8 +43,7 @@ func ShardKey(key string) *types.ShardKey {
 	return &types.ShardKey{ShardKey: key}
 }
 
-// ShardKey specifies that "shard key" header for a request. It is a shared
-// option across different requests.
+// Chooser overrides the peer.Chooser for a request.
 func Chooser(f func(peer.Identifier, peer.Transport) (peer.Chooser, error)) *types.ChooserFactory {
 	return &types.ChooserFactory{NewChooser: f}
 }

--- a/x/yarpctest/request.go
+++ b/x/yarpctest/request.go
@@ -20,7 +20,10 @@
 
 package yarpctest
 
-import "go.uber.org/yarpc/x/yarpctest/types"
+import (
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/x/yarpctest/types"
+)
 
 // Service specifies the "service" header for a request. It is a shared
 // option across different requests.
@@ -38,4 +41,10 @@ func Procedure(procedure string) *types.Procedure {
 // option across different requests.
 func ShardKey(key string) *types.ShardKey {
 	return &types.ShardKey{ShardKey: key}
+}
+
+// ShardKey specifies that "shard key" header for a request. It is a shared
+// option across different requests.
+func Chooser(f func(peer.Identifier, peer.Transport) (peer.Chooser, error)) *types.ChooserFactory {
+	return &types.ChooserFactory{NewChooser: f}
 }

--- a/x/yarpctest/request_stream.go
+++ b/x/yarpctest/request_stream.go
@@ -37,7 +37,6 @@ import (
 // GRPCStreamRequest creates a new grpc stream request.
 func GRPCStreamRequest(options ...api.ClientStreamRequestOption) api.Action {
 	return api.ActionFunc(func(t testing.TB) {
-
 		opts := api.NewClientStreamRequestOpts()
 		for _, option := range options {
 			option.ApplyClientStreamRequest(&opts)

--- a/x/yarpctest/request_stream.go
+++ b/x/yarpctest/request_stream.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/peer/hostport"
 	"go.uber.org/yarpc/transport/grpc"
 	"go.uber.org/yarpc/x/yarpctest/api"
 )
@@ -36,13 +37,16 @@ import (
 // GRPCStreamRequest creates a new grpc stream request.
 func GRPCStreamRequest(options ...api.ClientStreamRequestOption) api.Action {
 	return api.ActionFunc(func(t testing.TB) {
+
 		opts := api.NewClientStreamRequestOpts()
 		for _, option := range options {
 			option.ApplyClientStreamRequest(&opts)
 		}
 
 		trans := grpc.NewTransport()
-		out := trans.NewSingleOutbound(fmt.Sprintf("127.0.0.1:%d", opts.Port))
+		chooser, err := opts.NewChooser(hostport.PeerIdentifier(fmt.Sprintf("127.0.0.1:%d", opts.Port)), trans)
+		require.NoError(t, err, "failed to create chooser")
+		out := trans.NewOutbound(chooser)
 
 		require.NoError(t, trans.Start())
 		defer func() { assert.NoError(t, trans.Stop()) }()
@@ -50,7 +54,7 @@ func GRPCStreamRequest(options ...api.ClientStreamRequestOption) api.Action {
 		require.NoError(t, out.Start())
 		defer func() { assert.NoError(t, out.Stop()) }()
 
-		err := callStream(t, out, opts.GiveRequest, opts.StreamActions)
+		err = callStream(t, out, opts.GiveRequest, opts.StreamActions)
 		if len(opts.WantErrMsgs) > 0 {
 			require.Error(t, err)
 			for _, wantErrMsg := range opts.WantErrMsgs {

--- a/x/yarpctest/types/request.go
+++ b/x/yarpctest/types/request.go
@@ -20,7 +20,10 @@
 
 package types
 
-import "go.uber.org/yarpc/x/yarpctest/api"
+import (
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/x/yarpctest/api"
+)
 
 // Service is a concrete type that represents the "service" for a request.
 // It can be used in multiple interfaces.
@@ -68,4 +71,20 @@ func (n *ShardKey) ApplyRequest(opts *api.RequestOpts) {
 // ApplyClientStreamRequest implements api.ClientStreamRequestOption
 func (n *ShardKey) ApplyClientStreamRequest(opts *api.ClientStreamRequestOpts) {
 	opts.GiveRequest.Meta.ShardKey = n.ShardKey
+}
+
+// ChooserFactory is a concrete type that providers the peer chooser for the
+// request.
+type ChooserFactory struct {
+	NewChooser func(peer.Identifier, peer.Transport) (peer.Chooser, error)
+}
+
+// ApplyRequest implements api.RequestOption
+func (n *ChooserFactory) ApplyRequest(opts *api.RequestOpts) {
+	// opts.GiveRequest.ShardKey = n.ShardKey
+}
+
+// ApplyClientStreamRequest implements api.ClientStreamRequestOption
+func (n *ChooserFactory) ApplyClientStreamRequest(opts *api.ClientStreamRequestOpts) {
+	opts.NewChooser = n.NewChooser
 }

--- a/x/yarpctest/types/request.go
+++ b/x/yarpctest/types/request.go
@@ -79,11 +79,6 @@ type ChooserFactory struct {
 	NewChooser func(peer.Identifier, peer.Transport) (peer.Chooser, error)
 }
 
-// ApplyRequest implements api.RequestOption
-func (n *ChooserFactory) ApplyRequest(opts *api.RequestOpts) {
-	// opts.GiveRequest.ShardKey = n.ShardKey
-}
-
 // ApplyClientStreamRequest implements api.ClientStreamRequestOption
 func (n *ChooserFactory) ApplyClientStreamRequest(opts *api.ClientStreamRequestOpts) {
 	opts.NewChooser = n.NewChooser


### PR DESCRIPTION
We have an issue in the gRPC streaming outbound where we call OnFinish on the chosen peer, after the initial request was made.

The direct peer list uses places its "ReleasePeer" call in the "OnFinish" function, which the gRPC transport is prematurely calling.

Therefore, when streaming is used with the direct peer list this causes the flapping behavior, since the connection is being immediately closed. Other peer lists do not have this issue since peer lists retain the peers until they are actively removed from an updater, ie UNS.