### PR TITLE
Fix peer selection in power of two random choices to look at 2 peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Tweaked peer selection in two random choices to always look at two different peers.
 ### Removed
 - Disable `rpc-caller-procedure` header temporarily by stop propoagating CallerProcedure in the outbound middleware.
 

--- a/peer/tworandomchoices/tworandomchoices.go
+++ b/peer/tworandomchoices/tworandomchoices.go
@@ -101,11 +101,16 @@ func (l *twoRandomChoicesList) Choose(_ *transport.Request) peer.StatusPeer {
 	if numSubs == 1 {
 		return l.subscribers[0].peer
 	}
-	i := l.random.Intn(numSubs)
-	j := i + 1 + l.random.Intn(numSubs-1)
-	if j >= numSubs {
-		j -= numSubs
+	i := rand.Intn(numSubs)
+	s := rand.Intn(numSubs)
+	if i == j {
+		if j == 0 {
+			j = numSubs - 1
+		} else {
+			j--
+		}
 	}
+
 	if l.subscribers[i].pending.Load() > l.subscribers[j].pending.Load() {
 		i = j
 	}


### PR DESCRIPTION
The current version doesn't guarantee that we always select different
peers for comparison, which makes the selection less effective.

In fact, if you look at the comments on the original PR, it appears
the intention was to guarantee that selected peers are unique:
https://github.com/yarpc/yarpc-go/pull/1539#pullrequestreview-144136407

But this is not the case.

The CPU cost of both implementations is the same - it's totally
dominated by selecting the two random peers.

I have a bit of code to test these:

```
package main

import (
	"fmt"
	"math/rand"
	"strconv"
	"testing"
	"time"
)

func BenchmarkMe(b *testing.B) {
	for _, n := range []int{2, 5, 10, 50, 100, 500, 1000} {
		b.Run(strconv.Itoa(n), func(b *testing.B) {
			b.Run("two rand", func(b *testing.B) {
				for i := 0; i < b.N; i++ {
					rand.Intn(n)
					rand.Intn(n)
				}
			})
			b.Run("if/else", func(b *testing.B) {
				for i := 0; i < b.N; i++ {
					f := rand.Intn(n)
					s := rand.Intn(n)
					if f == s {
						if s == 0 {
							s = n - 1
						} else {
							s--
						}
					}
				}
			})
			b.Run("overflow", func(b *testing.B) {
				for i := 0; i < b.N; i++ {
					i := rand.Intn(n)
					j := i + 1 + rand.Intn(n)
					if j >= n {
						j -= n
					}
				}
			})
		})
	}
}

func stddev(m map[int]int) float64 {
	sum := 0.0

	for _, v := range m {
		sum += float64(v)
	}

	sum = sum / float64(len(m))

	stdDev := 0.0
	for _, v := range m {
		diff := sum - float64(v)
		stdDev += diff * diff
	}
	return stdDev / sum
}

func runTest(name string, fn func(m map[int]int) (int, int)) {
	N := 1000000
	counter := make(map[int]int, 100)
	dups := 0
	for i := 0; i < N; i++ {
		i, j := fn(counter)
		counter[i]++
		counter[j]++
		if i == j {
			dups++
		}
	}
         fmt.Println(name, "stddev:", stddev(counter), "number of dups:", dups)
}

func TestMe(t *testing.T) {
	n := 10
	rand.Seed(time.Now().UnixNano())

	runTest("if-else", func(m map[int]int) (int, int) {
		f := rand.Intn(n)
		s := rand.Intn(n)
		if f == s {
			if s == 0 {
				s = n - 1
			} else {
				s--
			}
		}
		return f, s
	})

	runTest("overflow", func(m map[int]int) (int, int) {
		i := rand.Intn(n)
		j := i + 1 + rand.Intn(n)
		if j >= n {
			j -= n
		}
		return i, j
	})

	runTest("n rand", func(m map[int]int) (int, int) {
		i := rand.Intn(n)
		j := rand.Intn(n)
		for i == j {
			j = rand.Intn(n)
		}
		return i, j
	})
}
```

Output for benchmark is:
```
BenchmarkMe/2/two_rand-8                33460016                34.63 ns/op            0 B/op          0 allocs/op
BenchmarkMe/2/if/else-8                 35100212                34.08 ns/op            0 B/op          0 allocs/op
BenchmarkMe/2/overflow-8                34215274                34.12 ns/op            0 B/op          0 allocs/op
BenchmarkMe/5/two_rand-8                31336039                38.46 ns/op            0 B/op          0 allocs/op
BenchmarkMe/5/if/else-8                 29535964                37.64 ns/op            0 B/op          0 allocs/op
BenchmarkMe/5/overflow-8                30915375                37.76 ns/op            0 B/op          0 allocs/op
BenchmarkMe/10/two_rand-8               31075015                37.47 ns/op            0 B/op          0 allocs/op
BenchmarkMe/10/if/else-8                30048549                37.73 ns/op            0 B/op          0 allocs/op
BenchmarkMe/10/overflow-8               28364646                37.84 ns/op            0 B/op          0 allocs/op
BenchmarkMe/50/two_rand-8               31314180                37.65 ns/op            0 B/op          0 allocs/op
BenchmarkMe/50/if/else-8                31191262                37.41 ns/op            0 B/op          0 allocs/op
BenchmarkMe/50/overflow-8               30800410                38.08 ns/op            0 B/op          0 allocs/op
BenchmarkMe/100/two_rand-8              30347300                38.96 ns/op            0 B/op          0 allocs/op
BenchmarkMe/100/if/else-8               30435844                39.31 ns/op            0 B/op          0 allocs/op
BenchmarkMe/100/overflow-8              31478190                39.88 ns/op            0 B/op          0 allocs/op
BenchmarkMe/500/two_rand-8              28073970                38.77 ns/op            0 B/op          0 allocs/op
BenchmarkMe/500/if/else-8               28468599                40.46 ns/op            0 B/op          0 allocs/op
BenchmarkMe/500/overflow-8              28595578                40.54 ns/op            0 B/op          0 allocs/op
BenchmarkMe/1000/two_rand-8             28018666                39.80 ns/op            0 B/op          0 allocs/op
BenchmarkMe/1000/if/else-8              30894926                39.73 ns/op            0 B/op          0 allocs/op
BenchmarkMe/1000/overflow-8             27568603                39.36 ns/op            0 B/op          0 allocs/op
```

The test output is:
```
if-else stddev: 4.81526 number of dups: 0
overflow stddev: 3.07755 number of dups: 100726
n rand stddev: 10.97677 number of dups: 0
```
- stddev is good in all cases - with more runs it fluctuates <20 for all solutions
- overflow solution (current yarpc) shows duplication (same peer selected twice) in ~10% of the cases.