### PR TITLE
Observability: add payload size and TTL histograms in outbound calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - observability: Add request and response payload size histogram
-- api: expose `BodySize` field in the transport request, middleware can use
-  this field to get or update the request body size
+- api: expose `BodySize` field in the transport request/response, middleware can use
+  this field to get or update the request/response body size
 ### Fixed
 - yarpc: service name can contain `_` now.
 

--- a/api/transport/response.go
+++ b/api/transport/response.go
@@ -28,8 +28,14 @@ import (
 
 // Response is the low level response representation.
 type Response struct {
-	Headers          Headers
-	Body             io.ReadCloser
+	Headers Headers
+	Body    io.ReadCloser
+	// Response payload size before any compression applied by the protocol
+	// When using the HTTP transport, this value is set from the HTTP header
+	// content-length. It should be noted that this value is set manually and
+	// will not be updated automatically if the body is being modified
+	BodySize int
+
 	ApplicationError bool
 	// ApplicationErrorMeta adds information about the application error.
 	// This field will only be set if `ApplicationError` is true.

--- a/encoding/json/observability_test.go
+++ b/encoding/json/observability_test.go
@@ -74,7 +74,7 @@ func TestJsonMetrics(t *testing.T) {
 			{Name: "timeout_ttl_ms"},
 			{Name: "ttl_ms", Value: []int64{1000}},
 		}
-		testutils.AssertHistograms(t, wantHistograms, serverMetricsRoot.Snapshot().Histograms)
+		testutils.AssertClientAndServerHistograms(t, wantHistograms, clientMetricsRoot, serverMetricsRoot)
 	})
 }
 

--- a/encoding/json/outbound.go
+++ b/encoding/json/outbound.go
@@ -77,6 +77,8 @@ func (c jsonClient) Call(ctx context.Context, procedure string, reqBody interfac
 	}
 
 	treq.Body = bytes.NewReader(encoded)
+	treq.BodySize = len(encoded)
+
 	tres, appErr := c.cc.GetUnaryOutbound().Call(ctx, &treq)
 	if tres == nil {
 		return appErr

--- a/encoding/protobuf/observability_test.go
+++ b/encoding/protobuf/observability_test.go
@@ -124,7 +124,7 @@ func TestProtobufMetrics(t *testing.T) {
 			{Name: "timeout_ttl_ms"},
 			{Name: "ttl_ms", Value: []int64{1000}},
 		}
-		testutils.AssertHistograms(t, wantHistograms, serverMetricsRoot.Snapshot().Histograms)
+		testutils.AssertClientAndServerHistograms(t, wantHistograms, clientMetricsRoot, serverMetricsRoot)
 	})
 }
 

--- a/encoding/protobuf/outbound.go
+++ b/encoding/protobuf/outbound.go
@@ -157,6 +157,7 @@ func (c *client) buildTransportRequest(ctx context.Context, requestMethodName st
 		}
 		if requestData != nil {
 			transportRequest.Body = bytes.NewReader(requestData)
+			transportRequest.BodySize = len(requestData)
 		}
 		return ctx, call, transportRequest, cleanup, nil
 	}

--- a/encoding/thrift/observability_test.go
+++ b/encoding/thrift/observability_test.go
@@ -180,7 +180,7 @@ func TestThriftMetrics(t *testing.T) {
 					{Name: "timeout_ttl_ms"},
 					{Name: "ttl_ms", Value: []int64{1000}},
 				}
-				testutils.AssertHistograms(t, wantHistograms, serverMetricsRoot.Snapshot().Histograms)
+				testutils.AssertClientAndServerHistograms(t, wantHistograms, clientMetricsRoot, serverMetricsRoot)
 			})
 		})
 	}

--- a/encoding/thrift/outbound.go
+++ b/encoding/thrift/outbound.go
@@ -151,6 +151,7 @@ func (c thriftClient) Call(ctx context.Context, reqBody envelope.Enveloper, opts
 		return wire.Value{}, err
 	}
 
+	// TODO: Avoid double copy and reuse the buffer read by tchannel outbound
 	buf := bytes.NewBuffer(make([]byte, 0, _defaultBufferSize))
 	if _, err = buf.ReadFrom(tres.Body); err != nil {
 		return wire.Value{}, err
@@ -239,6 +240,7 @@ func (c thriftClient) buildTransportRequest(reqBody envelope.Enveloper) (*transp
 	}
 
 	treq.Body = &buffer
+	treq.BodySize = buffer.Len()
 	return &treq, proto, nil
 }
 

