### PR TITLE
New: added new options and config for hashring32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - peer/hashring32: Support using an application header as the shard key, instead
   of `transport.Request#ShardKey`
+- peer/hashring32: options NumReplicas and NumPeersEstimate are not private
+  anymore and can be used by consumer of the pkg.
+
 
 ## [1.47.2] - 2020-09-16
 ### Fixed

--- a/peer/hashring32/config_test.go
+++ b/peer/hashring32/config_test.go
@@ -22,6 +22,7 @@ package hashring32
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/yarpc/api/peer"
@@ -32,9 +33,15 @@ import (
 
 func TestPendingHeapConfig(t *testing.T) {
 	s := Spec(nil, nil)
+	duration := time.Second * 1
+
 	c := Config{
-		OffsetHeader:     "offsetHeader",
-		ReplicaDelimiter: "#",
+		OffsetHeader:            "offsetHeader",
+		ReplicaDelimiter:        "#",
+		NumReplicas:             5,
+		NumPeersEstimate:        1000,
+		AlternateShardKeyHeader: "test-header",
+		DefaultChooseTimeout:    &duration,
 	}
 	build := s.BuildPeerList.(func(c Config, t peer.Transport, k *yarpcconfig.Kit) (peer.ChooserList, error))
 	pl, err := build(c, yarpctest.NewFakeTransport(), nil)

--- a/peer/hashring32/list.go
+++ b/peer/hashring32/list.go
@@ -133,6 +133,46 @@ func (o loggerOption) apply(opts *options) {
 	opts.logger = o.logger
 }
 
+// NumReplicas allos client to specify the number of replicas to use for each peer.
+//
+// More replicas produces a more even distribution of entities and slower
+// membership updates.
+func NumReplicas(n int) Option {
+	return numReplicasOption{numReplicas: n}
+}
+
+type numReplicasOption struct {
+	numReplicas int
+}
+
+func (n numReplicasOption) apply(opts *options) {
+	opts.peerRingOptions = append(
+		opts.peerRingOptions,
+		hashring32.NumReplicas(
+			n.numReplicas,
+		),
+	)
+}
+
+// NumPeersEstimate allows client to specifiy an estimate for the number of identified peers
+// the hashring will contain.
+func NumPeersEstimate(n int) Option {
+	return numPeersEstimateOption{numPeersEstimate: n}
+}
+
+type numPeersEstimateOption struct {
+	numPeersEstimate int
+}
+
+func (n numPeersEstimateOption) apply(opts *options) {
+	opts.peerRingOptions = append(
+		opts.peerRingOptions,
+		hashring32.NumPeersEstimate(
+			n.numPeersEstimate,
+		),
+	)
+}
+
 // DefaultChooseTimeout specifies the default timeout to add to 'Choose' calls
 // without context deadlines. This prevents long-lived streams from setting
 // calling deadlines.

--- a/peer/hashring32/list_test.go
+++ b/peer/hashring32/list_test.go
@@ -43,6 +43,8 @@ func TestAddRemoveAndChoose(t *testing.T) {
 		PeerOverrideHeader("poTest"),
 		ReplicaDelimiter("#"),
 		Logger(zaptest.NewLogger(t)),
+		NumReplicas(5),
+		NumPeersEstimate(2),
 	)
 
 	pl.Start()
@@ -91,6 +93,8 @@ func TestAddRemoveAndChooseWithAlternateShardKeyHeader(t *testing.T) {
 		ReplicaDelimiter("#"),
 		AlternateShardKeyHeader("test-header-shard-key"),
 		Logger(zaptest.NewLogger(t)),
+		NumReplicas(5),
+		NumPeersEstimate(2),
 	)
 
 	pl.Start()
@@ -140,6 +144,8 @@ func TestOverrideChooseAndRemoveOverrideChoose(t *testing.T) {
 		OffsetHeader("test"),
 		PeerOverrideHeader("poTest"),
 		ReplicaDelimiter("#"),
+		NumReplicas(5),
+		NumPeersEstimate(2),
 	)
 
 	pl.Start()


### PR DESCRIPTION
This PR adds more public options for configuring the hashring32, we can now configure the ring with:

- NumReplicas (config + option)
- NumPeersEstimate (config + option)
- AlternateShardKeyHeader (config)

Previously, those options were internal to the hashring and could not be configured by another pkg than yarpc

- [x] Description and context for reviewers: one partner, one stranger
- [x] Docs (package doc)
- [x] Entry in CHANGELOG.md
