### PR TITLE
Allow wrapping application errors with YARPC status code #2069

### DIFF
--- a/yarpcerrors/errors.go
+++ b/yarpcerrors/errors.go
@@ -26,6 +26,19 @@ import (
 	"fmt"
 )
 
+// Wrap returns a new Status that wraps the original error.
+//
+// The Code should never be CodeOK, if it is, this will return nil.
+func Wrap(code Code, err error) *Status {
+	if code == CodeOK {
+		return nil
+	}
+	return &Status{
+		code: code,
+		err:  &wrapError{err: err},
+	}
+}
+
 // Newf returns a new Status.
 //
 // The Code should never be CodeOK, if it is, this will return nil.


### PR DESCRIPTION
I want to register a YARPC middleware that implements non-functional error handling logic, common for all service handlers, while still providing the YARPC status from the concrete handler.

I noticed that yarpcerrors.Status implements the idiomatic error wrapping. However, I am unable to instantiate a yarpcerrors.Status while also settings the status code.

We want to enable application handlers to return YARPC status code to the framework while preserving the original error. This is useful when you have a middleware that inspects and does application-specific error handling for all endpoints.

This is implemented by exposing a `yarpcerrors.Wrap` function, similar to `yarpcerrors.Newf` that wraps an external error with a status code instead of creating a new error chain. Wrapping is done with the internal `wrapError` struct.

- [x] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [ ] Entry in CHANGELOG.md
