### PR TITLE
Extract application error meta headers from outbound TChannel requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - observability: Errors are logged with their associated error code under the
   `errorCode` field. Errors created outside of `protobuf.NewError` and
   `yarpcerrors` will yield `CodeUnknown`.
+- Using the `yarpc.code` annotation, services may specify an associated
+`yarpcerrors.Code` for Thrift exceptions.
+- Metrics and logs now include Thrift exception names and related YARPC code, if
+  annotated. If a `yarpc.code` annotation is specified for a Thrift exception,
+  metrics will classify it as a client or server failure, like a `yarpcerrors`
+  error. If the YARPC code is not specified for the Thrift exception, it will
+  continue to be assumed a client failure.
+
 ### Removed
 - Removed `yarpcproto` package that enabled "oneway" Protobuf signatures.
 

--- a/transport/tchannel/outbound_test.go
+++ b/transport/tchannel/outbound_test.go
@@ -292,7 +292,19 @@ func TestApplicationError(t *testing.T) {
 		func(ctx context.Context, call *tchannel.InboundCall) {
 			call.Response().SetApplicationError()
 
-			err := writeArgs(call.Response(), []byte{0x00, 0x00}, []byte("foo"))
+			err := writeArgs(
+				call.Response(),
+				[]byte{
+					0x00, 0x02,
+					0x00, 0x1c, '$', 'r', 'p', 'c', '$', '-', 'a', 'p', 'p', 'l', 'i', 'c', 'a', 't', 'i', 'o', 'n',
+					'-', 'e', 'r', 'r', 'o', 'r', '-', 'c', 'o', 'd', 'e',
+					0x00, 0x02, '1', '0',
+					0x00, 0x1c, '$', 'r', 'p', 'c', '$', '-', 'a', 'p', 'p', 'l', 'i', 'c', 'a', 't', 'i', 'o', 'n',
+					'-', 'e', 'r', 'r', 'o', 'r', '-', 'n', 'a', 'm', 'e',
+					0x00, 0x03, 'b', 'A', 'z',
+				},
+				[]byte("foo"),
+			)
 			assert.NoError(t, err, "failed to write response")
 		}))
 
@@ -314,6 +326,19 @@ func TestApplicationError(t *testing.T) {
 	)
 	require.NoError(t, err, "failed to make call")
 	assert.True(t, res.ApplicationError, "application error was not set")
+	assert.NotNil(t, res.ApplicationErrorMeta.Code, "application error code was not set")
+	assert.Equal(
+		t,
+		yarpcerrors.CodeAborted,
+		*res.ApplicationErrorMeta.Code,
+		"application error code does not match the expected one",
+	)
+	assert.Equal(
+		t,
+		"bAz",
+		res.ApplicationErrorMeta.Name,
+		"application error name does not match the expected one",
+	)
 
 }
 


### PR DESCRIPTION
When executing outbound TChannel calls, YARPC should inspect the response headers for the newly introduced reserved ones used to propagate the application error metadata. If the headers are found, the transport response should carry the values and the observability stack will emit them to logs and stats accordingly

- [X] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [X] Entry in CHANGELOG.md
