### PR TITLE
Fixed: tworandomchoices now handle its own locking

### DIFF
--- a/peer/tworandomchoices/tworandomchoices.go
+++ b/peer/tworandomchoices/tworandomchoices.go
@@ -22,6 +22,7 @@ package tworandomchoices
 
 import (
 	"math/rand"
+	"sync"
 	"time"
 
 	"go.uber.org/yarpc/api/peer"
@@ -32,6 +33,8 @@ import (
 type twoRandomChoicesList struct {
 	subscribers []*subscriber
 	random      *rand.Rand
+
+	m sync.RWMutex
 }
 
 // Option configures the peer list implementation constructor.
@@ -58,6 +61,9 @@ func newTwoRandomChoicesList(cap int, source rand.Source) *twoRandomChoicesList 
 }
 
 func (l *twoRandomChoicesList) Add(peer peer.StatusPeer, _ peer.Identifier) abstractlist.Subscriber {
+	l.m.Lock()
+	defer l.m.Unlock()
+
 	index := len(l.subscribers)
 	l.subscribers = append(l.subscribers, &subscriber{
 		index: index,
@@ -67,6 +73,9 @@ func (l *twoRandomChoicesList) Add(peer peer.StatusPeer, _ peer.Identifier) abst
 }
 
 func (l *twoRandomChoicesList) Remove(peer peer.StatusPeer, _ peer.Identifier, ps abstractlist.Subscriber) {
+	l.m.Lock()
+	defer l.m.Unlock()
+
 	sub, ok := ps.(*subscriber)
 	if !ok || len(l.subscribers) == 0 {
 		return
@@ -79,6 +88,9 @@ func (l *twoRandomChoicesList) Remove(peer peer.StatusPeer, _ peer.Identifier, p
 }
 
 func (l *twoRandomChoicesList) Choose(_ *transport.Request) peer.StatusPeer {
+	l.m.RLock()
+	defer l.m.RUnlock()
+
 	numSubs := len(l.subscribers)
 	if numSubs == 0 {
 		return nil


### PR DESCRIPTION
This diff is part of an effort of changing the locking system of the interface `type Implementation interface`

Previously, when using (and based on the documentation) `Implementation` method should Add/Remove/Choose should be called within a write lock. Now each implementation will handle its locks.

Here, the implementation tworandomchoices will do a readlock instead of a writelock for the method Choose. Better performances :)

It should be noted, that upstream caller will need to remove their write lock. There is no breaking of functionality if those locks are not removed, only degraded performances.

- [x] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [ ] Entry in CHANGELOG.md
