### PR TITLE
Accept gRPC dial options in transportSpec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Added
+- gRPC: accept dialer options in gRPC transportSpec config
 
 ## [1.49.1] - 2020-11-17
 ### Fixed

--- a/transport/grpc/config.go
+++ b/transport/grpc/config.go
@@ -186,6 +186,7 @@ type transportSpec struct {
 	TransportOptions []TransportOption
 	InboundOptions   []InboundOption
 	OutboundOptions  []OutboundOption
+	DialOptions      []DialOption
 }
 
 func newTransportSpec(opts ...Option) (*transportSpec, error) {
@@ -198,6 +199,8 @@ func newTransportSpec(opts ...Option) (*transportSpec, error) {
 			transportSpec.InboundOptions = append(transportSpec.InboundOptions, opt)
 		case OutboundOption:
 			transportSpec.OutboundOptions = append(transportSpec.OutboundOptions, opt)
+		case DialOption:
+			transportSpec.DialOptions = append(transportSpec.DialOptions, opt)
 		default:
 			return nil, fmt.Errorf("unknown option of type %T: %v", o, o)
 		}
@@ -260,8 +263,7 @@ func (t *transportSpec) buildOutbound(outboundConfig *OutboundConfig, tr transpo
 		return nil, newTransportCastError(tr)
 	}
 
-	dialer := trans.NewDialer(outboundConfig.dialOptions(kit)...)
-
+	dialer := trans.NewDialer(append(outboundConfig.dialOptions(kit), t.DialOptions...)...)
 	var chooser peer.Chooser
 	if outboundConfig.Empty() {
 		if outboundConfig.Address == "" {

--- a/transport/grpc/config_test.go
+++ b/transport/grpc/config_test.go
@@ -276,7 +276,7 @@ func TestTransportSpec(t *testing.T) {
 			},
 		},
 		{
-			desc: "simple outbound with dial custom dialer",
+			desc: "simple outbound with custom dialer option",
 			outboundCfg: attrs{
 				"myservice": attrs{
 					TransportName: attrs{"address": "localhost:54569"},

--- a/transport/grpc/config_test.go
+++ b/transport/grpc/config_test.go
@@ -23,6 +23,7 @@ package grpc
 import (
 	"context"
 	"net"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -31,6 +32,8 @@ import (
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/peer"
 	"go.uber.org/yarpc/yarpcconfig"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
 )
 
 func TestNewTransportSpecOptions(t *testing.T) {
@@ -379,6 +382,58 @@ func TestTransportSpec(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestContextDialerOptionUsage(t *testing.T) {
+	type attrs map[string]interface{}
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer lis.Close()
+	server := grpc.NewServer()
+	defer server.Stop()
+	go func() {
+		require.NoError(t, server.Serve(lis))
+	}()
+
+	dialContextInvoked := int32(0)
+	dialer := func(ctx context.Context, addr string) (net.Conn, error) {
+		atomic.AddInt32(&dialContextInvoked, 1)
+		return (&net.Dialer{}).DialContext(ctx, "tcp", addr)
+	}
+	configurator := yarpcconfig.New()
+	err = configurator.RegisterTransport(TransportSpec(ContextDialer(dialer)))
+	require.NoError(t, err)
+	cfgData := attrs{
+		"outbounds": attrs{
+			"myservice": attrs{
+				TransportName: attrs{"address": lis.Addr().String()},
+			},
+		},
+	}
+	cfg, err := configurator.LoadConfig("foo", cfgData)
+	require.NoError(t, err)
+	outbound, ok := cfg.Outbounds["myservice"].Unary.(*Outbound)
+	require.True(t, ok)
+	defer outbound.Stop()
+	single := outbound.peerChooser.(*peer.Single)
+	require.NoError(t, single.Start())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	peer, _, err := single.Choose(ctx, &transport.Request{})
+	require.NoError(t, err)
+	grpcPeer, ok := peer.(*grpcPeer)
+	require.True(t, ok)
+
+	for {
+		state := grpcPeer.clientConn.GetState()
+		if grpcPeer.clientConn.GetState() == connectivity.Ready {
+			break
+		}
+		grpcPeer.clientConn.WaitForStateChange(ctx, state)
+	}
+	require.Equal(t, connectivity.Ready, grpcPeer.clientConn.GetState())
+	require.Equal(t, int32(1), dialContextInvoked)
 }
 
 func mapResolver(m map[string]string) func(string) (string, bool) {


### PR DESCRIPTION
gRPC transport spec can now accept dial options, specifically to custom dial gRPC connection

- [X] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [X] Entry in CHANGELOG.md
