### PR TITLE
Observability: extend payload buckets up to 256MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Changed
+### Added
 - observability: extend response, and request payload size histogram buckets up to 256MB.
 
 ## [1.53.2] - 2021-04-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Changed
+- observability: extend response, and request payload size histogram buckets up to 256MB.
 
 ## [1.53.2] - 2021-04-16
 ### Removed

--- a/internal/observability/graph.go
+++ b/internal/observability/graph.go
@@ -40,8 +40,8 @@ var (
 	// configurable.
 	_bucketsMs = bucket.NewRPCLatency()
 	// Bytes buckets for payload size histograms, containing exponential buckets
-	// in range of 0B, 1B, 2B, ... 4MB
-	_bucketsBytes = append([]int64{0}, bucket.NewExponential(1, 2, 23)...)
+	// in range of 0B, 1B, 2B, ... 256MB.
+	_bucketsBytes = append([]int64{0}, bucket.NewExponential(1, 2, 29)...)
 )
 
 type directionName string

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -1932,7 +1932,7 @@ func TestMiddlewareSuccessSnapshot(t *testing.T) {
 	buf := bufferpool.Get()
 	defer bufferpool.Put(buf)
 
-	buf.Write([]byte("body"))
+	buf.Write(make([]byte, 1024*1024*128))
 
 	ctx, cancel := context.WithDeadline(context.Background(), timeVal.Add(time.Millisecond*time.Duration(ttlMs)))
 	defer cancel()
@@ -1951,7 +1951,7 @@ func TestMiddlewareSuccessSnapshot(t *testing.T) {
 			BodySize:        buf.Len(),
 		},
 		&transporttest.FakeResponseWriter{},
-		fakeHandler{responseData: []byte("test response")},
+		fakeHandler{responseData: make([]byte, 1024*1024*256)},
 	)
 	assert.NoError(t, err, "Unexpected transport error.")
 
@@ -1983,13 +1983,13 @@ func TestMiddlewareSuccessSnapshot(t *testing.T) {
 				Name:   "request_payload_size_bytes",
 				Tags:   tags,
 				Unit:   time.Millisecond,
-				Values: []int64{4},
+				Values: []int64{134217728}, // 128MB
 			},
 			{
 				Name:   "response_payload_size_bytes",
 				Tags:   tags,
 				Unit:   time.Millisecond,
-				Values: []int64{16},
+				Values: []int64{268435456}, // 256MB
 			},
 			{
 				Name: "server_failure_latency_ms",

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -1932,7 +1932,7 @@ func TestMiddlewareSuccessSnapshot(t *testing.T) {
 	buf := bufferpool.Get()
 	defer bufferpool.Put(buf)
 
-	buf.Write(make([]byte, 1024*1024*128))
+	buf.Write([]byte("body"))
 
 	ctx, cancel := context.WithDeadline(context.Background(), timeVal.Add(time.Millisecond*time.Duration(ttlMs)))
 	defer cancel()
@@ -1948,10 +1948,12 @@ func TestMiddlewareSuccessSnapshot(t *testing.T) {
 			RoutingKey:      "rk",
 			RoutingDelegate: "rd",
 			Body:            buf,
-			BodySize:        buf.Len(),
+			// overwrite with fixed value of 256MB to test large bucket.
+			// large buffer body causes CI to timeout.
+			BodySize: 1024 * 1024 * 256,
 		},
 		&transporttest.FakeResponseWriter{},
-		fakeHandler{responseData: make([]byte, 1024*1024*256)},
+		fakeHandler{responseData: make([]byte, 1024*1024*16)},
 	)
 	assert.NoError(t, err, "Unexpected transport error.")
 
@@ -1983,13 +1985,13 @@ func TestMiddlewareSuccessSnapshot(t *testing.T) {
 				Name:   "request_payload_size_bytes",
 				Tags:   tags,
 				Unit:   time.Millisecond,
-				Values: []int64{134217728}, // 128MB
+				Values: []int64{268435456}, // 256MB
 			},
 			{
 				Name:   "response_payload_size_bytes",
 				Tags:   tags,
 				Unit:   time.Millisecond,
-				Values: []int64{268435456}, // 256MB
+				Values: []int64{16777216}, // 16MB
 			},
 			{
 				Name: "server_failure_latency_ms",


### PR DESCRIPTION
Extend response, and request payload size histogram buckets up to 256MB, earlier it was limited to 4MB. Tested on M3 with increased buckets, there seems no runtime impact on histogram queries.

- [X] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [X] Entry in CHANGELOG.md
