### PR TITLE
Extend yarpctest with CallOption matchers

### DIFF
--- a/yarpctest/call_option_matchers.go
+++ b/yarpctest/call_option_matchers.go
@@ -1,0 +1,173 @@
+package yarpctest
+
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/api/encoding"
+	"go.uber.org/yarpc/api/transport"
+)
+
+var (
+	_ gomock.Matcher = (*headerMatcher)(nil)
+	_ gomock.Matcher = (*routingDelegateMatcher)(nil)
+	_ gomock.Matcher = (*shardKeyMatcher)(nil)
+	_ gomock.Matcher = (*routingKeyMatcher)(nil)
+)
+
+type headerMatcher struct {
+	t             *testing.T
+	expectedKey   string
+	expectedValue string
+}
+
+// Returns a gomock.Matcher that matches a CallOption that sets a header.
+func NewHeaderMatcher(t *testing.T, key string, value string) gomock.Matcher {
+	return &headerMatcher{
+		t:             t,
+		expectedKey:   key,
+		expectedValue: value,
+	}
+}
+
+func (h headerMatcher) Matches(x interface{}) bool {
+	option, ok := x.(yarpc.CallOption)
+	if !ok {
+		return false
+	}
+
+	req := writeOptionToRequest(h.t, option)
+
+	if req.Headers.Len() != 1 {
+		return false
+	}
+
+	for k, v := range req.Headers.Items() {
+		return h.expectedKey == k && h.expectedValue == v
+	}
+
+	return false
+}
+
+func (h headerMatcher) String() string {
+	return fmt.Sprintf("header %s:%s", h.expectedKey, h.expectedValue)
+}
+
+type routingDelegateMatcher struct {
+	t             *testing.T
+	expectedValue string
+}
+
+// Returns a gomock.Matcher that matches a CallOption that sets the routing delegate.
+func NewRoutingDelegateMatcher(t *testing.T, value string) gomock.Matcher {
+	return &routingDelegateMatcher{
+		t:             t,
+		expectedValue: value,
+	}
+}
+
+func (r routingDelegateMatcher) Matches(x interface{}) bool {
+	option, ok := x.(yarpc.CallOption)
+	if !ok {
+		return false
+	}
+
+	req := writeOptionToRequest(r.t, option)
+
+	return r.expectedValue == req.RoutingDelegate
+}
+
+func (r routingDelegateMatcher) String() string {
+	return fmt.Sprintf("routing delegate: %s", r.expectedValue)
+}
+
+type shardKeyMatcher struct {
+	t             *testing.T
+	expectedValue string
+}
+
+// Returns a gomock.Matcher that matches a CallOption that sets the shard key
+func NewShardKeyMatcher(t *testing.T, value string) gomock.Matcher {
+	return &shardKeyMatcher{
+		t:             t,
+		expectedValue: value,
+	}
+}
+
+func (r shardKeyMatcher) Matches(x interface{}) bool {
+	option, ok := x.(yarpc.CallOption)
+	if !ok {
+		return false
+	}
+
+	req := writeOptionToRequest(r.t, option)
+
+	return r.expectedValue == req.ShardKey
+}
+
+func (r shardKeyMatcher) String() string {
+	return fmt.Sprintf("shard key: %s", r.expectedValue)
+}
+
+type routingKeyMatcher struct {
+	t             *testing.T
+	expectedValue string
+}
+
+// Returns a gomock.Matcher that matches a CallOption that sets the routing key
+func NewRoutingKeyMatcher(t *testing.T, value string) gomock.Matcher {
+	return &routingKeyMatcher{
+		t:             t,
+		expectedValue: value,
+	}
+}
+
+func (r routingKeyMatcher) Matches(x interface{}) bool {
+	option, ok := x.(yarpc.CallOption)
+	if !ok {
+		return false
+	}
+
+	req := writeOptionToRequest(r.t, option)
+
+	return r.expectedValue == req.RoutingKey
+}
+
+func (r routingKeyMatcher) String() string {
+	return fmt.Sprintf("routing key: %s", r.expectedValue)
+}
+
+func writeOptionToRequest(t *testing.T, opt yarpc.CallOption) *transport.Request {
+	outboundCall := encoding.NewOutboundCall(encoding.CallOption(opt))
+
+	req := &transport.Request{}
+	_, err := outboundCall.WriteToRequest(context.Background(), req)
+	if err != nil {
+		t.Fatalf("failed to write option request: %v", err)
+	}
+
+	return req
+}

