### PR TITLE
V2 Protobuf Error APIs

### DIFF
--- a/encoding/protobuf/v2/error.go
+++ b/encoding/protobuf/v2/error.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Uber Technologies, Inc.
+// Copyright (c) 2022 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/encoding/protobuf/v2/error.go
+++ b/encoding/protobuf/v2/error.go
@@ -30,6 +30,7 @@ import (
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/grpcerrorcodes"
 	"go.uber.org/yarpc/yarpcerrors"
+	rpc_status "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/anypb"
 )
@@ -217,13 +218,13 @@ func convertFromYARPCError(encoding transport.Encoding, err error, codec *codec)
 	if yarpcErr.Details() == nil {
 		return err
 	}
-	st := &status.Status{}
-	unmarshalErr := unmarshalBytes(encoding, yarpcErr.Details(), st.Proto(), codec)
+	st := &rpc_status.Status{}
+	unmarshalErr := unmarshalBytes(encoding, yarpcErr.Details(), st, codec)
 	if unmarshalErr != nil {
 		return unmarshalErr
 	}
 
-	return newErrorWithDetails(yarpcErr.Code(), yarpcErr.Message(), st.Proto().GetDetails())
+	return newErrorWithDetails(yarpcErr.Code(), yarpcErr.Message(), st.GetDetails())
 }
 
 func newErrorWithDetails(code yarpcerrors.Code, message string, details []*any.Any) error {

--- a/encoding/protobuf/v2/error.go
+++ b/encoding/protobuf/v2/error.go
@@ -1,0 +1,246 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package v2
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes/any"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/grpcerrorcodes"
+	"go.uber.org/yarpc/yarpcerrors"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+const (
+	// format for converting error details to string
+	_errDetailsFmt = "[]{ %s }"
+	// format for converting a single message to string
+	_errDetailFmt = "%s{%s}"
+)
+
+var _ error = (*pberror)(nil)
+
+type pberror struct {
+	code    yarpcerrors.Code
+	message string
+	details []*any.Any
+}
+
+func (err *pberror) Error() string {
+	var b strings.Builder
+	b.WriteString("code:")
+	b.WriteString(err.code.String())
+	if err.message != "" {
+		b.WriteString(" message:")
+		b.WriteString(err.message)
+	}
+	return b.String()
+}
+
+// NewError returns a new YARPC protobuf error. To access the error's fields,
+// use the yarpcerrors package APIs for the code and message, and the
+// `GetErrorDetails(error)` function for error details. The `yarpcerrors.Details()`
+// will not work on this error.
+//
+// If the Code is CodeOK, this will return nil.
+func NewError(code yarpcerrors.Code, message string, options ...ErrorOption) error {
+	if code == yarpcerrors.CodeOK {
+		return nil
+	}
+	pbErr := &pberror{
+		code:    code,
+		message: message,
+	}
+	for _, opt := range options {
+		if err := opt.apply(pbErr); err != nil {
+			return err
+		}
+	}
+	return pbErr
+}
+
+// GetErrorDetails returns the error details of the error.
+//
+// This method supports extracting details from wrapped errors.
+//
+// Each element in the returned slice of interface{} is either a proto.Message
+// or an error to explain why the element is not a proto.Message, most likely
+// because the error detail could not be unmarshaled.
+func GetErrorDetails(err error) []interface{} {
+	var target *pberror
+	if errors.As(err, &target) && len(target.details) > 0 {
+		results := make([]interface{}, 0, len(target.details))
+		for _, ghAny := range target.details {
+			detail, err := ghAny.UnmarshalNew()
+			if err != nil {
+				results = append(results, err)
+				continue
+			}
+			results = append(results, detail)
+		}
+		return results
+	}
+	return nil
+}
+
+// ErrorOption is an option for the NewError constructor.
+type ErrorOption struct{ apply func(*pberror) error }
+
+// WithErrorDetails adds to the details of the error.
+// If any errors are encountered, it returns the first error encountered.
+func WithErrorDetails(details ...proto.Message) ErrorOption {
+	return ErrorOption{func(err *pberror) error {
+		for _, detail := range details {
+			any, terr := anypb.New(proto.MessageV2(detail))
+			if terr != nil {
+				return terr
+			}
+			err.details = append(err.details, any)
+		}
+		return nil
+	}}
+}
+
+// convertToYARPCError is to be used for handling errors on the inbound side.
+func convertToYARPCError(encoding transport.Encoding, err error, codec *codec, resw transport.ResponseWriter) error {
+	if err == nil {
+		return nil
+	}
+	var pberr *pberror
+	if errors.As(err, &pberr) {
+		setApplicationErrorMeta(pberr, resw)
+		status, sterr := createStatusWithDetail(pberr, encoding, codec)
+		if sterr != nil {
+			return sterr
+		}
+		return status
+	}
+	return err
+}
+
+func createStatusWithDetail(pberr *pberror, encoding transport.Encoding, codec *codec) (*yarpcerrors.Status, error) {
+	if pberr.code == yarpcerrors.CodeOK {
+		return nil, errors.New("no status error for error with code OK")
+	}
+
+	st := status.New(grpcerrorcodes.YARPCCodeToGRPCCode[pberr.code], pberr.message)
+	// Here we check that status.New has returned a valid error.
+	if st.Err() == nil {
+		return nil, fmt.Errorf("no status error for error with code %d", pberr.code)
+	}
+	pst := st.Proto()
+	pst.Details = pberr.details
+
+	detailsBytes, cleanup, marshalErr := marshal(encoding, pst, codec)
+	if marshalErr != nil {
+		return nil, marshalErr
+	}
+	defer cleanup()
+	yarpcDet := make([]byte, len(detailsBytes))
+	copy(yarpcDet, detailsBytes)
+	return yarpcerrors.Newf(pberr.code, pberr.message).WithDetails(yarpcDet), nil
+}
+
+func setApplicationErrorMeta(pberr *pberror, resw transport.ResponseWriter) {
+	applicationErroMetaSetter, ok := resw.(transport.ApplicationErrorMetaSetter)
+	if !ok {
+		return
+	}
+
+	decodedDetails := GetErrorDetails(pberr)
+	var appErrName string
+	if len(decodedDetails) > 0 { // only grab the first name since this will be emitted with metrics
+		decodedMsg := proto.MessageV2(decodedDetails[0].(proto.Message))
+		appErrName = messageNameWithoutPackage(string(decodedMsg.ProtoReflect().Descriptor().FullName()))
+	}
+
+	details := make([]string, 0, len(decodedDetails))
+	for _, detail := range decodedDetails {
+		details = append(details, protobufMessageToString(detail.(proto.Message)))
+	}
+
+	applicationErroMetaSetter.SetApplicationErrorMeta(&transport.ApplicationErrorMeta{
+		Name:    appErrName,
+		Details: fmt.Sprintf(_errDetailsFmt, strings.Join(details, " , ")),
+	})
+}
+
+// messageNameWithoutPackage strips the package name, returning just the type
+// name.
+//
+// For example:
+//  uber.foo.bar.TypeName -> TypeName
+func messageNameWithoutPackage(messageName string) string {
+	if i := strings.LastIndex(messageName, "."); i >= 0 {
+		return messageName[i+1:]
+	}
+	return messageName
+}
+
+func protobufMessageToString(message proto.Message) string {
+	newMsg := proto.MessageV2(message)
+	newMsg.ProtoReflect().Descriptor().FullName()
+	return fmt.Sprintf(_errDetailFmt,
+		messageNameWithoutPackage(proto.MessageName(message)),
+		proto.CompactTextString(message))
+}
+
+// convertFromYARPCError is to be used for handling errors on the outbound side.
+func convertFromYARPCError(encoding transport.Encoding, err error, codec *codec) error {
+	if err == nil || !yarpcerrors.IsStatus(err) {
+		return err
+	}
+	yarpcErr := yarpcerrors.FromError(err)
+	if yarpcErr.Details() == nil {
+		return err
+	}
+	st := &status.Status{}
+	unmarshalErr := unmarshalBytes(encoding, yarpcErr.Details(), st.Proto(), codec)
+	if unmarshalErr != nil {
+		return unmarshalErr
+	}
+
+	return newErrorWithDetails(yarpcErr.Code(), yarpcErr.Message(), st.Proto().GetDetails())
+}
+
+func newErrorWithDetails(code yarpcerrors.Code, message string, details []*any.Any) error {
+	return &pberror{
+		code:    code,
+		message: message,
+		details: details,
+	}
+}
+
+func (err *pberror) YARPCError() *yarpcerrors.Status {
+	if err == nil {
+		return nil
+	}
+	status, statusErr := createStatusWithDetail(err, Encoding, newCodec(nil))
+	if statusErr != nil {
+		return yarpcerrors.FromError(statusErr)
+	}
+	return status
+}

--- a/encoding/protobuf/v2/error_external_test.go
+++ b/encoding/protobuf/v2/error_external_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Uber Technologies, Inc.
+// Copyright (c) 2022 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/encoding/protobuf/v2/error_external_test.go
+++ b/encoding/protobuf/v2/error_external_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package v2_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes/wrappers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/encoding/protobuf/v2"
+	"go.uber.org/yarpc/yarpcerrors"
+)
+
+func TestGetDetailsFromWrappedError(t *testing.T) {
+	errDetail := &wrappers.BytesValue{Value: []byte("err detail bytes")}
+
+	pbErr := v2.NewError(
+		yarpcerrors.CodeAborted,
+		"aborted",
+		v2.WithErrorDetails(errDetail))
+
+	wrappedErr := fmt.Errorf("wrapped err 2: %w", fmt.Errorf("wrapped err 1: %w", pbErr))
+
+	details := v2.GetErrorDetails(wrappedErr)
+	require.Len(t, details, 1, "expected exactly one detail")
+	errDet := details[0].(proto.Message)
+	assert.True(t, proto.Equal(errDetail, errDet), "unexpected detail")
+}

