### PR TITLE
tchannel: Add support for retrieving native error codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - logging: Thrift exceptions and Protobuf error details are logged under the
   `appErrMessage` field.
 - grpc: Enabled outbound introspection for debug pages.
+- experimental: Added `tchannel.GetResponseErrorMeta` API for retrieving native
+  TChannel error response codes.
 ### Removed
 - Removed `yarpcproto` package that enabled "oneway" Protobuf signatures.
 

--- a/transport/tchannel/error.go
+++ b/transport/tchannel/error.go
@@ -28,6 +28,14 @@ import (
 	"go.uber.org/yarpc/yarpcerrors"
 )
 
+func fromSystemError(err tchannel.SystemError) error {
+	code, ok := _tchannelCodeToCode[err.Code()]
+	if !ok {
+		return yarpcerrors.Newf(yarpcerrors.CodeInternal, "got tchannel.SystemError %v which did not have a matching YARPC code", err)
+	}
+	return yarpcerrors.Newf(code, err.Message())
+}
+
 func toYARPCError(req *transport.Request, err error) error {
 	if err == nil {
 		return err

--- a/transport/tchannel/error_external_test.go
+++ b/transport/tchannel/error_external_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tchannel_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber/tchannel-go"
+	"go.uber.org/yarpc/api/transport"
+	ytchannel "go.uber.org/yarpc/transport/tchannel"
+	"go.uber.org/yarpc/yarpcerrors"
+)
+
+func TestResponseErrorMetaIntegration(t *testing.T) {
+	const networkErrMsg = "a network error!"
+
+	// use vanilla TChannel server to force return a system error
+	tchHandler := func(ctx context.Context, call *tchannel.InboundCall) {
+		networkErr := tchannel.NewSystemError(tchannel.ErrCodeNetwork, networkErrMsg)
+		require.NoError(t, call.Response().SendSystemError(networkErr), "failed to send system error")
+	}
+	server, err := tchannel.NewChannel("test", &tchannel.ChannelOptions{
+		Handler: tchannel.HandlerFunc(tchHandler),
+	})
+	require.NoError(t, err, "could not create TChannel channel")
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err, "failed to create listener")
+	server.Serve(listener)
+	defer server.Close()
+
+	// init client
+	clientTransport, err := ytchannel.NewTransport(ytchannel.ServiceName("foo"))
+	require.NoError(t, err, "failed to create TChannel client transport")
+	require.NoError(t, clientTransport.Start(), "could not start client transport")
+	defer func() { assert.NoError(t, clientTransport.Stop(), "did not cleanly shutdown client transport") }()
+
+	client := clientTransport.NewSingleOutbound(listener.Addr().String())
+	require.NoError(t, client.Start(), "could not start outbound")
+	defer func() { assert.NoError(t, client.Stop(), "did not cleanly shutdown outbound") }()
+
+	// call server
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, err = client.Call(ctx, &transport.Request{
+		Service: "foo",
+		Body:    bytes.NewBufferString("bar"),
+	})
+	require.Error(t, err, "expected call failure")
+
+	// ensure this is still a `yarpcerrors.Status` error
+	require.True(t, yarpcerrors.IsStatus(err), "expected YARPC status error")
+	require.Equal(t, networkErrMsg, yarpcerrors.FromError(err).Message(), "unexpected 'yarpcerrors' error message")
+	require.Equal(t, networkErrMsg, errors.Unwrap(err).Error(), "unexpected unwrapped error message")
+	assert.IsType(t, &yarpcerrors.Status{}, err, "expected YARPC status type") // ensure type switching still works
+
+	// verify response meta
+	meta := ytchannel.GetResponseErrorMeta(err)
+	require.NotNil(t, meta, "unable to retrieve response meta")
+	assert.Equal(t, tchannel.ErrCodeNetwork.String(), meta.Code.String(), "unexpected response code")
+}

--- a/transport/tchannel/error_test.go
+++ b/transport/tchannel/error_test.go
@@ -73,3 +73,32 @@ func TestToYARPCError(t *testing.T) {
 		})
 	}
 }
+
+func TestGetResponseErrorMeta(t *testing.T) {
+	tests := []struct {
+		name string
+		give error
+		want *ResponseErrorMeta
+	}{
+		{
+			name: "nil",
+		},
+		{
+			name: "wrong error",
+			give: errors.New("not a yarpc/tchannel error"),
+		},
+		{
+			name: "success",
+			give: fromSystemError(tchannel.NewSystemError(tchannel.ErrCodeProtocol, "foo bar").(tchannel.SystemError)),
+			want: &ResponseErrorMeta{
+				Code: tchannel.ErrCodeProtocol,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, GetResponseErrorMeta(tt.give), "unexpected")
+		})
+	}
+}


### PR DESCRIPTION
This introduces an experimental API that allows us to transparently
surface native TChannel response codes back to clients. This peels
back some of YARPC's agnosticism, since YARPC's mapping of TChannel
codes to YARPC codes is lossy.

This change allows clients and outbound middleware to act transport
specific/lower level codes (like network errors:
`tchannel.ErrCodeNetwork`) for implementing better fault tolerance
like retries.

The first commit is a minor refactor to re-arrange the code, the second
commit includes the change.

- [x] Description and context for reviewers: one partner, one stranger
- [x] Docs (package doc)
- [x] Entry in CHANGELOG.md
