### PR TITLE
thrift: Use correct YARPCError* interfaces for `ApplicationErrorMeta`

### DIFF
--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/readonlystoreserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/readonlystoreserver/server.go
@@ -65,9 +65,9 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 
 type handler struct{ impl Interface }
 
-type errorNamer interface{ ErrorName() string }
+type yarpcErrorNamer interface{ YARPCErrorName() string }
 
-type yarpcErrorCodeExtractor interface{ YARPCCode() *yarpcerrors.Code }
+type yarpcErrorCoder interface{ YARPCErrorCode() *yarpcerrors.Code }
 
 func (h handler) Integer(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args atomic.ReadOnlyStore_Integer_Args
@@ -85,11 +85,11 @@ func (h handler) Integer(ctx context.Context, body wire.Value) (thrift.Response,
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Body = result
-		if namer, ok := appErr.(errorNamer); ok {
-			response.ApplicationErrorName = namer.ErrorName()
+		if namer, ok := appErr.(yarpcErrorNamer); ok {
+			response.ApplicationErrorName = namer.YARPCErrorName()
 		}
-		if extractor, ok := appErr.(yarpcErrorCodeExtractor); ok {
-			response.ApplicationErrorCode = extractor.YARPCCode()
+		if extractor, ok := appErr.(yarpcErrorCoder); ok {
+			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		response.ApplicationError = appErr
 	}

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storeserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storeserver/server.go
@@ -98,9 +98,9 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 
 type handler struct{ impl Interface }
 
-type errorNamer interface{ ErrorName() string }
+type yarpcErrorNamer interface{ YARPCErrorName() string }
 
-type yarpcErrorCodeExtractor interface{ YARPCCode() *yarpcerrors.Code }
+type yarpcErrorCoder interface{ YARPCErrorCode() *yarpcerrors.Code }
 
 func (h handler) CompareAndSwap(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args atomic.Store_CompareAndSwap_Args
@@ -118,11 +118,11 @@ func (h handler) CompareAndSwap(ctx context.Context, body wire.Value) (thrift.Re
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Body = result
-		if namer, ok := appErr.(errorNamer); ok {
-			response.ApplicationErrorName = namer.ErrorName()
+		if namer, ok := appErr.(yarpcErrorNamer); ok {
+			response.ApplicationErrorName = namer.YARPCErrorName()
 		}
-		if extractor, ok := appErr.(yarpcErrorCodeExtractor); ok {
-			response.ApplicationErrorCode = extractor.YARPCCode()
+		if extractor, ok := appErr.(yarpcErrorCoder); ok {
+			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		response.ApplicationError = appErr
 	}
@@ -155,11 +155,11 @@ func (h handler) Increment(ctx context.Context, body wire.Value) (thrift.Respons
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Body = result
-		if namer, ok := appErr.(errorNamer); ok {
-			response.ApplicationErrorName = namer.ErrorName()
+		if namer, ok := appErr.(yarpcErrorNamer); ok {
+			response.ApplicationErrorName = namer.YARPCErrorName()
 		}
-		if extractor, ok := appErr.(yarpcErrorCodeExtractor); ok {
-			response.ApplicationErrorCode = extractor.YARPCCode()
+		if extractor, ok := appErr.(yarpcErrorCoder); ok {
+			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		response.ApplicationError = appErr
 	}

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/baseserviceserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/baseserviceserver/server.go
@@ -50,9 +50,9 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 
 type handler struct{ impl Interface }
 
-type errorNamer interface{ ErrorName() string }
+type yarpcErrorNamer interface{ YARPCErrorName() string }
 
-type yarpcErrorCodeExtractor interface{ YARPCCode() *yarpcerrors.Code }
+type yarpcErrorCoder interface{ YARPCErrorCode() *yarpcerrors.Code }
 
 func (h handler) Healthy(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args common.BaseService_Healthy_Args
@@ -70,11 +70,11 @@ func (h handler) Healthy(ctx context.Context, body wire.Value) (thrift.Response,
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Body = result
-		if namer, ok := appErr.(errorNamer); ok {
-			response.ApplicationErrorName = namer.ErrorName()
+		if namer, ok := appErr.(yarpcErrorNamer); ok {
+			response.ApplicationErrorName = namer.YARPCErrorName()
 		}
-		if extractor, ok := appErr.(yarpcErrorCodeExtractor); ok {
-			response.ApplicationErrorCode = extractor.YARPCCode()
+		if extractor, ok := appErr.(yarpcErrorCoder); ok {
+			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		response.ApplicationError = appErr
 	}

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendemptyserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendemptyserver/server.go
@@ -64,9 +64,9 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 
 type handler struct{ impl Interface }
 
-type errorNamer interface{ ErrorName() string }
+type yarpcErrorNamer interface{ YARPCErrorName() string }
 
-type yarpcErrorCodeExtractor interface{ YARPCCode() *yarpcerrors.Code }
+type yarpcErrorCoder interface{ YARPCErrorCode() *yarpcerrors.Code }
 
 func (h handler) Hello(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args common.ExtendEmpty_Hello_Args
@@ -84,11 +84,11 @@ func (h handler) Hello(ctx context.Context, body wire.Value) (thrift.Response, e
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Body = result
-		if namer, ok := appErr.(errorNamer); ok {
-			response.ApplicationErrorName = namer.ErrorName()
+		if namer, ok := appErr.(yarpcErrorNamer); ok {
+			response.ApplicationErrorName = namer.YARPCErrorName()
 		}
-		if extractor, ok := appErr.(yarpcErrorCodeExtractor); ok {
-			response.ApplicationErrorCode = extractor.YARPCCode()
+		if extractor, ok := appErr.(yarpcErrorCoder); ok {
+			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		response.ApplicationError = appErr
 	}

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/nameserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/nameserver/server.go
@@ -50,9 +50,9 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 
 type handler struct{ impl Interface }
 
-type errorNamer interface{ ErrorName() string }
+type yarpcErrorNamer interface{ YARPCErrorName() string }
 
-type yarpcErrorCodeExtractor interface{ YARPCCode() *yarpcerrors.Code }
+type yarpcErrorCoder interface{ YARPCErrorCode() *yarpcerrors.Code }
 
 func (h handler) Name(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args extends.Name_Name_Args
@@ -70,11 +70,11 @@ func (h handler) Name(ctx context.Context, body wire.Value) (thrift.Response, er
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Body = result
-		if namer, ok := appErr.(errorNamer); ok {
-			response.ApplicationErrorName = namer.ErrorName()
+		if namer, ok := appErr.(yarpcErrorNamer); ok {
+			response.ApplicationErrorName = namer.YARPCErrorName()
 		}
-		if extractor, ok := appErr.(yarpcErrorCodeExtractor); ok {
-			response.ApplicationErrorCode = extractor.YARPCCode()
+		if extractor, ok := appErr.(yarpcErrorCoder); ok {
+			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		response.ApplicationError = appErr
 	}

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/weather/weatherserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/weather/weatherserver/server.go
@@ -50,9 +50,9 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 
 type handler struct{ impl Interface }
 
-type errorNamer interface{ ErrorName() string }
+type yarpcErrorNamer interface{ YARPCErrorName() string }
 
-type yarpcErrorCodeExtractor interface{ YARPCCode() *yarpcerrors.Code }
+type yarpcErrorCoder interface{ YARPCErrorCode() *yarpcerrors.Code }
 
 func (h handler) Check(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args weather.Weather_Check_Args
@@ -70,11 +70,11 @@ func (h handler) Check(ctx context.Context, body wire.Value) (thrift.Response, e
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Body = result
-		if namer, ok := appErr.(errorNamer); ok {
-			response.ApplicationErrorName = namer.ErrorName()
+		if namer, ok := appErr.(yarpcErrorNamer); ok {
+			response.ApplicationErrorName = namer.YARPCErrorName()
 		}
-		if extractor, ok := appErr.(yarpcErrorCodeExtractor); ok {
-			response.ApplicationErrorCode = extractor.YARPCCode()
+		if extractor, ok := appErr.(yarpcErrorCoder); ok {
+			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		response.ApplicationError = appErr
 	}

--- a/encoding/thrift/thriftrw-plugin-yarpc/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/server.go
@@ -115,9 +115,9 @@ type handler struct{ impl Interface }
 
 <$yarpcerrors := import "go.uber.org/yarpc/yarpcerrors">
 
-type errorNamer interface { ErrorName() string }
+type yarpcErrorNamer interface { YARPCErrorName() string }
 
-type yarpcErrorCodeExtractor interface { YARPCCode() *yarpcerrors.Code }
+type yarpcErrorCoder interface { YARPCErrorCode() *yarpcerrors.Code }
 <end>
 
 <$service := .>
@@ -158,12 +158,12 @@ func (h handler) <.Name>(ctx <$context>.Context, body <$wire>.Value) (<$thrift>.
 	var response <$thrift>.Response
 	if err == nil {
 		response.IsApplicationError = hadError
-		response.Body = result	
-		if namer, ok := appErr.(errorNamer); ok {
-			response.ApplicationErrorName = namer.ErrorName()
+		response.Body = result
+		if namer, ok := appErr.(yarpcErrorNamer); ok {
+			response.ApplicationErrorName = namer.YARPCErrorName()
  		}
-		if extractor, ok := appErr.(yarpcErrorCodeExtractor); ok {
-			response.ApplicationErrorCode = extractor.YARPCCode()
+		if extractor, ok := appErr.(yarpcErrorCoder); ok {
+			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		response.ApplicationError = appErr
 	}

--- a/internal/crossdock/thrift/echo/echoserver/server.go
+++ b/internal/crossdock/thrift/echo/echoserver/server.go
@@ -71,9 +71,9 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 
 type handler struct{ impl Interface }
 
-type errorNamer interface{ ErrorName() string }
+type yarpcErrorNamer interface{ YARPCErrorName() string }
 
-type yarpcErrorCodeExtractor interface{ YARPCCode() *yarpcerrors.Code }
+type yarpcErrorCoder interface{ YARPCErrorCode() *yarpcerrors.Code }
 
 func (h handler) Echo(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args echo.Echo_Echo_Args
@@ -91,11 +91,11 @@ func (h handler) Echo(ctx context.Context, body wire.Value) (thrift.Response, er
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Body = result
-		if namer, ok := appErr.(errorNamer); ok {
-			response.ApplicationErrorName = namer.ErrorName()
+		if namer, ok := appErr.(yarpcErrorNamer); ok {
+			response.ApplicationErrorName = namer.YARPCErrorName()
 		}
-		if extractor, ok := appErr.(yarpcErrorCodeExtractor); ok {
-			response.ApplicationErrorCode = extractor.YARPCCode()
+		if extractor, ok := appErr.(yarpcErrorCoder); ok {
+			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		response.ApplicationError = appErr
 	}

--- a/internal/crossdock/thrift/gauntlet/secondserviceserver/server.go
+++ b/internal/crossdock/thrift/gauntlet/secondserviceserver/server.go
@@ -86,9 +86,9 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 
 type handler struct{ impl Interface }
 
-type errorNamer interface{ ErrorName() string }
+type yarpcErrorNamer interface{ YARPCErrorName() string }
 
-type yarpcErrorCodeExtractor interface{ YARPCCode() *yarpcerrors.Code }
+type yarpcErrorCoder interface{ YARPCErrorCode() *yarpcerrors.Code }
 
 func (h handler) BlahBlah(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args gauntlet.SecondService_BlahBlah_Args
@@ -106,11 +106,11 @@ func (h handler) BlahBlah(ctx context.Context, body wire.Value) (thrift.Response
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Body = result
-		if namer, ok := appErr.(errorNamer); ok {
-			response.ApplicationErrorName = namer.ErrorName()
+		if namer, ok := appErr.(yarpcErrorNamer); ok {
+			response.ApplicationErrorName = namer.YARPCErrorName()
 		}
-		if extractor, ok := appErr.(yarpcErrorCodeExtractor); ok {
-			response.ApplicationErrorCode = extractor.YARPCCode()
+		if extractor, ok := appErr.(yarpcErrorCoder); ok {
+			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		response.ApplicationError = appErr
 	}
@@ -134,11 +134,11 @@ func (h handler) SecondtestString(ctx context.Context, body wire.Value) (thrift.
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Body = result
-		if namer, ok := appErr.(errorNamer); ok {
-			response.ApplicationErrorName = namer.ErrorName()
+		if namer, ok := appErr.(yarpcErrorNamer); ok {
+			response.ApplicationErrorName = namer.YARPCErrorName()
 		}
-		if extractor, ok := appErr.(yarpcErrorCodeExtractor); ok {
-			response.ApplicationErrorCode = extractor.YARPCCode()
+		if extractor, ok := appErr.(yarpcErrorCoder); ok {
+			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		response.ApplicationError = appErr
 	}

--- a/internal/crossdock/thrift/gauntlet/thrifttestserver/server.go
+++ b/internal/crossdock/thrift/gauntlet/thrifttestserver/server.go
@@ -396,9 +396,9 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 
 type handler struct{ impl Interface }
 
-type errorNamer interface{ ErrorName() string }
+type yarpcErrorNamer interface{ YARPCErrorName() string }
 
-type yarpcErrorCodeExtractor interface{ YARPCCode() *yarpcerrors.Code }
+type yarpcErrorCoder interface{ YARPCErrorCode() *yarpcerrors.Code }
 
 func (h handler) TestBinary(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args gauntlet.ThriftTest_TestBinary_Args
@@ -416,11 +416,11 @@ func (h handler) TestBinary(ctx context.Context, body wire.Value) (thrift.Respon
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Body = result
-		if namer, ok := appErr.(errorNamer); ok {
-			response.ApplicationErrorName = namer.ErrorName()
+		if namer, ok := appErr.(yarpcErrorNamer); ok {
+			response.ApplicationErrorName = namer.YARPCErrorName()
 		}
-		if extractor, ok := appErr.(yarpcErrorCodeExtractor); ok {
-			response.ApplicationErrorCode = extractor.YARPCCode()
+		if extractor, ok := appErr.(yarpcErrorCoder); ok {
+			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		response.ApplicationError = appErr
 	}
@@ -444,11 +444,11 @@ func (h handler) TestByte(ctx context.Context, body wire.Value) (thrift.Response
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Body = result
-		if namer, ok := appErr.(errorNamer); ok {
-			response.ApplicationErrorName = namer.ErrorName()
+		if namer, ok := appErr.(yarpcErrorNamer); ok {
+			response.ApplicationErrorName = namer.YARPCErrorName()
 		}
-		if extractor, ok := appErr.(yarpcErrorCodeExtractor); ok {
-			response.ApplicationErrorCode = extractor.YARPCCode()
+		if extractor, ok := appErr.(yarpcErrorCoder); ok {
+			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		response.ApplicationError = appErr
 	}
@@ -472,11 +472,11 @@ func (h handler) TestDouble(ctx context.Context, body wire.Value) (thrift.Respon
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Body = result
-		if namer, ok := appErr.(errorNamer); ok {
-			response.ApplicationErrorName = namer.ErrorName()
+		if namer, ok := appErr.(yarpcErrorNamer); ok {
+			response.ApplicationErrorName = namer.YARPCErrorName()
 		}
-		if extractor, ok := appErr.(yarpcErrorCodeExtractor); ok {
-			response.ApplicationErrorCode = extractor.YARPCCode()
+		if extractor, ok := appErr.(yarpcErrorCoder); ok {
+			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		response.ApplicationError = appErr
 	}
@@ -500,11 +500,11 @@ func (h handler) TestEnum(ctx context.Context, body wire.Value) (thrift.Response
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Body = result
-		if namer, ok := appErr.(errorNamer); ok {
-			response.ApplicationErrorName = namer.ErrorName()
+		if namer, ok := appErr.(yarpcErrorNamer); ok {
+			response.ApplicationErrorName = namer.YARPCErrorName()
 		}
-		if extractor, ok := appErr.(yarpcErrorCodeExtractor); ok {
-			response.ApplicationErrorCode = extractor.YARPCCode()
+		if extractor, ok := appErr.(yarpcErrorCoder); ok {
+			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		response.ApplicationError = appErr
 	}
@@ -528,11 +528,11 @@ func (h handler) TestException(ctx context.Context, body wire.Value) (thrift.Res
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Body = result
-		if namer, ok := appErr.(errorNamer); ok {
-			response.ApplicationErrorName = namer.ErrorName()
+		if namer, ok := appErr.(yarpcErrorNamer); ok {
+			response.ApplicationErrorName = namer.YARPCErrorName()
 		}
-		if extractor, ok := appErr.(yarpcErrorCodeExtractor); ok {
-			response.ApplicationErrorCode = extractor.YARPCCode()
+		if extractor, ok := appErr.(yarpcErrorCoder); ok {
+			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		response.ApplicationError = appErr
 	}
@@ -556,11 +556,11 @@ func (h handler) TestI32(ctx context.Context, body wire.Value) (thrift.Response,
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Body = result
-		if namer, ok := appErr.(errorNamer); ok {
-			response.ApplicationErrorName = namer.ErrorName()
+		if namer, ok := appErr.(yarpcErrorNamer); ok {
+			response.ApplicationErrorName = namer.YARPCErrorName()
 		}
-		if extractor, ok := appErr.(yarpcErrorCodeExtractor); ok {
-			response.ApplicationErrorCode = extractor.YARPCCode()
+		if extractor, ok := appErr.(yarpcErrorCoder); ok {
+			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		response.ApplicationError = appErr
 	}
@@ -584,11 +584,11 @@ func (h handler) TestI64(ctx context.Context, body wire.Value) (thrift.Response,
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Body = result
-		if namer, ok := appErr.(errorNamer); ok {
-			response.ApplicationErrorName = namer.ErrorName()
+		if namer, ok := appErr.(yarpcErrorNamer); ok {
+			response.ApplicationErrorName = namer.YARPCErrorName()
 		}
-		if extractor, ok := appErr.(yarpcErrorCodeExtractor); ok {
-			response.ApplicationErrorCode = extractor.YARPCCode()
+		if extractor, ok := appErr.(yarpcErrorCoder); ok {
+			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		response.ApplicationError = appErr
 	}
@@ -612,11 +612,11 @@ func (h handler) TestInsanity(ctx context.Context, body wire.Value) (thrift.Resp
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Body = result
-		if namer, ok := appErr.(errorNamer); ok {
-			response.ApplicationErrorName = namer.ErrorName()
+		if namer, ok := appErr.(yarpcErrorNamer); ok {
+			response.ApplicationErrorName = namer.YARPCErrorName()
 		}
-		if extractor, ok := appErr.(yarpcErrorCodeExtractor); ok {
-			response.ApplicationErrorCode = extractor.YARPCCode()
+		if extractor, ok := appErr.(yarpcErrorCoder); ok {
+			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		response.ApplicationError = appErr
 	}
@@ -640,11 +640,11 @@ func (h handler) TestList(ctx context.Context, body wire.Value) (thrift.Response
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Body = result
-		if namer, ok := appErr.(errorNamer); ok {
-			response.ApplicationErrorName = namer.ErrorName()
+		if namer, ok := appErr.(yarpcErrorNamer); ok {
+			response.ApplicationErrorName = namer.YARPCErrorName()
 		}
-		if extractor, ok := appErr.(yarpcErrorCodeExtractor); ok {
-			response.ApplicationErrorCode = extractor.YARPCCode()
+		if extractor, ok := appErr.(yarpcErrorCoder); ok {
+			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		response.ApplicationError = appErr
 	}
@@ -668,11 +668,11 @@ func (h handler) TestMap(ctx context.Context, body wire.Value) (thrift.Response,
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Body = result
-		if namer, ok := appErr.(errorNamer); ok {
-			response.ApplicationErrorName = namer.ErrorName()
+		if namer, ok := appErr.(yarpcErrorNamer); ok {
+			response.ApplicationErrorName = namer.YARPCErrorName()
 		}
-		if extractor, ok := appErr.(yarpcErrorCodeExtractor); ok {
-			response.ApplicationErrorCode = extractor.YARPCCode()
+		if extractor, ok := appErr.(yarpcErrorCoder); ok {
+			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		response.ApplicationError = appErr
 	}
@@ -696,11 +696,11 @@ func (h handler) TestMapMap(ctx context.Context, body wire.Value) (thrift.Respon
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Body = result
-		if namer, ok := appErr.(errorNamer); ok {
-			response.ApplicationErrorName = namer.ErrorName()
+		if namer, ok := appErr.(yarpcErrorNamer); ok {
+			response.ApplicationErrorName = namer.YARPCErrorName()
 		}
-		if extractor, ok := appErr.(yarpcErrorCodeExtractor); ok {
-			response.ApplicationErrorCode = extractor.YARPCCode()
+		if extractor, ok := appErr.(yarpcErrorCoder); ok {
+			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		response.ApplicationError = appErr
 	}
@@ -724,11 +724,11 @@ func (h handler) TestMulti(ctx context.Context, body wire.Value) (thrift.Respons
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Body = result
-		if namer, ok := appErr.(errorNamer); ok {
-			response.ApplicationErrorName = namer.ErrorName()
+		if namer, ok := appErr.(yarpcErrorNamer); ok {
+			response.ApplicationErrorName = namer.YARPCErrorName()
 		}
-		if extractor, ok := appErr.(yarpcErrorCodeExtractor); ok {
-			response.ApplicationErrorCode = extractor.YARPCCode()
+		if extractor, ok := appErr.(yarpcErrorCoder); ok {
+			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		response.ApplicationError = appErr
 	}
@@ -752,11 +752,11 @@ func (h handler) TestMultiException(ctx context.Context, body wire.Value) (thrif
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Body = result
-		if namer, ok := appErr.(errorNamer); ok {
-			response.ApplicationErrorName = namer.ErrorName()
+		if namer, ok := appErr.(yarpcErrorNamer); ok {
+			response.ApplicationErrorName = namer.YARPCErrorName()
 		}
-		if extractor, ok := appErr.(yarpcErrorCodeExtractor); ok {
-			response.ApplicationErrorCode = extractor.YARPCCode()
+		if extractor, ok := appErr.(yarpcErrorCoder); ok {
+			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		response.ApplicationError = appErr
 	}
@@ -780,11 +780,11 @@ func (h handler) TestNest(ctx context.Context, body wire.Value) (thrift.Response
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Body = result
-		if namer, ok := appErr.(errorNamer); ok {
-			response.ApplicationErrorName = namer.ErrorName()
+		if namer, ok := appErr.(yarpcErrorNamer); ok {
+			response.ApplicationErrorName = namer.YARPCErrorName()
 		}
-		if extractor, ok := appErr.(yarpcErrorCodeExtractor); ok {
-			response.ApplicationErrorCode = extractor.YARPCCode()
+		if extractor, ok := appErr.(yarpcErrorCoder); ok {
+			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		response.ApplicationError = appErr
 	}
@@ -817,11 +817,11 @@ func (h handler) TestSet(ctx context.Context, body wire.Value) (thrift.Response,
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Body = result
-		if namer, ok := appErr.(errorNamer); ok {
-			response.ApplicationErrorName = namer.ErrorName()
+		if namer, ok := appErr.(yarpcErrorNamer); ok {
+			response.ApplicationErrorName = namer.YARPCErrorName()
 		}
-		if extractor, ok := appErr.(yarpcErrorCodeExtractor); ok {
-			response.ApplicationErrorCode = extractor.YARPCCode()
+		if extractor, ok := appErr.(yarpcErrorCoder); ok {
+			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		response.ApplicationError = appErr
 	}
@@ -845,11 +845,11 @@ func (h handler) TestString(ctx context.Context, body wire.Value) (thrift.Respon
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Body = result
-		if namer, ok := appErr.(errorNamer); ok {
-			response.ApplicationErrorName = namer.ErrorName()
+		if namer, ok := appErr.(yarpcErrorNamer); ok {
+			response.ApplicationErrorName = namer.YARPCErrorName()
 		}
-		if extractor, ok := appErr.(yarpcErrorCodeExtractor); ok {
-			response.ApplicationErrorCode = extractor.YARPCCode()
+		if extractor, ok := appErr.(yarpcErrorCoder); ok {
+			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		response.ApplicationError = appErr
 	}
@@ -873,11 +873,11 @@ func (h handler) TestStringMap(ctx context.Context, body wire.Value) (thrift.Res
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Body = result
-		if namer, ok := appErr.(errorNamer); ok {
-			response.ApplicationErrorName = namer.ErrorName()
+		if namer, ok := appErr.(yarpcErrorNamer); ok {
+			response.ApplicationErrorName = namer.YARPCErrorName()
 		}
-		if extractor, ok := appErr.(yarpcErrorCodeExtractor); ok {
-			response.ApplicationErrorCode = extractor.YARPCCode()
+		if extractor, ok := appErr.(yarpcErrorCoder); ok {
+			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		response.ApplicationError = appErr
 	}
@@ -901,11 +901,11 @@ func (h handler) TestStruct(ctx context.Context, body wire.Value) (thrift.Respon
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Body = result
-		if namer, ok := appErr.(errorNamer); ok {
-			response.ApplicationErrorName = namer.ErrorName()
+		if namer, ok := appErr.(yarpcErrorNamer); ok {
+			response.ApplicationErrorName = namer.YARPCErrorName()
 		}
-		if extractor, ok := appErr.(yarpcErrorCodeExtractor); ok {
-			response.ApplicationErrorCode = extractor.YARPCCode()
+		if extractor, ok := appErr.(yarpcErrorCoder); ok {
+			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		response.ApplicationError = appErr
 	}
@@ -929,11 +929,11 @@ func (h handler) TestTypedef(ctx context.Context, body wire.Value) (thrift.Respo
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Body = result
-		if namer, ok := appErr.(errorNamer); ok {
-			response.ApplicationErrorName = namer.ErrorName()
+		if namer, ok := appErr.(yarpcErrorNamer); ok {
+			response.ApplicationErrorName = namer.YARPCErrorName()
 		}
-		if extractor, ok := appErr.(yarpcErrorCodeExtractor); ok {
-			response.ApplicationErrorCode = extractor.YARPCCode()
+		if extractor, ok := appErr.(yarpcErrorCoder); ok {
+			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		response.ApplicationError = appErr
 	}
@@ -957,11 +957,11 @@ func (h handler) TestVoid(ctx context.Context, body wire.Value) (thrift.Response
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Body = result
-		if namer, ok := appErr.(errorNamer); ok {
-			response.ApplicationErrorName = namer.ErrorName()
+		if namer, ok := appErr.(yarpcErrorNamer); ok {
+			response.ApplicationErrorName = namer.YARPCErrorName()
 		}
-		if extractor, ok := appErr.(yarpcErrorCodeExtractor); ok {
-			response.ApplicationErrorCode = extractor.YARPCCode()
+		if extractor, ok := appErr.(yarpcErrorCoder); ok {
+			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		response.ApplicationError = appErr
 	}

--- a/internal/crossdock/thrift/oneway/onewayserver/server.go
+++ b/internal/crossdock/thrift/oneway/onewayserver/server.go
@@ -71,9 +71,9 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 
 type handler struct{ impl Interface }
 
-type errorNamer interface{ ErrorName() string }
+type yarpcErrorNamer interface{ YARPCErrorName() string }
 
-type yarpcErrorCodeExtractor interface{ YARPCCode() *yarpcerrors.Code }
+type yarpcErrorCoder interface{ YARPCErrorCode() *yarpcerrors.Code }
 
 func (h handler) Echo(ctx context.Context, body wire.Value) error {
 	var args oneway.Oneway_Echo_Args

--- a/internal/examples/thrift-hello/hello/echo/helloserver/server.go
+++ b/internal/examples/thrift-hello/hello/echo/helloserver/server.go
@@ -71,9 +71,9 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 
 type handler struct{ impl Interface }
 
-type errorNamer interface{ ErrorName() string }
+type yarpcErrorNamer interface{ YARPCErrorName() string }
 
-type yarpcErrorCodeExtractor interface{ YARPCCode() *yarpcerrors.Code }
+type yarpcErrorCoder interface{ YARPCErrorCode() *yarpcerrors.Code }
 
 func (h handler) Echo(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args echo.Hello_Echo_Args
@@ -91,11 +91,11 @@ func (h handler) Echo(ctx context.Context, body wire.Value) (thrift.Response, er
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Body = result
-		if namer, ok := appErr.(errorNamer); ok {
-			response.ApplicationErrorName = namer.ErrorName()
+		if namer, ok := appErr.(yarpcErrorNamer); ok {
+			response.ApplicationErrorName = namer.YARPCErrorName()
 		}
-		if extractor, ok := appErr.(yarpcErrorCodeExtractor); ok {
-			response.ApplicationErrorCode = extractor.YARPCCode()
+		if extractor, ok := appErr.(yarpcErrorCoder); ok {
+			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		response.ApplicationError = appErr
 	}

--- a/internal/examples/thrift-keyvalue/keyvalue/kv/keyvalueserver/server.go
+++ b/internal/examples/thrift-keyvalue/keyvalue/kv/keyvalueserver/server.go
@@ -88,9 +88,9 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 
 type handler struct{ impl Interface }
 
-type errorNamer interface{ ErrorName() string }
+type yarpcErrorNamer interface{ YARPCErrorName() string }
 
-type yarpcErrorCodeExtractor interface{ YARPCCode() *yarpcerrors.Code }
+type yarpcErrorCoder interface{ YARPCErrorCode() *yarpcerrors.Code }
 
 func (h handler) GetValue(ctx context.Context, body wire.Value) (thrift.Response, error) {
 	var args kv.KeyValue_GetValue_Args
@@ -108,11 +108,11 @@ func (h handler) GetValue(ctx context.Context, body wire.Value) (thrift.Response
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Body = result
-		if namer, ok := appErr.(errorNamer); ok {
-			response.ApplicationErrorName = namer.ErrorName()
+		if namer, ok := appErr.(yarpcErrorNamer); ok {
+			response.ApplicationErrorName = namer.YARPCErrorName()
 		}
-		if extractor, ok := appErr.(yarpcErrorCodeExtractor); ok {
-			response.ApplicationErrorCode = extractor.YARPCCode()
+		if extractor, ok := appErr.(yarpcErrorCoder); ok {
+			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		response.ApplicationError = appErr
 	}
@@ -136,11 +136,11 @@ func (h handler) SetValue(ctx context.Context, body wire.Value) (thrift.Response
 	if err == nil {
 		response.IsApplicationError = hadError
 		response.Body = result
-		if namer, ok := appErr.(errorNamer); ok {
-			response.ApplicationErrorName = namer.ErrorName()
+		if namer, ok := appErr.(yarpcErrorNamer); ok {
+			response.ApplicationErrorName = namer.YARPCErrorName()
 		}
-		if extractor, ok := appErr.(yarpcErrorCodeExtractor); ok {
-			response.ApplicationErrorCode = extractor.YARPCCode()
+		if extractor, ok := appErr.(yarpcErrorCoder); ok {
+			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		response.ApplicationError = appErr
 	}

--- a/internal/examples/thrift-oneway/sink/helloserver/server.go
+++ b/internal/examples/thrift-oneway/sink/helloserver/server.go
@@ -71,9 +71,9 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 
 type handler struct{ impl Interface }
 
-type errorNamer interface{ ErrorName() string }
+type yarpcErrorNamer interface{ YARPCErrorName() string }
 
-type yarpcErrorCodeExtractor interface{ YARPCCode() *yarpcerrors.Code }
+type yarpcErrorCoder interface{ YARPCErrorCode() *yarpcerrors.Code }
 
 func (h handler) Sink(ctx context.Context, body wire.Value) error {
 	var args sink.Hello_Sink_Args


### PR DESCRIPTION
This fixes a small (unreleased) bug introduced in #1901. All YARPC
generated methods on thrift types use `YARPCError*` as the prefix. The
generated code was incorrectly using `ErrorName` and `YARPCCode`,
resulting in the `ApplicationErrorMeta` not being set properly.

This was discovered while building an integration test. Since this
feature is not fully completed (missing outbound side) we cannot put
up the integration test just yet, so this PR only includes the name
change.

The template change is in:
- `encoding/thrift/thriftrw-plugin-yarpc/server.go`
The rest of the changes are generated code changes.

- [x] Description and context for reviewers: one partner, one stranger
