### PR TITLE
observability: Log error codes in observability middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- observability: Errors are logged with their associated error code under the
+  `errorCode` field. Errors created outside of `protobuf.NewError` and
+  `yarpcerrors` will yield `CodeUnknown`.
 ### Removed
 - Removed `yarpcproto` package that enabled "oneway" Protobuf signatures.
 

--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -197,6 +197,9 @@ func (c call) endLogs(
 		}
 	} else {
 		fields = append(fields, zap.Error(err))
+		if code := yarpcerrors.FromError(err).Code(); code != yarpcerrors.CodeOK {
+			fields = append(fields, zap.String(_errorCodeLogKey, code.String()))
+		}
 	}
 	fields = append(fields, extraLogFields...)
 	ce.Write(fields...)

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -232,6 +232,7 @@ func TestMiddlewareLogging(t *testing.T) {
 				zap.Bool("successful", false),
 				zap.Skip(),
 				zap.Error(rawErr),
+				zap.String(_errorCodeLogKey, "unknown"),
 			},
 		},
 		{
@@ -277,6 +278,7 @@ func TestMiddlewareLogging(t *testing.T) {
 				zap.Bool("successful", false),
 				zap.Skip(),
 				zap.Error(rawErr),
+				zap.String(_errorCodeLogKey, "unknown"),
 			},
 		},
 		{
@@ -292,6 +294,7 @@ func TestMiddlewareLogging(t *testing.T) {
 				zap.Bool("successful", false),
 				zap.Skip(),
 				zap.Error(yErrNoDetails),
+				zap.String(_errorCodeLogKey, "aborted"),
 			},
 		},
 		{
@@ -307,6 +310,7 @@ func TestMiddlewareLogging(t *testing.T) {
 				zap.Bool("successful", false),
 				zap.Skip(),
 				zap.Error(yErrWithDetails),
+				zap.String(_errorCodeLogKey, "aborted"),
 			},
 		},
 	}


### PR DESCRIPTION
This minor change adds an `errorCode` field to the existing
observability middleware logs. Previously, codes would only appear in
the error field. This made it difficult to group logs by error codes
since the message is part of the string message.

Logs will now contain an additional `errorCode` field, ie:

```
...
error: "code:aborted message:this is my message"
errorCode: "aborted"
```

- [x] Description and context for reviewers: one partner, one stranger
- [x] Entry in CHANGELOG.md
