### PR TITLE
strip http2 pseudo-header field from request before http outbound call

### DIFF
--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -363,7 +363,7 @@ func (o *Outbound) createRequest(treq *transport.Request) (*http.Request, error)
 		if v, ok := treq.Headers.Get(http2AuthorityPseudoHeader); ok {
 			hreq.Host = v
 		}
-		// strip all http2 pseud-header fields
+		// strip all http2 pseudo-header fields
 		for _, k := range http2PseudoHeaders {
 			treq.Headers.Del(k)
 		}

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -360,7 +360,7 @@ func (o *Outbound) createRequest(treq *transport.Request) (*http.Request, error)
 		// An intermediary that converts an HTTP/2 request to HTTP/1.1 MUST
 		// create a Host header field if one is not present in a request by
 		// copying the value of the ":authority" pseudo-header field.
-		if v, ok := treq.Headers.Get(http2AuthorityPseudoHeader); ok {
+		if v, ok := treq.Headers.Get(http2AuthorityPseudoHeader); ok && hreq.Host == "" {
 			hreq.Host = v
 		}
 		// strip all http2 pseudo-header fields

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -640,12 +640,14 @@ func TestGRPCInHTTPOut(t *testing.T) {
 		func(w http.ResponseWriter, req *http.Request) {
 			defer req.Body.Close()
 			h := req.Header
-			// make sure all pesudo fields are reset
+			// make sure all pesudo-header fields are unset
 			for _, k := range http2PseudoHeaders {
 				assert.Zero(t, h.Get(k))
 			}
-			assert.Equal(t, "app-val1", h.Get("Rpc-Header-app-key1"))
+			// Host field came from ":authority" pesudo-header field
 			assert.Equal(t, "test-authority", req.Host)
+			// other application header are still set and prefixed
+			assert.Equal(t, "app-val1", h.Get("Rpc-Header-app-key1"))
 			_, err := w.Write([]byte("http header return"))
 			assert.NoError(t, err)
 		},


### PR DESCRIPTION
- [x] Description and context for reviewers: one partner, one stranger

In case grpc inbound  http outbound, and the request contains http2
specific pseudo-header fields, http outbound call will fail. 

Making the fix on authority field based on the [RFC](https://tools.ietf.org/html/rfc7540#section-8.1.2.3):
An intermediary that converts an HTTP/2 request to HTTP/1.1 MUST
create a Host header field if one is not present in a request by
copying the value of the ":authority" pseudo-header field.

For other pseduo-header fields, http transport will strip those before
forwarding to a http outbound.

The added test will fail before the fix:

```
--- FAIL: TestGRPCInHTTPOut (0.00s)
    outbound_test.go:676:
        	Error Trace:	outbound_test.go:676
        	Error:      	Received unexpected error:
        	            	code:unknown message:unknown error from http client: Post "http://127.0.0.1:63722": net/http: invalid header field name "Rpc-Header-:path"
        	Test:       	TestGRPCInHTTPOut
```
- [x] Entry in CHANGELOG.md
Fixed an issue when sending requests with http2 pseduo-header field to http outbound.