### PR TITLE
CHANGELOG: Fix version links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1311,6 +1311,7 @@ This release requires regeneration of ThriftRW code.
 ## 0.1.0 - 2016-08-31
 
 - Initial release.
+
 [Unreleased]: https://github.com/yarpc/yarpc-go/compare/v1.49.1...HEAD
 [1.49.1]: https://github.com/yarpc/yarpc-go/compare/v1.49.0...v1.49.1
 [1.49.0]: https://github.com/yarpc/yarpc-go/compare/v1.48.0...v1.49.0


### PR DESCRIPTION
The link list needs to be in a separate paragraph or it becomes part of
the text of the previous paragraph.
