### PR TITLE
Add support for sending and reading stream headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- gRPC Streaming: Added the ability to send and read stream response headers.
 - thrift: Using the `rpc.code` annotation, services may specify an associated
   error code for Thrift exceptions. Metrics will classify the exception as a
   client or server failure like a `yarpcerrors` error. If a Thrift exception is

--- a/api/transport/stream_test.go
+++ b/api/transport/stream_test.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package transport_test
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/api/transport/transporttest"
+)
+
+func TestServerStreamHeaders(t *testing.T) {
+	items := map[string]string{"header-key": "header-value"}
+	headers := transport.HeadersFromMap(items)
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockStream := transporttest.NewMockStream(mockCtrl)
+
+	t.Run("unimplemented", func(t *testing.T) {
+		serverStream, err := transport.NewServerStream(mockStream)
+		require.NoError(t, err)
+
+		err = serverStream.SendHeaders(headers)
+		assert.Error(t, err)
+	})
+
+	t.Run("send-headers", func(t *testing.T) {
+		fakeWriter := &fakeWriter{
+			Stream: mockStream,
+		}
+		serverStream, err := transport.NewServerStream(fakeWriter)
+		require.NoError(t, err)
+
+		err = serverStream.SendHeaders(headers)
+		assert.NoError(t, err)
+		assert.Equal(t, items, fakeWriter.headers.Items())
+	})
+}
+
+var _ transport.StreamHeadersWriter = (*fakeWriter)(nil)
+
+type fakeWriter struct {
+	transport.Stream
+
+	headers transport.Headers
+}
+
+func (fw *fakeWriter) SendHeaders(headers transport.Headers) error {
+	fw.headers = headers
+	return nil
+}
+
+func TestClientStreamHeaders(t *testing.T) {
+	items := map[string]string{"header-key": "header-value"}
+	headers := transport.HeadersFromMap(items)
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockStream := transporttest.NewMockStreamCloser(mockCtrl)
+
+	t.Run("unimplemented", func(t *testing.T) {
+		clientStream, err := transport.NewClientStream(mockStream)
+		require.NoError(t, err)
+
+		_, err = clientStream.Headers()
+		assert.Error(t, err)
+	})
+
+	t.Run("send-headers", func(t *testing.T) {
+		fakeReader := &fakeReader{
+			StreamCloser: mockStream,
+			headers:      headers,
+		}
+		clientStream, err := transport.NewClientStream(fakeReader)
+		require.NoError(t, err)
+
+		headers, err = clientStream.Headers()
+		assert.NoError(t, err)
+		assert.Equal(t, items, fakeReader.headers.Items())
+	})
+}
+
+var _ transport.StreamHeadersReader = (*fakeReader)(nil)
+
+type fakeReader struct {
+	transport.StreamCloser
+
+	headers transport.Headers
+}
+
+func (fr *fakeReader) Headers() (transport.Headers, error) {
+	return fr.headers, nil
+}

--- a/api/transport/stream_test.go
+++ b/api/transport/stream_test.go
@@ -59,7 +59,7 @@ func TestServerStreamHeaders(t *testing.T) {
 	})
 }
 
