### PR TITLE
thrift: use more generic `rpc.code` annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - observability: Errors are logged with their associated error code under the
   `errorCode` field. Errors created outside of `protobuf.NewError` and
   `yarpcerrors` will yield `CodeUnknown`.
-- Using the `yarpc.code` annotation, services may specify an associated
+- Using the `rpc.code` annotation, services may specify an associated
 `yarpcerrors.Code` for Thrift exceptions (TChannel-only).
 - Metrics and logs now include Thrift exception names and related YARPC code, if
-  annotated. If a `yarpc.code` annotation is specified for a Thrift exception,
+  annotated. If a `rpc.code` annotation is specified for a Thrift exception,
   metrics will classify it as a client or server failure, like a `yarpcerrors`
   error. If the YARPC code is not specified for the Thrift exception, it will
   continue to be assumed a client failure. (TChannel-only)

--- a/encoding/thrift/internal/observabilitytest/test.thrift
+++ b/encoding/thrift/internal/observabilitytest/test.thrift
@@ -1,7 +1,7 @@
 exception ExceptionWithCode {
     1: required string val
 } (
-    yarpc.code = "invalid-argument"
+    rpc.code = "invalid-argument"
 )
 
 exception ExceptionWithoutCode {

--- a/encoding/thrift/internal/observabilitytest/test/test.go
+++ b/encoding/thrift/internal/observabilitytest/test/test.go
@@ -318,11 +318,11 @@ var ThriftModule = &thriftreflect.ThriftModule{
 	Name:     "test",
 	Package:  "go.uber.org/yarpc/encoding/thrift/internal/observabilitytest/test",
 	FilePath: "test.thrift",
-	SHA1:     "cdf6876939a1ea3a06a7bc8657588e71cab4de97",
+	SHA1:     "ce9de193a0c4d26a1c123f56d81ee4ec06b4cda7",
 	Raw:      rawIDL,
 }
 
-const rawIDL = "exception ExceptionWithCode {\n    1: required string val\n} (\n    yarpc.code = \"invalid-argument\"\n)\n\nexception ExceptionWithoutCode {\n    1: required string val\n}\n\nservice TestService  {\n    string Call(1: required string key) throws (\n      1: ExceptionWithCode exCode,\n      2: ExceptionWithoutCode exNoCode,\n    )\n}\n"
+const rawIDL = "exception ExceptionWithCode {\n    1: required string val\n} (\n    rpc.code = \"invalid-argument\"\n)\n\nexception ExceptionWithoutCode {\n    1: required string val\n}\n\nservice TestService  {\n    string Call(1: required string key) throws (\n      1: ExceptionWithCode exCode,\n      2: ExceptionWithoutCode exNoCode,\n    )\n}\n"
 
 // TestService_Call_Args represents the arguments for the TestService.Call function.
 //

--- a/encoding/thrift/internal/observabilitytest/test/types_yarpc.go
+++ b/encoding/thrift/internal/observabilitytest/test/types_yarpc.go
@@ -27,7 +27,7 @@ import yarpcerrors "go.uber.org/yarpc/yarpcerrors"
 
 // YARPCErrorCode returns a yarpcerrors.CodeInvalidArgument for ExceptionWithCode.
 //
-// This is derived from the yarpc.code annotation on the Thrift exception.
+// This is derived from the rpc.code annotation on the Thrift exception.
 func (e *ExceptionWithCode) YARPCErrorCode() *yarpcerrors.Code {
 	code := yarpcerrors.CodeInvalidArgument
 	return &code
@@ -38,7 +38,7 @@ func (e *ExceptionWithCode) YARPCErrorName() string { return "ExceptionWithCode"
 
 // YARPCErrorCode returns nil for ExceptionWithoutCode.
 //
-// This is derived from the yarpc.code annotation on the Thrift exception.
+// This is derived from the rpc.code annotation on the Thrift exception.
 func (e *ExceptionWithoutCode) YARPCErrorCode() *yarpcerrors.Code {
 
 	return nil

--- a/encoding/thrift/thriftrw-plugin-yarpc/exception.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/exception.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	_errorCodeAnnotationKey = "yarpc.code"
+	_errorCodeAnnotationKey = "rpc.code"
 )
 
 const yarpcerrorTemplate = `
@@ -46,7 +46,7 @@ package <$pkgname>
 	<$yarpcerrors := import "go.uber.org/yarpc/yarpcerrors" ->
 	// YARPCErrorCode returns <if isSetYARPCCode .Annotations>a <getYARPCErrorCode .><else>nil<end> for <$val.Name>.
 	//
-	// This is derived from the yarpc.code annotation on the Thrift exception.
+	// This is derived from the rpc.code annotation on the Thrift exception.
 	func (e *<$val.Name>) YARPCErrorCode() *<$yarpcerrors>.Code {
 		<if isSetYARPCCode .Annotations>code := <getYARPCErrorCode .>
 		return &code
@@ -122,7 +122,7 @@ func getYARPCErrorCode(t *compile.StructSpec) string {
 	var errorCode yarpcerrors.Code
 
 	if err := errorCode.UnmarshalText([]byte(errorCodeString)); err != nil {
-		panic(fmt.Sprintf("invalid yarpc.code annotation: %s\n%s", err.Error(), _availableCodes))
+		panic(fmt.Sprintf("invalid rpc.code annotation: %s\n%s", err.Error(), _availableCodes))
 	}
 
 	result, ok := _errorCodeToTypeName[errorCode]

--- a/encoding/thrift/thriftrw-plugin-yarpc/exception_test.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/exception_test.go
@@ -44,7 +44,7 @@ func TestGetYARPCErrorCode(t *testing.T) {
 			Annotations: map[string]string{_errorCodeAnnotationKey: "foo"},
 		}
 		assert.PanicsWithValue(t,
-			"invalid yarpc.code annotation: unknown code string: foo\nAvailable codes: cancelled,unknown,invalid-argument,deadline-exceeded,not-found,already-exists,permission-denied,resource-exhausted,failed-precondition,aborted,out-of-range,unimplemented,internal,unavailable,data-loss,unauthenticated",
+			"invalid rpc.code annotation: unknown code string: foo\nAvailable codes: cancelled,unknown,invalid-argument,deadline-exceeded,not-found,already-exists,permission-denied,resource-exhausted,failed-precondition,aborted,out-of-range,unimplemented,internal,unavailable,data-loss,unauthenticated",
 			func() { getYARPCErrorCode(spec) },
 			"unexpected panic")
 	})

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic.thrift
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic.thrift
@@ -3,14 +3,14 @@ include "./common.thrift"
 exception KeyDoesNotExist {
     1: optional string key
 } (
-    yarpc.code = "invalid-argument"
+    rpc.code = "invalid-argument"
 )
 
 exception IntegerMismatchError {
     1: required i64 expectedValue
     2: required i64 gotValue
 } (
-    yarpc.code = "invalid-argument"
+    rpc.code = "invalid-argument"
 )
 
 struct CompareAndSwap {

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/atomic.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/atomic.go
@@ -933,14 +933,14 @@ var ThriftModule = &thriftreflect.ThriftModule{
 	Name:     "atomic",
 	Package:  "go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic",
 	FilePath: "atomic.thrift",
-	SHA1:     "5fa4db5d11736b0e054eab0c770e37bd133667ff",
+	SHA1:     "47c002a62f6db940ca97b53d72f12f4732e35f4c",
 	Includes: []*thriftreflect.ThriftModule{
 		common.ThriftModule,
 	},
 	Raw: rawIDL,
 }
 
-const rawIDL = "include \"./common.thrift\"\n\nexception KeyDoesNotExist {\n    1: optional string key\n} (\n    yarpc.code = \"invalid-argument\"\n)\n\nexception IntegerMismatchError {\n    1: required i64 expectedValue\n    2: required i64 gotValue\n} (\n    yarpc.code = \"invalid-argument\"\n)\n\nstruct CompareAndSwap {\n    1: required string key\n    2: required i64 currentValue\n    3: required i64 newValue\n}\n\nservice ReadOnlyStore extends common.BaseService {\n    i64 integer(1: string key) throws (1: KeyDoesNotExist doesNotExist)\n}\n\nservice Store extends ReadOnlyStore {\n    void increment(1: string key, 2: i64 value)\n\n    void compareAndSwap(1: CompareAndSwap request)\n        throws (1: IntegerMismatchError mismatch)\n\n    oneway void forget(1: string key)\n}\n\n\n// This struct intentionally has the same shape as the `CompareAndSwap` wrapper\n// `Store_CompareAndSwap_Args`, except all fields are optional.\n\n// We use this to generate an invalid payload for testing.\nstruct OptionalCompareAndSwapWrapper {\n    1: optional OptionalCompareAndSwap cas\n}\n\nstruct OptionalCompareAndSwap {\n    1: optional string key\n    2: optional i64 currentValue\n    3: optional i64 newValue\n}\n"
+const rawIDL = "include \"./common.thrift\"\n\nexception KeyDoesNotExist {\n    1: optional string key\n} (\n    rpc.code = \"invalid-argument\"\n)\n\nexception IntegerMismatchError {\n    1: required i64 expectedValue\n    2: required i64 gotValue\n} (\n    rpc.code = \"invalid-argument\"\n)\n\nstruct CompareAndSwap {\n    1: required string key\n    2: required i64 currentValue\n    3: required i64 newValue\n}\n\nservice ReadOnlyStore extends common.BaseService {\n    i64 integer(1: string key) throws (1: KeyDoesNotExist doesNotExist)\n}\n\nservice Store extends ReadOnlyStore {\n    void increment(1: string key, 2: i64 value)\n\n    void compareAndSwap(1: CompareAndSwap request)\n        throws (1: IntegerMismatchError mismatch)\n\n    oneway void forget(1: string key)\n}\n\n\n// This struct intentionally has the same shape as the `CompareAndSwap` wrapper\n// `Store_CompareAndSwap_Args`, except all fields are optional.\n\n// We use this to generate an invalid payload for testing.\nstruct OptionalCompareAndSwapWrapper {\n    1: optional OptionalCompareAndSwap cas\n}\n\nstruct OptionalCompareAndSwap {\n    1: optional string key\n    2: optional i64 currentValue\n    3: optional i64 newValue\n}\n"
 
 // ReadOnlyStore_Integer_Args represents the arguments for the ReadOnlyStore.integer function.
 //

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/types_yarpc.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/types_yarpc.go
@@ -7,7 +7,7 @@ import yarpcerrors "go.uber.org/yarpc/yarpcerrors"
 
 // YARPCErrorCode returns a yarpcerrors.CodeInvalidArgument for IntegerMismatchError.
 //
-// This is derived from the yarpc.code annotation on the Thrift exception.
+// This is derived from the rpc.code annotation on the Thrift exception.
 func (e *IntegerMismatchError) YARPCErrorCode() *yarpcerrors.Code {
 	code := yarpcerrors.CodeInvalidArgument
 	return &code
@@ -18,7 +18,7 @@ func (e *IntegerMismatchError) YARPCErrorName() string { return "IntegerMismatch
 
 // YARPCErrorCode returns a yarpcerrors.CodeInvalidArgument for KeyDoesNotExist.
 //
-// This is derived from the yarpc.code annotation on the Thrift exception.
+// This is derived from the rpc.code annotation on the Thrift exception.
 func (e *KeyDoesNotExist) YARPCErrorCode() *yarpcerrors.Code {
 	code := yarpcerrors.CodeInvalidArgument
 	return &code

--- a/encoding/thrift/thriftrw-plugin-yarpc/main.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/main.go
@@ -21,16 +21,16 @@
 // thriftrw-plugin-yarpc implements a plugin for ThriftRW that generates code
 // compatible with YARPC.
 //
-// thriftrw-plugin-yarpc supports "yarpc.code" annotations on Thrift exceptions.
+// thriftrw-plugin-yarpc supports "rpc.code" annotations on Thrift exceptions.
 // For example:
 //
 //  exception ExceptionWithCode {
 //    1: required string val
 //  } (
-//    yarpc.code = "invalid-argument"
+//    rpc.code = "invalid-argument"
 //  )
 //
-// The "yarpc.code" annotation can be any code from yarpcerrors, except
+// The "rpc.code" annotation can be any code from yarpcerrors, except
 // 'CodeOK'. Available string names satisfy `Code.UnmarshalText`. These include:
 //  - "cancelled"
 //  - "unknown"

--- a/internal/crossdock/thrift/gauntlet/types_yarpc.go
+++ b/internal/crossdock/thrift/gauntlet/types_yarpc.go
@@ -27,7 +27,7 @@ import yarpcerrors "go.uber.org/yarpc/yarpcerrors"
 
 // YARPCErrorCode returns nil for Xception.
 //
-// This is derived from the yarpc.code annotation on the Thrift exception.
+// This is derived from the rpc.code annotation on the Thrift exception.
 func (e *Xception) YARPCErrorCode() *yarpcerrors.Code {
 
 	return nil
@@ -38,7 +38,7 @@ func (e *Xception) YARPCErrorName() string { return "Xception" }
 
 // YARPCErrorCode returns nil for Xception2.
 //
-// This is derived from the yarpc.code annotation on the Thrift exception.
+// This is derived from the rpc.code annotation on the Thrift exception.
 func (e *Xception2) YARPCErrorCode() *yarpcerrors.Code {
 
 	return nil

--- a/internal/examples/thrift-keyvalue/keyvalue/kv/types_yarpc.go
+++ b/internal/examples/thrift-keyvalue/keyvalue/kv/types_yarpc.go
@@ -27,7 +27,7 @@ import yarpcerrors "go.uber.org/yarpc/yarpcerrors"
 
 // YARPCErrorCode returns nil for ResourceDoesNotExist.
 //
-// This is derived from the yarpc.code annotation on the Thrift exception.
+// This is derived from the rpc.code annotation on the Thrift exception.
 func (e *ResourceDoesNotExist) YARPCErrorCode() *yarpcerrors.Code {
 
 	return nil


### PR DESCRIPTION
For consistency with other RPC frameworks, like one in Java, ideally
we can use the same terminology and not tie a YARPC/framework specific
annotation to an agnostic Thrift IDL.

This change simply modifies the annotation to `rpc.code` instead
`yarpc.code`.

- [x] Description and context for reviewers: one partner, one stranger
- [x] Docs (package doc)
- [x] Entry in CHANGELOG.md
