### PR TITLE
Fixed: changelog was not updated with v1.53.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 - No changes yet.
 
+## [1.53.1] - 2021-03-30
+- v1.53.1 is v1.52.0. v1.53.0 has a backward compatible issue with the new header
+  `rpc-caller-procedure` added in v1.53.0.
+
 ## [1.53.0] - 2021-03-12
 ### Added
 - gRPC: accept keepalive parameters for gRPC outbound configuration.
@@ -1343,6 +1347,7 @@ This release requires regeneration of ThriftRW code.
 - Initial release.
 
 [Unreleased]: https://github.com/yarpc/yarpc-go/compare/v1.53.0...HEAD
+[1.53.1]: https://github.com/yarpc/yarpc-go/compare/v1.51.0...v1.52.0
 [1.53.0]: https://github.com/yarpc/yarpc-go/compare/v1.52.0...v1.53.0
 [1.52.0]: https://github.com/yarpc/yarpc-go/compare/v1.51.0...v1.52.0
 [1.51.0]: https://github.com/yarpc/yarpc-go/compare/v1.50.0...v1.51.0


### PR DESCRIPTION
We released the version 1.53.1 as a hot tag to mitigate issues with 1.53.0.
1.53.1 is actually v1.52.0. This diff updates the changelog which was not updated

- [x] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [x] Entry in CHANGELOG.md
