### PR TITLE
Add default Choose timeout to peer lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- `abstractlist` accepts a `DefaultChooseTimeout` option for applying to
-`context`s without deadlines.
+- peer lists accepts a `DefaultChooseTimeout` configuration for applying to
+  `context`s without deadlines.
 ### Fixed
 - yarpcerrors: `fmt` verbs are ignored when no args are passed to error
   constructors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `abstractlist` accepts a `DefaultChooseTimeout` option for applying to
+`context`s without deadlines.
 ### Fixed
 - yarpcerrors: `fmt` verbs are ignored when no args are passed to error
   constructors.
 - Fix gRPC streaming when used with the direct peer chooser.
+- Streaming calls do not require contexts with deadlines. Users should use
+  cancelable contexts for long-lived streams instead of timeouts.
 
 ## [1.45.0] - 2020-04-21
 ### Added

--- a/peer/abstractlist/list_test.go
+++ b/peer/abstractlist/list_test.go
@@ -33,6 +33,7 @@ import (
 	"go.uber.org/yarpc/internal/introspection"
 	"go.uber.org/yarpc/internal/testtime"
 	"go.uber.org/yarpc/peer/abstractpeer"
+	"go.uber.org/yarpc/peer/hostport"
 	"go.uber.org/yarpc/yarpctest"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
@@ -384,4 +385,24 @@ func TestWaitForNeverStarted(t *testing.T) {
 	_, _, err := list.Choose(ctx, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "context finished while waiting for instance to start: context deadline exceeded")
+}
+
+func TestDefaultChooseTimeout(t *testing.T) {
+	fakeTransport := yarpctest.NewFakeTransport()
+	listImplementation := &mraList{}
+	req := &transport.Request{}
+
+	list := New("foo-list", fakeTransport, listImplementation, DefaultChooseTimeout(0))
+	require.NoError(t, list.Start(), "peer list failed to start")
+
+	err := list.Update(peer.ListUpdates{Additions: []peer.Identifier{
+		hostport.PeerIdentifier("foo:peer"),
+	}})
+	require.NoError(t, err, "could not add fake peer to list")
+
+	// no deadline
+	ctx := context.Background()
+
+	_, _, err = list.Choose(ctx, req)
+	assert.NoError(t, err, "expected to choose peer without context deadline")
 }

--- a/peer/pendingheap/list_test.go
+++ b/peer/pendingheap/list_test.go
@@ -45,10 +45,6 @@ import (
 	"go.uber.org/zap/zaptest"
 )
 
-var (
-	_noContextDeadlineError = yarpcerrors.Newf(yarpcerrors.CodeInvalidArgument, `"fewest-pending-requests" peer list can't wait for peer without a context deadline`)
-)
-
 func newNotRunningError(err string) error {
 	return yarpcerrors.FailedPreconditionErrorf(`"fewest-pending-requests" peer list is not running: %s`, err)
 }
@@ -478,17 +474,6 @@ func TestPeerHeapList(t *testing.T) {
 					Wait: 20 * time.Millisecond,
 				},
 				ChooseAction{ExpectedPeer: "1"},
-			},
-			expectedRunning: true,
-		},
-		{
-			msg: "no blocking with no context deadline",
-			peerListActions: []PeerListAction{
-				StartAction{},
-				ChooseAction{
-					InputContext: context.Background(),
-					ExpectedErr:  _noContextDeadlineError,
-				},
 			},
 			expectedRunning: true,
 		},

