### PR TITLE
Fixed: service name can contain _ 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-No changes yet.
+- yarpc: service name can contain `_` now.
 
 ## [1.48.0] - 2020-10-07
 ### Added

--- a/internal/servicename.go
+++ b/internal/servicename.go
@@ -76,6 +76,8 @@ func checkForbiddenCharacters(name string) error {
 			continue
 		case c == '-':
 			continue
+		case c == '_':
+			continue
 		default:
 			return fmt.Errorf("service name %q contains characters other than [0-9a-z] and hyphens", name)
 		}

--- a/internal/servicename_test.go
+++ b/internal/servicename_test.go
@@ -33,6 +33,7 @@ func TestValidServiceNames(t *testing.T) {
 		"supper-skipper",
 		"supperskipper83",
 		"supper-skipper83",
+		"supper_skipper83",
 		"a77ab7g4-51cb-4808-a9ef-875568bde54a", // not valid UUID
 		"eviluuid26695g10-a384-48e7-8867-6d48b7fae80a", // not valid UUID
 		"a77gb7e4-51cb-4808-a9ef-875568bde54aeviluuid", // not valid UUID
@@ -53,7 +54,6 @@ func TestInvalidServiceNames(t *testing.T) {
 		"26695g10-a384-48e7-8867-6d48b7fae80a", // not valid UUID, but starts with a number.
 		"superSkipper",
 		"SuperSkipper",
-		"super_skipper",
 		"083superskipper",
 		"茶",
 		"super skipper",
@@ -62,6 +62,7 @@ func TestInvalidServiceNames(t *testing.T) {
 		"",
 		"    ",
 		"-",
+		"_",
 		"no--duplication",
 		"no---duplication",
 		"endswithadash-",


### PR DESCRIPTION
Previously service name could not contain a `_` it his name, now it can :)

- [x] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [x] Entry in CHANGELOG.md
