### PR TITLE
Fixed: peer/direct - peer connections were closed even if they were still used.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet
+### Fixed
+- peer/direct: peer connections were closed even if they were still used.
 
 ## [1.55.0] - 2021-07-06
 - Downgrade github.com/apache/thrift to the previously-compatible version (0.10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- peer/direct: peer connections were closed even if they were still used.
+- peer/direct: peer connections were closed even if they were still in use.
 
 ## [1.55.0] - 2021-07-06
 - Downgrade github.com/apache/thrift to the previously-compatible version (0.10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- No changes yet
+
 ## [1.55.0] - 2021-07-06
 - Downgrade github.com/apache/thrift to the previously-compatible version (0.10)
 
@@ -1371,6 +1374,7 @@ This release requires regeneration of ThriftRW code.
 
 - Initial release.
 
+[Unreleased]: https://github.com/yarpc/yarpc-go/compare/v1.55.0...HEAD
 [1.55.0]: https://github.com/yarpc/yarpc-go/compare/v1.54.2...v1.55.0
 [1.54.2]: https://github.com/yarpc/yarpc-go/compare/v1.54.1...v1.54.2
 [1.54.1]: https://github.com/yarpc/yarpc-go/compare/v1.54.0...v1.54.1

--- a/peer/direct/direct.go
+++ b/peer/direct/direct.go
@@ -96,7 +96,9 @@ func (c *Chooser) Choose(ctx context.Context, req *transport.Request) (peer.Peer
 	}
 
 	id := hostport.Identify(req.ShardKey)
-	sub := &peerSubscriber{}
+	sub := &peerSubscriber{
+		peerIdentifier: id,
+	}
 
 	transportPeer, err := c.transport.RetainPeer(id, sub)
 	if err != nil {
@@ -113,6 +115,14 @@ func (c *Chooser) Choose(ctx context.Context, req *transport.Request) (peer.Peer
 	return transportPeer, onFinish, nil
 }
 
-type peerSubscriber struct{}
+type peerSubscriber struct {
+	// Even if the peerIdentifier of peerSubscriber is not used,
+	// struct with no fields does not behave the same way as struct with fields.
+	// For instance, with no fields and p1 := &peerSubscriber{}, p2 := &peerSubscriber{}
+	// &p1 == &p2 will be true.
+	// Internally, YARPC stores this *peerSubscriber as a hash's key. p1 and p2 must be differents.
+	// More details here: https://dave.cheney.net/2014/03/25/the-empty-struct
+	peerIdentifier peer.Identifier
+}
 
 func (d *peerSubscriber) NotifyStatusChanged(_ peer.Identifier) {}

--- a/peer/direct/direct.go
+++ b/peer/direct/direct.go
@@ -120,7 +120,7 @@ type peerSubscriber struct {
 	// struct with no fields does not behave the same way as struct with fields.
 	// For instance, with no fields and p1 := &peerSubscriber{}, p2 := &peerSubscriber{}
 	// &p1 == &p2 will be true.
-	// Internally, YARPC stores this *peerSubscriber as a hash's key. p1 and p2 must be differents.
+	// Internally, YARPC stores this *peerSubscriber as a hash's key. p1 and p2 must be different.
 	// More details here: https://dave.cheney.net/2014/03/25/the-empty-struct
 	peerIdentifier peer.Identifier
 }

--- a/peer/direct/direct_test.go
+++ b/peer/direct/direct_test.go
@@ -140,11 +140,12 @@ func TestPeerSubscriber(t *testing.T) {
 		// Here we test that concurrent calls of RetainPeer and ReleasePeer
 		// methods from grpc.NewTransport does not return any errors.
 		const addr = "foohost:barport"
-		numberOfConcurrentCalls := 100
-		grpcTransport := grpc.NewTransport()
-		dialer := grpcTransport.NewDialer()
+		dialer := grpc.NewTransport().NewDialer()
+
 		var wg sync.WaitGroup
+		numberOfConcurrentCalls := 100
 		wg.Add(numberOfConcurrentCalls)
+
 		for i := 0; i < numberOfConcurrentCalls; i++ {
 			go func() {
 				defer wg.Done()

--- a/peer/direct/direct_test.go
+++ b/peer/direct/direct_test.go
@@ -140,12 +140,12 @@ func TestPeerSubscriber(t *testing.T) {
 		// Here we test that concurrent calls of RetainPeer and ReleasePeer
 		// methods from grpc.NewTransport does not return any errors.
 		const addr = "foohost:barport"
-		numberOfChooseCalls := 100
+		numberOfConcurrentCalls := 100
 		grpcTransport := grpc.NewTransport()
 		dialer := grpcTransport.NewDialer()
 		var wg sync.WaitGroup
-		wg.Add(numberOfChooseCalls)
-		for i := 0; i < numberOfChooseCalls; i++ {
+		wg.Add(numberOfConcurrentCalls)
+		for i := 0; i < numberOfConcurrentCalls; i++ {
 			go func() {
 				defer wg.Done()
 				id := hostport.Identify(addr)

--- a/peer/direct/direct_test.go
+++ b/peer/direct/direct_test.go
@@ -115,3 +115,9 @@ func TestDirect(t *testing.T) {
 		onFinish(nil)
 	})
 }
+
+func TestPeerSubscriber(t *testing.T) {
+	p1 := &peerSubscriber{}
+	p2 := &peerSubscriber{}
+	assert.False(t, p1 == p2)
+}

--- a/peer/direct/direct_test.go
+++ b/peer/direct/direct_test.go
@@ -116,6 +116,13 @@ func TestDirect(t *testing.T) {
 	})
 }
 
+// TestPeerSubscriber tests that two new created peerSubscriber
+// are not even.
+// struct with no fields does not behave the same way as struct with fields.
+// For instance, with no fields and p1 := &peerSubscriber{}, p2 := &peerSubscriber{}
+// &p1 == &p2 will be true.
+// Internally, YARPC stores this *peerSubscriber as a hash's key. p1 and p2 must be different.
+// More details here: https://dave.cheney.net/2014/03/25/the-empty-struct
 func TestPeerSubscriber(t *testing.T) {
 	p1 := &peerSubscriber{}
 	p2 := &peerSubscriber{}

--- a/peer/direct/direct_test.go
+++ b/peer/direct/direct_test.go
@@ -142,7 +142,7 @@ func TestPeerSubscriber(t *testing.T) {
 		const addr = "foohost:barport"
 		numberOfChooseCalls := 100
 		grpcTransport := grpc.NewTransport()
-
+		dialer := grpcTransport.NewDialer()
 		var wg sync.WaitGroup
 		wg.Add(numberOfChooseCalls)
 		for i := 0; i < numberOfChooseCalls; i++ {
@@ -152,9 +152,9 @@ func TestPeerSubscriber(t *testing.T) {
 				sub := &peerSubscriber{
 					peerIdentifier: id,
 				}
-				transportPeer, err := grpcTransport.RetainPeer(id, sub)
+				transportPeer, err := dialer.RetainPeer(id, sub)
 				assert.NoError(t, err)
-				err = grpcTransport.ReleasePeer(transportPeer, sub)
+				err = dialer.ReleasePeer(transportPeer, sub)
 				assert.NoError(t, err)
 			}()
 		}

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package yarpc // import "go.uber.org/yarpc"
 
 // Version is the current version of YARPC.
-const Version = "1.55.0"
+const Version = "1.56.0-dev"


### PR DESCRIPTION
With the peer/direct configuration, peers were closed even if they were still used. For instance with the following, client could get  the error `transport is closing`:

```
wg := sync.WaitGroup{}
wg.Add(2)
go func() {
  defer wg.Done()
  _, err1 = client.Login(ctx, nil, yarpc.WithShardKey("localhost:5791"))
}()
go func() {
  defer wg.Done()
  _, err2 = client.Login(ctx, nil, yarpc.WithShardKey("localhost:5791"))
}()
wg.Wait()
```

Internally, YARPC stores a list of peer.Subscriber with `subscribers  map[peer.Subscriber]struct{}` - see https://github.com/yarpc/yarpc-go/blob/dev/peer/abstractpeer/peer.go#L61
The direct peer strategy used to give the following `peer.Subscriber` `type peerSubscriber struct {}` - see https://github.com/yarpc/yarpc-go/blob/dev/peer/direct/direct.go#L116

`type peerSubscriber struct {}` is an empty struct and will have behavior of an empty struct, for instance
```
p1 := &peerSubscriber{}
p2 := &peerSubscriber{}
&p1 == &p2 // this will be true, in fact p1 and p2 have the same pointer address
```
More details of empty struct usage here: https://dave.cheney.net/2014/03/25/the-empty-struct


The issue here is that with concurrent call, for instance 2, `subscribers  map[peer.Subscriber]struct{}` will only have one subscribers in the map instead of 2 (since p1 and p2 are equal). In result, when the call of p1 would be done, YARPC would not see any subscriber anymore and would stopped the connection of the peer while there is still an ongoing call for p2. Hence the error returned would be `transport is closing`.

In this diff, a new field has been added to peerSubscriber, so every peerSubscriber is now unique internally. New `peerSubscriber` do not have the same address anymore.
```
type peerSubscriber struct {
    peerIdentifier peer.Identifier
}
p1 := &peerSubscriber{}
p2 := &peerSubscriber{}
&p1 == &p2 // this will be false
```

- [x] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [x] Entry in CHANGELOG.md