--- a/peer/randpeer/config.go
+++ b/peer/randpeer/config.go
@@ -22,6 +22,7 @@ package randpeer
 
 import (
 	"fmt"
+	"time"
 
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/yarpcconfig"
@@ -32,6 +33,10 @@ import (
 type Configuration struct {
 	Capacity *int `config:"capacity"`
 	FailFast bool `config:"failFast"`
+	// DefaultChooseTimeout specifies the deadline to add to Choose calls if not
+	// present. This enables calls without deadlines, ie streaming, to choose
+	// peers without waiting indefinitely.
+	DefaultChooseTimeout *time.Duration `config:"defaultChooseTimeout"`
 }
 
 // Spec returns a configuration specification for the random peer list
@@ -76,7 +81,9 @@ func SpecWithOptions(options ...ListOption) yarpcconfig.PeerListSpec {
 			if cfg.FailFast {
 				opts = append(opts, FailFast())
 			}
-
+			if cfg.DefaultChooseTimeout != nil {
+				opts = append(opts, DefaultChooseTimeout(*cfg.DefaultChooseTimeout))
+			}
 			return New(t, opts...), nil
 		},
 	}

--- a/peer/randpeer/list_test.go
+++ b/peer/randpeer/list_test.go
@@ -45,10 +45,6 @@ import (
 	"go.uber.org/zap/zaptest"
 )
 
-var (
-	_noContextDeadlineError = yarpcerrors.Newf(yarpcerrors.CodeInvalidArgument, `"random" peer list can't wait for peer without a context deadline`)
-)
-
 func newNotRunningError(err string) error {
 	return yarpcerrors.FailedPreconditionErrorf(`"random" peer list is not running: %s`, err)
 }
@@ -424,17 +420,6 @@ func TestRandPeer(t *testing.T) {
 					Wait: 20 * time.Millisecond,
 				},
 				ChooseAction{ExpectedPeer: "1"},
-			},
-			expectedRunning: true,
-		},
-		{
-			msg: "no blocking with no context deadline",
-			peerListActions: []PeerListAction{
-				StartAction{},
-				ChooseAction{
-					InputContext: context.Background(),
-					ExpectedErr:  _noContextDeadlineError,
-				},
 			},
 			expectedRunning: true,
 		},

--- a/peer/roundrobin/list_test.go
+++ b/peer/roundrobin/list_test.go
@@ -48,10 +48,7 @@ import (
 	"go.uber.org/zap/zaptest"
 )
 
