### PR TITLE
grpc: Enable outbound introspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `protobuf.NewError` and `yarpcerrors` will yield `CodeUnknown`.
 - logging: Thrift exceptions and Protobuf error details are logged under the
   `appErrMessage` field.
+- grpc: Enabled outbound introspection for debug pages.
 ### Removed
 - Removed `yarpcproto` package that enabled "oneway" Protobuf signatures.
 

--- a/transport/grpc/outbound_test.go
+++ b/transport/grpc/outbound_test.go
@@ -283,3 +283,21 @@ func TestCallServiceMatch(t *testing.T) {
 		})
 	}
 }
+
+func TestOutboundIntrospection(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	grpcTransport := NewTransport()
+	o := grpcTransport.NewSingleOutbound(listener.Addr().String())
+
+	assert.Equal(t, TransportName, o.Introspect().Transport)
+	assert.Equal(t, "Stopped", o.Introspect().State)
+	assert.False(t, o.IsRunning())
+
+	require.NoError(t, o.Start(), "could not start outbound")
+	assert.Equal(t, "Running", o.Introspect().State)
+
+	require.NoError(t, o.Stop(), "could not stop outbound")
+	assert.Equal(t, "Stopped", o.Introspect().State)
+}


### PR DESCRIPTION
This enables outbound introspection so that gRPC outbounds provide
readable information on debug pages.

Ref T6290919

- [x] Description and context for reviewers: one partner, one stranger
- [x] Entry in CHANGELOG.md
