### PR TITLE
Support whitelisting transport-encoding combinations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   context error. Dropped responses are logged under the `dropped` field.
 - Introspection APIs are added to `api/x/introspection`. This enabling custom
   outbounds, inbounds and peer lists to use YARPC's existing `x/debug` page.
+- Introduced `api/x/restriction` for preventing unwanted transport-encoding
+  combinations. This may cause panics for existing Fx services on start-up.
 ### Fixed
 - yarpcerrors: `fmt` verbs are ignored when no args are passed to error
   constructors.

--- a/api/x/restriction/restricter.go
+++ b/api/x/restriction/restricter.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package restriction is an experimental package for preventing unwanted
+// transport-encoding pairs.
+//
+// This package is under `x/` and subject to change. See README for details on
+// 'x' packages.
+package restriction
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"go.uber.org/yarpc/api/transport"
+)
+
+// Checker is used by encoding clients, for example Protobuf and Thrift, to
+// prevent unwanted transport-encoding combinations.
+//
+// Errors indicate whitelisted combinations.
+type Checker interface {
+	Check(encoding transport.Encoding, transportName string) error
+}
+
+// Tuple defines a combination to whitelist.
+type Tuple struct {
+	Transport string
+	Encoding  transport.Encoding
+}
+
+// Validate verifes that a tuple has all fields set.
+func (t Tuple) Validate() error {
+	if t.Transport == "" || t.Encoding == "" {
+		return errors.New("tuple missing must have all fields set")
+	}
+	return nil
+}
+
+// String implements fmt.Stringer.
+func (t Tuple) String() string {
+	return fmt.Sprintf("%s/%s", t.Transport, t.Encoding)
+}
+
+type checker struct {
+	availableMsg string
+	tuples       map[Tuple]struct{}
+}
+
+// NewChecker creates a Checker with a whitelist tuple combinations.
+func NewChecker(tuples ...Tuple) (Checker, error) {
+	if len(tuples) == 0 {
+		return nil, errors.New("NewChecker requires at least one whitelisted tuple")
+	}
+
+	m := make(map[Tuple]struct{}, len(tuples))
+	for _, t := range tuples {
+		if err := t.Validate(); err != nil {
+			return nil, err
+		}
+		m[t] = struct{}{}
+	}
+
+	elements := make([]string, 0, len(tuples))
+	for _, t := range tuples {
+		elements = append(elements, t.String())
+	}
+
+	return &checker{
+		tuples:       m,
+		availableMsg: strings.Join(elements, ","),
+	}, nil
+}
+
+// Check returns nil for supported transport/encoding combinations and errors
+// for unsupported combinations. Errors indicate whitelisted combinations.
+//
+// Nil Checker will alwas return nil.
+func (r *checker) Check(encoding transport.Encoding, transportName string) error {
+	t := Tuple{
+		Transport: transportName,
+		Encoding:  encoding,
+	}
+
+	if _, ok := r.tuples[t]; ok {
+		return nil
+	}
+
+	return fmt.Errorf("%q is not a whitelisted combination, available: %q", t.String(), r.availableMsg)
+}

--- a/api/x/restriction/restricter_test.go
+++ b/api/x/restriction/restricter_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package restriction
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/api/transport"
+)
+
+func TestRestricter(t *testing.T) {
+	const (
+		testEncoding  = transport.Encoding("test-encoding")
+		testTransport = "test-transport"
+	)
+
+	t.Run("no tuples", func(t *testing.T) {
+		c, err := NewChecker( /* empty */ )
+		assert.Error(t, err, "expected successful creation")
+		assert.Nil(t, c, "expected nil checker")
+	})
+
+	t.Run("whitelisted tuple", func(t *testing.T) {
+		r, err := NewChecker(Tuple{
+			Transport: testTransport,
+			Encoding:  testEncoding,
+		})
+		require.NoError(t, err, "expected successful creation")
+
+		t.Run("success", func(t *testing.T) {
+			err = r.Check(testEncoding, testTransport)
+			assert.NoError(t, err, "expected success")
+		})
+
+		t.Run("err", func(t *testing.T) {
+			err = r.Check("enc", "trans")
+			assert.EqualError(t, err,
+				`"trans/enc" is not a whitelisted combination, available: "test-transport/test-encoding"`)
+		})
+	})
+
+	t.Run("invalid tuple", func(t *testing.T) {
+		_, err := NewChecker(Tuple{
+			Transport: "",
+			Encoding:  "",
+		})
+		require.EqualError(t, err, "tuple missing must have all fields set")
+	})
+}

