### PR TITLE
Fixed: mark panic error as server error in observability

### DIFF
--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -136,7 +136,7 @@ func (c call) endWithAppError(
 // EndWithPanic ends the call with additional panic metrics
 func (c call) EndWithPanic(err error) {
 	c.edge.panics.Inc()
-	c.endWithAppError(callResult{err: err, isApplicationError: true})
+	c.endWithAppError(callResult{err: err})
 }
 
 func (c call) endLogs(

--- a/internal/observability/middleware.go
+++ b/internal/observability/middleware.go
@@ -22,7 +22,6 @@ package observability
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"go.uber.org/net/metrics"
@@ -272,8 +271,7 @@ func (m *Middleware) handlePanicForCall(call call, transportType transport.Type)
 	// As this middleware is the one and only one with Metrics responsibility, we just panic again after
 	// checking for panic without actually recovering from it
 	if e := recover(); e != nil {
-		err := fmt.Errorf("panic: %v", e)
-
+		err := yarpcerrors.InternalErrorf("panic %v", e)
 		// Emit only the panic metrics
 		if transportType == transport.Streaming {
 			call.EndStreamWithPanic(err)

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -2175,7 +2175,7 @@ func TestUnaryInboundApplicationPanics(t *testing.T) {
 		return tags
 	}
 	tags := newTags(_directionInbound, "")
-	errTags := newTags(_directionInbound, "application_error")
+	errTags := newTags(_directionInbound, "internal")
 
 	t.Run("Test panic in Handle", func(t *testing.T) {
 		// As our fake handler is mocked to panic in the call, test that the invocation panics
@@ -2200,17 +2200,16 @@ func TestUnaryInboundApplicationPanics(t *testing.T) {
 
 		want := &metrics.RootSnapshot{
 			Counters: []metrics.Snapshot{
-				{Name: "caller_failures", Tags: errTags, Value: 1},
 				{Name: "calls", Tags: tags, Value: 1},
 				{Name: "panics", Tags: tags, Value: 1},
+				{Name: "server_failures", Tags: errTags, Value: 1},
 				{Name: "successes", Tags: tags, Value: 0},
 			},
 			Histograms: []metrics.HistogramSnapshot{
 				{
-					Name:   "caller_failure_latency_ms",
-					Tags:   tags,
-					Unit:   time.Millisecond,
-					Values: []int64{1},
+					Name: "caller_failure_latency_ms",
+					Tags: tags,
+					Unit: time.Millisecond,
 				},
 				{
 					Name:   "request_payload_size_bytes",
@@ -2224,9 +2223,10 @@ func TestUnaryInboundApplicationPanics(t *testing.T) {
 					Unit: time.Millisecond,
 				},
 				{
-					Name: "server_failure_latency_ms",
-					Tags: tags,
-					Unit: time.Millisecond,
+					Name:   "server_failure_latency_ms",
+					Tags:   tags,
+					Unit:   time.Millisecond,
+					Values: []int64{1},
 				},
 				{
 					Name: "success_latency_ms",
@@ -2277,7 +2277,7 @@ func TestOneWayInboundApplicationPanics(t *testing.T) {
 		return tags
 	}
 	tags := newTags(_directionInbound, "")
-	errTags := newTags(_directionInbound, "application_error")
+	errTags := newTags(_directionInbound, "internal")
 
 	t.Run("Test panic in Handle", func(t *testing.T) {
 		// As our fake handler is mocked to panic in the call, test that the invocation panics
@@ -2301,17 +2301,16 @@ func TestOneWayInboundApplicationPanics(t *testing.T) {
 
 		want := &metrics.RootSnapshot{
 			Counters: []metrics.Snapshot{
-				{Name: "caller_failures", Tags: errTags, Value: 1},
 				{Name: "calls", Tags: tags, Value: 1},
 				{Name: "panics", Tags: tags, Value: 1},
+				{Name: "server_failures", Tags: errTags, Value: 1},
 				{Name: "successes", Tags: tags, Value: 0},
 			},
 			Histograms: []metrics.HistogramSnapshot{
 				{
-					Name:   "caller_failure_latency_ms",
-					Tags:   tags,
-					Unit:   time.Millisecond,
-					Values: []int64{1},
+					Name: "caller_failure_latency_ms",
+					Tags: tags,
+					Unit: time.Millisecond,
 				},
 				{
 					Name:   "request_payload_size_bytes",
@@ -2325,9 +2324,10 @@ func TestOneWayInboundApplicationPanics(t *testing.T) {
 					Unit: time.Millisecond,
 				},
 				{
-					Name: "server_failure_latency_ms",
-					Tags: tags,
-					Unit: time.Millisecond,
+					Name:   "server_failure_latency_ms",
+					Tags:   tags,
+					Unit:   time.Millisecond,
+					Values: []int64{1},
 				},
 				{
 					Name: "success_latency_ms",
@@ -2392,7 +2392,7 @@ func TestStreamingInboundApplicationPanics(t *testing.T) {
 		return tags
 	}
 	tags := newTags(_directionInbound, "")
-	errTags := newTags(_directionInbound, "unknown_internal_yarpc")
+	errTags := newTags(_directionInbound, "internal")
 
 	t.Run("Test panic in HandleStream", func(t *testing.T) {
 		// As our fake handler is mocked to panic in the call, test that the invocation panics


### PR DESCRIPTION
Previously, when reporting emitting panics metric, error was marked as application_error.
`application_error` are defined as client error for thrift exception, panics does not enter in this categorization but should be emitted as internal error to the system.

Note: panic for streaming were marked as unknown_internal_yarpc error, I moved it to internal error

- [x] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [ ] Entry in CHANGELOG.md
