### PR TITLE
Observability: emit zero payload sizes

### DIFF
--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -240,15 +240,13 @@ func (c call) endStats(
 		c.edge.ttls.Observe(deadlineTime.Sub(c.started))
 	}
 
-	if res.requestSize > 0 {
-		c.edge.requestPayloadSizes.IncBucket(int64(res.requestSize))
-	}
+	c.edge.requestPayloadSizes.IncBucket(int64(res.requestSize))
 
 	if res.err == nil && !res.isApplicationError {
 		c.edge.successes.Inc()
 		c.edge.latencies.Observe(elapsed)
 
-		if res.responseSize > 0 {
+		if c.rpcType == transport.Unary {
 			c.edge.responsePayloadSizes.IncBucket(int64(res.responseSize))
 		}
 		return

--- a/internal/observability/graph.go
+++ b/internal/observability/graph.go
@@ -40,8 +40,8 @@ var (
 	// configurable.
 	_bucketsMs = bucket.NewRPCLatency()
 	// Bytes buckets for payload size histograms, containing exponential buckets
-	// from 1B to 4MB
-	_bucketsBytes = bucket.NewExponential(1, 2, 23)
+	// in range of 0B, 1B, 2B, ... 4MB
+	_bucketsBytes = append([]int64{0}, bucket.NewExponential(1, 2, 23)...)
 )
 
 type directionName string

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -1999,9 +1999,10 @@ func TestApplicationErrorSnapShot(t *testing.T) {
 						Values: []int64{1},
 					},
 					{
-						Name: "request_payload_size_bytes",
-						Tags: tags,
-						Unit: time.Millisecond,
+						Name:   "request_payload_size_bytes",
+						Tags:   tags,
+						Unit:   time.Millisecond,
+						Values: []int64{0},
 					},
 					{
 						Name: "response_payload_size_bytes",
@@ -2104,14 +2105,16 @@ func TestUnaryInboundApplicationPanics(t *testing.T) {
 					Values: []int64{1}, // XXX this test flaps mysteriously. This figure is sometimes higher.
 				},
 				{
-					Name: "request_payload_size_bytes",
-					Tags: tags,
-					Unit: time.Millisecond,
+					Name:   "request_payload_size_bytes",
+					Tags:   tags,
+					Unit:   time.Millisecond,
+					Values: []int64{0},
 				},
 				{
-					Name: "response_payload_size_bytes",
-					Tags: tags,
-					Unit: time.Millisecond,
+					Name:   "response_payload_size_bytes",
+					Tags:   tags,
+					Unit:   time.Millisecond,
+					Values: []int64{0},
 				},
 				{
 					Name: "server_failure_latency_ms",


### PR DESCRIPTION
This change adds zero in the payload size histogram bucket and emits payload size even when response/response is zero.

- [X] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [ ] Entry in CHANGELOG.md
