### PR TITLE
Perf: avoid redundant buffer read in thrift inbound

### DIFF
--- a/encoding/thrift/inbound.go
+++ b/encoding/thrift/inbound.go
@@ -48,12 +48,15 @@ type thriftOnewayHandler struct {
 }
 
 func (t thriftUnaryHandler) Handle(ctx context.Context, treq *transport.Request, rw transport.ResponseWriter) error {
-	buf := bufferpool.Get()
-	defer bufferpool.Put(buf)
-
 	ctx, call := encodingapi.NewInboundCall(ctx)
 
-	reqValue, responder, err := decodeRequest(call, buf, treq, wire.Call, t.Protocol, t.Enveloping)
+	body, deferFn, err := getBody(treq)
+	if err != nil {
+		return err
+	}
+	defer deferFn()
+
+	reqValue, responder, err := decodeRequest(call, treq, body, wire.Call, t.Protocol, t.Enveloping)
 	if err != nil {
 		return err
 	}
@@ -98,12 +101,15 @@ func (t thriftUnaryHandler) Handle(ctx context.Context, treq *transport.Request,
 }
 
 func (t thriftOnewayHandler) HandleOneway(ctx context.Context, treq *transport.Request) error {
-	buf := bufferpool.Get()
-	defer bufferpool.Put(buf)
+	body, deferFn, err := getBody(treq)
+	if err != nil {
+		return err
+	}
+	defer deferFn()
 
 	ctx, call := encodingapi.NewInboundCall(ctx)
 
-	reqValue, _, err := decodeRequest(call, buf, treq, wire.OneWay, t.Protocol, t.Enveloping)
+	reqValue, _, err := decodeRequest(call, treq, body, wire.OneWay, t.Protocol, t.Enveloping)
 	if err != nil {
 		return err
 	}
@@ -116,11 +122,8 @@ func (t thriftOnewayHandler) HandleOneway(ctx context.Context, treq *transport.R
 func decodeRequest(
 	// call is an inboundCall populated from the transport request and context.
 	call *encodingapi.InboundCall,
-	// buf is a byte buffer from the buffer pool, that will be released back to
-	// the buffer pool by the caller after it is finished with the decoded
-	// request payload. Thrift requests read sets, maps, and lists lazilly.
-	buf *bufferpool.Buffer,
 	treq *transport.Request,
+	reader io.ReaderAt,
 	// reqEnvelopeType indicates the expected envelope type, if an envelope is
 	// present.
 	reqEnvelopeType wire.EnvelopeType,
@@ -148,16 +151,6 @@ func decodeRequest(
 		return wire.Value{}, nil, err
 	}
 
-	// TODO: extra copy can be avoid if body already implements Bytes() method
-	if _, err := buf.ReadFrom(treq.Body); err != nil {
-		return wire.Value{}, nil, err
-	}
-	if err := closeReader(treq.Body); err != nil {
-		return wire.Value{}, nil, err
-	}
-
-	reader := bytes.NewReader(buf.Bytes())
-
 	// Discover or choose the appropriate envelope
 	if agnosticProto, ok := proto.(protocol.EnvelopeAgnosticProtocol); ok {
 		return agnosticProto.DecodeRequest(reqEnvelopeType, reader)
@@ -172,7 +165,7 @@ func decodeEnvelopedRequest(
 	treq *transport.Request,
 	reqEnvelopeType wire.EnvelopeType,
 	proto protocol.Protocol,
-	reader *bytes.Reader,
+	reader io.ReaderAt,
 ) (wire.Value, protocol.Responder, error) {
 	var envelope wire.Envelope
 	envelope, err := proto.DecodeEnveloped(reader)
@@ -190,7 +183,7 @@ func decodeEnvelopedRequest(
 
 func decodeUnenvelopedRequest(
 	proto protocol.Protocol,
-	reader *bytes.Reader,
+	reader io.ReaderAt,
 ) (wire.Value, protocol.Responder, error) {
 	reqValue, err := proto.Decode(reader, wire.TStruct)
 	if err != nil {
@@ -208,4 +201,29 @@ func closeReader(r io.Reader) error {
 	}
 
 	return closer.Close()
+}
+
+// getBody avoids redundant copy if the transport request is already
+// io.ReaderAt compatible. If not, it creates buffer using bufferpool and returns
+// deferFn to delay bufferpool release
+// This is mainly done as tchannel transport handler decodes the body already and
+// sets it to io.ReaderAt compatible instance
+func getBody(treq *transport.Request) (body io.ReaderAt, deferFn func(), err error) {
+	deferFn = func() {}
+	if reader, ok := treq.Body.(io.ReaderAt); ok {
+		body = reader
+		return
+	}
+
+	buf := bufferpool.Get()
+	if _, err = buf.ReadFrom(treq.Body); err != nil {
+		return
+	}
+	if err = closeReader(treq.Body); err != nil {
+		return
+	}
+
+	body = bytes.NewReader(buf.Bytes())
+	deferFn = func() { bufferpool.Put(buf) }
+	return
 }

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -21,6 +21,7 @@
 package tchannel
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"strconv"
@@ -203,7 +204,7 @@ func (h handler) callHandler(ctx context.Context, call inboundCall, responseWrit
 		return err
 	}
 
-	treq.Body = buf
+	treq.Body = bytes.NewReader(buf.Bytes())
 	treq.BodySize = buf.Len()
 
 	if err := transport.ValidateRequest(treq); err != nil {


### PR DESCRIPTION
This change avoids double buffer read in thrift inbound handler by leveraging `io.ReaderAt` compatible instance used by `tchannel` transport handler.

- [X] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [ ] Entry in CHANGELOG.md
