### PR TITLE
Refactor: add explicit request size field in transport request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - observability: Add request and response payload size histogram
-- api: expose `BodySize` field in the transport request, middlewares
-  can use this field to get or update the request body size
+- api: expose `BodySize` field in the transport request, middleware can use
+  this field to get or update the request body size
 ### Fixed
 - yarpc: service name can contain `_` now.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - observability: Add request and response payload size histogram
+- api: expose `BodySize` field in the transport request, middlewares
+  can use this field to get or update the request body size
 ### Fixed
 - yarpc: service name can contain `_` now.
 

--- a/api/transport/request.go
+++ b/api/transport/request.go
@@ -66,6 +66,9 @@ type Request struct {
 
 	// Request payload.
 	Body io.Reader
+
+	// Request payload size
+	BodySize int
 }
 
 // ToRequestMeta converts a Request into a RequestMeta.

--- a/api/transport/request.go
+++ b/api/transport/request.go
@@ -68,7 +68,9 @@ type Request struct {
 	Body io.Reader
 
 	// Request payload size before any compression applied by the protocol
-	// HTTP requests set this value as content-length header
+	// When using the HTTP transport, this value is set from the HTTP header
+	// content-length. It should be noted that this value is set manually and
+	// will not be updated automatically if the body is being modified
 	BodySize int
 }
 

--- a/api/transport/request.go
+++ b/api/transport/request.go
@@ -67,7 +67,8 @@ type Request struct {
 	// Request payload.
 	Body io.Reader
 
-	// Request payload size
+	// Request payload size before any compression applied by the protocol
+	// HTTP requests set this value as content-length header
 	BodySize int
 }
 

--- a/api/transport/stream.go
+++ b/api/transport/stream.go
@@ -200,5 +200,6 @@ type Stream interface {
 // StreamMessage represents information that can be read off of an individual
 // message in the stream.
 type StreamMessage struct {
-	Body io.ReadCloser
+	Body     io.ReadCloser
+	BodySize int
 }

--- a/encoding/protobuf/stream.go
+++ b/encoding/protobuf/stream.go
@@ -63,6 +63,7 @@ func writeToStream(ctx context.Context, stream transport.Stream, message proto.M
 				Reader: bytes.NewReader(messageData),
 				closer: cleanup,
 			},
+			BodySize: len(messageData),
 		},
 	)
 }

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -1300,6 +1300,7 @@ func TestMiddlewareSuccessSnapshot(t *testing.T) {
 			RoutingKey:      "rk",
 			RoutingDelegate: "rd",
 			Body:            buf,
+			BodySize:        buf.Len(),
 		},
 		&transporttest.FakeResponseWriter{},
 		fakeHandler{responseData: []byte("test response")},
@@ -1399,6 +1400,7 @@ func TestMiddlewareSuccessSnapshotForOneWay(t *testing.T) {
 			RoutingKey:      "rk",
 			RoutingDelegate: "rd",
 			Body:            buf,
+			BodySize:        buf.Len(),
 		},
 		fakeHandler{responseData: []byte("test response")},
 	)
@@ -1493,6 +1495,7 @@ func TestMiddlewareFailureSnapshot(t *testing.T) {
 			RoutingKey:      "rk",
 			RoutingDelegate: "rd",
 			Body:            buf,
+			BodySize:        buf.Len(),
 		},
 		&transporttest.FakeResponseWriter{},
 		fakeHandler{err: fmt.Errorf("yuno"), applicationErr: false, responseData: []byte("error")},
