### PR TITLE
Support configuration of histogram latency buckets

### DIFF
--- a/config.go
+++ b/config.go
@@ -157,6 +157,9 @@ type MetricsConfig struct {
 	// TagsBlocklist enlists tags' keys that should be suppressed from all the metrics
 	// emitted from w/in YARPC middleware.
 	TagsBlocklist []string
+	// LatencyBucketsMs is a ordered list of latency buckets in milliseconds used
+	// for all the latency histograms emitted w/in YARPC observability middleware.
+	LatencyBucketsMs []int64
 }
 
 func (c MetricsConfig) scope(name string, logger *zap.Logger) (*metrics.Scope, context.CancelFunc) {

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -107,6 +107,7 @@ func addObservingMiddleware(cfg Config, meter *metrics.Scope, logger *zap.Logger
 		Scope:               meter,
 		ContextExtractor:    extractor,
 		MetricTagsBlocklist: cfg.Metrics.TagsBlocklist,
+		LatencyBucketsMs:    cfg.Metrics.LatencyBucketsMs,
 		Levels: observability.LevelsConfig{
 			Default: observability.DirectionalLevelsConfig{
 				Success:          cfg.Logging.Levels.Success,

--- a/internal/observability/graph_test.go
+++ b/internal/observability/graph_test.go
@@ -49,11 +49,11 @@ func TestEdgeNopFallbacks(t *testing.T) {
 	var tagsBlocklist []string
 
 	// Should succeed, covered by middleware tests.
-	_ = newEdge(zap.NewNop(), meter, tagsBlocklist, req, string(_directionOutbound), transport.Unary)
+	_ = newEdge(zap.NewNop(), meter, tagsBlocklist, req, string(_directionOutbound), transport.Unary, nil)
 
 	// Should fall back to no-op metrics.
 	// Usage of nil metrics should not panic, should not observe changes.
-	e := newEdge(zap.NewNop(), meter, tagsBlocklist, req, string(_directionOutbound), transport.Unary)
+	e := newEdge(zap.NewNop(), meter, tagsBlocklist, req, string(_directionOutbound), transport.Unary, nil)
 
 	e.calls.Inc()
 	assert.Equal(t, int64(0), e.calls.Load(), "Expected to fall back to no-op metrics.")

--- a/internal/observability/middleware.go
+++ b/internal/observability/middleware.go
@@ -94,6 +94,10 @@ type Config struct {
 	// metrics emitted by the middleware.
 	MetricTagsBlocklist []string
 
+	// LatencyBucketsMs is a ordered list of latency buckets in milliseconds used
+	// by the middleware for all the latency histograms.
+	LatencyBucketsMs []int64
+
 	// ContextExtractor Extracts request-scoped information from the context for logging.
 	ContextExtractor ContextExtractor
 
@@ -147,7 +151,7 @@ type DirectionalLevelsConfig struct {
 // NewMiddleware constructs an observability middleware with the provided
 // configuration.
 func NewMiddleware(cfg Config) *Middleware {
-	m := &Middleware{newGraph(cfg.Scope, cfg.Logger, cfg.ContextExtractor, cfg.MetricTagsBlocklist)}
+	m := &Middleware{newGraph(cfg)}
 
 	// Apply the default levels
 	applyLogLevelsConfig(&m.graph.inboundLevels, &cfg.Levels.Default)

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -1927,6 +1927,7 @@ func TestMiddlewareSuccessSnapshot(t *testing.T) {
 		Logger:           zap.NewNop(),
 		Scope:            meter,
 		ContextExtractor: NewNopContextExtractor(),
+		LatencyBucketsMs: []int64{1, 20000},
 	})
 
 	buf := bufferpool.Get()
@@ -2013,7 +2014,7 @@ func TestMiddlewareSuccessSnapshot(t *testing.T) {
 				Name:   "ttl_ms",
 				Tags:   tags,
 				Unit:   time.Millisecond,
-				Values: []int64{ttlMs},
+				Values: []int64{20000},
 			},
 		},
 	}

--- a/yarpcconfig/configurator_test.go
+++ b/yarpcconfig/configurator_test.go
@@ -362,6 +362,25 @@ func TestConfigurator(t *testing.T) {
 			},
 		},
 		{
+			desc: "latency buckets",
+			test: func(*testing.T, *gomock.Controller) (tt testCase) {
+				tt.serviceName = "foo"
+				tt.give = whitespace.Expand(`
+					metrics:
+						latencyBucketsMs: [1, 2, 3, 10, 100]
+				`)
+				tt.wantConfig = yarpc.Config{
+					Name: "foo",
+					Metrics: yarpc.MetricsConfig{
+						LatencyBucketsMs: []int64{
+							1, 2, 3, 10, 100,
+						},
+					},
+				}
+				return
+			},
+		},
+		{
 			desc: "application error, invalid type",
 			test: func(*testing.T, *gomock.Controller) (tt testCase) {
 				tt.give = whitespace.Expand(`

--- a/yarpcconfig/decode.go
+++ b/yarpcconfig/decode.go
@@ -40,12 +40,14 @@ type yarpcConfig struct {
 
 // metrics allows configuring the way metrics are emitted from YAML
 type metrics struct {
-	TagsBlocklist []string `config:"tagsBlocklist"`
+	TagsBlocklist    []string `config:"tagsBlocklist"`
+	LatencyBucketsMs []int64  `config:"latencyBucketsMs"`
 }
 
 // Fills values from this object into the provided YARPC config.
 func (m *metrics) fill(cfg *yarpc.Config) {
 	cfg.Metrics.TagsBlocklist = m.TagsBlocklist
+	cfg.Metrics.LatencyBucketsMs = m.LatencyBucketsMs
 }
 
 // logging allows configuring the log levels from YAML.


### PR DESCRIPTION
Latency buckets are a static list of buckets that cannot be configured by the application. With this change, users can pass a custom ordered list of buckets in milliseconds. These buckets will be used by all the histograms emitted from the yarpc observability middleware.

```
yarpc:
  metrics:
    latencyBucketsMs: [1, 2, 4, 8, 16, 1024]
```

- [X] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [X] Entry in CHANGELOG.md
