### PR TITLE
New: added panic observability for oneway request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - gRPC: accept keepalive parameters for the outbound gRPC connection.
-- observability: panic metrics are reported for Oneway request.
+- observability: panic metrics are reported for inbound oneway request.
 
 ## [1.51.0] - 2021-02-04
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - gRPC: accept keepalive parameters for the outbound gRPC connection.
-- observability: panic metrics is resported for Oneway request.
+- observability: panic metrics are reported for Oneway request.
 
 ## [1.51.0] - 2021-02-04
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - gRPC: accept keepalive parameters for the outbound gRPC connection.
+- observability: panic metrics is resported for Oneway request.
 
 ## [1.51.0] - 2021-02-04
 ### Added

--- a/internal/observability/middleware.go
+++ b/internal/observability/middleware.go
@@ -211,6 +211,7 @@ func (m *Middleware) Call(ctx context.Context, req *transport.Request, out trans
 // HandleOneway implements middleware.OnewayInbound.
 func (m *Middleware) HandleOneway(ctx context.Context, req *transport.Request, h transport.OnewayHandler) error {
 	call := m.graph.begin(ctx, transport.Oneway, _directionInbound, req)
+	defer m.handlePanicForCall(call, transport.Oneway)
 	err := h.HandleOneway(ctx, req)
 	call.End(callResult{err: err, requestSize: req.BodySize})
 	return err


### PR DESCRIPTION
When OneWay request did panic, yarpc did not report any metrics regarding the panic. Now it does like streaming and unary request

- [x] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [x] Entry in CHANGELOG.md