@@ -1605,6 +1608,7 @@ func TestMiddlewareFailureWithDeadlineExceededSnapshot(t *testing.T) {
 			RoutingKey:      "rk",
 			RoutingDelegate: "rd",
 			Body:            buf,
+			BodySize:        buf.Len(),
 		},
 		&transporttest.FakeResponseWriter{},
 		fakeHandler{
@@ -2054,7 +2058,8 @@ func TestStreamingMetrics(t *testing.T) {
 			&fakeStream{
 				request: req,
 				receiveMsg: &transport.StreamMessage{
-					Body: readCloser{bytes.NewReader([]byte("Foobar"))},
+					Body:     readCloser{bytes.NewReader([]byte("Foobar"))},
+					BodySize: 6,
 				},
 			},
 		)
@@ -2064,7 +2069,8 @@ func TestStreamingMetrics(t *testing.T) {
 				err := stream.SendMessage(
 					context.Background(),
 					&transport.StreamMessage{
-						Body: readCloser{bytes.NewReader([]byte("test"))},
+						Body:     readCloser{bytes.NewReader([]byte("test"))},
+						BodySize: 4,
 					},
 				)
 				require.NoError(t, err)

--- a/internal/observability/stream.go
+++ b/internal/observability/stream.go
@@ -85,9 +85,7 @@ func (c call) WrapServerStream(stream *transport.ServerStream) *transport.Server
 
 func (s *streamWrapper) SendMessage(ctx context.Context, msg *transport.StreamMessage) error {
 	if s.call.direction == _directionInbound && msg != nil {
-		if body, ok := msg.Body.(lenWrapper); ok {
-			s.edge.streamResponsePayloadSizes.IncBucket(int64(body.Len()))
-		}
+		s.edge.streamResponsePayloadSizes.IncBucket(int64(msg.BodySize))
 	}
 
 	err := s.StreamCloser.SendMessage(ctx, msg)
@@ -110,9 +108,7 @@ func (s *streamWrapper) SendMessage(ctx context.Context, msg *transport.StreamMe
 func (s *streamWrapper) ReceiveMessage(ctx context.Context) (*transport.StreamMessage, error) {
 	msg, err := s.StreamCloser.ReceiveMessage(ctx)
 	if err == nil && msg != nil && s.call.direction == _directionInbound {
-		if body, ok := msg.Body.(lenWrapper); ok {
-			s.edge.streamRequestPayloadSizes.IncBucket(int64(body.Len()))
-		}
+		s.edge.streamRequestPayloadSizes.IncBucket(int64(msg.BodySize))
 	}
 	// Receiving EOF does not constitute an error for the purposes of metrics and alerts.
 	// This is the only special case.

--- a/transport/grpc/handler.go
+++ b/transport/grpc/handler.go
@@ -178,6 +178,7 @@ func (h *handler) handleUnary(
 	// Buffers are documented to always return a nil error.
 	_, _ = requestBuffer.Write(requestData)
 	transportRequest.Body = requestBuffer
+	transportRequest.BodySize = len(requestData)
 
 	responseWriter := newResponseWriter()
 	defer responseWriter.Close()

--- a/transport/grpc/stream.go
+++ b/transport/grpc/stream.go
@@ -78,7 +78,10 @@ func (ss *serverStream) ReceiveMessage(_ context.Context) (*transport.StreamMess
 	if err := ss.stream.RecvMsg(&msg); err != nil {
 		return nil, toYARPCStreamError(err)
 	}
-	return &transport.StreamMessage{Body: readCloser{bytes.NewReader(msg)}}, nil
+	return &transport.StreamMessage{
+		Body:     readCloser{bytes.NewReader(msg)},
+		BodySize: len(msg),
+	}, nil
 }
 
 type readCloser struct {

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -204,6 +204,7 @@ func (h handler) callHandler(ctx context.Context, call inboundCall, responseWrit
 	}
 
 	treq.Body = buf
+	treq.BodySize = buf.Len()
 
 	if err := transport.ValidateRequest(treq); err != nil {
 		return err


### PR DESCRIPTION
Passing around body enclosed in a `lenWrapper` could cause issues if another middleware is sandwiched after transport and modifies the body. This change also removes redundant buffer copy in http transport handler
n

- [X] Description and context for reviewers: one partner, one stranger
- [X] Entry in CHANGELOG.md