### PR TITLE
Allow go_package to have semicolon separated name

### DIFF
--- a/internal/protoplugin/registry.go
+++ b/internal/protoplugin/registry.go
@@ -304,7 +304,11 @@ func defaultGoPackageName(f *descriptor.FileDescriptorProto) string {
 func packageIdentityName(f *descriptor.FileDescriptorProto) string {
 	if f.Options != nil && f.Options.GoPackage != nil {
 		gopkg := f.Options.GetGoPackage()
-		idx := strings.LastIndex(gopkg, "/")
+		idx := strings.Index(gopkg, ";")
+		if idx >= 0 {
+			return gopkg[idx+1:]
+		}
+		idx = strings.LastIndex(gopkg, "/")
 		if idx < 0 {
 			return gopkg
 		}

--- a/internal/protoplugin/registry.go
+++ b/internal/protoplugin/registry.go
@@ -304,6 +304,7 @@ func defaultGoPackageName(f *descriptor.FileDescriptorProto) string {
 func packageIdentityName(f *descriptor.FileDescriptorProto) string {
 	if f.Options != nil && f.Options.GoPackage != nil {
 		gopkg := f.Options.GetGoPackage()
+		// if go_package specifies an alias in the form of full/path/package;alias, use alias over package
 		idx := strings.Index(gopkg, ";")
 		if idx >= 0 {
 			return gopkg[idx+1:]

--- a/internal/protoplugin/registry_test.go
+++ b/internal/protoplugin/registry_test.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package protoplugin
+
+import (
+	"testing"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/gogo/protobuf/protoc-gen-gogo/descriptor"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGoPackageName(t *testing.T) {
+	tests := []struct {
+		msg           string
+		protoFileName *string
+		protoPackage  *string
+		goPackage     *string
+		expectedName  string
+	}{
+		{
+			msg:          "short go_package",
+			goPackage:    proto.String("package"),
+			expectedName: "package",
+		},
+		{
+			msg:          "full go_package",
+			goPackage:    proto.String("path/to/package"),
+			expectedName: "package",
+		},
+		{
+			msg:          "full go_package with alias",
+			goPackage:    proto.String("path/to/package;alias"),
+			expectedName: "alias",
+		},
+		{
+			msg:          "proto package",
+			protoPackage: proto.String("proto.package"),
+			expectedName: "proto_package",
+		},
+		{
+			msg:           "proto file name",
+			protoFileName: proto.String("path/filename.proto"),
+			expectedName:  "filename",
+		},
+		{
+			msg:          "prefer go_package over proto package",
+			goPackage:    proto.String("path/to/package1"),
+			protoPackage: proto.String("proto.package2"),
+			expectedName: "package1",
+		},
+		{
+			msg:           "prefer proto package over proto file name",
+			protoPackage:  proto.String("proto.package"),
+			protoFileName: proto.String("filename.proto"),
+			expectedName:  "proto_package",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.msg, func(t *testing.T) {
+			proto := &descriptor.FileDescriptorProto{
+				Name:    test.protoFileName,
+				Package: test.protoPackage,
+				Options: &descriptor.FileOptions{
+					GoPackage: test.goPackage,
+				},
+			}
+			assert.Equal(t, test.expectedName, defaultGoPackageName(proto))
+		})
+	}
+}


### PR DESCRIPTION
Both [goland/protobuf](https://github.com/protocolbuffers/protobuf-go/blob/9d4d1ca5ed7bb0a5d8351a79a7b0a6a2dd8eb69b/compiler/protogen/protogen.go#L582) and [gogo](https://github.com/gogo/protobuf/blob/b03c65ea87cdc3521ede29f62fe3ce239267c1bc/protoc-gen-gogo/generator/generator.go#L334) supports `go_package` option in form:
```
option go_package = "path/to/package;name";
```

This can be useful when user wants to specify generated file output based on `go_package` path and also set different package name.

It is particularly relevant when path involves versioning, like my case:
```
option go_package = "github.com/uber/cadence/.gen/proto/api/v1;apiv1";
```

Currently `protoc-gen-yarpc-go` fails with error:
```
--yarpc-go_out: could not format go code: 5:12: expected declaration, found apiv1
```

- [x] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [ ] Entry in CHANGELOG.md
