### PR TITLE
tchannel: Propagate transport.Request#Caller field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - grpc: Enabled outbound introspection for debug pages.
 - experimental: Added `tchannel.GetResponseErrorMeta` API for retrieving native
   TChannel error response codes.
+### Fixed
+- tchannel: middleware may modify the outbound `transport.Request#Caller` field,
+  similar to gRPC and HTTP outbounds.
 ### Removed
 - Removed `yarpcproto` package that enabled "oneway" Protobuf signatures.
 

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -119,6 +119,7 @@ func callWithPeer(ctx context.Context, req *transport.Request, peer *tchannel.Pe
 	format := tchannel.Format(req.Encoding)
 	callOptions := tchannel.CallOptions{
 		Format:          format,
+		CallerName:      req.Caller,
 		ShardKey:        req.ShardKey,
 		RoutingKey:      req.RoutingKey,
 		RoutingDelegate: req.RoutingDelegate,


### PR DESCRIPTION
Currently, TChannel callers cannot modify the outbound caller field on
the `transport.Request`. This was previously due to a limitation in
TChannel until https://github.com/uber/tchannel-go/pull/741.

This change enables us to create transparent TChannel proxies, such
that a target service can observe the originating caller
name. TChannel proxies can introduce the option to forward the name of
the proxy as the caller (current behaviour) or the name of the
originating caller.

This behaviour is already supported for gRPC and HTTP.
- https://sourcegraph.com/github.com/yarpc/yarpc-go@ff06e63f11ec8970bb1db1f569362f12b27fb868/-/blob/transport/grpc/headers.go#L93
- https://sourcegraph.com/github.com/yarpc/yarpc-go@ff06e63f11ec8970bb1db1f569362f12b27fb868/-/blob/transport/http/outbound.go#L359

Ref: MA-3219

- [x] Description and context for reviewers: one partner, one stranger
- [x] Entry in CHANGELOG.md