-var (
-	_noContextDeadlineError = yarpcerrors.Newf(yarpcerrors.CodeInvalidArgument, `"round-robin" peer list can't wait for peer without a context deadline`)
-	_notRunningErrorFormat  = `"round-robin" peer list is not running: %s`
-)
+var _notRunningErrorFormat = `"round-robin" peer list is not running: %s`
 
 func newNotRunningError(err string) error {
 	return yarpcerrors.FailedPreconditionErrorf(_notRunningErrorFormat, err)
@@ -545,17 +542,6 @@ func TestRoundRobinList(t *testing.T) {
 		// 	},
 		// 	expectedRunning: true,
 		// },
-		{
-			msg: "no blocking with no context deadline",
-			peerListActions: []PeerListAction{
-				StartAction{},
-				ChooseAction{
-					InputContext: context.Background(),
-					ExpectedErr:  _noContextDeadlineError,
-				},
-			},
-			expectedRunning: true,
-		},
 		{
 			msg:                        "add unavailable peer",
 			retainedAvailablePeerIDs:   []string{"1"},

--- a/peer/tworandomchoices/list_test.go
+++ b/peer/tworandomchoices/list_test.go
@@ -45,10 +45,6 @@ import (
 	"go.uber.org/zap/zaptest"
 )
 
-var (
-	_noContextDeadlineError = yarpcerrors.Newf(yarpcerrors.CodeInvalidArgument, `"two-random-choices" peer list can't wait for peer without a context deadline`)
-)
-
 func newNotRunningError(err string) error {
 	return yarpcerrors.FailedPreconditionErrorf(`"two-random-choices" peer list is not running: %s`, err)
 }
@@ -424,17 +420,6 @@ func TestTwoRandomChoicesPeer(t *testing.T) {
 					Wait: 20 * time.Millisecond,
 				},
 				ChooseAction{ExpectedPeer: "1"},
-			},
-			expectedRunning: true,
-		},
-		{
-			msg: "no blocking with no context deadline",
-			peerListActions: []PeerListAction{
-				StartAction{},
-				ChooseAction{
-					InputContext: context.Background(),
-					ExpectedErr:  _noContextDeadlineError,
-				},
 			},
 			expectedRunning: true,
 		},

--- a/transport/grpc/external_integration_test.go
+++ b/transport/grpc/external_integration_test.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package grpc_test
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/prototest/example"
+	"go.uber.org/yarpc/internal/prototest/examplepb"
+	"go.uber.org/yarpc/peer/hostport"
+	"go.uber.org/yarpc/peer/roundrobin"
+	"go.uber.org/yarpc/transport/grpc"
+)
+
+func TestStreamingWithNoCtxDeadline(t *testing.T) {
+	// This test ensures that we can use gRPC streaming without a context deadline
+	// set. For long-lived streams, it should be unnecesary for users to set a
+	// deadline; instead they should use context.WithCancel to cancel the stream.
+
+	const serviceName = "service-name"
+
+	// init YARPC transport / inbound / outbound
+	grpcTransport := grpc.NewTransport()
+	peerList := roundrobin.New(grpcTransport)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err, "could not start listener")
+	inbound := grpcTransport.NewInbound(listener)
+
+	dispatcher := yarpc.NewDispatcher(yarpc.Config{
+		Name:     serviceName,
+		Inbounds: yarpc.Inbounds{inbound},
+		Outbounds: yarpc.Outbounds{
+			serviceName: {
+				ServiceName: serviceName,
+				Stream:      grpcTransport.NewOutbound(peerList),
+			},
+		},
+	})
+	dispatcher.Register(
+		examplepb.BuildFooYARPCProcedures(
+			example.NewFooYARPCServer(transport.NewHeaders())))
+
+	require.NoError(t, dispatcher.Start(), "could not start dispatcher")
+	defer func() { assert.NoError(t, dispatcher.Stop(), "could not stop dispatcher") }()
+
+	// add streaming peer so we can call ourself
+	err = peerList.Update(peer.ListUpdates{Additions: []peer.Identifier{
+		hostport.PeerIdentifier(listener.Addr().String()),
+	}})
+	require.NoError(t, err, "could not add peer to peer list")
+
+	waitForPeerAvailable(t, peerList, time.Second)
+
+	// init streaming client
+	client := examplepb.NewFooYARPCClient(dispatcher.ClientConfig(serviceName))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	streamClient, err := client.EchoBoth(ctx)
+	require.NoError(t, err, "could not create client stream")
+
+	// veryify we can send a request
+	err = streamClient.Send(&examplepb.EchoBothRequest{
+		Message:      "test message!",
+		NumResponses: 0,
+	})
+	require.NoError(t, err, "could not send message")
+	assert.NoError(t, streamClient.CloseSend(), "could not close stream")
+}
+
+// waitForPeerAvailable ensures that the peer becomes available before
+// proceeding, and that we do not wait forever.
+func waitForPeerAvailable(t *testing.T, peerList *roundrobin.List, wait time.Duration) {
+	peerAvailable := make(chan struct{})
+	go func() {
+		for {
+			if peerList.Peers()[0].Status().ConnectionStatus == peer.Available {
+				close(peerAvailable)
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+
+	select {
+	case <-time.After(wait):
+		t.Fatal("failed waiting to connect to peer")
+	case <-peerAvailable:
+		return
+	}
+}


### PR DESCRIPTION
This introduces a default `Choose` timeout to peer lists. Previously, all peer
lists required a context deadline. However, that behavior clashes with
streaming, since long-lived streams should not need to specify a
deadline/timeout on the context.

Now with this change, streaming calls do not require deadlines on the context.
Peer lists will set a default of 500ms on the deadline so that we do not wait
indefinitely for a peer to become available.

Commits are individually reviewable and will be rebased, unsquashed.

- [x] Description and context for reviewers: one partner, one stranger
- [x] Docs (package doc)
- [x] Entry in CHANGELOG.md

T5793585