### PR TITLE
http: Support transport.ApplicationErrorMeta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `errorCode` field. Errors created outside of `protobuf.NewError` and
   `yarpcerrors` will yield `CodeUnknown`.
 - Using the `rpc.code` annotation, services may specify an associated
-`yarpcerrors.Code` for Thrift exceptions (TChannel-only).
+  `yarpcerrors.Code` for Thrift exceptions.
 - Metrics and logs now include Thrift exception names and related YARPC code, if
   annotated. If a `rpc.code` annotation is specified for a Thrift exception,
   metrics will classify it as a client or server failure, like a `yarpcerrors`
   error. If the YARPC code is not specified for the Thrift exception, it will
-  continue to be assumed a client failure. (TChannel-only)
-- observability: Thrift exceptions are logged under the `appErrMessage` field
-  (TChannel-only).
-
+  continue to be assumed a client failure.
+- observability: Thrift exceptions are logged under the `appErrMessage` field.
 ### Removed
 - Removed `yarpcproto` package that enabled "oneway" Protobuf signatures.
 

--- a/transport/http/constants.go
+++ b/transport/http/constants.go
@@ -104,6 +104,11 @@ const (
 	_applicationErrorNameHeader    = "Rpc-Application-Error-Name"
 	_applicationErrorCodeHeader    = "Rpc-Application-Error-Code"
 	_applicationErrorMessageHeader = "Rpc-Application-Error-Message"
+
+	// largest header value length for `transport.ApplicationErrorMeta#Message`
+	_maxAppErrMessageHeaderLen = 256
+	// truncated message if we've exceeded the '_maxAppErrMessageHeaderLen'
+	_truncatedHeaderMessage = " (truncated)"
 )
 
 // Valid values for the Rpc-Status header.

--- a/transport/http/constants.go
+++ b/transport/http/constants.go
@@ -99,6 +99,13 @@ const (
 	BothResponseErrorHeader = "Rpc-Both-Response-Error"
 )
 
