### PR TITLE
Fixed: added mutext in UpdatePendingRequestCount of TwoRandomeChoices

### DIFF
--- a/peer/abstractlist/list.go
+++ b/peer/abstractlist/list.go
@@ -75,6 +75,7 @@ type Implementation interface {
 // pending request count changes.
 // A peer list implementation may have a single subscriber or a subscriber for
 // each peer.
+// UpdatePendingRequestCount is thread safe to be called
 type Subscriber interface {
 	UpdatePendingRequestCount(int)
 }

--- a/peer/tworandomchoices/tworandomchoices.go
+++ b/peer/tworandomchoices/tworandomchoices.go
@@ -110,7 +110,7 @@ func (l *twoRandomChoicesList) Choose(_ *transport.Request) peer.StatusPeer {
 	return l.subscribers[i].peer
 }
 
-func (l *twoRandomChoicesList) UpdatePendingRequestCountForPeer(s *subscriber, pendingRequestCount int) {
+func (l *twoRandomChoicesList) updatePendingRequestCountForPeer(s *subscriber, pendingRequestCount int) {
 	l.m.Lock()
 	defer l.m.Unlock()
 
@@ -127,5 +127,5 @@ type subscriber struct {
 var _ abstractlist.Subscriber = (*subscriber)(nil)
 
 func (s *subscriber) UpdatePendingRequestCount(pendingRequestCount int) {
-	s.list.UpdatePendingRequestCountForPeer(s, pendingRequestCount)
+	s.list.updatePendingRequestCountForPeer(s, pendingRequestCount)
 }


### PR DESCRIPTION
Previously, it was the responsibility of the caller to lock call on UpdatePendingRequestCount. This has been changed with https://github.com/yarpc/yarpc-go/commit/a977f562f7d0ad0aae3172a22e48ec923f3d1773 where the struct is now responsible of doing the lock. For UpdatePendingRequestCount in tworandomechoices, we use atomic which is faster than a mutex

Note: only tworandomchoices needs this because other peer strategy does not use UpdatePendingRequestCount. The other one which was using it is pendingchoice which was already implementing the lock system

- [x ] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [ ] Entry in CHANGELOG.md