--- a/encoding/protobuf/external_test.go
+++ b/encoding/protobuf/external_test.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package protobuf_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/api/x/restriction"
+	"go.uber.org/yarpc/encoding/protobuf/internal/testpb"
+	"go.uber.org/yarpc/transport/grpc"
+)
+
+func TestFxClient(t *testing.T) {
+	const serviceName = "foo-service"
+
+	d := yarpc.NewDispatcher(yarpc.Config{
+		Name: "foo-caller",
+		Outbounds: yarpc.Outbounds{
+			serviceName: {Unary: grpc.NewTransport().NewSingleOutbound("http://yarpc")},
+		},
+	})
+
+	t.Run("success", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			p := testpb.FxTestYARPCClientParams{
+				Provider: d,
+			}
+			f := testpb.NewFxTestYARPCClient(serviceName).(func(testpb.FxTestYARPCClientParams) testpb.FxTestYARPCClientResult)
+			f(p)
+		}, "failed to build client")
+	})
+
+	t.Run("invalid config", func(t *testing.T) {
+		assert.PanicsWithValue(t, `no configured outbound transport for outbound key "nope"`, func() {
+			p := testpb.FxTestYARPCClientParams{
+				Provider: d,
+			}
+			f := testpb.NewFxTestYARPCClient("nope").(func(testpb.FxTestYARPCClientParams) testpb.FxTestYARPCClientResult)
+			f(p)
+		}, "expected panics")
+	})
+
+	t.Run("restriction success", func(t *testing.T) {
+		r, err := restriction.NewChecker(restriction.Tuple{
+			Transport: "grpc", Encoding: "proto",
+		})
+		require.NoError(t, err, "could not create restriction checker")
+
+		assert.NotPanics(t, func() {
+			p := testpb.FxTestYARPCClientParams{
+				Provider:    d,
+				Restriction: r,
+			}
+			f := testpb.NewFxTestYARPCClient(serviceName).(func(testpb.FxTestYARPCClientParams) testpb.FxTestYARPCClientResult)
+			f(p)
+		}, "failed to build client")
+	})
+
+	t.Run("restriction error", func(t *testing.T) {
+		r, err := restriction.NewChecker(restriction.Tuple{
+			Transport: "http", Encoding: "proto",
+		})
+		require.NoError(t, err, "could not create restriction checker")
+
+		assert.PanicsWithValue(t, `"grpc/proto" is not a whitelisted combination, available: "http/proto"`, func() {
+			p := testpb.FxTestYARPCClientParams{
+				Provider:    d,
+				Restriction: r,
+			}
+			f := testpb.NewFxTestYARPCClient(serviceName).(func(testpb.FxTestYARPCClientParams) testpb.FxTestYARPCClientResult)
+			f(p)
+		}, "failed to build client")
+	})
+}

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/readonlystorefx/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/readonlystorefx/client.go
@@ -6,6 +6,8 @@ package readonlystorefx
 import (
 	fx "go.uber.org/fx"
 	yarpc "go.uber.org/yarpc"
+	transport "go.uber.org/yarpc/api/transport"
+	restriction "go.uber.org/yarpc/api/x/restriction"
 	thrift "go.uber.org/yarpc/encoding/thrift"
 	readonlystoreclient "go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/readonlystoreclient"
 )
