### PR TITLE
Refactor Observability middleware and tests

### DIFF
--- a/encoding/json/observability_test.go
+++ b/encoding/json/observability_test.go
@@ -33,6 +33,7 @@ import (
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/json"
+	"go.uber.org/yarpc/internal/testutils"
 	"go.uber.org/yarpc/transport/http"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -55,71 +56,26 @@ func TestJsonMetrics(t *testing.T) {
 	assert.NoError(t, err, "unexpected call error")
 
 	t.Run("counters", func(t *testing.T) {
-		wantCounters := []counterAssertion{
+		wantCounters := []testutils.CounterAssertion{
 			{Name: "calls", Value: 1},
 			{Name: "panics"},
 			{Name: "successes", Value: 1},
 		}
 
-		assertClientAndServerMetrics(t, wantCounters, clientMetricsRoot, serverMetricsRoot)
+		testutils.AssertClientAndServerCounters(t, wantCounters, clientMetricsRoot, serverMetricsRoot)
 	})
 	t.Run("inbound histograms", func(t *testing.T) {
-		wantHistograms := []histogramAssertion{
+		wantHistograms := []testutils.HistogramAssertion{
 			{Name: "caller_failure_latency_ms"},
 			{Name: "request_payload_size_bytes", Value: []int64{32}},
 			{Name: "response_payload_size_bytes", Value: []int64{32}},
 			{Name: "server_failure_latency_ms"},
-			{Name: "success_latency_ms", Value: []int64{1}},
+			{Name: "success_latency_ms", IgnoreValueCompare: true, ValueLength: 1},
 			{Name: "timeout_ttl_ms"},
 			{Name: "ttl_ms", Value: []int64{1000}},
 		}
-		assertHistogram(t, wantHistograms, serverMetricsRoot.Snapshot().Histograms)
+		testutils.AssertHistograms(t, wantHistograms, serverMetricsRoot.Snapshot().Histograms)
 	})
-}
-
-type counterAssertion struct {
-	Name  string
-	Tags  map[string]string
-	Value int
-}
-
-type histogramAssertion struct {
-	Name  string
-	Tags  map[string]string
-	Value []int64
-}
-
-func assertClientAndServerMetrics(t *testing.T, counterAssertions []counterAssertion, clientSnapshot, serverSnapshot *metrics.Root) {
-	t.Run("inbound", func(t *testing.T) {
-		assertMetrics(t, counterAssertions, serverSnapshot.Snapshot().Counters)
-	})
-	t.Run("outbound", func(t *testing.T) {
-		assertMetrics(t, counterAssertions, clientSnapshot.Snapshot().Counters)
-	})
-}
-
-func assertMetrics(t *testing.T, counterAssertions []counterAssertion, snapshot []metrics.Snapshot) {
-	require.Len(t, counterAssertions, len(snapshot), "unexpected number of counters")
-
-	for i, wantCounter := range counterAssertions {
-		require.Equal(t, wantCounter.Name, snapshot[i].Name, "unexpected counter")
-		assert.EqualValues(t, wantCounter.Value, snapshot[i].Value, "unexpected counter value")
-		for wantTagKey, wantTagVal := range wantCounter.Tags {
-			assert.Equal(t, wantTagVal, snapshot[i].Tags[wantTagKey], "unexpected value for %q", wantTagKey)
-		}
-	}
-}
-
-func assertHistogram(t *testing.T, histogramAssertions []histogramAssertion, snapshot []metrics.HistogramSnapshot) {
-	require.Len(t, histogramAssertions, len(snapshot), "unexpected number of histograms")
-
-	for i, wantCounter := range histogramAssertions {
-		require.Equal(t, wantCounter.Name, snapshot[i].Name, "unexpected histogram")
-		assert.EqualValues(t, wantCounter.Value, snapshot[i].Values, "unexpected histogram value")
-		for wantTagKey, wantTagVal := range wantCounter.Tags {
-			assert.Equal(t, wantTagVal, snapshot[i].Tags[wantTagKey], "unexpected value for %q", wantTagKey)
-		}
-	}
 }
 
 func initClientAndServer(t *testing.T) (json.Client, *metrics.Root, *metrics.Root, func()) {

--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -90,15 +90,15 @@ type levels struct {
 	success, failure, applicationError zapcore.Level
 }
 
-func (c call) End(res *callResult) {
+func (c call) End(res callResult) {
 	c.endWithAppError(res)
 }
 
-func (c call) EndCallWithAppError(res *callResult) {
+func (c call) EndCallWithAppError(res callResult) {
 	c.endWithAppError(res)
 }
 
-func (c call) EndHandleWithAppError(res *callResult) {
+func (c call) EndHandleWithAppError(res callResult) {
 	if res.ctxOverrideErr == nil {
 		c.endWithAppError(res)
 		return
@@ -115,17 +115,18 @@ func (c call) EndHandleWithAppError(res *callResult) {
 		droppedField = zap.String(_dropped, _droppedSuccessLog)
 	}
 
-	c.endWithAppError(&callResult{
-		err:          res.ctxOverrideErr,
-		requestSize:  res.requestSize,
-		responseSize: res.responseSize,
-	},
+	c.endWithAppError(
+		callResult{
+			err:          res.ctxOverrideErr,
+			requestSize:  res.requestSize,
+			responseSize: res.responseSize,
+		},
 		droppedField,
 	)
 }
 
 func (c call) endWithAppError(
-	res *callResult,
+	res callResult,
 	extraLogFields ...zap.Field) {
 	elapsed := _timeNow().Sub(c.started)
 	c.endLogs(elapsed, res.err, res.isApplicationError, res.applicationErrorMeta, extraLogFields...)
@@ -135,7 +136,7 @@ func (c call) endWithAppError(
 // EndWithPanic ends the call with additional panic metrics
 func (c call) EndWithPanic(err error) {
 	c.edge.panics.Inc()
-	c.endWithAppError(&callResult{err: err, isApplicationError: true})
+	c.endWithAppError(callResult{err: err, isApplicationError: true})
 }
 
 func (c call) endLogs(
@@ -231,7 +232,7 @@ func (c call) endLogs(
 
 func (c call) endStats(
 	elapsed time.Duration,
-	res *callResult,
+	res callResult,
 ) {
 	c.edge.calls.Inc()
 

--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -75,69 +75,67 @@ type call struct {
 	levels *levels
 }
 
+type callResult struct {
+	err            error
+	ctxOverrideErr error
+
+	isApplicationError   bool
+	applicationErrorMeta *transport.ApplicationErrorMeta
+
+	requestSize  int
+	responseSize int
+}
+
 type levels struct {
 	success, failure, applicationError zapcore.Level
 }
 
-func (c call) End(err error, requestSize int) {
-	c.endWithAppError(err, false /* isApplicationError */, nil /* applicationErrorMeta */, requestSize, 0)
+func (c call) End(res *callResult) {
+	c.endWithAppError(res)
 }
 
-func (c call) EndCallWithAppError(
-	err error,
-	isApplicationError bool,
-	applicationErrorMeta *transport.ApplicationErrorMeta,
-) {
-	c.endWithAppError(err, isApplicationError, applicationErrorMeta, 0, 0)
+func (c call) EndCallWithAppError(res *callResult) {
+	c.endWithAppError(res)
 }
 
-func (c call) EndHandleWithAppError(err error,
-	isApplicationError bool,
-	applicationErrorMeta *transport.ApplicationErrorMeta,
-	ctxOverrideErr error,
-	requestSize int,
-	responseSize int) {
-	if ctxOverrideErr == nil {
-		c.endWithAppError(err, isApplicationError, applicationErrorMeta, requestSize, responseSize)
+func (c call) EndHandleWithAppError(res *callResult) {
+	if res.ctxOverrideErr == nil {
+		c.endWithAppError(res)
 		return
 	}
 
 	// We'll override the user's response with the appropriate context error. Also, log
 	// the dropped response.
 	var droppedField zap.Field
-	if isApplicationError && err == nil { // Thrift exceptions
+	if res.isApplicationError && res.err == nil { // Thrift exceptions
 		droppedField = zap.String(_dropped, _droppedAppErrLog)
-	} else if err != nil { // other errors
-		droppedField = zap.String(_dropped, fmt.Sprintf(_droppedErrLogFmt, err))
+	} else if res.err != nil { // other errors
+		droppedField = zap.String(_dropped, fmt.Sprintf(_droppedErrLogFmt, res.err))
 	} else {
 		droppedField = zap.String(_dropped, _droppedSuccessLog)
 	}
 
-	c.endWithAppError(ctxOverrideErr,
-		false, /* application error */
-		nil,   /* application failure */
-		requestSize,
-		responseSize,
+	c.endWithAppError(&callResult{
+		err:          res.ctxOverrideErr,
+		requestSize:  res.requestSize,
+		responseSize: res.responseSize,
+	},
 		droppedField,
 	)
 }
 
 func (c call) endWithAppError(
-	err error,
-	isApplicationError bool,
-	applicationErrorMeta *transport.ApplicationErrorMeta,
-	requestSize int,
-	responseSize int,
+	res *callResult,
 	extraLogFields ...zap.Field) {
 	elapsed := _timeNow().Sub(c.started)
-	c.endLogs(elapsed, err, isApplicationError, applicationErrorMeta, extraLogFields...)
-	c.endStats(elapsed, err, isApplicationError, applicationErrorMeta, requestSize, responseSize)
+	c.endLogs(elapsed, res.err, res.isApplicationError, res.applicationErrorMeta, extraLogFields...)
+	c.endStats(elapsed, res)
 }
 
 // EndWithPanic ends the call with additional panic metrics
 func (c call) EndWithPanic(err error) {
 	c.edge.panics.Inc()
-	c.endWithAppError(err, true /* isApplicationError */, nil, 0, 0 /* applicationErrorMeta */)
+	c.endWithAppError(&callResult{err: err, isApplicationError: true})
 }
 
 func (c call) endLogs(
@@ -233,11 +231,7 @@ func (c call) endLogs(
 
 func (c call) endStats(
 	elapsed time.Duration,
-	err error,
-	isApplicationError bool,
-	applicationErrorMeta *transport.ApplicationErrorMeta,
-	requestSize int,
-	responseSize int,
+	res *callResult,
 ) {
 	c.edge.calls.Inc()
 
@@ -246,36 +240,36 @@ func (c call) endStats(
 			c.edge.ttls.Observe(deadlineTime.Sub(c.started))
 		}
 
-		if requestSize > 0 {
-			c.edge.requestPayloadSizes.IncBucket(int64(requestSize))
+		if res.requestSize > 0 {
+			c.edge.requestPayloadSizes.IncBucket(int64(res.requestSize))
 		}
 	}
 
-	if err == nil && !isApplicationError {
+	if res.err == nil && !res.isApplicationError {
 		c.edge.successes.Inc()
 		c.edge.latencies.Observe(elapsed)
 
-		if c.direction == _directionInbound && responseSize > 0 {
-			c.edge.responsePayloadSizes.IncBucket(int64(responseSize))
+		if c.direction == _directionInbound && res.responseSize > 0 {
+			c.edge.responsePayloadSizes.IncBucket(int64(res.responseSize))
 		}
 		return
 	}
 
 	appErrorName := _notSet
-	if applicationErrorMeta != nil && applicationErrorMeta.Name != "" {
-		appErrorName = applicationErrorMeta.Name
+	if res.applicationErrorMeta != nil && res.applicationErrorMeta.Name != "" {
+		appErrorName = res.applicationErrorMeta.Name
 	}
 
-	if yarpcerrors.IsStatus(err) {
-		status := yarpcerrors.FromError(err)
+	if yarpcerrors.IsStatus(res.err) {
+		status := yarpcerrors.FromError(res.err)
 		errCode := status.Code()
 		c.endStatsFromFault(elapsed, errCode, appErrorName)
 		return
 	}
 
-	if isApplicationError {
-		if applicationErrorMeta != nil && applicationErrorMeta.Code != nil {
-			c.endStatsFromFault(elapsed, *applicationErrorMeta.Code, appErrorName)
+	if res.isApplicationError {
+		if res.applicationErrorMeta != nil && res.applicationErrorMeta.Code != nil {
+			c.endStatsFromFault(elapsed, *res.applicationErrorMeta.Code, appErrorName)
 			return
 		}
 

--- a/internal/observability/middleware.go
+++ b/internal/observability/middleware.go
@@ -177,12 +177,14 @@ func (m *Middleware) Handle(ctx context.Context, req *transport.Request, w trans
 
 	// TODO: refactor EndHandleWithAppError to accept args in a callResult struct
 	call.EndHandleWithAppError(
-		err,
-		wrappedWriter.isApplicationError,
-		wrappedWriter.applicationErrorMeta,
-		ctxErr,
-		requestSize,
-		wrappedWriter.responseSize)
+		&callResult{
+			err:                  err,
+			ctxOverrideErr:       ctxErr,
+			isApplicationError:   wrappedWriter.isApplicationError,
+			applicationErrorMeta: wrappedWriter.applicationErrorMeta,
+			requestSize:          requestSize,
+			responseSize:         wrappedWriter.responseSize,
+		})
 
 	if ctxErr != nil {
 		err = ctxErr
@@ -202,7 +204,7 @@ func (m *Middleware) Call(ctx context.Context, req *transport.Request, out trans
 		isApplicationError = res.ApplicationError
 		applicationErrorMeta = res.ApplicationErrorMeta
 	}
-	call.EndCallWithAppError(err, isApplicationError, applicationErrorMeta)
+	call.EndCallWithAppError(&callResult{err: err, isApplicationError: isApplicationError, applicationErrorMeta: applicationErrorMeta})
 	return res, err
 }
 
@@ -214,7 +216,7 @@ func (m *Middleware) HandleOneway(ctx context.Context, req *transport.Request, h
 		requestSize = wrapper.Len()
 	}
 	err := h.HandleOneway(ctx, req)
-	call.End(err, requestSize)
+	call.End(&callResult{err: err, requestSize: requestSize})
 	return err
 }
 
@@ -222,7 +224,7 @@ func (m *Middleware) HandleOneway(ctx context.Context, req *transport.Request, h
 func (m *Middleware) CallOneway(ctx context.Context, req *transport.Request, out transport.OnewayOutbound) (transport.Ack, error) {
 	call := m.graph.begin(ctx, transport.Oneway, _directionOutbound, req)
 	ack, err := out.CallOneway(ctx, req)
-	call.End(err, 0)
+	call.End(&callResult{err: err})
 	return ack, err
 }
 

--- a/internal/testutils/metricutils.go
+++ b/internal/testutils/metricutils.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package testutils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/net/metrics"
+)
+
+// CounterAssertion holds expected counter metric
+type CounterAssertion struct {
+	Name  string
+	Tags  map[string]string
+	Value int
+}
+
+// HistogramAssertion holds expected histogram metric
+type HistogramAssertion struct {
+	Name  string
+	Tags  map[string]string
+	Value []int64
+
+	// Values are not compared, rather length of values is asserted
+	IgnoreValueCompare bool
+	ValueLength        int
+}
+
+// AssertCounters asserts expected counters with metrics snapshot
+func AssertCounters(t *testing.T, counterAssertions []CounterAssertion, snapshot []metrics.Snapshot) {
+	require.Len(t, counterAssertions, len(snapshot), snapshot)
+
+	for i, wantCounter := range counterAssertions {
+		require.Equal(t, wantCounter.Name, snapshot[i].Name, "unexpected counter %s", snapshot[i].Name)
+		assert.EqualValues(t, wantCounter.Value, snapshot[i].Value, "unexpected counter value for %s", wantCounter.Name)
+		for wantTagKey, wantTagVal := range wantCounter.Tags {
+			assert.Equal(t, wantTagVal, snapshot[i].Tags[wantTagKey], "unexpected value for %q", wantTagKey)
+		}
+	}
+}
+
+// AssertHistograms asserts expected histograms with histogram snapshot
+func AssertHistograms(t *testing.T, histogramAssertions []HistogramAssertion, snapshot []metrics.HistogramSnapshot) {
+	require.Len(t, histogramAssertions, len(snapshot), "unexpected number of histograms")
+
+	for i, wantHistogram := range histogramAssertions {
+		require.Equal(t, wantHistogram.Name, snapshot[i].Name, "unexpected histogram %s", wantHistogram.Name)
+		if wantHistogram.IgnoreValueCompare {
+			assert.Equal(t, wantHistogram.ValueLength, len(snapshot[i].Values),
+				"unexpected histogram value length for %s", wantHistogram.Name)
+		} else {
+			assert.EqualValues(t, wantHistogram.Value, snapshot[i].Values, "unexpected histogram value for %s", wantHistogram.Name)
+		}
+		for wantTagKey, wantTagVal := range wantHistogram.Tags {
+			assert.Equal(t, wantTagVal, snapshot[i].Tags[wantTagKey], "unexpected value for %q", wantTagKey)
+		}
+	}
+}
+
+// AssertClientAndServerCounters asserts expected counters on client and server snapshots
+func AssertClientAndServerCounters(t *testing.T, counterAssertions []CounterAssertion, clientSnapshot, serverSnapshot *metrics.Root) {
+	t.Run("inbound", func(t *testing.T) {
+		AssertCounters(t, counterAssertions, serverSnapshot.Snapshot().Counters)
+	})
+	t.Run("outbound", func(t *testing.T) {
+		AssertCounters(t, counterAssertions, clientSnapshot.Snapshot().Counters)
+	})
+}


### PR DESCRIPTION
This PR refactors observability middleware to cleanly pass arguments wrapped in a struct, reuse redundant utils across encoding tests and fixes few flaky histogram tests

- [X] Description and context for reviewers: one partner, one stranger