-var _ transport.StreamHeadersWriter = (*fakeWriter)(nil)
+var _ transport.StreamHeadersSender = (*fakeWriter)(nil)
 
 type fakeWriter struct {
 	transport.Stream

--- a/internal/observability/stream.go
+++ b/internal/observability/stream.go
@@ -37,7 +37,7 @@ const (
 
 var (
 	_ transport.StreamCloser        = (*streamWrapper)(nil)
-	_ transport.StreamHeadersWriter = (*streamWrapper)(nil)
+	_ transport.StreamHeadersSender = (*streamWrapper)(nil)
 	_ transport.StreamHeadersReader = (*streamWrapper)(nil)
 )
 
@@ -132,7 +132,7 @@ func (s *streamWrapper) Close(ctx context.Context) error {
 }
 
 func (s *streamWrapper) SendHeaders(headers transport.Headers) error {
-	return transport.WriteStreamHeaders(s.StreamCloser, headers)
+	return transport.SendStreamHeaders(s.StreamCloser, headers)
 }
 
 func (s *streamWrapper) Headers() (transport.Headers, error) {
@@ -151,5 +151,5 @@ func (c nopCloser) Close(ctx context.Context) error {
 }
 
 func (c nopCloser) SendHeaders(headers transport.Headers) error {
-	return transport.WriteStreamHeaders(c.Stream, headers)
+	return transport.SendStreamHeaders(c.Stream, headers)
 }

--- a/transport/grpc/stream.go
+++ b/transport/grpc/stream.go
@@ -23,7 +23,6 @@ package grpc
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"io"
 	"io/ioutil"
 
@@ -38,7 +37,7 @@ import (
 )
 
 var (
-	_ transport.StreamHeadersWriter = (*serverStream)(nil)
+	_ transport.StreamHeadersSender = (*serverStream)(nil)
 	_ transport.StreamHeadersReader = (*clientStream)(nil)
 )
 
@@ -155,15 +154,9 @@ func (cs *clientStream) Headers() (transport.Headers, error) {
 	}
 	headers := transport.NewHeadersWithCapacity(len(md))
 	for k, vs := range md {
-		v := vs[0]
-		if len(vs) > 1 {
-			b, err := json.Marshal(vs)
-			if err != nil {
-				return headers, err
-			}
-			v = string(b)
+		if len(vs) > 0 {
+			headers = headers.With(k, vs[0])
 		}
-		headers = headers.With(k, v)
 	}
 	return headers, nil
 }

--- a/transport/grpc/stream.go
+++ b/transport/grpc/stream.go
@@ -163,7 +163,6 @@ func (cs *clientStream) Headers() (transport.Headers, error) {
 			}
 			v = string(b)
 		}
-
 		headers = headers.With(k, v)
 	}
 	return headers, nil

--- a/transport/grpc/stream_test.go
+++ b/transport/grpc/stream_test.go
@@ -226,6 +226,7 @@ func TestStreaming(t *testing.T) {
 					Proc(
 						Name("proc"),
 						OrderedStreamHandler(
+							StreamSendHeaders(map[string]string{"key": "value"}),
 							WantHeader("req_key", "req_val"),
 							WantHeader("req_key2", "req_val2"),
 							RecvStreamMsg("test"),
@@ -241,6 +242,7 @@ func TestStreaming(t *testing.T) {
 					WithHeader("req_key", "req_val"),
 					WithHeader("req_key2", "req_val2"),
 					ClientStreamActions(
+						WantHeaders(map[string]string{"key": "value"}),
 						SendStreamMsg("test"),
 						RecvStreamErr(io.EOF.Error()),
 					),

--- a/x/yarpctest/handler_stream.go
+++ b/x/yarpctest/handler_stream.go
@@ -143,3 +143,10 @@ func StreamHandlerError(err error) api.ServerStreamAction {
 		return err
 	})
 }
+
+// StreamSendHeaders is an action to send stream headers.
+func StreamSendHeaders(headers map[string]string) api.ServerStreamAction {
+	return api.ServerStreamActionFunc(func(c *transport.ServerStream) error {
+		return c.SendHeaders(transport.HeadersFromMap(headers))
+	})
+}

--- a/x/yarpctest/request_stream.go
+++ b/x/yarpctest/request_stream.go
@@ -106,3 +106,16 @@ func CloseStream() api.ClientStreamAction {
 		require.NoError(t, c.Close(context.Background()))
 	})
 }
+
+// Headers is an action to fetch the client stream headers.
+func WantHeaders(want map[string]string) api.ClientStreamAction {
+	return api.ClientStreamActionFunc(func(t testing.TB, c *transport.ClientStream) {
+		got, err := c.Headers()
+		require.NoError(t, err)
+		for k, v := range want {
+			g, ok := got.Get(k)
+			require.True(t, ok)
+			assert.Equal(t, v, g)
+		}
+	})
+}

--- a/x/yarpctest/request_stream.go
+++ b/x/yarpctest/request_stream.go
@@ -107,7 +107,7 @@ func CloseStream() api.ClientStreamAction {
 	})
 }
 
-// Headers is an action to fetch the client stream headers.
+// WantHeaders is an action to fetch the client stream headers.
 func WantHeaders(want map[string]string) api.ClientStreamAction {
 	return api.ClientStreamActionFunc(func(t testing.TB, c *transport.ClientStream) {
 		got, err := c.Headers()


### PR DESCRIPTION
- [x] Description and context for reviewers: one partner, one stranger
- [x] Docs (package doc)
- [x] Entry in CHANGELOG.md

This change adds support for [gRPC Streaming Response Headers](https://grpc.github.io/grpc/cpp/md_doc__p_r_o_t_o_c_o_l-_h_t_t_p2.html).

`Response → (Response-Headers *Length-Prefixed-Message Trailers) / Trailers-Only`

These headers are only sent in the initial response to the stream request, and can carry information about the subsequent stream.

Note we only add the gRPC [`SendHeader()`](https://pkg.go.dev/google.golang.org/grpc?tab=doc#SendHeader) method. [`SetHeader()`](https://pkg.go.dev/google.golang.org/grpc?tab=doc#SetHeader) would be more useful for middleware.

Note we do not support the trailer metadata as in the `Trailers-Only`.