### PR TITLE
introspection: Add gRPC-go version to debug page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - peer lists accepts a `DefaultChooseTimeout` configuration for applying to
   `context`s without deadlines.
+- gRPC-go version is added to debug pages.
 ### Fixed
 - yarpcerrors: `fmt` verbs are ignored when no args are passed to error
   constructors.

--- a/introspection.go
+++ b/introspection.go
@@ -27,6 +27,7 @@ import (
 	tchannel "github.com/uber/tchannel-go"
 	thriftrw "go.uber.org/thriftrw/version"
 	"go.uber.org/yarpc/internal/introspection"
+	"google.golang.org/grpc"
 )
 
 // Introspect returns detailed information about the dispatcher. This function
@@ -89,5 +90,6 @@ var PackageVersions = []introspection.PackageVersion{
 	{Name: "yarpc", Version: Version},
 	{Name: "tchannel", Version: tchannel.VersionInfo},
 	{Name: "thriftrw", Version: thriftrw.Version},
+	{Name: "grpc-go", Version: grpc.Version},
 	{Name: "go", Version: runtime.Version()},
 }


### PR DESCRIPTION
This adds the gRPC-go version to the list of packages reported on the
debug page. I couldn't add `gogo/protobuf` version since they do not
expose a version variable.

- [x] Entry in CHANGELOG.md
