### PR TITLE
Add hashing library to glide.yaml for legacy projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - tchannel: middleware may modify the outbound `transport.Request#Caller` field,
   similar to gRPC and HTTP outbounds.
+- Added `github.com/dgryski/go-farm` dependency to `glide.yaml` for legacy
+  projects.
 ### Removed
 - Removed `yarpcproto` package that enabled "oneway" Protobuf signatures.
 

--- a/glide.yaml
+++ b/glide.yaml
@@ -72,6 +72,8 @@ import:
 # pull from Glide. Use older versions until we can upgrade to Go modules.
 - package: github.com/prometheus/client_golang
   version: '>= 0.9, < 1.2.0'
+- package: github.com/dgryski/go-farm
+  version: master
 testImport:
 - package: github.com/stretchr/testify
   # No version pin because some of our dependencies aren't pinning.


### PR DESCRIPTION
This adds the https://github.com/dgryski/go-farm library to the `glide.yaml` for
projects that have yet to migrate to go modules. There's no version for this
library so we pin to master. This seems relatively safe as the library rarely
changes.

This prevents legacy projects from needing to pin the dependency manually.

https://github.com/yarpc/yarpc-go/blob/dev/go.mod#L10