### PR TITLE
yarpcerrors: Unwrap once

### DIFF
--- a/yarpcerrors/errors.go
+++ b/yarpcerrors/errors.go
@@ -87,7 +87,10 @@ func fromError(err error) (st *Status, ok bool) {
 //
 // See "errors" package documentation for details.
 func (s *Status) Unwrap() error {
-	return errors.Unwrap(s.err)
+	if s == nil {
+		return nil
+	}
+	return s.err
 }
 
 // IsStatus returns whether the provided error is a YARPC error, or has a

--- a/yarpcerrors/errors_test.go
+++ b/yarpcerrors/errors_test.go
@@ -21,6 +21,7 @@
 package yarpcerrors
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -171,7 +172,20 @@ func TestErrUnwrap(t *testing.T) {
 
 	assert.Equal(t, FromError(yErr).Message(), "wrap my custom err: my custom error", "unexpected message")
 	assert.Equal(t, myErr, errors.Unwrap(yErr), "expected original error")
+	assert.Equal(t, myErr, errors.Unwrap(FromError(myErr)), "expected original error")
 	assert.True(t, errors.Is(yErr, myErr), "expected original error")
+}
+
+func TestErrUnwrapIs(t *testing.T) {
+	err := FromError(context.DeadlineExceeded)
+	assert.True(t, errors.Is(err, context.DeadlineExceeded), "errors be errors, yo")
+}
+
+func TestErrUnwrapNil(t *testing.T) {
+	assert.NotPanics(t, func() {
+		var err *Status
+		errors.Unwrap(err)
+	})
 }
 
 type customYARPCError struct {


### PR DESCRIPTION
`yarpcerrors.(*Status).Unwrap` directly return the inner error which
gives the expected behavior when using `FromError`.

Original implementation unwrapped the inner error.

Also makes it safe to unwrap a nil `*Status`.

Fixes: T6597121

- [ ] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [ ] Entry in CHANGELOG.md
