### PR TITLE
thrift: Use google.rpc.codes enum name for rpc.code annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - observability: Errors are logged with their associated error code under the
   `errorCode` field. Errors created outside of `protobuf.NewError` and
   `yarpcerrors` will yield `CodeUnknown`.
-- Using the `rpc.code` annotation, services may specify an associated
-  `yarpcerrors.Code` for Thrift exceptions.
+- Using the `rpc.code` annotation, services may specify an associated code for
+  Thrift exceptions.
 - Metrics and logs now include Thrift exception names and related YARPC code, if
   annotated. If a `rpc.code` annotation is specified for a Thrift exception,
   metrics will classify it as a client or server failure, like a `yarpcerrors`

--- a/encoding/thrift/internal/observabilitytest/test.thrift
+++ b/encoding/thrift/internal/observabilitytest/test.thrift
@@ -1,7 +1,7 @@
 exception ExceptionWithCode {
     1: required string val
 } (
-    rpc.code = "invalid-argument"
+    rpc.code = "INVALID_ARGUMENT"
 )
 
 exception ExceptionWithoutCode {

--- a/encoding/thrift/internal/observabilitytest/test/test.go
+++ b/encoding/thrift/internal/observabilitytest/test/test.go
@@ -318,11 +318,11 @@ var ThriftModule = &thriftreflect.ThriftModule{
 	Name:     "test",
 	Package:  "go.uber.org/yarpc/encoding/thrift/internal/observabilitytest/test",
 	FilePath: "test.thrift",
-	SHA1:     "ce9de193a0c4d26a1c123f56d81ee4ec06b4cda7",
+	SHA1:     "f07207affcfb87ac57bdb9c77ddbf92ef5c6ddba",
 	Raw:      rawIDL,
 }
 
-const rawIDL = "exception ExceptionWithCode {\n    1: required string val\n} (\n    rpc.code = \"invalid-argument\"\n)\n\nexception ExceptionWithoutCode {\n    1: required string val\n}\n\nservice TestService  {\n    string Call(1: required string key) throws (\n      1: ExceptionWithCode exCode,\n      2: ExceptionWithoutCode exNoCode,\n    )\n}\n"
+const rawIDL = "exception ExceptionWithCode {\n    1: required string val\n} (\n    rpc.code = \"INVALID_ARGUMENT\"\n)\n\nexception ExceptionWithoutCode {\n    1: required string val\n}\n\nservice TestService  {\n    string Call(1: required string key) throws (\n      1: ExceptionWithCode exCode,\n      2: ExceptionWithoutCode exNoCode,\n    )\n}\n"
 
 // TestService_Call_Args represents the arguments for the TestService.Call function.
 //

--- a/encoding/thrift/thriftrw-plugin-yarpc/exception.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/exception.go
@@ -141,7 +141,7 @@ func getYARPCErrorCode(t *compile.StructSpec) string {
 	errorCodeString := t.Annotations[_errorCodeAnnotationKey]
 	yCode, ok := _gRPCCodeNameToYARPCErrorCodeType[errorCodeString]
 	if !ok {
-		panic(fmt.Sprintf("invalid rpc.code annotation: %q\n%s", errorCodeString, _availableCodes))
+		panic(fmt.Sprintf("invalid rpc.code annotation for %q: %q\n%s", t.Name, errorCodeString, _availableCodes))
 	}
 	return yCode
 }

--- a/encoding/thrift/thriftrw-plugin-yarpc/exception_test.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/exception_test.go
@@ -28,8 +28,11 @@ import (
 )
 
 func TestGetYARPCErrorCode(t *testing.T) {
+	const exName = "MyException"
+
 	t.Run("success", func(t *testing.T) {
 		spec := &compile.StructSpec{
+			Name:        exName,
 			Annotations: map[string]string{_errorCodeAnnotationKey: "ABORTED"},
 		}
 		assert.NotPanics(t, func() {
@@ -41,12 +44,12 @@ func TestGetYARPCErrorCode(t *testing.T) {
 
 	t.Run("panic fail", func(t *testing.T) {
 		spec := &compile.StructSpec{
+			Name:        exName,
 			Annotations: map[string]string{_errorCodeAnnotationKey: "foo"},
 		}
 		assert.PanicsWithValue(t,
-			"invalid rpc.code annotation: \"foo\"\nAvailable codes: CANCELLED,UNKNOWN,INVALID_ARGUMENT,DEADLINE_EXCEEDED,NOT_FOUND,ALREADY_EXISTS,PERMISSION_DENIED,RESOURCE_EXHAUSTED,FAILED_PRECONDITION,ABORTED,OUT_OF_RANGE,UNIMPLEMENTED,INTERNAL,UNAVAILABLE,DATA_LOSS,UNAUTHENTICATED",
+			"invalid rpc.code annotation for \"MyException\": \"foo\"\nAvailable codes: CANCELLED,UNKNOWN,INVALID_ARGUMENT,DEADLINE_EXCEEDED,NOT_FOUND,ALREADY_EXISTS,PERMISSION_DENIED,RESOURCE_EXHAUSTED,FAILED_PRECONDITION,ABORTED,OUT_OF_RANGE,UNIMPLEMENTED,INTERNAL,UNAVAILABLE,DATA_LOSS,UNAUTHENTICATED",
 			func() { getYARPCErrorCode(spec) },
 			"unexpected panic")
 	})
-
 }

--- a/encoding/thrift/thriftrw-plugin-yarpc/exception_test.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/exception_test.go
@@ -30,7 +30,7 @@ import (
 func TestGetYARPCErrorCode(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		spec := &compile.StructSpec{
-			Annotations: map[string]string{_errorCodeAnnotationKey: "aborted"},
+			Annotations: map[string]string{_errorCodeAnnotationKey: "ABORTED"},
 		}
 		assert.NotPanics(t, func() {
 			want := "yarpcerrors.CodeAborted"
@@ -44,7 +44,7 @@ func TestGetYARPCErrorCode(t *testing.T) {
 			Annotations: map[string]string{_errorCodeAnnotationKey: "foo"},
 		}
 		assert.PanicsWithValue(t,
-			"invalid rpc.code annotation: unknown code string: foo\nAvailable codes: cancelled,unknown,invalid-argument,deadline-exceeded,not-found,already-exists,permission-denied,resource-exhausted,failed-precondition,aborted,out-of-range,unimplemented,internal,unavailable,data-loss,unauthenticated",
+			"invalid rpc.code annotation: \"foo\"\nAvailable codes: CANCELLED,UNKNOWN,INVALID_ARGUMENT,DEADLINE_EXCEEDED,NOT_FOUND,ALREADY_EXISTS,PERMISSION_DENIED,RESOURCE_EXHAUSTED,FAILED_PRECONDITION,ABORTED,OUT_OF_RANGE,UNIMPLEMENTED,INTERNAL,UNAVAILABLE,DATA_LOSS,UNAUTHENTICATED",
 			func() { getYARPCErrorCode(spec) },
 			"unexpected panic")
 	})

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic.thrift
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic.thrift
@@ -3,14 +3,14 @@ include "./common.thrift"
 exception KeyDoesNotExist {
     1: optional string key
 } (
-    rpc.code = "invalid-argument"
+    rpc.code = "INVALID_ARGUMENT"
 )
 
 exception IntegerMismatchError {
     1: required i64 expectedValue
     2: required i64 gotValue
 } (
-    rpc.code = "invalid-argument"
+    rpc.code = "INVALID_ARGUMENT"
 )
 
 struct CompareAndSwap {

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/atomic.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/atomic.go
@@ -933,14 +933,14 @@ var ThriftModule = &thriftreflect.ThriftModule{
 	Name:     "atomic",
 	Package:  "go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic",
 	FilePath: "atomic.thrift",
-	SHA1:     "47c002a62f6db940ca97b53d72f12f4732e35f4c",
+	SHA1:     "86799ad54683404a517c661f6f10d83cf7afa99e",
 	Includes: []*thriftreflect.ThriftModule{
 		common.ThriftModule,
 	},
 	Raw: rawIDL,
 }
 
-const rawIDL = "include \"./common.thrift\"\n\nexception KeyDoesNotExist {\n    1: optional string key\n} (\n    rpc.code = \"invalid-argument\"\n)\n\nexception IntegerMismatchError {\n    1: required i64 expectedValue\n    2: required i64 gotValue\n} (\n    rpc.code = \"invalid-argument\"\n)\n\nstruct CompareAndSwap {\n    1: required string key\n    2: required i64 currentValue\n    3: required i64 newValue\n}\n\nservice ReadOnlyStore extends common.BaseService {\n    i64 integer(1: string key) throws (1: KeyDoesNotExist doesNotExist)\n}\n\nservice Store extends ReadOnlyStore {\n    void increment(1: string key, 2: i64 value)\n\n    void compareAndSwap(1: CompareAndSwap request)\n        throws (1: IntegerMismatchError mismatch)\n\n    oneway void forget(1: string key)\n}\n\n\n// This struct intentionally has the same shape as the `CompareAndSwap` wrapper\n// `Store_CompareAndSwap_Args`, except all fields are optional.\n\n// We use this to generate an invalid payload for testing.\nstruct OptionalCompareAndSwapWrapper {\n    1: optional OptionalCompareAndSwap cas\n}\n\nstruct OptionalCompareAndSwap {\n    1: optional string key\n    2: optional i64 currentValue\n    3: optional i64 newValue\n}\n"
+const rawIDL = "include \"./common.thrift\"\n\nexception KeyDoesNotExist {\n    1: optional string key\n} (\n    rpc.code = \"INVALID_ARGUMENT\"\n)\n\nexception IntegerMismatchError {\n    1: required i64 expectedValue\n    2: required i64 gotValue\n} (\n    rpc.code = \"INVALID_ARGUMENT\"\n)\n\nstruct CompareAndSwap {\n    1: required string key\n    2: required i64 currentValue\n    3: required i64 newValue\n}\n\nservice ReadOnlyStore extends common.BaseService {\n    i64 integer(1: string key) throws (1: KeyDoesNotExist doesNotExist)\n}\n\nservice Store extends ReadOnlyStore {\n    void increment(1: string key, 2: i64 value)\n\n    void compareAndSwap(1: CompareAndSwap request)\n        throws (1: IntegerMismatchError mismatch)\n\n    oneway void forget(1: string key)\n}\n\n\n// This struct intentionally has the same shape as the `CompareAndSwap` wrapper\n// `Store_CompareAndSwap_Args`, except all fields are optional.\n\n// We use this to generate an invalid payload for testing.\nstruct OptionalCompareAndSwapWrapper {\n    1: optional OptionalCompareAndSwap cas\n}\n\nstruct OptionalCompareAndSwap {\n    1: optional string key\n    2: optional i64 currentValue\n    3: optional i64 newValue\n}\n"
 
 // ReadOnlyStore_Integer_Args represents the arguments for the ReadOnlyStore.integer function.
 //

--- a/encoding/thrift/thriftrw-plugin-yarpc/main.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/main.go
@@ -27,27 +27,33 @@
 //  exception ExceptionWithCode {
 //    1: required string val
 //  } (
-//    rpc.code = "invalid-argument"
+//    rpc.code = "INVALID_ARGUMENT"
 //  )
 //
-// The "rpc.code" annotation can be any code from yarpcerrors, except
-// 'CodeOK'. Available string names satisfy `Code.UnmarshalText`. These include:
-//  - "cancelled"
-//  - "unknown"
-//  - "invalid-argument"
-//  - "deadline-exceeded"
-//  - "not-found"
-//  - "already-exists"
-//  - "permission-denied"
-//  - "resource-exhausted"
-//  - "failed-precondition"
-//  - "aborted"
-//  - "out-of-range"
-//  - "unimplemented"
-//  - "internal"
-//  - "unavailable"
-//  - "data-loss"
-//  - "unauthenticated"
+// The "rpc.code" annotation can be any code matching the string name of gRPC
+// status enum codes. YARPC error codes match 1-1 with these codes, however gRPC
+// uses a different string name representation. We choose to use the raw gRPC
+// enum code names instead to ensure cross-language compatibility with other
+// languages, such as Java.
+//  - https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto
+//
+// Available string names method:
+//  - "CANCELLED"
+//  - "UNKNOWN"
+//  - "INVALID_ARGUMENT"
+//  - "DEADLINE_EXCEEDED"
+//  - "NOT_FOUND"
+//  - "ALREADY_EXISTS"
+//  - "PERMISSION_DENIED"
+//  - "RESOURCE_EXHAUSTED"
+//  - "FAILED_PRECONDITION"
+//  - "ABORTED"
+//  - "OUT_OF_RANGE"
+//  - "UNIMPLEMENTED"
+//  - "INTERNAL"
+//  - "UNAVAILABLE"
+//  - "DATA_LOSS"
+//  - "UNAUTHENTICATED"
 //
 // Adding codes will affect YARPC's observability middleware classification of
 // client and server errors for Thrift exceptions.


### PR DESCRIPTION
This change uses the native gRPC enum code names to derive the code
annotations, instead of using `yarpcerrors`. These names are derived
from the `google.rpc.codes` Protobuf file:

- https://github.com/googleapis/googleapis/blob/b26f6585d60a811b415a00570ad7650d7b3b7bda/google/rpc/code.proto#L41

Unfortunately, `yarpcerrors` string code name representations are
inconsistent with gRPC's:

- https://github.com/yarpc/yarpc-go/blob/a471b8ec71047ae92683262313a0b04fa847f27c/yarpcerrors/codes.go#L143
- https://github.com/grpc/grpc-go/blob/abfbf74f21d37c828ecae93451a06b513653d0ff/codes/code_string.go#L25

Furthermore, Java has no name string overrides. For enums in Java, you
can use the `toString` or `name` methods to derive the name, but since
neither have been overriden, the string equivalents are simply the
name of the enum, as-is. The Java enum names match the
`google.rpc.codes` list 1-1.

- https://grpc.github.io/grpc-java/javadoc/io/grpc/Status.Code.html

Since we want IDL files to remain language/framework agnostic, we use
the raw enum name for annotations. This ensures YARPC flavoured code
names do not leak across a Java framework equivalent.

- [x] Description and context for reviewers: one partner, one stranger
- [x] Entry in CHANGELOG.md
