### PR TITLE
Accept gRPC keepalive parameters from gRPC outbound config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- gRPC: accept keepalive paramters from yaml configurator for the gRPC outbounds.
+- gRPC: accept keepalive parameters for gRPC outbound configuration.
 
 ## [1.52.0] - 2021-02-12
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Added
+- gRPC: accept keepalive paramters from yaml configurator for the gRPC outbounds.
 
 ## [1.52.0] - 2021-02-12
 ### Added

--- a/transport/grpc/config.go
+++ b/transport/grpc/config.go
@@ -212,7 +212,9 @@ func (c OutboundKeepaliveConfig) dialOptions() ([]DialOption, error) {
 
 	var err error
 
-	keepaliveTime := time.Second * 30
+	// gRPC keepalive expects time to be minimum 10s.
+	// read more: https://pkg.go.dev/google.golang.org/grpc/keepalive#ClientParameters
+	keepaliveTime := time.Second * 10
 	if c.Time != "" {
 		keepaliveTime, err = time.ParseDuration(c.Time)
 		if err != nil {
@@ -220,7 +222,9 @@ func (c OutboundKeepaliveConfig) dialOptions() ([]DialOption, error) {
 		}
 	}
 
-	keepaliveTimeout := time.Second * 30
+	// gRPC keepalive defaults timeout to 20s.
+	// read more: https://pkg.go.dev/google.golang.org/grpc/keepalive#ClientParameters
+	keepaliveTimeout := time.Second * 20
 	if c.Timeout != "" {
 		keepaliveTimeout, err = time.ParseDuration(c.Timeout)
 		if err != nil {

--- a/transport/grpc/config.go
+++ b/transport/grpc/config.go
@@ -23,6 +23,7 @@ package grpc
 import (
 	"fmt"
 	"net"
+	"time"
 
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
@@ -30,6 +31,7 @@ import (
 	"go.uber.org/yarpc/peer/hostport"
 	"go.uber.org/yarpc/yarpcconfig"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
 )
 
 // TransportSpec returns a TransportSpec for the gRPC transport.
@@ -151,6 +153,11 @@ func (c InboundTLSConfig) newInboundCredentials() (credentials.TransportCredenti
 //        tls:
 //          enabled: true
 //        compressor: gzip
+//        grpc-keepalive:
+//          enabled: true
+//          time:    10s
+//          timeout: 30s
+//          permit-without-stream: true
 //
 type OutboundConfig struct {
 	yarpcconfig.PeerChooser
@@ -159,13 +166,21 @@ type OutboundConfig struct {
 	Address string            `config:"address,interpolate"`
 	TLS     OutboundTLSConfig `config:"tls"`
 	// Compressor to use by default if the server side supports it
-	Compressor string `config:"compressor"`
+	Compressor string                  `config:"compressor"`
+	Keepalive  OutboundKeepaliveConfig `config:"grpc-keepalive"`
 }
 
-func (c OutboundConfig) dialOptions(kit *yarpcconfig.Kit) []DialOption {
+func (c OutboundConfig) dialOptions(kit *yarpcconfig.Kit) ([]DialOption, error) {
 	opts := c.TLS.dialOptions()
 	opts = append(opts, Compressor(kit.Compressor(c.Compressor)))
-	return opts
+
+	keepaliveOpts, err := c.Keepalive.dialOptions()
+	if err != nil {
+		return nil, err
+	}
+
+	opts = append(opts, keepaliveOpts...)
+	return opts, nil
 }
 
 // OutboundTLSConfig configures TLS for a gRPC outbound.
@@ -180,6 +195,45 @@ func (c OutboundTLSConfig) dialOptions() []DialOption {
 	creds := credentials.NewClientTLSFromCert(nil, "")
 	option := DialerCredentials(creds)
 	return []DialOption{option}
+}
+
+// OutboundKeepaliveConfig configures gRPC keepalive for a gRPC outbound.
+type OutboundKeepaliveConfig struct {
+	Enabled             bool   `config:"enabled"`
+	Time                string `config:"time"`
+	Timeout             string `config:"timeout"`
+	PermitWithoutStream bool   `config:"permit-without-stream"`
+}
+
+func (c OutboundKeepaliveConfig) dialOptions() ([]DialOption, error) {
+	if !c.Enabled {
+		return nil, nil
+	}
+
+	var err error
+
+	keepaliveTime := time.Second * 30
+	if c.Time != "" {
+		keepaliveTime, err = time.ParseDuration(c.Time)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse gRPC keepalive time: %v", err)
+		}
+	}
+
+	keepaliveTimeout := time.Second * 30
+	if c.Timeout != "" {
+		keepaliveTimeout, err = time.ParseDuration(c.Timeout)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse gRPC keepalive timeout: %v", err)
+		}
+	}
+
+	option := KeepaliveParams(keepalive.ClientParameters{
+		Time:                keepaliveTime,
+		Timeout:             keepaliveTimeout,
+		PermitWithoutStream: c.PermitWithoutStream,
+	})
+	return []DialOption{option}, nil
 }
 
 type transportSpec struct {
@@ -263,7 +317,12 @@ func (t *transportSpec) buildOutbound(outboundConfig *OutboundConfig, tr transpo
 		return nil, newTransportCastError(tr)
 	}
 
-	dialer := trans.NewDialer(append(outboundConfig.dialOptions(kit), t.DialOptions...)...)
+	dialOpts, err := outboundConfig.dialOptions(kit)
+	if err != nil {
+		return nil, err
+	}
+
+	dialer := trans.NewDialer(append(dialOpts, t.DialOptions...)...)
 	var chooser peer.Chooser
 	if outboundConfig.Empty() {
 		if outboundConfig.Address == "" {

--- a/transport/grpc/config_test.go
+++ b/transport/grpc/config_test.go
@@ -359,8 +359,8 @@ func TestTransportSpec(t *testing.T) {
 				"myservice": {
 					Address: "localhost:54816",
 					Keepalive: &keepalive.ClientParameters{
-						Timeout: time.Second * 30,
-						Time:    time.Second * 30,
+						Timeout: time.Second * 20,
+						Time:    time.Second * 10,
 					},
 				},
 			},


### PR DESCRIPTION
- [X] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [X] Entry in CHANGELOG.md

This allows clients to pass gRPC keepalive parameters from the YAML configurator, similar to compress/TLS configs. This is useful when keepalive must be enabled from YARPCFx clients who do not prefer using the transportSpec API.

Example: 
```
grpc:
  address: "127.0.0.1:5432"
  grpc-keepalive:
    enabled: true
    time:    10s
    timeout: 30s
    permit-without-stream: true
```
