### PR TITLE
add leak test to transport/http package and fix tests accordingly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/uber/tchannel-go v1.16.0
 	go.uber.org/atomic v1.5.1
 	go.uber.org/fx v1.10.0
-	go.uber.org/goleak v1.0.0 // indirect
+	go.uber.org/goleak v1.0.0
 	go.uber.org/multierr v1.4.0
 	go.uber.org/net/metrics v1.3.0
 	go.uber.org/thriftrw v1.25.0

--- a/transport/http/inbound_test.go
+++ b/transport/http/inbound_test.go
@@ -96,8 +96,7 @@ func TestInboundStartError(t *testing.T) {
 	x := NewTransport()
 	i := x.NewInbound("invalid")
 	i.SetRouter(new(transporttest.MockRouter))
-	err := i.Start()
-	assert.Error(t, err, "expected failure")
+	assert.Error(t, i.Start(), "expected failure")
 }
 
 func TestInboundStartErrorBadGrabHeader(t *testing.T) {
@@ -119,6 +118,7 @@ func TestInboundMux(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	httpTransport := NewTransport()
+	defer httpTransport.Stop()
 	// TODO transport lifecycle
 
 	mux := http.NewServeMux()

--- a/transport/http/leak_test.go
+++ b/transport/http/leak_test.go
@@ -1,0 +1,10 @@
+package http
+
+import (
+	"go.uber.org/goleak"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/transport/http/leak_test.go
+++ b/transport/http/leak_test.go
@@ -1,8 +1,28 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 package http
 
 import (
-	"go.uber.org/goleak"
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -91,6 +91,7 @@ func TestCallSuccess(t *testing.T) {
 	defer successServer.Close()
 
 	httpTransport := NewTransport()
+	defer httpTransport.Stop()
 	out := httpTransport.NewSingleOutbound(successServer.URL)
 	require.NoError(t, out.Start(), "failed to start outbound")
 	defer out.Stop()
@@ -162,6 +163,7 @@ func TestOutboundHeaders(t *testing.T) {
 	}
 
 	httpTransport := NewTransport()
+	defer httpTransport.Stop()
 
 	for _, tt := range tests {
 		server := httptest.NewServer(http.HandlerFunc(
@@ -245,6 +247,7 @@ func TestOutboundApplicationError(t *testing.T) {
 	}
 
 	httpTransport := NewTransport()
+	defer httpTransport.Stop()
 
 	for _, tt := range tests {
 		server := httptest.NewServer(http.HandlerFunc(
@@ -308,6 +311,7 @@ func TestCallFailures(t *testing.T) {
 	defer internalErrorServer.Close()
 
 	httpTransport := NewTransport()
+	defer httpTransport.Stop()
 
 	tests := []struct {
 		url      string
@@ -341,6 +345,7 @@ func TestCallFailures(t *testing.T) {
 
 func TestStartMultiple(t *testing.T) {
 	httpTransport := NewTransport()
+	defer httpTransport.Stop()
 	out := httpTransport.NewSingleOutbound("http://localhost:9999")
 
 	var wg sync.WaitGroup
@@ -362,6 +367,7 @@ func TestStartMultiple(t *testing.T) {
 
 func TestStopMultiple(t *testing.T) {
 	httpTransport := NewTransport()
+	defer httpTransport.Stop()
 	out := httpTransport.NewSingleOutbound("http://127.0.0.1:9999")
 
 	err := out.Start()
@@ -386,6 +392,7 @@ func TestStopMultiple(t *testing.T) {
 
 func TestCallWithoutStarting(t *testing.T) {
 	httpTransport := NewTransport()
+	defer httpTransport.Stop()
 	out := httpTransport.NewSingleOutbound("http://127.0.0.1:9999")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 200*testtime.Millisecond)
@@ -443,7 +450,10 @@ func TestGetPeerForRequestErr(t *testing.T) {
 
 func TestWithCoreHeaders(t *testing.T) {
 	endpoint := "http://127.0.0.1:9999"
-	out := NewTransport().NewSingleOutbound(endpoint)
+	httpTransport := NewTransport()
+	defer httpTransport.Stop()
+	out := httpTransport.NewSingleOutbound(endpoint)
+	defer out.Stop()
 	require.NoError(t, out.Start())
 
 	httpReq := httptest.NewRequest("", endpoint, nil)
@@ -466,6 +476,7 @@ func TestWithCoreHeaders(t *testing.T) {
 
 func TestNoRequest(t *testing.T) {
 	tran := NewTransport()
+	defer tran.Stop()
 	out := tran.NewSingleOutbound("localhost:0")
 
 	_, err := out.Call(context.Background(), nil)
@@ -476,7 +487,9 @@ func TestNoRequest(t *testing.T) {
 }
 
 func TestOutboundNoDeadline(t *testing.T) {
-	out := NewTransport().NewSingleOutbound("http://foo-host:8080")
+	tran := NewTransport()
+	defer tran.Stop()
+	out := tran.NewSingleOutbound("http://foo-host:8080")
 
 	_, err := out.call(context.Background(), &transport.Request{})
 	assert.Equal(t, yarpcerrors.Newf(yarpcerrors.CodeInvalidArgument, "missing context deadline"), err)
@@ -494,6 +507,7 @@ func TestServiceMatchSuccess(t *testing.T) {
 	defer matchServer.Close()
 
 	httpTransport := NewTransport()
+	defer httpTransport.Stop()
 	out := httpTransport.NewSingleOutbound(matchServer.URL)
 	require.NoError(t, out.Start(), "failed to start outbound")
 	defer out.Stop()
@@ -518,6 +532,7 @@ func TestServiceMatchFailed(t *testing.T) {
 	defer mismatchServer.Close()
 
 	httpTransport := NewTransport()
+	defer httpTransport.Stop()
 	out := httpTransport.NewSingleOutbound(mismatchServer.URL)
 	require.NoError(t, out.Start(), "failed to start outbound")
 	defer out.Stop()
@@ -542,6 +557,7 @@ func TestServiceMatchNoHeader(t *testing.T) {
 	defer noHeaderServer.Close()
 
 	httpTransport := NewTransport()
+	defer httpTransport.Stop()
 	out := httpTransport.NewSingleOutbound(noHeaderServer.URL)
 	require.NoError(t, out.Start(), "failed to start outbound")
 	defer out.Stop()

--- a/transport/http/roundtrip_test.go
+++ b/transport/http/roundtrip_test.go
@@ -63,6 +63,7 @@ func TestRoundTripSuccess(t *testing.T) {
 
 	// start outbound
 	httpTransport := NewTransport()
+	defer httpTransport.Stop()
 	var out transport.UnaryOutbound = httpTransport.NewSingleOutbound(echoServer.URL)
 	require.NoError(t, out.Start(), "failed to start outbound")
 	defer out.Stop()
@@ -99,9 +100,12 @@ func TestRoundTripTimeout(t *testing.T) {
 		func(w http.ResponseWriter, r *http.Request) {
 			<-r.Context().Done() // never respond
 		}))
+	defer server.Close()
 
+	tran := NewTransport()
+	defer tran.Stop()
 	// start outbound
-	out := NewTransport().NewSingleOutbound(server.URL)
+	out := tran.NewSingleOutbound(server.URL)
 	require.NoError(t, out.Start(), "failed to start outbound")
 	defer out.Stop()
 
@@ -131,8 +135,11 @@ func TestRoundTripTimeout(t *testing.T) {
 func TestRoundTripNoDeadline(t *testing.T) {
 	URL := "http://foo-host"
 
-	out := NewTransport().NewSingleOutbound(URL)
+	tran := NewTransport()
+	defer tran.Stop()
+	out := tran.NewSingleOutbound(URL)
 	require.NoError(t, out.Start(), "could not start outbound")
+	defer out.Stop()
 
 	hreq, err := http.NewRequest("GET", URL, nil /* body */)
 	require.NoError(t, err)

--- a/transport/http/transport_test.go
+++ b/transport/http/transport_test.go
@@ -247,6 +247,7 @@ func TestTransport(t *testing.T) {
 			defer mockCtrl.Finish()
 
 			transport := NewTransport()
+			defer transport.Stop()
 
 			deps := TransportDeps{
 				PeerIdentifiers: createPeerIdentifierMap(tt.identifiers),


### PR DESCRIPTION
- Add a leak test to make sure there is goroutine leakage in the package. There is a few failures after adding the test from tests. The http transport will try to retain the connection after starting the outbound. Without an explicit `Stop`, we will see errors like:
```
goroutine 751 [chan receive]:
go.uber.org/yarpc/transport/http.(*httpPeer).MaintainConn(0xc0001332c0)
	/Users/allenlu/gocode/src/github.com/yarpc/yarpc-go/transport/http/peer.go:152 +0x89
created by go.uber.org/yarpc/transport/http.(*Transport).getOrCreatePeer
	/Users/allenlu/gocode/src/github.com/yarpc/yarpc-go/transport/http/transport.go:342 +0x13a
]
FAIL	go.uber.org/yarpc/transport/http	8.248s
```
- [ ] Entry in CHANGELOG.md
add leak test to transport/http package and fix tests accordingly