### PR TITLE
Move HTTP request header population logic into createRequest

### DIFF
--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -252,7 +252,6 @@ func (o *Outbound) call(ctx context.Context, treq *transport.Request) (*transpor
 	if err != nil {
 		return nil, err
 	}
-	hreq.Header = applicationHeaders.ToHTTPHeaders(treq.Headers, nil)
 	ctx, hreq, span, err := o.withOpentracingSpan(ctx, hreq, treq, start)
 	if err != nil {
 		return nil, err
@@ -339,7 +338,12 @@ func (o *Outbound) getPeerForRequest(ctx context.Context, treq *transport.Reques
 
 func (o *Outbound) createRequest(treq *transport.Request) (*http.Request, error) {
 	newURL := *o.urlTemplate
-	return http.NewRequest("POST", newURL.String(), treq.Body)
+	if hreq, err := http.NewRequest("POST", newURL.String(), treq.Body); err != nil {
+		return nil, err
+	} else {
+		hreq.Header = applicationHeaders.ToHTTPHeaders(treq.Headers, nil)
+		return hreq, err
+	}
 }
 
 func (o *Outbound) withOpentracingSpan(ctx context.Context, req *http.Request, treq *transport.Request, start time.Time) (context.Context, *http.Request, opentracing.Span, error) {

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -338,12 +338,12 @@ func (o *Outbound) getPeerForRequest(ctx context.Context, treq *transport.Reques
 
 func (o *Outbound) createRequest(treq *transport.Request) (*http.Request, error) {
 	newURL := *o.urlTemplate
-	if hreq, err := http.NewRequest("POST", newURL.String(), treq.Body); err != nil {
+	hreq, err := http.NewRequest("POST", newURL.String(), treq.Body)
+	if err != nil {
 		return nil, err
-	} else {
-		hreq.Header = applicationHeaders.ToHTTPHeaders(treq.Headers, nil)
-		return hreq, err
 	}
+	hreq.Header = applicationHeaders.ToHTTPHeaders(treq.Headers, nil)
+	return hreq, err
 }
 
 func (o *Outbound) withOpentracingSpan(ctx context.Context, req *http.Request, treq *transport.Request, start time.Time) (context.Context, *http.Request, opentracing.Span, error) {

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -85,7 +85,7 @@ func TestCreateRequest(t *testing.T) {
 			wantError:   true,
 		},
 		{
-			desc: "wrong uri",
+			desc: "successful creation",
 			treq: &transport.Request{
 				Headers: transport.HeadersFromMap(appHeader),
 			},

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -27,6 +27,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strconv"
 	"sync"
 	"testing"
@@ -64,6 +65,50 @@ func TestNewSingleOutboundPanic(t *testing.T) {
 		NewTransport().NewSingleOutbound("127.0.0.1:")
 	},
 		"expected to panic")
+}
+
+func TestCreateRequest(t *testing.T) {
+	appHeader := map[string]string{
+		"app-key1": "app-val1",
+		"app-key2": "app-val2",
+	}
+	tests := []struct {
+		desc        string
+		urlTemplate *url.URL
+		treq        *transport.Request
+		wantError   bool
+	}{
+		{
+			desc:        "wrong uri",
+			urlTemplate: &url.URL{Scheme: "%"}, // invalid
+			treq:        &transport.Request{},
+			wantError:   true,
+		},
+		{
+			desc: "wrong uri",
+			treq: &transport.Request{
+				Headers: transport.HeadersFromMap(appHeader),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			o := &Outbound{urlTemplate: defaultURLTemplate}
+			if tt.urlTemplate != nil {
+				o.urlTemplate = tt.urlTemplate
+			}
+			hreq, err := o.createRequest(tt.treq)
+			if tt.wantError {
+				assert.Error(t, err)
+				return
+			}
+			assert.Len(t, hreq.Header, len(appHeader), "wrong number of header")
+			for k, v := range appHeader {
+				assert.Equal(t, v, hreq.Header.Get(ApplicationHeaderPrefix+k), "header value mismatch")
+			}
+		})
+	}
 }
 
 func TestCallSuccess(t *testing.T) {


### PR DESCRIPTION
- [x] Description and context for reviewers: one partner, one stranger
Move header population logic into createRequest so it is easy to handle
HTTP1.X versus HTTP2.0 request conversion.

`createRequest` has a single reference in the whole codebase so this is
safe to do.