### PR TITLE
New: added tag version in metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+- observability: all metrics provide a version tag value.
 
 ## [1.51.0] - 2021-02-04
 ### Added
 - observability: Add metric tags blocklist configuration. Allows to stub high cardinality tags emitted
-  in the observability middleware
+  in the observability middleware.
 
 ## [1.50.0] - 2021-01-22
 ### Added

--- a/config.go
+++ b/config.go
@@ -165,6 +165,7 @@ func (c MetricsConfig) scope(name string, logger *zap.Logger) (*metrics.Scope, c
 	meter := parent.Tagged(metrics.Tags{
 		"component":  _packageName,
 		"dispatcher": name,
+		"version":    Version,
 	})
 
 	// When we have c.Metrics, we do not push


### PR DESCRIPTION
With this PR, metrics of yarpc will have automatically a tag version.

This is very useful for filtering metrics based on the version of the library

- [x] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [x] Entry in CHANGELOG.md
