### PR TITLE
grpc: log headers values upon validation error

### DIFF
--- a/transport/grpc/handler_test.go
+++ b/transport/grpc/handler_test.go
@@ -116,7 +116,7 @@ func TestInvalidStreamMultipleHeaders(t *testing.T) {
 	_, err = h.getBasicTransportRequest(ctx, "service/proc")
 
 	require.Contains(t, err.Error(), "code:invalid-argument")
-	require.Contains(t, err.Error(), "header has more than one value: rpc-caller")
+	require.Contains(t, err.Error(), "header has more than one value: rpc-caller:[caller1 caller2]")
 }
 
 func TestToGRPCError(t *testing.T) {

--- a/transport/grpc/headers.go
+++ b/transport/grpc/headers.go
@@ -213,7 +213,7 @@ func getApplicationHeaders(md metadata.MD) (transport.Headers, error) {
 		case 1:
 			value = values[0]
 		default:
-			return headers, yarpcerrors.InvalidArgumentErrorf("header has more than one value: %s", header)
+			return headers, yarpcerrors.InvalidArgumentErrorf("header has more than one value: %s:%v", header, values)
 		}
 		headers = headers.With(header, value)
 	}

--- a/transport/grpc/headers.go
+++ b/transport/grpc/headers.go
@@ -128,7 +128,7 @@ func metadataToTransportRequest(md metadata.MD) (*transport.Request, error) {
 		case 1:
 			value = values[0]
 		default:
-			return nil, yarpcerrors.InvalidArgumentErrorf("header has more than one value: %s", header)
+			return nil, yarpcerrors.InvalidArgumentErrorf("header has more than one value: %s:%v", header, values)
 		}
 		header = transport.CanonicalizeHeaderKey(header)
 		switch header {


### PR DESCRIPTION
In gRPC, there is validation on reserved headers to ensure there are not more than one values associated with header (e.g. rpc-service, rpc-caller). I experienced this today, and logging the header values would have saved me some debugging time. 



