### PR TITLE
Make encoding.CallOption work with reflect.DeepEqual

### DIFF
--- a/api/encoding/call_options_test.go
+++ b/api/encoding/call_options_test.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package encoding
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Ensuring these are equal via `reflect.DeepEqual` ensures that gomock by default can assert equality on CallOptions
+// in tests without custom matchers
+func TestCallOptionsReflectEquals(t *testing.T) {
+	opt1 := WithHeader("a-header", "a-value")
+	opt2 := WithHeader("a-header", "a-value")
+
+	require.True(t, reflect.DeepEqual(opt1, opt2))
+}
+
+func TestManyCallOptionsReflectEquals(t *testing.T) {
+	opts1 := []CallOption{WithHeader("a-header", "a-value"), WithRoutingKey("a-routing-key")}
+	opts2 := []CallOption{WithHeader("a-header", "a-value"), WithRoutingKey("a-routing-key")}
+	opts3 := []CallOption{WithShardKey("a-shard-key")}
+
+	require.True(t, reflect.DeepEqual(opts1, opts2))
+	require.False(t, reflect.DeepEqual(opts1, opts3))
+	require.False(t, reflect.DeepEqual(opts2, opts3))
+}

--- a/api/encoding/outbound_call.go
+++ b/api/encoding/outbound_call.go
@@ -47,7 +47,7 @@ type OutboundCall struct {
 func NewOutboundCall(options ...CallOption) *OutboundCall {
 	var call OutboundCall
 	for _, opt := range options {
-		opt.apply(&call)
+		opt.opt.apply(&call)
 	}
 	return &call
 }


### PR DESCRIPTION
 # Background
`thriftrw-plugin-yarpc` generates gomock compatible mocks for clients. For
example see `./internal/examples/thrift-oneway/sink/hellotest/client.go`.

If the code under test using the client sets a `CallOption` it is not possible
for gomock to validate if a `CallOption` set in the test matches the code under
test. For example if a test does:

```
client.EXPECT().Sink(
  context.Background(),
  expectedRequest,
  yarpc.WithHeader("xpr-routing-destination", "dca11")).Return(responsenil), nil)
```

the mock always fails because `gomock` uses `reflect.DeepEqual` to compare the
expected `CallOption` with the actual `CallOption`. Since `CallOption` contains
a function member `reflect.DeepEqual` always returns false. This can be
validated via:

```
h2 := yarpc.WithHeader("a-header", "a-value")
h3 := yarpc.WithHeader("a-header", "a-value")

// This is always false
reflect.DeepEqual(h2, h3)
```

 # Implementation
To fix the above issue, I have changed the `CallOption` type to be
`reflect.DeepEqual` friendly by removing the function member and following the
[guidance on functional options][1].

To ensure we never regress, I have also added a simple test that exercises
`reflect.DeepEqual` and CallOption.

[1]: https://github.com/uber-go/guide/blob/e4602992ffbc465ea14bce5501cdbfc361fd8c96/style.md#functional-options

- [ ] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [ ] Entry in CHANGELOG.md
