### PR TITLE
Revert "Fixed: support of go 1.15 (#1961)"

### DIFF
--- a/.buildkite/pipeline-default.yml
+++ b/.buildkite/pipeline-default.yml
@@ -1,4 +1,11 @@
 steps:
+  - name: ":docker: :package: 1.13"
+    plugins:
+      docker-compose#v2.0.0:
+        build: yarpc-go-1.13
+        image-repository: 027047743804.dkr.ecr.us-east-2.amazonaws.com/uber
+    agents:
+      queue: builders
   - name: ":docker: :package: 1.14"
     plugins:
       docker-compose#v2.0.0:
@@ -6,17 +13,39 @@ steps:
         image-repository: 027047743804.dkr.ecr.us-east-2.amazonaws.com/uber
     agents:
       queue: builders
-  - name: ":docker: :package: 1.15"
-    plugins:
-      docker-compose#v2.0.0:
-        build: yarpc-go-1.15
-        image-repository: 027047743804.dkr.ecr.us-east-2.amazonaws.com/uber
-    agents:
-      queue: builders
   - wait
-  - name: ":go: 1.14 test - %n"
+  - name: ":go: 1.13 test - %n"
     command: "make test"
     parallelism: 2
+    plugins:
+      docker-compose#v2.0.0:
+        run: yarpc-go-1.13
+    agents:
+      queue: workers
+  - name: ":go: 1.13 examples"
+    command: "make examples"
+    plugins:
+      docker-compose#v2.0.0:
+        run: yarpc-go-1.13
+    agents:
+      queue: workers
+  - name: ":go: 1.14 test - %n"
+    command: "make codecov"
+    parallelism: 6
+    plugins:
+      docker-compose#v2.0.0:
+        run: yarpc-go-1.14
+    agents:
+      queue: workers
+  - name: ":go: 1.14 crossdock"
+    command: "make crossdock-codecov"
+    plugins:
+      docker-compose#v2.0.0:
+        run: yarpc-go-1.14
+    agents:
+      queue: workers
+  - name: ":go: 1.14 lint"
+    command: "make lint"
     plugins:
       docker-compose#v2.0.0:
         run: yarpc-go-1.14
@@ -27,34 +56,5 @@ steps:
     plugins:
       docker-compose#v2.0.0:
         run: yarpc-go-1.14
-    agents:
-      queue: workers
-  - name: ":go: 1.15 test - %n"
-    command: "make codecov"
-    parallelism: 6
-    plugins:
-      docker-compose#v2.0.0:
-        run: yarpc-go-1.15
-    agents:
-      queue: workers
-  - name: ":go: 1.15 crossdock"
-    command: "make crossdock-codecov"
-    plugins:
-      docker-compose#v2.0.0:
-        run: yarpc-go-1.15
-    agents:
-      queue: workers
-  - name: ":go: 1.15 lint"
-    command: "make lint"
-    plugins:
-      docker-compose#v2.0.0:
-        run: yarpc-go-1.15
-    agents:
-      queue: workers
-  - name: ":go: 1.15 examples"
-    command: "make examples"
-    plugins:
-      docker-compose#v2.0.0:
-        run: yarpc-go-1.15
     agents:
       queue: workers

--- a/.buildkite/pipeline-update-deps.yml
+++ b/.buildkite/pipeline-update-deps.yml
@@ -1,17 +1,17 @@
 steps:
-  - name: ":docker: :package: 1.14"
+  - name: ":docker: :package: 1.13"
     plugins:
       docker-compose#v2.0.0:
-        build: yarpc-go-1.14
+        build: yarpc-go-1.13
         image-repository: 027047743804.dkr.ecr.us-east-2.amazonaws.com/uber
     agents:
       queue: builders
   - wait
-  - name: ":go: 1.14 update-deps"
+  - name: ":go: 1.13 update-deps"
     command: "etc/bin/update-deps.sh"
     plugins:
       docker-compose#v2.0.0:
-        run: yarpc-go-1.14
+        run: yarpc-go-1.13
         env:
           # The script needs the following environment variables in addition
           # to those provided by the docker-compose.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Removed
+- Reverted `go.mod` Go version from 1.14 to 1.13.
 
 ## [1.47.0] - 2020-08-31
 ### Added

--- a/Dockerfile.1.13
+++ b/Dockerfile.1.13
@@ -1,4 +1,4 @@
-FROM golang:1.15
+FROM golang:1.13
 
 ENV SUPPRESS_DOCKER 1
 WORKDIR /yarpc

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,10 @@
 version: '3'
 services:
 
-  yarpc-go-1.14:
+  yarpc-go-1.13:
     build:
       context: .
-      dockerfile: Dockerfile.1.14
+      dockerfile: Dockerfile.1.13
     environment:
       - TEST_TIME_SCALE=5
       - THIS_CHUNK=${BUILDKITE_PARALLEL_JOB}
@@ -23,10 +23,10 @@ services:
       - BUILDKITE_REPO
       - GO111MODULE=on
 
-  yarpc-go-1.15:
+  yarpc-go-1.14:
     build:
       context: .
-      dockerfile: Dockerfile.1.15
+      dockerfile: Dockerfile.1.14
     environment:
       - TEST_TIME_SCALE=5
       - THIS_CHUNK=${BUILDKITE_PARALLEL_JOB}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.uber.org/yarpc
 
-go 1.14
+go 1.13
 
 require (
 	github.com/apache/thrift v0.13.0 // indirect

--- a/internal/examples/go.mod
+++ b/internal/examples/go.mod
@@ -1,6 +1,6 @@
 module go.uber.org/yarpc/internal/examples
 
-go 1.14
+go 1.13
 
 require (
 	github.com/gogo/protobuf v1.3.1


### PR DESCRIPTION
This reverts commit 124312047fcb6e418838aea7cfee156b17beacff.

This caused an internal issue that prevented some projects from
copmiling the plugins from the latest version of `yarpc`. Reverting
this change for now as the fix will take time and changes on this
release are time-sensitive for some teams.

We can reintroduce this in the next minor.

Ref: GM-638

- [x] Description and context for reviewers: one partner, one stranger
- [x] Entry in CHANGELOG.md
