### PR TITLE
add an option to disable Rpc-Service response header for tchannel transport

### DIFF
--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -98,13 +98,13 @@ func (c tchannelCall) Response() inboundCallResponse {
 
 // handler wraps a transport.UnaryHandler into a TChannel Handler.
 type handler struct {
-	existing                map[string]tchannel.Handler
-	router                  transport.Router
-	tracer                  opentracing.Tracer
-	headerCase              headerCase
-	logger                  *zap.Logger
-	newResponseWriter       func(inboundCallResponse, tchannel.Format, headerCase) responseWriter
-	disableRpcServiceHeader bool
+	existing                       map[string]tchannel.Handler
+	router                         transport.Router
+	tracer                         opentracing.Tracer
+	headerCase                     headerCase
+	logger                         *zap.Logger
+	newResponseWriter              func(inboundCallResponse, tchannel.Format, headerCase) responseWriter
+	excludeServiceHeaderInResponse bool
 }
 
 func (h handler) Handle(ctx ncontext.Context, call *tchannel.InboundCall) {
@@ -116,7 +116,7 @@ func (h handler) handle(ctx context.Context, call inboundCall) {
 	responseWriter := h.newResponseWriter(call.Response(), call.Format(), h.headerCase)
 	defer responseWriter.ReleaseBuffer()
 
-	if !h.disableRpcServiceHeader {
+	if !h.excludeServiceHeaderInResponse {
 		// echo accepted rpc-service in response header
 		responseWriter.AddHeader(ServiceHeaderKey, call.ServiceName())
 	}

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -98,12 +98,13 @@ func (c tchannelCall) Response() inboundCallResponse {
 
 // handler wraps a transport.UnaryHandler into a TChannel Handler.
 type handler struct {
-	existing          map[string]tchannel.Handler
-	router            transport.Router
-	tracer            opentracing.Tracer
-	headerCase        headerCase
-	logger            *zap.Logger
-	newResponseWriter func(inboundCallResponse, tchannel.Format, headerCase) responseWriter
+	existing                map[string]tchannel.Handler
+	router                  transport.Router
+	tracer                  opentracing.Tracer
+	headerCase              headerCase
+	logger                  *zap.Logger
+	newResponseWriter       func(inboundCallResponse, tchannel.Format, headerCase) responseWriter
+	disableRpcServiceHeader bool
 }
 
 func (h handler) Handle(ctx ncontext.Context, call *tchannel.InboundCall) {
@@ -115,8 +116,10 @@ func (h handler) handle(ctx context.Context, call inboundCall) {
 	responseWriter := h.newResponseWriter(call.Response(), call.Format(), h.headerCase)
 	defer responseWriter.ReleaseBuffer()
 
-	// echo accepted rpc-service in response header
-	responseWriter.AddHeader(ServiceHeaderKey, call.ServiceName())
+	if !h.disableRpcServiceHeader {
+		// echo accepted rpc-service in response header
+		responseWriter.AddHeader(ServiceHeaderKey, call.ServiceName())
+	}
 
 	err := h.callHandler(ctx, call, responseWriter)
 

--- a/transport/tchannel/handler_test.go
+++ b/transport/tchannel/handler_test.go
@@ -809,7 +809,7 @@ func TestRpcServiceHeader(t *testing.T) {
 	hw := &handlerWriter{}
 	h := handler{
 		headerCase: canonicalizedHeaderCase,
-		newResponseWriter: func(_ inboundCallResponse, _ tchannel.Format, _ headerCase) responseWriter {
+		newResponseWriter: func(inboundCallResponse, tchannel.Format, headerCase) responseWriter {
 			return hw
 		},
 	}

--- a/transport/tchannel/handler_test.go
+++ b/transport/tchannel/handler_test.go
@@ -825,7 +825,7 @@ func TestRpcServiceHeader(t *testing.T) {
 	h.handle(ctx, call)
 	assert.Equal(t, expectedServiceHeader, hw.headers.OriginalItems()[ServiceHeaderKey])
 
-	h.disableRpcServiceHeader = true
+	h.excludeServiceHeaderInResponse = true
 	hw.headers.Del(ServiceHeaderKey)
 	h.handle(ctx, call)
 	assert.Equal(t, "", hw.headers.OriginalItems()[ServiceHeaderKey])

--- a/transport/tchannel/handler_test.go
+++ b/transport/tchannel/handler_test.go
@@ -805,6 +805,32 @@ func TestTruncatedHeader(t *testing.T) {
 	}
 }
 
+func TestRpcServiceHeader(t *testing.T) {
+	hw := &handlerWriter{}
+	h := handler{
+		headerCase: canonicalizedHeaderCase,
+		newResponseWriter: func(_ inboundCallResponse, _ tchannel.Format, _ headerCase) responseWriter {
+			return hw
+		},
+	}
+	resp := newResponseRecorder()
+	expectedServiceHeader := "foo"
+	call := &fakeInboundCall{
+		service: expectedServiceHeader,
+		resp:    resp,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	h.handle(ctx, call)
+	assert.Equal(t, expectedServiceHeader, hw.headers.OriginalItems()[ServiceHeaderKey])
+
+	h.disableRpcServiceHeader = true
+	hw.headers.Del(ServiceHeaderKey)
+	h.handle(ctx, call)
+	assert.Equal(t, "", hw.headers.OriginalItems()[ServiceHeaderKey])
+}
+
 type testUnaryHandler struct {
 	err error
 	fn  func()

--- a/transport/tchannel/options.go
+++ b/transport/tchannel/options.go
@@ -50,17 +50,18 @@ var _ Option = (TransportOption)(nil)
 // peer lists.
 // TODO update above when NewTransport is real.
 type transportOptions struct {
-	ch                    Channel
-	tracer                opentracing.Tracer
-	logger                *zap.Logger
-	addr                  string
-	listener              net.Listener
-	dialer                func(ctx context.Context, network, hostPort string) (net.Conn, error)
-	name                  string
-	connTimeout           time.Duration
-	connBackoffStrategy   backoffapi.Strategy
-	originalHeaders       bool
-	nativeTChannelMethods NativeTChannelMethods
+	ch                      Channel
+	tracer                  opentracing.Tracer
+	logger                  *zap.Logger
+	addr                    string
+	listener                net.Listener
+	dialer                  func(ctx context.Context, network, hostPort string) (net.Conn, error)
+	name                    string
+	connTimeout             time.Duration
+	connBackoffStrategy     backoffapi.Strategy
+	originalHeaders         bool
+	nativeTChannelMethods   NativeTChannelMethods
+	disableRpcServiceHeader bool
 }
 
 // newTransportOptions constructs the default transport options struct
@@ -218,5 +219,12 @@ type NativeTChannelMethods interface {
 func WithNativeTChannelMethods(nativeMethods NativeTChannelMethods) TransportOption {
 	return func(option *transportOptions) {
 		option.nativeTChannelMethods = nativeMethods
+	}
+}
+
+// WithDisableRpcServiceHeader disables adding the $rpc$-service header
+func WithDisableRpcServiceHeader() TransportOption {
+	return func(option *transportOptions) {
+		option.disableRpcServiceHeader = true
 	}
 }

--- a/transport/tchannel/options.go
+++ b/transport/tchannel/options.go
@@ -50,18 +50,18 @@ var _ Option = (TransportOption)(nil)
 // peer lists.
 // TODO update above when NewTransport is real.
 type transportOptions struct {
-	ch                      Channel
-	tracer                  opentracing.Tracer
-	logger                  *zap.Logger
-	addr                    string
-	listener                net.Listener
-	dialer                  func(ctx context.Context, network, hostPort string) (net.Conn, error)
-	name                    string
-	connTimeout             time.Duration
-	connBackoffStrategy     backoffapi.Strategy
-	originalHeaders         bool
-	nativeTChannelMethods   NativeTChannelMethods
-	disableRpcServiceHeader bool
+	ch                             Channel
+	tracer                         opentracing.Tracer
+	logger                         *zap.Logger
+	addr                           string
+	listener                       net.Listener
+	dialer                         func(ctx context.Context, network, hostPort string) (net.Conn, error)
+	name                           string
+	connTimeout                    time.Duration
+	connBackoffStrategy            backoffapi.Strategy
+	originalHeaders                bool
+	nativeTChannelMethods          NativeTChannelMethods
+	excludeServiceHeaderInResponse bool
 }
 
 // newTransportOptions constructs the default transport options struct
@@ -222,9 +222,9 @@ func WithNativeTChannelMethods(nativeMethods NativeTChannelMethods) TransportOpt
 	}
 }
 
-// DisableRpcServiceHeader disables adding the $rpc$-service header
-func DisableRpcServiceHeader() TransportOption {
+// ExcludeServiceHeaderInResponse stop adding the $rpc$-service response header for inbounds
+func ExcludeServiceHeaderInResponse() TransportOption {
 	return func(option *transportOptions) {
-		option.disableRpcServiceHeader = true
+		option.excludeServiceHeaderInResponse = true
 	}
 }

--- a/transport/tchannel/options.go
+++ b/transport/tchannel/options.go
@@ -222,8 +222,8 @@ func WithNativeTChannelMethods(nativeMethods NativeTChannelMethods) TransportOpt
 	}
 }
 
-// WithDisableRpcServiceHeader disables adding the $rpc$-service header
-func WithDisableRpcServiceHeader() TransportOption {
+// DisableRpcServiceHeader disables adding the $rpc$-service header
+func DisableRpcServiceHeader() TransportOption {
 	return func(option *transportOptions) {
 		option.disableRpcServiceHeader = true
 	}

--- a/transport/tchannel/transport.go
+++ b/transport/tchannel/transport.go
@@ -70,7 +70,8 @@ type Transport struct {
 
 	peers map[string]*tchannelPeer
 
-	nativeTChannelMethods NativeTChannelMethods
+	nativeTChannelMethods   NativeTChannelMethods
+	disableRpcServiceHeader bool
 }
 
 // NewTransport is a YARPC transport that facilitates sending and receiving
@@ -104,19 +105,20 @@ func (o transportOptions) newTransport() *Transport {
 		headerCase = originalHeaderCase
 	}
 	return &Transport{
-		once:                  lifecycle.NewOnce(),
-		name:                  o.name,
-		addr:                  o.addr,
-		listener:              o.listener,
-		dialer:                o.dialer,
-		connTimeout:           o.connTimeout,
-		connBackoffStrategy:   o.connBackoffStrategy,
-		peers:                 make(map[string]*tchannelPeer),
-		tracer:                o.tracer,
-		logger:                logger,
-		headerCase:            headerCase,
-		newResponseWriter:     newHandlerWriter,
-		nativeTChannelMethods: o.nativeTChannelMethods,
+		once:                    lifecycle.NewOnce(),
+		name:                    o.name,
+		addr:                    o.addr,
+		listener:                o.listener,
+		dialer:                  o.dialer,
+		connTimeout:             o.connTimeout,
+		connBackoffStrategy:     o.connBackoffStrategy,
+		peers:                   make(map[string]*tchannelPeer),
+		tracer:                  o.tracer,
+		logger:                  logger,
+		headerCase:              headerCase,
+		newResponseWriter:       newHandlerWriter,
+		nativeTChannelMethods:   o.nativeTChannelMethods,
+		disableRpcServiceHeader: o.disableRpcServiceHeader,
 	}
 }
 
@@ -209,11 +211,12 @@ func (t *Transport) start() error {
 	chopts := tchannel.ChannelOptions{
 		Tracer: t.tracer,
 		Handler: handler{
-			router:            t.router,
-			tracer:            t.tracer,
-			headerCase:        t.headerCase,
-			logger:            t.logger,
-			newResponseWriter: t.newResponseWriter,
+			router:                  t.router,
+			tracer:                  t.tracer,
+			headerCase:              t.headerCase,
+			logger:                  t.logger,
+			newResponseWriter:       t.newResponseWriter,
+			disableRpcServiceHeader: t.disableRpcServiceHeader,
 		},
 		OnPeerStatusChanged: t.onPeerStatusChanged,
 		Dialer:              t.dialer,

--- a/transport/tchannel/transport.go
+++ b/transport/tchannel/transport.go
@@ -70,8 +70,8 @@ type Transport struct {
 
 	peers map[string]*tchannelPeer
 
-	nativeTChannelMethods   NativeTChannelMethods
-	disableRpcServiceHeader bool
+	nativeTChannelMethods          NativeTChannelMethods
+	excludeServiceHeaderInResponse bool
 }
 
 // NewTransport is a YARPC transport that facilitates sending and receiving
@@ -105,20 +105,20 @@ func (o transportOptions) newTransport() *Transport {
 		headerCase = originalHeaderCase
 	}
 	return &Transport{
-		once:                    lifecycle.NewOnce(),
-		name:                    o.name,
-		addr:                    o.addr,
-		listener:                o.listener,
-		dialer:                  o.dialer,
-		connTimeout:             o.connTimeout,
-		connBackoffStrategy:     o.connBackoffStrategy,
-		peers:                   make(map[string]*tchannelPeer),
-		tracer:                  o.tracer,
-		logger:                  logger,
-		headerCase:              headerCase,
-		newResponseWriter:       newHandlerWriter,
-		nativeTChannelMethods:   o.nativeTChannelMethods,
-		disableRpcServiceHeader: o.disableRpcServiceHeader,
+		once:                           lifecycle.NewOnce(),
+		name:                           o.name,
+		addr:                           o.addr,
+		listener:                       o.listener,
+		dialer:                         o.dialer,
+		connTimeout:                    o.connTimeout,
+		connBackoffStrategy:            o.connBackoffStrategy,
+		peers:                          make(map[string]*tchannelPeer),
+		tracer:                         o.tracer,
+		logger:                         logger,
+		headerCase:                     headerCase,
+		newResponseWriter:              newHandlerWriter,
+		nativeTChannelMethods:          o.nativeTChannelMethods,
+		excludeServiceHeaderInResponse: o.excludeServiceHeaderInResponse,
 	}
 }
 
@@ -211,12 +211,12 @@ func (t *Transport) start() error {
 	chopts := tchannel.ChannelOptions{
 		Tracer: t.tracer,
 		Handler: handler{
-			router:                  t.router,
-			tracer:                  t.tracer,
-			headerCase:              t.headerCase,
-			logger:                  t.logger,
-			newResponseWriter:       t.newResponseWriter,
-			disableRpcServiceHeader: t.disableRpcServiceHeader,
+			router:                         t.router,
+			tracer:                         t.tracer,
+			headerCase:                     t.headerCase,
+			logger:                         t.logger,
+			newResponseWriter:              t.newResponseWriter,
+			excludeServiceHeaderInResponse: t.excludeServiceHeaderInResponse,
 		},
 		OnPeerStatusChanged: t.onPeerStatusChanged,
 		Dialer:              t.dialer,


### PR DESCRIPTION
Adding an option to disable adding $rpc$-service header for tchannel transport. The config (excludeServiceHeaderInResponse) is a TransportOption and by default it is false and preserves existing functionality. One would have to explicitly turn it on by using ExcludeServiceHeaderInResponse() transport option. If excludeServiceHeaderInResponse is set to true, the $rpc$-service header will not be added to response.

The $rpc$-service header does not play well if there are tchannel-go [inbound](https://github.com/yarpc/yarpc-go/blob/dev/transport/tchannel/header.go#L242-L243) servers in the call graph. The service name validation makes it very difficult to upgrade to yarpc. 