--- a/yarpctest/call_option_matchers_test.go
+++ b/yarpctest/call_option_matchers_test.go
@@ -1,0 +1,68 @@
+package yarpctest
+
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc"
+)
+
+func TestHeaderMatcher(t *testing.T) {
+	opt1 := yarpc.WithHeader("a-header", "a-value")
+	opt2 := yarpc.WithHeader("a-header", "another-value")
+
+	matcher := NewHeaderMatcher(t, "a-header", "a-value")
+
+	require.True(t, matcher.Matches(opt1))
+	require.False(t, matcher.Matches(opt2))
+}
+
+func TestRoutingDelegateMatcher(t *testing.T) {
+	opt1 := yarpc.WithRoutingDelegate("a-routing-delegate")
+	opt2 := yarpc.WithRoutingDelegate("another-routing-delegate")
+
+	matcher := NewRoutingDelegateMatcher(t, "a-routing-delegate")
+
+	require.True(t, matcher.Matches(opt1))
+	require.False(t, matcher.Matches(opt2))
+}
+
+func TestRoutingKeyMatcher(t *testing.T) {
+	opt1 := yarpc.WithRoutingKey("a-routing-key")
+	opt2 := yarpc.WithRoutingKey("another-routing-key")
+
+	matcher := NewRoutingKeyMatcher(t, "a-routing-key")
+
+	require.True(t, matcher.Matches(opt1))
+	require.False(t, matcher.Matches(opt2))
+}
+
+func TestShardKeyMatcher(t *testing.T) {
+	opt1 := yarpc.WithShardKey("a-shard-key")
+	opt2 := yarpc.WithShardKey("another-shard-key")
+
+	matcher := NewShardKeyMatcher(t, "a-shard-key")
+
+	require.True(t, matcher.Matches(opt1))
+	require.False(t, matcher.Matches(opt2))
+}


### PR DESCRIPTION
# Background
`thriftrw-plugin-yarpc` generates gomock compatible mocks for clients. For
example see `./internal/examples/thrift-oneway/sink/hellotest/client.go`.

If the code under test using the client sets a `CallOption` it is not possible
for gomock to validate if a `CallOption` set in the test matches the code under
test. For example if a test does:

```
client.EXPECT().Sink(
  context.Background(),
  expectedRequest,
  yarpc.WithHeader("xpr-routing-destination", "dca11")).Return(responsenil), nil)
```

the mock always fails because `gomock` uses `reflect.DeepEqual` to compare the
expected `CallOption` with the actual `CallOption`. Since `CallOption` contains
a function member `reflect.DeepEqual` always returns false. This can be
validated via:

```
h2 := yarpc.WithHeader("a-header", "a-value")
h3 := yarpc.WithHeader("a-header", "a-value")

// This is always false
reflect.DeepEqual(h2, h3)
```

To fix this issue, in a large go code base, I wrote custom `gomock.Matcher`
implementations. I think it would be best to move those matchers into
`yarpctest` so they can be distributed widely.

# Implementation

In the `yarpctest` module four new public functions are added:
  * `NewHeaderMatcher`
  * `NewRoutingDelegateMatcher`
  * `NewShardKeyMatcher`
  * `NewRoutingKeyMatcher`

Each of these functions returns a `gomock.Matcher` which matches their
respective `CallOption`.

Note: This patch is missing an example where these matchers are used, seeking
feedback on how to do this.

- [ ] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [ ] Entry in CHANGELOG.md
