### PR TITLE
default to thriftrw nowire for both client and server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
 - Bump minimum version of go.uber.org/thriftrw to v1.29.2.
+- Default to thriftrw NoWire for both client and server.
 
 ## [1.57.1] - 2021-09-31
 ### Changed

--- a/encoding/thrift/outbound_nowire.go
+++ b/encoding/thrift/outbound_nowire.go
@@ -75,7 +75,9 @@ func NewNoWire(c Config, opts ...ClientOption) NoWireClient {
 	// So Config is really the internal config as far as consumers of the
 	// generated client are concerned.
 
-	var cc clientConfig
+	// default NoWire to true because this is the our final state to achieve
+	// but we still allow users to opt out by overriding NoWire to false.
+	cc := clientConfig{NoWire: true}
 	for _, opt := range opts {
 		opt.applyClientOption(&cc)
 	}

--- a/encoding/thrift/register.go
+++ b/encoding/thrift/register.go
@@ -85,7 +85,9 @@ type Service struct {
 // BuildProcedures builds a list of Procedures from a Thrift service
 // specification.
 func BuildProcedures(s Service, opts ...RegisterOption) []transport.Procedure {
-	var rc registerConfig
+	// default NoWire to true because this is the our final state to achieve
+	// but we still allow users to opt out by overriding NoWire to false.
+	rc := registerConfig{NoWire: true}
 	for _, opt := range opts {
 		opt.applyRegisterOption(&rc)
 	}


### PR DESCRIPTION
- [X] Description and context for reviewers: one partner, one stranger
Before we were relying the zero value of bool to disable `NoWire` by default. This diff change the behavior to default to `NoWire`

- [X] Entry in CHANGELOG.md
default to thriftrw's nowire for both client and server