### PR TITLE
Fixed: usage of write lock for choose method of strategies randpeer and tworandomchoices

### DIFF
--- a/peer/randpeer/list_test.go
+++ b/peer/randpeer/list_test.go
@@ -629,15 +629,18 @@ func TestParallelChoose(t *testing.T) {
 		impl.Add(nil, nil)
 	}
 
-	var wg sync.WaitGroup
-	for i := 0; i < 100; i++ {
-		wg.Add(1)
-		go func() {
-			for j := 0; j < 5000; j++ {
-				impl.Choose(nil)
-			}
-			wg.Done()
-		}()
-	}
-	wg.Wait()
+	assert.NotPanics(t, func() {
+		var wg sync.WaitGroup
+		for i := 0; i < 100; i++ {
+			wg.Add(1)
+			go func() {
+				for j := 0; j < 5000; j++ {
+					impl.Choose(nil)
+				}
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+	})
+
 }

--- a/peer/randpeer/list_test.go
+++ b/peer/randpeer/list_test.go
@@ -26,6 +26,7 @@ import (
 	"net"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -619,4 +620,24 @@ func TestFailFastConfig(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "has 1 peer but it is not responsive")
+}
+
+func TestParallelChoose(t *testing.T) {
+	impl := NewImplementation()
+
+	for i := 0; i < 5000; i++ {
+		impl.Add(nil, nil)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			for j := 0; j < 5000; j++ {
+				impl.Choose(nil)
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
 }

--- a/peer/randpeer/random.go
+++ b/peer/randpeer/random.go
@@ -87,8 +87,8 @@ func (r *randomList) Remove(peer peer.StatusPeer, _ peer.Identifier, ps abstract
 }
 
 func (r *randomList) Choose(_ *transport.Request) peer.StatusPeer {
-	r.m.RLock()
-	defer r.m.RUnlock()
+	r.m.Lock()
+	defer r.m.Unlock()
 
 	if len(r.subscribers) == 0 {
 		return nil

--- a/peer/randpeer/random.go
+++ b/peer/randpeer/random.go
@@ -87,6 +87,8 @@ func (r *randomList) Remove(peer peer.StatusPeer, _ peer.Identifier, ps abstract
 }
 
 func (r *randomList) Choose(_ *transport.Request) peer.StatusPeer {
+	// Usage of a wite lock because r.random.Intn is not thread safe
+	// see: https://golang.org/pkg/math/rand/
 	r.m.Lock()
 	defer r.m.Unlock()
 

--- a/peer/tworandomchoices/list_test.go
+++ b/peer/tworandomchoices/list_test.go
@@ -602,17 +602,19 @@ func TestParallelChoose(t *testing.T) {
 		impl.Add(nil, nil)
 	}
 
-	var wg sync.WaitGroup
-	for i := 0; i < 100; i++ {
-		wg.Add(1)
-		go func() {
-			for j := 0; j < 5000; j++ {
-				impl.Choose(nil)
-			}
-			wg.Done()
-		}()
-	}
-	wg.Wait()
+	assert.NotPanics(t, func() {
+		var wg sync.WaitGroup
+		for i := 0; i < 100; i++ {
+			wg.Add(1)
+			go func() {
+				for j := 0; j < 5000; j++ {
+					impl.Choose(nil)
+				}
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+	})
 }
 
 func TestFailFastConfig(t *testing.T) {

--- a/peer/tworandomchoices/list_test.go
+++ b/peer/tworandomchoices/list_test.go
@@ -26,6 +26,7 @@ import (
 	"net"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -578,6 +579,40 @@ func TestTwoRandomChoicesPeer(t *testing.T) {
 			assert.Equal(t, tt.expectedRunning, pl.IsRunning(), "Peer list should match expected final running state")
 		})
 	}
+}
+
+func BenchmarkParallelChoose(b *testing.B) {
+	impl := NewImplementation()
+
+	for i := 0; i < 5000; i++ {
+		impl.Add(nil, nil)
+	}
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			impl.Choose(nil)
+		}
+	})
+}
+
+func TestParallelChoose(t *testing.T) {
+	impl := NewImplementation()
+
+	for i := 0; i < 5000; i++ {
+		impl.Add(nil, nil)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			for j := 0; j < 5000; j++ {
+				impl.Choose(nil)
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
 }
 
 func TestFailFastConfig(t *testing.T) {

--- a/peer/tworandomchoices/tworandomchoices.go
+++ b/peer/tworandomchoices/tworandomchoices.go
@@ -89,6 +89,8 @@ func (l *twoRandomChoicesList) Remove(peer peer.StatusPeer, _ peer.Identifier, p
 }
 
 func (l *twoRandomChoicesList) Choose(_ *transport.Request) peer.StatusPeer {
+	// Usage of a wite lock because r.random.Intn is not thread safe
+	// see: https://golang.org/pkg/math/rand/
 	l.m.Lock()
 	defer l.m.Unlock()
 

--- a/peer/tworandomchoices/tworandomchoices.go
+++ b/peer/tworandomchoices/tworandomchoices.go
@@ -89,8 +89,8 @@ func (l *twoRandomChoicesList) Remove(peer peer.StatusPeer, _ peer.Identifier, p
 }
 
 func (l *twoRandomChoicesList) Choose(_ *transport.Request) peer.StatusPeer {
-	l.m.RLock()
-	defer l.m.RUnlock()
+	l.m.Lock()
+	defer l.m.Unlock()
 
 	numSubs := len(l.subscribers)
 	if numSubs == 0 {


### PR DESCRIPTION
Based on the golang documentation, when rand is used with a NewSource it is not thread safe anymore:

```
The default Source is safe for concurrent use by multiple goroutines, but Sources created by NewSource are not.
```

In this PR, instead of using read lock for the method chooses of randpeer and tworandomchoices, we know use the a write lock.

Added some unittests to catch this issue if this lock is being changed to a read lock again.
Tested locally without the lock resulted into panics:
```
Running tool: /usr/local/bin/go test -timeout 30s -coverprofile=/var/folders/c7/x79rp2793gscfbw0y1xfw6km0000gn/T/vscode-goPNEWvX/go-code-cover go.uber.org/yarpc/peer/randpeer

panic: runtime error: index out of range [-1]

goroutine 336 [running]:
math/rand.(*rngSource).Uint64(...)
	/usr/local/Cellar/go/1.15/libexec/src/math/rand/rng.go:249
math/rand.(*rngSource).Int63(0xc00016ca00, 0x5433db0a222ab108)
	/usr/local/Cellar/go/1.15/libexec/src/math/rand/rng.go:234 +0x98
math/rand.(*Rand).Int63(...)
	/usr/local/Cellar/go/1.15/libexec/src/math/rand/rand.go:85
math/rand.(*Rand).Int31(...)
	/usr/local/Cellar/go/1.15/libexec/src/math/rand/rand.go:99
math/rand.(*Rand).Int31n(0xc00048e7b0, 0x12631bad00001388, 0x2e30d0f5000011ca)
	/usr/local/Cellar/go/1.15/libexec/src/math/rand/rand.go:134 +0x5f
math/rand.(*Rand).Intn(0xc00048e7b0, 0x1388, 0x11ca)
	/usr/local/Cellar/go/1.15/libexec/src/math/rand/rand.go:172 +0x45
go.uber.org/yarpc/peer/randpeer.(*randomList).Choose(0xc000486700, 0x0, 0x0, 0x0)
	/Users/awilhelm@uber.com/go/src/go.uber.org/yarpc-go/peer/randpeer/random.go:96 +0x9a
go.uber.org/yarpc/peer/randpeer.TestParallelChoose.func1(0x17da700, 0xc000486700, 0xc0004168e0)
	/Users/awilhelm@uber.com/go/src/go.uber.org/yarpc-go/peer/randpeer/list_test.go:637 +0x44
created by go.uber.org/yarpc/peer/randpeer.TestParallelChoose
	/Users/awilhelm@uber.com/go/src/go.uber.org/yarpc-go/peer/randpeer/list_test.go:635 +0xf4
FAIL	go.uber.org/yarpc/peer/randpeer	0.768s
FAIL
```

- [x] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [ ] Entry in CHANGELOG.md
