### PR TITLE
Increase latency histogram buckets upto 120 seconds

### DIFF
--- a/internal/observability/graph.go
+++ b/internal/observability/graph.go
@@ -38,7 +38,9 @@ var (
 	_defaultGraphSize = 128
 	// Latency buckets for histograms. At some point, we may want to make these
 	// configurable.
-	_bucketsMs = bucket.NewRPCLatency()
+	_bucketsMs = append(bucket.NewRPCLatency(),
+		20000, 30000, 40000, 50000, 60000, 70000, 80000, 90000, 100000, 110000, 120000,
+	)
 	// Bytes buckets for payload size histograms, containing exponential buckets
 	// in range of 0B, 1B, 2B, ... 256MB.
 	_bucketsBytes = append([]int64{0}, bucket.NewExponential(1, 2, 29)...)

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -1920,7 +1920,7 @@ func TestUnaryInboundApplicationErrors(t *testing.T) {
 func TestMiddlewareSuccessSnapshot(t *testing.T) {
 	timeVal := time.Now()
 	defer stubTimeWithTimeVal(timeVal)()
-	ttlMs := int64(1000)
+	ttlMs := int64(119999)
 	root := metrics.New()
 	meter := root.Scope()
 	mw := NewMiddleware(Config{
@@ -2117,7 +2117,7 @@ func TestMiddlewareSuccessSnapshotWithTagsFiltered(t *testing.T) {
 				Name:   "ttl_ms",
 				Tags:   tags,
 				Unit:   time.Millisecond,
-				Values: []int64{ttlMs},
+				Values: []int64{120000},
 			},
 		},
 	}


### PR DESCRIPTION
Latency buckets are currently limited to up to 10s, any endpoint that takes longer than 10s goes to the infinite bucket. This change increases the buckets in intervals of 10s,  up to 120s.

- [X] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [X] Entry in CHANGELOG.md
