### PR TITLE
Rename ApplicationErrorMeta `Message` field to `Details`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   code under the `errorCode` field. Errors created outside of
   `protobuf.NewError` and `yarpcerrors` will yield `CodeUnknown`.
 - logging: Thrift exceptions and Protobuf error details are logged under the
-  `appErrMessage` field.
+  `errorDetails` field.
 - grpc: Enabled outbound introspection for debug pages.
 - experimental: Added `tchannel.GetResponseErrorMeta` API for retrieving native
   TChannel error response codes.

--- a/api/transport/response.go
+++ b/api/transport/response.go
@@ -56,14 +56,14 @@ type ResponseWriter interface {
 }
 
 // ApplicationErrorMeta contains additional information to describe the
-// application error, such as an error name, code and message.
+// application error, using an error name, code and details string.
 //
 // Fields are optional for backwards-compatibility and may not be present in all
 // responses.
 type ApplicationErrorMeta struct {
-	Message string
-	Name    string
 	Code    *yarpcerrors.Code
+	Name    string
+	Details string
 }
 
 // ApplicationErrorMetaSetter enables setting the name of an

--- a/encoding/protobuf/error.go
+++ b/encoding/protobuf/error.go
@@ -162,7 +162,7 @@ func setApplicationErrorMeta(pberr *pberror, resw transport.ResponseWriter) {
 
 	applicationErroMetaSetter.SetApplicationErrorMeta(&transport.ApplicationErrorMeta{
 		Name:    appErrName,
-		Message: fmt.Sprintf(_errDetailsFmt, strings.Join(details, " , ")),
+		Details: fmt.Sprintf(_errDetailsFmt, strings.Join(details, " , ")),
 	})
 }
 

--- a/encoding/protobuf/error_test.go
+++ b/encoding/protobuf/error_test.go
@@ -93,7 +93,7 @@ func TestConvertToYARPCErrorApplicationErrorMeta(t *testing.T) {
 	assert.Equal(t, "StringValue", resw.ApplicationErrorMeta.Name, "expected first error detail name")
 	assert.Equal(t,
 		"[]{ StringValue{value:\"detail message\" } , Int32Value{value:42 } , BytesValue{value:\"detail bytes\" } }",
-		resw.ApplicationErrorMeta.Message,
+		resw.ApplicationErrorMeta.Details,
 		"unexpected string of error details")
 	assert.Nil(t, resw.ApplicationErrorMeta.Code, "code should nil")
 }

--- a/encoding/protobuf/observability_test.go
+++ b/encoding/protobuf/observability_test.go
@@ -68,7 +68,7 @@ func TestProtobufErrorDetailObservability(t *testing.T) {
 		wantFields := []zapcore.Field{
 			zap.String("errorCode", "invalid-argument"),
 			zap.String("errorName", "StringValue"),
-			zap.String("appErrorMessage", "[]{ StringValue{value:\"string value\" } , Int32Value{value:100 } }"),
+			zap.String("errorDetails", "[]{ StringValue{value:\"string value\" } , Int32Value{value:100 } }"),
 		}
 		assertLogs(t, wantFields, observedLogs.TakeAll())
 	})

--- a/encoding/thrift/inbound.go
+++ b/encoding/thrift/inbound.go
@@ -78,7 +78,7 @@ func (t thriftUnaryHandler) Handle(ctx context.Context, treq *transport.Request,
 
 		if applicationErrorMetaSetter, ok := rw.(transport.ApplicationErrorMetaSetter); ok {
 			applicationErrorMetaSetter.SetApplicationErrorMeta(&transport.ApplicationErrorMeta{
-				Message: res.ApplicationErrorMessage,
+				Details: res.ApplicationErrorDetails,
 				Name:    res.ApplicationErrorName,
 				Code:    res.ApplicationErrorCode,
 			})

--- a/encoding/thrift/internal/observabilitytest/test/testserviceserver/server.go
+++ b/encoding/thrift/internal/observabilitytest/test/testserviceserver/server.go
@@ -98,7 +98,7 @@ func (h handler) Call(ctx context.Context, body wire.Value) (thrift.Response, er
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		if appErr != nil {
-			response.ApplicationErrorMessage = appErr.Error()
+			response.ApplicationErrorDetails = appErr.Error()
 		}
 	}
 

--- a/encoding/thrift/observability_test.go
+++ b/encoding/thrift/observability_test.go
@@ -77,7 +77,7 @@ func TestThriftExceptionObservability(t *testing.T) {
 					zap.String("error", "application_error"),
 					zap.String("errorName", "ExceptionWithCode"),
 					zap.String("errorCode", "data-loss"),
-					zap.String("appErrorMessage", "ExceptionWithCode{Val: exception with code}"),
+					zap.String("errorDetails", "ExceptionWithCode{Val: exception with code}"),
 				}
 				assertLogs(t, wantFields, observedLogs.TakeAll())
 			})
@@ -121,7 +121,7 @@ func TestThriftExceptionObservability(t *testing.T) {
 				wantFields := []zapcore.Field{
 					zap.String("error", "application_error"),
 					zap.String("errorName", "ExceptionWithoutCode"),
-					zap.String("appErrorMessage", "ExceptionWithoutCode{Val: exception with no code}"),
+					zap.String("errorDetails", "ExceptionWithoutCode{Val: exception with no code}"),
 				}
 				assertLogs(t, wantFields, observedLogs.TakeAll())
 			})

