### PR TITLE
Added internal APIs for reading and writing a proto.Message from a stream

### DIFF
--- a/encoding/protobuf/v2/stream.go
+++ b/encoding/protobuf/v2/stream.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2022 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package v2
+
+import (
+	"bytes"
+	"context"
+
+	"go.uber.org/yarpc/api/transport"
+	"google.golang.org/protobuf/proto"
+)
+
+// readFromStream reads a proto.Message from a stream.
+func readFromStream(
+	ctx context.Context,
+	stream transport.Stream,
+	newMessage func() proto.Message,
+	codec *codec,
+) (proto.Message, error) {
+	streamMsg, err := stream.ReceiveMessage(ctx)
+	if err != nil {
+		return nil, convertFromYARPCError(Encoding, err, codec)
+	}
+	message := newMessage()
+	if err := unmarshal(stream.Request().Meta.Encoding, streamMsg.Body, message, codec); err != nil {
+		streamMsg.Body.Close()
+		return nil, err
+	}
+	if streamMsg.Body != nil {
+		streamMsg.Body.Close()
+	}
+	return message, nil
+}
+
+// writeToStream writes a proto.Message to a stream.
+func writeToStream(ctx context.Context, stream transport.Stream, message proto.Message, codec *codec) error {
+	messageData, cleanup, err := marshal(stream.Request().Meta.Encoding, message, codec)
+	if err != nil {
+		return err
+	}
+	return stream.SendMessage(
+		ctx,
+		&transport.StreamMessage{
+			Body: readCloser{
+				Reader: bytes.NewReader(messageData),
+				closer: cleanup,
+			},
+			BodySize: len(messageData),
+		},
+	)
+}
+
+type readCloser struct {
+	*bytes.Reader
+	closer func()
+}
+
+func (r readCloser) Close() error {
+	r.closer()
+	return nil
+}

--- a/encoding/protobuf/v2/stream_unit_test.go
+++ b/encoding/protobuf/v2/stream_unit_test.go
@@ -57,7 +57,8 @@ func TestReadFromStreamDecodeError(t *testing.T) {
 	clientStream, err := transport.NewClientStream(stream)
 	require.NoError(t, err)
 
-	_, err = readFromStream(ctx, clientStream, func() proto.Message { return nil }, newCodec(nil /*AnyResolver*/))
+	_, err = readFromStream(ctx, clientStream, func() proto.Message { return nil },
+	newCodec(nil /*AnyResolver*/))
 
 	assert.Equal(t, wantErr, err)
 }
@@ -90,5 +91,6 @@ func TestWriteToStreamInvalidEncoding(t *testing.T) {
 
 	err = writeToStream(ctx, clientStream, nil, newCodec(nil /*AnyResolver*/))
 
-	assert.Equal(t, yarpcerrors.Newf(yarpcerrors.CodeInternal, "encoding.Expect should have handled encoding \"raw\" but did not"), err)
+	assert.Equal(t, yarpcerrors.Newf(yarpcerrors.CodeInternal,
+		"encoding.Expect should have handled encoding \"raw\" but did not"), err)
 }

--- a/encoding/protobuf/v2/stream_unit_test.go
+++ b/encoding/protobuf/v2/stream_unit_test.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2022 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package v2
+
+import (
+	"context"
+	"errors"
+	"io/ioutil"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/api/transport/transporttest"
+	"go.uber.org/yarpc/yarpcerrors"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestReadFromStreamDecodeError(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	ctx := context.Background()
+	wantErr := errors.New("error")
+
+	stream := transporttest.NewMockStreamCloser(mockCtrl)
+	stream.EXPECT().ReceiveMessage(ctx).Return(&transport.StreamMessage{
+		Body: ioutil.NopCloser(readErr{err: wantErr}),
+	}, nil)
+	stream.EXPECT().Request().Return(
+		&transport.StreamRequest{
+			Meta: &transport.RequestMeta{
+				Encoding: Encoding,
+			},
+		},
+	)
+
+	clientStream, err := transport.NewClientStream(stream)
+	require.NoError(t, err)
+
+	_, err = readFromStream(ctx, clientStream, func() proto.Message { return nil }, newCodec(nil /*AnyResolver*/))
+
+	assert.Equal(t, wantErr, err)
+}
+
+type readErr struct {
+	err error
+}
+
+func (r readErr) Read(p []byte) (n int, err error) {
+	return 0, r.err
+}
+
+func TestWriteToStreamInvalidEncoding(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	ctx := context.Background()
+
+	stream := transporttest.NewMockStreamCloser(mockCtrl)
+	stream.EXPECT().Request().Return(
+		&transport.StreamRequest{
+			Meta: &transport.RequestMeta{
+				Encoding: transport.Encoding("raw"),
+			},
+		},
+	)
+
+	clientStream, err := transport.NewClientStream(stream)
+	require.NoError(t, err)
+
+	err = writeToStream(ctx, clientStream, nil, newCodec(nil /*AnyResolver*/))
+
+	assert.Equal(t, yarpcerrors.Newf(yarpcerrors.CodeInternal, "encoding.Expect should have handled encoding \"raw\" but did not"), err)
+}


### PR DESCRIPTION
- [ ] Description and context for reviewers: one partner, one stranger

This diff aims to add APIs for reading and writing a proto.Message from a stream. This is almost similar to what we have in v1/gogo APIs currently. Integrations test will be added later once v2 plugin is merged.
