### PR TITLE
Perf: avoid redundant buffer read in thrift outbound

### DIFF
--- a/encoding/thrift/outbound.go
+++ b/encoding/thrift/outbound.go
@@ -24,6 +24,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 
 	"go.uber.org/thriftrw/envelope"
 	"go.uber.org/thriftrw/protocol"
@@ -151,13 +152,21 @@ func (c thriftClient) Call(ctx context.Context, reqBody envelope.Enveloper, opts
 		return wire.Value{}, err
 	}
 
-	// TODO: Avoid double copy and reuse the buffer read by tchannel outbound
-	buf := bytes.NewBuffer(make([]byte, 0, _defaultBufferSize))
-	if _, err = buf.ReadFrom(tres.Body); err != nil {
-		return wire.Value{}, err
+	var bodyReader io.ReaderAt
+
+	// optimization for avoiding additional buffer copy as tchannel outbound
+	// already decodes the body into io.ReaderAt compatible type
+	if body, ok := tres.Body.(io.ReaderAt); ok {
+		bodyReader = body
+	} else {
+		buf := bytes.NewBuffer(make([]byte, 0, _defaultBufferSize))
+		if _, err = buf.ReadFrom(tres.Body); err != nil {
+			return wire.Value{}, err
+		}
+		bodyReader = bytes.NewReader(buf.Bytes())
 	}
 
-	envelope, err := proto.DecodeEnveloped(bytes.NewReader(buf.Bytes()))
+	envelope, err := proto.DecodeEnveloped(bodyReader)
 	if err != nil {
 		return wire.Value{}, errors.ResponseBodyDecodeError(treq, err)
 	}

--- a/encoding/thrift/outbound.go
+++ b/encoding/thrift/outbound.go
@@ -156,6 +156,8 @@ func (c thriftClient) Call(ctx context.Context, reqBody envelope.Enveloper, opts
 
 	// optimization for avoiding additional buffer copy as tchannel outbound
 	// already decodes the body into io.ReaderAt compatible type
+	// thrift deserialiser reads sets, maps, and lists lazilly which makes
+	// buffer pool unusable as response handling is out of scope of this method
 	if body, ok := tres.Body.(io.ReaderAt); ok {
 		bodyReader = body
 	} else {

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -24,7 +24,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"strconv"
 
 	"github.com/uber/tchannel-go"
@@ -199,7 +198,7 @@ func callWithPeer(ctx context.Context, req *transport.Request, peer *tchannel.Pe
 
 	resp := &transport.Response{
 		Headers:          headers,
-		Body:             ioutil.NopCloser(buf),
+		Body:             readCloser{bytes.NewReader(buf.Bytes())},
 		BodySize:         buf.Len(),
 		ApplicationError: res.ApplicationError(),
 		ApplicationErrorMeta: &transport.ApplicationErrorMeta{
@@ -313,3 +312,9 @@ func (o *Outbound) Introspect() introspection.OutboundStatus {
 		Chooser:   chooser,
 	}
 }
+
+type readCloser struct {
+	*bytes.Reader
+}
+
+func (r readCloser) Close() error { return nil }


### PR DESCRIPTION
This change avoid additional buffer reads in thrift encoding outbound response parsing as tchannel outbound already decodes the body

- [ ] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [ ] Entry in CHANGELOG.md
