### PR TITLE
Fixed: protobuf error with details did not work when detail message were not registered in the proto registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Fixed
 - introspection: wrong display of proto procedure name.
+- error details: propagation of protobuf error details did not work if the any message was not
+  registered in the gogo proto registry.
 
 ## [1.53.2] - 2021-04-16
 ### Removed

--- a/encoding/protobuf/error.go
+++ b/encoding/protobuf/error.go
@@ -144,10 +144,10 @@ func convertToYARPCError(encoding transport.Encoding, err error, codec *codec, r
 }
 
 func createStatusWithDetail(pberr *pberror, encoding transport.Encoding, codec *codec) (*yarpcerrors.Status, error) {
-	st := status.New(grpcerrorcodes.YARPCCodeToGRPCCode[pberr.code], pberr.message)
-	st.Proto().Details = pberr.details
+	st := status.New(grpcerrorcodes.YARPCCodeToGRPCCode[pberr.code], pberr.message).Proto()
+	st.Details = pberr.details
 
-	detailsBytes, cleanup, marshalErr := marshal(encoding, st.Proto(), codec)
+	detailsBytes, cleanup, marshalErr := marshal(encoding, st, codec)
 	if marshalErr != nil {
 		return nil, marshalErr
 	}

--- a/transport/grpc/integration_test.go
+++ b/transport/grpc/integration_test.go
@@ -130,7 +130,10 @@ func TestYARPCErrorWithDetails(t *testing.T) {
 	te.do(t, func(t *testing.T, e *testEnv) {
 		e.KeyValueYARPCServer.SetNextError(protobuf.NewError(yarpcerrors.CodeNotFound, "hello world", protobuf.WithErrorDetails(&examplepb.SetValueResponse{})))
 		err := e.SetValueYARPC(context.Background(), "foo", "bar")
-		assert.Equal(t, protobuf.NewError(yarpcerrors.CodeNotFound, "hello world", protobuf.WithErrorDetails(&examplepb.SetValueResponse{})), err)
+		require.Len(t, protobuf.GetErrorDetails(err), 1)
+		assert.Equal(t, protobuf.GetErrorDetails(err)[0], &examplepb.SetValueResponse{})
+		assert.Equal(t, yarpcerrors.FromError(err).Code(), yarpcerrors.CodeNotFound)
+		assert.Equal(t, yarpcerrors.FromError(err).Message(), "hello world")
 	})
 }
 


### PR DESCRIPTION
The propagation of protobuf error details did not work if one of the any message was not registered in the protobuf registry. Details, message and code error were lost if one of the detail could not be decoded/encoded.

For instance, if you have the following chain of services A -> B -> C and let's assume than B returns blindly the errors from C to A. If C returns the the error code.Internal, "this an error" and details []ErrorDetails1{} and B would not have registered ErrorDetails1{} in the gogo proto registry, A would get an unknown error with message "unknown error".

The issue happened in the encoding pkg, the issue was that the `pbeer` would internaly store a list of interface[] (which could contain errors or proto.Message) instead of a list of types.Any. `pbeer` was always deserializing all details (even when details were not used). When the same error would be returned, the list of interface would be then serialized. The issue happened here when sometimes errors and not proto.Message where in the list. Hence yarpc would stop to propagate all informations of terror.
To fix the issue, instead of decoding details all the time, yarpc only do when details are being fetched with the method  `GetErrorDetails`. The benefits of this is that pberr now stores types.Any and not []interface details anymore.

- [X] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [X] Entry in CHANGELOG.md
