### PR TITLE
Preparing release v1.53.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.53.2] - 2021-04-16
 ### Removed
 - Disable `rpc-caller-procedure` header temporarily by stop propoagating CallerProcedure in the outbound middleware.
 
@@ -1347,7 +1347,7 @@ This release requires regeneration of ThriftRW code.
 
 - Initial release.
 
-[Unreleased]: https://github.com/yarpc/yarpc-go/compare/v1.53.0...HEAD
+[1.53.2]: https://github.com/yarpc/yarpc-go/compare/v1.53.1...v1.53.2
 [1.53.1]: https://github.com/yarpc/yarpc-go/compare/v1.51.0...v1.52.0
 [1.53.0]: https://github.com/yarpc/yarpc-go/compare/v1.52.0...v1.53.0
 [1.52.0]: https://github.com/yarpc/yarpc-go/compare/v1.51.0...v1.52.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Removed
+- Disable `rpc-caller-procedure` header temporarily by stop propoagating CallerProcedure in the outbound middleware.
 
 ## [1.53.0] - 2021-03-12
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.53.2] - 2021-04-16
 ### Removed
-- Disable `rpc-caller-procedure` header temporarily by stop propoagating CallerProcedure in the outbound middleware.
+- Disable `rpc-caller-procedure` header temporarily by stopping the `CallerProcedure` propagation.
 
 ## [1.53.1] - 2021-03-30
 - v1.53.1 is v1.52.0. v1.53.0 has a backward compatible issue with the new header

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 - Disable `rpc-caller-procedure` header temporarily by stop propoagating CallerProcedure in the outbound middleware.
 
+## [1.53.1] - 2021-03-30
+- v1.53.1 is v1.52.0. v1.53.0 has a backward compatible issue with the new header
+  `rpc-caller-procedure` added in v1.53.0.
+
 ## [1.53.0] - 2021-03-12
 ### Added
 - gRPC: accept keepalive parameters for gRPC outbound configuration.
@@ -1344,6 +1348,7 @@ This release requires regeneration of ThriftRW code.
 - Initial release.
 
 [Unreleased]: https://github.com/yarpc/yarpc-go/compare/v1.53.0...HEAD
+[1.53.1]: https://github.com/yarpc/yarpc-go/compare/v1.51.0...v1.52.0
 [1.53.0]: https://github.com/yarpc/yarpc-go/compare/v1.52.0...v1.53.0
 [1.52.0]: https://github.com/yarpc/yarpc-go/compare/v1.51.0...v1.52.0
 [1.51.0]: https://github.com/yarpc/yarpc-go/compare/v1.50.0...v1.51.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- No changes yet.
+
 ## [1.53.0] - 2021-03-12
 ### Added
 - gRPC: accept keepalive parameters for gRPC outbound configuration.
@@ -1339,6 +1342,7 @@ This release requires regeneration of ThriftRW code.
 
 - Initial release.
 
+[Unreleased]: https://github.com/yarpc/yarpc-go/compare/v1.53.0...HEAD
 [1.53.0]: https://github.com/yarpc/yarpc-go/compare/v1.52.0...v1.53.0
 [1.52.0]: https://github.com/yarpc/yarpc-go/compare/v1.51.0...v1.52.0
 [1.51.0]: https://github.com/yarpc/yarpc-go/compare/v1.50.0...v1.51.0

--- a/internal/firstoutboundmiddleware/middleware.go
+++ b/internal/firstoutboundmiddleware/middleware.go
@@ -26,7 +26,6 @@ package firstoutboundmiddleware
 import (
 	"context"
 
-	"go.uber.org/yarpc/api/encoding"
 	"go.uber.org/yarpc/api/middleware"
 	"go.uber.org/yarpc/api/transport"
 )
@@ -74,12 +73,6 @@ func update(ctx context.Context, req *transport.Request, out transport.Outbound)
 	if namer, ok := out.(transport.Namer); ok {
 		req.Transport = namer.TransportName()
 	}
-
-	// Update the caller procedure to the current procedure making this request
-	call := encoding.CallFromContext(ctx)
-	if call != nil {
-		req.CallerProcedure = call.Procedure()
-	}
 }
 
 func updateStream(ctx context.Context, req *transport.StreamRequest, out transport.Outbound) {
@@ -91,11 +84,5 @@ func updateStream(ctx context.Context, req *transport.StreamRequest, out transpo
 	// requests to a different outbound type.
 	if namer, ok := out.(transport.Namer); ok {
 		req.Meta.Transport = namer.TransportName()
-	}
-
-	// Update the caller procedure to the current procedure making this request
-	call := encoding.CallFromContext(ctx)
-	if call != nil {
-		req.Meta.CallerProcedure = call.Procedure()
 	}
 }

--- a/internal/firstoutboundmiddleware/middleware_test.go
+++ b/internal/firstoutboundmiddleware/middleware_test.go
@@ -54,7 +54,7 @@ func TestFirstOutboundMidleware(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, "fake", string(req.Transport))
-		assert.Equal(t, "ABC", string(req.CallerProcedure))
+		assert.Equal(t, "", string(req.CallerProcedure))
 	})
 
 	t.Run("oneway", func(t *testing.T) {
@@ -66,7 +66,7 @@ func TestFirstOutboundMidleware(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, "fake", string(req.Transport))
-		assert.Equal(t, "ABC", string(req.CallerProcedure))
+		assert.Equal(t, "", string(req.CallerProcedure))
 	})
 
 	t.Run("stream", func(t *testing.T) {
@@ -78,6 +78,6 @@ func TestFirstOutboundMidleware(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, "fake", string(streamReq.Meta.Transport))
-		assert.Equal(t, "ABC", string(streamReq.Meta.CallerProcedure))
+		assert.Equal(t, "", string(streamReq.Meta.CallerProcedure))
 	})
 }