--- a/encoding/thrift/response.go
+++ b/encoding/thrift/response.go
@@ -31,7 +31,7 @@ type Response struct {
 
 	IsApplicationError bool
 
-	ApplicationErrorMessage string
+	ApplicationErrorDetails string
 	ApplicationErrorName    string
 	ApplicationErrorCode    *yarpcerrors.Code
 }

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/readonlystoreserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/readonlystoreserver/server.go
@@ -92,7 +92,7 @@ func (h handler) Integer(ctx context.Context, body wire.Value) (thrift.Response,
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		if appErr != nil {
-			response.ApplicationErrorMessage = appErr.Error()
+			response.ApplicationErrorDetails = appErr.Error()
 		}
 	}
 

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storeserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storeserver/server.go
@@ -125,7 +125,7 @@ func (h handler) CompareAndSwap(ctx context.Context, body wire.Value) (thrift.Re
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		if appErr != nil {
-			response.ApplicationErrorMessage = appErr.Error()
+			response.ApplicationErrorDetails = appErr.Error()
 		}
 	}
 
@@ -164,7 +164,7 @@ func (h handler) Increment(ctx context.Context, body wire.Value) (thrift.Respons
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		if appErr != nil {
-			response.ApplicationErrorMessage = appErr.Error()
+			response.ApplicationErrorDetails = appErr.Error()
 		}
 	}
 

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/baseserviceserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/baseserviceserver/server.go
@@ -77,7 +77,7 @@ func (h handler) Healthy(ctx context.Context, body wire.Value) (thrift.Response,
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		if appErr != nil {
-			response.ApplicationErrorMessage = appErr.Error()
+			response.ApplicationErrorDetails = appErr.Error()
 		}
 	}
 

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendemptyserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendemptyserver/server.go
@@ -91,7 +91,7 @@ func (h handler) Hello(ctx context.Context, body wire.Value) (thrift.Response, e
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		if appErr != nil {
-			response.ApplicationErrorMessage = appErr.Error()
+			response.ApplicationErrorDetails = appErr.Error()
 		}
 	}
 

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/nameserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/nameserver/server.go
@@ -77,7 +77,7 @@ func (h handler) Name(ctx context.Context, body wire.Value) (thrift.Response, er
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		if appErr != nil {
-			response.ApplicationErrorMessage = appErr.Error()
+			response.ApplicationErrorDetails = appErr.Error()
 		}
 	}
 

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/weather/weatherserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/weather/weatherserver/server.go
@@ -77,7 +77,7 @@ func (h handler) Check(ctx context.Context, body wire.Value) (thrift.Response, e
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		if appErr != nil {
-			response.ApplicationErrorMessage = appErr.Error()
+			response.ApplicationErrorDetails = appErr.Error()
 		}
 	}
 

--- a/encoding/thrift/thriftrw-plugin-yarpc/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/server.go
@@ -166,7 +166,7 @@ func (h handler) <.Name>(ctx <$context>.Context, body <$wire>.Value) (<$thrift>.
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		if appErr != nil {
-			response.ApplicationErrorMessage = appErr.Error()
+			response.ApplicationErrorDetails = appErr.Error()
 		}
 	}
 

--- a/internal/crossdock/thrift/echo/echoserver/server.go
+++ b/internal/crossdock/thrift/echo/echoserver/server.go
@@ -98,7 +98,7 @@ func (h handler) Echo(ctx context.Context, body wire.Value) (thrift.Response, er
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		if appErr != nil {
-			response.ApplicationErrorMessage = appErr.Error()
+			response.ApplicationErrorDetails = appErr.Error()
 		}
 	}
 

--- a/internal/crossdock/thrift/gauntlet/secondserviceserver/server.go
+++ b/internal/crossdock/thrift/gauntlet/secondserviceserver/server.go
@@ -113,7 +113,7 @@ func (h handler) BlahBlah(ctx context.Context, body wire.Value) (thrift.Response
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		if appErr != nil {
-			response.ApplicationErrorMessage = appErr.Error()
+			response.ApplicationErrorDetails = appErr.Error()
 		}
 	}
 
@@ -143,7 +143,7 @@ func (h handler) SecondtestString(ctx context.Context, body wire.Value) (thrift.
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		if appErr != nil {
-			response.ApplicationErrorMessage = appErr.Error()
+			response.ApplicationErrorDetails = appErr.Error()
 		}
 	}
 

--- a/internal/crossdock/thrift/gauntlet/thrifttestserver/server.go
+++ b/internal/crossdock/thrift/gauntlet/thrifttestserver/server.go
@@ -423,7 +423,7 @@ func (h handler) TestBinary(ctx context.Context, body wire.Value) (thrift.Respon
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		if appErr != nil {
-			response.ApplicationErrorMessage = appErr.Error()
+			response.ApplicationErrorDetails = appErr.Error()
 		}
 	}
 
@@ -453,7 +453,7 @@ func (h handler) TestByte(ctx context.Context, body wire.Value) (thrift.Response
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		if appErr != nil {
-			response.ApplicationErrorMessage = appErr.Error()
+			response.ApplicationErrorDetails = appErr.Error()
 		}
 	}
 
@@ -483,7 +483,7 @@ func (h handler) TestDouble(ctx context.Context, body wire.Value) (thrift.Respon
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		if appErr != nil {
-			response.ApplicationErrorMessage = appErr.Error()
+			response.ApplicationErrorDetails = appErr.Error()
 		}
 	}
 
@@ -513,7 +513,7 @@ func (h handler) TestEnum(ctx context.Context, body wire.Value) (thrift.Response
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		if appErr != nil {
-			response.ApplicationErrorMessage = appErr.Error()
+			response.ApplicationErrorDetails = appErr.Error()
 		}
 	}
 
@@ -543,7 +543,7 @@ func (h handler) TestException(ctx context.Context, body wire.Value) (thrift.Res
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		if appErr != nil {
-			response.ApplicationErrorMessage = appErr.Error()
+			response.ApplicationErrorDetails = appErr.Error()
 		}
 	}
 
