### PR TITLE
observability: Override responses with Context errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - peer lists accepts a `DefaultChooseTimeout` configuration for applying to
   `context`s without deadlines.
 - gRPC-go version is added to debug pages.
+### Changed
+- observability: if a context deadline exceeded (timeout) or context cancelled
+  error is observed, handler responses (success and errors) are replaced by the
+  context error.
 ### Fixed
 - yarpcerrors: `fmt` verbs are ignored when no args are passed to error
   constructors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - observability: if a context deadline exceeded (timeout) or context cancelled
   error is observed, handler responses (success and errors) are replaced by the
-  context error.
+  context error. Dropped responses are logged under the `dropped` field.
 ### Fixed
 - yarpcerrors: `fmt` verbs are ignored when no args are passed to error
   constructors.

--- a/internal/crossdock/client/errorshttpclient/behavior.go
+++ b/internal/crossdock/client/errorshttpclient/behavior.go
@@ -334,10 +334,9 @@ func Run(t crossdock.T) {
 				"RPC-Encoding":   "raw",
 				"Context-TTL-MS": "100",
 			},
-			wantStatus: 504,
-			skipStatus: 400,
-			wantBodyContains: `call to procedure "waitfortimeout/raw"` +
-				` of service "yarpc-test" from caller "yarpc-test" timed out after`,
+			wantStatus:       504,
+			skipStatus:       400,
+			wantBodyContains: `call to procedure "waitfortimeout/raw" of service "yarpc-test" from caller "yarpc-test" timed out`,
 		},
 		{
 			// We call sleep through the proxy Phone.
@@ -361,7 +360,7 @@ func Run(t crossdock.T) {
 				` "yarpc-test": BadRequest: unrecognized procedure "sleep" for` +
 				` service "yarpc-test"` + "\n",
 			wantStatus:       504,
-			wantBodyContains: `client timeout for procedure "sleep" of service "yarpc-test" after`,
+			wantBodyContains: `call to procedure "phone" of service "yarpc-test" from caller "yarpc-test" timed out`,
 		},
 	}
 

--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -67,10 +67,18 @@ type levels struct {
 }
 
 func (c call) End(err error) {
-	c.EndWithAppError(err, false)
+	c.endWithAppError(err, false)
 }
 
