### PR TITLE
Disabling caller procedure in yarpc outbound middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Removed
-- Disable CallerProcedure header temporarily by stop propoagating this header in the outbound middleware.
+- Disable `rpc-caller-procedure` header temporarily by stop propoagating CallerProcedure in the outbound middleware.
 
 ## [1.53.0] - 2021-03-12
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Removed
+- Disable CallerProcedure header temporarily by stop propoagating this header in the outbound middleware.
 
 ## [1.53.0] - 2021-03-12
 ### Added

--- a/internal/firstoutboundmiddleware/middleware.go
+++ b/internal/firstoutboundmiddleware/middleware.go
@@ -26,7 +26,6 @@ package firstoutboundmiddleware
 import (
 	"context"
 
-	"go.uber.org/yarpc/api/encoding"
 	"go.uber.org/yarpc/api/middleware"
 	"go.uber.org/yarpc/api/transport"
 )
@@ -74,12 +73,6 @@ func update(ctx context.Context, req *transport.Request, out transport.Outbound)
 	if namer, ok := out.(transport.Namer); ok {
 		req.Transport = namer.TransportName()
 	}
-
-	// Update the caller procedure to the current procedure making this request
-	call := encoding.CallFromContext(ctx)
-	if call != nil {
-		req.CallerProcedure = call.Procedure()
-	}
 }
 
 func updateStream(ctx context.Context, req *transport.StreamRequest, out transport.Outbound) {
@@ -91,11 +84,5 @@ func updateStream(ctx context.Context, req *transport.StreamRequest, out transpo
 	// requests to a different outbound type.
 	if namer, ok := out.(transport.Namer); ok {
 		req.Meta.Transport = namer.TransportName()
-	}
-
-	// Update the caller procedure to the current procedure making this request
-	call := encoding.CallFromContext(ctx)
-	if call != nil {
-		req.Meta.CallerProcedure = call.Procedure()
 	}
 }

--- a/internal/firstoutboundmiddleware/middleware_test.go
+++ b/internal/firstoutboundmiddleware/middleware_test.go
@@ -54,7 +54,7 @@ func TestFirstOutboundMidleware(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, "fake", string(req.Transport))
-		assert.Equal(t, "ABC", string(req.CallerProcedure))
+		assert.Equal(t, "", string(req.CallerProcedure))
 	})
 
 	t.Run("oneway", func(t *testing.T) {
@@ -66,7 +66,7 @@ func TestFirstOutboundMidleware(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, "fake", string(req.Transport))
-		assert.Equal(t, "ABC", string(req.CallerProcedure))
+		assert.Equal(t, "", string(req.CallerProcedure))
 	})
 
 	t.Run("stream", func(t *testing.T) {
@@ -78,6 +78,6 @@ func TestFirstOutboundMidleware(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, "fake", string(streamReq.Meta.Transport))
-		assert.Equal(t, "ABC", string(streamReq.Meta.CallerProcedure))
+		assert.Equal(t, "", string(streamReq.Meta.CallerProcedure))
 	})
 }


### PR DESCRIPTION
There was bug found wrt caller procedure not being backward compatible, specially in the case where proxy tries to copy inbound headers to outbound headers. 
While the fix is in progress, disabling the caller procedure propagation in outbound layer to unblock the other changes.