### PR TITLE
debug: Fix outbound deterministic ordering

### DIFF
--- a/dispatcher_introspection.go
+++ b/dispatcher_introspection.go
@@ -103,7 +103,11 @@ func (o outboundStatuses) Len() int {
 	return len(o)
 }
 func (o outboundStatuses) Less(i, j int) bool {
-	return o[i].OutboundKey < o[j].OutboundKey && o[i].RPCType < o[j].RPCType
+	if o[i].OutboundKey == o[j].OutboundKey {
+		return o[i].RPCType < o[j].RPCType
+	}
+
+	return o[i].OutboundKey < o[j].OutboundKey
 }
 func (o outboundStatuses) Swap(i, j int) {
 	o[i], o[j] = o[j], o[i]

--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -875,21 +875,21 @@ func TestIntrospect(t *testing.T) {
 			{
 				outboundKey: "test-client-http",
 				endpoint:    "http://127.0.0.1:1234",
-				rpcType:     "unary",
+				rpcType:     "oneway",
 			},
 			{
 				outboundKey: "test-client-http",
 				endpoint:    "http://127.0.0.1:1234",
-				rpcType:     "oneway",
-			},
-			{
-				outboundKey: "test-client-tchannel-channel",
-				endpoint:    "127.0.0.1:2345",
 				rpcType:     "unary",
 			},
 			{
 				outboundKey: "test-client-tchannel",
 				endpoint:    "127.0.0.1:3456",
+				rpcType:     "unary",
+			},
+			{
+				outboundKey: "test-client-tchannel-channel",
+				endpoint:    "127.0.0.1:2345",
 				rpcType:     "unary",
 			},
 		}


### PR DESCRIPTION
This fixes the sorting used by the outbound statuses and tests
introduced in #1929 to actually be deterministic. If the outbound
name is identical we compare against the RPC type.