### PR TITLE
Preparing release v1.54.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [1.54.2] - 2021-06-11
-- go.uber.org/yarpc@v1.54.1 points to v1.54.0 instead of v1.54.1.
+- go.uber.org/yarpc@v1.54.1 points to v1.54.0 instead of v1.54.1. This release unblocks
+  go.uber.org/yarpc to serve v1.54.1 through v1.54.2.
 
 ## [1.54.1] - 2021-06-11
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [1.54.1] - 2021-06-01
+## [1.54.2] - 2021-06-11
+- go.uber.org/yarpc@v1.54.1 points to v1.54.0 instead of v1.54.1.
+
+## [1.54.1] - 2021-06-11
 ### Fixed
 - protobuf error: a protobuf error created with an invalid code returns a unknown
   error.
@@ -1364,6 +1367,7 @@ This release requires regeneration of ThriftRW code.
 
 - Initial release.
 
+[1.54.2]: https://github.com/yarpc/yarpc-go/compare/v1.54.1...v1.54.2
 [1.54.1]: https://github.com/yarpc/yarpc-go/compare/v1.54.0...v1.54.1
 [1.54.0]: https://github.com/yarpc/yarpc-go/compare/v1.53.2...v1.54.0
 [1.53.2]: https://github.com/yarpc/yarpc-go/compare/v1.53.1...v1.53.2

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package yarpc // import "go.uber.org/yarpc"
 
 // Version is the current version of YARPC.
-const Version = "1.54.1"
+const Version = "1.54.2"


### PR DESCRIPTION
Due to a tag deletion while releasing v1.54.1, go.uber.org/yarpc@1.54.1 points to 1.54.0 instead of 1.54.1. Creating this release for the proxy to catch up....
 
- [x] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [x] Entry in CHANGELOG.md