+const (
+	// Headers for propagating transport.ApplicationErrorMeta.
+	_applicationErrorNameHeader    = "Rpc-Application-Error-Name"
+	_applicationErrorCodeHeader    = "Rpc-Application-Error-Code"
+	_applicationErrorMessageHeader = "Rpc-Application-Error-Message"
+)
+
 // Valid values for the Rpc-Status header.
 const (
 	// The request was successful.

--- a/transport/http/handler.go
+++ b/transport/http/handler.go
@@ -25,6 +25,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/opentracing/opentracing-go"
@@ -239,6 +240,11 @@ func (h handler) createSpan(ctx context.Context, req *http.Request, treq *transp
 	return ctx, span
 }
 
+var (
+	_ transport.ResponseWriter             = (*responseWriter)(nil)
+	_ transport.ApplicationErrorMetaSetter = (*responseWriter)(nil)
+)
+
 // responseWriter adapts a http.ResponseWriter into a transport.ResponseWriter.
 type responseWriter struct {
 	w      http.ResponseWriter
@@ -263,6 +269,21 @@ func (rw *responseWriter) AddHeaders(h transport.Headers) {
 
 func (rw *responseWriter) SetApplicationError() {
 	rw.w.Header().Set(ApplicationStatusHeader, ApplicationErrorStatus)
+}
+
+func (rw *responseWriter) SetApplicationErrorMeta(meta *transport.ApplicationErrorMeta) {
+	if meta == nil {
+		return
+	}
+	if meta.Code != nil {
+		rw.w.Header().Set(_applicationErrorCodeHeader, strconv.Itoa(int(*meta.Code)))
+	}
+	if meta.Name != "" {
+		rw.w.Header().Set(_applicationErrorNameHeader, meta.Name)
+	}
+	if meta.Message != "" {
+		rw.w.Header().Set(_applicationErrorMessageHeader, meta.Message)
+	}
 }
 
 func (rw *responseWriter) AddSystemHeader(key string, value string) {

--- a/transport/http/handler.go
+++ b/transport/http/handler.go
@@ -282,8 +282,16 @@ func (rw *responseWriter) SetApplicationErrorMeta(meta *transport.ApplicationErr
 		rw.w.Header().Set(_applicationErrorNameHeader, meta.Name)
 	}
 	if meta.Message != "" {
-		rw.w.Header().Set(_applicationErrorMessageHeader, meta.Message)
+		rw.w.Header().Set(_applicationErrorMessageHeader, truncateAppErrMessage(meta.Message))
 	}
+}
+
+func truncateAppErrMessage(val string) string {
+	if len(val) <= _maxAppErrMessageHeaderLen {
+		return val
+	}
+	stripIndex := _maxAppErrMessageHeaderLen - len(_truncatedHeaderMessage)
+	return val[:stripIndex] + _truncatedHeaderMessage
 }
 
 func (rw *responseWriter) AddSystemHeader(key string, value string) {

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -211,10 +211,18 @@ func TestOutboundHeaders(t *testing.T) {
 }
 
 func TestOutboundApplicationError(t *testing.T) {
+	const (
+		appErrMessage = "thrift ex message"
+		appErrName    = "thrift ex name"
+	)
+
 	tests := []struct {
-		desc     string
-		status   string
-		appError bool
+		desc          string
+		status        string
+		appError      bool
+		appErrName    string
+		appErrMessage string
+		appErrCode    yarpcerrors.Code
 	}{
 		{
 			desc:     "ok",
@@ -222,9 +230,12 @@ func TestOutboundApplicationError(t *testing.T) {
 			appError: false,
 		},
 		{
-			desc:     "error",
-			status:   "error",
-			appError: true,
+			desc:          "error",
+			status:        "error",
+			appError:      true,
+			appErrName:    appErrName,
+			appErrMessage: appErrMessage,
+			appErrCode:    yarpcerrors.CodeNotFound,
 		},
 		{
 			desc:     "not an error",
@@ -239,6 +250,13 @@ func TestOutboundApplicationError(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Add("Rpc-Status", tt.status)
+
+				if tt.appError {
+					w.Header().Add(_applicationErrorMessageHeader, tt.appErrMessage)
+					w.Header().Add(_applicationErrorNameHeader, tt.appErrName)
+					w.Header().Add(_applicationErrorCodeHeader, strconv.Itoa(int(tt.appErrCode)))
+				}
+
 				defer r.Body.Close()
 			},
 		))
@@ -262,6 +280,12 @@ func TestOutboundApplicationError(t *testing.T) {
 		})
 
 		assert.Equal(t, res.ApplicationError, tt.appError, "%v: application status", tt.desc)
+		if tt.appError {
+			require.NotNil(t, res.ApplicationErrorMeta)
+			assert.Equal(t, tt.appErrMessage, res.ApplicationErrorMeta.Message)
+			assert.Equal(t, tt.appErrName, res.ApplicationErrorMeta.Name)
+			assert.Equal(t, &tt.appErrCode, res.ApplicationErrorMeta.Code)
+		}
 
 		if !assert.NoError(t, err, "%v: call failed", tt.desc) {
 			continue

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -288,7 +288,7 @@ func truncateAppErrMessage(val string) string {
 	if len(val) <= _maxAppErrMessageHeaderLen {
 		return val
 	}
-	stripIndex := len(val) - len(_truncatedHeaderMessage) - 1
+	stripIndex := _maxAppErrMessageHeaderLen - len(_truncatedHeaderMessage)
 	return val[:stripIndex] + _truncatedHeaderMessage
 }
 

--- a/transport/tchannel/handler_test.go
+++ b/transport/tchannel/handler_test.go
@@ -784,7 +784,7 @@ func TestTruncatedHeader(t *testing.T) {
 		},
 		{
 			name:         "truncate",
-			value:        strings.Repeat("b", _maxAppErrMessageHeaderLen+1),
+			value:        strings.Repeat("b", _maxAppErrMessageHeaderLen*2),
 			wantTruncate: true,
 		},
 	}


### PR DESCRIPTION
This change brings HTTP parity with TChannel, for propagating the
`transport.ApplicationErrorMeta` type. Concretely, these individually reviewable
commits enable HTTP/Thrift exceptions to have better observability by including
codes (derived by the `rpc.code` annotation on Thrift exceptions) and names to
metrics and logs.

- [x] Description and context for reviewers: one partner, one stranger
- [x] Entry in CHANGELOG.md
