### PR TITLE
Improve Protobuf error details observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- observability: Errors are logged with their associated error code under the
-  `errorCode` field. Errors created outside of `protobuf.NewError` and
-  `yarpcerrors` will yield `CodeUnknown`.
-- Using the `rpc.code` annotation, services may specify an associated code for
-  Thrift exceptions.
-- Metrics and logs now include Thrift exception names and related YARPC code, if
-  annotated. If a `rpc.code` annotation is specified for a Thrift exception,
-  metrics will classify it as a client or server failure, like a `yarpcerrors`
-  error. If the YARPC code is not specified for the Thrift exception, it will
-  continue to be assumed a client failure.
-- observability: Thrift exceptions are logged under the `appErrMessage` field.
+- thrift: Using the `rpc.code` annotation, services may specify an associated
+  error code for Thrift exceptions. Metrics will classify the exception as a
+  client or server failure like a `yarpcerrors` error. If a Thrift exception is
+  not annotated with a code, it will continue to be classified as a client
+  failure.
+- logging: Errors and annotated Thrift exceptions are logged with their error
+  code under the `errorCode` field. Errors created outside of
+  `protobuf.NewError` and `yarpcerrors` will yield `CodeUnknown`.
+- logging: Thrift exceptions and Protobuf error details are logged under the
+  `appErrMessage` field.
 ### Removed
 - Removed `yarpcproto` package that enabled "oneway" Protobuf signatures.
 

--- a/encoding/protobuf/error.go
+++ b/encoding/protobuf/error.go
@@ -22,6 +22,7 @@ package protobuf
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/gogo/googleapis/google/rpc"
@@ -30,6 +31,13 @@ import (
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/grpcerrorcodes"
 	"go.uber.org/yarpc/yarpcerrors"
+)
+
+const (
+	// format for converting error details to string
+	_errDetailsFmt = "[]{ %s }"
+	// format for converting a single message to string
+	_errDetailFmt = "%s{%s}"
 )
 
 var _ error = (*pberror)(nil)
@@ -103,7 +111,7 @@ func WithErrorDetails(details ...proto.Message) ErrorOption {
 }
 
 // convertToYARPCError is to be used for handling errors on the inbound side.