--- a/transport/grpc/handler_test.go
+++ b/transport/grpc/handler_test.go
@@ -116,7 +116,7 @@ func TestInvalidStreamMultipleHeaders(t *testing.T) {
 	_, err = h.getBasicTransportRequest(ctx, "service/proc")
 
 	require.Contains(t, err.Error(), "code:invalid-argument")
-	require.Contains(t, err.Error(), "header has more than one value: rpc-caller")
+	require.Contains(t, err.Error(), "header has more than one value: rpc-caller:[caller1 caller2]")
 }
 
 func TestToGRPCError(t *testing.T) {

--- a/transport/grpc/headers.go
+++ b/transport/grpc/headers.go
@@ -128,7 +128,7 @@ func metadataToTransportRequest(md metadata.MD) (*transport.Request, error) {
 		case 1:
 			value = values[0]
 		default:
-			return nil, yarpcerrors.InvalidArgumentErrorf("header has more than one value: %s", header)
+			return nil, yarpcerrors.InvalidArgumentErrorf("header has more than one value: %s:%v", header, values)
 		}
 		header = transport.CanonicalizeHeaderKey(header)
 		switch header {
@@ -213,7 +213,7 @@ func getApplicationHeaders(md metadata.MD) (transport.Headers, error) {
 		case 1:
 			value = values[0]
 		default:
-			return headers, yarpcerrors.InvalidArgumentErrorf("header has more than one value: %s", header)
+			return headers, yarpcerrors.InvalidArgumentErrorf("header has more than one value: %s:%v", header, values)
 		}
 		headers = headers.With(header, value)
 	}

--- a/transport/grpc/headers_test.go
+++ b/transport/grpc/headers_test.go
@@ -214,3 +214,57 @@ func TestMDReadWriterDuplicateKey(t *testing.T) {
 	mdRW.Set(key, "overwritten")
 	assert.Equal(t, []string{"overwritten"}, md[key], "expected overwritten values")
 }
+
+func TestGetApplicationHeaders(t *testing.T) {
+	tests := []struct {
+		msg         string
+		meta        metadata.MD
+		wantHeaders map[string]string
+		wantErr     string
+	}{
+		{
+			msg:         "nil",
+			meta:        nil,
+			wantHeaders: nil,
+		},
+		{
+			msg:         "empty",
+			meta:        metadata.MD{},
+			wantHeaders: nil,
+		},
+		{
+			msg: "success",
+			meta: metadata.MD{
+				"rpc-service":         []string{"foo"}, // reserved header
+				"test-header-empty":   []string{},      // no value
+				"test-header-valid-1": []string{"test-value-1"},
+				"test-Header-Valid-2": []string{"test-value-2"},
+			},
+			wantHeaders: map[string]string{
+				"test-header-valid-1": "test-value-1",
+				"test-header-valid-2": "test-value-2",
+			},
+		},
+		{
+			msg: "error: multiple values for one header",
+			meta: metadata.MD{
+				"test-header-valid": []string{"test-value"},
+				"test-header-dup":   []string{"test-value-1", "test-value-2"},
+			},
+			wantErr: "header has more than one value: test-header-dup:[test-value-1 test-value-2]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			got, err := getApplicationHeaders(tt.meta)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr, "unexpecte error message")
+				return
+			}
+			require.NoError(t, err, "failed to extract application headers")
+			assert.Equal(t, tt.wantHeaders, got.Items(), "unexpected headers")
+		})
+	}
+}

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package yarpc // import "go.uber.org/yarpc"
 
 // Version is the current version of YARPC.
-const Version = "1.53.0"
+const Version = "1.54.0-dev"

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package yarpc // import "go.uber.org/yarpc"
 
 // Version is the current version of YARPC.
-const Version = "1.54.0-dev"
+const Version = "1.53.2"


### PR DESCRIPTION
Release [v1.53.0](https://github.com/yarpc/yarpc-go/pull/2053) without caller procedure in the outbound middleware
- [X] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [X] Entry in CHANGELOG.md