--- a/encoding/protobuf/v2/error_test.go
+++ b/encoding/protobuf/v2/error_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Uber Technologies, Inc.
+// Copyright (c) 2022 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/encoding/protobuf/v2/error_test.go
+++ b/encoding/protobuf/v2/error_test.go
@@ -1,0 +1,274 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package v2
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes/any"
+	"github.com/golang/protobuf/ptypes/wrappers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/api/transport/transporttest"
+	"go.uber.org/yarpc/yarpcerrors"
+	rpc_status "google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestNewOK(t *testing.T) {
+	err := NewError(yarpcerrors.CodeOK, "okay")
+	assert.Nil(t, err)
+
+	assert.Equal(t, yarpcerrors.FromError(err).Code(), yarpcerrors.CodeOK)
+	assert.Equal(t, yarpcerrors.FromError(err).Message(), "")
+}
+
+func TestNew(t *testing.T) {
+	err := NewError(yarpcerrors.CodeNotFound, "unfounded accusation")
+	assert.Equal(t, yarpcerrors.FromError(err).Code(), yarpcerrors.CodeNotFound)
+	assert.Equal(t, yarpcerrors.FromError(err).Message(), "unfounded accusation")
+	assert.Contains(t, err.Error(), "unfounded accusation")
+}
+
+func TestForeignError(t *testing.T) {
+	err := errors.New("to err is go")
+	assert.Equal(t, yarpcerrors.FromError(err).Code(), yarpcerrors.CodeUnknown)
+	assert.Equal(t, yarpcerrors.FromError(err).Message(), "to err is go")
+}
+
+func TestConvertToYARPCErrorWithWrappedError(t *testing.T) {
+	errDetail := &wrappers.BytesValue{Value: []byte("err detail bytes")}
+
+	pbErr := NewError(
+		yarpcerrors.CodeAborted,
+		"aborted",
+		WithErrorDetails(errDetail))
+
+	wrappedErr := fmt.Errorf("wrapped err 2: %w", fmt.Errorf("wrapped err 1: %w", pbErr))
+
+	err := convertToYARPCError(Encoding, wrappedErr, &codec{}, nil /* resw */)
+	require.True(t, yarpcerrors.IsStatus(err), "unexpected error")
+	assert.Equal(t, yarpcerrors.FromError(err).Code(), yarpcerrors.CodeAborted, "unexpected err code")
+	assert.Equal(t, yarpcerrors.FromError(err).Message(), "aborted", "unexpected error message")
+
+	gotDetails := yarpcerrors.FromError(err).Details()
+	assert.NotEmpty(t, gotDetails, "no details marshaled")
+}
+
+func TestConvertToYARPCErrorApplicationErrorMeta(t *testing.T) {
+	errDetails := []proto.Message{
+		&wrappers.StringValue{Value: "detail message"},
+		&wrappers.Int32Value{Value: 42},
+		&wrappers.BytesValue{Value: []byte("detail bytes")},
+	}
+
+	pbErr := NewError(
+		yarpcerrors.CodeAborted,
+		"aborted",
+		WithErrorDetails(errDetails...))
+
+	resw := &transporttest.FakeResponseWriter{}
+	err := convertToYARPCError(Encoding, pbErr, &codec{}, resw)
+	require.Error(t, err)
+
+	require.NotNil(t, resw.ApplicationErrorMeta)
+	assert.Equal(t, "StringValue", resw.ApplicationErrorMeta.Name, "expected first error detail name")
+	assert.Equal(t,
+		`[]{ StringValue{value:"detail message" } , Int32Value{value:42 } , BytesValue{value:"detail bytes" } }`,
+		resw.ApplicationErrorMeta.Details,
+		"unexpected string of error details")
+	assert.Nil(t, resw.ApplicationErrorMeta.Code, "code should nil")
+}
+
+func TestMessageNameWithoutPackage(t *testing.T) {
+	tests := []struct {
+		name string
+		give string
+		want string
+	}{
+		{
+			name: "fqn",
+			give: "uber.foo.bar.baz.MessageName",
+			want: "MessageName",
+		},
+		{
+			name: "not fully qualified",
+			give: "MyMessage",
+			want: "MyMessage",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, messageNameWithoutPackage(tt.give), "unexpected trim")
+		})
+	}
+}
+
+type yarpcError interface{ YARPCError() *yarpcerrors.Status }
+
+func TestPbErrorToYARPCError(t *testing.T) {
+	tests := []struct {
+		name             string
+		code             yarpcerrors.Code
+		message          string
+		details          []proto.Message
+		expectedGRPCCode codes.Code
+	}{
+		{
+			name:             "pbError without details",
+			code:             yarpcerrors.CodeAborted,
+			message:          "simple test",
+			expectedGRPCCode: codes.Aborted,
+		},
+		{
+			name:             "pbError with single detail",
+			code:             yarpcerrors.CodeInternal,
+			message:          "internal error",
+			expectedGRPCCode: codes.Internal,
+			details: []proto.Message{
+				&wrappers.StringValue{Value: "test value"},
+			},
+		},
+		{
+			name:             "pbError with multiple details",
+			code:             yarpcerrors.CodeNotFound,
+			message:          "not found error",
+			expectedGRPCCode: codes.NotFound,
+			details: []proto.Message{
+				&wrappers.StringValue{Value: "test value"},
+				&wrappers.Int32Value{Value: 45},
+				&any.Any{Value: []byte{1, 2, 3, 4, 5}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var errOpts []ErrorOption
+			if len(tt.details) > 0 {
+				errOpts = append(errOpts, WithErrorDetails(tt.details...))
+			}
+			pberror := NewError(tt.code, tt.message, errOpts...)
+			st := pberror.(yarpcError).YARPCError()
+			assert.Equal(t, st.Code(), tt.code)
+			assert.Equal(t, st.Message(), tt.message)
+
+			statusPb := rpc_status.Status{}
+			err := proto.Unmarshal(st.Details(), &statusPb)
+			assert.NoError(t, err, "unexpected unmarshal error")
+
+			status := status.FromProto(&statusPb)
+			assert.Equal(t, tt.expectedGRPCCode, status.Code(), "unexpected grpc status code")
+			assert.Equal(t, tt.message, status.Message(), "unexpected grpc status message")
+			assert.Len(t, status.Details(), len(tt.details), "unexpected details length")
+			for i, detail := range tt.details {
+				assert.True(t, proto.Equal(detail,status.Details()[i].(proto.Message)))
+			}
+		})
+	}
+}
+
+func TestConvertToYARPCErrorWithIncorrectEncoding(t *testing.T) {
+	pberr := &pberror{code: yarpcerrors.CodeAborted, message: "test"}
+	err := convertToYARPCError("thrift", pberr, &codec{}, nil)
+	assert.Error(t, err, "unexpected empty error")
+	assert.Equal(t, err.Error(),
+		"code:internal message:encoding.Expect should have handled encoding \"thrift\" but did not")
+}
+
+func TestConvertFromYARPCError(t *testing.T) {
+	t.Run("incorrect encoding", func(t *testing.T) {
+		yerr := yarpcerrors.Newf(yarpcerrors.CodeAborted, "test").WithDetails([]byte{1, 2})
+		err := convertFromYARPCError("thrift", yerr, &codec{})
+		assert.Equal(t, err.Error(),
+			`code:internal message:encoding.Expect should have handled encoding "thrift" but did not`)
+	})
+	t.Run("empty details", func(t *testing.T) {
+		yerr := yarpcerrors.Newf(yarpcerrors.CodeAborted, "test")
+		err := convertFromYARPCError(Encoding, yerr, &codec{})
+		assert.Equal(t, err.Error(), "code:aborted message:test")
+	})
+}
+
+func TestCreateStatusWithDetailErrors(t *testing.T) {
+	t.Run("code ok", func(t *testing.T) {
+		pberr := &pberror{code: yarpcerrors.CodeOK, message: "test"}
+		_, err := createStatusWithDetail(pberr, Encoding, &codec{})
+		assert.Error(t, err, "unexpected empty error")
+		assert.Equal(t, err.Error(), "no status error for error with code OK")
+	})
+
+	t.Run("unsupported code", func(t *testing.T) {
+		pberr := &pberror{code: 99, message: "test"}
+		_, err := createStatusWithDetail(pberr, Encoding, &codec{})
+		assert.Error(t, err, "unexpected empty error")
+		assert.Equal(t, err.Error(), "no status error for error with code 99")
+	})
+
+	t.Run("unsupported encoding", func(t *testing.T) {
+		pberr := &pberror{code: yarpcerrors.CodeAborted}
+		_, err := createStatusWithDetail(pberr, "thrift", &codec{})
+		assert.Error(t, err, "unexpected empty error")
+		assert.Equal(t, err.Error(),
+			"code:internal message:encoding.Expect should have handled encoding \"thrift\" but did not")
+	})
+}
+
+func TestErrorHandling(t *testing.T) {
+	t.Run("GetErrorDetail empty error handling", func(t *testing.T) {
+		assert.Nil(t, GetErrorDetails(nil), "unexpected details")
+	})
+	t.Run("GetErrorDetail non pberror", func(t *testing.T) {
+		assert.Nil(t, GetErrorDetails(errors.New("test")), "unexpected details")
+	})
+	t.Run("GetErrorDetail with no error detail", func(t *testing.T) {
+		err := NewError(
+			yarpcerrors.CodeAborted,
+			"aborted")
+		assert.Nil(t, GetErrorDetails(err), "unexpected details")
+	})
+	t.Run("PbError empty error handling", func(t *testing.T) {
+		var pbErr *pberror
+		assert.Nil(t, pbErr.YARPCError(), "unexpected yarpcerror")
+	})
+	t.Run("PbError with nil detail message", func(t *testing.T) {
+		pbErr := &pberror{
+			details: []*any.Any{nil},
+		}
+		require.Len(t, GetErrorDetails(pbErr), 1)
+		assert.Equal(t, strings.ReplaceAll(GetErrorDetails(pbErr)[0].(error).Error(), "\u00a0", " "),
+			fmt.Errorf("proto: invalid empty type URL").Error())
+	})
+	t.Run("NewError with nil error detail", func(t *testing.T) {
+		err := NewError(
+			yarpcerrors.CodeAborted,
+			"aborted",
+			WithErrorDetails([]proto.Message{nil}...))
+		assert.Equal(t, strings.ReplaceAll(err.Error(), "\u00a0", " "),
+			fmt.Errorf("proto: invalid nil source message").Error())
+	})
+}


### PR DESCRIPTION
- [ ] Description and context for reviewers: one partner, one stranger

This PR contains v2 error apis for protobuf encoding. It doesn't contain integration tests as they will require yarpc protobuf stubs generated with v2 plugin(which will be present in the next PRs).
