### PR TITLE
add helper function to create HTTP/1 CONNECT requests from HTTP/2

### DIFF
--- a/transport/http/http2.go
+++ b/transport/http/http2.go
@@ -1,0 +1,55 @@
+package http
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"go.uber.org/yarpc/api/transport"
+)
+
+const (
+	http2SchemePseudoHeader    = ":scheme"
+	http2MethodPseudoHeader    = ":method"
+	http2AuthorityPseudoHeader = ":authority"
+	http2PathPseudoHeader      = ":path"
+)
+
+var (
+	errMalformedHTTP2ConnectRequestExtraScheme    = malformedHTTP2ConnectRequestError(http2SchemePseudoHeader, false)
+	errMalformedHTTP2ConnectRequestExtraPath      = malformedHTTP2ConnectRequestError(http2PathPseudoHeader, false)
+	errMalformedHTTP2ConnectRequestExtraAuthority = malformedHTTP2ConnectRequestError(http2AuthorityPseudoHeader, true)
+)
+
+func malformedHTTP2ConnectRequestError(h string, shouldContain bool) error {
+	base := "HTTP2 CONNECT request "
+	if shouldContain {
+		base += fmt.Sprintf("must contain pseudo header %q", h)
+	} else {
+		base += fmt.Sprintf("must not contain pseudo header %q", h)
+	}
+	return errors.New(base)
+}
+
+// take a HTTP/2 request with CONNECT method, mostly with grpc implementation request
+// and convert to a HTTP/1.X equivalent request.
+// All comments below are quotes from RFC7540:
+// https://tools.ietf.org/html/rfc7540#section-8.3
+func fromHTTP2ConnectRequest(treq *transport.Request) (*http.Request, error) {
+	// The ":scheme" and ":path" pseudo-header fields MUST be omitted.
+	if _, ok := treq.Headers.Get(http2SchemePseudoHeader); ok {
+		return nil, errMalformedHTTP2ConnectRequestExtraScheme
+	}
+	if _, ok := treq.Headers.Get(http2PathPseudoHeader); ok {
+		return nil, errMalformedHTTP2ConnectRequestExtraPath
+	}
+
+	// The ":authority" pseudo-header field contains the host and port to
+	// connect to
+	if a, ok := treq.Headers.Get(http2AuthorityPseudoHeader); ok {
+		url := &url.URL{Host: a}
+		return http.NewRequest(http.MethodConnect, url.String(), nil)
+	}
+	return nil, errMalformedHTTP2ConnectRequestExtraAuthority
+}

--- a/transport/http/http2.go
+++ b/transport/http/http2.go
@@ -37,9 +37,9 @@ const (
 )
 
 var (
-	errMalformedHTTP2ConnectRequestExtraScheme    = malformedHTTP2ConnectRequestError(http2SchemePseudoHeader, false)
-	errMalformedHTTP2ConnectRequestExtraPath      = malformedHTTP2ConnectRequestError(http2PathPseudoHeader, false)
-	errMalformedHTTP2ConnectRequestExtraAuthority = malformedHTTP2ConnectRequestError(http2AuthorityPseudoHeader, true)
+	errMalformedHTTP2ConnectRequestExtraScheme      = malformedHTTP2ConnectRequestError(http2SchemePseudoHeader, false)
+	errMalformedHTTP2ConnectRequestExtraPath        = malformedHTTP2ConnectRequestError(http2PathPseudoHeader, false)
+	errMalformedHTTP2ConnectRequestMissingAuthority = malformedHTTP2ConnectRequestError(http2AuthorityPseudoHeader, true)
 )
 
 func malformedHTTP2ConnectRequestError(h string, shouldContain bool) error {
@@ -71,5 +71,5 @@ func fromHTTP2ConnectRequest(treq *transport.Request) (*http.Request, error) {
 		url := &url.URL{Host: a}
 		return http.NewRequest(http.MethodConnect, url.String(), nil)
 	}
-	return nil, errMalformedHTTP2ConnectRequestExtraAuthority
+	return nil, errMalformedHTTP2ConnectRequestMissingAuthority
 }

--- a/transport/http/http2.go
+++ b/transport/http/http2.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package http
 
 import (

--- a/transport/http/http2_test.go
+++ b/transport/http/http2_test.go
@@ -54,7 +54,7 @@ func TestFromHTTP2ConnectRequest(t *testing.T) {
 			wantError: `HTTP2 CONNECT request must contain pseudo header ":authority"`,
 		},
 		{
-			desc: "malformed CONNECT request: :authority header missing",
+			desc: "wellformed CONNECT request",
 			treq: &transport.Request{
 				Headers: transport.HeadersFromMap(map[string]string{":authority": "127.0.0.1:1234"}),
 			},

--- a/transport/http/http2_test.go
+++ b/transport/http/http2_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc/api/transport"
 )
 
@@ -68,6 +69,7 @@ func TestFromHTTP2ConnectRequest(t *testing.T) {
 				assert.EqualError(t, err, tt.wantError)
 				return
 			}
+			require.NoError(t, err)
 			assert.Equal(t, http.MethodConnect, req.Method)
 		})
 	}