@@ -573,7 +573,7 @@ func (h handler) TestI32(ctx context.Context, body wire.Value) (thrift.Response,
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		if appErr != nil {
-			response.ApplicationErrorMessage = appErr.Error()
+			response.ApplicationErrorDetails = appErr.Error()
 		}
 	}
 
@@ -603,7 +603,7 @@ func (h handler) TestI64(ctx context.Context, body wire.Value) (thrift.Response,
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		if appErr != nil {
-			response.ApplicationErrorMessage = appErr.Error()
+			response.ApplicationErrorDetails = appErr.Error()
 		}
 	}
 
@@ -633,7 +633,7 @@ func (h handler) TestInsanity(ctx context.Context, body wire.Value) (thrift.Resp
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		if appErr != nil {
-			response.ApplicationErrorMessage = appErr.Error()
+			response.ApplicationErrorDetails = appErr.Error()
 		}
 	}
 
@@ -663,7 +663,7 @@ func (h handler) TestList(ctx context.Context, body wire.Value) (thrift.Response
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		if appErr != nil {
-			response.ApplicationErrorMessage = appErr.Error()
+			response.ApplicationErrorDetails = appErr.Error()
 		}
 	}
 
@@ -693,7 +693,7 @@ func (h handler) TestMap(ctx context.Context, body wire.Value) (thrift.Response,
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		if appErr != nil {
-			response.ApplicationErrorMessage = appErr.Error()
+			response.ApplicationErrorDetails = appErr.Error()
 		}
 	}
 
@@ -723,7 +723,7 @@ func (h handler) TestMapMap(ctx context.Context, body wire.Value) (thrift.Respon
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		if appErr != nil {
-			response.ApplicationErrorMessage = appErr.Error()
+			response.ApplicationErrorDetails = appErr.Error()
 		}
 	}
 
@@ -753,7 +753,7 @@ func (h handler) TestMulti(ctx context.Context, body wire.Value) (thrift.Respons
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		if appErr != nil {
-			response.ApplicationErrorMessage = appErr.Error()
+			response.ApplicationErrorDetails = appErr.Error()
 		}
 	}
 
@@ -783,7 +783,7 @@ func (h handler) TestMultiException(ctx context.Context, body wire.Value) (thrif
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		if appErr != nil {
-			response.ApplicationErrorMessage = appErr.Error()
+			response.ApplicationErrorDetails = appErr.Error()
 		}
 	}
 
@@ -813,7 +813,7 @@ func (h handler) TestNest(ctx context.Context, body wire.Value) (thrift.Response
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		if appErr != nil {
-			response.ApplicationErrorMessage = appErr.Error()
+			response.ApplicationErrorDetails = appErr.Error()
 		}
 	}
 
@@ -852,7 +852,7 @@ func (h handler) TestSet(ctx context.Context, body wire.Value) (thrift.Response,
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		if appErr != nil {
-			response.ApplicationErrorMessage = appErr.Error()
+			response.ApplicationErrorDetails = appErr.Error()
 		}
 	}
 
@@ -882,7 +882,7 @@ func (h handler) TestString(ctx context.Context, body wire.Value) (thrift.Respon
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		if appErr != nil {
-			response.ApplicationErrorMessage = appErr.Error()
+			response.ApplicationErrorDetails = appErr.Error()
 		}
 	}
 
@@ -912,7 +912,7 @@ func (h handler) TestStringMap(ctx context.Context, body wire.Value) (thrift.Res
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		if appErr != nil {
-			response.ApplicationErrorMessage = appErr.Error()
+			response.ApplicationErrorDetails = appErr.Error()
 		}
 	}
 
@@ -942,7 +942,7 @@ func (h handler) TestStruct(ctx context.Context, body wire.Value) (thrift.Respon
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		if appErr != nil {
-			response.ApplicationErrorMessage = appErr.Error()
+			response.ApplicationErrorDetails = appErr.Error()
 		}
 	}
 
@@ -972,7 +972,7 @@ func (h handler) TestTypedef(ctx context.Context, body wire.Value) (thrift.Respo
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		if appErr != nil {
-			response.ApplicationErrorMessage = appErr.Error()
+			response.ApplicationErrorDetails = appErr.Error()
 		}
 	}
 
@@ -1002,7 +1002,7 @@ func (h handler) TestVoid(ctx context.Context, body wire.Value) (thrift.Response
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		if appErr != nil {
-			response.ApplicationErrorMessage = appErr.Error()
+			response.ApplicationErrorDetails = appErr.Error()
 		}
 	}
 

--- a/internal/examples/thrift-hello/hello/echo/helloserver/server.go
+++ b/internal/examples/thrift-hello/hello/echo/helloserver/server.go
@@ -98,7 +98,7 @@ func (h handler) Echo(ctx context.Context, body wire.Value) (thrift.Response, er
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		if appErr != nil {
-			response.ApplicationErrorMessage = appErr.Error()
+			response.ApplicationErrorDetails = appErr.Error()
 		}
 	}
 

--- a/internal/examples/thrift-keyvalue/keyvalue/kv/keyvalueserver/server.go
+++ b/internal/examples/thrift-keyvalue/keyvalue/kv/keyvalueserver/server.go
@@ -115,7 +115,7 @@ func (h handler) GetValue(ctx context.Context, body wire.Value) (thrift.Response
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		if appErr != nil {
-			response.ApplicationErrorMessage = appErr.Error()
+			response.ApplicationErrorDetails = appErr.Error()
 		}
 	}
 
@@ -145,7 +145,7 @@ func (h handler) SetValue(ctx context.Context, body wire.Value) (thrift.Response
 			response.ApplicationErrorCode = extractor.YARPCErrorCode()
 		}
 		if appErr != nil {
-			response.ApplicationErrorMessage = appErr.Error()
+			response.ApplicationErrorDetails = appErr.Error()
 		}
 	}
 

