### PR TITLE
Fixed: protobuf.GetErrorDetails return nil if the given err does not have any details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Fixed
+- error details: protobuf.GetErrorDetails returns nil instead of an empty array
+  if there is no details in the given error.
 
 ## [1.54.0] - 2021-06-01
 ### Added

--- a/encoding/protobuf/error.go
+++ b/encoding/protobuf/error.go
@@ -95,7 +95,7 @@ func GetErrorDetails(err error) []interface{} {
 		return nil
 	}
 	var target *pberror
-	if errors.As(err, &target) {
+	if errors.As(err, &target) && len(target.details) > 0 {
 		results := make([]interface{}, 0, len(target.details))
 		for _, any := range target.details {
 			detail := &types.DynamicAny{}

--- a/encoding/protobuf/error_test.go
+++ b/encoding/protobuf/error_test.go
@@ -236,6 +236,12 @@ func TestErrorHandling(t *testing.T) {
 	t.Run("GetErrorDetail non pberror", func(t *testing.T) {
 		assert.Nil(t, GetErrorDetails(errors.New("test")), "unexpected details")
 	})
+	t.Run("GetErrorDetail with no error detail", func(t *testing.T) {
+		err := NewError(
+			yarpcerrors.CodeAborted,
+			"aborted")
+		assert.Nil(t, GetErrorDetails(err), "unexpected details")
+	})
 	t.Run("PbError empty error handling", func(t *testing.T) {
 		var pbErr *pberror
 		assert.Nil(t, pbErr.YARPCError(), "unexpected yarpcerror")


### PR DESCRIPTION
The following PR (https://github.com/yarpc/yarpc-go/pull/2067) added a regression in the way error are handled with protobuf.

Previously, if the given err did not have any details, nil would be returned.
In this diff we return nil if there are no details in the given error instead of an empty array.

- [X] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [X] Entry in CHANGELOG.md