--- a/transport/http/http2_test.go
+++ b/transport/http/http2_test.go
@@ -1,0 +1,54 @@
+package http
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/yarpc/api/transport"
+)
+
+func TestFromHTTP2ConnectRequest(t *testing.T) {
+	tests := []struct {
+		desc      string
+		treq      *transport.Request
+		wantError error
+	}{
+		{
+			desc: "malformed CONNECT request: :scheme header set",
+			treq: &transport.Request{
+				Headers: transport.HeadersFromMap(map[string]string{":scheme": "http2"}),
+			},
+			wantError: errMalformedHTTP2ConnectRequestExtraScheme,
+		},
+		{
+			desc: "malformed CONNECT request: :path header set",
+			treq: &transport.Request{
+				Headers: transport.HeadersFromMap(map[string]string{":path": "foo/path"}),
+			},
+			wantError: errMalformedHTTP2ConnectRequestExtraPath,
+		},
+		{
+			desc:      "malformed CONNECT request: :authority header missing",
+			treq:      &transport.Request{},
+			wantError: errMalformedHTTP2ConnectRequestExtraAuthority,
+		},
+		{
+			desc: "malformed CONNECT request: :authority header missing",
+			treq: &transport.Request{
+				Headers: transport.HeadersFromMap(map[string]string{":authority": "127.0.0.1:1234"}),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			req, err := fromHTTP2ConnectRequest(tt.treq)
+			if tt.wantError != nil {
+				assert.EqualError(t, err, tt.wantError.Error())
+				return
+			}
+			assert.Equal(t, http.MethodConnect, req.Method)
+		})
+	}
+}

--- a/transport/http/http2_test.go
+++ b/transport/http/http2_test.go
@@ -32,26 +32,26 @@ func TestFromHTTP2ConnectRequest(t *testing.T) {
 	tests := []struct {
 		desc      string
 		treq      *transport.Request
-		wantError error
+		wantError string
 	}{
 		{
 			desc: "malformed CONNECT request: :scheme header set",
 			treq: &transport.Request{
 				Headers: transport.HeadersFromMap(map[string]string{":scheme": "http2"}),
 			},
-			wantError: errMalformedHTTP2ConnectRequestExtraScheme,
+			wantError: `HTTP2 CONNECT request must not contain pseudo header ":scheme"`,
 		},
 		{
 			desc: "malformed CONNECT request: :path header set",
 			treq: &transport.Request{
 				Headers: transport.HeadersFromMap(map[string]string{":path": "foo/path"}),
 			},
-			wantError: errMalformedHTTP2ConnectRequestExtraPath,
+			wantError: `HTTP2 CONNECT request must not contain pseudo header ":path"`,
 		},
 		{
 			desc:      "malformed CONNECT request: :authority header missing",
 			treq:      &transport.Request{},
-			wantError: errMalformedHTTP2ConnectRequestExtraAuthority,
+			wantError: `HTTP2 CONNECT request must contain pseudo header ":authority"`,
 		},
 		{
 			desc: "malformed CONNECT request: :authority header missing",
@@ -64,8 +64,8 @@ func TestFromHTTP2ConnectRequest(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			req, err := fromHTTP2ConnectRequest(tt.treq)
-			if tt.wantError != nil {
-				assert.EqualError(t, err, tt.wantError.Error())
+			if tt.wantError != "" {
+				assert.EqualError(t, err, tt.wantError)
 				return
 			}
 			assert.Equal(t, http.MethodConnect, req.Method)

--- a/transport/http/http2_test.go
+++ b/transport/http/http2_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package http
 
 import (


### PR DESCRIPTION
- [x] Description and context for reviewers: one partner, one stranger
Part of change to support proxying grpc inbound request to an http
outbound. #2026
This diff adds help function that will be used later to
convert a HTTP/2 CONNECT request to HTTP/1. 
From the RFC https://tools.ietf.org/html/rfc7540#section-8.3
CONNECT method has to be taken care of specially.
This fits in the big picture as:
```
func createRequest(treq *transport.Request)(*http.Request, error){
    if http2Request{
        if connect request {
            return fromHTTP2ConnectRequest(treq)
        }
        // non-connect request coming in the next PR
    }
}
```
- [ ] Docs (package doc)
- [ ] Entry in CHANGELOG.md