### PR TITLE
[discussion point] Allow setting rpc-load response header

### DIFF
--- a/transport/grpc/headers.go
+++ b/transport/grpc/headers.go
@@ -65,6 +65,8 @@ const (
 	// ApplicationErrorHeader is the header key that will contain a non-empty value
 	// if there was an application error.
 	ApplicationErrorHeader = "rpc-application-error"
+	// Load header is used to send load reports back to the caller.
+	LoadHeader = "rpc-load"
 
 	// _applicationErrorNameHeader is the header for the name of the application
 	// error.
@@ -89,6 +91,11 @@ const (
 // transport.CanonicalizeHeaderKey
 
 func isReserved(header string) bool {
+	// Allow setting the load header by the application.
+	// This is to be used by opt-in middlewares.
+	if header == LoadHeader {
+		return false
+	}
 	return strings.HasPrefix(strings.ToLower(header), "rpc-")
 }
 


### PR DESCRIPTION
Hello,

I have a use-case where I'd like the application send back load reports back to the caller.
This is to be used by load balancer to select the most appropriate peer.

My current plan was to simply use a middleware - this covers my use case.

However, I am unable to set the `rpc-load` header which seems preferable -
this data clearly is `rpc` related.

This change proposes to simply allow-list the `rpc-load` header.
All applications would be able to set it indiscriminately. This opens us to a potential mis-use,
but I think this is fine - we're all adults here, and someone would need to do it on purpose.

Some alternatives that came to mind:
- use different header, like `lb-load` (load-balancing-load). It's possible, but kinda breaks
  the niceness of `rpc` headers
- rather than creating allow list per header, create an allow list per middleware - we'd then knew
  who is exactly setting this. This seems tricky though
- create a new `SetRPCLoad` method, possibly similar to #2027.
  This is quite a bit more verbose, and we'd still need to allow anyone to set it (?)
- move the whole rpc-load middleware into yarpc
  I'd rather not do this (yet?) - the middleware is/will change, will require bumping/updating.
  The load balancer work will also be very specific, so not sure if that belongs in yarpc (yet?).

Please share your thoughts :)

- [ ] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [ ] Entry in CHANGELOG.md
