### PR TITLE
debug: Sort outbound statuses by outbound name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix gRPC streaming when used with the direct peer chooser.
 - Streaming calls do not require contexts with deadlines. Users should use
   cancelable contexts for long-lived streams instead of timeouts.
+- Outbound status on debug pages is ordered by outbound name.
 ## Removed
 - The `x/yarpcmeta` package is completely removed.
 

--- a/dispatcher_introspection.go
+++ b/dispatcher_introspection.go
@@ -23,6 +23,7 @@ package yarpc
 import (
 	"fmt"
 	"runtime"
+	"sort"
 
 	tchannel "github.com/uber/tchannel-go"
 	thriftrw "go.uber.org/thriftrw/version"
@@ -73,6 +74,9 @@ func (d *Dispatcher) Introspect() introspection.DispatcherStatus {
 			outbounds = append(outbounds, status)
 		}
 	}
+
+	sort.Sort(outboundStatuses(outbounds)) // keep debug pages deterministic
+
 	procedures := introspection.IntrospectProcedures(d.table.Procedures())
 	return introspection.DispatcherStatus{
 		Name:            d.name,
@@ -91,4 +95,16 @@ var PackageVersions = []introspection.PackageVersion{
 	{Name: "thriftrw", Version: thriftrw.Version},
 	{Name: "grpc-go", Version: grpc.Version},
 	{Name: "go", Version: runtime.Version()},
+}
+
+type outboundStatuses []introspection.OutboundStatus
+
+func (o outboundStatuses) Len() int {
+	return len(o)
+}
+func (o outboundStatuses) Less(i, j int) bool {
+	return o[i].OutboundKey < o[j].OutboundKey && o[i].RPCType < o[j].RPCType
+}
+func (o outboundStatuses) Swap(i, j int) {
+	o[i], o[j] = o[j], o[i]
 }


### PR DESCRIPTION
Currently, debug oages for outbounds are not deterministic. Refreshing
the page changes the order of the outbounds. This change sorts the
outbounds by outbound name and RPC type (unary/oneway) for a better
user experience.

Tests are updated to reflect determinism.

- [x] Description and context for reviewers: one partner, one stranger
- [x] Entry in CHANGELOG.md
