### PR TITLE
Observability: add ttl histogram for inbound requests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -23,3 +23,4 @@ internal/examples/thrift-keyvalue/keyvalue/server/server
 internal/examples/thrift-oneway/thrift-oneway
 internal/service-test/service-test
 .idea
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@
 /internal/examples/thrift-oneway/thrift-oneway
 /internal/service-test/service-test
 .idea
+.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   of `transport.Request#ShardKey`
 - peer/hashring32: options NumReplicas and NumPeersEstimate are not private
   anymore and can be used by consumer of the pkg.
+- observability: introduced inbound requests TTL histogram using context deadline 
+  to monitor caller TTL distribution
 
 
 ## [1.47.2] - 2020-09-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   of `transport.Request#ShardKey`
 - peer/hashring32: options NumReplicas and NumPeersEstimate are not private
   anymore and can be used by consumer of the pkg.
-- observability: introduced inbound requests TTL histogram using context deadline 
-  to monitor caller TTL distribution
+- observability: Add caller request TTL histogram in inbound middleware
 
 
 ## [1.47.2] - 2020-09-16

--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -307,6 +307,11 @@ func (c call) endStatsFromFault(elapsed time.Duration, code yarpcerrors.Code, ap
 		); err == nil {
 			counter.Inc()
 		}
+		if c.direction == _directionInbound && code == yarpcerrors.CodeDeadlineExceeded {
+			if deadlineTime, ok := c.ctx.Deadline(); ok {
+				c.edge.timeoutTtls.Observe(deadlineTime.Sub(c.started))
+			}
+		}
 
 	default:
 		// If this code is executed we've hit an error code outside the usual error

--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -234,6 +234,13 @@ func (c call) endStats(
 	applicationErrorMeta *transport.ApplicationErrorMeta,
 ) {
 	c.edge.calls.Inc()
+
+	if c.direction == _directionInbound {
+		if deadlineTime, ok := c.ctx.Deadline(); ok {
+			c.edge.ttls.Observe(deadlineTime.Sub(c.started))
+		}
+	}
+
 	if err == nil && !isApplicationError {
 		c.edge.successes.Inc()
 		c.edge.latencies.Observe(elapsed)

--- a/internal/observability/common_test.go
+++ b/internal/observability/common_test.go
@@ -149,7 +149,11 @@ func (s *fakeStream) Close(context.Context) error {
 }
 
 func stubTime() func() {
+	return stubTimeWithTimeVal(time.Time{})
+}
+
+func stubTimeWithTimeVal(timeVal time.Time) func() {
 	prev := _timeNow
-	_timeNow = func() time.Time { return time.Time{} }
+	_timeNow = func() time.Time { return timeVal }
 	return func() { _timeNow = prev }
 }


### PR DESCRIPTION
This change adds histogram distribution for incoming requests TTL set by the caller, which could be used to find callers making requests with very small TTL

- [x] Description and context for reviewers: one partner, one stranger
- [x] Entry in CHANGELOG.md
