### PR TITLE
Observability changes to emit callerProcedure tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+- observability:
+  - emit the source_procedure tag in metrics, uses req.CallerProcedure to populate this tag
+  - add the sourceProcedure tag in logging, uses req.CallerProcedure to populate this tag
 
 ## [1.52.0] - 2021-02-12
 ### Added

--- a/internal/observability/graph.go
+++ b/internal/observability/graph.go
@@ -101,6 +101,7 @@ func (g *graph) begin(ctx context.Context, rpcType transport.Type, direction dir
 	d.Add(req.Procedure)
 	d.Add(req.RoutingKey)
 	d.Add(req.RoutingDelegate)
+	d.Add(req.CallerProcedure)
 	d.Add(string(direction))
 	d.Add(rpcType.String())
 	e := g.getOrCreateEdge(d.Digest(), req, string(direction), rpcType)
@@ -201,6 +202,7 @@ func newEdge(logger *zap.Logger, meter *metrics.Scope, metricTagsBlocklist []str
 		"encoding":         string(req.Encoding),
 		"routing_key":      req.RoutingKey,
 		"routing_delegate": req.RoutingDelegate,
+		"source_procedure": req.CallerProcedure,
 		"direction":        direction,
 		"rpc_type":         rpcType.String(),
 	}
@@ -473,6 +475,7 @@ func newEdge(logger *zap.Logger, meter *metrics.Scope, metricTagsBlocklist []str
 		zap.String("encoding", string(req.Encoding)),
 		zap.String("routingKey", req.RoutingKey),
 		zap.String("routingDelegate", req.RoutingDelegate),
+		zap.String("sourceProcedure", req.CallerProcedure),
 		zap.String("direction", direction),
 	)
 	return &edge{

--- a/internal/observability/graph_test.go
+++ b/internal/observability/graph_test.go
@@ -44,6 +44,7 @@ func TestEdgeNopFallbacks(t *testing.T) {
 		ShardKey:        "sk",
 		RoutingKey:      "rk",
 		RoutingDelegate: "rd",
+		CallerProcedure: "cp",
 	}
 
 	var tagsBlocklist []string

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -178,6 +178,7 @@ func TestMiddlewareLogging(t *testing.T) {
 		ShardKey:        "shard01",
 		RoutingKey:      "routing-key",
 		RoutingDelegate: "routing-delegate",
+		CallerProcedure: "caller-procedure",
 		Body:            strings.NewReader("body"),
 	}
 
@@ -196,6 +197,7 @@ func TestMiddlewareLogging(t *testing.T) {
 			zap.String("encoding", string(req.Encoding)),
 			zap.String("routingKey", req.RoutingKey),
 			zap.String("routingDelegate", req.RoutingDelegate),
+			zap.String("sourceProcedure", req.CallerProcedure),
 		}
 	}
 
@@ -501,6 +503,7 @@ func TestMiddlewareStreamingLogging(t *testing.T) {
 			ShardKey:        "shard-key",
 			RoutingKey:      "routing-key",
 			RoutingDelegate: "routing-delegate",
+			CallerProcedure: "caller-procedure",
 		},
 	}
 
@@ -514,6 +517,7 @@ func TestMiddlewareStreamingLogging(t *testing.T) {
 			zap.String("encoding", string(req.Meta.Encoding)),
 			zap.String("routingKey", req.Meta.RoutingKey),
 			zap.String("routingDelegate", req.Meta.RoutingDelegate),
+			zap.String("sourceProcedure", req.Meta.CallerProcedure),
 		}
 		return append(fields, extraFields...)
 	}
