### PR TITLE
New: added option OffsetGeneratorValue in hashring32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - observability: Add request and response payload size histogram
 - api: expose `BodySize` field in the transport request/response, middleware can use
   this field to get or update the request/response body size
+- hashring32: new option OffsetGeneratorValue
 ### Fixed
 - yarpc: service name can contain `_` now.
 

--- a/peer/hashring32/config.go
+++ b/peer/hashring32/config.go
@@ -36,6 +36,15 @@ type Config struct {
 	// in the Choose function.
 	OffsetHeader string `config:"offsetHeader"`
 
+	// OffsetGeneratorValue allows clients to generate an offset automatically when using hashring32
+	//
+	// For example, if this value is set to 4, the offset used by hashring32
+	// will be between [0-4].
+	//
+	// It should be noted that this option will not be used if the option
+	// OffsetHeader is being used.
+	OffsetGeneratorValue int `config:"offsetGeneratorValue"`
+
 	// PeerOverrideHeader allows clients to pass a header containing the shard
 	// identifier for a specific peer to override the destination address for
 	// the outgoing request.
@@ -99,6 +108,10 @@ func Spec(logger *zap.Logger, meter *metrics.Scope) yarpcconfig.PeerListSpec {
 
 			if c.NumPeersEstimate != 0 {
 				opts = append(opts, NumPeersEstimate(c.NumPeersEstimate))
+			}
+
+			if c.OffsetGeneratorValue != 0 && c.OffsetHeader == "" {
+				opts = append(opts, OffsetGeneratorValue(c.OffsetGeneratorValue))
 			}
 
 			return New(

--- a/peer/hashring32/config_test.go
+++ b/peer/hashring32/config_test.go
@@ -48,3 +48,21 @@ func TestPendingHeapConfig(t *testing.T) {
 	assert.NoError(t, err, "must construct a peer list")
 	pl.Update(peer.ListUpdates{Additions: []peer.Identifier{hostport.PeerIdentifier("127.0.0.1:8080")}})
 }
+
+func TestOffsetGeneratorValueConfig(t *testing.T) {
+	s := Spec(nil, nil)
+	duration := time.Second * 1
+
+	c := Config{
+		OffsetGeneratorValue:    4,
+		ReplicaDelimiter:        "#",
+		NumReplicas:             5,
+		NumPeersEstimate:        1000,
+		AlternateShardKeyHeader: "test-header",
+		DefaultChooseTimeout:    &duration,
+	}
+	build := s.BuildPeerList.(func(c Config, t peer.Transport, k *yarpcconfig.Kit) (peer.ChooserList, error))
+	pl, err := build(c, yarpctest.NewFakeTransport(), nil)
+	assert.NoError(t, err, "must construct a peer list")
+	pl.Update(peer.ListUpdates{Additions: []peer.Identifier{hostport.PeerIdentifier("127.0.0.1:8080")}})
+}

--- a/peer/hashring32/list.go
+++ b/peer/hashring32/list.go
@@ -36,6 +36,7 @@ import (
 
 type options struct {
 	offsetHeader            string
+	offsetGeneratorValue    int
 	peerOverrideHeader      string
 	alternateShardKeyHeader string
 	peerRingOptions         []hashring32.Option
@@ -60,6 +61,26 @@ type offsetHeaderOption struct {
 
 func (o offsetHeaderOption) apply(opts *options) {
 	opts.offsetHeader = o.offsetHeader
+}
+
+// OffsetGeneratorValue is the option function that client might give
+// if they want to generate an offset automatically when using hashring32
+//
+// For example, if this value is set to 4, the offset used by hashring32
+// will be between [0-4].
+//
+// It should be noted that this option will not be used if the option
+// OffsetHeader is being used.
+func OffsetGeneratorValue(offsetGenerator int) Option {
+	return offsetGeneratorValueOption{offsetGeneratorValue: offsetGenerator}
+}
+
+type offsetGeneratorValueOption struct {
+	offsetGeneratorValue int
+}
+
+func (o offsetGeneratorValueOption) apply(opts *options) {
+	opts.offsetGeneratorValue = o.offsetGeneratorValue
 }
 
 // PeerOverrideHeader allows clients to pass a header containing the shard
@@ -205,6 +226,7 @@ func New(transport peer.Transport, hashFunc hashring32.HashFunc32, opts ...Optio
 		options.offsetHeader,
 		options.peerOverrideHeader,
 		options.alternateShardKeyHeader,
+		options.offsetGeneratorValue,
 		logger,
 		options.peerRingOptions...,
 	)

--- a/peer/hashring32/ring.go
+++ b/peer/hashring32/ring.go
@@ -161,9 +161,7 @@ func (pr *peerRing) Choose(req *transport.Request) peer.StatusPeer {
 		if err != nil {
 			pr.logger.Error("yarpc/hashring32: offset header is not a valid integer", zap.String("offsetHeader", key), zap.Error(err))
 		}
-	}
-
-	if !ok && pr.offsetGeneratorValue != 0 {
+	} else if pr.offsetGeneratorValue != 0 {
 		n = pr.random.Intn(pr.offsetGeneratorValue)
 	}
 


### PR DESCRIPTION
Added new option OffsetGeneratorValue in hashring32.

This option can be used to generate random offset value when using the strategy hashring32.
For example, if this value is set to 4, the offset used by hashring32 will be between [0-4].
This is another option than using OffsetHeader which forces the client to do this.

- [x] Description and context for reviewers: one partner, one stranger
- [x] Docs (package doc)
- [x] Entry in CHANGELOG.md
