### PR TITLE
Added tags filtering for YARPC middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+- Add metric tags blocklist to enable filtering of certain tags emitted from the middleware 
 
 ## [1.50.0] - 2021-01-22
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Add metric tags blocklist to enable stubbing of high cardinality tags emitted from the middleware 
+### Added
+- observability: Add metric tags blocklist configuration. Allows to stub high cardinality tags emitted
+  in the observability middleware
 
 ## [1.50.0] - 2021-01-22
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Add metric tags blocklist to enable filtering of certain tags emitted from the middleware 
+- Add metric tags blocklist to enable stubbing of high cardinality tags emitted from the middleware 
 
 ## [1.50.0] - 2021-01-22
 ### Added

--- a/config.go
+++ b/config.go
@@ -131,6 +131,9 @@ type MetricsConfig struct {
 	// default, metrics are collected in memory but not pushed.
 	// TODO deprecate this option for metrics configuration.
 	Tally tally.Scope
+	// Tags that should be suppressed from all the metrics emitted from w/in
+	// YARPC middleware
+	TagsBlocklist []string
 }
 
 func (c MetricsConfig) scope(name string, logger *zap.Logger) (*metrics.Scope, context.CancelFunc) {

--- a/config.go
+++ b/config.go
@@ -131,8 +131,8 @@ type MetricsConfig struct {
 	// default, metrics are collected in memory but not pushed.
 	// TODO deprecate this option for metrics configuration.
 	Tally tally.Scope
-	// Tags that should be suppressed from all the metrics emitted from w/in
-	// YARPC middleware
+	// TagsBlocklist enlists tags' keys that should be suppressed from all the metrics
+	// emitted from w/in YARPC middleware.
 	TagsBlocklist []string
 }
 

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -106,6 +106,7 @@ func addObservingMiddleware(cfg Config, meter *metrics.Scope, logger *zap.Logger
 		Logger:           logger,
 		Scope:            meter,
 		ContextExtractor: extractor,
+		MetricTagsBlocklist: cfg.Metrics.TagsBlocklist,
 		Levels: observability.LevelsConfig{
 			Default: observability.DirectionalLevelsConfig{
 				Success:          cfg.Logging.Levels.Success,

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -103,9 +103,9 @@ func addObservingMiddleware(cfg Config, meter *metrics.Scope, logger *zap.Logger
 	}
 
 	observer := observability.NewMiddleware(observability.Config{
-		Logger:           logger,
-		Scope:            meter,
-		ContextExtractor: extractor,
+		Logger:              logger,
+		Scope:               meter,
+		ContextExtractor:    extractor,
 		MetricTagsBlocklist: cfg.Metrics.TagsBlocklist,
 		Levels: observability.LevelsConfig{
 			Default: observability.DirectionalLevelsConfig{

--- a/internal/observability/graph.go
+++ b/internal/observability/graph.go
@@ -203,7 +203,7 @@ func newEdge(logger *zap.Logger, meter *metrics.Scope, metricTagsBlocklist []str
 
 	if metricTagsBlocklist != nil {
 		for _, filteredKey := range metricTagsBlocklist {
-			delete(tags, filteredKey)
+			tags[filteredKey] = "__redacted__"
 		}
 	}
 

--- a/internal/observability/graph.go
+++ b/internal/observability/graph.go
@@ -54,9 +54,9 @@ const (
 // A graph represents a collection of services: each service is a node, and we
 // collect stats for each caller-callee-transport-encoding-procedure-rk-sk-rd edge.
 type graph struct {
-	meter   *metrics.Scope
-	logger  *zap.Logger
-	extract ContextExtractor
+	meter               *metrics.Scope
+	logger              *zap.Logger
+	extract             ContextExtractor
 	metricTagsBlocklist []string
 
 	edgesMu sync.RWMutex
@@ -143,7 +143,7 @@ func (g *graph) createEdge(key []byte, req *transport.Request, direction string,
 		return e
 	}
 
-	e := newEdge(g.logger, g.meter, g.metricTagsBlocklist, direction, rpcType, req)
+	e := newEdge(g.logger, g.meter, g.metricTagsBlocklist, req, direction, rpcType)
 	g.edges[string(key)] = e
 	return e
 }
@@ -188,7 +188,7 @@ type streamEdge struct {
 
 // newEdge constructs a new edge. Since Registries enforce metric uniqueness,
 // edges should be cached and re-used for each RPC.
-func newEdge(logger *zap.Logger, meter *metrics.Scope, metricTagsBlocklist []string, direction string, rpcType transport.Type, req *transport.Request) *edge {
+func newEdge(logger *zap.Logger, meter *metrics.Scope, metricTagsBlocklist []string, req *transport.Request, direction string, rpcType transport.Type) *edge {
 	tags := metrics.Tags{
 		"source":           req.Caller,
 		"dest":             req.Service,

--- a/internal/observability/graph.go
+++ b/internal/observability/graph.go
@@ -188,7 +188,7 @@ type streamEdge struct {
 
 // newEdge constructs a new edge. Since Registries enforce metric uniqueness,
 // edges should be cached and re-used for each RPC.
-func newEdge(logger *zap.Logger, meter *metrics.Scope, metricTagsBlocklist *[]string, direction string, rpcType transport.Type, req *transport.Request) *edge {
+func newEdge(logger *zap.Logger, meter *metrics.Scope, metricTagsBlocklist []string, direction string, rpcType transport.Type, req *transport.Request) *edge {
 	tags := metrics.Tags{
 		"source":           req.Caller,
 		"dest":             req.Service,
@@ -202,7 +202,7 @@ func newEdge(logger *zap.Logger, meter *metrics.Scope, metricTagsBlocklist *[]st
 	}
 
 	if metricTagsBlocklist != nil {
-		for _, filteredKey := range *metricTagsBlocklist {
+		for _, filteredKey := range metricTagsBlocklist {
 			delete(tags, filteredKey)
 		}
 	}

--- a/internal/observability/graph.go
+++ b/internal/observability/graph.go
@@ -57,7 +57,7 @@ type graph struct {
 	meter   *metrics.Scope
 	logger  *zap.Logger
 	extract ContextExtractor
-	metricTagsBlocklist *[]string
+	metricTagsBlocklist []string
 
 	edgesMu sync.RWMutex
 	edges   map[string]*edge
@@ -65,7 +65,7 @@ type graph struct {
 	inboundLevels, outboundLevels levels
 }
 
-func newGraph(meter *metrics.Scope, logger *zap.Logger, extract ContextExtractor, metricTagsBlocklist *[]string) graph {
+func newGraph(meter *metrics.Scope, logger *zap.Logger, extract ContextExtractor, metricTagsBlocklist []string) graph {
 	return graph{
 		edges:               make(map[string]*edge, _defaultGraphSize),
 		meter:               meter,

--- a/internal/observability/graph.go
+++ b/internal/observability/graph.go
@@ -49,7 +49,7 @@ type directionName string
 const (
 	_directionOutbound directionName = "outbound"
 	_directionInbound  directionName = "inbound"
-	_redactedTagVal                  = "__redacted__"
+	_redactedTagVal                  = "__dropped__"
 )
 
 // A graph represents a collection of services: each service is a node, and we

--- a/internal/observability/graph.go
+++ b/internal/observability/graph.go
@@ -49,7 +49,7 @@ type directionName string
 const (
 	_directionOutbound directionName = "outbound"
 	_directionInbound  directionName = "inbound"
-	_filteredTagVal                  = "__redacted__"
+	_redactedTagVal                  = "__redacted__"
 )
 
 // A graph represents a collection of services: each service is a node, and we
@@ -203,7 +203,7 @@ func newEdge(logger *zap.Logger, meter *metrics.Scope, metricTagsBlocklist []str
 	}
 
 	for _, tagName := range metricTagsBlocklist {
-		tags[tagName] = _filteredTagVal
+		tags[tagName] = _redactedTagVal
 	}
 
 	// metrics for all RPCs

--- a/internal/observability/graph.go
+++ b/internal/observability/graph.go
@@ -49,6 +49,7 @@ type directionName string
 const (
 	_directionOutbound directionName = "outbound"
 	_directionInbound  directionName = "inbound"
+	_filteredTagVal                  = "__redacted__"
 )
 
 // A graph represents a collection of services: each service is a node, and we
@@ -201,10 +202,8 @@ func newEdge(logger *zap.Logger, meter *metrics.Scope, metricTagsBlocklist []str
 		"rpc_type":         rpcType.String(),
 	}
 
-	if metricTagsBlocklist != nil {
-		for _, filteredKey := range metricTagsBlocklist {
-			tags[filteredKey] = "__redacted__"
-		}
+	for _, tagName := range metricTagsBlocklist {
+		tags[tagName] = _filteredTagVal
 	}
 
 	// metrics for all RPCs

--- a/internal/observability/graph.go
+++ b/internal/observability/graph.go
@@ -49,7 +49,10 @@ type directionName string
 const (
 	_directionOutbound directionName = "outbound"
 	_directionInbound  directionName = "inbound"
-	_redactedTagVal                  = "__dropped__"
+
+	// _droppedTagValue represents the value of a metric tag when the tag
+	// is being blocked.
+	_droppedTagValue = "__dropped__"
 )
 
 // A graph represents a collection of services: each service is a node, and we
@@ -203,7 +206,7 @@ func newEdge(logger *zap.Logger, meter *metrics.Scope, metricTagsBlocklist []str
 	}
 
 	for _, tagName := range metricTagsBlocklist {
-		tags[tagName] = _redactedTagVal
+		tags[tagName] = _droppedTagValue
 	}
 
 	// metrics for all RPCs

--- a/internal/observability/graph_test.go
+++ b/internal/observability/graph_test.go
@@ -46,12 +46,14 @@ func TestEdgeNopFallbacks(t *testing.T) {
 		RoutingDelegate: "rd",
 	}
 
+	var tagsBlocklist []string
+
 	// Should succeed, covered by middleware tests.
-	_ = newEdge(zap.NewNop(), meter, req, string(_directionOutbound), transport.Unary)
+	_ = newEdge(zap.NewNop(), meter, tagsBlocklist, string(_directionOutbound), transport.Unary, req)
 
 	// Should fall back to no-op metrics.
 	// Usage of nil metrics should not panic, should not observe changes.
-	e := newEdge(zap.NewNop(), meter, req, string(_directionOutbound), transport.Unary)
+	e := newEdge(zap.NewNop(), meter, tagsBlocklist, string(_directionOutbound), transport.Unary, req)
 
 	e.calls.Inc()
 	assert.Equal(t, int64(0), e.calls.Load(), "Expected to fall back to no-op metrics.")

--- a/internal/observability/graph_test.go
+++ b/internal/observability/graph_test.go
@@ -49,11 +49,11 @@ func TestEdgeNopFallbacks(t *testing.T) {
 	var tagsBlocklist []string
 
 	// Should succeed, covered by middleware tests.
-	_ = newEdge(zap.NewNop(), meter, tagsBlocklist, string(_directionOutbound), transport.Unary, req)
+	_ = newEdge(zap.NewNop(), meter, tagsBlocklist, req, string(_directionOutbound), transport.Unary)
 
 	// Should fall back to no-op metrics.
 	// Usage of nil metrics should not panic, should not observe changes.
-	e := newEdge(zap.NewNop(), meter, tagsBlocklist, string(_directionOutbound), transport.Unary, req)
+	e := newEdge(zap.NewNop(), meter, tagsBlocklist, req, string(_directionOutbound), transport.Unary)
 
 	e.calls.Inc()
 	assert.Equal(t, int64(0), e.calls.Load(), "Expected to fall back to no-op metrics.")

--- a/internal/observability/middleware.go
+++ b/internal/observability/middleware.go
@@ -91,11 +91,11 @@ type Config struct {
 	// Scope to which metrics are emitted.
 	Scope *metrics.Scope
 
-	// List of metric tags being suppressed from being tagged on
-	// metrics emitted by the middleware
+	// MetricTagsBlocklist of metric tags being suppressed from being tagged on
+	// metrics emitted by the middleware.
 	MetricTagsBlocklist []string
 
-	// Extracts request-scoped information from the context for logging.
+	// ContextExtractor Extracts request-scoped information from the context for logging.
 	ContextExtractor ContextExtractor
 
 	// Levels specify log levels for various classes of requests.

--- a/internal/observability/middleware.go
+++ b/internal/observability/middleware.go
@@ -91,6 +91,9 @@ type Config struct {
 	// Scope to which metrics are emitted.
 	Scope *metrics.Scope
 
+	// TODO
+	MetricTagsBlocklist *[]string
+
 	// Extracts request-scoped information from the context for logging.
 	ContextExtractor ContextExtractor
 
@@ -130,7 +133,7 @@ type DirectionalLevelsConfig struct {
 // NewMiddleware constructs an observability middleware with the provided
 // configuration.
 func NewMiddleware(cfg Config) *Middleware {
-	m := &Middleware{newGraph(cfg.Scope, cfg.Logger, cfg.ContextExtractor)}
+	m := &Middleware{newGraph(cfg.Scope, cfg.Logger, cfg.ContextExtractor, cfg.MetricTagsBlocklist)}
 
 	// Apply the default levels
 	applyLogLevelsConfig(&m.graph.inboundLevels, &cfg.Levels.Default)

--- a/internal/observability/middleware.go
+++ b/internal/observability/middleware.go
@@ -93,7 +93,7 @@ type Config struct {
 
 	// List of metric tags being suppressed from being tagged on
 	// metrics emitted by the middleware
-	MetricTagsBlocklist *[]string
+	MetricTagsBlocklist []string
 
 	// Extracts request-scoped information from the context for logging.
 	ContextExtractor ContextExtractor

--- a/internal/observability/middleware.go
+++ b/internal/observability/middleware.go
@@ -91,7 +91,8 @@ type Config struct {
 	// Scope to which metrics are emitted.
 	Scope *metrics.Scope
 
-	// TODO
+	// List of metric tags being suppressed from being tagged on
+	// metrics emitted by the middleware
 	MetricTagsBlocklist *[]string
 
 	// Extracts request-scoped information from the context for logging.

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -1270,7 +1270,7 @@ func TestUnaryInboundApplicationErrors(t *testing.T) {
 	assert.Equal(t, expected, entry, "Unexpected log entry written.")
 }
 
-func TestMiddlewareSuccessSnapshotNoTagsFiltering(t *testing.T) {
+func TestMiddlewareSuccessSnapshot(t *testing.T) {
 	timeVal := time.Now()
 	defer stubTimeWithTimeVal(timeVal)()
 	ttlMs := int64(1000)

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -1414,14 +1414,15 @@ func TestMiddlewareSuccessSnapshotWithTagsFiltered(t *testing.T) {
 
 	snap := root.Snapshot()
 	tags := metrics.Tags{
-		"dest":        "service",
-		"direction":   "inbound",
-		"transport":   "unknown",
-		"encoding":    "raw",
-		"procedure":   "procedure",
-		"routing_key": "rk",
-		"rpc_type":    transport.Unary.String(),
-		"source":      "caller",
+		"dest":             "service",
+		"direction":        "inbound",
+		"transport":        "unknown",
+		"encoding":         "raw",
+		"procedure":        "procedure",
+		"routing_key":      "rk",
+		"routing_delegate": "__redacted__",
+		"rpc_type":         transport.Unary.String(),
+		"source":           "caller",
 	}
 	want := &metrics.RootSnapshot{
 		Counters: []metrics.Snapshot{

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -1420,7 +1420,7 @@ func TestMiddlewareSuccessSnapshotWithTagsFiltered(t *testing.T) {
 		"encoding":         "raw",
 		"procedure":        "procedure",
 		"routing_key":      "rk",
-		"routing_delegate": "__redacted__",
+		"routing_delegate": "__dropped__",
 		"rpc_type":         transport.Unary.String(),
 		"source":           "caller",
 	}

--- a/yarpcconfig/configurator.go
+++ b/yarpcconfig/configurator.go
@@ -313,6 +313,7 @@ func (c *Configurator) load(serviceName string, cfg *yarpcConfig) (_ yarpc.Confi
 	}
 
 	cfg.Logging.fill(&yc)
+	cfg.Metrics.fill(&yc)
 	return yc, nil
 }
 

--- a/yarpcconfig/configurator_test.go
+++ b/yarpcconfig/configurator_test.go
@@ -161,6 +161,26 @@ func TestConfigurator(t *testing.T) {
 			},
 		},
 		{
+			desc: "metric tags blocklist",
+			test: func(*testing.T, *gomock.Controller) (tt testCase) {
+				tt.serviceName = "foo"
+				tt.give = whitespace.Expand(`
+					metrics:
+						tagsBlocklist:
+							- "routing_delegate"
+				`)
+				tt.wantConfig = yarpc.Config{
+					Name: "foo",
+					Metrics: yarpc.MetricsConfig{
+						TagsBlocklist: []string{
+							"routing_delegate",
+						},
+					},
+				}
+				return
+			},
+		},
+		{
 			desc: "application error, invalid type",
 			test: func(*testing.T, *gomock.Controller) (tt testCase) {
 				tt.give = whitespace.Expand(`

--- a/yarpcconfig/decode.go
+++ b/yarpcconfig/decode.go
@@ -35,17 +35,17 @@ type yarpcConfig struct {
 	Outbounds  clientConfigs                  `config:"outbounds"`
 	Transports map[string]config.AttributeMap `config:"transports"`
 	Logging    logging                        `config:"logging"`
-	Metrics    metrics						  `config:"metrics"`
+	Metrics    metrics                        `config:"metrics"`
 }
 
 // metrics allows configuring the way metrics are emitted from YAML
 type metrics struct {
-	tagsBlocklist []string `config:"tagsBlocklist"`
+	TagsBlocklist []string `config:"tagsBlocklist"`
 }
 
 // Fills values from this object into the provided YARPC config.
 func (m *metrics) fill(cfg *yarpc.Config) {
-	cfg.Metrics.TagsBlocklist = m.tagsBlocklist
+	cfg.Metrics.TagsBlocklist = m.TagsBlocklist
 }
 
 // logging allows configuring the log levels from YAML.

--- a/yarpcconfig/decode.go
+++ b/yarpcconfig/decode.go
@@ -35,6 +35,17 @@ type yarpcConfig struct {
 	Outbounds  clientConfigs                  `config:"outbounds"`
 	Transports map[string]config.AttributeMap `config:"transports"`
 	Logging    logging                        `config:"logging"`
+	Metrics    metrics						  `config:"metrics"`
+}
+
+// metrics allows configuring the way metrics are emitted from YAML
+type metrics struct {
+	tagsBlocklist []string `config:"tagsBlocklist"`
+}
+
+// Fills values from this object into the provided YARPC config.
+func (m *metrics) fill(cfg *yarpc.Config) {
+	cfg.Metrics.TagsBlocklist = m.tagsBlocklist
 }
 
 // logging allows configuring the log levels from YAML.


### PR DESCRIPTION
Added tags filtering for YARPC middleware allowing to selectively preempt emission of certain tags on the configuration level to allow to avoid blow-up in cardinality due to some high-cardinality aspects (like "routing_delegate" for city-sharded services)

More context could be found in the (internal) ticket RPC-366.

- [x] Description and context for reviewers: one partner, one stranger
- [x] Docs (package doc)
- [x] Entry in CHANGELOG.md