-func (c call) EndWithAppError(err error, isApplicationError bool) {
+func (c call) EndCallWithAppError(err error, isApplicationError bool) {
+	c.endWithAppError(err, isApplicationError)
+}
+
+func (c call) EndHandleWithAppError(err error, isApplicationError bool) {
+	c.endWithAppError(err, isApplicationError)
+}
+
+func (c call) endWithAppError(err error, isApplicationError bool) {
 	elapsed := _timeNow().Sub(c.started)
 	c.endLogs(elapsed, err, isApplicationError)
 	c.endStats(elapsed, err, isApplicationError)
@@ -79,7 +87,7 @@ func (c call) EndWithAppError(err error, isApplicationError bool) {
 // EndWithPanic ends the call with additional panic metrics
 func (c call) EndWithPanic(err error) {
 	c.edge.panics.Inc()
-	c.EndWithAppError(err, true)
+	c.endWithAppError(err, true)
 }
 
 func (c call) endLogs(elapsed time.Duration, err error, isApplicationError bool) {

--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -74,8 +74,13 @@ func (c call) EndCallWithAppError(err error, isApplicationError bool) {
 	c.endWithAppError(err, isApplicationError)
 }
 
-func (c call) EndHandleWithAppError(err error, isApplicationError bool) {
-	c.endWithAppError(err, isApplicationError)
+func (c call) EndHandleWithAppError(err error, isApplicationError bool, ctxOverrideErr error) {
+	if ctxOverrideErr == nil {
+		c.endWithAppError(err, isApplicationError)
+		return
+	}
+
+	c.endWithAppError(ctxOverrideErr, isApplicationError)
 }
 
 func (c call) endWithAppError(err error, isApplicationError bool) {

--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -22,6 +22,7 @@ package observability
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"go.uber.org/yarpc/api/transport"
@@ -42,6 +43,11 @@ const (
 	_successStreamClose = "Successfully closed stream"
 	_errorStreamOpen    = "Error creating stream"
 	_errorStreamClose   = "Error closing stream"
+
+	_dropped           = "dropped"
+	_droppedAppErrLog  = "dropped application error due to context timeout or cancelation"
+	_droppedErrLogFmt  = "dropped error due to context timeout or cancelation: %v"
+	_droppedSuccessLog = "dropped handler success due to context timeout or cancelation"
 )
 
 // A call represents a single RPC along an edge.
@@ -51,7 +57,7 @@ const (
 type call struct {
 	edge    *edge
 	extract ContextExtractor
-	fields  [5]zapcore.Field
+	fields  [6]zapcore.Field
 
 	started   time.Time
 	ctx       context.Context
@@ -80,7 +86,18 @@ func (c call) EndHandleWithAppError(err error, isApplicationError bool, ctxOverr
 		return
 	}
 
-	c.endWithAppError(ctxOverrideErr, isApplicationError)
+	// We'll override the user's response with the appropriate context error. Also, log
+	// the dropped response.
+	var droppedField zap.Field
+	if isApplicationError && err == nil { // Thrift exceptions
+		droppedField = zap.String(_dropped, _droppedAppErrLog)
+	} else if err != nil { // other errors
+		droppedField = zap.String(_dropped, fmt.Sprintf(_droppedErrLogFmt, err))
+	} else {
+		droppedField = zap.String(_dropped, _droppedSuccessLog)
+	}
+
+	c.endWithAppError(ctxOverrideErr, false /* application error */, droppedField)
 }
 
 func (c call) endWithAppError(err error, isApplicationError bool, extraLogFields ...zap.Field) {

--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -83,9 +83,9 @@ func (c call) EndHandleWithAppError(err error, isApplicationError bool, ctxOverr
 	c.endWithAppError(ctxOverrideErr, isApplicationError)
 }
 
-func (c call) endWithAppError(err error, isApplicationError bool) {
+func (c call) endWithAppError(err error, isApplicationError bool, extraLogFields ...zap.Field) {
 	elapsed := _timeNow().Sub(c.started)
-	c.endLogs(elapsed, err, isApplicationError)
+	c.endLogs(elapsed, err, isApplicationError, extraLogFields...)
 	c.endStats(elapsed, err, isApplicationError)
 }
 
@@ -95,7 +95,7 @@ func (c call) EndWithPanic(err error) {
 	c.endWithAppError(err, true)
 }
 
-func (c call) endLogs(elapsed time.Duration, err error, isApplicationError bool) {
+func (c call) endLogs(elapsed time.Duration, err error, isApplicationError bool, extraLogFields ...zap.Field) {
 	appErrBitWithNoError := isApplicationError && err == nil // ie Thrift exception
 
 	var ce *zapcore.CheckedEntry
@@ -148,6 +148,7 @@ func (c call) endLogs(elapsed time.Duration, err error, isApplicationError bool)
 	} else {
 		fields = append(fields, zap.Error(err))
 	}
+	fields = append(fields, extraLogFields...)
 	ce.Write(fields...)
 }
 

--- a/internal/observability/ctx_middleware_test.go
+++ b/internal/observability/ctx_middleware_test.go
@@ -1,0 +1,134 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package observability
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/api/transport/transporttest"
+	"go.uber.org/yarpc/yarpcerrors"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestContextMiddleware(t *testing.T) {
+	const (
+		ctxDeadlineExceededMsg = `call to procedure "my-procedure" of service "my-service" from caller "my-caller" timed out`
+		ctxCancelledMsg        = `call to procedure "my-procedure" of service "my-service" from caller "my-caller" was canceled`
+	)
+
+	infoLevel := zapcore.InfoLevel
+
+	mw := NewMiddleware(Config{
+		Logger:           zap.NewNop(),
+		ContextExtractor: NewNopContextExtractor(),
+		Levels: LevelsConfig{
+			Default: DirectionalLevelsConfig{
+				Success:          &infoLevel,
+				ApplicationError: &infoLevel,
+				Failure:          &infoLevel,
+			},
+		},
+	})
+
+	tests := []struct {
+		name       string
+		handlerErr error
+		ctx        func() context.Context
+
+		wantDeadlineExceeded bool
+		wantCtxCancelled     bool
+	}{
+		{
+			name: "no-op with no handler err",
+			ctx:  func() context.Context { return context.Background() },
+		},
+		{
+			name:       "no-op with handler err",
+			handlerErr: errors.New("an err"),
+			ctx:        func() context.Context { return context.Background() },
+		},
+		{
+			name:       "ctx deadline exceeded error",
+			handlerErr: fmt.Errorf("my custom error"),
+			ctx: func() context.Context {
+				ctx, cancel := context.WithTimeout(context.Background(), -1)
+				cancel()
+				return ctx
+			},
+			wantDeadlineExceeded: true,
+		},
+		{
+			name:       "ctx cancelled error",
+			handlerErr: fmt.Errorf("my custom error"),
+			ctx: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			},
+			wantCtxCancelled: true,
+		},
+	}
+
+	req := &transport.Request{
+		Service:   "my-service",
+		Procedure: "my-procedure",
+		Caller:    "my-caller",
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := &testHandler{err: tt.handlerErr}
+			err := mw.Handle(tt.ctx(), req, &transporttest.FakeResponseWriter{}, handler)
+
+			if tt.wantDeadlineExceeded {
+				assert.EqualError(t,
+					err,
+					yarpcerrors.DeadlineExceededErrorf(ctxDeadlineExceededMsg).Error(),
+					"expected deadline exceeded error override")
+				return
+			}
+
+			if tt.wantCtxCancelled {
+				assert.EqualError(t,
+					err,
+					yarpcerrors.CancelledErrorf(ctxCancelledMsg).Error(),
+					"expected cancelled yarpcerror code")
+				return
+			}
+
+			assert.Equal(t, tt.handlerErr, err, "unexpected error")
+		})
+	}
+}
+
+type testHandler struct {
+	err error
+}
+
+func (h *testHandler) Handle(ctx context.Context, req *transport.Request, resw transport.ResponseWriter) error {
+	return h.err
+}

--- a/internal/observability/ctx_middleware_test.go
+++ b/internal/observability/ctx_middleware_test.go
@@ -27,11 +27,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/api/transport/transporttest"
 	"go.uber.org/yarpc/yarpcerrors"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestContextMiddleware(t *testing.T) {
@@ -40,10 +42,10 @@ func TestContextMiddleware(t *testing.T) {
 		ctxCancelledMsg        = `call to procedure "my-procedure" of service "my-service" from caller "my-caller" was canceled`
 	)
 
+	core, logs := observer.New(zapcore.DebugLevel)
 	infoLevel := zapcore.InfoLevel
-
 	mw := NewMiddleware(Config{
-		Logger:           zap.NewNop(),
+		Logger:           zap.New(core),
 		ContextExtractor: NewNopContextExtractor(),
 		Levels: LevelsConfig{
 			Default: DirectionalLevelsConfig{
@@ -57,22 +59,32 @@ func TestContextMiddleware(t *testing.T) {
 	tests := []struct {
 		name       string
 		handlerErr error
+		appErr     bool
 		ctx        func() context.Context
 
 		wantDeadlineExceeded bool
 		wantCtxCancelled     bool
 	}{
 		{
-			name: "no-op with no handler err",
+			name: "no-op/handler success",
 			ctx:  func() context.Context { return context.Background() },
 		},
 		{
-			name:       "no-op with handler err",
+			name:       "no-op/handler err",
 			handlerErr: errors.New("an err"),
 			ctx:        func() context.Context { return context.Background() },
 		},
 		{
-			name:       "ctx deadline exceeded error",
+			name: "deadline exceeded/handler success",
+			ctx: func() context.Context {
+				ctx, cancel := context.WithTimeout(context.Background(), -1)
+				cancel()
+				return ctx
+			},
+			wantDeadlineExceeded: true,
+		},
+		{
+			name:       "deadline exceeded/handler err",
 			handlerErr: fmt.Errorf("my custom error"),
 			ctx: func() context.Context {
 				ctx, cancel := context.WithTimeout(context.Background(), -1)
@@ -82,13 +94,42 @@ func TestContextMiddleware(t *testing.T) {
 			wantDeadlineExceeded: true,
 		},
 		{
-			name:       "ctx cancelled error",
+			name: "deadline exceeded/app err",
+			ctx: func() context.Context {
+				ctx, cancel := context.WithTimeout(context.Background(), -1)
+				cancel()
+				return ctx
+			},
+			appErr:               true,
+			wantDeadlineExceeded: true,
+		},
+		{
+			name: "cancelled error/handler success",
+			ctx: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			},
+			wantCtxCancelled: true,
+		},
+		{
+			name:       "cancelled error/handler err",
 			handlerErr: fmt.Errorf("my custom error"),
 			ctx: func() context.Context {
 				ctx, cancel := context.WithCancel(context.Background())
 				cancel()
 				return ctx
 			},
+			wantCtxCancelled: true,
+		},
+		{
+			name: "cancelled error/app err",
+			ctx: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			},
+			appErr:           true,
 			wantCtxCancelled: true,
 		},
 	}
@@ -99,9 +140,33 @@ func TestContextMiddleware(t *testing.T) {
 		Caller:    "my-caller",
 	}
 
+	expectLogField := func(appErr bool, err error) *zap.Field {
+		dropMsg := _droppedSuccessLog
+		if err == nil && appErr {
+			dropMsg = _droppedAppErrLog
+		} else if err != nil {
+			dropMsg = fmt.Sprintf(_droppedErrLogFmt, err)
+		}
+		log := zap.String(_dropped, dropMsg)
+		return &log
+	}
+
+	getDropLogField := func(t *testing.T) *zap.Field {
+		entries := logs.TakeAll()
+		require.Equal(t, 1, len(entries), "unexpected number of logs written: %v", entries)
+		for _, f := range entries[0].Context {
+			if f.Key == _dropped {
+				return &f
+			}
+		}
+		return nil
+	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handler := &testHandler{err: tt.handlerErr}
+			defer logs.TakeAll() // throw away logs for next run
+
+			handler := &testHandler{err: tt.handlerErr, appErr: tt.appErr}
 			err := mw.Handle(tt.ctx(), req, &transporttest.FakeResponseWriter{}, handler)
 
 			if tt.wantDeadlineExceeded {
@@ -109,6 +174,8 @@ func TestContextMiddleware(t *testing.T) {
 					err,
 					yarpcerrors.DeadlineExceededErrorf(ctxDeadlineExceededMsg).Error(),
 					"expected deadline exceeded error override")
+
+				assert.Equal(t, expectLogField(tt.appErr, tt.handlerErr), getDropLogField(t), "unexpected log")
 				return
 			}
 
@@ -117,18 +184,25 @@ func TestContextMiddleware(t *testing.T) {
 					err,
 					yarpcerrors.CancelledErrorf(ctxCancelledMsg).Error(),
 					"expected cancelled yarpcerror code")
+
+				assert.Equal(t, expectLogField(tt.appErr, tt.handlerErr), getDropLogField(t), "unexpected log")
 				return
 			}
 
 			assert.Equal(t, tt.handlerErr, err, "unexpected error")
+			assert.Nil(t, getDropLogField(t), "unexpectedly saw 'dropped' log field")
 		})
 	}
 }
 
 type testHandler struct {
-	err error
+	err    error
+	appErr bool
 }
 
 func (h *testHandler) Handle(ctx context.Context, req *transport.Request, resw transport.ResponseWriter) error {
+	if h.appErr {
+		resw.SetApplicationError()
+	}
 	return h.err
 }

--- a/internal/observability/middleware.go
+++ b/internal/observability/middleware.go
@@ -142,7 +142,7 @@ func (m *Middleware) Handle(ctx context.Context, req *transport.Request, w trans
 
 	wrappedWriter := newWriter(w)
 	err := h.Handle(ctx, req, wrappedWriter)
-	call.EndWithAppError(err, wrappedWriter.isApplicationError)
+	call.EndHandleWithAppError(err, wrappedWriter.isApplicationError)
 	wrappedWriter.free()
 	return err
 }
@@ -156,7 +156,7 @@ func (m *Middleware) Call(ctx context.Context, req *transport.Request, out trans
 	if res != nil {
 		isApplicationError = res.ApplicationError
 	}
-	call.EndWithAppError(err, isApplicationError)
+	call.EndCallWithAppError(err, isApplicationError)
 	return res, err
 }
 

--- a/internal/observability/middleware.go
+++ b/internal/observability/middleware.go
@@ -27,6 +27,7 @@ import (
 
 	"go.uber.org/net/metrics"
 	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/yarpcerrors"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -142,7 +143,11 @@ func (m *Middleware) Handle(ctx context.Context, req *transport.Request, w trans
 
 	wrappedWriter := newWriter(w)
 	err := h.Handle(ctx, req, wrappedWriter)
-	call.EndHandleWithAppError(err, wrappedWriter.isApplicationError)
+	ctxErr := ctxErrOverride(ctx, req)
+	call.EndHandleWithAppError(err, wrappedWriter.isApplicationError, ctxErr)
+	if ctxErr != nil {
+		err = ctxErr
+	}
 	wrappedWriter.free()
 	return err
 }
@@ -196,6 +201,22 @@ func (m *Middleware) CallStream(ctx context.Context, request *transport.StreamRe
 		return nil, err
 	}
 	return call.WrapClientStream(clientStream), nil
+}
+
+func ctxErrOverride(ctx context.Context, req *transport.Request) (ctxErr error) {
+	if ctx.Err() == context.DeadlineExceeded {
+		return yarpcerrors.DeadlineExceededErrorf(
+			"call to procedure %q of service %q from caller %q timed out",
+			req.Procedure, req.Service, req.Caller)
+	}
+
+	if ctx.Err() == context.Canceled {
+		return yarpcerrors.CancelledErrorf(
+			"call to procedure %q of service %q from caller %q was canceled",
+			req.Procedure, req.Service, req.Caller)
+	}
+
+	return nil
 }
 
 // handlePanicForCall checks for a panic without actually recovering from it


### PR DESCRIPTION
If a caller timed out waiting for a request, it would emit a timeout. However,
the YARPC callee would continue fulfilling the request, and emit/log the success
or error, never reporting a timeout. This causes a misalignment of metrics
between YARPC metrics and caller/sidecar metrics. YARPC callees were never
returning timeout errors.

To fix this, this change overrides handler responses with the context error, if
the observability middleware sees that the context deadline expired or if there
was a context cancellation. Users responses are thrown away, but logged in 
the existing YARPC logs, under a `dropped` field.

Commits are individually reviewable and will be rebased onto dev.

- [x] Description and context for reviewers: one partner, one stranger
- [x] Entry in CHANGELOG.md