@@ -14,7 +16,8 @@ import (
 type Params struct {
 	fx.In
 
-	Provider yarpc.ClientConfig
+	Provider    yarpc.ClientConfig
+	Restriction restriction.Checker `optional:"true"`
 }
 
 // Result defines the output of the ReadOnlyStore client module. It provides a
@@ -38,7 +41,13 @@ type Result struct {
 // 	)
 func Client(name string, opts ...thrift.ClientOption) interface{} {
 	return func(p Params) Result {
-		client := readonlystoreclient.New(p.Provider.ClientConfig(name), opts...)
+		cc := p.Provider.ClientConfig(name)
+		if namer, ok := cc.GetUnaryOutbound().(transport.Namer); ok && p.Restriction != nil {
+			if err := p.Restriction.Check(thrift.Encoding, namer.TransportName()); err != nil {
+				panic(err.Error())
+			}
+		}
+		client := readonlystoreclient.New(cc, opts...)
 		return Result{Client: client}
 	}
 }

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storefx/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storefx/client.go
@@ -6,6 +6,8 @@ package storefx
 import (
 	fx "go.uber.org/fx"
 	yarpc "go.uber.org/yarpc"
+	transport "go.uber.org/yarpc/api/transport"
+	restriction "go.uber.org/yarpc/api/x/restriction"
 	thrift "go.uber.org/yarpc/encoding/thrift"
 	storeclient "go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storeclient"
 )
@@ -14,7 +16,8 @@ import (
 type Params struct {
 	fx.In
 
-	Provider yarpc.ClientConfig
+	Provider    yarpc.ClientConfig
+	Restriction restriction.Checker `optional:"true"`
 }
 
 // Result defines the output of the Store client module. It provides a
@@ -38,7 +41,13 @@ type Result struct {
 // 	)
 func Client(name string, opts ...thrift.ClientOption) interface{} {
 	return func(p Params) Result {
-		client := storeclient.New(p.Provider.ClientConfig(name), opts...)
+		cc := p.Provider.ClientConfig(name)
+		if namer, ok := cc.GetUnaryOutbound().(transport.Namer); ok && p.Restriction != nil {
+			if err := p.Restriction.Check(thrift.Encoding, namer.TransportName()); err != nil {
+				panic(err.Error())
+			}
+		}
+		client := storeclient.New(cc, opts...)
 		return Result{Client: client}
 	}
 }

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/baseservicefx/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/baseservicefx/client.go
@@ -6,6 +6,8 @@ package baseservicefx
 import (
 	fx "go.uber.org/fx"
 	yarpc "go.uber.org/yarpc"
+	transport "go.uber.org/yarpc/api/transport"
+	restriction "go.uber.org/yarpc/api/x/restriction"
 	thrift "go.uber.org/yarpc/encoding/thrift"
 	baseserviceclient "go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/baseserviceclient"
 )
@@ -14,7 +16,8 @@ import (
 type Params struct {
 	fx.In
 
-	Provider yarpc.ClientConfig
+	Provider    yarpc.ClientConfig
+	Restriction restriction.Checker `optional:"true"`
 }
 
 // Result defines the output of the BaseService client module. It provides a
@@ -38,7 +41,13 @@ type Result struct {
 // 	)
 func Client(name string, opts ...thrift.ClientOption) interface{} {
 	return func(p Params) Result {
-		client := baseserviceclient.New(p.Provider.ClientConfig(name), opts...)
+		cc := p.Provider.ClientConfig(name)
+		if namer, ok := cc.GetUnaryOutbound().(transport.Namer); ok && p.Restriction != nil {
+			if err := p.Restriction.Check(thrift.Encoding, namer.TransportName()); err != nil {
+				panic(err.Error())
+			}
+		}
+		client := baseserviceclient.New(cc, opts...)
 		return Result{Client: client}
 	}
 }

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendemptyfx/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendemptyfx/client.go
@@ -6,6 +6,8 @@ package extendemptyfx
 import (
 	fx "go.uber.org/fx"
 	yarpc "go.uber.org/yarpc"
+	transport "go.uber.org/yarpc/api/transport"
+	restriction "go.uber.org/yarpc/api/x/restriction"
 	thrift "go.uber.org/yarpc/encoding/thrift"
 	extendemptyclient "go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendemptyclient"
 )
@@ -14,7 +16,8 @@ import (
 type Params struct {
 	fx.In
 
-	Provider yarpc.ClientConfig
+	Provider    yarpc.ClientConfig
+	Restriction restriction.Checker `optional:"true"`
 }
 
 // Result defines the output of the ExtendEmpty client module. It provides a
@@ -38,7 +41,13 @@ type Result struct {
 // 	)
 func Client(name string, opts ...thrift.ClientOption) interface{} {
 	return func(p Params) Result {
-		client := extendemptyclient.New(p.Provider.ClientConfig(name), opts...)
+		cc := p.Provider.ClientConfig(name)
+		if namer, ok := cc.GetUnaryOutbound().(transport.Namer); ok && p.Restriction != nil {
+			if err := p.Restriction.Check(thrift.Encoding, namer.TransportName()); err != nil {
+				panic(err.Error())
+			}
+		}
+		client := extendemptyclient.New(cc, opts...)
 		return Result{Client: client}
 	}
 }

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendonlyfx/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendonlyfx/client.go
@@ -6,6 +6,8 @@ package extendonlyfx
 import (
 	fx "go.uber.org/fx"
 	yarpc "go.uber.org/yarpc"
+	transport "go.uber.org/yarpc/api/transport"
+	restriction "go.uber.org/yarpc/api/x/restriction"
 	thrift "go.uber.org/yarpc/encoding/thrift"
 	extendonlyclient "go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendonlyclient"
 )
@@ -14,7 +16,8 @@ import (
 type Params struct {
 	fx.In
 
-	Provider yarpc.ClientConfig
+	Provider    yarpc.ClientConfig
+	Restriction restriction.Checker `optional:"true"`
 }
 
 // Result defines the output of the ExtendOnly client module. It provides a
@@ -38,7 +41,13 @@ type Result struct {
 // 	)
 func Client(name string, opts ...thrift.ClientOption) interface{} {
 	return func(p Params) Result {
-		client := extendonlyclient.New(p.Provider.ClientConfig(name), opts...)
+		cc := p.Provider.ClientConfig(name)
+		if namer, ok := cc.GetUnaryOutbound().(transport.Namer); ok && p.Restriction != nil {
+			if err := p.Restriction.Check(thrift.Encoding, namer.TransportName()); err != nil {
+				panic(err.Error())
+			}
+		}
+		client := extendonlyclient.New(cc, opts...)
 		return Result{Client: client}
 	}
 }

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/barfx/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/barfx/client.go
@@ -6,6 +6,8 @@ package barfx
 import (
 	fx "go.uber.org/fx"
 	yarpc "go.uber.org/yarpc"
+	transport "go.uber.org/yarpc/api/transport"
+	restriction "go.uber.org/yarpc/api/x/restriction"
 	thrift "go.uber.org/yarpc/encoding/thrift"
 	barclient "go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/barclient"
 )
@@ -14,7 +16,8 @@ import (
 type Params struct {
 	fx.In
 
-	Provider yarpc.ClientConfig
+	Provider    yarpc.ClientConfig
+	Restriction restriction.Checker `optional:"true"`
 }
 
 // Result defines the output of the Bar client module. It provides a
@@ -38,7 +41,13 @@ type Result struct {
 // 	)
 func Client(name string, opts ...thrift.ClientOption) interface{} {
 	return func(p Params) Result {
-		client := barclient.New(p.Provider.ClientConfig(name), opts...)
+		cc := p.Provider.ClientConfig(name)
+		if namer, ok := cc.GetUnaryOutbound().(transport.Namer); ok && p.Restriction != nil {
+			if err := p.Restriction.Check(thrift.Encoding, namer.TransportName()); err != nil {
+				panic(err.Error())
+			}
+		}
+		client := barclient.New(cc, opts...)
 		return Result{Client: client}
 	}
 }

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/foofx/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/foofx/client.go
@@ -6,6 +6,8 @@ package foofx
 import (
 	fx "go.uber.org/fx"
 	yarpc "go.uber.org/yarpc"
+	transport "go.uber.org/yarpc/api/transport"
+	restriction "go.uber.org/yarpc/api/x/restriction"
 	thrift "go.uber.org/yarpc/encoding/thrift"
 	fooclient "go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/fooclient"
 )
@@ -14,7 +16,8 @@ import (
 type Params struct {
 	fx.In
 
-	Provider yarpc.ClientConfig
+	Provider    yarpc.ClientConfig
+	Restriction restriction.Checker `optional:"true"`
 }
 
 // Result defines the output of the Foo client module. It provides a
@@ -38,7 +41,13 @@ type Result struct {
 // 	)
 func Client(name string, opts ...thrift.ClientOption) interface{} {
 	return func(p Params) Result {
-		client := fooclient.New(p.Provider.ClientConfig(name), opts...)
+		cc := p.Provider.ClientConfig(name)
+		if namer, ok := cc.GetUnaryOutbound().(transport.Namer); ok && p.Restriction != nil {
+			if err := p.Restriction.Check(thrift.Encoding, namer.TransportName()); err != nil {
+				panic(err.Error())
+			}
+		}
+		client := fooclient.New(cc, opts...)
 		return Result{Client: client}
 	}
 }

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/namefx/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/namefx/client.go
@@ -6,6 +6,8 @@ package namefx
 import (
 	fx "go.uber.org/fx"
 	yarpc "go.uber.org/yarpc"
+	transport "go.uber.org/yarpc/api/transport"
+	restriction "go.uber.org/yarpc/api/x/restriction"
 	thrift "go.uber.org/yarpc/encoding/thrift"
 	nameclient "go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/nameclient"
 )
@@ -14,7 +16,8 @@ import (
 type Params struct {
 	fx.In
 
-	Provider yarpc.ClientConfig
+	Provider    yarpc.ClientConfig
+	Restriction restriction.Checker `optional:"true"`
 }
 
 // Result defines the output of the Name client module. It provides a
@@ -38,7 +41,13 @@ type Result struct {
 // 	)
 func Client(name string, opts ...thrift.ClientOption) interface{} {
 	return func(p Params) Result {
-		client := nameclient.New(p.Provider.ClientConfig(name), opts...)
+		cc := p.Provider.ClientConfig(name)
+		if namer, ok := cc.GetUnaryOutbound().(transport.Namer); ok && p.Restriction != nil {
+			if err := p.Restriction.Check(thrift.Encoding, namer.TransportName()); err != nil {
+				panic(err.Error())
+			}
+		}
+		client := nameclient.New(cc, opts...)
 		return Result{Client: client}
 	}
 }

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/weather/weatherfx/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/weather/weatherfx/client.go
@@ -6,6 +6,8 @@ package weatherfx
 import (
 	fx "go.uber.org/fx"
 	yarpc "go.uber.org/yarpc"
+	transport "go.uber.org/yarpc/api/transport"
+	restriction "go.uber.org/yarpc/api/x/restriction"
 	thrift "go.uber.org/yarpc/encoding/thrift"
 	weatherclient "go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/weather/weatherclient"
 )
@@ -14,7 +16,8 @@ import (
 type Params struct {
 	fx.In
 
-	Provider yarpc.ClientConfig
+	Provider    yarpc.ClientConfig
+	Restriction restriction.Checker `optional:"true"`
 }
 
 // Result defines the output of the Weather client module. It provides a
@@ -38,7 +41,13 @@ type Result struct {
 // 	)
 func Client(name string, opts ...thrift.ClientOption) interface{} {
 	return func(p Params) Result {
-		client := weatherclient.New(p.Provider.ClientConfig(name), opts...)
+		cc := p.Provider.ClientConfig(name)
+		if namer, ok := cc.GetUnaryOutbound().(transport.Namer); ok && p.Restriction != nil {
+			if err := p.Restriction.Check(thrift.Encoding, namer.TransportName()); err != nil {
+				panic(err.Error())
+			}
+		}
+		client := weatherclient.New(cc, opts...)
 		return Result{Client: client}
 	}
 }

--- a/internal/crossdock/thrift/echo/echofx/client.go
+++ b/internal/crossdock/thrift/echo/echofx/client.go
@@ -26,6 +26,8 @@ package echofx
 import (
 	fx "go.uber.org/fx"
 	yarpc "go.uber.org/yarpc"
+	transport "go.uber.org/yarpc/api/transport"
+	restriction "go.uber.org/yarpc/api/x/restriction"
 	thrift "go.uber.org/yarpc/encoding/thrift"
 	echoclient "go.uber.org/yarpc/internal/crossdock/thrift/echo/echoclient"
 )
@@ -34,7 +36,8 @@ import (
 type Params struct {
 	fx.In
 
-	Provider yarpc.ClientConfig
+	Provider    yarpc.ClientConfig
+	Restriction restriction.Checker `optional:"true"`
 }
 
 // Result defines the output of the Echo client module. It provides a
@@ -58,7 +61,13 @@ type Result struct {
 // 	)
 func Client(name string, opts ...thrift.ClientOption) interface{} {
 	return func(p Params) Result {
-		client := echoclient.New(p.Provider.ClientConfig(name), opts...)
+		cc := p.Provider.ClientConfig(name)
+		if namer, ok := cc.GetUnaryOutbound().(transport.Namer); ok && p.Restriction != nil {
+			if err := p.Restriction.Check(thrift.Encoding, namer.TransportName()); err != nil {
+				panic(err.Error())
+			}
+		}
+		client := echoclient.New(cc, opts...)
 		return Result{Client: client}
 	}
 }

--- a/internal/crossdock/thrift/gauntlet/secondservicefx/client.go
+++ b/internal/crossdock/thrift/gauntlet/secondservicefx/client.go
@@ -26,6 +26,8 @@ package secondservicefx
 import (
 	fx "go.uber.org/fx"
 	yarpc "go.uber.org/yarpc"
+	transport "go.uber.org/yarpc/api/transport"
+	restriction "go.uber.org/yarpc/api/x/restriction"
 	thrift "go.uber.org/yarpc/encoding/thrift"
 	secondserviceclient "go.uber.org/yarpc/internal/crossdock/thrift/gauntlet/secondserviceclient"
 )
@@ -34,7 +36,8 @@ import (
 type Params struct {
 	fx.In
 
-	Provider yarpc.ClientConfig
+	Provider    yarpc.ClientConfig
+	Restriction restriction.Checker `optional:"true"`
 }
 
 // Result defines the output of the SecondService client module. It provides a
@@ -58,7 +61,13 @@ type Result struct {
 // 	)
 func Client(name string, opts ...thrift.ClientOption) interface{} {
 	return func(p Params) Result {
-		client := secondserviceclient.New(p.Provider.ClientConfig(name), opts...)
+		cc := p.Provider.ClientConfig(name)
+		if namer, ok := cc.GetUnaryOutbound().(transport.Namer); ok && p.Restriction != nil {
+			if err := p.Restriction.Check(thrift.Encoding, namer.TransportName()); err != nil {
+				panic(err.Error())
+			}
+		}
+		client := secondserviceclient.New(cc, opts...)
 		return Result{Client: client}
 	}
 }

--- a/internal/crossdock/thrift/gauntlet/thrifttestfx/client.go
+++ b/internal/crossdock/thrift/gauntlet/thrifttestfx/client.go
@@ -26,6 +26,8 @@ package thrifttestfx
 import (
 	fx "go.uber.org/fx"
 	yarpc "go.uber.org/yarpc"
+	transport "go.uber.org/yarpc/api/transport"
+	restriction "go.uber.org/yarpc/api/x/restriction"
 	thrift "go.uber.org/yarpc/encoding/thrift"
 	thrifttestclient "go.uber.org/yarpc/internal/crossdock/thrift/gauntlet/thrifttestclient"
 )
@@ -34,7 +36,8 @@ import (
 type Params struct {
 	fx.In
 
-	Provider yarpc.ClientConfig
+	Provider    yarpc.ClientConfig
+	Restriction restriction.Checker `optional:"true"`
 }
 
 // Result defines the output of the ThriftTest client module. It provides a
@@ -58,7 +61,13 @@ type Result struct {
 // 	)
 func Client(name string, opts ...thrift.ClientOption) interface{} {
 	return func(p Params) Result {
-		client := thrifttestclient.New(p.Provider.ClientConfig(name), opts...)
+		cc := p.Provider.ClientConfig(name)
+		if namer, ok := cc.GetUnaryOutbound().(transport.Namer); ok && p.Restriction != nil {
+			if err := p.Restriction.Check(thrift.Encoding, namer.TransportName()); err != nil {
+				panic(err.Error())
+			}
+		}
+		client := thrifttestclient.New(cc, opts...)
 		return Result{Client: client}
 	}
 }

--- a/internal/crossdock/thrift/oneway/onewayfx/client.go
+++ b/internal/crossdock/thrift/oneway/onewayfx/client.go
@@ -26,6 +26,8 @@ package onewayfx
 import (
 	fx "go.uber.org/fx"
 	yarpc "go.uber.org/yarpc"
+	transport "go.uber.org/yarpc/api/transport"
+	restriction "go.uber.org/yarpc/api/x/restriction"
 	thrift "go.uber.org/yarpc/encoding/thrift"
 	onewayclient "go.uber.org/yarpc/internal/crossdock/thrift/oneway/onewayclient"
 )
@@ -34,7 +36,8 @@ import (
 type Params struct {
 	fx.In
 
-	Provider yarpc.ClientConfig
+	Provider    yarpc.ClientConfig
+	Restriction restriction.Checker `optional:"true"`
 }
 
 // Result defines the output of the Oneway client module. It provides a
@@ -58,7 +61,13 @@ type Result struct {
 // 	)
 func Client(name string, opts ...thrift.ClientOption) interface{} {
 	return func(p Params) Result {
-		client := onewayclient.New(p.Provider.ClientConfig(name), opts...)
+		cc := p.Provider.ClientConfig(name)
+		if namer, ok := cc.GetUnaryOutbound().(transport.Namer); ok && p.Restriction != nil {
+			if err := p.Restriction.Check(thrift.Encoding, namer.TransportName()); err != nil {
+				panic(err.Error())
+			}
+		}
+		client := onewayclient.New(cc, opts...)
 		return Result{Client: client}
 	}
 }

--- a/internal/examples/protobuf/examplepb/example.pb.yarpc.go
+++ b/internal/examples/protobuf/examplepb/example.pb.yarpc.go
@@ -33,6 +33,7 @@ import (
 	"go.uber.org/fx"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/api/x/restriction"
 	"go.uber.org/yarpc/encoding/protobuf"
 	"go.uber.org/yarpc/encoding/protobuf/reflection"
 	"go.uber.org/yarpc/yarpcproto"
@@ -119,7 +120,8 @@ type FxKeyValueYARPCClientParams struct {
 	fx.In
 
 	Provider    yarpc.ClientConfig
-	AnyResolver jsonpb.AnyResolver `name:"yarpcfx" optional:"true"`
+	AnyResolver jsonpb.AnyResolver  `name:"yarpcfx" optional:"true"`
+	Restriction restriction.Checker `optional:"true"`
 }
 
 // FxKeyValueYARPCClientResult defines the output
@@ -144,8 +146,18 @@ type FxKeyValueYARPCClientResult struct {
 //  )
 func NewFxKeyValueYARPCClient(name string, options ...protobuf.ClientOption) interface{} {
 	return func(params FxKeyValueYARPCClientParams) FxKeyValueYARPCClientResult {
+		cc := params.Provider.ClientConfig(name)
+
+		if params.Restriction != nil {
+			if namer, ok := cc.GetUnaryOutbound().(transport.Namer); ok {
+				if err := params.Restriction.Check(protobuf.Encoding, namer.TransportName()); err != nil {
+					panic(err.Error())
+				}
+			}
+		}
+
 		return FxKeyValueYARPCClientResult{
-			Client: newKeyValueYARPCClient(params.Provider.ClientConfig(name), params.AnyResolver, options...),
+			Client: newKeyValueYARPCClient(cc, params.AnyResolver, options...),
 		}
 	}
 }
@@ -349,7 +361,8 @@ type FxSinkYARPCClientParams struct {
 	fx.In
 
 	Provider    yarpc.ClientConfig
-	AnyResolver jsonpb.AnyResolver `name:"yarpcfx" optional:"true"`
+	AnyResolver jsonpb.AnyResolver  `name:"yarpcfx" optional:"true"`
+	Restriction restriction.Checker `optional:"true"`
 }
 
 // FxSinkYARPCClientResult defines the output
@@ -374,8 +387,18 @@ type FxSinkYARPCClientResult struct {
 //  )
 func NewFxSinkYARPCClient(name string, options ...protobuf.ClientOption) interface{} {
 	return func(params FxSinkYARPCClientParams) FxSinkYARPCClientResult {
+		cc := params.Provider.ClientConfig(name)
+
+		if params.Restriction != nil {
+			if namer, ok := cc.GetUnaryOutbound().(transport.Namer); ok {
+				if err := params.Restriction.Check(protobuf.Encoding, namer.TransportName()); err != nil {
+					panic(err.Error())
+				}
+			}
+		}
+
 		return FxSinkYARPCClientResult{
-			Client: newSinkYARPCClient(params.Provider.ClientConfig(name), params.AnyResolver, options...),
+			Client: newSinkYARPCClient(cc, params.AnyResolver, options...),
 		}
 	}
 }
@@ -591,7 +614,8 @@ type FxFooYARPCClientParams struct {
 	fx.In
 
 	Provider    yarpc.ClientConfig
-	AnyResolver jsonpb.AnyResolver `name:"yarpcfx" optional:"true"`
+	AnyResolver jsonpb.AnyResolver  `name:"yarpcfx" optional:"true"`
+	Restriction restriction.Checker `optional:"true"`
 }
 
 // FxFooYARPCClientResult defines the output
@@ -616,8 +640,18 @@ type FxFooYARPCClientResult struct {
 //  )
 func NewFxFooYARPCClient(name string, options ...protobuf.ClientOption) interface{} {
 	return func(params FxFooYARPCClientParams) FxFooYARPCClientResult {
+		cc := params.Provider.ClientConfig(name)
+
+		if params.Restriction != nil {
+			if namer, ok := cc.GetUnaryOutbound().(transport.Namer); ok {
+				if err := params.Restriction.Check(protobuf.Encoding, namer.TransportName()); err != nil {
+					panic(err.Error())
+				}
+			}
+		}
+
 		return FxFooYARPCClientResult{
-			Client: newFooYARPCClient(params.Provider.ClientConfig(name), params.AnyResolver, options...),
+			Client: newFooYARPCClient(cc, params.AnyResolver, options...),
 		}
 	}
 }

--- a/internal/examples/thrift-hello/hello/echo/hellofx/client.go
+++ b/internal/examples/thrift-hello/hello/echo/hellofx/client.go
@@ -26,6 +26,8 @@ package hellofx
 import (
 	fx "go.uber.org/fx"
 	yarpc "go.uber.org/yarpc"
+	transport "go.uber.org/yarpc/api/transport"
+	restriction "go.uber.org/yarpc/api/x/restriction"
 	thrift "go.uber.org/yarpc/encoding/thrift"
 	helloclient "go.uber.org/yarpc/internal/examples/thrift-hello/hello/echo/helloclient"
 )
@@ -34,7 +36,8 @@ import (
 type Params struct {
 	fx.In
 
-	Provider yarpc.ClientConfig
+	Provider    yarpc.ClientConfig
+	Restriction restriction.Checker `optional:"true"`
 }
 
 // Result defines the output of the Hello client module. It provides a
@@ -58,7 +61,13 @@ type Result struct {
 // 	)
 func Client(name string, opts ...thrift.ClientOption) interface{} {
 	return func(p Params) Result {
-		client := helloclient.New(p.Provider.ClientConfig(name), opts...)
+		cc := p.Provider.ClientConfig(name)
+		if namer, ok := cc.GetUnaryOutbound().(transport.Namer); ok && p.Restriction != nil {
+			if err := p.Restriction.Check(thrift.Encoding, namer.TransportName()); err != nil {
+				panic(err.Error())
+			}
+		}
+		client := helloclient.New(cc, opts...)
 		return Result{Client: client}
 	}
 }

--- a/internal/examples/thrift-keyvalue/keyvalue/kv/keyvaluefx/client.go
+++ b/internal/examples/thrift-keyvalue/keyvalue/kv/keyvaluefx/client.go
@@ -26,6 +26,8 @@ package keyvaluefx
 import (
 	fx "go.uber.org/fx"
 	yarpc "go.uber.org/yarpc"
+	transport "go.uber.org/yarpc/api/transport"
+	restriction "go.uber.org/yarpc/api/x/restriction"
 	thrift "go.uber.org/yarpc/encoding/thrift"
 	keyvalueclient "go.uber.org/yarpc/internal/examples/thrift-keyvalue/keyvalue/kv/keyvalueclient"
 )
@@ -34,7 +36,8 @@ import (
 type Params struct {
 	fx.In
 
-	Provider yarpc.ClientConfig
+	Provider    yarpc.ClientConfig
+	Restriction restriction.Checker `optional:"true"`
 }
 
 // Result defines the output of the KeyValue client module. It provides a
@@ -58,7 +61,13 @@ type Result struct {
 // 	)
 func Client(name string, opts ...thrift.ClientOption) interface{} {
 	return func(p Params) Result {
-		client := keyvalueclient.New(p.Provider.ClientConfig(name), opts...)
+		cc := p.Provider.ClientConfig(name)
+		if namer, ok := cc.GetUnaryOutbound().(transport.Namer); ok && p.Restriction != nil {
+			if err := p.Restriction.Check(thrift.Encoding, namer.TransportName()); err != nil {
+				panic(err.Error())
+			}
+		}
+		client := keyvalueclient.New(cc, opts...)
 		return Result{Client: client}
 	}
 }

--- a/internal/examples/thrift-oneway/sink/hellofx/client.go
+++ b/internal/examples/thrift-oneway/sink/hellofx/client.go
@@ -26,6 +26,8 @@ package hellofx
 import (
 	fx "go.uber.org/fx"
 	yarpc "go.uber.org/yarpc"
+	transport "go.uber.org/yarpc/api/transport"
+	restriction "go.uber.org/yarpc/api/x/restriction"
 	thrift "go.uber.org/yarpc/encoding/thrift"
 	helloclient "go.uber.org/yarpc/internal/examples/thrift-oneway/sink/helloclient"
 )
@@ -34,7 +36,8 @@ import (
 type Params struct {
 	fx.In
 
-	Provider yarpc.ClientConfig
+	Provider    yarpc.ClientConfig
+	Restriction restriction.Checker `optional:"true"`
 }
 
 // Result defines the output of the Hello client module. It provides a
@@ -58,7 +61,13 @@ type Result struct {
 // 	)
 func Client(name string, opts ...thrift.ClientOption) interface{} {
 	return func(p Params) Result {
-		client := helloclient.New(p.Provider.ClientConfig(name), opts...)
+		cc := p.Provider.ClientConfig(name)
+		if namer, ok := cc.GetUnaryOutbound().(transport.Namer); ok && p.Restriction != nil {
+			if err := p.Restriction.Check(thrift.Encoding, namer.TransportName()); err != nil {
+				panic(err.Error())
+			}
+		}
+		client := helloclient.New(cc, opts...)
 		return Result{Client: client}
 	}
 }

--- a/internal/prototest/examplepb/example.pb.yarpc.go
+++ b/internal/prototest/examplepb/example.pb.yarpc.go
@@ -33,6 +33,7 @@ import (
 	"go.uber.org/fx"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/api/x/restriction"
 	"go.uber.org/yarpc/encoding/protobuf"
 	"go.uber.org/yarpc/encoding/protobuf/reflection"
 	"go.uber.org/yarpc/yarpcproto"
@@ -119,7 +120,8 @@ type FxKeyValueYARPCClientParams struct {
 	fx.In
 
 	Provider    yarpc.ClientConfig
-	AnyResolver jsonpb.AnyResolver `name:"yarpcfx" optional:"true"`
+	AnyResolver jsonpb.AnyResolver  `name:"yarpcfx" optional:"true"`
+	Restriction restriction.Checker `optional:"true"`
 }
 
 // FxKeyValueYARPCClientResult defines the output
@@ -144,8 +146,18 @@ type FxKeyValueYARPCClientResult struct {
 //  )
 func NewFxKeyValueYARPCClient(name string, options ...protobuf.ClientOption) interface{} {
 	return func(params FxKeyValueYARPCClientParams) FxKeyValueYARPCClientResult {
+		cc := params.Provider.ClientConfig(name)
+
+		if params.Restriction != nil {
+			if namer, ok := cc.GetUnaryOutbound().(transport.Namer); ok {
+				if err := params.Restriction.Check(protobuf.Encoding, namer.TransportName()); err != nil {
+					panic(err.Error())
+				}
+			}
+		}
+
 		return FxKeyValueYARPCClientResult{
-			Client: newKeyValueYARPCClient(params.Provider.ClientConfig(name), params.AnyResolver, options...),
+			Client: newKeyValueYARPCClient(cc, params.AnyResolver, options...),
 		}
 	}
 }
@@ -349,7 +361,8 @@ type FxSinkYARPCClientParams struct {
 	fx.In
 
 	Provider    yarpc.ClientConfig
-	AnyResolver jsonpb.AnyResolver `name:"yarpcfx" optional:"true"`
+	AnyResolver jsonpb.AnyResolver  `name:"yarpcfx" optional:"true"`
+	Restriction restriction.Checker `optional:"true"`
 }
 
 // FxSinkYARPCClientResult defines the output
@@ -374,8 +387,18 @@ type FxSinkYARPCClientResult struct {
 //  )
 func NewFxSinkYARPCClient(name string, options ...protobuf.ClientOption) interface{} {
 	return func(params FxSinkYARPCClientParams) FxSinkYARPCClientResult {
+		cc := params.Provider.ClientConfig(name)
+
+		if params.Restriction != nil {
+			if namer, ok := cc.GetUnaryOutbound().(transport.Namer); ok {
+				if err := params.Restriction.Check(protobuf.Encoding, namer.TransportName()); err != nil {
+					panic(err.Error())
+				}
+			}
+		}
+
 		return FxSinkYARPCClientResult{
-			Client: newSinkYARPCClient(params.Provider.ClientConfig(name), params.AnyResolver, options...),
+			Client: newSinkYARPCClient(cc, params.AnyResolver, options...),
 		}
 	}
 }
@@ -591,7 +614,8 @@ type FxFooYARPCClientParams struct {
 	fx.In
 
 	Provider    yarpc.ClientConfig
-	AnyResolver jsonpb.AnyResolver `name:"yarpcfx" optional:"true"`
+	AnyResolver jsonpb.AnyResolver  `name:"yarpcfx" optional:"true"`
+	Restriction restriction.Checker `optional:"true"`
 }
 
 // FxFooYARPCClientResult defines the output
@@ -616,8 +640,18 @@ type FxFooYARPCClientResult struct {
 //  )
 func NewFxFooYARPCClient(name string, options ...protobuf.ClientOption) interface{} {
 	return func(params FxFooYARPCClientParams) FxFooYARPCClientResult {
+		cc := params.Provider.ClientConfig(name)
+
+		if params.Restriction != nil {
+			if namer, ok := cc.GetUnaryOutbound().(transport.Namer); ok {
+				if err := params.Restriction.Check(protobuf.Encoding, namer.TransportName()); err != nil {
+					panic(err.Error())
+				}
+			}
+		}
+
 		return FxFooYARPCClientResult{
-			Client: newFooYARPCClient(params.Provider.ClientConfig(name), params.AnyResolver, options...),
+			Client: newFooYARPCClient(cc, params.AnyResolver, options...),
 		}
 	}
 }


### PR DESCRIPTION
This introduces an `api/x/restriction` package which enables encoding clients
(ie Protobuf and Thrift) to fail on start up.

Note that These changes only affect Fx clients and that an internal `yarpcfx`
layer would need to add the restriction checker to Fx apps.

I suggest we keep this in an `x` package so we can iterate further as 
necessary.

Since the added check is only in the Fx layer, we can push it down to the
non-Fx client layer without breaking compatibility guarantees in a future
change.

- [x] Description and context for reviewers: one partner, one stranger
- [x] Docs (package doc)
- [x] Entry in CHANGELOG.md

---

Adding the restriction checker to non-YARPC clients can be done in a follow-up.
However, users would have to manually construct the checker and likely set it as
a client option which is not intuitive / easy to miss, for example:

```
foopb.NewFooServerYARPCClient(
   dispatcher.ClientConfig(service),
   protobuf.WithRestrictionChecker(...)))
```