### PR TITLE
Fix memory leak in HTTP outbound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Fixed
+- Http: fix memory and connection leak in http outbound call handler
 
 ## [1.49.1] - 2020-11-17
 ### Fixed

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -226,6 +226,8 @@ func (o *Outbound) CallOneway(ctx context.Context, treq *transport.Request) (tra
 		return nil, yarpcerrors.InvalidArgumentErrorf("request for http oneway outbound was nil")
 	}
 
+	// res is used to close the response body to avoid memory/connection leak
+	// even when the response body is empty
 	res, err := o.call(ctx, treq)
 	if err != nil {
 		return nil, err

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -226,9 +226,13 @@ func (o *Outbound) CallOneway(ctx context.Context, treq *transport.Request) (tra
 		return nil, yarpcerrors.InvalidArgumentErrorf("request for http oneway outbound was nil")
 	}
 
-	_, err := o.call(ctx, treq)
+	res, err := o.call(ctx, treq)
 	if err != nil {
 		return nil, err
+	}
+
+	if err = res.Body.Close(); err != nil {
+		return nil, yarpcerrors.Newf(yarpcerrors.CodeInternal, err.Error())
 	}
 
 	return time.Now(), nil
@@ -267,6 +271,9 @@ func (o *Outbound) call(ctx context.Context, treq *transport.Request) (*transpor
 
 	// Service name match validation, return yarpcerrors.CodeInternal error if not match
 	if match, resSvcName := checkServiceMatch(treq.Service, response.Header); !match {
+		if err = response.Body.Close(); err != nil {
+			return nil, yarpcerrors.Newf(yarpcerrors.CodeInternal, err.Error())
+		}
 		return nil, transport.UpdateSpanWithErr(span,
 			yarpcerrors.InternalErrorf("service name sent from the request "+
 				"does not match the service name received in the response, sent %q, got: %q", treq.Service, resSvcName))

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -33,12 +33,15 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc/api/peer/peertest"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/raw"
 	"go.uber.org/yarpc/internal/testtime"
+	"go.uber.org/yarpc/peer/abstractpeer"
+	"go.uber.org/yarpc/pkg/lifecycle"
 	"go.uber.org/yarpc/yarpcerrors"
 )
 
@@ -680,4 +683,100 @@ func TestServiceMatchNoHeader(t *testing.T) {
 		Service: "Service",
 	})
 	require.NoError(t, err)
+}
+
+type RoundTripFunc func(req *http.Request) *http.Response
+
+func (f RoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req), nil
+}
+
+type errorReadCloser struct {
+	closeErr error
+}
+
+func (errorReadCloser) Read(p []byte) (n int, err error) {
+	return
+}
+
+func (e errorReadCloser) Close() error {
+	return e.closeErr
+}
+
+func TestCallResponseCloseError(t *testing.T) {
+	httpTransport := Transport{
+		client: &http.Client{
+			Transport: RoundTripFunc(func(req *http.Request) *http.Response {
+				return &http.Response{
+					StatusCode: 200,
+					Body:       errorReadCloser{closeErr: errors.New("test error")},
+					Header: http.Header{
+						"Rpc-Service": []string{"wrong-service"},
+					},
+				}
+			}),
+		},
+		tracer: opentracing.GlobalTracer(),
+	}
+	ctrl := gomock.NewController(t)
+	chooser := peertest.NewMockChooser(ctrl)
+	chooser.EXPECT().Start().Return(nil)
+	peer := &httpPeer{
+		Peer: &abstractpeer.Peer{},
+	}
+	chooser.EXPECT().Choose(gomock.Any(), gomock.Any()).Return(peer, func(error) {}, nil)
+	o := &Outbound{
+		once:              lifecycle.NewOnce(),
+		chooser:           chooser,
+		urlTemplate:       defaultURLTemplate,
+		tracer:            httpTransport.tracer,
+		transport:         &httpTransport,
+		bothResponseError: true,
+	}
+	err := o.Start()
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
+	defer cancel()
+	_, err = o.Call(ctx, &transport.Request{
+		Service: "Service",
+	})
+	require.Errorf(t, err, "Received unexpected error:code:internal message:test error")
+}
+
+func TestCallOneWayResponseCloseError(t *testing.T) {
+	httpTransport := Transport{
+		client: &http.Client{
+			Transport: RoundTripFunc(func(req *http.Request) *http.Response {
+				return &http.Response{
+					StatusCode: 200,
+					Body:       errorReadCloser{closeErr: errors.New("test error")},
+					Header:     http.Header{},
+				}
+			}),
+		},
+		tracer: opentracing.GlobalTracer(),
+	}
+	ctrl := gomock.NewController(t)
+	chooser := peertest.NewMockChooser(ctrl)
+	chooser.EXPECT().Start().Return(nil)
+	peer := &httpPeer{
+		Peer: &abstractpeer.Peer{},
+	}
+	chooser.EXPECT().Choose(gomock.Any(), gomock.Any()).Return(peer, func(error) {}, nil)
+	o := &Outbound{
+		once:              lifecycle.NewOnce(),
+		chooser:           chooser,
+		urlTemplate:       defaultURLTemplate,
+		tracer:            httpTransport.tracer,
+		transport:         &httpTransport,
+		bothResponseError: true,
+	}
+	err := o.Start()
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
+	defer cancel()
+	_, err = o.CallOneway(ctx, &transport.Request{
+		Service: "Service",
+	})
+	require.Errorf(t, err, "Received unexpected error:code:internal message:test error")
 }


### PR DESCRIPTION
Response body from net/http roundtrip must be closed, skipping which resulted in memory and connection leak. 

Read more about body field: https://golang.org/pkg/net/http/#Response

- [X] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [X] Entry in CHANGELOG.md
