### PR TITLE
Fixed: setup new default radix config in hashring32

### DIFF
--- a/peer/hashring32/internal/hashring32/hashring32.go
+++ b/peer/hashring32/internal/hashring32/hashring32.go
@@ -80,11 +80,10 @@ func New(hash HashFunc32, options ...Option) *Hashring32 {
 	ring.hashesArray = make([]uint32, 0, capacity)
 	ring.membersMapByHash = make(map[uint32](map[string]struct{}), capacity)
 	ring.membersSet = make(map[string]struct{}, ring.numPeersEstimate)
-	// TODO: Adjust parameters base on benchmarks
 	ring.sorter = radixsort32.New(
 		radixsort32.Radix(16),
 		radixsort32.MaxLen(capacity),
-		radixsort32.MinLen(1000))
+		radixsort32.MinLen(6000))
 
 	return ring
 }


### PR DESCRIPTION
Previously, radix sorting will be used when the given array would be bigger than 1000 elements.
Based on the following benchmark, https://golang.org/pkg/sort/#SliceStable is more effective than radix sorting until ~6000 elements.

**Radix SortingBenchmark**
1000 elements
➜  radixsort32 git:(dev) ✗ go test -count=1 -bench=.
goos: darwin
goarch: amd64
pkg: go.uber.org/yarpc/peer/hashring32/internal/radixsort32
BenchmarkSortSize1000KRadix16-12    	   19892	     54296 ns/op	   11342 B/op	       4 allocs/op
PASS
ok  	go.uber.org/yarpc/peer/hashring32/internal/radixsort32	2.244s

2000 elements
➜  radixsort32 git:(dev) ✗ go test -count=1 -bench=.
goos: darwin
goarch: amd64
pkg: go.uber.org/yarpc/peer/hashring32/internal/radixsort32
BenchmarkSortSize2000KRadix16-12    	   18507	     54956 ns/op	   10495 B/op	       4 allocs/op
PASS
ok  	go.uber.org/yarpc/peer/hashring32/internal/radixsort32	2.294s

6000 elements
➜  radixsort32 git:(dev) ✗ go test -count=1 -bench=.
goos: darwin
goarch: amd64
pkg: go.uber.org/yarpc/peer/hashring32/internal/radixsort32
BenchmarkSortSize6000KRadix16-12    	   16214	     65707 ns/op	   28677 B/op	       4 allocs/op
PASS
ok  	go.uber.org/yarpc/peer/hashring32/internal/radixsort32	1.931s

**STD Sorting Benchmark**
1000 elements
➜  radixsort32 git:(DefaultMinLengthRdixSort) ✗ go test -count=1 -bench=.
goos: darwin
goarch: amd64
pkg: go.uber.org/yarpc/peer/hashring32/internal/radixsort32
BenchmarkSortSize15000KRadix16-12    	  215388	      6599 ns/op	    4160 B/op	       3 allocs/op
PASS
ok  	go.uber.org/yarpc/peer/hashring32/internal/radixsort32	1.513s

2000 elements
➜  radixsort32 git:(dev) ✗ go test -count=1 -bench=.
goos: darwin
goarch: amd64
pkg: go.uber.org/yarpc/peer/hashring32/internal/radixsort32
BenchmarkSortSize2000KRadix16-12    	   93668	     13620 ns/op	    8257 B/op	       3 allocs/op
PASS
ok  	go.uber.org/yarpc/peer/hashring32/internal/radixsort32	1.946s

6000 elements
➜  radixsort32 git:(dev) ✗ go test -count=1 -bench=.
goos: darwin
goarch: amd64
pkg: go.uber.org/yarpc/peer/hashring32/internal/radixsort32
BenchmarkSortSize6000KRadix16-12    	   26089	     48230 ns/op	   24643 B/op	       3 allocs/op
PASS
ok  	go.uber.org/yarpc/peer/hashring32/internal/radixsort32	1.767s

For 1000 elements, CPU gain is about ~5x and Memory ~3x!

This should not affect any consumers since functionally speaking the result of the sorting will be the same

- [x] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [ ] Entry in CHANGELOG.md