--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -37,9 +37,9 @@ const (
 	_errorNameMetricsKey = "error_name"
 	_notSet              = "__not_set__"
 
-	_errorNameLogKey       = "errorName"
-	_errorCodeLogKey       = "errorCode"
-	_appErrorMessageLogKey = "appErrorMessage"
+	_errorNameLogKey    = "errorName"
+	_errorCodeLogKey    = "errorCode"
+	_errorDetailsLogKey = "errorDetails"
 
 	_successfulInbound  = "Handled inbound request."
 	_successfulOutbound = "Made outbound call."
@@ -199,8 +199,8 @@ func (c call) endLogs(
 			if applicationErrorMeta.Name != "" {
 				fields = append(fields, zap.String(_errorNameLogKey, applicationErrorMeta.Name))
 			}
-			if applicationErrorMeta.Message != "" {
-				fields = append(fields, zap.String(_appErrorMessageLogKey, applicationErrorMeta.Message))
+			if applicationErrorMeta.Details != "" {
+				fields = append(fields, zap.String(_errorDetailsLogKey, applicationErrorMeta.Details))
 			}
 		}
 
@@ -213,8 +213,8 @@ func (c call) endLogs(
 			if applicationErrorMeta.Name != "" {
 				fields = append(fields, zap.String(_errorNameLogKey, applicationErrorMeta.Name))
 			}
-			if applicationErrorMeta.Message != "" {
-				fields = append(fields, zap.String(_appErrorMessageLogKey, applicationErrorMeta.Message))
+			if applicationErrorMeta.Details != "" {
+				fields = append(fields, zap.String(_errorDetailsLogKey, applicationErrorMeta.Details))
 			}
 		}
 

--- a/internal/observability/common_test.go
+++ b/internal/observability/common_test.go
@@ -36,7 +36,7 @@ type fakeHandler struct {
 	err                   error
 	applicationErr        bool
 	applicationErrName    string
-	applicationErrMessage string
+	applicationErrDetails string
 	applicationErrCode    *yarpcerrors.Code
 	applicationPanic      bool
 	handleStream          func(*transport.ServerStream)
@@ -51,7 +51,7 @@ func (h fakeHandler) Handle(_ context.Context, _ *transport.Request, rw transpor
 
 		if applicationErrorMetaSetter, ok := rw.(transport.ApplicationErrorMetaSetter); ok {
 			applicationErrorMetaSetter.SetApplicationErrorMeta(&transport.ApplicationErrorMeta{
-				Message: h.applicationErrMessage,
+				Details: h.applicationErrDetails,
 				Name:    h.applicationErrName,
 				Code:    h.applicationErrCode,
 			})
@@ -84,7 +84,7 @@ type fakeOutbound struct {
 	err                   error
 	applicationErr        bool
 	applicationErrName    string
-	applicationErrMessage string
+	applicationErrDetails string
 	applicationErrCode    *yarpcerrors.Code
 	stream                fakeStream
 }
@@ -93,7 +93,7 @@ func (o fakeOutbound) Call(context.Context, *transport.Request) (*transport.Resp
 	return &transport.Response{
 		ApplicationError: o.applicationErr,
 		ApplicationErrorMeta: &transport.ApplicationErrorMeta{
-			Message: o.applicationErrMessage,
+			Details: o.applicationErrDetails,
 			Name:    o.applicationErrName,
 			Code:    o.applicationErrCode,
 		}}, o.err

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -183,7 +183,7 @@ func TestMiddlewareLogging(t *testing.T) {
 	yErrNoDetails := yarpcerrors.Newf(yarpcerrors.CodeAborted, "fail")
 	yErrWithDetails := yarpcerrors.Newf(yarpcerrors.CodeAborted, "fail").WithDetails([]byte("err detail"))
 	yErrResourceExhausted := yarpcerrors.CodeResourceExhausted
-	appErrMessage := "an app error message, usually from thriftEx.Error()!"
+	appErrDetails := "an app error detail string, usually from thriftEx.Error()!"
 
 	baseFields := func() []zapcore.Field {
 		return []zapcore.Field{
@@ -202,7 +202,7 @@ func TestMiddlewareLogging(t *testing.T) {
 		err                   error             // downstream error
 		applicationErr        bool              // downstream application error
 		applicationErrName    string            // downstream application error name
-		applicationErrMessage string            // downstream application error message
+		applicationErrDetails string            // downstream application error message
 		applicationErrCode    *yarpcerrors.Code // downstream application error code
 		wantErrLevel          zapcore.Level
 		wantInboundMsg        string
@@ -239,7 +239,7 @@ func TestMiddlewareLogging(t *testing.T) {
 		{
 			desc:                  "thrift application error with no name",
 			applicationErr:        true,
-			applicationErrMessage: appErrMessage,
+			applicationErrDetails: appErrDetails,
 			wantErrLevel:          zapcore.WarnLevel,
 			wantInboundMsg:        "Error handling inbound request.",
 			wantOutboundMsg:       "Error making outbound call.",
@@ -248,14 +248,14 @@ func TestMiddlewareLogging(t *testing.T) {
 				zap.Bool("successful", false),
 				zap.Skip(),
 				zap.String("error", "application_error"),
-				zap.String("appErrorMessage", appErrMessage),
+				zap.String("errorDetails", appErrDetails),
 			},
 		},
 		{
 			desc:                  "thrift application error with name and code",
 			applicationErr:        true,
 			applicationErrName:    "FunkyThriftError",
-			applicationErrMessage: appErrMessage,
+			applicationErrDetails: appErrDetails,
 			applicationErrCode:    &yErrResourceExhausted,
 			wantErrLevel:          zapcore.WarnLevel,
 			wantInboundMsg:        "Error handling inbound request.",
@@ -267,7 +267,7 @@ func TestMiddlewareLogging(t *testing.T) {
 				zap.String("error", "application_error"),
 				zap.String("errorCode", "resource-exhausted"),
 				zap.String("errorName", "FunkyThriftError"),
-				zap.String("appErrorMessage", appErrMessage),
+				zap.String("errorDetails", appErrDetails),
 			},
 		},
 		{
@@ -308,7 +308,7 @@ func TestMiddlewareLogging(t *testing.T) {
 			err:                   yErrNoDetails,
 			applicationErr:        true, // always true for Protobuf handler errors
 			wantErrLevel:          zapcore.ErrorLevel,
-			applicationErrMessage: appErrMessage,
+			applicationErrDetails: appErrDetails,
 			applicationErrName:    "MyErrMessageName",
 			wantInboundMsg:        "Error handling inbound request.",
 			wantOutboundMsg:       "Error making outbound call.",
@@ -319,7 +319,7 @@ func TestMiddlewareLogging(t *testing.T) {
 				zap.Error(yErrNoDetails),
 				zap.String(_errorCodeLogKey, "aborted"),
 				zap.String(_errorNameLogKey, "MyErrMessageName"),
-				zap.String(_appErrorMessageLogKey, appErrMessage),
+				zap.String(_errorDetailsLogKey, appErrDetails),
 			},
 		},
 		{
@@ -345,7 +345,7 @@ func TestMiddlewareLogging(t *testing.T) {
 			err:                   t.err,
 			applicationErr:        t.applicationErr,
 			applicationErrName:    t.applicationErrName,
-			applicationErrMessage: t.applicationErrMessage,
+			applicationErrDetails: t.applicationErrDetails,
 			applicationErrCode:    t.applicationErrCode,
 		}
 	}
@@ -355,7 +355,7 @@ func TestMiddlewareLogging(t *testing.T) {
 			err:                   t.err,
 			applicationErr:        t.applicationErr,
 			applicationErrName:    t.applicationErrName,
-			applicationErrMessage: t.applicationErrMessage,
+			applicationErrDetails: t.applicationErrDetails,
 			applicationErrCode:    t.applicationErrCode,
 		}
 	}
@@ -2063,7 +2063,7 @@ func TestNewWriterIsEmpty(t *testing.T) {
 
 	w.SetApplicationError()
 	w.SetApplicationErrorMeta(&transport.ApplicationErrorMeta{
-		Message: "foo", Name: "bar", Code: &code,
+		Details: "foo", Name: "bar", Code: &code,
 	})
 	w.free()
 

--- a/transport/grpc/external_integration_test.go
+++ b/transport/grpc/external_integration_test.go
@@ -128,7 +128,7 @@ func TestFoo(t *testing.T) {
 		procedureName = "test-procedure"
 
 		appErrName    = "ProtoAppErrName"
-		appErrMessage = " this is an app error message!"
+		appErrDetails = " this is an app error detail string!"
 
 		portName = "port"
 	)
@@ -142,7 +142,7 @@ func TestFoo(t *testing.T) {
 			}
 			metaSetter.SetApplicationErrorMeta(&transport.ApplicationErrorMeta{
 				Name:    appErrName,
-				Message: appErrMessage,
+				Details: appErrDetails,
 			})
 			return nil
 		})}
@@ -154,7 +154,7 @@ func TestFoo(t *testing.T) {
 			// verify gRPC propagating `transport.ApplicationErrorMeta`
 			require.NotNil(t, res.ApplicationErrorMeta, "missing transport.ApplicationErrorMeta")
 			assert.Equal(t, appErrName, res.ApplicationErrorMeta.Name, "incorrect app error name")
-			assert.Equal(t, appErrMessage, res.ApplicationErrorMeta.Message, "incorrect app error message")
+			assert.Equal(t, appErrDetails, res.ApplicationErrorMeta.Details, "incorrect app error message")
 			assert.Nil(t, res.ApplicationErrorMeta.Code, "unexpected code")
 
 			return res, err

--- a/transport/grpc/headers.go
+++ b/transport/grpc/headers.go
@@ -69,9 +69,9 @@ const (
 	// _applicationErrorNameHeader is the header for the name of the application
 	// error.
 	_applicationErrorNameHeader = "rpc-application-error-name"
-	// _applicationErrorNameHeader is the header for the the application error
-	// message.
-	_applicationErrorMessageHeader = "rpc-application-error-message"
+	// _applicationErrorDetailsHeader is the header for the the application error
+	// meta details string.
+	_applicationErrorDetailsHeader = "rpc-application-error-details"
 
 	// ApplicationErrorHeaderValue is the value that will be set for
 	// ApplicationErrorHeader is there was an application error.
@@ -157,16 +157,16 @@ func metadataToApplicationErrorMeta(responseMD metadata.MD) *transport.Applicati
 		return nil
 	}
 
-	var message, name string
-	if header := responseMD[_applicationErrorMessageHeader]; len(header) == 1 {
-		message = header[0]
+	var details, name string
+	if header := responseMD[_applicationErrorDetailsHeader]; len(header) == 1 {
+		details = header[0]
 	}
 	if header := responseMD[_applicationErrorNameHeader]; len(header) == 1 {
 		name = header[0]
 	}
 
 	return &transport.ApplicationErrorMeta{
-		Message: message,
+		Details: details,
 		Name:    name,
 		// ignore Code, this should be derived from the error since codes are
 		// natively supported in gRPC and YARPC

--- a/transport/grpc/response_writer.go
+++ b/transport/grpc/response_writer.go
@@ -72,8 +72,8 @@ func (r *responseWriter) SetApplicationErrorMeta(meta *transport.ApplicationErro
 	if meta.Name != "" {
 		r.AddSystemHeader(_applicationErrorNameHeader, meta.Name)
 	}
-	if meta.Message != "" {
-		r.AddSystemHeader(_applicationErrorMessageHeader, meta.Message)
+	if meta.Details != "" {
+		r.AddSystemHeader(_applicationErrorDetailsHeader, meta.Details)
 	}
 }
 

--- a/transport/http/constants.go
+++ b/transport/http/constants.go
@@ -103,11 +103,11 @@ const (
 	// Headers for propagating transport.ApplicationErrorMeta.
 	_applicationErrorNameHeader    = "Rpc-Application-Error-Name"
 	_applicationErrorCodeHeader    = "Rpc-Application-Error-Code"
-	_applicationErrorMessageHeader = "Rpc-Application-Error-Message"
+	_applicationErrorDetailsHeader = "Rpc-Application-Error-Details"
 
-	// largest header value length for `transport.ApplicationErrorMeta#Message`
-	_maxAppErrMessageHeaderLen = 256
-	// truncated message if we've exceeded the '_maxAppErrMessageHeaderLen'
+	// largest header value length for `transport.ApplicationErrorMeta#Details`
+	_maxAppErrDetailsHeaderLen = 256
+	// truncated message if we've exceeded the '_maxAppErrDetailsHeaderLen'
 	_truncatedHeaderMessage = " (truncated)"
 )
 

--- a/transport/http/handler.go
+++ b/transport/http/handler.go
@@ -281,16 +281,16 @@ func (rw *responseWriter) SetApplicationErrorMeta(meta *transport.ApplicationErr
 	if meta.Name != "" {
 		rw.w.Header().Set(_applicationErrorNameHeader, meta.Name)
 	}
-	if meta.Message != "" {
-		rw.w.Header().Set(_applicationErrorMessageHeader, truncateAppErrMessage(meta.Message))
+	if meta.Details != "" {
+		rw.w.Header().Set(_applicationErrorDetailsHeader, truncateAppErrDetails(meta.Details))
 	}
 }
 
-func truncateAppErrMessage(val string) string {
-	if len(val) <= _maxAppErrMessageHeaderLen {
+func truncateAppErrDetails(val string) string {
+	if len(val) <= _maxAppErrDetailsHeaderLen {
 		return val
 	}
-	stripIndex := _maxAppErrMessageHeaderLen - len(_truncatedHeaderMessage)
+	stripIndex := _maxAppErrDetailsHeaderLen - len(_truncatedHeaderMessage)
 	return val[:stripIndex] + _truncatedHeaderMessage
 }
 

--- a/transport/http/handler_test.go
+++ b/transport/http/handler_test.go
@@ -419,7 +419,7 @@ func headerCopyWithout(headers http.Header, names ...string) http.Header {
 
 func TestResponseWriter(t *testing.T) {
 	const (
-		appErrMessage = "thrift ex message"
+		appErrDetails = "thrift ex message"
 		appErrName    = "thrift ex name"
 	)
 	appErrCode := yarpcerrors.CodeAborted
@@ -434,7 +434,7 @@ func TestResponseWriter(t *testing.T) {
 	writer.AddHeaders(headers)
 
 	writer.SetApplicationErrorMeta(&transport.ApplicationErrorMeta{
-		Message: appErrMessage,
+		Details: appErrDetails,
 		Name:    appErrName,
 		Code:    &appErrCode,
 	})
@@ -447,7 +447,7 @@ func TestResponseWriter(t *testing.T) {
 	assert.Equal(t, "123", recorder.Header().Get("rpc-header-shard-key"))
 	assert.Equal(t, "hello", recorder.Body.String())
 
-	assert.Equal(t, appErrMessage, recorder.Header().Get(_applicationErrorMessageHeader))
+	assert.Equal(t, appErrDetails, recorder.Header().Get(_applicationErrorDetailsHeader))
 	assert.Equal(t, appErrName, recorder.Header().Get(_applicationErrorNameHeader))
 	assert.Equal(t, strconv.Itoa(int(appErrCode)), recorder.Header().Get(_applicationErrorCodeHeader))
 }
@@ -464,18 +464,18 @@ func TestTruncatedHeader(t *testing.T) {
 		},
 		{
 			name:  "max",
-			value: strings.Repeat("a", _maxAppErrMessageHeaderLen),
+			value: strings.Repeat("a", _maxAppErrDetailsHeaderLen),
 		},
 		{
 			name:         "truncate",
-			value:        strings.Repeat("b", _maxAppErrMessageHeaderLen*2),
+			value:        strings.Repeat("b", _maxAppErrDetailsHeaderLen*2),
 			wantTruncate: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := truncateAppErrMessage(tt.value)
+			got := truncateAppErrDetails(tt.value)
 
 			if !tt.wantTruncate {
 				assert.Equal(t, tt.value, got, "expected no-op")
@@ -483,7 +483,7 @@ func TestTruncatedHeader(t *testing.T) {
 			}
 
 			assert.True(t, strings.HasSuffix(got, _truncatedHeaderMessage), "unexpected truncate suffix")
-			assert.Len(t, got, _maxAppErrMessageHeaderLen, "did not truncate")
+			assert.Len(t, got, _maxAppErrDetailsHeaderLen, "did not truncate")
 		})
 	}
 }

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -277,7 +277,7 @@ func (o *Outbound) call(ctx context.Context, treq *transport.Request) (*transpor
 		Body:             response.Body,
 		ApplicationError: response.Header.Get(ApplicationStatusHeader) == ApplicationErrorStatus,
 		ApplicationErrorMeta: &transport.ApplicationErrorMeta{
-			Message: response.Header.Get(_applicationErrorMessageHeader),
+			Details: response.Header.Get(_applicationErrorDetailsHeader),
 			Name:    response.Header.Get(_applicationErrorNameHeader),
 			Code:    getYARPCApplicationErrorCode(response.Header.Get(_applicationErrorCodeHeader)),
 		},

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -212,7 +212,7 @@ func TestOutboundHeaders(t *testing.T) {
 
 func TestOutboundApplicationError(t *testing.T) {
 	const (
-		appErrMessage = "thrift ex message"
+		appErrDetails = "thrift ex message"
 		appErrName    = "thrift ex name"
 	)
 
@@ -221,7 +221,7 @@ func TestOutboundApplicationError(t *testing.T) {
 		status        string
 		appError      bool
 		appErrName    string
-		appErrMessage string
+		appErrDetails string
 		appErrCode    yarpcerrors.Code
 	}{
 		{
@@ -234,7 +234,7 @@ func TestOutboundApplicationError(t *testing.T) {
 			status:        "error",
 			appError:      true,
 			appErrName:    appErrName,
-			appErrMessage: appErrMessage,
+			appErrDetails: appErrDetails,
 			appErrCode:    yarpcerrors.CodeNotFound,
 		},
 		{
@@ -252,7 +252,7 @@ func TestOutboundApplicationError(t *testing.T) {
 				w.Header().Add("Rpc-Status", tt.status)
 
 				if tt.appError {
-					w.Header().Add(_applicationErrorMessageHeader, tt.appErrMessage)
+					w.Header().Add(_applicationErrorDetailsHeader, tt.appErrDetails)
 					w.Header().Add(_applicationErrorNameHeader, tt.appErrName)
 					w.Header().Add(_applicationErrorCodeHeader, strconv.Itoa(int(tt.appErrCode)))
 				}
@@ -282,7 +282,7 @@ func TestOutboundApplicationError(t *testing.T) {
 		assert.Equal(t, res.ApplicationError, tt.appError, "%v: application status", tt.desc)
 		if tt.appError {
 			require.NotNil(t, res.ApplicationErrorMeta)
-			assert.Equal(t, tt.appErrMessage, res.ApplicationErrorMeta.Message)
+			assert.Equal(t, tt.appErrDetails, res.ApplicationErrorMeta.Details)
 			assert.Equal(t, tt.appErrName, res.ApplicationErrorMeta.Name)
 			assert.Equal(t, &tt.appErrCode, res.ApplicationErrorMeta.Code)
 		}

--- a/transport/tchannel/constants.go
+++ b/transport/tchannel/constants.go
@@ -29,9 +29,9 @@ const (
 	// for Outbounds.
 	TransportName = "tchannel"
 
-	// largest header value length for `transport.ApplicationErrorMeta#Message`
-	_maxAppErrMessageHeaderLen = 256
-	// truncated message if we've exceeded the '_maxAppErrMessageHeaderLen'
+	// largest header value length for `transport.ApplicationErrorMeta#Details`
+	_maxAppErrDetailsHeaderLen = 256
+	// truncated message if we've exceeded the '_maxAppErrDetailsHeaderLen'
 	_truncatedHeaderMessage = " (truncated)"
 )
 

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -279,16 +279,16 @@ func (hw *handlerWriter) SetApplicationErrorMeta(applicationErrorMeta *transport
 	if applicationErrorMeta.Name != "" {
 		hw.AddHeader(ApplicationErrorNameHeaderKey, applicationErrorMeta.Name)
 	}
-	if applicationErrorMeta.Message != "" {
-		hw.AddHeader(ApplicationErrorMessageHeaderKey, truncateAppErrMessage(applicationErrorMeta.Message))
+	if applicationErrorMeta.Details != "" {
+		hw.AddHeader(ApplicationErrorDetailsHeaderKey, truncateAppErrDetails(applicationErrorMeta.Details))
 	}
 }
 
-func truncateAppErrMessage(val string) string {
-	if len(val) <= _maxAppErrMessageHeaderLen {
+func truncateAppErrDetails(val string) string {
+	if len(val) <= _maxAppErrDetailsHeaderLen {
 		return val
 	}
-	stripIndex := _maxAppErrMessageHeaderLen - len(_truncatedHeaderMessage)
+	stripIndex := _maxAppErrDetailsHeaderLen - len(_truncatedHeaderMessage)
 	return val[:stripIndex] + _truncatedHeaderMessage
 }
 

--- a/transport/tchannel/handler_test.go
+++ b/transport/tchannel/handler_test.go
@@ -556,7 +556,7 @@ func TestResponseWriter(t *testing.T) {
 					&transport.ApplicationErrorMeta{
 						Name:    "bAz",
 						Code:    &yErrAborted,
-						Message: "App Error Message",
+						Details: "App Error Details",
 					},
 				)
 				_, err := w.Write([]byte("hello"))
@@ -565,7 +565,7 @@ func TestResponseWriter(t *testing.T) {
 			arg2: map[string]string{
 				"$rpc$-application-error-code":    "10",
 				"$rpc$-application-error-name":    "bAz",
-				"$rpc$-application-error-message": "App Error Message",
+				"$rpc$-application-error-details": "App Error Details",
 			},
 			arg3:             []byte("hello"),
 			applicationError: true,
@@ -780,18 +780,18 @@ func TestTruncatedHeader(t *testing.T) {
 		},
 		{
 			name:  "max",
-			value: strings.Repeat("a", _maxAppErrMessageHeaderLen),
+			value: strings.Repeat("a", _maxAppErrDetailsHeaderLen),
 		},
 		{
 			name:         "truncate",
-			value:        strings.Repeat("b", _maxAppErrMessageHeaderLen*2),
+			value:        strings.Repeat("b", _maxAppErrDetailsHeaderLen*2),
 			wantTruncate: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := truncateAppErrMessage(tt.value)
+			got := truncateAppErrDetails(tt.value)
 
 			if !tt.wantTruncate {
 				assert.Equal(t, tt.value, got, "expected no-op")
@@ -799,7 +799,7 @@ func TestTruncatedHeader(t *testing.T) {
 			}
 
 			assert.True(t, strings.HasSuffix(got, _truncatedHeaderMessage), "unexpected truncate suffix")
-			assert.Len(t, got, _maxAppErrMessageHeaderLen, "did not truncate")
+			assert.Len(t, got, _maxAppErrDetailsHeaderLen, "did not truncate")
 		})
 	}
 }

--- a/transport/tchannel/header.go
+++ b/transport/tchannel/header.go
@@ -43,8 +43,9 @@ const (
 	ServiceHeaderKey = "$rpc$-service"
 	// ApplicationErrorNameHeaderKey is the response header key for the application error name.
 	ApplicationErrorNameHeaderKey = "$rpc$-application-error-name"
-	// ApplicationErrorMessageHeaderKey is the response header key for the application error messages.
-	ApplicationErrorMessageHeaderKey = "$rpc$-application-error-message"
+	// ApplicationErrorDetailsHeaderKey is the response header key for the
+	// application error details string.
+	ApplicationErrorDetailsHeaderKey = "$rpc$-application-error-details"
 	// ApplicationErrorCodeHeaderKey is the response header key for the application error code.
 	ApplicationErrorCodeHeaderKey = "$rpc$-application-error-code"
 )
@@ -55,7 +56,7 @@ var _reservedHeaderKeys = map[string]struct{}{
 	ErrorMessageHeaderKey:            {},
 	ServiceHeaderKey:                 {},
 	ApplicationErrorNameHeaderKey:    {},
-	ApplicationErrorMessageHeaderKey: {},
+	ApplicationErrorDetailsHeaderKey: {},
 	ApplicationErrorCodeHeaderKey:    {},
 }
 

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -181,7 +181,7 @@ func callWithPeer(ctx context.Context, req *transport.Request, peer *tchannel.Pe
 
 	applicationErrorName, _ := headers.Get(ApplicationErrorNameHeaderKey)
 	applicationErrorCode := getApplicationErrorCodeFromHeaders(headers)
-	applicationErrorMessage, _ := headers.Get(ApplicationErrorMessageHeaderKey)
+	applicationErrorDetails, _ := headers.Get(ApplicationErrorDetailsHeaderKey)
 
 	err = getResponseError(headers)
 	deleteReservedHeaders(headers)
@@ -191,7 +191,7 @@ func callWithPeer(ctx context.Context, req *transport.Request, peer *tchannel.Pe
 		Body:             resBody,
 		ApplicationError: res.ApplicationError(),
 		ApplicationErrorMeta: &transport.ApplicationErrorMeta{
-			Message: applicationErrorMessage,
+			Details: applicationErrorDetails,
 			Name:    applicationErrorName,
 			Code:    applicationErrorCode,
 		},

--- a/transport/tchannel/outbound_test.go
+++ b/transport/tchannel/outbound_test.go
@@ -343,7 +343,7 @@ func TestApplicationError(t *testing.T) {
 					'-', 'e', 'r', 'r', 'o', 'r', '-', 'n', 'a', 'm', 'e',
 					0x00, 0x03, 'b', 'A', 'z',
 					0x00, 0x1f, '$', 'r', 'p', 'c', '$', '-', 'a', 'p', 'p', 'l', 'i', 'c', 'a', 't', 'i', 'o', 'n',
-					'-', 'e', 'r', 'r', 'o', 'r', '-', 'm', 'e', 's', 's', 'a', 'g', 'e',
+					'-', 'e', 'r', 'r', 'o', 'r', '-', 'd', 'e', 't', 'a', 'i', 'l', 's',
 					0x00, 0x03, 'F', 'o', 'O',
 				},
 				[]byte("foo"),
@@ -370,7 +370,7 @@ func TestApplicationError(t *testing.T) {
 	require.NoError(t, err, "failed to make call")
 	require.True(t, res.ApplicationError, "application error was not set")
 	require.NotNil(t, res.ApplicationErrorMeta.Code, "application error code was not set")
-	assert.Equal(t, "FoO", res.ApplicationErrorMeta.Message, "unexpected error message")
+	assert.Equal(t, "FoO", res.ApplicationErrorMeta.Details, "unexpected error message")
 	assert.Equal(
 		t,
 		yarpcerrors.CodeAborted,


### PR DESCRIPTION
This refactor changes the `transport.ApplicationErrorMeta`'s `Message`
field to `Details`. The term `Message` is confusing in Protobuf and
Thrift encodings, since the contents of this field is the stringified
version of the gRPC/Protobuf error detail or Thrift exception.

- For Protobuf, errors may have a code, name, message and details; the
message is the error message.

- For Thrift, errors cannot have a message, but can have a name and
 exception.

This change renames all cases to use the term details (for both
encodings) as it aligns better with gRPC/Protobuf (which we try to
emphasize). For Thrift users, `details` can be understood as
"detailing the exception".

This also changes the `zap` logging field from `appErrMessage` to
`errorDetails`. This aligns with the existing error log fields:
`error`, `errorName`, `errorCode`.

Important changes are in the following files:
- api/transport/response.go (changing `Message` to `Details`)
- internal/observability/call.go (log field from `appErrMessage` to `errorDetails`)

Note that this is **not** a breaking change since this feature is 
unreleased.

- [x] Description and context for reviewers: one partner, one stranger