--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -236,21 +236,19 @@ func (c call) endStats(
 ) {
 	c.edge.calls.Inc()
 
-	if c.direction == _directionInbound {
-		if deadlineTime, ok := c.ctx.Deadline(); ok {
-			c.edge.ttls.Observe(deadlineTime.Sub(c.started))
-		}
+	if deadlineTime, ok := c.ctx.Deadline(); ok {
+		c.edge.ttls.Observe(deadlineTime.Sub(c.started))
+	}
 
-		if res.requestSize > 0 {
-			c.edge.requestPayloadSizes.IncBucket(int64(res.requestSize))
-		}
+	if res.requestSize > 0 {
+		c.edge.requestPayloadSizes.IncBucket(int64(res.requestSize))
 	}
 
 	if res.err == nil && !res.isApplicationError {
 		c.edge.successes.Inc()
 		c.edge.latencies.Observe(elapsed)
 
-		if c.direction == _directionInbound && res.responseSize > 0 {
+		if res.responseSize > 0 {
 			c.edge.responsePayloadSizes.IncBucket(int64(res.responseSize))
 		}
 		return
@@ -316,7 +314,7 @@ func (c call) endStatsFromFault(elapsed time.Duration, code yarpcerrors.Code, ap
 		); err == nil {
 			counter.Inc()
 		}
-		if c.direction == _directionInbound && code == yarpcerrors.CodeDeadlineExceeded {
+		if code == yarpcerrors.CodeDeadlineExceeded {
 			if deadlineTime, ok := c.ctx.Deadline(); ok {
 				c.edge.timeoutTtls.Observe(deadlineTime.Sub(c.started))
 			}

--- a/internal/observability/common_test.go
+++ b/internal/observability/common_test.go
@@ -21,7 +21,9 @@
 package observability
 
 import (
+	"bytes"
 	"context"
+	"io/ioutil"
 	"time"
 
 	"go.uber.org/yarpc/api/transport"
@@ -92,6 +94,8 @@ type fakeOutbound struct {
 	applicationErrDetails string
 	applicationErrCode    *yarpcerrors.Code
 	stream                fakeStream
+
+	body []byte
 }
 
 func (o fakeOutbound) Call(context.Context, *transport.Request) (*transport.Response, error) {
@@ -101,7 +105,7 @@ func (o fakeOutbound) Call(context.Context, *transport.Request) (*transport.Resp
 			Details: o.applicationErrDetails,
 			Name:    o.applicationErrName,
 			Code:    o.applicationErrCode,
-		}}, o.err
+		}, Body: ioutil.NopCloser(bytes.NewReader(o.body)), BodySize: len(o.body)}, o.err
 }
 
 func (o fakeOutbound) CallOneway(context.Context, *transport.Request) (transport.Ack, error) {

--- a/internal/observability/common_test.go
+++ b/internal/observability/common_test.go
@@ -105,7 +105,9 @@ func (o fakeOutbound) Call(context.Context, *transport.Request) (*transport.Resp
 			Details: o.applicationErrDetails,
 			Name:    o.applicationErrName,
 			Code:    o.applicationErrCode,
-		}, Body: ioutil.NopCloser(bytes.NewReader(o.body)), BodySize: len(o.body)}, o.err
+		},
+		Body:     ioutil.NopCloser(bytes.NewReader(o.body)),
+		BodySize: len(o.body)}, o.err
 }
 
 func (o fakeOutbound) CallOneway(context.Context, *transport.Request) (transport.Ack, error) {

--- a/internal/observability/middleware.go
+++ b/internal/observability/middleware.go
@@ -187,14 +187,18 @@ func (m *Middleware) Call(ctx context.Context, req *transport.Request, out trans
 
 	isApplicationError := false
 	var applicationErrorMeta *transport.ApplicationErrorMeta
+	var responseSize int
 	if res != nil {
 		isApplicationError = res.ApplicationError
 		applicationErrorMeta = res.ApplicationErrorMeta
+		responseSize = res.BodySize
 	}
 	callRes := callResult{
 		err:                  err,
 		isApplicationError:   isApplicationError,
 		applicationErrorMeta: applicationErrorMeta,
+		requestSize:          req.BodySize,
+		responseSize:         responseSize,
 	}
 	call.EndCallWithAppError(callRes)
 	return res, err
@@ -212,7 +216,7 @@ func (m *Middleware) HandleOneway(ctx context.Context, req *transport.Request, h
 func (m *Middleware) CallOneway(ctx context.Context, req *transport.Request, out transport.OnewayOutbound) (transport.Ack, error) {
 	call := m.graph.begin(ctx, transport.Oneway, _directionOutbound, req)
 	ack, err := out.CallOneway(ctx, req)
-	call.End(callResult{err: err})
+	call.End(callResult{err: err, requestSize: req.BodySize})
 	return ack, err
 }
 

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -1370,6 +1370,203 @@ func TestMiddlewareSuccessSnapshot(t *testing.T) {
 	assert.Equal(t, want, snap, "Unexpected snapshot of metrics.")
 }
 
+func TestMiddlewareSuccessSnapshotForCall(t *testing.T) {
+	defer stubTimeWithTimeVal(time.Now())()
+	ttlMs := int64(1000)
+	root := metrics.New()
+	meter := root.Scope()
+	mw := NewMiddleware(Config{
+		Logger:           zap.NewNop(),
+		Scope:            meter,
+		ContextExtractor: NewNopContextExtractor(),
+	})
+
+	buf := bufferpool.Get()
+	defer bufferpool.Put(buf)
+
+	buf.Write([]byte("body"))
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Millisecond*time.Duration(ttlMs)))
+	defer cancel()
+	_, err := mw.Call(
+		ctx,
+		&transport.Request{
+			Caller:          "caller",
+			Service:         "service",
+			Transport:       "",
+			Encoding:        "raw",
+			Procedure:       "procedure",
+			ShardKey:        "sk",
+			RoutingKey:      "rk",
+			RoutingDelegate: "rd",
+			Body:            buf,
+			BodySize:        buf.Len(),
+		},
+		&fakeOutbound{body: []byte("body")},
+	)
+	assert.NoError(t, err, "Unexpected transport error.")
+
+	snap := root.Snapshot()
+	tags := metrics.Tags{
+		"dest":             "service",
+		"direction":        "outbound",
+		"transport":        "unknown",
+		"encoding":         "raw",
+		"procedure":        "procedure",
+		"routing_delegate": "rd",
+		"routing_key":      "rk",
+		"rpc_type":         transport.Unary.String(),
+		"source":           "caller",
+	}
+	want := &metrics.RootSnapshot{
+		Counters: []metrics.Snapshot{
+			{Name: "calls", Tags: tags, Value: 1},
+			{Name: "panics", Tags: tags, Value: 0},
+			{Name: "successes", Tags: tags, Value: 1},
+		},
+		Histograms: []metrics.HistogramSnapshot{
+			{
+				Name: "caller_failure_latency_ms",
+				Tags: tags,
+				Unit: time.Millisecond,
+			},
+			{
+				Name:   "request_payload_size_bytes",
+				Tags:   tags,
+				Unit:   time.Millisecond,
+				Values: []int64{4},
+			},
+			{
+				Name:   "response_payload_size_bytes",
+				Tags:   tags,
+				Unit:   time.Millisecond,
+				Values: []int64{4},
+			},
+			{
+				Name: "server_failure_latency_ms",
+				Tags: tags,
+				Unit: time.Millisecond,
+			},
+			{
+				Name:   "success_latency_ms",
+				Tags:   tags,
+				Unit:   time.Millisecond,
+				Values: []int64{1},
+			},
+			{
+				Name: "timeout_ttl_ms",
+				Tags: tags,
+				Unit: time.Millisecond,
+			},
+			{
+				Name:   "ttl_ms",
+				Tags:   tags,
+				Unit:   time.Millisecond,
+				Values: []int64{ttlMs},
+			},
+		},
+	}
+	assert.Equal(t, want, snap, "Unexpected snapshot of metrics.")
+}
+
+func TestMiddlewareSuccessSnapshotForCallOnWay(t *testing.T) {
+	defer stubTimeWithTimeVal(time.Now())()
+	ttlMs := int64(1000)
+	root := metrics.New()
+	meter := root.Scope()
+	mw := NewMiddleware(Config{
+		Logger:           zap.NewNop(),
+		Scope:            meter,
+		ContextExtractor: NewNopContextExtractor(),
+	})
+
+	buf := bufferpool.Get()
+	defer bufferpool.Put(buf)
+
+	buf.Write([]byte("body"))
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Millisecond*time.Duration(ttlMs)))
+	defer cancel()
+	_, err := mw.CallOneway(
+		ctx,
+		&transport.Request{
+			Caller:          "caller",
+			Service:         "service",
+			Transport:       "",
+			Encoding:        "raw",
+			Procedure:       "procedure",
+			ShardKey:        "sk",
+			RoutingKey:      "rk",
+			RoutingDelegate: "rd",
+			Body:            buf,
+			BodySize:        buf.Len(),
+		},
+		&fakeOutbound{body: []byte("body")},
+	)
+	assert.NoError(t, err, "Unexpected transport error.")
+
+	snap := root.Snapshot()
+	tags := metrics.Tags{
+		"dest":             "service",
+		"direction":        "outbound",
+		"transport":        "unknown",
+		"encoding":         "raw",
+		"procedure":        "procedure",
+		"routing_delegate": "rd",
+		"routing_key":      "rk",
+		"rpc_type":         transport.Oneway.String(),
+		"source":           "caller",
+	}
+	want := &metrics.RootSnapshot{
+		Counters: []metrics.Snapshot{
+			{Name: "calls", Tags: tags, Value: 1},
+			{Name: "panics", Tags: tags, Value: 0},
+			{Name: "successes", Tags: tags, Value: 1},
+		},
+		Histograms: []metrics.HistogramSnapshot{
+			{
+				Name: "caller_failure_latency_ms",
+				Tags: tags,
+				Unit: time.Millisecond,
+			},
+			{
+				Name:   "request_payload_size_bytes",
+				Tags:   tags,
+				Unit:   time.Millisecond,
+				Values: []int64{4},
+			},
+			{
+				Name: "response_payload_size_bytes",
+				Tags: tags,
+				Unit: time.Millisecond,
+			},
+			{
+				Name: "server_failure_latency_ms",
+				Tags: tags,
+				Unit: time.Millisecond,
+			},
+			{
+				Name:   "success_latency_ms",
+				Tags:   tags,
+				Unit:   time.Millisecond,
+				Values: []int64{1},
+			},
+			{
+				Name: "timeout_ttl_ms",
+				Tags: tags,
+				Unit: time.Millisecond,
+			},
+			{
+				Name:   "ttl_ms",
+				Tags:   tags,
+				Unit:   time.Millisecond,
+				Values: []int64{ttlMs},
+			},
+		},
+	}
+	assert.Equal(t, want, snap, "Unexpected snapshot of metrics.")
+}
+
 func TestMiddlewareSuccessSnapshotForOneWay(t *testing.T) {
 	defer stubTimeWithTimeVal(time.Now())()
 	ttlMs := int64(1000)

--- a/internal/testutils/metricutils.go
+++ b/internal/testutils/metricutils.go
@@ -86,3 +86,14 @@ func AssertClientAndServerCounters(t *testing.T, counterAssertions []CounterAsse
 		AssertCounters(t, counterAssertions, clientSnapshot.Snapshot().Counters)
 	})
 }