-func convertToYARPCError(encoding transport.Encoding, err error, codec *codec) error {
+func convertToYARPCError(encoding transport.Encoding, err error, codec *codec, resw transport.ResponseWriter) error {
 	if err == nil {
 		return nil
 	}
@@ -116,6 +124,8 @@ func convertToYARPCError(encoding transport.Encoding, err error, codec *codec) e
 		for _, detail := range pberr.details {
 			details = append(details, detail.(proto.Message))
 		}
+		setApplicationErrorMeta(pberr, resw)
+
 		st, convertErr := status.New(grpcerrorcodes.YARPCCodeToGRPCCode[pberr.code], pberr.message).WithDetails(details...)
 		if convertErr != nil {
 			return convertErr
@@ -130,6 +140,48 @@ func convertToYARPCError(encoding transport.Encoding, err error, codec *codec) e
 		return yarpcerrors.Newf(pberr.code, pberr.message).WithDetails(yarpcDet)
 	}
 	return err
+}
+
+func setApplicationErrorMeta(pberr *pberror, resw transport.ResponseWriter) {
+	applicationErroMetaSetter, ok := resw.(transport.ApplicationErrorMetaSetter)
+	if !ok {
+		return
+	}
+
+	var appErrName string
+	if len(pberr.details) > 0 { // only grab the first name since this will be emitted with metrics
+		appErrName = messageNameWithoutPackage(proto.MessageName(
+			pberr.details[0].(proto.Message)),
+		)
+	}
+
+	details := make([]string, 0, len(pberr.details))
+	for _, detail := range pberr.details {
+		details = append(details, protobufMessageToString(detail.(proto.Message)))
+	}
+
+	applicationErroMetaSetter.SetApplicationErrorMeta(&transport.ApplicationErrorMeta{
+		Name:    appErrName,
+		Message: fmt.Sprintf(_errDetailsFmt, strings.Join(details, " , ")),
+	})
+}
+
+// messageNameWithoutPackage strips the package name, returning just the type
+// name.
+//
+// For example:
+//  uber.foo.bar.TypeName -> TypeName
+func messageNameWithoutPackage(messageName string) string {
+	if i := strings.LastIndex(messageName, "."); i >= 0 {
+		return messageName[i+1:]
+	}
+	return messageName
+}
+
+func protobufMessageToString(message proto.Message) string {
+	return fmt.Sprintf(_errDetailFmt,
+		messageNameWithoutPackage(proto.MessageName(message)),
+		proto.CompactTextString(message))
 }
 
 // convertFromYARPCError is to be used for handling errors on the outbound side.

--- a/encoding/protobuf/inbound.go
+++ b/encoding/protobuf/inbound.go
@@ -76,7 +76,7 @@ func (u *unaryHandler) Handle(ctx context.Context, transportRequest *transport.R
 	if appErr != nil {
 		responseWriter.SetApplicationError()
 	}
-	return convertToYARPCError(transportRequest.Encoding, appErr, u.codec)
+	return convertToYARPCError(transportRequest.Encoding, appErr, u.codec, responseWriter)
 }
 
 type onewayHandler struct {
@@ -102,7 +102,7 @@ func (o *onewayHandler) HandleOneway(ctx context.Context, transportRequest *tran
 	if err != nil {
 		return err
 	}
-	return convertToYARPCError(transportRequest.Encoding, o.handleOneway(ctx, request), o.codec)
+	return convertToYARPCError(transportRequest.Encoding, o.handleOneway(ctx, request), o.codec, nil /*responseWriter*/)
 }
 
 type streamHandler struct {
@@ -125,7 +125,7 @@ func (s *streamHandler) HandleStream(stream *transport.ServerStream) error {
 		stream: stream,
 		codec:  s.codec,
 	}
-	return convertToYARPCError(transportRequest.Meta.Encoding, s.handle(protoStream), s.codec)
+	return convertToYARPCError(transportRequest.Meta.Encoding, s.handle(protoStream), s.codec, nil /*responseWriter*/)
 }
 
 func getProtoRequest(ctx context.Context, transportRequest *transport.Request, newRequest func() proto.Message, codec *codec) (context.Context, *apiencoding.InboundCall, proto.Message, error) {

--- a/encoding/protobuf/observability_test.go
+++ b/encoding/protobuf/observability_test.go
@@ -1,0 +1,221 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package protobuf_test
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/gogo/protobuf/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/net/metrics"
+	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/encoding/protobuf"
+	"go.uber.org/yarpc/encoding/protobuf/internal/testpb"
+	"go.uber.org/yarpc/transport/grpc"
+	"go.uber.org/yarpc/yarpcerrors"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+const (
+	_clientName = "caller"
+	_serverName = "callee"
+
+	// from observability middleware
+	_errorInbound  = "Error handling inbound request."
+	_errorOutbound = "Error making outbound call."
+)
+
+func TestProtobufErrorDetailObservability(t *testing.T) {
+	client, observedLogs, clientMetricsRoot, serverMetricsRoot, cleanup := initClientAndServer(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	_, err := client.Unary(ctx, &testpb.TestMessage{})
+	require.Error(t, err, "expected call error")
+
+	require.NotEmpty(t, protobuf.GetErrorDetails(err),
+		"no error details, found error of type '%T': %v", err, err)
+
+	t.Run("logs", func(t *testing.T) {
+		wantFields := []zapcore.Field{
+			zap.String("errorCode", "invalid-argument"),
+			zap.String("errorName", "StringValue"),
+			zap.String("appErrorMessage", "[]{ StringValue{value:\"string value\" } , Int32Value{value:100 } }"),
+		}
+		assertLogs(t, wantFields, observedLogs.TakeAll())
+	})
+
+	t.Run("metrics", func(t *testing.T) {
+		wantCounters := []counterAssertion{
+			{
+				Name: "caller_failures",
+				Tags: map[string]string{
+					"error":      "invalid-argument",
+					"error_name": "StringValue",
+				},
+				Value: 1,
+			},
+			{Name: "calls", Value: 1},
+			{Name: "panics"},
+			{Name: "successes"},
+		}
+
+		assertClientAndServerMetrics(t, wantCounters, clientMetricsRoot, serverMetricsRoot)
+	})
+}
+
+func assertLogs(t *testing.T, wantFields []zapcore.Field, logs []observer.LoggedEntry) {
+	require.Len(t, logs, 2, "unexpected number of logs")
+
+	t.Run("inbound", func(t *testing.T) {
+		require.Equal(t, _errorInbound, logs[0].Message, "unexpected log")
+		assertLogFields(t, wantFields, logs[0].Context)
+	})
+
+	t.Run("outbound", func(t *testing.T) {
+		require.Equal(t, _errorOutbound, logs[1].Message, "unexpected log")
+		assertLogFields(t, wantFields, logs[1].Context)
+	})
+}
+
+func assertLogFields(t *testing.T, wantFields, gotContext []zapcore.Field) {
+	gotFields := make(map[string]zapcore.Field)
+	for _, log := range gotContext {
+		gotFields[log.Key] = log
+	}
+
+	for _, want := range wantFields {
+		got, ok := gotFields[want.Key]
+		if assert.True(t, ok, "key %q not found", want.Key) {
+			assert.Equal(t, want, got, "unexpected log field")
+		}
+	}
+}
+
+type counterAssertion struct {
+	Name  string
+	Tags  map[string]string
+	Value int
+}
+
+func assertClientAndServerMetrics(t *testing.T, counterAssertions []counterAssertion, clientSnapshot, serverSnapshot *metrics.Root) {
+	t.Run("inbound", func(t *testing.T) {
+		assertMetrics(t, counterAssertions, serverSnapshot.Snapshot().Counters)
+	})
+	t.Run("outbound", func(t *testing.T) {
+		assertMetrics(t, counterAssertions, clientSnapshot.Snapshot().Counters)
+	})
+}
+
+func assertMetrics(t *testing.T, counterAssertions []counterAssertion, snapshot []metrics.Snapshot) {
+	require.Len(t, counterAssertions, len(snapshot), "unexpected number of counters")
+
+	for i, wantCounter := range counterAssertions {
+		require.Equal(t, wantCounter.Name, snapshot[i].Name, "unexpected counter")
+		assert.EqualValues(t, wantCounter.Value, snapshot[i].Value, "unexpected counter value")
+		for wantTagKey, wantTagVal := range wantCounter.Tags {
+			assert.Equal(t, wantTagVal, snapshot[i].Tags[wantTagKey], "unexpected value for %q", wantTagKey)
+		}
+	}
+}
+
+func initClientAndServer(t *testing.T) (
+	client testpb.TestYARPCClient,
+	observedLogs *observer.ObservedLogs,
+	clientMetricsRoot *metrics.Root,
+	serverMetricsRoot *metrics.Root,
+	cleanup func(),
+) {
+	loggerCore, observedLogs := observer.New(zapcore.DebugLevel)
+	clientMetricsRoot, serverMetricsRoot = metrics.New(), metrics.New()
+
+	serverAddr, cleanupServer := newServer(t, loggerCore, serverMetricsRoot)
+	client, cleanupClient := newClient(t, serverAddr, loggerCore, clientMetricsRoot)
+
+	_ = observedLogs.TakeAll() // ignore all start up logs
+
+	return client, observedLogs, clientMetricsRoot, serverMetricsRoot, func() {
+		cleanupServer()
+		cleanupClient()
+	}
+}
+
+func newServer(t *testing.T, loggerCore zapcore.Core, metricsRoot *metrics.Root) (addr string, cleanup func()) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	inbound := grpc.NewTransport().NewInbound(listener)
+	dispatcher := yarpc.NewDispatcher(yarpc.Config{
+		Name:     _serverName,
+		Inbounds: yarpc.Inbounds{inbound},
+		Logging:  yarpc.LoggingConfig{Zap: zap.New(loggerCore)},
+		Metrics:  yarpc.MetricsConfig{Metrics: metricsRoot.Scope()},
+	})
+
+	dispatcher.Register(testpb.BuildTestYARPCProcedures(&observabilityTestServer{}))
+	require.NoError(t, dispatcher.Start(), "could not start server dispatcher")
+
+	addr = inbound.Addr().String()
+	cleanup = func() { assert.NoError(t, dispatcher.Stop(), "could not stop dispatcher") }
+	return addr, cleanup
+}
+
+func newClient(t *testing.T, serverAddr string, loggerCore zapcore.Core, metricsRoot *metrics.Root) (client testpb.TestYARPCClient, cleanup func()) {
+	dispatcher := yarpc.NewDispatcher(yarpc.Config{
+		Name: _clientName,
+		Outbounds: map[string]transport.Outbounds{
+			_serverName: {
+				ServiceName: _serverName,
+				Unary:       grpc.NewTransport().NewSingleOutbound(serverAddr),
+			},
+		},
+		Logging: yarpc.LoggingConfig{Zap: zap.New(loggerCore)},
+		Metrics: yarpc.MetricsConfig{Metrics: metricsRoot.Scope()},
+	})
+
+	client = testpb.NewTestYARPCClient(dispatcher.ClientConfig(_serverName))
+	require.NoError(t, dispatcher.Start(), "could not start client dispatcher")
+
+	cleanup = func() { assert.NoError(t, dispatcher.Stop(), "could not stop dispatcher") }
+	return client, cleanup
+}
+
+type observabilityTestServer struct{}
+
+func (observabilityTestServer) Unary(context.Context, *testpb.TestMessage) (*testpb.TestMessage, error) {
+	details := []proto.Message{
+		&types.StringValue{Value: "string value"},
+		&types.Int32Value{Value: 100},
+	}
+	return nil, protobuf.NewError(yarpcerrors.CodeInvalidArgument, "my message", protobuf.WithErrorDetails(details...))
+}
+
+func (observabilityTestServer) Duplex(testpb.TestServiceDuplexYARPCServer) error { return nil }

--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -207,6 +207,16 @@ func (c call) endLogs(
 	} else if isApplicationError { // Protobuf error
 		fields = append(fields, zap.Error(err))
 		fields = append(fields, zap.String(_errorCodeLogKey, yarpcerrors.FromError(err).Code().String()))
+		if applicationErrorMeta != nil {
+			// ignore transport.ApplicationErrorMeta#Code, since we should get this
+			// directly from the error
+			if applicationErrorMeta.Name != "" {
+				fields = append(fields, zap.String(_errorNameLogKey, applicationErrorMeta.Name))
+			}
+			if applicationErrorMeta.Message != "" {
+				fields = append(fields, zap.String(_appErrorMessageLogKey, applicationErrorMeta.Message))
+			}
+		}
 
 	} else if err != nil { // unknown error
 		fields = append(fields, zap.Error(err))

--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -240,18 +240,16 @@ func (c call) endStats(
 		return
 	}
 
-	isStatus := yarpcerrors.IsStatus(err)
-
-	if isStatus {
-		status := yarpcerrors.FromError(err)
-		errCode := status.Code()
-		c.endStatsFromFault(elapsed, errCode, _notSet)
-		return
-	}
-
 	appErrorName := _notSet
 	if applicationErrorMeta != nil && applicationErrorMeta.Name != "" {
 		appErrorName = applicationErrorMeta.Name
+	}
+
+	if yarpcerrors.IsStatus(err) {
+		status := yarpcerrors.FromError(err)
+		errCode := status.Code()
+		c.endStatsFromFault(elapsed, errCode, appErrorName)
+		return
 	}
 
 	if isApplicationError {

--- a/internal/observability/middleware.go
+++ b/internal/observability/middleware.go
@@ -47,8 +47,7 @@ type writer struct {
 
 func newWriter(rw transport.ResponseWriter) *writer {
 	w := _writerPool.Get().(*writer)
-	w.isApplicationError = false
-	w.ResponseWriter = rw
+	*w = writer{ResponseWriter: rw} // reset
 	return w
 }
 

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -219,8 +219,7 @@ func TestMiddlewareLogging(t *testing.T) {
 			wantFields: []zapcore.Field{
 				zap.Duration("latency", 0),
 				zap.Bool("successful", true),
-				zap.Skip(),
-				zap.Skip(),
+				zap.Skip(), // ContextExtractor
 			},
 		},
 		{
@@ -266,8 +265,8 @@ func TestMiddlewareLogging(t *testing.T) {
 				zap.Bool("successful", false),
 				zap.Skip(),
 				zap.String("error", "application_error"),
-				zap.String("errorName", "FunkyThriftError"),
 				zap.String("errorCode", "resource-exhausted"),
+				zap.String("errorName", "FunkyThriftError"),
 				zap.String("appErrorMessage", appErrMessage),
 			},
 		},
@@ -1212,8 +1211,8 @@ func TestUnaryInboundApplicationErrors(t *testing.T) {
 		zap.Bool("successful", false),
 		zap.Skip(),
 		zap.String("error", "application_error"),
-		zap.String("errorName", "SomeFakeError"),
 		zap.String("errorCode", "already-exists"),
+		zap.String("errorName", "SomeFakeError"),
 	}
 
 	core, logs := observer.New(zap.DebugLevel)

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -2034,3 +2034,22 @@ func TestStreamingMetrics(t *testing.T) {
 		assert.Equal(t, want, snap, "unexpected metrics snapshot")
 	})
 }
+
+func TestNewWriterIsEmpty(t *testing.T) {
+	code := yarpcerrors.CodeDataLoss
+
+	// set all fields on the response writer
+	w := newWriter(&transporttest.FakeResponseWriter{})
+	require.NotNil(t, w, "writer must not be nil")
+
+	w.SetApplicationError()
+	w.SetApplicationErrorMeta(&transport.ApplicationErrorMeta{
+		Message: "foo", Name: "bar", Code: &code,
+	})
+	w.free()
+
+	w = newWriter(nil /*transport.ResponseWriter*/)
+	require.NotNil(t, w, "writer must not be nil")
+	assert.Equal(t, writer{}, *w,
+		"expected empty writer, fields were likely not cleared in the pool")
+}

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -303,6 +303,26 @@ func TestMiddlewareLogging(t *testing.T) {
 			},
 		},
 		{
+			// ie 'protobuf.NewError' return in Protobuf handler
+			desc:                  "yarpcerror, app error with name and code",
+			err:                   yErrNoDetails,
+			applicationErr:        true, // always true for Protobuf handler errors
+			wantErrLevel:          zapcore.ErrorLevel,
+			applicationErrMessage: appErrMessage,
+			applicationErrName:    "MyErrMessageName",
+			wantInboundMsg:        "Error handling inbound request.",
+			wantOutboundMsg:       "Error making outbound call.",
+			wantFields: []zapcore.Field{
+				zap.Duration("latency", 0),
+				zap.Bool("successful", false),
+				zap.Skip(), // ContextExtractor
+				zap.Error(yErrNoDetails),
+				zap.String(_errorCodeLogKey, "aborted"),
+				zap.String(_errorNameLogKey, "MyErrMessageName"),
+				zap.String(_appErrorMessageLogKey, appErrMessage),
+			},
+		},
+		{
 			// ie Protobuf error detail return in Protobuf handler
 			desc:            "err details, app error",
 			err:             yErrWithDetails,

--- a/transport/grpc/external_integration_test.go
+++ b/transport/grpc/external_integration_test.go
@@ -22,6 +22,7 @@ package grpc_test
 
 import (
 	"context"
+	"errors"
 	"net"
 	"testing"
 	"time"
@@ -29,6 +30,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/api/middleware"
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/prototest/example"
@@ -36,6 +38,9 @@ import (
 	"go.uber.org/yarpc/peer/hostport"
 	"go.uber.org/yarpc/peer/roundrobin"
 	"go.uber.org/yarpc/transport/grpc"
+	"go.uber.org/yarpc/x/yarpctest"
+	"go.uber.org/yarpc/x/yarpctest/api"
+	"go.uber.org/yarpc/x/yarpctest/types"
 )
 
 func TestStreamingWithNoCtxDeadline(t *testing.T) {
@@ -115,4 +120,63 @@ func waitForPeerAvailable(t *testing.T, peerList *roundrobin.List, wait time.Dur
 	case <-peerAvailable:
 		return
 	}
+}
+
+func TestFoo(t *testing.T) {
+	const (
+		serviceName   = "test-service"
+		procedureName = "test-procedure"
+
+		appErrName    = "ProtoAppErrName"
+		appErrMessage = " this is an app error message!"
+
+		portName = "port"
+	)
+
+	handler := &types.UnaryHandler{
+		Handler: api.UnaryHandlerFunc(func(ctx context.Context, req *transport.Request, resw transport.ResponseWriter) error {
+			// simulate Protobuf encoding setting `transport.ApplicationErrorMeta`
+			metaSetter, ok := resw.(transport.ApplicationErrorMetaSetter)
+			if !ok {
+				return errors.New("missing transport.ApplicationErrorMetaSetter")
+			}
+			metaSetter.SetApplicationErrorMeta(&transport.ApplicationErrorMeta{
+				Name:    appErrName,
+				Message: appErrMessage,
+			})
+			return nil
+		})}
+
+	outboundMwAssertion := middleware.UnaryOutboundFunc(
+		func(ctx context.Context, req *transport.Request, next transport.UnaryOutbound) (*transport.Response, error) {
+			res, err := next.Call(ctx, req)
+
+			// verify gRPC propagating `transport.ApplicationErrorMeta`
+			require.NotNil(t, res.ApplicationErrorMeta, "missing transport.ApplicationErrorMeta")
+			assert.Equal(t, appErrName, res.ApplicationErrorMeta.Name, "incorrect app error name")
+			assert.Equal(t, appErrMessage, res.ApplicationErrorMeta.Message, "incorrect app error message")
+			assert.Nil(t, res.ApplicationErrorMeta.Code, "unexpected code")
+
+			return res, err
+		})
+
+	portProvider := yarpctest.NewPortProvider(t)
+	service := yarpctest.GRPCService(
+		yarpctest.Name(serviceName),
+		portProvider.NamedPort(portName),
+		yarpctest.Proc(yarpctest.Name(procedureName), handler),
+	)
+	require.NoError(t, service.Start(t))
+	defer func() { assert.NoError(t, service.Stop(t)) }()
+
+	request := yarpctest.GRPCRequest(
+		yarpctest.Service(serviceName),
+		portProvider.NamedPort(portName),
+		yarpctest.Procedure(procedureName),
+		yarpctest.GiveTimeout(time.Second),
+		api.RequestOptionFunc(func(opts *api.RequestOpts) {
+			opts.UnaryMiddleware = []middleware.UnaryOutbound{outboundMwAssertion}
+		}),
+	)
+	request.Run(t)
 }

--- a/transport/grpc/headers.go
+++ b/transport/grpc/headers.go
@@ -66,6 +66,13 @@ const (
 	// if there was an application error.
 	ApplicationErrorHeader = "rpc-application-error"
 
+	// _applicationErrorNameHeader is the header for the name of the application
+	// error.
+	_applicationErrorNameHeader = "rpc-application-error-name"
+	// _applicationErrorNameHeader is the header for the the application error
+	// message.
+	_applicationErrorMessageHeader = "rpc-application-error-message"
+
 	// ApplicationErrorHeaderValue is the value that will be set for
 	// ApplicationErrorHeader is there was an application error.
 	//
@@ -143,6 +150,28 @@ func metadataToTransportRequest(md metadata.MD) (*transport.Request, error) {
 		}
 	}
 	return request, nil
+}
+
+func metadataToApplicationErrorMeta(responseMD metadata.MD) *transport.ApplicationErrorMeta {
+	if responseMD == nil {
+		return nil
+	}
+
+	var message, name string
+	if header := responseMD[_applicationErrorMessageHeader]; len(header) == 1 {
+		message = header[0]
+	}
+	if header := responseMD[_applicationErrorNameHeader]; len(header) == 1 {
+		name = header[0]
+	}
+
+	return &transport.ApplicationErrorMeta{
+		Message: message,
+		Name:    name,
+		// ignore Code, this should be derived from the error since codes are
+		// natively supported in gRPC and YARPC
+		Code: nil,
+	}
 }
 
 // addApplicationHeaders adds the headers to md.

--- a/transport/grpc/outbound.go
+++ b/transport/grpc/outbound.go
@@ -119,9 +119,10 @@ func (o *Outbound) Call(ctx context.Context, request *transport.Request) (*trans
 		return nil, err
 	}
 	return &transport.Response{
-		Body:             ioutil.NopCloser(bytes.NewBuffer(responseBody)),
-		Headers:          responseHeaders,
-		ApplicationError: metadataToIsApplicationError(responseMD),
+		Body:                 ioutil.NopCloser(bytes.NewBuffer(responseBody)),
+		Headers:              responseHeaders,
+		ApplicationError:     metadataToIsApplicationError(responseMD),
+		ApplicationErrorMeta: metadataToApplicationErrorMeta(responseMD),
 	}, invokeErr
 }
 

--- a/transport/grpc/response_writer.go
+++ b/transport/grpc/response_writer.go
@@ -28,6 +28,11 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
+var (
+	_ transport.ResponseWriter             = (*responseWriter)(nil)
+	_ transport.ApplicationErrorMetaSetter = (*responseWriter)(nil)
+)
+
 type responseWriter struct {
 	buffer    *bytes.Buffer
 	md        metadata.MD
@@ -58,6 +63,18 @@ func (r *responseWriter) AddHeaders(headers transport.Headers) {
 
 func (r *responseWriter) SetApplicationError() {
 	r.AddSystemHeader(ApplicationErrorHeader, ApplicationErrorHeaderValue)
+}
+func (r *responseWriter) SetApplicationErrorMeta(meta *transport.ApplicationErrorMeta) {
+	if meta == nil {
+		return
+	}
+
+	if meta.Name != "" {
+		r.AddSystemHeader(_applicationErrorNameHeader, meta.Name)
+	}
+	if meta.Message != "" {
+		r.AddSystemHeader(_applicationErrorMessageHeader, meta.Message)
+	}
 }
 
 func (r *responseWriter) AddSystemHeader(key string, value string) {


### PR DESCRIPTION
This change mimics the {HTTP,gRPC}/Thrift exception changes for improving
gRPC/Protobuf error details. The stack is similar to the Thrift changes (we log
all error details as strings and log/emit names). However, we have the following
notable differences:

- We use the first error detail message name as the name in metrics. gRPC error
details can contain multiple details, so we assume that the first is the most
important
- We do not use the fully-qualified message name in order to reduce cardinality
for metrics. (ie `FooMessage` instead of `uber.foo.bar.FooMessage`
- We ignore the `Code` field on the `transport.ApplicationErrorMeta` type, since
gRPC/Protobuf support errors with codes natively

Commits should be reviewed individually
 
- [x] Description and context for reviewers: one partner, one stranger
- [x] Entry in CHANGELOG.md
