### PR TITLE
Log Thrift exception as strings in observability middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   metrics will classify it as a client or server failure, like a `yarpcerrors`
   error. If the YARPC code is not specified for the Thrift exception, it will
   continue to be assumed a client failure. (TChannel-only)
+- observability: Thrift exceptions are logged under the `appErrMessage` field
+  (TChannel-only).
 
 ### Removed
 - Removed `yarpcproto` package that enabled "oneway" Protobuf signatures.

--- a/api/transport/response.go
+++ b/api/transport/response.go
@@ -21,8 +21,9 @@
 package transport
 
 import (
-	"go.uber.org/yarpc/yarpcerrors"
 	"io"
+
+	"go.uber.org/yarpc/yarpcerrors"
 )
 
 // Response is the low level response representation.
@@ -55,13 +56,14 @@ type ResponseWriter interface {
 }
 
 // ApplicationErrorMeta contains additional information to describe the
-// application error, such as an error name and code. This information is
-// optional for backwards-compatibility and may not be present in all
+// application error, such as an error name, code and message.
+//
+// Fields are optional for backwards-compatibility and may not be present in all
 // responses.
 type ApplicationErrorMeta struct {
-	Err  error
-	Name string            // optional
-	Code *yarpcerrors.Code // optional
+	Message string
+	Name    string
+	Code    *yarpcerrors.Code
 }
 
 // ApplicationErrorMetaSetter enables setting the name of an

--- a/encoding/thrift/inbound.go
+++ b/encoding/thrift/inbound.go
@@ -78,9 +78,9 @@ func (t thriftUnaryHandler) Handle(ctx context.Context, treq *transport.Request,
 
 		if applicationErrorMetaSetter, ok := rw.(transport.ApplicationErrorMetaSetter); ok {
 			applicationErrorMetaSetter.SetApplicationErrorMeta(&transport.ApplicationErrorMeta{
-				Err:  res.ApplicationError,
-				Name: res.ApplicationErrorName,
-				Code: res.ApplicationErrorCode,
+				Message: res.ApplicationErrorMessage,
+				Name:    res.ApplicationErrorName,
+				Code:    res.ApplicationErrorCode,
 			})
 		}
 	}

--- a/encoding/thrift/internal/observabilitytest/test/testserviceserver/server.go
+++ b/encoding/thrift/internal/observabilitytest/test/testserviceserver/server.go
@@ -97,7 +97,9 @@ func (h handler) Call(ctx context.Context, body wire.Value) (thrift.Response, er
 		if extractor, ok := appErr.(yarpcErrorCoder); ok {
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
-		response.ApplicationError = appErr
+		if appErr != nil {
+			response.ApplicationErrorMessage = appErr.Error()
+		}
 	}
 
 	return response, err

--- a/encoding/thrift/observability_test.go
+++ b/encoding/thrift/observability_test.go
@@ -75,6 +75,7 @@ func TestThriftExceptionObservability(t *testing.T) {
 				zap.String("error", "application_error"),
 				zap.String("errorName", "ExceptionWithCode"),
 				zap.String("errorCode", "invalid-argument"),
+				zap.String("appErrorMessage", "ExceptionWithCode{Val: exception with code}"),
 			}
 			assertLogs(t, wantFields, observedLogs.TakeAll())
 		})
@@ -116,6 +117,7 @@ func TestThriftExceptionObservability(t *testing.T) {
 			wantFields := []zapcore.Field{
 				zap.String("error", "application_error"),
 				zap.String("errorName", "ExceptionWithoutCode"),
+				zap.String("appErrorMessage", "ExceptionWithoutCode{Val: exception with no code}"),
 			}
 			assertLogs(t, wantFields, observedLogs.TakeAll())
 		})

