### PR TITLE
[encoding] add methods to expose original headers

### DIFF
--- a/api/encoding/call.go
+++ b/api/encoding/call.go
@@ -110,6 +110,21 @@ func (c *Call) Header(k string) string {
 	return ""
 }
 
+// OriginalHeaders returns a copy of the given request headers provided with the request.
+// The header key are not canonicalized and suitable for case-sensitive transport like TChannel.
+func (c *Call) OriginalHeaders() map[string]string {
+	if c == nil {
+		return nil
+	}
+
+	items := c.md.Headers().OriginalItems()
+	h := make(map[string]string, len(items))
+	for k, v := range items {
+		h[k] = v
+	}
+	return h
+}
+
 // HeaderNames returns a sorted list of the names of user defined headers
 // provided with this request.
 func (c *Call) HeaderNames() []string {

--- a/api/encoding/call_test.go
+++ b/api/encoding/call_test.go
@@ -44,6 +44,7 @@ func TestNilCall(t *testing.T) {
 	assert.Equal(t, "", call.CallerProcedure())
 	assert.Equal(t, "", call.Header("foo"))
 	assert.Empty(t, call.HeaderNames())
+	assert.Nil(t, call.OriginalHeaders())
 
 	assert.Error(t, call.WriteResponseHeader("foo", "bar"))
 }

--- a/api/encoding/call_test.go
+++ b/api/encoding/call_test.go
@@ -60,7 +60,8 @@ func TestReadFromRequest(t *testing.T) {
 		RoutingKey:      "rk",
 		RoutingDelegate: "rd",
 		CallerProcedure: "cp",
-		Headers:         transport.NewHeaders().With("foo", "bar"),
+		// later header's key/value takes precedence
+		Headers: transport.NewHeaders().With("Foo", "Bar").With("foo", "bar"),
 	})
 	call := CallFromContext(ctx)
 	require.NotNil(t, call)
@@ -74,6 +75,7 @@ func TestReadFromRequest(t *testing.T) {
 	assert.Equal(t, "rk", call.RoutingKey())
 	assert.Equal(t, "rd", call.RoutingDelegate())
 	assert.Equal(t, "bar", call.Header("foo"))
+	assert.Equal(t, map[string]string{"Foo": "Bar", "foo": "bar"}, call.OriginalHeaders())
 	assert.Equal(t, "cp", call.CallerProcedure())
 	assert.Len(t, call.HeaderNames(), 1)
 
@@ -94,7 +96,8 @@ func TestReadFromRequestMeta(t *testing.T) {
 		RoutingKey:      "rk",
 		RoutingDelegate: "rd",
 		CallerProcedure: "cp",
-		Headers:         transport.NewHeaders().With("foo", "bar"),
+		// later header's key/value takes precedence
+		Headers: transport.NewHeaders().With("Foo", "Bar").With("foo", "bar"),
 	})
 	call := CallFromContext(ctx)
 	require.NotNil(t, call)
@@ -109,6 +112,7 @@ func TestReadFromRequestMeta(t *testing.T) {
 	assert.Equal(t, "rd", call.RoutingDelegate())
 	assert.Equal(t, "cp", call.CallerProcedure())
 	assert.Equal(t, "bar", call.Header("foo"))
+	assert.Equal(t, map[string]string{"Foo": "Bar", "foo": "bar"}, call.OriginalHeaders())
 	assert.Len(t, call.HeaderNames(), 1)
 
 	assert.NoError(t, call.WriteResponseHeader("foo2", "bar2"))

--- a/call.go
+++ b/call.go
@@ -145,6 +145,12 @@ func (c *Call) Header(k string) string {
 	return (*encoding.Call)(c).Header(k)
 }
 
+// OriginalHeaders returns a copy of the given request headers provided with the request.
+// The header key are not canonicalized and suitable for case-sensitive transport like TChannel.
+func (c *Call) OriginalHeaders() map[string]string {
+	return (*encoding.Call)(c).OriginalHeaders()
+}
+
 // HeaderNames returns a sorted list of the names of user defined headers
 // provided with this request.
 func (c *Call) HeaderNames() []string {

--- a/call_test.go
+++ b/call_test.go
@@ -53,12 +53,13 @@ func TestCallFromContext(t *testing.T) {
 	ctx, inboundCall := encoding.NewInboundCall(context.Background())
 	err := inboundCall.ReadFromRequest(
 		&transport.Request{
-			Caller:          "foo",
-			Service:         "bar",
-			Transport:       "trans",
-			Encoding:        transport.Encoding("baz"),
-			Procedure:       "hello",
-			Headers:         transport.NewHeaders().With("foo", "bar"),
+			Caller:    "foo",
+			Service:   "bar",
+			Transport: "trans",
+			Encoding:  transport.Encoding("baz"),
+			Procedure: "hello",
+			// later header's key/value takes precedence
+			Headers:         transport.NewHeaders().With("Foo", "Bar").With("foo", "bar"),
 			ShardKey:        "one",
 			RoutingKey:      "two",
 			RoutingDelegate: "three",
@@ -73,6 +74,7 @@ func TestCallFromContext(t *testing.T) {
 	assert.Equal(t, transport.Encoding("baz"), call.Encoding())
 	assert.Equal(t, "hello", call.Procedure())
 	assert.Equal(t, "bar", call.Header("foo"))
+	assert.Equal(t, map[string]string{"Foo": "Bar", "foo": "bar"}, call.OriginalHeaders())
 	assert.Equal(t, []string{"foo"}, call.HeaderNames())
 	assert.Equal(t, "one", call.ShardKey())
 	assert.Equal(t, "two", call.RoutingKey())


### PR DESCRIPTION
We already made similar change in #1426 to store those original-case headers and plumbed into tchannel's implementation.

For TChannel(header is case-sensitive) proxying case working directly with tchannel-go, users need a way to access all the headers with its original case key. This PR adds a method in `Call` to users gets the baggage. We allocate a new map so the users can't mutate this state.
