### PR TITLE
thrift: Use a server error code in test

### DIFF
--- a/encoding/thrift/internal/observabilitytest/test.thrift
+++ b/encoding/thrift/internal/observabilitytest/test.thrift
@@ -1,7 +1,7 @@
 exception ExceptionWithCode {
     1: required string val
 } (
-    rpc.code = "INVALID_ARGUMENT"
+    rpc.code = "DATA_LOSS" // server error
 )
 
 exception ExceptionWithoutCode {

--- a/encoding/thrift/internal/observabilitytest/test/test.go
+++ b/encoding/thrift/internal/observabilitytest/test/test.go
@@ -318,11 +318,11 @@ var ThriftModule = &thriftreflect.ThriftModule{
 	Name:     "test",
 	Package:  "go.uber.org/yarpc/encoding/thrift/internal/observabilitytest/test",
 	FilePath: "test.thrift",
-	SHA1:     "f07207affcfb87ac57bdb9c77ddbf92ef5c6ddba",
+	SHA1:     "3c501036fe37f678648dd479c821bc57aa17b7d1",
 	Raw:      rawIDL,
 }
 
-const rawIDL = "exception ExceptionWithCode {\n    1: required string val\n} (\n    rpc.code = \"INVALID_ARGUMENT\"\n)\n\nexception ExceptionWithoutCode {\n    1: required string val\n}\n\nservice TestService  {\n    string Call(1: required string key) throws (\n      1: ExceptionWithCode exCode,\n      2: ExceptionWithoutCode exNoCode,\n    )\n}\n"
+const rawIDL = "exception ExceptionWithCode {\n    1: required string val\n} (\n    rpc.code = \"DATA_LOSS\" // server error\n)\n\nexception ExceptionWithoutCode {\n    1: required string val\n}\n\nservice TestService  {\n    string Call(1: required string key) throws (\n      1: ExceptionWithCode exCode,\n      2: ExceptionWithoutCode exNoCode,\n    )\n}\n"
 
 // TestService_Call_Args represents the arguments for the TestService.Call function.
 //

--- a/encoding/thrift/internal/observabilitytest/test/types_yarpc.go
+++ b/encoding/thrift/internal/observabilitytest/test/types_yarpc.go
@@ -25,11 +25,11 @@ package test
 
 import yarpcerrors "go.uber.org/yarpc/yarpcerrors"
 
-// YARPCErrorCode returns a yarpcerrors.CodeInvalidArgument for ExceptionWithCode.
+// YARPCErrorCode returns a yarpcerrors.CodeDataLoss for ExceptionWithCode.
 //
 // This is derived from the rpc.code annotation on the Thrift exception.
 func (e *ExceptionWithCode) YARPCErrorCode() *yarpcerrors.Code {
-	code := yarpcerrors.CodeInvalidArgument
+	code := yarpcerrors.CodeDataLoss
 	return &code
 }
 


### PR DESCRIPTION
This small change ensures that Thrift exceptions can be classified as
server exceptions if annotated with a "server fault" code. This is one
of the core features of this series of changes, so we should test for
it explicitly. Otherwise, no functionality has changed.

See the list of server code faults here:
- https://github.com/yarpc/yarpc-go/blob/30d10b8fe6294c1acccfef60c0025e9c9289bf01/internal/observability/codes.go#L57

- [x] Description and context for reviewers: one partner, one stranger