--- a/encoding/thrift/response.go
+++ b/encoding/thrift/response.go
@@ -31,9 +31,7 @@ type Response struct {
 
 	IsApplicationError bool
 
-	ApplicationError error
-
-	ApplicationErrorName string
-
-	ApplicationErrorCode *yarpcerrors.Code
+	ApplicationErrorMessage string
+	ApplicationErrorName    string
+	ApplicationErrorCode    *yarpcerrors.Code
 }

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/readonlystoreserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/readonlystoreserver/server.go
@@ -91,7 +91,9 @@ func (h handler) Integer(ctx context.Context, body wire.Value) (thrift.Response,
 		if extractor, ok := appErr.(yarpcErrorCoder); ok {
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
-		response.ApplicationError = appErr
+		if appErr != nil {
+			response.ApplicationErrorMessage = appErr.Error()
+		}
 	}
 
 	return response, err

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storeserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storeserver/server.go
@@ -124,7 +124,9 @@ func (h handler) CompareAndSwap(ctx context.Context, body wire.Value) (thrift.Re
 		if extractor, ok := appErr.(yarpcErrorCoder); ok {
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
-		response.ApplicationError = appErr
+		if appErr != nil {
+			response.ApplicationErrorMessage = appErr.Error()
+		}
 	}
 
 	return response, err
@@ -161,7 +163,9 @@ func (h handler) Increment(ctx context.Context, body wire.Value) (thrift.Respons
 		if extractor, ok := appErr.(yarpcErrorCoder); ok {
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
-		response.ApplicationError = appErr
+		if appErr != nil {
+			response.ApplicationErrorMessage = appErr.Error()
+		}
 	}
 
 	return response, err

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/baseserviceserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/baseserviceserver/server.go
@@ -76,7 +76,9 @@ func (h handler) Healthy(ctx context.Context, body wire.Value) (thrift.Response,
 		if extractor, ok := appErr.(yarpcErrorCoder); ok {
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
-		response.ApplicationError = appErr
+		if appErr != nil {
+			response.ApplicationErrorMessage = appErr.Error()
+		}
 	}
 
 	return response, err

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendemptyserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendemptyserver/server.go
@@ -90,7 +90,9 @@ func (h handler) Hello(ctx context.Context, body wire.Value) (thrift.Response, e
 		if extractor, ok := appErr.(yarpcErrorCoder); ok {
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
-		response.ApplicationError = appErr
+		if appErr != nil {
+			response.ApplicationErrorMessage = appErr.Error()
+		}
 	}
 
 	return response, err

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/nameserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/nameserver/server.go
@@ -76,7 +76,9 @@ func (h handler) Name(ctx context.Context, body wire.Value) (thrift.Response, er
 		if extractor, ok := appErr.(yarpcErrorCoder); ok {
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
-		response.ApplicationError = appErr
+		if appErr != nil {
+			response.ApplicationErrorMessage = appErr.Error()
+		}
 	}
 
 	return response, err

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/weather/weatherserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/weather/weatherserver/server.go
@@ -76,7 +76,9 @@ func (h handler) Check(ctx context.Context, body wire.Value) (thrift.Response, e
 		if extractor, ok := appErr.(yarpcErrorCoder); ok {
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
-		response.ApplicationError = appErr
+		if appErr != nil {
+			response.ApplicationErrorMessage = appErr.Error()
+		}
 	}
 
 	return response, err

--- a/encoding/thrift/thriftrw-plugin-yarpc/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/server.go
@@ -165,7 +165,9 @@ func (h handler) <.Name>(ctx <$context>.Context, body <$wire>.Value) (<$thrift>.
 		if extractor, ok := appErr.(yarpcErrorCoder); ok {
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
-		response.ApplicationError = appErr
+		if appErr != nil {
+			response.ApplicationErrorMessage = appErr.Error()
+		}
 	}
 
 	return response, err

--- a/internal/crossdock/thrift/echo/echoserver/server.go
+++ b/internal/crossdock/thrift/echo/echoserver/server.go
@@ -97,7 +97,9 @@ func (h handler) Echo(ctx context.Context, body wire.Value) (thrift.Response, er
 		if extractor, ok := appErr.(yarpcErrorCoder); ok {
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
-		response.ApplicationError = appErr
+		if appErr != nil {
+			response.ApplicationErrorMessage = appErr.Error()
+		}
 	}
 
 	return response, err

--- a/internal/crossdock/thrift/gauntlet/secondserviceserver/server.go
+++ b/internal/crossdock/thrift/gauntlet/secondserviceserver/server.go
@@ -112,7 +112,9 @@ func (h handler) BlahBlah(ctx context.Context, body wire.Value) (thrift.Response
 		if extractor, ok := appErr.(yarpcErrorCoder); ok {
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
-		response.ApplicationError = appErr
+		if appErr != nil {
+			response.ApplicationErrorMessage = appErr.Error()
+		}
 	}
 
 	return response, err
@@ -140,7 +142,9 @@ func (h handler) SecondtestString(ctx context.Context, body wire.Value) (thrift.
 		if extractor, ok := appErr.(yarpcErrorCoder); ok {
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
-		response.ApplicationError = appErr
+		if appErr != nil {
+			response.ApplicationErrorMessage = appErr.Error()
+		}
 	}
 
 	return response, err

--- a/internal/crossdock/thrift/gauntlet/thrifttestserver/server.go
+++ b/internal/crossdock/thrift/gauntlet/thrifttestserver/server.go
@@ -422,7 +422,9 @@ func (h handler) TestBinary(ctx context.Context, body wire.Value) (thrift.Respon
 		if extractor, ok := appErr.(yarpcErrorCoder); ok {
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
-		response.ApplicationError = appErr
+		if appErr != nil {
+			response.ApplicationErrorMessage = appErr.Error()
+		}
 	}
 
 	return response, err
@@ -450,7 +452,9 @@ func (h handler) TestByte(ctx context.Context, body wire.Value) (thrift.Response
 		if extractor, ok := appErr.(yarpcErrorCoder); ok {
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
-		response.ApplicationError = appErr
+		if appErr != nil {
+			response.ApplicationErrorMessage = appErr.Error()
+		}
 	}
 
 	return response, err
@@ -478,7 +482,9 @@ func (h handler) TestDouble(ctx context.Context, body wire.Value) (thrift.Respon
 		if extractor, ok := appErr.(yarpcErrorCoder); ok {
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
-		response.ApplicationError = appErr
+		if appErr != nil {
+			response.ApplicationErrorMessage = appErr.Error()
+		}
 	}
 
 	return response, err
@@ -506,7 +512,9 @@ func (h handler) TestEnum(ctx context.Context, body wire.Value) (thrift.Response
 		if extractor, ok := appErr.(yarpcErrorCoder); ok {
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
-		response.ApplicationError = appErr
+		if appErr != nil {
+			response.ApplicationErrorMessage = appErr.Error()
+		}
 	}
 
 	return response, err
@@ -534,7 +542,9 @@ func (h handler) TestException(ctx context.Context, body wire.Value) (thrift.Res
 		if extractor, ok := appErr.(yarpcErrorCoder); ok {
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
-		response.ApplicationError = appErr
+		if appErr != nil {
+			response.ApplicationErrorMessage = appErr.Error()
+		}
 	}
 
 	return response, err
@@ -562,7 +572,9 @@ func (h handler) TestI32(ctx context.Context, body wire.Value) (thrift.Response,
 		if extractor, ok := appErr.(yarpcErrorCoder); ok {
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
-		response.ApplicationError = appErr
+		if appErr != nil {
+			response.ApplicationErrorMessage = appErr.Error()
+		}
 	}
 
 	return response, err
@@ -590,7 +602,9 @@ func (h handler) TestI64(ctx context.Context, body wire.Value) (thrift.Response,
 		if extractor, ok := appErr.(yarpcErrorCoder); ok {
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
-		response.ApplicationError = appErr
+		if appErr != nil {
+			response.ApplicationErrorMessage = appErr.Error()
+		}
 	}
 
 	return response, err
@@ -618,7 +632,9 @@ func (h handler) TestInsanity(ctx context.Context, body wire.Value) (thrift.Resp
 		if extractor, ok := appErr.(yarpcErrorCoder); ok {
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
-		response.ApplicationError = appErr
+		if appErr != nil {
+			response.ApplicationErrorMessage = appErr.Error()
+		}
 	}
 
 	return response, err
@@ -646,7 +662,9 @@ func (h handler) TestList(ctx context.Context, body wire.Value) (thrift.Response
 		if extractor, ok := appErr.(yarpcErrorCoder); ok {
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
-		response.ApplicationError = appErr
+		if appErr != nil {
+			response.ApplicationErrorMessage = appErr.Error()
+		}
 	}
 
 	return response, err
@@ -674,7 +692,9 @@ func (h handler) TestMap(ctx context.Context, body wire.Value) (thrift.Response,
 		if extractor, ok := appErr.(yarpcErrorCoder); ok {
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
-		response.ApplicationError = appErr
+		if appErr != nil {
+			response.ApplicationErrorMessage = appErr.Error()
+		}
 	}
 
 	return response, err
@@ -702,7 +722,9 @@ func (h handler) TestMapMap(ctx context.Context, body wire.Value) (thrift.Respon
 		if extractor, ok := appErr.(yarpcErrorCoder); ok {
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
-		response.ApplicationError = appErr
+		if appErr != nil {
+			response.ApplicationErrorMessage = appErr.Error()
+		}
 	}
 
 	return response, err
@@ -730,7 +752,9 @@ func (h handler) TestMulti(ctx context.Context, body wire.Value) (thrift.Respons
 		if extractor, ok := appErr.(yarpcErrorCoder); ok {
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
-		response.ApplicationError = appErr
+		if appErr != nil {
+			response.ApplicationErrorMessage = appErr.Error()
+		}
 	}
 
 	return response, err
@@ -758,7 +782,9 @@ func (h handler) TestMultiException(ctx context.Context, body wire.Value) (thrif
 		if extractor, ok := appErr.(yarpcErrorCoder); ok {
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
-		response.ApplicationError = appErr
+		if appErr != nil {
+			response.ApplicationErrorMessage = appErr.Error()
+		}
 	}
 
 	return response, err
@@ -786,7 +812,9 @@ func (h handler) TestNest(ctx context.Context, body wire.Value) (thrift.Response
 		if extractor, ok := appErr.(yarpcErrorCoder); ok {
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
-		response.ApplicationError = appErr
+		if appErr != nil {
+			response.ApplicationErrorMessage = appErr.Error()
+		}
 	}
 
 	return response, err
@@ -823,7 +851,9 @@ func (h handler) TestSet(ctx context.Context, body wire.Value) (thrift.Response,
 		if extractor, ok := appErr.(yarpcErrorCoder); ok {
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
-		response.ApplicationError = appErr
+		if appErr != nil {
+			response.ApplicationErrorMessage = appErr.Error()
+		}
 	}
 
 	return response, err
@@ -851,7 +881,9 @@ func (h handler) TestString(ctx context.Context, body wire.Value) (thrift.Respon
 		if extractor, ok := appErr.(yarpcErrorCoder); ok {
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
-		response.ApplicationError = appErr
+		if appErr != nil {
+			response.ApplicationErrorMessage = appErr.Error()
+		}
 	}
 
 	return response, err
@@ -879,7 +911,9 @@ func (h handler) TestStringMap(ctx context.Context, body wire.Value) (thrift.Res
 		if extractor, ok := appErr.(yarpcErrorCoder); ok {
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
-		response.ApplicationError = appErr
+		if appErr != nil {
+			response.ApplicationErrorMessage = appErr.Error()
+		}
 	}
 
 	return response, err
@@ -907,7 +941,9 @@ func (h handler) TestStruct(ctx context.Context, body wire.Value) (thrift.Respon
 		if extractor, ok := appErr.(yarpcErrorCoder); ok {
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
-		response.ApplicationError = appErr
+		if appErr != nil {
+			response.ApplicationErrorMessage = appErr.Error()
+		}
 	}
 
 	return response, err
@@ -935,7 +971,9 @@ func (h handler) TestTypedef(ctx context.Context, body wire.Value) (thrift.Respo
 		if extractor, ok := appErr.(yarpcErrorCoder); ok {
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
-		response.ApplicationError = appErr
+		if appErr != nil {
+			response.ApplicationErrorMessage = appErr.Error()
+		}
 	}
 
 	return response, err
@@ -963,7 +1001,9 @@ func (h handler) TestVoid(ctx context.Context, body wire.Value) (thrift.Response
 		if extractor, ok := appErr.(yarpcErrorCoder); ok {
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
-		response.ApplicationError = appErr
+		if appErr != nil {
+			response.ApplicationErrorMessage = appErr.Error()
+		}
 	}
 
 	return response, err

--- a/internal/examples/thrift-hello/hello/echo/helloserver/server.go
+++ b/internal/examples/thrift-hello/hello/echo/helloserver/server.go
@@ -97,7 +97,9 @@ func (h handler) Echo(ctx context.Context, body wire.Value) (thrift.Response, er
 		if extractor, ok := appErr.(yarpcErrorCoder); ok {
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
-		response.ApplicationError = appErr
+		if appErr != nil {
+			response.ApplicationErrorMessage = appErr.Error()
+		}
 	}
 
 	return response, err

--- a/internal/examples/thrift-keyvalue/keyvalue/kv/keyvalueserver/server.go
+++ b/internal/examples/thrift-keyvalue/keyvalue/kv/keyvalueserver/server.go
@@ -114,7 +114,9 @@ func (h handler) GetValue(ctx context.Context, body wire.Value) (thrift.Response
 		if extractor, ok := appErr.(yarpcErrorCoder); ok {
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
-		response.ApplicationError = appErr
+		if appErr != nil {
+			response.ApplicationErrorMessage = appErr.Error()
+		}
 	}
 
 	return response, err
@@ -142,7 +144,9 @@ func (h handler) SetValue(ctx context.Context, body wire.Value) (thrift.Response
 		if extractor, ok := appErr.(yarpcErrorCoder); ok {
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
-		response.ApplicationError = appErr
+		if appErr != nil {
+			response.ApplicationErrorMessage = appErr.Error()
+		}
 	}
 
 	return response, err

--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -32,15 +32,19 @@ import (
 )
 
 const (
-	_error               = "error"
+	_error = "error"
+
 	_errorNameMetricsKey = "error_name"
-	_errorNameLogKey     = "errorName"
-	_errorCodeLogKey     = "errorCode"
 	_notSet              = "__not_set__"
-	_successfulInbound   = "Handled inbound request."
-	_successfulOutbound  = "Made outbound call."
-	_errorInbound        = "Error handling inbound request."
-	_errorOutbound       = "Error making outbound call."
+
+	_errorNameLogKey       = "errorName"
+	_errorCodeLogKey       = "errorCode"
+	_appErrorMessageLogKey = "appErrorMessage"
+
+	_successfulInbound  = "Handled inbound request."
+	_successfulOutbound = "Made outbound call."
+	_errorInbound       = "Error handling inbound request."
+	_errorOutbound      = "Error making outbound call."
 
 	_successStreamOpen  = "Successfully created stream"
 	_successStreamClose = "Successfully closed stream"
@@ -60,7 +64,7 @@ const (
 type call struct {
 	edge    *edge
 	extract ContextExtractor
-	fields  [8]zapcore.Field
+	fields  [9]zapcore.Field
 
 	started   time.Time
 	ctx       context.Context
@@ -193,6 +197,9 @@ func (c call) endLogs(
 			}
 			if applicationErrorMeta.Code != nil {
 				fields = append(fields, zap.String(_errorCodeLogKey, applicationErrorMeta.Code.String()))
+			}
+			if applicationErrorMeta.Message != "" {
+				fields = append(fields, zap.String(_appErrorMessageLogKey, applicationErrorMeta.Message))
 			}
 		}
 	} else {

--- a/internal/observability/common_test.go
+++ b/internal/observability/common_test.go
@@ -51,7 +51,6 @@ func (h fakeHandler) Handle(_ context.Context, _ *transport.Request, rw transpor
 
 	if applicationErrorMetaSetter, ok := rw.(transport.ApplicationErrorMetaSetter); ok {
 		applicationErrorMetaSetter.SetApplicationErrorMeta(&transport.ApplicationErrorMeta{
-			Err:  nil,
 			Name: h.applicationErrName,
 			Code: h.applicationErrCode,
 		})
@@ -91,9 +90,9 @@ func (o fakeOutbound) Call(context.Context, *transport.Request) (*transport.Resp
 	return &transport.Response{
 		ApplicationError: o.applicationErr,
 		ApplicationErrorMeta: &transport.ApplicationErrorMeta{
-			Err:  nil,
-			Name: o.applicationErrName,
-			Code: o.applicationErrCode,
+			Message: "",
+			Name:    o.applicationErrName,
+			Code:    o.applicationErrCode,
 		}}, o.err
 }
 

--- a/transport/tchannel/constants.go
+++ b/transport/tchannel/constants.go
@@ -22,10 +22,17 @@ package tchannel
 
 import "time"
 
-// TransportName is the name of the transport.
-//
-// This value is what is used as transport.Request#Transport and transport.Namer
-// for Outbounds.
-const TransportName = "tchannel"
+const (
+	// TransportName is the name of the transport.
+	//
+	// This value is what is used as transport.Request#Transport and transport.Namer
+	// for Outbounds.
+	TransportName = "tchannel"
+
+	// largest header value length for `transport.ApplicationErrorMeta#Message`
+	_maxAppErrMessageHeaderLen = 256
+	// truncated message if we've exceeded the '_maxAppErrMessageHeaderLen'
+	_truncatedHeaderMessage = " (truncated)"
+)
 
 var defaultConnTimeout = 500 * time.Millisecond

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -273,13 +273,14 @@ func (hw *handlerWriter) SetApplicationErrorMeta(applicationErrorMeta *transport
 	if applicationErrorMeta == nil {
 		return
 	}
-
 	if applicationErrorMeta.Code != nil {
 		hw.AddHeader(ApplicationErrorCodeHeaderKey, strconv.Itoa(int(*applicationErrorMeta.Code)))
 	}
-
 	if applicationErrorMeta.Name != "" {
 		hw.AddHeader(ApplicationErrorNameHeaderKey, applicationErrorMeta.Name)
+	}
+	if applicationErrorMeta.Message != "" {
+		hw.AddHeader(ApplicationErrorMessageHeaderKey, applicationErrorMeta.Message)
 	}
 }
 

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -280,8 +280,16 @@ func (hw *handlerWriter) SetApplicationErrorMeta(applicationErrorMeta *transport
 		hw.AddHeader(ApplicationErrorNameHeaderKey, applicationErrorMeta.Name)
 	}
 	if applicationErrorMeta.Message != "" {
-		hw.AddHeader(ApplicationErrorMessageHeaderKey, applicationErrorMeta.Message)
+		hw.AddHeader(ApplicationErrorMessageHeaderKey, truncateAppErrMessage(applicationErrorMeta.Message))
 	}
+}
+
+func truncateAppErrMessage(val string) string {
+	if len(val) <= _maxAppErrMessageHeaderLen {
+		return val
+	}
+	stripIndex := len(val) - len(_truncatedHeaderMessage) - 1
+	return val[:stripIndex] + _truncatedHeaderMessage
 }
 
 func (hw *handlerWriter) IsApplicationError() bool {

--- a/transport/tchannel/handler_test.go
+++ b/transport/tchannel/handler_test.go
@@ -553,16 +553,18 @@ func TestResponseWriter(t *testing.T) {
 				w.SetApplicationError()
 				w.SetApplicationErrorMeta(
 					&transport.ApplicationErrorMeta{
-						Name: "bAz",
-						Code: &yErrAborted,
+						Name:    "bAz",
+						Code:    &yErrAborted,
+						Message: "App Error Message",
 					},
 				)
 				_, err := w.Write([]byte("hello"))
 				require.NoError(t, err)
 			},
 			arg2: map[string]string{
-				"$rpc$-application-error-code": "10",
-				"$rpc$-application-error-name": "bAz",
+				"$rpc$-application-error-code":    "10",
+				"$rpc$-application-error-name":    "bAz",
+				"$rpc$-application-error-message": "App Error Message",
 			},
 			arg3:             []byte("hello"),
 			applicationError: true,

--- a/transport/tchannel/header.go
+++ b/transport/tchannel/header.go
@@ -43,17 +43,20 @@ const (
 	ServiceHeaderKey = "$rpc$-service"
 	// ApplicationErrorNameHeaderKey is the response header key for the application error name.
 	ApplicationErrorNameHeaderKey = "$rpc$-application-error-name"
+	// ApplicationErrorMessageHeaderKey is the response header key for the application error messages.
+	ApplicationErrorMessageHeaderKey = "$rpc$-application-error-message"
 	// ApplicationErrorCodeHeaderKey is the response header key for the application error code.
 	ApplicationErrorCodeHeaderKey = "$rpc$-application-error-code"
 )
 
 var _reservedHeaderKeys = map[string]struct{}{
-	ErrorCodeHeaderKey:            {},
-	ErrorNameHeaderKey:            {},
-	ErrorMessageHeaderKey:         {},
-	ServiceHeaderKey:              {},
-	ApplicationErrorNameHeaderKey: {},
-	ApplicationErrorCodeHeaderKey: {},
+	ErrorCodeHeaderKey:               {},
+	ErrorNameHeaderKey:               {},
+	ErrorMessageHeaderKey:            {},
+	ServiceHeaderKey:                 {},
+	ApplicationErrorNameHeaderKey:    {},
+	ApplicationErrorMessageHeaderKey: {},
+	ApplicationErrorCodeHeaderKey:    {},
 }
 
 func isReservedHeaderKey(key string) bool {

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -178,6 +178,7 @@ func callWithPeer(ctx context.Context, req *transport.Request, peer *tchannel.Pe
 
 	applicationErrorName, _ := headers.Get(ApplicationErrorNameHeaderKey)
 	applicationErrorCode := getApplicationErrorCodeFromHeaders(headers)
+	applicationErrorMessage, _ := headers.Get(ApplicationErrorMessageHeaderKey)
 
 	err = getResponseError(headers)
 	deleteReservedHeaders(headers)
@@ -187,7 +188,7 @@ func callWithPeer(ctx context.Context, req *transport.Request, peer *tchannel.Pe
 		Body:             resBody,
 		ApplicationError: res.ApplicationError(),
 		ApplicationErrorMeta: &transport.ApplicationErrorMeta{
-			Message: "",
+			Message: applicationErrorMessage,
 			Name:    applicationErrorName,
 			Code:    applicationErrorCode,
 		},

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -187,9 +187,9 @@ func callWithPeer(ctx context.Context, req *transport.Request, peer *tchannel.Pe
 		Body:             resBody,
 		ApplicationError: res.ApplicationError(),
 		ApplicationErrorMeta: &transport.ApplicationErrorMeta{
-			Err:  nil,
-			Name: applicationErrorName,
-			Code: applicationErrorCode,
+			Message: "",
+			Name:    applicationErrorName,
+			Code:    applicationErrorCode,
 		},
 	}
 	return resp, err

--- a/transport/tchannel/outbound_test.go
+++ b/transport/tchannel/outbound_test.go
@@ -295,13 +295,16 @@ func TestApplicationError(t *testing.T) {
 			err := writeArgs(
 				call.Response(),
 				[]byte{
-					0x00, 0x02,
+					0x00, 0x03,
 					0x00, 0x1c, '$', 'r', 'p', 'c', '$', '-', 'a', 'p', 'p', 'l', 'i', 'c', 'a', 't', 'i', 'o', 'n',
 					'-', 'e', 'r', 'r', 'o', 'r', '-', 'c', 'o', 'd', 'e',
 					0x00, 0x02, '1', '0',
 					0x00, 0x1c, '$', 'r', 'p', 'c', '$', '-', 'a', 'p', 'p', 'l', 'i', 'c', 'a', 't', 'i', 'o', 'n',
 					'-', 'e', 'r', 'r', 'o', 'r', '-', 'n', 'a', 'm', 'e',
 					0x00, 0x03, 'b', 'A', 'z',
+					0x00, 0x1f, '$', 'r', 'p', 'c', '$', '-', 'a', 'p', 'p', 'l', 'i', 'c', 'a', 't', 'i', 'o', 'n',
+					'-', 'e', 'r', 'r', 'o', 'r', '-', 'm', 'e', 's', 's', 'a', 'g', 'e',
+					0x00, 0x03, 'F', 'o', 'O',
 				},
 				[]byte("foo"),
 			)
@@ -325,8 +328,9 @@ func TestApplicationError(t *testing.T) {
 		},
 	)
 	require.NoError(t, err, "failed to make call")
-	assert.True(t, res.ApplicationError, "application error was not set")
-	assert.NotNil(t, res.ApplicationErrorMeta.Code, "application error code was not set")
+	require.True(t, res.ApplicationError, "application error was not set")
+	require.NotNil(t, res.ApplicationErrorMeta.Code, "application error code was not set")
+	assert.Equal(t, "FoO", res.ApplicationErrorMeta.Message, "unexpected error message")
 	assert.Equal(
 		t,
 		yarpcerrors.CodeAborted,


### PR DESCRIPTION
This introduces a series of individually reviewable commits that enables the
observability middleware to log the string version of a Thrift exception (ie
calling the `Error()` method on an exception), making Thrift exception logs more
useful. A previous PR already adds the Thrift exception name to logs.

Note that the `ApplicationErrorMeta` field `Err` is renamed to `Message`. This
code has not been released and is therefore not a breaking change.

Fixes T3302757

- [x] Description and context for reviewers: one partner, one stranger
- [x] Entry in CHANGELOG.md
