### PR TITLE
gRPC: accept gRPC keepalive parameters for outbound connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Added
+- gRPC: accept keepalive parameters for the outbound gRPC connection.
 
 ## [1.51.0] - 2021-02-04
 ### Added


### PR DESCRIPTION
This allows clients to now enable gRPC Keepalive probes on the outbound connections.

- [X] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [X] Entry in CHANGELOG.md
