### PR TITLE
[introspection] return proto native procedure names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Fixed wrong display of proto procedure name in introspection.
-- No changes yet.
+### Fixed
+- introspection: wrong display of proto procedure name.
 
 ## [1.53.2] - 2021-04-16
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fixed wrong display of proto procedure name in introspection.
 - No changes yet.
 
 ## [1.53.2] - 2021-04-16

--- a/internal/introspection/router_test.go
+++ b/internal/introspection/router_test.go
@@ -38,8 +38,13 @@ func TestProcedureName(t *testing.T) {
 			want: "/full.path.to.service/method",
 		},
 		{
+			msg:  "json encoding",
+			p:    Procedure{Encoding: "json", Name: "full.path.to.service::method"},
+			want: "full.path.to.service::method",
+		},
+		{
 			msg:  "thrift encoding",
-			p:    Procedure{Encoding: "thrift ", Name: "full.path.to.service::method"},
+			p:    Procedure{Encoding: "thrift", Name: "full.path.to.service::method"},
 			want: "full.path.to.service::method",
 		},
 	}

--- a/x/debug/debug.go
+++ b/x/debug/debug.go
@@ -102,7 +102,7 @@ var (
 		</tr>
 		{{range .Procedures}}
 		<tr>
-			<td>{{.Name}}</td>
+			<td>{{.ProcedureName}}</td>
 			<td>{{.Encoding}}</td>
 			<td>{{.Signature}}</td>
 			<td>{{.RPCType}}</td>


### PR DESCRIPTION
- [x] Description and context for reviewers: one partner, one stranger
Currently the proto procedure name is using yarpc convention of :: as
delimiter. This is confusing because gRPC curl clients tend to use
slash.
This diff conditionally displays proto procedures with / as delimiter.
`grpc.health.v1.Health::Check` => `/grpc.health.v1.Health/Check`
```
grpc.health.v1.Health::Check	json		Unary
grpc.health.v1.Health::Check	proto		Unary
```
- [ ] Docs (package doc)
- [x] Entry in CHANGELOG.md
Fixed wrong display of proto procedure name in introspection.