@@ -981,12 +985,13 @@ func TestMiddlewareStreamingLogging(t *testing.T) {
 func TestMiddlewareMetrics(t *testing.T) {
 	defer stubTime()()
 	req := &transport.Request{
-		Caller:    "caller",
-		Service:   "service",
-		Transport: "",
-		Encoding:  "raw",
-		Procedure: "procedure",
-		Body:      strings.NewReader("body"),
+		Caller:          "caller",
+		Service:         "service",
+		Transport:       "",
+		Encoding:        "raw",
+		Procedure:       "procedure",
+		CallerProcedure: "callerprocedure",
+		Body:            strings.NewReader("body"),
 	}
 
 	yErrAlreadyExists := yarpcerrors.CodeAlreadyExists
@@ -1197,6 +1202,7 @@ func getKey(req *transport.Request, direction string, rpcType transport.Type) (k
 	d.Add(req.Procedure)
 	d.Add(req.RoutingKey)
 	d.Add(req.RoutingDelegate)
+	d.Add(req.CallerProcedure)
 	d.Add(direction)
 	d.Add(rpcType.String())
 	return d.Digest(), d.Free
@@ -1216,6 +1222,7 @@ func TestUnaryInboundApplicationErrors(t *testing.T) {
 		ShardKey:        "shard01",
 		RoutingKey:      "routing-key",
 		RoutingDelegate: "routing-delegate",
+		CallerProcedure: "caller-procedure",
 		Body:            strings.NewReader("body"),
 	}
 
@@ -1227,6 +1234,7 @@ func TestUnaryInboundApplicationErrors(t *testing.T) {
 		zap.String("encoding", string(req.Encoding)),
 		zap.String("routingKey", req.RoutingKey),
 		zap.String("routingDelegate", req.RoutingDelegate),
+		zap.String("sourceProcedure", req.CallerProcedure),
 		zap.String("direction", string(_directionInbound)),
 		zap.String("rpcType", "Unary"),
 		zap.Duration("latency", 0),
@@ -1300,6 +1308,7 @@ func TestMiddlewareSuccessSnapshot(t *testing.T) {
 			ShardKey:        "sk",
 			RoutingKey:      "rk",
 			RoutingDelegate: "rd",
+			CallerProcedure: "cp",
 			Body:            buf,
 			BodySize:        buf.Len(),
 		},
@@ -1316,6 +1325,7 @@ func TestMiddlewareSuccessSnapshot(t *testing.T) {
 		"encoding":         "raw",
 		"procedure":        "procedure",
 		"routing_delegate": "rd",
+		"source_procedure": "cp",
 		"routing_key":      "rk",
 		"rpc_type":         transport.Unary.String(),
 		"source":           "caller",
@@ -1404,6 +1414,7 @@ func TestMiddlewareSuccessSnapshotWithTagsFiltered(t *testing.T) {
 			ShardKey:        "sk",
 			RoutingKey:      "rk",
 			RoutingDelegate: "rd",
+			CallerProcedure: "cp",
 			Body:            buf,
 			BodySize:        buf.Len(),
 		},
@@ -1421,6 +1432,7 @@ func TestMiddlewareSuccessSnapshotWithTagsFiltered(t *testing.T) {
 		"procedure":        "procedure",
 		"routing_key":      "rk",
 		"routing_delegate": "__dropped__",
+		"source_procedure": "cp",
 		"rpc_type":         transport.Unary.String(),
 		"source":           "caller",
 	}
@@ -1505,6 +1517,7 @@ func TestMiddlewareSuccessSnapshotForCall(t *testing.T) {
 			ShardKey:        "sk",
 			RoutingKey:      "rk",
 			RoutingDelegate: "rd",
+			CallerProcedure: "cp",
 			Body:            buf,
 			BodySize:        buf.Len(),
 		},
@@ -1520,6 +1533,7 @@ func TestMiddlewareSuccessSnapshotForCall(t *testing.T) {
 		"encoding":         "raw",
 		"procedure":        "procedure",
 		"routing_delegate": "rd",
+		"source_procedure": "cp",
 		"routing_key":      "rk",
 		"rpc_type":         transport.Unary.String(),
 		"source":           "caller",
@@ -1605,6 +1619,7 @@ func TestMiddlewareSuccessSnapshotForCallOnWay(t *testing.T) {
 			ShardKey:        "sk",
 			RoutingKey:      "rk",
 			RoutingDelegate: "rd",
+			CallerProcedure: "cp",
 			Body:            buf,
 			BodySize:        buf.Len(),
 		},
@@ -1620,6 +1635,7 @@ func TestMiddlewareSuccessSnapshotForCallOnWay(t *testing.T) {
 		"encoding":         "raw",
 		"procedure":        "procedure",
 		"routing_delegate": "rd",
+		"source_procedure": "cp",
 		"routing_key":      "rk",
 		"rpc_type":         transport.Oneway.String(),
 		"source":           "caller",
@@ -1704,6 +1720,7 @@ func TestMiddlewareSuccessSnapshotForOneWay(t *testing.T) {
 			ShardKey:        "sk",
 			RoutingKey:      "rk",
 			RoutingDelegate: "rd",
+			CallerProcedure: "cp",
 			Body:            buf,
 			BodySize:        buf.Len(),
 		},
@@ -1719,6 +1736,7 @@ func TestMiddlewareSuccessSnapshotForOneWay(t *testing.T) {
 		"encoding":         "raw",
 		"procedure":        "procedure",
 		"routing_delegate": "rd",
+		"source_procedure": "cp",
 		"routing_key":      "rk",
 		"rpc_type":         transport.Oneway.String(),
 		"source":           "caller",
@@ -1799,6 +1817,7 @@ func TestMiddlewareFailureSnapshot(t *testing.T) {
 			ShardKey:        "sk",
 			RoutingKey:      "rk",
 			RoutingDelegate: "rd",
+			CallerProcedure: "cp",
 			Body:            buf,
 			BodySize:        buf.Len(),
 		},
@@ -1814,6 +1833,7 @@ func TestMiddlewareFailureSnapshot(t *testing.T) {
 		"encoding":         "raw",
 		"procedure":        "procedure",
 		"routing_delegate": "rd",
+		"source_procedure": "cp",
 		"routing_key":      "rk",
 		"rpc_type":         transport.Unary.String(),
 		"source":           "caller",
@@ -1827,6 +1847,7 @@ func TestMiddlewareFailureSnapshot(t *testing.T) {
 		"error_name":       _notSet,
 		"procedure":        "procedure",
 		"routing_delegate": "rd",
+		"source_procedure": "cp",
 		"routing_key":      "rk",
 		"rpc_type":         transport.Unary.String(),
 		"source":           "caller",
@@ -1913,6 +1934,7 @@ func TestMiddlewareFailureWithDeadlineExceededSnapshot(t *testing.T) {
 			ShardKey:        "sk",
 			RoutingKey:      "rk",
 			RoutingDelegate: "rd",
+			CallerProcedure: "cp",
 			Body:            buf,
 			BodySize:        buf.Len(),
 		},
@@ -1932,6 +1954,7 @@ func TestMiddlewareFailureWithDeadlineExceededSnapshot(t *testing.T) {
 		"encoding":         "raw",
 		"procedure":        "procedure",
 		"routing_delegate": "rd",
+		"source_procedure": "cp",
 		"routing_key":      "rk",
 		"rpc_type":         transport.Unary.String(),
 		"source":           "caller",
@@ -1945,6 +1968,7 @@ func TestMiddlewareFailureWithDeadlineExceededSnapshot(t *testing.T) {
 		"error_name":       _notSet,
 		"procedure":        "procedure",
 		"routing_delegate": "rd",
+		"source_procedure": "cp",
 		"routing_key":      "rk",
 		"rpc_type":         transport.Unary.String(),
 		"source":           "caller",
@@ -2059,6 +2083,7 @@ func TestApplicationErrorSnapShot(t *testing.T) {
 					ShardKey:        "sk",
 					RoutingKey:      "rk",
 					RoutingDelegate: "rd",
+					CallerProcedure: "cp",
 				},
 				&transporttest.FakeResponseWriter{},
 				fakeHandler{
@@ -2077,6 +2102,7 @@ func TestApplicationErrorSnapShot(t *testing.T) {
 				"encoding":         "raw",
 				"procedure":        "procedure",
 				"routing_delegate": "rd",
+				"source_procedure": "cp",
 				"routing_key":      "rk",
 				"rpc_type":         transport.Unary.String(),
 				"source":           "caller",
@@ -2088,6 +2114,7 @@ func TestApplicationErrorSnapShot(t *testing.T) {
 				"encoding":         "raw",
 				"procedure":        "procedure",
 				"routing_delegate": "rd",
+				"source_procedure": "cp",
 				"routing_key":      "rk",
 				"rpc_type":         transport.Unary.String(),
 				"source":           "caller",
@@ -2163,6 +2190,7 @@ func TestUnaryInboundApplicationPanics(t *testing.T) {
 			"encoding":         "raw",
 			"procedure":        "procedure",
 			"routing_delegate": "rd",
+			"source_procedure": "cp",
 			"routing_key":      "rk",
 			"rpc_type":         transport.Unary.String(),
 			"source":           "caller",
@@ -2191,6 +2219,7 @@ func TestUnaryInboundApplicationPanics(t *testing.T) {
 					ShardKey:        "sk",
 					RoutingKey:      "rk",
 					RoutingDelegate: "rd",
+					CallerProcedure: "cp",
 				},
 				&transporttest.FakeResponseWriter{},
 				fakeHandler{applicationPanic: true},
@@ -2265,6 +2294,7 @@ func TestUnaryOutboundApplicationPanics(t *testing.T) {
 			"encoding":         "raw",
 			"procedure":        "procedure",
 			"routing_delegate": "rd",
+			"source_procedure": "cp",
 			"routing_key":      "rk",
 			"rpc_type":         transport.Unary.String(),
 			"source":           "caller",
@@ -2293,6 +2323,7 @@ func TestUnaryOutboundApplicationPanics(t *testing.T) {
 					ShardKey:        "sk",
 					RoutingKey:      "rk",
 					RoutingDelegate: "rd",
+					CallerProcedure: "cp",
 				},
 				fakeOutbound{applicationPanic: true},
 			)
@@ -2365,6 +2396,7 @@ func TestOnewayInboundApplicationPanics(t *testing.T) {
 			"encoding":         "raw",
 			"procedure":        "procedure",
 			"routing_delegate": "rd",
+			"source_procedure": "cp",
 			"routing_key":      "rk",
 			"rpc_type":         transport.Oneway.String(),
 			"source":           "caller",
@@ -2393,6 +2425,7 @@ func TestOnewayInboundApplicationPanics(t *testing.T) {
 					ShardKey:        "sk",
 					RoutingKey:      "rk",
 					RoutingDelegate: "rd",
+					CallerProcedure: "cp",
 				},
 				fakeHandler{applicationPanic: true},
 			)
@@ -2466,6 +2499,7 @@ func TestOnewayOutboundApplicationPanics(t *testing.T) {
 			"encoding":         "raw",
 			"procedure":        "procedure",
 			"routing_delegate": "rd",
+			"source_procedure": "cp",
 			"routing_key":      "rk",
 			"rpc_type":         transport.Oneway.String(),
 			"source":           "caller",
@@ -2494,6 +2528,7 @@ func TestOnewayOutboundApplicationPanics(t *testing.T) {
 					ShardKey:        "sk",
 					RoutingKey:      "rk",
 					RoutingDelegate: "rd",
+					CallerProcedure: "cp",
 				},
 				fakeOutbound{applicationPanic: true},
 			)
@@ -2570,6 +2605,7 @@ func TestStreamingInboundApplicationPanics(t *testing.T) {
 				ShardKey:        "sk",
 				RoutingKey:      "rk",
 				RoutingDelegate: "rd",
+				CallerProcedure: "cp",
 			},
 		},
 	})
@@ -2582,6 +2618,7 @@ func TestStreamingInboundApplicationPanics(t *testing.T) {
 			"procedure":        "procedure",
 			"routing_delegate": "rd",
 			"routing_key":      "rk",
+			"source_procedure": "cp",
 			"rpc_type":         transport.Streaming.String(),
 			"source":           "caller",
 			"transport":        "unknown",
@@ -2658,6 +2695,7 @@ func TestStreamingOutboundApplicationPanics(t *testing.T) {
 				ShardKey:        "sk",
 				RoutingKey:      "rk",
 				RoutingDelegate: "rd",
+				CallerProcedure: "cp",
 			},
 		},
 	})
@@ -2669,6 +2707,7 @@ func TestStreamingOutboundApplicationPanics(t *testing.T) {
 			"encoding":         "raw",
 			"procedure":        "procedure",
 			"routing_delegate": "rd",
+			"source_procedure": "cp",
 			"routing_key":      "rk",
 			"rpc_type":         transport.Streaming.String(),
 			"source":           "caller",
@@ -2743,6 +2782,7 @@ func TestStreamingMetrics(t *testing.T) {
 			ShardKey:        "sk",
 			RoutingKey:      "rk",
 			RoutingDelegate: "rd",
+			CallerProcedure: "cp",
 		},
 	}
 
@@ -2753,6 +2793,7 @@ func TestStreamingMetrics(t *testing.T) {
 			"encoding":         "raw",
 			"procedure":        "procedure",
 			"routing_delegate": "rd",
+			"source_procedure": "cp",
 			"routing_key":      "rk",
 			"rpc_type":         transport.Streaming.String(),
 			"source":           "caller",


### PR DESCRIPTION
### Background: 
For observability, we are able to identify caller services for a service endpoint but we don't have caller procedure -> callee procedure mapping in that. Caller procedure information in other services can only be provided through yarpc header. So we propose to add a header "CallerProcedure" in the yarpc request which would reference the name of the procedure this service making the request. This will improve the observability in services as well as for yarpc.
Changes to add callerProcedure header in to yarpc was covered under [pull request](https://github.com/yarpc/yarpc-go/pull/2027)

### Changes:
This pull request particularly covers adding observability changes in yarpc
   *  to emit the source_procedure tag in metrics, uses req.CallerProcedure to populate this tag
   *  to add the sourceProcedure tag in logging, uses req.CallerProcedure to populate this tag