### PR TITLE
peer: Expose Implementation constructors

### DIFF
--- a/peer/hashring32/list.go
+++ b/peer/hashring32/list.go
@@ -42,7 +42,7 @@ type options struct {
 	logger               *zap.Logger
 }
 
-// Option customizes the behavior of hashring32 implementation.
+// Option customizes the behavior of hashring32 peer list.
 type Option interface {
 	apply(*options)
 }

--- a/peer/hashring32/ring.go
+++ b/peer/hashring32/ring.go
@@ -26,9 +26,31 @@ import (
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/peer/abstractlist"
+	"go.uber.org/yarpc/peer/hashring32/internal/farmhashring"
 	"go.uber.org/yarpc/peer/hashring32/internal/hashring32"
 	"go.uber.org/zap"
 )
+
+// NewImplementation creates a new hashring32 abstractlist.Implementation.
+//
+// Use this constructor instead of NewList, when wanting to do custom peer
+// connection management.
+func NewImplementation(opts ...Option) abstractlist.Implementation {
+	options := options{
+		logger: zap.NewNop(),
+	}
+	for _, o := range opts {
+		o.apply(&options)
+	}
+
+	return newPeerRing(
+		farmhashring.Fingerprint32,
+		options.offsetHeader,
+		options.peerOverrideHeader,
+		options.logger,
+		options.peerRingOptions...,
+	)
+}
 
 // newPeerRing creates a new peerRing with an initial capacity
 func newPeerRing(hashFunc hashring32.HashFunc32, offsetHeader, peerOverrideHeader string, logger *zap.Logger, option ...hashring32.Option) *peerRing {

--- a/peer/pendingheap/heap.go
+++ b/peer/pendingheap/heap.go
@@ -23,6 +23,7 @@ package pendingheap
 import (
 	"container/heap"
 	"sync"
+	"time"
 
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
@@ -46,7 +47,27 @@ type pendingHeap struct {
 	nextRand func(numPeers int) int
 }
 
-var _ abstractlist.Implementation = (*pendingHeap)(nil)
+// Option configures the peer list implementation constructor.
+type Option interface {
+	apply(*options)
+}
+
+type options struct{}
+
+// NewImplementation creates a new fewest pending heap
+// abstractlist.Implementation.
+//
+// Use this constructor instead of NewList, when wanting to do custom peer
+// connection management.
+func NewImplementation(opts ...Option) abstractlist.Implementation {
+	return newHeap(nextRand(time.Now().UnixNano()))
+}
+
+func newHeap(nextRand func(numPeers int) int) *pendingHeap {
+	return &pendingHeap{
+		nextRand: nextRand,
+	}
+}
 
 func (ph *pendingHeap) Choose(req *transport.Request) peer.StatusPeer {
 	ph.Lock()

--- a/peer/pendingheap/list.go
+++ b/peer/pendingheap/list.go
@@ -115,9 +115,7 @@ func New(transport peer.Transport, opts ...ListOption) *List {
 		list: abstractlist.New(
 			"fewest-pending-requests",
 			transport,
-			&pendingHeap{
-				nextRand: nextRandFn,
-			},
+			newHeap(nextRandFn),
 			plOpts...,
 		),
 	}

--- a/peer/randpeer/random.go
+++ b/peer/randpeer/random.go
@@ -22,6 +22,7 @@ package randpeer
 
 import (
 	"math/rand"
+	"time"
 
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
@@ -33,14 +34,27 @@ type randomList struct {
 	random      *rand.Rand
 }
 
+// Option configures the peer list implementation constructor.
+type Option interface {
+	apply(*options)
+}
+
+type options struct{}
+
+// NewImplementation creates a new random abstractlist.Implementation.
+//
+// Use this constructor instead of NewList, when wanting to do custom peer
+// connection management.
+func NewImplementation(opts ...Option) abstractlist.Implementation {
+	return newRandomList(10, rand.NewSource(time.Now().UnixNano()))
+}
+
 func newRandomList(cap int, source rand.Source) *randomList {
 	return &randomList{
 		subscribers: make([]*subscriber, 0, cap),
 		random:      rand.New(source),
 	}
 }
-
-var _ abstractlist.Implementation = (*randomList)(nil)
 
 func (r *randomList) Add(peer peer.StatusPeer, _ peer.Identifier) abstractlist.Subscriber {
 	index := len(r.subscribers)

--- a/peer/roundrobin/list.go
+++ b/peer/roundrobin/list.go
@@ -116,7 +116,7 @@ func New(transport peer.Transport, opts ...ListOption) *List {
 		list: abstractlist.New(
 			"round-robin",
 			transport,
-			newPeerRing(),
+			NewImplementation(),
 			plOpts...,
 		),
 	}

--- a/peer/roundrobin/peerring.go
+++ b/peer/roundrobin/peerring.go
@@ -28,8 +28,18 @@ import (
 	"go.uber.org/yarpc/peer/abstractlist"
 )
 
-// newPeerRing creates a new peerRing with an initial capacity
-func newPeerRing() *peerRing {
+// Option configures the peer list implementation constructor.
+type Option interface {
+	apply(*options)
+}
+
+type options struct{}
+
+// NewImplementation creates a new round-robin abstractlist.Implementation.
+//
+// Use this constructor instead of NewList, when wanting to do custom peer
+// connection management.
+func NewImplementation(opts ...Option) abstractlist.Implementation {
 	return &peerRing{}
 }
 
@@ -46,8 +56,6 @@ func (s *subscriber) UpdatePendingRequestCount(int) {}
 type peerRing struct {
 	nextNode *ring.Ring
 }
-
-var _ abstractlist.Implementation = (*peerRing)(nil)
 
 // Add a peer.StatusPeer to the end of the peerRing, if the ring is empty it
 // initializes the nextNode marker

--- a/peer/tworandomchoices/tworandomchoices.go
+++ b/peer/tworandomchoices/tworandomchoices.go
@@ -22,6 +22,7 @@ package tworandomchoices
 
 import (
 	"math/rand"
+	"time"
 
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
@@ -33,14 +34,28 @@ type twoRandomChoicesList struct {
 	random      *rand.Rand
 }
 
+// Option configures the peer list implementation constructor.
+type Option interface {
+	apply(*options)
+}
+
+type options struct{}
+
+// NewImplementation creates a new fewest pending heap
+// abstractlist.Implementation.
+//
+// Use this constructor instead of NewList, when wanting to do custom peer
+// connection management.
+func NewImplementation(opts ...Option) abstractlist.Implementation {
+	return newTwoRandomChoicesList(10, rand.NewSource(time.Now().UnixNano()))
+}
+
 func newTwoRandomChoicesList(cap int, source rand.Source) *twoRandomChoicesList {
 	return &twoRandomChoicesList{
 		subscribers: make([]*subscriber, 0, cap),
 		random:      rand.New(source),
 	}
 }
-
-var _ abstractlist.Implementation = (*twoRandomChoicesList)(nil)
 
 func (l *twoRandomChoicesList) Add(peer peer.StatusPeer, _ peer.Identifier) abstractlist.Subscriber {
 	index := len(l.subscribers)


### PR DESCRIPTION
This change makes the constructors of all peer list implementations
public. This will enable users of custom peer connection management
schemes (such as advanced sharders) to benefit from the various load
balancing behaviours (roundrobin, pick two, random, etc) without
requiring, yet another fork. Few users should ever need this.

Constructors are forward compatible with an unused `Option` interface,
since changing a public function signature is a breaking change.

Ref T6505549

- [x] Description and context for reviewers: one partner, one stranger