+
+// AssertClientAndServerHistograms asserts expected histograms on client and server snapshots
+func AssertClientAndServerHistograms(t *testing.T, histogramAssertions []HistogramAssertion,
+	clientSnapshot, serverSnapshot *metrics.Root) {
+	t.Run("inbound", func(t *testing.T) {
+		AssertHistograms(t, histogramAssertions, serverSnapshot.Snapshot().Histograms)
+	})
+	t.Run("outbound", func(t *testing.T) {
+		AssertHistograms(t, histogramAssertions, clientSnapshot.Snapshot().Histograms)
+	})
+}

--- a/transport/grpc/outbound.go
+++ b/transport/grpc/outbound.go
@@ -124,6 +124,7 @@ func (o *Outbound) Call(ctx context.Context, request *transport.Request) (*trans
 	}
 	return &transport.Response{
 		Body:                 ioutil.NopCloser(bytes.NewBuffer(responseBody)),
+		BodySize:             len(responseBody),
 		Headers:              responseHeaders,
 		ApplicationError:     metadataToIsApplicationError(responseMD),
 		ApplicationErrorMeta: metadataToApplicationErrorMeta(responseMD),

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -275,6 +275,7 @@ func (o *Outbound) call(ctx context.Context, treq *transport.Request) (*transpor
 	tres := &transport.Response{
 		Headers:          applicationHeaders.FromHTTPHeaders(response.Header, transport.NewHeaders()),
 		Body:             response.Body,
+		BodySize:         int(response.ContentLength),
 		ApplicationError: response.Header.Get(ApplicationStatusHeader) == ApplicationErrorStatus,
 		ApplicationErrorMeta: &transport.ApplicationErrorMeta{
 			Details: response.Header.Get(_applicationErrorDetailsHeader),

--- a/transport/tchannel/constants.go
+++ b/transport/tchannel/constants.go
@@ -33,6 +33,8 @@ const (
 	_maxAppErrDetailsHeaderLen = 256
 	// truncated message if we've exceeded the '_maxAppErrDetailsHeaderLen'
 	_truncatedHeaderMessage = " (truncated)"
+
+	_defaultBufferSize = 1024 // 1k
 )
 
 var defaultConnTimeout = 500 * time.Millisecond


### PR DESCRIPTION
Now request/response payload sizes and TTL histograms are emitted for outbound calls for all the transport and encoding.
This also adds an overhead of double buffer copy between tchannel outbound handler and thrift encoding outbound handler,   which will be taken care in the following PR.

- [X] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [ ] Entry in CHANGELOG.md
