### PR TITLE
tchannel: Drop redundant "handler failed" log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Outbound status on debug pages is ordered by outbound name.
 ## Removed
 - The `x/yarpcmeta` package is completely removed.
+- tchannel: dropped "handler failed" log. Context error override change makes
+  this log redundant as richer information exists in observability logs.
 
 ## [1.45.0] - 2020-04-21
 ### Added

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -127,7 +127,6 @@ func (h handler) handle(ctx context.Context, call inboundCall) {
 		if err := call.Response().SendSystemError(getSystemError(err)); err != nil {
 			h.logger.Error("SendSystemError failed", zap.Error(err))
 		}
-		h.logger.Error("handler failed", zap.Error(err))
 		return
 	}
 	if err != nil && responseWriter.IsApplicationError() {


### PR DESCRIPTION
This drops the "handler failed" log in the TChannel transport. This
log was unnecessarily added when we were increasing observability
around TChannel internal errors in #1561.

The context error override in #1930 ensures that makes this log
redundant as richer information exists in observability logs,
including latency and request attributes.

Furthermore, we've had issues with this log since the latency is
included in the message and makes aggregation extremely difficult.

Ref T5802517

- [x] Description and context for reviewers: one partner, one stranger
- [x] Entry in CHANGELOG.md
