### PR TITLE
grpc: add a test for getApplicationHeaders

### DIFF
--- a/transport/grpc/headers_test.go
+++ b/transport/grpc/headers_test.go
@@ -234,8 +234,8 @@ func TestGetApplicationHeaders(t *testing.T) {
 		},
 		{
 			msg: "success",
-			meta: map[string][]string{
-				"rpc-service":         []string{"foo"}, // reserved
+			meta: metadata.MD{
+				"rpc-service":         []string{"foo"}, // reserved header
 				"test-header-empty":   []string{},      // no value
 				"test-header-valid-1": []string{"test-value-1"},
 				"test-Header-Valid-2": []string{"test-value-2"},
@@ -247,7 +247,7 @@ func TestGetApplicationHeaders(t *testing.T) {
 		},
 		{
 			msg: "error: multiple values for one header",
-			meta: map[string][]string{
+			meta: metadata.MD{
 				"test-header-valid": []string{"test-value"},
 				"test-header-dup":   []string{"test-value-1", "test-value-2"},
 			},
@@ -263,7 +263,6 @@ func TestGetApplicationHeaders(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.wantErr, "unexpecte error message")
 				return
 			}
-
 			require.NoError(t, err, "failed to extract application headers")
 			assert.Equal(t, tt.wantHeaders, got.Items(), "unexpected headers")
 		})

--- a/transport/grpc/headers_test.go
+++ b/transport/grpc/headers_test.go
@@ -251,7 +251,7 @@ func TestGetApplicationHeaders(t *testing.T) {
 				"test-header-valid": []string{"test-value"},
 				"test-header-dup":   []string{"test-value-1", "test-value-2"},
 			},
-			wantErr: "header has more than one value: test-header-dup",
+			wantErr: "header has more than one value: test-header-dup:[test-value-1 test-value-2]",
 		},
 	}
 

--- a/transport/grpc/headers_test.go
+++ b/transport/grpc/headers_test.go
@@ -214,3 +214,58 @@ func TestMDReadWriterDuplicateKey(t *testing.T) {
 	mdRW.Set(key, "overwritten")
 	assert.Equal(t, []string{"overwritten"}, md[key], "expected overwritten values")
 }
+
+func TestGetApplicationHeaders(t *testing.T) {
+	tests := []struct {
+		msg         string
+		meta        metadata.MD
+		wantHeaders map[string]string
+		wantErr     string
+	}{
+		{
+			msg:         "nil",
+			meta:        nil,
+			wantHeaders: nil,
+		},
+		{
+			msg:         "empty",
+			meta:        metadata.MD{},
+			wantHeaders: nil,
+		},
+		{
+			msg: "success",
+			meta: map[string][]string{
+				"rpc-service":         []string{"foo"}, // reserved
+				"test-header-empty":   []string{},      // no value
+				"test-header-valid-1": []string{"test-value-1"},
+				"test-Header-Valid-2": []string{"test-value-2"},
+			},
+			wantHeaders: map[string]string{
+				"test-header-valid-1": "test-value-1",
+				"test-header-valid-2": "test-value-2",
+			},
+		},
+		{
+			msg: "error: multiple values for one header",
+			meta: map[string][]string{
+				"test-header-valid": []string{"test-value"},
+				"test-header-dup":   []string{"test-value-1", "test-value-2"},
+			},
+			wantErr: "header has more than one value: test-header-dup",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			got, err := getApplicationHeaders(tt.meta)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr, "unexpecte error message")
+				return
+			}
+
+			require.NoError(t, err, "failed to extract application headers")
+			assert.Equal(t, tt.wantHeaders, got.Items(), "unexpected headers")
+		})
+	}
+}


### PR DESCRIPTION
A follow up on https://github.com/yarpc/yarpc-go/pull/2055 where I realized we didn't have proper
test coverage for the response header extraction, this add it