### PR TITLE
encoding/thrift: Provide new 'NoWire' register and client options

### DIFF
--- a/encoding/thrift/options.go
+++ b/encoding/thrift/options.go
@@ -27,6 +27,7 @@ type clientConfig struct {
 	Protocol    protocol.Protocol
 	Enveloping  bool
 	Multiplexed bool
+	NoWire      bool
 }
 
 // ClientOption customizes the behavior of a Thrift client.
@@ -38,6 +39,7 @@ type registerConfig struct {
 	ServiceName string
 	Protocol    protocol.Protocol
 	Enveloping  bool
+	NoWire      bool
 }
 
 // RegisterOption customizes the behavior of a Thrift handler during
@@ -153,4 +155,22 @@ func (p protocolOption) applyRegisterOption(c *registerConfig) {
 // It defaults to the Binary protocol.
 func Protocol(p protocol.Protocol) Option {
 	return protocolOption{Protocol: p}
+}
+
+// NoWire is an option that specifies to *not* use the thriftrw.Wire
+// intermediary format.  Note that if this is enabled, and a
+// 'protocol.Protocol' is provided (e.g., via thrift.Protocol)m that provided
+// protocol must be able to satisfy the 'stream.Protocol' interface.
+func NoWire(enable bool) Option {
+	return noWireOption{Enable: enable}
+}
+
+type noWireOption struct{ Enable bool }
+
+func (nw noWireOption) applyClientOption(c *clientConfig) {
+	c.NoWire = nw.Enable
+}
+
+func (nw noWireOption) applyRegisterOption(c *registerConfig) {
+	c.NoWire = nw.Enable
 }

--- a/encoding/thrift/options.go
+++ b/encoding/thrift/options.go
@@ -158,9 +158,10 @@ func Protocol(p protocol.Protocol) Option {
 }
 
 // NoWire is an option that specifies to *not* use the thriftrw.Wire
-// intermediary format.  Note that if this is enabled, and a
-// 'protocol.Protocol' is provided (e.g., via thrift.Protocol)m that provided
-// protocol must be able to satisfy the 'stream.Protocol' interface.
+// intermediary format. Note that if this is enabled, and a
+// 'protocol.Protocol' is provided (e.g., via thrift.Protocol) that provided
+// protocol must be able to satisfy the 'stream.RequestReader' interface.
+// Will become the default option.
 func NoWire(enable bool) Option {
 	return noWireOption{Enable: enable}
 }

--- a/encoding/thrift/register.go
+++ b/encoding/thrift/register.go
@@ -95,8 +95,10 @@ func BuildProcedures(s Service, opts ...RegisterOption) []transport.Procedure {
 		proto = rc.Protocol
 	}
 
+	// Only if we're trying to use the 'NoWire' implementation do we check if the
+	// config's `Protocol` provides the streaming ones needed.
 	var streamReqReader stream.RequestReader = binary.Default
-	if rc.Protocol != nil && rc.NoWire {
+	if rc.NoWire && rc.Protocol != nil {
 		if sp, ok := rc.Protocol.(stream.RequestReader); ok {
 			streamReqReader = sp
 		}
@@ -115,7 +117,7 @@ func BuildProcedures(s Service, opts ...RegisterOption) []transport.Procedure {
 		case transport.Unary:
 			if rc.NoWire {
 				spec = transport.NewUnaryHandlerSpec(thriftNoWireHandler{
-					NoWireHandler: method.HandlerSpec.NoWire,
+					Handler:       method.HandlerSpec.NoWire,
 					RequestReader: streamReqReader,
 				})
 			} else {
@@ -128,7 +130,7 @@ func BuildProcedures(s Service, opts ...RegisterOption) []transport.Procedure {
 		case transport.Oneway:
 			if rc.NoWire {
 				spec = transport.NewOnewayHandlerSpec(thriftNoWireHandler{
-					NoWireHandler: method.HandlerSpec.NoWire,
+					Handler:       method.HandlerSpec.NoWire,
 					RequestReader: streamReqReader,
 				})
 			} else {

--- a/encoding/thrift/register.go
+++ b/encoding/thrift/register.go
@@ -95,10 +95,10 @@ func BuildProcedures(s Service, opts ...RegisterOption) []transport.Procedure {
 		proto = rc.Protocol
 	}
 
-	var streamProto stream.Protocol = binary.Default
+	var streamReqReader stream.RequestReader = binary.Default
 	if rc.Protocol != nil && rc.NoWire {
-		if sp, ok := rc.Protocol.(stream.Protocol); ok {
-			streamProto = sp
+		if sp, ok := rc.Protocol.(stream.RequestReader); ok {
+			streamReqReader = sp
 		}
 	}
 
@@ -116,8 +116,7 @@ func BuildProcedures(s Service, opts ...RegisterOption) []transport.Procedure {
 			if rc.NoWire {
 				spec = transport.NewUnaryHandlerSpec(thriftNoWireHandler{
 					NoWireHandler: method.HandlerSpec.NoWire,
-					Protocol:      streamProto,
-					Enveloping:    rc.Enveloping,
+					RequestReader: streamReqReader,
 				})
 			} else {
 				spec = transport.NewUnaryHandlerSpec(thriftUnaryHandler{
@@ -130,8 +129,7 @@ func BuildProcedures(s Service, opts ...RegisterOption) []transport.Procedure {
 			if rc.NoWire {
 				spec = transport.NewOnewayHandlerSpec(thriftNoWireHandler{
 					NoWireHandler: method.HandlerSpec.NoWire,
-					Protocol:      streamProto,
-					Enveloping:    rc.Enveloping,
+					RequestReader: streamReqReader,
 				})
 			} else {
 				spec = transport.NewOnewayHandlerSpec(thriftOnewayHandler{

--- a/encoding/thrift/thriftrw-plugin-yarpc/roundtrip_test.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/roundtrip_test.go
@@ -55,27 +55,34 @@ import (
 )
 
 func TestRoundTrip(t *testing.T) {
-	tests := []struct{ enveloped, multiplexed bool }{
-		{true, true},
+	tests := []struct{ enveloped, multiplexed, nowire bool }{
+		{true, true, true},
+		{true, true, false},
 		// Skipping for now until flaky test fixed.
 		// Uncomment this when fixed.
 		// https://github.com/yarpc/yarpc-go/issues/1171
-		//{true, false},
-		{false, true},
-		{false, false},
+		//{true, false, true},
+		//{true, false, false},
+		{false, true, true},
+		{false, true, false},
+		{false, false, true},
+		{false, false, false},
 	}
 
 	for _, tt := range tests {
-		name := fmt.Sprintf("enveloped(%v)/multiplexed(%v)", tt.enveloped, tt.multiplexed)
-		t.Run(name, func(t *testing.T) { testRoundTrip(t, tt.enveloped, tt.multiplexed) })
+		name := fmt.Sprintf("enveloped(%v)/multiplexed(%v)/nowire(%v)", tt.enveloped, tt.multiplexed, tt.nowire)
+		t.Run(name, func(t *testing.T) { testRoundTrip(t, tt.enveloped, tt.multiplexed, tt.nowire) })
 	}
 }
 
-func testRoundTrip(t *testing.T, enveloped, multiplexed bool) {
+func testRoundTrip(t *testing.T, enveloped, multiplexed, nowire bool) {
+	t.Helper()
+
 	var serverOpts []thrift.RegisterOption
 	if enveloped {
 		serverOpts = append(serverOpts, thrift.Enveloped)
 	}
+	serverOpts = append(serverOpts, thrift.NoWire(nowire))
 
 	var clientOpts []string
 	if enveloped {


### PR DESCRIPTION
Allow for leveraging the new thriftrw-'nowire' implementations through a new
'registerOption' and a new 'clientOption' in an opt-in manner.

These can be injected via yarpcfx through passing in a `NoWire(bool)` option
into the dependency graph.

- [ ] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [ ] Entry in CHANGELOG.md
