### PR TITLE
Added logging for CallerProcedure header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+- Added logging for CallerProcedure header
 
 ## [1.53.0] - 2021-03-12
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Added logging for CallerProcedure header
+### Added
+- observability: added key `sourceProcedure` in logging. The value of the key will be the `CallerProcedure` value of the request.
 
 ## [1.53.0] - 2021-03-12
 ### Added

--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -146,14 +146,6 @@ func (c call) EndWithPanic(err error) {
 	c.endWithAppError(callResult{err: err})
 }
 
-// addMoreFieldsFromTransportRequest adds the fields which are part of transport request but not part of the edge.
-// Dont forget to increase the capacity of call.fields by 1 if adding field here.
-func (c call) addMoreFieldsFromTransportRequest(fields []zap.Field) []zap.Field {
-	// add callerProcedure in to logs
-	fields = append(fields, zap.String("sourceProcedure", c.req.CallerProcedure))
-	return fields
-}
-
 func (c call) endLogs(
 	elapsed time.Duration,
 	err error,
@@ -231,7 +223,7 @@ func (c call) endLogs(
 	}
 
 	fields := c.fields[:0]
-	fields = c.addMoreFieldsFromTransportRequest(fields)
+	fields = append(fields, zap.String("sourceProcedure", c.req.CallerProcedure))
 	fields = append(fields, zap.String("rpcType", c.rpcType.String()))
 	fields = append(fields, zap.Duration("latency", elapsed))
 	fields = append(fields, zap.Bool("successful", err == nil && !isApplicationError))
@@ -493,7 +485,7 @@ func (c call) logStreamEvent(err error, success bool, succMsg, errMsg string, ex
 	}
 
 	fields := c.fields[:0]
-	fields = c.addMoreFieldsFromTransportRequest(fields)
+	fields = append(fields, zap.String("sourceProcedure", c.req.CallerProcedure))
 	fields = append(fields, zap.String("rpcType", c.rpcType.String()),
 		zap.Bool("successful", success),
 		c.extract(c.ctx),

--- a/internal/observability/graph.go
+++ b/internal/observability/graph.go
@@ -105,6 +105,7 @@ func (g *graph) begin(ctx context.Context, rpcType transport.Type, direction dir
 	d.Add(req.Procedure)
 	d.Add(req.RoutingKey)
 	d.Add(req.RoutingDelegate)
+	d.Add(req.CallerProcedure)
 	d.Add(string(direction))
 	d.Add(rpcType.String())
 	e := g.getOrCreateEdge(d.Digest(), req, string(direction), rpcType)
@@ -477,6 +478,7 @@ func newEdge(logger *zap.Logger, meter *metrics.Scope, metricTagsBlocklist []str
 		zap.String("encoding", string(req.Encoding)),
 		zap.String("routingKey", req.RoutingKey),
 		zap.String("routingDelegate", req.RoutingDelegate),
+		zap.String("sourceProcedure", req.CallerProcedure),
 		zap.String("direction", direction),
 	)
 	return &edge{

--- a/internal/observability/graph.go
+++ b/internal/observability/graph.go
@@ -105,7 +105,6 @@ func (g *graph) begin(ctx context.Context, rpcType transport.Type, direction dir
 	d.Add(req.Procedure)
 	d.Add(req.RoutingKey)
 	d.Add(req.RoutingDelegate)
-	d.Add(req.CallerProcedure)
 	d.Add(string(direction))
 	d.Add(rpcType.String())
 	e := g.getOrCreateEdge(d.Digest(), req, string(direction), rpcType)

--- a/internal/observability/graph.go
+++ b/internal/observability/graph.go
@@ -477,7 +477,6 @@ func newEdge(logger *zap.Logger, meter *metrics.Scope, metricTagsBlocklist []str
 		zap.String("encoding", string(req.Encoding)),
 		zap.String("routingKey", req.RoutingKey),
 		zap.String("routingDelegate", req.RoutingDelegate),
-		zap.String("sourceProcedure", req.CallerProcedure),
 		zap.String("direction", direction),
 	)
 	return &edge{

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -1852,7 +1852,6 @@ func getKey(req *transport.Request, direction string, rpcType transport.Type) (k
 	d.Add(req.Procedure)
 	d.Add(req.RoutingKey)
 	d.Add(req.RoutingDelegate)
-	d.Add(req.CallerProcedure)
 	d.Add(direction)
 	d.Add(rpcType.String())
 	return d.Digest(), d.Free

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -279,6 +279,7 @@ func TestMiddlewareLoggingWithApplicationErrorConfiguration(t *testing.T) {
 		ShardKey:        "shard01",
 		RoutingKey:      "routing-key",
 		RoutingDelegate: "routing-delegate",
+		CallerProcedure: "caller-procedure",
 		Body:            strings.NewReader("body"),
 	}
 
@@ -297,6 +298,7 @@ func TestMiddlewareLoggingWithApplicationErrorConfiguration(t *testing.T) {
 			zap.String("encoding", string(req.Encoding)),
 			zap.String("routingKey", req.RoutingKey),
 			zap.String("routingDelegate", req.RoutingDelegate),
+			zap.String("sourceProcedure", req.CallerProcedure),
 		}
 	}
 
@@ -621,6 +623,7 @@ func TestMiddlewareLoggingWithServerErrorConfiguration(t *testing.T) {
 			zap.String("encoding", string(req.Encoding)),
 			zap.String("routingKey", req.RoutingKey),
 			zap.String("routingDelegate", req.RoutingDelegate),
+			zap.String("sourceProcedure", req.CallerProcedure),
 		}
 	}
 
@@ -961,6 +964,7 @@ func TestMiddlewareStreamingSuccess(t *testing.T) {
 			ShardKey:        "shard-key",
 			RoutingKey:      "routing-key",
 			RoutingDelegate: "routing-delegate",
+			CallerProcedure: "caller-procedure",
 		},
 	}
 
@@ -974,6 +978,7 @@ func TestMiddlewareStreamingSuccess(t *testing.T) {
 			zap.String("encoding", string(req.Meta.Encoding)),
 			zap.String("routingKey", req.Meta.RoutingKey),
 			zap.String("routingDelegate", req.Meta.RoutingDelegate),
+			zap.String("sourceProcedure", req.Meta.CallerProcedure),
 		}
 		return append(fields, extraFields...)
 	}
@@ -1156,6 +1161,7 @@ func TestMiddlewareStreamingLoggingErrorWithFailureConfiguration(t *testing.T) {
 			zap.String("encoding", string(req.Meta.Encoding)),
 			zap.String("routingKey", req.Meta.RoutingKey),
 			zap.String("routingDelegate", req.Meta.RoutingDelegate),
+			zap.String("sourceProcedure", req.Meta.CallerProcedure),
 		}
 		return append(fields, extraFields...)
 	}
@@ -1516,6 +1522,7 @@ func TestMiddlewareStreamingLoggingErrorWithServerClientConfiguration(t *testing
 			ShardKey:        "shard-key",
 			RoutingKey:      "routing-key",
 			RoutingDelegate: "routing-delegate",
+			CallerProcedure: "caller-procedure",
 		},
 	}
 
@@ -1529,6 +1536,7 @@ func TestMiddlewareStreamingLoggingErrorWithServerClientConfiguration(t *testing
 			zap.String("encoding", string(req.Meta.Encoding)),
 			zap.String("routingKey", req.Meta.RoutingKey),
 			zap.String("routingDelegate", req.Meta.RoutingDelegate),
+			zap.String("sourceProcedure", req.Meta.CallerProcedure),
 		}
 		return append(fields, extraFields...)
 	}
@@ -1844,6 +1852,7 @@ func getKey(req *transport.Request, direction string, rpcType transport.Type) (k
 	d.Add(req.Procedure)
 	d.Add(req.RoutingKey)
 	d.Add(req.RoutingDelegate)
+	d.Add(req.CallerProcedure)
 	d.Add(direction)
 	d.Add(rpcType.String())
 	return d.Digest(), d.Free
@@ -1874,6 +1883,7 @@ func TestUnaryInboundApplicationErrors(t *testing.T) {
 		zap.String("encoding", string(req.Encoding)),
 		zap.String("routingKey", req.RoutingKey),
 		zap.String("routingDelegate", req.RoutingDelegate),
+		zap.String("sourceProcedure", req.CallerProcedure),
 		zap.String("direction", string(_directionInbound)),
 		zap.String("rpcType", "Unary"),
 		zap.Duration("latency", 0),


### PR DESCRIPTION
CallerProcedure header was added as part of [pull request-2027](https://github.com/yarpc/yarpc-go/pull/2027).
This pull request is the follow up request and takes care of specifically logging for the CallerProcedure header. 