### PR TITLE
New: added panic metrics for outbound calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - gRPC: accept keepalive parameters for the outbound gRPC connection.
-- observability: panic metrics are reported for inbound oneway requests and for outbound stream, oneway and unary requests.
+- observability: panic metrics are now also reported for these type of requests:
+  - inbound oneway
+  - outbound stream
+  - outbound oneway
+  - outbound unary
 
 ## [1.51.0] - 2021-02-04
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - gRPC: accept keepalive parameters for the outbound gRPC connection.
-- observability: panic metrics are reported for inbound oneway request.
+- observability: panic metrics are reported for inbound oneway requests and for outbound stream, oneway and unary requests.
 
 ## [1.51.0] - 2021-02-04
 ### Added

--- a/internal/observability/common_test.go
+++ b/internal/observability/common_test.go
@@ -93,12 +93,17 @@ type fakeOutbound struct {
 	applicationErrName    string
 	applicationErrDetails string
 	applicationErrCode    *yarpcerrors.Code
+	applicationPanic      bool
 	stream                fakeStream
 
 	body []byte
 }
 
 func (o fakeOutbound) Call(context.Context, *transport.Request) (*transport.Response, error) {
+	if o.applicationPanic {
+		panic("application panicked")
+	}
+
 	return &transport.Response{
 		ApplicationError: o.applicationErr,
 		ApplicationErrorMeta: &transport.ApplicationErrorMeta{
@@ -111,6 +116,10 @@ func (o fakeOutbound) Call(context.Context, *transport.Request) (*transport.Resp
 }
 
 func (o fakeOutbound) CallOneway(context.Context, *transport.Request) (transport.Ack, error) {
+	if o.applicationPanic {
+		panic("application panicked")
+	}
+
 	if o.err != nil {
 		return nil, o.err
 	}
@@ -118,6 +127,10 @@ func (o fakeOutbound) CallOneway(context.Context, *transport.Request) (transport
 }
 
 func (o fakeOutbound) CallStream(ctx context.Context, request *transport.StreamRequest) (*transport.ClientStream, error) {
+	if o.applicationPanic {
+		panic("application panicked")
+	}
+
 	if o.err != nil {
 		return nil, o.err
 	}

--- a/internal/observability/middleware.go
+++ b/internal/observability/middleware.go
@@ -186,6 +186,8 @@ func (m *Middleware) Handle(ctx context.Context, req *transport.Request, w trans
 // Call implements middleware.UnaryOutbound.
 func (m *Middleware) Call(ctx context.Context, req *transport.Request, out transport.UnaryOutbound) (*transport.Response, error) {
 	call := m.graph.begin(ctx, transport.Unary, _directionOutbound, req)
+	defer m.handlePanicForCall(call, transport.Unary)
+
 	res, err := out.Call(ctx, req)
 
 	isApplicationError := false
@@ -211,6 +213,7 @@ func (m *Middleware) Call(ctx context.Context, req *transport.Request, out trans
 func (m *Middleware) HandleOneway(ctx context.Context, req *transport.Request, h transport.OnewayHandler) error {
 	call := m.graph.begin(ctx, transport.Oneway, _directionInbound, req)
 	defer m.handlePanicForCall(call, transport.Oneway)
+
 	err := h.HandleOneway(ctx, req)
 	call.End(callResult{err: err, requestSize: req.BodySize})
 	return err
@@ -219,6 +222,8 @@ func (m *Middleware) HandleOneway(ctx context.Context, req *transport.Request, h
 // CallOneway implements middleware.OnewayOutbound.
 func (m *Middleware) CallOneway(ctx context.Context, req *transport.Request, out transport.OnewayOutbound) (transport.Ack, error) {
 	call := m.graph.begin(ctx, transport.Oneway, _directionOutbound, req)
+	defer m.handlePanicForCall(call, transport.Oneway)
+
 	ack, err := out.CallOneway(ctx, req)
 	call.End(callResult{err: err, requestSize: req.BodySize})
 	return ack, err
@@ -238,6 +243,13 @@ func (m *Middleware) HandleStream(serverStream *transport.ServerStream, h transp
 // CallStream implements middleware.StreamOutbound.
 func (m *Middleware) CallStream(ctx context.Context, request *transport.StreamRequest, out transport.StreamOutbound) (*transport.ClientStream, error) {
 	call := m.graph.begin(ctx, transport.Streaming, _directionOutbound, request.Meta.ToRequest())
+	defer m.handlePanicForCall(call, transport.Streaming)
+
+	// TODO: metrics for outbound stream and inbound stream are not reported
+	// in the same way. HandleStream increases the metric calls by 1 before passing
+	// the request while CallStream does it after passing the request.
+	// In case of panics in CallStream, the metrics calls will not be increased
+	// while it will in HandleStream.
 	clientStream, err := out.CallStream(ctx, request)
 	call.EndStreamHandshakeWithError(err)
 	if err != nil {
@@ -264,12 +276,12 @@ func ctxErrOverride(ctx context.Context, req *transport.Request) (ctxErr error) 
 
 // handlePanicForCall checks for a panic without actually recovering from it
 // it must be called in defer otherwise recover will act as a no-op
-// The only action this method takes is to emit panic metrics
+// The only action this method takes is to emit panic metrics.
 func (m *Middleware) handlePanicForCall(call call, transportType transport.Type) {
 	// We only want to emit panic metrics without actually recovering from it
 	// Actual recovery from a panic happens at top of the stack in transport's Handler Invoker
 	// As this middleware is the one and only one with Metrics responsibility, we just panic again after
-	// checking for panic without actually recovering from it
+	// checking for panic without actually recovering from it.
 	if e := recover(); e != nil {
 		err := yarpcerrors.InternalErrorf("panic %v", e)
 		// Emit only the panic metrics

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -2249,7 +2249,107 @@ func TestUnaryInboundApplicationPanics(t *testing.T) {
 	})
 }
 
-func TestOneWayInboundApplicationPanics(t *testing.T) {
+func TestUnaryOutboundApplicationPanics(t *testing.T) {
+	var err error
+	root := metrics.New()
+	scope := root.Scope()
+	mw := NewMiddleware(Config{
+		Logger:           zap.NewNop(),
+		Scope:            scope,
+		ContextExtractor: NewNopContextExtractor(),
+	})
+	newTags := func(direction directionName, withErr string) metrics.Tags {
+		tags := metrics.Tags{
+			"dest":             "service",
+			"direction":        string(direction),
+			"encoding":         "raw",
+			"procedure":        "procedure",
+			"routing_delegate": "rd",
+			"routing_key":      "rk",
+			"rpc_type":         transport.Unary.String(),
+			"source":           "caller",
+			"transport":        "unknown",
+		}
+		if withErr != "" {
+			tags["error"] = withErr
+			tags["error_name"] = "__not_set__"
+		}
+		return tags
+	}
+	tags := newTags(_directionOutbound, "")
+	errTags := newTags(_directionOutbound, "internal")
+
+	t.Run("Test panic in Call", func(t *testing.T) {
+		// As our fake handler is mocked to panic in the call, test that the invocation panics
+		assert.Panics(t, func() {
+			_, err = mw.Call(
+				context.Background(),
+				&transport.Request{
+					Caller:          "caller",
+					Service:         "service",
+					Transport:       "",
+					Encoding:        "raw",
+					Procedure:       "procedure",
+					ShardKey:        "sk",
+					RoutingKey:      "rk",
+					RoutingDelegate: "rd",
+				},
+				fakeOutbound{applicationPanic: true},
+			)
+		})
+		require.NoError(t, err)
+
+		want := &metrics.RootSnapshot{
+			Counters: []metrics.Snapshot{
+				{Name: "calls", Tags: tags, Value: 1},
+				{Name: "panics", Tags: tags, Value: 1},
+				{Name: "server_failures", Tags: errTags, Value: 1},
+				{Name: "successes", Tags: tags, Value: 0},
+			},
+			Histograms: []metrics.HistogramSnapshot{
+				{
+					Name: "caller_failure_latency_ms",
+					Tags: tags,
+					Unit: time.Millisecond,
+				},
+				{
+					Name:   "request_payload_size_bytes",
+					Tags:   tags,
+					Unit:   time.Millisecond,
+					Values: []int64{0},
+				},
+				{
+					Name: "response_payload_size_bytes",
+					Tags: tags,
+					Unit: time.Millisecond,
+				},
+				{
+					Name:   "server_failure_latency_ms",
+					Tags:   tags,
+					Unit:   time.Millisecond,
+					Values: []int64{1},
+				},
+				{
+					Name: "success_latency_ms",
+					Tags: tags,
+					Unit: time.Millisecond,
+				},
+				{
+					Name: "timeout_ttl_ms",
+					Tags: tags,
+					Unit: time.Millisecond,
+				},
+				{
+					Name: "ttl_ms",
+					Tags: tags,
+					Unit: time.Millisecond,
+				},
+			},
+		}
+		assert.Equal(t, want, root.Snapshot(), "unexpected metrics snapshot")
+	})
+}
+func TestOnewayInboundApplicationPanics(t *testing.T) {
 	var err error
 	root := metrics.New()
 	scope := root.Scope()
@@ -2279,7 +2379,7 @@ func TestOneWayInboundApplicationPanics(t *testing.T) {
 	tags := newTags(_directionInbound, "")
 	errTags := newTags(_directionInbound, "internal")
 
-	t.Run("Test panic in Handle", func(t *testing.T) {
+	t.Run("Test panic in HandleOneway", func(t *testing.T) {
 		// As our fake handler is mocked to panic in the call, test that the invocation panics
 		assert.Panics(t, func() {
 			err = mw.HandleOneway(
@@ -2295,6 +2395,107 @@ func TestOneWayInboundApplicationPanics(t *testing.T) {
 					RoutingDelegate: "rd",
 				},
 				fakeHandler{applicationPanic: true},
+			)
+		})
+		require.NoError(t, err)
+
+		want := &metrics.RootSnapshot{
+			Counters: []metrics.Snapshot{
+				{Name: "calls", Tags: tags, Value: 1},
+				{Name: "panics", Tags: tags, Value: 1},
+				{Name: "server_failures", Tags: errTags, Value: 1},
+				{Name: "successes", Tags: tags, Value: 0},
+			},
+			Histograms: []metrics.HistogramSnapshot{
+				{
+					Name: "caller_failure_latency_ms",
+					Tags: tags,
+					Unit: time.Millisecond,
+				},
+				{
+					Name:   "request_payload_size_bytes",
+					Tags:   tags,
+					Unit:   time.Millisecond,
+					Values: []int64{0},
+				},
+				{
+					Name: "response_payload_size_bytes",
+					Tags: tags,
+					Unit: time.Millisecond,
+				},
+				{
+					Name:   "server_failure_latency_ms",
+					Tags:   tags,
+					Unit:   time.Millisecond,
+					Values: []int64{1},
+				},
+				{
+					Name: "success_latency_ms",
+					Tags: tags,
+					Unit: time.Millisecond,
+				},
+				{
+					Name: "timeout_ttl_ms",
+					Tags: tags,
+					Unit: time.Millisecond,
+				},
+				{
+					Name: "ttl_ms",
+					Tags: tags,
+					Unit: time.Millisecond,
+				},
+			},
+		}
+		assert.Equal(t, want, root.Snapshot(), "unexpected metrics snapshot")
+	})
+}
+
+func TestOnewayOutboundApplicationPanics(t *testing.T) {
+	var err error
+	root := metrics.New()
+	scope := root.Scope()
+	mw := NewMiddleware(Config{
+		Logger:           zap.NewNop(),
+		Scope:            scope,
+		ContextExtractor: NewNopContextExtractor(),
+	})
+	newTags := func(direction directionName, withErr string) metrics.Tags {
+		tags := metrics.Tags{
+			"dest":             "service",
+			"direction":        string(direction),
+			"encoding":         "raw",
+			"procedure":        "procedure",
+			"routing_delegate": "rd",
+			"routing_key":      "rk",
+			"rpc_type":         transport.Oneway.String(),
+			"source":           "caller",
+			"transport":        "unknown",
+		}
+		if withErr != "" {
+			tags["error"] = withErr
+			tags["error_name"] = "__not_set__"
+		}
+		return tags
+	}
+	tags := newTags(_directionOutbound, "")
+	errTags := newTags(_directionOutbound, "internal")
+
+	t.Run("Test panic in CallOneway", func(t *testing.T) {
+		// As our fake handler is mocked to panic in the call, test that the invocation panics
+		assert.Panics(t, func() {
+			_, err = mw.CallOneway(
+				context.Background(),
+				&transport.Request{
+					Caller:          "caller",
+					Service:         "service",
+					Transport:       "",
+					Encoding:        "raw",
+					Procedure:       "procedure",
+					ShardKey:        "sk",
+					RoutingKey:      "rk",
+					RoutingDelegate: "rd",
+				},
+				fakeOutbound{applicationPanic: true},
 			)
 		})
 		require.NoError(t, err)
@@ -2436,7 +2637,97 @@ func TestStreamingInboundApplicationPanics(t *testing.T) {
 		}
 		assert.Equal(t, want, root.Snapshot(), "unexpected metrics snapshot")
 	})
+}
 
+func TestStreamingOutboundApplicationPanics(t *testing.T) {
+	root := metrics.New()
+	scope := root.Scope()
+	mw := NewMiddleware(Config{
+		Logger:           zap.NewNop(),
+		Scope:            scope,
+		ContextExtractor: NewNopContextExtractor(),
+	})
+	stream, err := transport.NewServerStream(&fakeStream{
+		request: &transport.StreamRequest{
+			Meta: &transport.RequestMeta{
+				Caller:          "caller",
+				Service:         "service",
+				Transport:       "",
+				Encoding:        "raw",
+				Procedure:       "procedure",
+				ShardKey:        "sk",
+				RoutingKey:      "rk",
+				RoutingDelegate: "rd",
+			},
+		},
+	})
+	require.NoError(t, err)
+	newTags := func(direction directionName, withErr string) metrics.Tags {
+		tags := metrics.Tags{
+			"dest":             "service",
+			"direction":        string(direction),
+			"encoding":         "raw",
+			"procedure":        "procedure",
+			"routing_delegate": "rd",
+			"routing_key":      "rk",
+			"rpc_type":         transport.Streaming.String(),
+			"source":           "caller",
+			"transport":        "unknown",
+		}
+		if withErr != "" {
+			tags["error"] = withErr
+			tags["error_name"] = "__not_set__"
+		}
+		return tags
+	}
+	tags := newTags(_directionOutbound, "")
+	errTags := newTags(_directionOutbound, "internal")
+
+	t.Run("Test panic in CallStream", func(t *testing.T) {
+		// As our fake handler is mocked to panic in the call, test that the invocation panics
+		assert.Panics(t, func() {
+			_, err = mw.CallStream(
+				context.Background(),
+				stream.Request(),
+				fakeOutbound{applicationPanic: true})
+		})
+		require.NoError(t, err)
+
+		want := &metrics.RootSnapshot{
+			Counters: []metrics.Snapshot{
+				{Name: "calls", Tags: tags, Value: 0},
+				{Name: "panics", Tags: tags, Value: 1},
+				{Name: "server_failures", Tags: errTags, Value: 1},
+				{Name: "stream_receive_successes", Tags: tags, Value: 0},
+				{Name: "stream_receives", Tags: tags, Value: 0},
+				{Name: "stream_send_successes", Tags: tags, Value: 0},
+				{Name: "stream_sends", Tags: tags, Value: 0},
+				{Name: "successes", Tags: tags, Value: 0},
+			},
+			Gauges: []metrics.Snapshot{
+				{Name: "streams_active", Tags: tags, Value: -1},
+			},
+			Histograms: []metrics.HistogramSnapshot{
+				{
+					Name:   "stream_duration_ms",
+					Tags:   tags,
+					Unit:   time.Millisecond,
+					Values: []int64{1},
+				},
+				{
+					Name: "stream_request_payload_size_bytes",
+					Tags: tags,
+					Unit: time.Millisecond,
+				},
+				{
+					Name: "stream_response_payload_size_bytes",
+					Tags: tags,
+					Unit: time.Millisecond,
+				},
+			},
+		}
+		assert.Equal(t, want, root.Snapshot(), "unexpected metrics snapshot")
+	})
 }
 
 func TestStreamingMetrics(t *testing.T) {

--- a/internal/observability/stream.go
+++ b/internal/observability/stream.go
@@ -84,6 +84,7 @@ func (c call) WrapServerStream(stream *transport.ServerStream) *transport.Server
 }
 
 func (s *streamWrapper) SendMessage(ctx context.Context, msg *transport.StreamMessage) error {
+	// TODO: handle panic for metrics
 	if s.call.direction == _directionInbound && msg != nil {
 		s.edge.streamResponsePayloadSizes.IncBucket(int64(msg.BodySize))
 	}
@@ -106,6 +107,7 @@ func (s *streamWrapper) SendMessage(ctx context.Context, msg *transport.StreamMe
 }
 
 func (s *streamWrapper) ReceiveMessage(ctx context.Context) (*transport.StreamMessage, error) {
+	// TODO: handle panic for metrics
 	msg, err := s.StreamCloser.ReceiveMessage(ctx)
 	if err == nil && msg != nil && s.call.direction == _directionInbound {
 		s.edge.streamRequestPayloadSizes.IncBucket(int64(msg.BodySize))


### PR DESCRIPTION
Previously, panics metrics were only emitted for inbound request and not for outbound request.

Most panics will happen (and will be reported) in inbound middleware since this the entry point of a request (while outbound is the end of the flow). Panics should also be reported in the outbound middleware, this can happen for the following scenarios:
- Panic in YARPC
- Panic in other outbound middleware 

It is important to emit this metrics for better observability of the system. This PR adds the same logic of panic observability (as the one in the inbound middleware) for all outbound middleware; unary, oneway and streaming.

- [X] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [X] Entry in CHANGELOG.md
