### PR TITLE
Fixed: remove HTTP2 pseudo-headers when propagating HTTP/2 request to HTTP/1 service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 - http: allow multiple interception options and execute in order at runtime.
+- http: remove HTTP/2 pseudo headers for HTTP/2 requests propagated to HTTP/1 service through
+  YARPC transport middleware.
 
 ## [1.55.1] - 2021-07-14
 ### Fixed
 - peer/direct: peer connections were closed even if they were still in use.
 - configuration: clarify error message for the special case of attempting to use a peer list
   updater when none have been registered.
-- protoplugin: generated golang code from the yarpc plugin follows same GoType conventions as gogo/protobuf.  
+- protoplugin: generated golang code from the yarpc plugin follows same GoType conventions as gogo/protobuf.
 
 ## [1.55.0] - 2021-07-06
 - Downgrade github.com/apache/thrift to the previously-compatible version (0.10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Fixed
+- http: remove HTTP/2 pseudo headers for HTTP/2 requests propagated to HTTP/1 service through
+  YARPC transport middleware.
 
 ## [1.56.0] - 2021-07-22
 - http: allow multiple interception options and execute in order at runtime.
-- http: remove HTTP/2 pseudo headers for HTTP/2 requests propagated to HTTP/1 service through
-  YARPC transport middleware.
 
 ## [1.55.1] - 2021-07-14
 ### Fixed

--- a/transport/http/constants.go
+++ b/transport/http/constants.go
@@ -130,3 +130,20 @@ const (
 // ApplicationHeaderPrefix is the prefix added to application header keys to
 // send them in requests or responses.
 const ApplicationHeaderPrefix = "Rpc-Header-"
+
+const (
+	_http2AuthorityPseudoHeader = ":authority"
+	_http2MethodPseudoHeader    = ":method"
+	_http2PathPseudoHeader      = ":path"
+	_http2SchemePseudoHeader    = ":scheme"
+)
+
+var (
+	// list of pseusdo htt2 headers from https://tools.ietf.org/html/rfc7540#section-8.1.2.3
+	_http2PseudoHeaders = []string{
+		_http2AuthorityPseudoHeader,
+		_http2MethodPseudoHeader,
+		_http2PathPseudoHeader,
+		_http2SchemePseudoHeader,
+	}
+)

--- a/transport/http/header.go
+++ b/transport/http/header.go
@@ -71,8 +71,7 @@ func (hm headerMapper) FromHTTPHeaders(from http.Header, to transport.Headers) t
 
 func (hm headerMapper) deleteHTTP2PseudoHeadersIfNeeded(from transport.Headers) transport.Headers {
 	// deleting all http2 pseudo-header fields
-	// RFC https://tools.ietf.org/html/rfc7540#section-8.1.2.3 does not mention
-	// what to do with those headers though.
+	// RFC https://tools.ietf.org/html/rfc7540#section-8.1.2.3
 	// :method -> this can be removed, YARPC uses POST for all HTTP requests.
 	// :path -> this can be removed, this is handled by YARPC with RPC-procedure.
 	// :scheme -> this can be removed, scheme is defined in the URI (http or https).

--- a/transport/http/header.go
+++ b/transport/http/header.go
@@ -78,9 +78,9 @@ func (hm headerMapper) deleteHTTP2PseudoHeadersIfNeeded(from transport.Headers) 
 	// :authority -> even if the RFC advises to copy :authority into host header, it is safe to remove it
 	// here. Host of the request is controlled through the YARPC outbound configuration.
 	for _, k := range _http2PseudoHeaders {
-		if _, ok := from.Get(k); ok {
+		if v, ok := from.Get(k); ok {
 			from.Del(k)
-			log.Printf("WARN: HTTP2 pseudo-header %s was deleted", k)
+			log.Printf("WARN: HTTP2 pseudo-header %s:%s was deleted", k, v)
 		}
 	}
 	return from

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -53,7 +53,18 @@ var (
 	_ introspection.IntrospectableOutbound = (*Outbound)(nil)
 )
 
-var defaultURLTemplate, _ = url.Parse("http://localhost")
+const http2AuthorityPseudoHeader = ":authority"
+
+var (
+	defaultURLTemplate, _ = url.Parse("http://localhost")
+	// from https://tools.ietf.org/html/rfc7540#section-8.1.2.3
+	http2PseudoHeaders = []string{
+		":method",
+		":scheme",
+		http2AuthorityPseudoHeader,
+		":path",
+	}
+)
 
 // OutboundOption customizes an HTTP Outbound.
 type OutboundOption func(*Outbound)
@@ -342,8 +353,23 @@ func (o *Outbound) createRequest(treq *transport.Request) (*http.Request, error)
 	if err != nil {
 		return nil, err
 	}
+	// grpc in, http out case
+	if treq.Transport == "grpc" {
+		// from https://tools.ietf.org/html/rfc7540#section-8.1.2.3
+		// For ":authority", ...
+		// An intermediary that converts an HTTP/2 request to HTTP/1.1 MUST
+		// create a Host header field if one is not present in a request by
+		// copying the value of the ":authority" pseudo-header field.
+		if v, ok := treq.Headers.Get(http2AuthorityPseudoHeader); ok {
+			hreq.Host = v
+		}
+		// strip all http2 pseud-header fields
+		for _, k := range http2PseudoHeaders {
+			treq.Headers.Del(k)
+		}
+	}
 	hreq.Header = applicationHeaders.ToHTTPHeaders(treq.Headers, nil)
-	return hreq, err
+	return hreq, nil
 }
 
 func (o *Outbound) withOpentracingSpan(ctx context.Context, req *http.Request, treq *transport.Request, start time.Time) (context.Context, *http.Request, opentracing.Span, error) {

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -343,7 +343,7 @@ func (o *Outbound) createRequest(treq *transport.Request) (*http.Request, error)
 	if err != nil {
 		return nil, err
 	}
-	// YARPC needs to omit the HTTP/2 pseudo headers when a HTTP/2 request (gRPC)
+	// YARPC needs to remove all the HTTP/2 pseudo headers when a HTTP/2 request (gRPC)
 	// was propagated from a YARPC transport middleware to a HTTP/1 service.
 	// It should be noted that net/http will return an error if a pseudo
 	// header is given along a HTTP/1 request.

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -348,18 +348,19 @@ func (o *Outbound) createRequest(treq *transport.Request) (*http.Request, error)
 	// It should be noted that net/http will return an error if a pseudo
 	// header is given along a HTTP/1 request.
 	// see: https://cs.opensource.google/go/x/net/+/c6fcb2db:http/httpguts/httplex.go;l=203
-	deleteHTTP2PseudoHeadersIfNeeded(treq)
-	hreq.Header = applicationHeaders.ToHTTPHeaders(treq.Headers, nil)
+	headers := deleteHTTP2PseudoHeadersIfNeeded(treq)
+	hreq.Header = applicationHeaders.ToHTTPHeaders(headers, nil)
 	return hreq, nil
 }
 
-func deleteHTTP2PseudoHeadersIfNeeded(from *transport.Request) {
+func deleteHTTP2PseudoHeadersIfNeeded(from *transport.Request) transport.Headers {
 	// Internally, YARPC uses the transport name gRPC for HTTP2 requests.
 	// There is no reference of http2 with transport.Request.
 	if from.Transport != grpc.TransportName {
-		return
+		return from.Headers
 	}
 
+	headers := from.Headers
 	// deleting all http2 pseudo-header fields
 	// RFC https://tools.ietf.org/html/rfc7540#section-8.1.2.3 does not mention
 	// what to do with those headers though.
@@ -369,8 +370,9 @@ func deleteHTTP2PseudoHeadersIfNeeded(from *transport.Request) {
 	// :authority -> even if the RFC advises to copy :authority into host header, it is safe to remove it
 	// here. Host of the request is controlled with the configuration.
 	for _, k := range _http2PseudoHeaders {
-		from.Headers.Del(k)
+		headers.Del(k)
 	}
+	return headers
 }
 
 func (o *Outbound) withOpentracingSpan(ctx context.Context, req *http.Request, treq *transport.Request, start time.Time) (context.Context, *http.Request, opentracing.Span, error) {

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -363,7 +363,7 @@ func (o *Outbound) createRequest(treq *transport.Request) (*http.Request, error)
 		if v, ok := treq.Headers.Get(http2AuthorityPseudoHeader); ok {
 			hreq.Host = v
 		}
-		// strip all http2 pseud-header fields
+		// strip all http2 pseudo-header fields
 		for _, k := range http2PseudoHeaders {
 			treq.Headers.Del(k)
 		}

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -360,7 +360,7 @@ func (o *Outbound) createRequest(treq *transport.Request) (*http.Request, error)
 		// An intermediary that converts an HTTP/2 request to HTTP/1.1 MUST
 		// create a Host header field if one is not present in a request by
 		// copying the value of the ":authority" pseudo-header field.
-		if v, ok := treq.Headers.Get(http2AuthorityPseudoHeader); ok {
+		if v, ok := treq.Headers.Get(http2AuthorityPseudoHeader); ok && hreq.Host == "" {
 			hreq.Host = v
 		}
 		// strip all http2 pseudo-header fields

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -343,43 +343,36 @@ func (o *Outbound) createRequest(treq *transport.Request) (*http.Request, error)
 	if err != nil {
 		return nil, err
 	}
-
 	// YARPC needs to omit the HTTP/2 pseudo headers when a HTTP/2 request (gRPC)
 	// was propagated from a YARPC transport middleware to a HTTP/1 service.
 	// It should be noted that net/http will return an error if a pseudo
 	// header is given along a HTTP/1 request.
 	// see: https://cs.opensource.google/go/x/net/+/c6fcb2db:http/httpguts/httplex.go;l=203
-	hreq = omitHTTP2PseudoHeadersIfNeeded(treq, hreq)
-	hreq.Header = applicationHeaders.ToHTTPHeaders(treq.Headers, nil)
+	headers := deleteHTTP2PseudoHeadersIfNeeded(treq)
+	hreq.Header = applicationHeaders.ToHTTPHeaders(headers, nil)
 	return hreq, nil
 }
 
-func omitHTTP2PseudoHeadersIfNeeded(treq *transport.Request, hreq *http.Request) *http.Request {
+func deleteHTTP2PseudoHeadersIfNeeded(from *transport.Request) transport.Headers {
 	// Internally, YARPC uses the transport name gRPC for HTTP2 requests.
 	// There is no reference of http2 with transport.Request.
-	if treq.Transport != grpc.TransportName {
-		return hreq
+	if from.Transport != grpc.TransportName {
+		return from.Headers
 	}
 
-	// from https://tools.ietf.org/html/rfc7540#section-8.1.2.3
-	// For ":authority", ...
-	// An intermediary that converts an HTTP/2 request to HTTP/1.1 MUST
-	// create a Host header field if one is not present in a request by
-	// copying the value of the ":authority" pseudo-header field.
-	if v, ok := treq.Headers.Get(_http2AuthorityPseudoHeader); ok && hreq.Host == "" {
-		hreq.Host = v
-	}
-	// deleting all other http2 pseudo-header fields
+	// deleting all http2 pseudo-header fields
 	// RFC https://tools.ietf.org/html/rfc7540#section-8.1.2.3 does not mention
 	// what to do with those headers though.
 	// :method -> this can be removed, YARPC uses POST for all HTTP requests.
 	// :path -> this can be removed, this is handled by YARPC with RPC-procedure.
 	// :scheme -> this can be removed, scheme is defined in the URI (http or https).
+	// :authority -> even if the RFC advises to copy :authority into host, it is safe to remove it
+	// here. Host of the request is controlled with the configuration.
 	for _, k := range _http2PseudoHeaders {
-		treq.Headers.Del(k)
+		from.Headers.Del(k)
 	}
 
-	return hreq
+	return from.Headers
 }
 
 func (o *Outbound) withOpentracingSpan(ctx context.Context, req *http.Request, treq *transport.Request, start time.Time) (context.Context, *http.Request, opentracing.Span, error) {

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -371,8 +371,6 @@ func deleteHTTP2PseudoHeadersIfNeeded(from *transport.Request) {
 	for _, k := range _http2PseudoHeaders {
 		from.Headers.Del(k)
 	}
-
-	return
 }
 
 func (o *Outbound) withOpentracingSpan(ctx context.Context, req *http.Request, treq *transport.Request, start time.Time) (context.Context, *http.Request, opentracing.Span, error) {

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -366,7 +366,7 @@ func deleteHTTP2PseudoHeadersIfNeeded(from *transport.Request) {
 	// :method -> this can be removed, YARPC uses POST for all HTTP requests.
 	// :path -> this can be removed, this is handled by YARPC with RPC-procedure.
 	// :scheme -> this can be removed, scheme is defined in the URI (http or https).
-	// :authority -> even if the RFC advises to copy :authority into host, it is safe to remove it
+	// :authority -> even if the RFC advises to copy :authority into host header, it is safe to remove it
 	// here. Host of the request is controlled with the configuration.
 	for _, k := range _http2PseudoHeaders {
 		from.Headers.Del(k)

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -348,16 +348,16 @@ func (o *Outbound) createRequest(treq *transport.Request) (*http.Request, error)
 	// It should be noted that net/http will return an error if a pseudo
 	// header is given along a HTTP/1 request.
 	// see: https://cs.opensource.google/go/x/net/+/c6fcb2db:http/httpguts/httplex.go;l=203
-	headers := deleteHTTP2PseudoHeadersIfNeeded(treq)
-	hreq.Header = applicationHeaders.ToHTTPHeaders(headers, nil)
+	deleteHTTP2PseudoHeadersIfNeeded(treq)
+	hreq.Header = applicationHeaders.ToHTTPHeaders(treq.Headers, nil)
 	return hreq, nil
 }
 
-func deleteHTTP2PseudoHeadersIfNeeded(from *transport.Request) transport.Headers {
+func deleteHTTP2PseudoHeadersIfNeeded(from *transport.Request) {
 	// Internally, YARPC uses the transport name gRPC for HTTP2 requests.
 	// There is no reference of http2 with transport.Request.
 	if from.Transport != grpc.TransportName {
-		return from.Headers
+		return
 	}
 
 	// deleting all http2 pseudo-header fields
@@ -372,7 +372,7 @@ func deleteHTTP2PseudoHeadersIfNeeded(from *transport.Request) transport.Headers
 		from.Headers.Del(k)
 	}
 
-	return from.Headers
+	return
 }
 
 func (o *Outbound) withOpentracingSpan(ctx context.Context, req *http.Request, treq *transport.Request, start time.Time) (context.Context, *http.Request, opentracing.Span, error) {

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -689,7 +689,7 @@ func TestGRPCInHTTPOut(t *testing.T) {
 			defer req.Body.Close()
 			h := req.Header
 			// make sure all pesudo-header fields are unset
-			for _, k := range http2PseudoHeaders {
+			for _, k := range _http2PseudoHeaders {
 				assert.Zero(t, h.Get(k))
 			}
 			// Host field came from ":authority" pesudo-header field

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -692,8 +692,6 @@ func TestGRPCInHTTPOut(t *testing.T) {
 			for _, k := range _http2PseudoHeaders {
 				assert.Zero(t, h.Get(k))
 			}
-			// Host field came from ":authority" pesudo-header field
-			assert.Equal(t, "test-authority", req.Host)
 			// other application header are still set and prefixed
 			assert.Equal(t, "app-val1", h.Get("Rpc-Header-app-key1"))
 			_, err := w.Write([]byte("http header return"))

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -688,12 +688,14 @@ func TestGRPCInHTTPOut(t *testing.T) {
 		func(w http.ResponseWriter, req *http.Request) {
 			defer req.Body.Close()
 			h := req.Header
-			// make sure all pesudo fields are reset
+			// make sure all pesudo-header fields are unset
 			for _, k := range http2PseudoHeaders {
 				assert.Zero(t, h.Get(k))
 			}
-			assert.Equal(t, "app-val1", h.Get("Rpc-Header-app-key1"))
+			// Host field came from ":authority" pesudo-header field
 			assert.Equal(t, "test-authority", req.Host)
+			// other application header are still set and prefixed
+			assert.Equal(t, "app-val1", h.Get("Rpc-Header-app-key1"))
 			_, err := w.Write([]byte("http header return"))
 			assert.NoError(t, err)
 		},

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -683,6 +683,47 @@ func TestServiceMatchSuccess(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestGRPCInHTTPOut(t *testing.T) {
+	matchServer := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, req *http.Request) {
+			defer req.Body.Close()
+			h := req.Header
+			// make sure all pesudo fields are reset
+			for _, k := range http2PseudoHeaders {
+				assert.Zero(t, h.Get(k))
+			}
+			assert.Equal(t, "app-val1", h.Get("Rpc-Header-app-key1"))
+			assert.Equal(t, "test-authority", req.Host)
+			_, err := w.Write([]byte("http header return"))
+			assert.NoError(t, err)
+		},
+	))
+	defer matchServer.Close()
+
+	httpTransport := NewTransport()
+	defer httpTransport.Stop()
+	out := httpTransport.NewSingleOutbound(matchServer.URL)
+	require.NoError(t, out.Start(), "failed to start outbound")
+	defer out.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
+	defer cancel()
+	_, err := out.Call(ctx, &transport.Request{
+		Service:   "Service",
+		Transport: "grpc",
+		Headers: transport.HeadersFromMap(
+			map[string]string{
+				"app-key1":   "app-val1",
+				":authority": "test-authority",
+				":method":    "PUT",
+				":path":      "www.example.com",
+				":scheme":    "http",
+			},
+		),
+	})
+	require.NoError(t, err)
+}
+
 func TestServiceMatchFailed(t *testing.T) {
 	mismatchServer := httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
- [x] Description and context for reviewers: one partner, one stranger

In case grpc inbound (HTTP/2) ->  http outbound (HTTP/1) (for instance with a YARPC middleware), and the request contains http2 specific pseudo-header fields, the http outbound call will fail. 

All pseudo-headers are being removed for the request.

The added test will fail before the fix:

```
--- FAIL: TestGRPCInHTTPOut (0.00s)
    outbound_test.go:676:
        	Error Trace:	outbound_test.go:676
        	Error:      	Received unexpected error:
        	            	code:unknown message:unknown error from http client: Post "http://127.0.0.1:63722": net/http: invalid header field name "Rpc-Header-:path"
        	Test:       	TestGRPCInHTTPOut
```

It should be noted that this fix will be harmless for services. net/http rejects already header with rune `:`. With this diff, in the worst case we let more request to go.

- [x] Entry in CHANGELOG.md

Note: this is a duplicate of https://github.com/yarpc/yarpc-go/pull/2026 with refactoring, rebase and more comments