### PR TITLE
Fixed: error created with protobuf.NewError with invalid code does not return unknown error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Fixed
+- protobuf error: a protobuf error created with an invalid code returns a unknown
+  error again.
 
 ## [1.54.0] - 2021-06-01
 ### Added

--- a/encoding/protobuf/error.go
+++ b/encoding/protobuf/error.go
@@ -151,10 +151,15 @@ func createStatusWithDetail(pberr *pberror, encoding transport.Encoding, codec *
 		return nil, errors.New("no status error for error with code OK")
 	}
 
-	st := status.New(grpcerrorcodes.YARPCCodeToGRPCCode[pberr.code], pberr.message).Proto()
-	st.Details = pberr.details
+	st := status.New(grpcerrorcodes.YARPCCodeToGRPCCode[pberr.code], pberr.message)
+	// Here we check that status.New is a valid error
+	if st.Err() == nil {
+		return nil, errors.New("no status error for error with code OK")
+	}
+	pst := st.Proto()
+	pst.Details = pberr.details
 
-	detailsBytes, cleanup, marshalErr := marshal(encoding, st, codec)
+	detailsBytes, cleanup, marshalErr := marshal(encoding, pst, codec)
 	if marshalErr != nil {
 		return nil, marshalErr
 	}

--- a/encoding/protobuf/error.go
+++ b/encoding/protobuf/error.go
@@ -154,7 +154,7 @@ func createStatusWithDetail(pberr *pberror, encoding transport.Encoding, codec *
 	st := status.New(grpcerrorcodes.YARPCCodeToGRPCCode[pberr.code], pberr.message)
 	// Here we check that status.New has returned a valid error.
 	if st.Err() == nil {
-		return nil, errors.New(fmt.Sprintf("no status error for error with code %d", pberr.code))
+		return nil, fmt.Errorf("no status error for error with code %d", pberr.code)
 	}
 	pst := st.Proto()
 	pst.Details = pberr.details

--- a/encoding/protobuf/error.go
+++ b/encoding/protobuf/error.go
@@ -152,7 +152,7 @@ func createStatusWithDetail(pberr *pberror, encoding transport.Encoding, codec *
 	}
 
 	st := status.New(grpcerrorcodes.YARPCCodeToGRPCCode[pberr.code], pberr.message)
-	// Here we check that status.New is a valid error
+	// Here we check that status.New has returned a valid error.
 	if st.Err() == nil {
 		return nil, errors.New("no status error for error with code OK")
 	}

--- a/encoding/protobuf/error_test.go
+++ b/encoding/protobuf/error_test.go
@@ -213,8 +213,15 @@ func TestConvertFromYARPCError(t *testing.T) {
 }
 
 func TestCreateStatusWithDetailErrors(t *testing.T) {
-	t.Run("unsupported code", func(t *testing.T) {
+	t.Run("code ok", func(t *testing.T) {
 		pberr := &pberror{code: yarpcerrors.CodeOK, message: "test"}
+		_, err := createStatusWithDetail(pberr, Encoding, &codec{})
+		assert.Error(t, err, "unexpected empty error")
+		assert.Equal(t, err.Error(), "no status error for error with code OK")
+	})
+
+	t.Run("unsupported code", func(t *testing.T) {
+		pberr := &pberror{code: 99, message: "test"}
 		_, err := createStatusWithDetail(pberr, Encoding, &codec{})
 		assert.Error(t, err, "unexpected empty error")
 		assert.Equal(t, err.Error(), "no status error for error with code OK")


### PR DESCRIPTION
The following PR (https://github.com/yarpc/yarpc-go/pull/2067) added a regression in the way error are handled with protobuf.

Before https://github.com/yarpc/yarpc-go/pull/2067, error created with `protobuf.NewError` would return an unknown yarpcerror if a wrong code was given (for instance 99). This capability was lost with https://github.com/yarpc/yarpc-go/pull/2067.
This is because in https://github.com/yarpc/yarpc-go/pull/2067, the following line changed:
```
st, convertErr := status.New(grpcerrorcodes.YARPCCodeToGRPCCode[pberr.code], pberr.message).WithDetails(details...) //old
st := status.New(grpcerrorcodes.YARPCCodeToGRPCCode[pberr.code], pberr.message) // new
```
The issue is that the call to `WithDetails()` would return a convertErr if the status code of status was Ok (see https://github.com/gogo/status/blob/master/status.go#L176). Once this call removed, no check were done on the status anymore.
In this PR, we add back this check by calling the method `Err()`

- [x] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [x] Entry in CHANGELOG.md
