### PR TITLE
Added internal APIs for Inbound and Outbound

### DIFF
--- a/encoding/protobuf/v2/inbound.go
+++ b/encoding/protobuf/v2/inbound.go
@@ -1,0 +1,144 @@
+// Copyright (c) 2022 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package v2
+
+import (
+	"context"
+
+	apiencoding "go.uber.org/yarpc/api/encoding"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/pkg/errors"
+	"google.golang.org/protobuf/proto"
+)
+
+type unaryHandler struct {
+	handle     func(context.Context, proto.Message) (proto.Message, error)
+	newRequest func() proto.Message
+	codec      *codec
+}
+
+func newUnaryHandler(
+	handle func(context.Context, proto.Message) (proto.Message, error),
+	newRequest func() proto.Message,
+	codec *codec,
+) *unaryHandler {
+	return &unaryHandler{
+		handle:     handle,
+		newRequest: newRequest,
+		codec:      codec,
+	}
+}
+
+func (u *unaryHandler) Handle(ctx context.Context, transportRequest *transport.Request, responseWriter transport.ResponseWriter) error {
+	ctx, call, request, err := getProtoRequest(ctx, transportRequest, u.newRequest, u.codec)
+	if err != nil {
+		return err
+	}
+
+	response, appErr := u.handle(ctx, request)
+
+	if err := call.WriteToResponse(responseWriter); err != nil {
+		return err
+	}
+	var responseData []byte
+	var responseCleanup func()
+	if response != nil {
+		responseData, responseCleanup, err = marshal(transportRequest.Encoding, response, u.codec)
+		if responseCleanup != nil {
+			defer responseCleanup()
+		}
+		if err != nil {
+			return errors.ResponseBodyEncodeError(transportRequest, err)
+		}
+	}
+	_, err = responseWriter.Write(responseData)
+	if err != nil {
+		return err
+	}
+	if appErr != nil {
+		responseWriter.SetApplicationError()
+	}
+	return convertToYARPCError(transportRequest.Encoding, appErr, u.codec, responseWriter)
+}
+
+type onewayHandler struct {
+	handleOneway func(context.Context, proto.Message) error
+	newRequest   func() proto.Message
+	codec        *codec
+}
+
+func newOnewayHandler(
+	handleOneway func(context.Context, proto.Message) error,
+	newRequest func() proto.Message,
+	codec *codec,
+) *onewayHandler {
+	return &onewayHandler{
+		handleOneway: handleOneway,
+		newRequest:   newRequest,
+		codec:        codec,
+	}
+}
+
+func (o *onewayHandler) HandleOneway(ctx context.Context, transportRequest *transport.Request) error {
+	ctx, _, request, err := getProtoRequest(ctx, transportRequest, o.newRequest, o.codec)
+	if err != nil {
+		return err
+	}
+	return convertToYARPCError(transportRequest.Encoding, o.handleOneway(ctx, request), o.codec, nil /*responseWriter*/)
+}
+
+type streamHandler struct {
+	handle func(*ServerStream) error
+	codec  *codec
+}
+
+func newStreamHandler(handle func(*ServerStream) error) *streamHandler {
+	return &streamHandler{handle, newCodec(nil /*AnyResolver*/)}
+}
+
+func (s *streamHandler) HandleStream(stream *transport.ServerStream) error {
+	ctx, call := apiencoding.NewInboundCallWithOptions(stream.Context(), apiencoding.DisableResponseHeaders())
+	transportRequest := stream.Request()
+	if err := call.ReadFromRequestMeta(transportRequest.Meta); err != nil {
+		return err
+	}
+	protoStream := &ServerStream{
+		ctx:    ctx,
+		stream: stream,
+		codec:  s.codec,
+	}
+	return convertToYARPCError(transportRequest.Meta.Encoding, s.handle(protoStream), s.codec, nil /*responseWriter*/)
+}
+
+func getProtoRequest(ctx context.Context, transportRequest *transport.Request, newRequest func() proto.Message, codec *codec) (context.Context, *apiencoding.InboundCall, proto.Message, error) {
+	if err := errors.ExpectEncodings(transportRequest, Encoding, JSONEncoding); err != nil {
+		return nil, nil, nil, err
+	}
+	ctx, call := apiencoding.NewInboundCall(ctx)
+	if err := call.ReadFromRequest(transportRequest); err != nil {
+		return nil, nil, nil, err
+	}
+	request := newRequest()
+	if err := unmarshal(transportRequest.Encoding, transportRequest.Body, request, codec); err != nil {
+		return nil, nil, nil, errors.RequestBodyDecodeError(transportRequest, err)
+	}
+	return ctx, call, request, nil
+}

--- a/encoding/protobuf/v2/outbound.go
+++ b/encoding/protobuf/v2/outbound.go
@@ -1,0 +1,199 @@
+// Copyright (c) 2022 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package v2
+
+import (
+	"bytes"
+	"context"
+
+	"go.uber.org/yarpc"
+	apiencoding "go.uber.org/yarpc/api/encoding"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/pkg/encoding"
+	"go.uber.org/yarpc/pkg/errors"
+	"go.uber.org/yarpc/pkg/procedure"
+	"go.uber.org/yarpc/yarpcerrors"
+	"google.golang.org/protobuf/proto"
+)
+
+type client struct {
+	serviceName    string
+	outboundConfig *transport.OutboundConfig
+	encoding       transport.Encoding
+	codec          *codec
+}
+
+func newClient(serviceName string, clientConfig transport.ClientConfig, anyResolver AnyResolver, options ...ClientOption) *client {
+	outboundConfig := toOutboundConfig(clientConfig)
+	client := &client{
+		serviceName:    serviceName,
+		outboundConfig: outboundConfig,
+		encoding:       Encoding,
+		codec:          newCodec(anyResolver),
+	}
+	for _, option := range options {
+		option.apply(client)
+	}
+	return client
+}
+
+func toOutboundConfig(cc transport.ClientConfig) *transport.OutboundConfig {
+	if outboundConfig, ok := cc.(*transport.OutboundConfig); ok {
+		return outboundConfig
+	}
+	// If the config is not an *OutboundConfig we assume the only Outbound is
+	// unary and create our own outbound config.
+	// If there is no unary outbound, this function will panic, but, we're kinda
+	// stuck with that. (and why the hell are you passing a oneway-only client
+	// config to protobuf anyway?).
+	return &transport.OutboundConfig{
+		CallerName: cc.Caller(),
+		Outbounds: transport.Outbounds{
+			ServiceName: cc.Service(),
+			Unary:       cc.GetUnaryOutbound(),
+		},
+	}
+}
+
+func (c *client) Call(
+	ctx context.Context,
+	requestMethodName string,
+	request proto.Message,
+	newResponse func() proto.Message,
+	options ...yarpc.CallOption,
+) (proto.Message, error) {
+	ctx, call, transportRequest, cleanup, err := c.buildTransportRequest(ctx, requestMethodName, request, options)
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if err != nil {
+		return nil, err
+	}
+	unaryOutbound := c.outboundConfig.Outbounds.Unary
+	if unaryOutbound == nil {
+		return nil, yarpcerrors.InternalErrorf("no unary outbounds for OutboundConfig %s", c.outboundConfig.CallerName)
+	}
+	transportResponse, appErr := unaryOutbound.Call(ctx, transportRequest)
+	appErr = convertFromYARPCError(transportRequest.Encoding, appErr, c.codec)
+	if transportResponse == nil {
+		return nil, appErr
+	}
+	if transportResponse.Body != nil {
+		// thrift is not checking the error, should be consistent
+		defer transportResponse.Body.Close()
+	}
+	if _, err := call.ReadFromResponse(ctx, transportResponse); err != nil {
+		return nil, err
+	}
+	var response proto.Message
+	if transportResponse.Body != nil {
+		response = newResponse()
+		if err := unmarshal(transportRequest.Encoding, transportResponse.Body, response, c.codec); err != nil {
+			return nil, errors.ResponseBodyDecodeError(transportRequest, err)
+		}
+	}
+	return response, appErr
+}
+
+func (c *client) CallOneway(
+	ctx context.Context,
+	requestMethodName string,
+	request proto.Message,
+	options ...yarpc.CallOption,
+) (transport.Ack, error) {
+	ctx, _, transportRequest, cleanup, err := c.buildTransportRequest(ctx, requestMethodName, request, options)
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if err != nil {
+		return nil, err
+	}
+	onewayOutbound := c.outboundConfig.Outbounds.Oneway
+	if onewayOutbound == nil {
+		return nil, yarpcerrors.InternalErrorf("no oneway outbounds for OutboundConfig %s", c.outboundConfig.CallerName)
+	}
+	ack, err := onewayOutbound.CallOneway(ctx, transportRequest)
+	return ack, convertFromYARPCError(transportRequest.Encoding, err, c.codec)
+}
+
+func (c *client) buildTransportRequest(ctx context.Context, requestMethodName string, request proto.Message, options []yarpc.CallOption) (context.Context, *apiencoding.OutboundCall, *transport.Request, func(), error) {
+	transportRequest := &transport.Request{
+		Caller:    c.outboundConfig.CallerName,
+		Service:   c.outboundConfig.Outbounds.ServiceName,
+		Procedure: procedure.ToName(c.serviceName, requestMethodName),
+		Encoding:  c.encoding,
+	}
+	call := apiencoding.NewOutboundCall(encoding.FromOptions(options)...)
+	ctx, err := call.WriteToRequest(ctx, transportRequest)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	if transportRequest.Encoding != Encoding && transportRequest.Encoding != JSONEncoding {
+		return nil, nil, nil, nil, yarpcerrors.Newf(yarpcerrors.CodeInternal, "can only use encodings %q or %q, but %q was specified", Encoding, JSONEncoding, transportRequest.Encoding)
+	}
+	if request != nil {
+		requestData, cleanup, err := marshal(transportRequest.Encoding, request, c.codec)
+		if err != nil {
+			return nil, nil, nil, cleanup, errors.RequestBodyEncodeError(transportRequest, err)
+		}
+		if requestData != nil {
+			transportRequest.Body = bytes.NewReader(requestData)
+			transportRequest.BodySize = len(requestData)
+		}
+		return ctx, call, transportRequest, cleanup, nil
+	}
+	return ctx, call, transportRequest, nil, nil
+}
+
+func (c *client) CallStream(
+	ctx context.Context,
+	requestMethodName string,
+	opts ...yarpc.CallOption,
+) (*ClientStream, error) {
+	streamRequest := &transport.StreamRequest{
+		Meta: &transport.RequestMeta{
+			Caller:    c.outboundConfig.CallerName,
+			Service:   c.outboundConfig.Outbounds.ServiceName,
+			Procedure: procedure.ToName(c.serviceName, requestMethodName),
+			Encoding:  c.encoding,
+		},
+	}
+	call, err := apiencoding.NewStreamOutboundCall(encoding.FromOptions(opts)...)
+	if err != nil {
+		return nil, err
+	}
+	ctx, err = call.WriteToRequestMeta(ctx, streamRequest.Meta)
+	if err != nil {
+		return nil, err
+	}
+	if streamRequest.Meta.Encoding != Encoding && streamRequest.Meta.Encoding != JSONEncoding {
+		return nil, yarpcerrors.InternalErrorf("can only use encodings %q or %q, but %q was specified", Encoding, JSONEncoding, streamRequest.Meta.Encoding)
+	}
+	streamOutbound := c.outboundConfig.Outbounds.Stream
+	if streamOutbound == nil {
+		return nil, yarpcerrors.InternalErrorf("no stream outbounds for OutboundConfig %s", c.outboundConfig.CallerName)
+	}
+	stream, err := streamOutbound.CallStream(ctx, streamRequest)
+	if err != nil {
+		return nil, convertFromYARPCError(streamRequest.Meta.Encoding, err, c.codec)
+	}
+	return &ClientStream{stream: stream, codec: c.codec}, nil
+}

--- a/encoding/protobuf/v2/protobuf.go
+++ b/encoding/protobuf/v2/protobuf.go
@@ -1,0 +1,294 @@
+// Copyright (c) 2022 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package v2
+
+import (
+	"context"
+	"reflect"
+	"strings"
+
+	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/pkg/procedure"
+	"go.uber.org/yarpc/yarpcerrors"
+	"google.golang.org/protobuf/proto"
+)
+
+// UseJSON says to use the json encoding for client/server communication.
+var UseJSON ClientOption = useJSON{}
+
+// ***all below functions should only be called by generated code***
+
+// BuildProceduresParams contains the parameters for BuildProcedures.
+type BuildProceduresParams struct {
+	ServiceName         string
+	UnaryHandlerParams  []BuildProceduresUnaryHandlerParams
+	OnewayHandlerParams []BuildProceduresOnewayHandlerParams
+	StreamHandlerParams []BuildProceduresStreamHandlerParams
+}
+
+// BuildProceduresUnaryHandlerParams contains the parameters for a UnaryHandler for BuildProcedures.
+type BuildProceduresUnaryHandlerParams struct {
+	MethodName string
+	Handler    transport.UnaryHandler
+}
+
+// BuildProceduresOnewayHandlerParams contains the parameters for a OnewayHandler for BuildProcedures.
+type BuildProceduresOnewayHandlerParams struct {
+	MethodName string
+	Handler    transport.OnewayHandler
+}
+
+// BuildProceduresStreamHandlerParams contains the parameters for a StreamHandler for BuildProcedures.
+type BuildProceduresStreamHandlerParams struct {
+	MethodName string
+	Handler    transport.StreamHandler
+}
+
+// BuildProcedures builds the transport.Procedures.
+func BuildProcedures(params BuildProceduresParams) []transport.Procedure {
+	procedures := make([]transport.Procedure, 0, 2*(len(params.UnaryHandlerParams)+len(params.OnewayHandlerParams)))
+	for _, unaryHandlerParams := range params.UnaryHandlerParams {
+		procedures = append(
+			procedures,
+			transport.Procedure{
+				Name:        procedure.ToName(params.ServiceName, unaryHandlerParams.MethodName),
+				HandlerSpec: transport.NewUnaryHandlerSpec(unaryHandlerParams.Handler),
+				Encoding:    Encoding,
+			},
+			transport.Procedure{
+				Name:        procedure.ToName(params.ServiceName, unaryHandlerParams.MethodName),
+				HandlerSpec: transport.NewUnaryHandlerSpec(unaryHandlerParams.Handler),
+				Encoding:    JSONEncoding,
+			},
+		)
+	}
+	for _, onewayHandlerParams := range params.OnewayHandlerParams {
+		procedures = append(
+			procedures,
+			transport.Procedure{
+				Name:        procedure.ToName(params.ServiceName, onewayHandlerParams.MethodName),
+				HandlerSpec: transport.NewOnewayHandlerSpec(onewayHandlerParams.Handler),
+				Encoding:    Encoding,
+			},
+			transport.Procedure{
+				Name:        procedure.ToName(params.ServiceName, onewayHandlerParams.MethodName),
+				HandlerSpec: transport.NewOnewayHandlerSpec(onewayHandlerParams.Handler),
+				Encoding:    JSONEncoding,
+			},
+		)
+	}
+	for _, streamHandlerParams := range params.StreamHandlerParams {
+		procedures = append(
+			procedures,
+			transport.Procedure{
+				Name:        procedure.ToName(params.ServiceName, streamHandlerParams.MethodName),
+				HandlerSpec: transport.NewStreamHandlerSpec(streamHandlerParams.Handler),
+				Encoding:    Encoding,
+			},
+			transport.Procedure{
+				Name:        procedure.ToName(params.ServiceName, streamHandlerParams.MethodName),
+				HandlerSpec: transport.NewStreamHandlerSpec(streamHandlerParams.Handler),
+				Encoding:    JSONEncoding,
+			},
+		)
+	}
+	return procedures
+}
+
+// Client is a protobuf client.
+type Client interface {
+	Call(
+		ctx context.Context,
+		requestMethodName string,
+		request proto.Message,
+		newResponse func() proto.Message,
+		options ...yarpc.CallOption,
+	) (proto.Message, error)
+	CallOneway(
+		ctx context.Context,
+		requestMethodName string,
+		request proto.Message,
+		options ...yarpc.CallOption,
+	) (transport.Ack, error)
+}
+
+// StreamClient is a protobuf client with streaming.
+type StreamClient interface {
+	Client
+
+	CallStream(
+		ctx context.Context,
+		requestMethodName string,
+		opts ...yarpc.CallOption,
+	) (*ClientStream, error)
+}
+
+// ClientOption is an option for a new Client.
+type ClientOption interface {
+	apply(*client)
+}
+
+// ClientParams contains the parameters for creating a new Client.
+type ClientParams struct {
+	ServiceName  string
+	ClientConfig transport.ClientConfig
+	AnyResolver  AnyResolver
+	Options      []ClientOption
+}
+
+// NewClient creates a new client.
+func NewClient(params ClientParams) Client {
+	return newClient(params.ServiceName, params.ClientConfig, params.AnyResolver, params.Options...)
+}
+
+// NewStreamClient creates a new stream client.
+func NewStreamClient(params ClientParams) StreamClient {
+	return newClient(params.ServiceName, params.ClientConfig, params.AnyResolver, params.Options...)
+}
+
+// UnaryHandlerParams contains the parameters for creating a new UnaryHandler.
+type UnaryHandlerParams struct {
+	Handle      func(context.Context, proto.Message) (proto.Message, error)
+	NewRequest  func() proto.Message
+	AnyResolver AnyResolver
+}
+
+// NewUnaryHandler returns a new UnaryHandler.
+func NewUnaryHandler(params UnaryHandlerParams) transport.UnaryHandler {
+	return newUnaryHandler(
+		params.Handle,
+		params.NewRequest,
+		newCodec(params.AnyResolver),
+	)
+}
+
+// OnewayHandlerParams contains the parameters for creating a new OnewayHandler.
+type OnewayHandlerParams struct {
+	Handle      func(context.Context, proto.Message) error
+	NewRequest  func() proto.Message
+	AnyResolver AnyResolver
+}
+
+// NewOnewayHandler returns a new OnewayHandler.
+func NewOnewayHandler(params OnewayHandlerParams) transport.OnewayHandler {
+	return newOnewayHandler(
+		params.Handle,
+		params.NewRequest,
+		newCodec(params.AnyResolver),
+	)
+}
+
+// StreamHandlerParams contains the parameters for creating a new StreamHandler.
+type StreamHandlerParams struct {
+	Handle func(*ServerStream) error
+}
+
+// NewStreamHandler returns a new StreamHandler.
+func NewStreamHandler(params StreamHandlerParams) transport.StreamHandler {
+	return newStreamHandler(params.Handle)
+}
+
+// ClientBuilderOptions returns ClientOptions that yarpc.InjectClients should use for a
+// specific client given information about the field into which the client is being injected.
+func ClientBuilderOptions(_ transport.ClientConfig, structField reflect.StructField) []ClientOption {
+	var opts []ClientOption
+	for _, opt := range uniqueLowercaseStrings(strings.Split(structField.Tag.Get("proto"), ",")) {
+		switch opt {
+		case "json":
+			opts = append(opts, UseJSON)
+		}
+	}
+	return opts
+}
+
+// CastError returns an error saying that generated code could not properly cast a proto.Message to it's expected type.
+func CastError(expectedType proto.Message, actualType proto.Message) error {
+	return yarpcerrors.Newf(yarpcerrors.CodeInternal, "expected proto.Message to have type %T but had type %T", expectedType, actualType)
+}
+
+type useJSON struct{}
+
+func (useJSON) apply(client *client) {
+	client.encoding = JSONEncoding
+}
+
+func uniqueLowercaseStrings(s []string) []string {
+	m := make(map[string]bool, len(s))
+	for _, e := range s {
+		if e != "" {
+			m[strings.ToLower(e)] = true
+		}
+	}
+	c := make([]string, 0, len(m))
+	for key := range m {
+		c = append(c, key)
+	}
+	return c
+}
+
+// ClientStream is a protobuf-specific client stream.
+type ClientStream struct {
+	stream *transport.ClientStream
+	codec  *codec
+}
+
+// Context returns the context of the stream.
+func (c *ClientStream) Context() context.Context {
+	return c.stream.Context()
+}
+
+// Receive will receive a protobuf message from the client stream.
+func (c *ClientStream) Receive(newMessage func() proto.Message, options ...yarpc.StreamOption) (proto.Message, error) {
+	return readFromStream(context.Background(), c.stream, newMessage, c.codec)
+}
+
+// Send will send a protobuf message to the client stream.
+func (c *ClientStream) Send(message proto.Message, options ...yarpc.StreamOption) error {
+	return writeToStream(context.Background(), c.stream, message, c.codec)
+}
+
+// Close will close the protobuf stream.
+func (c *ClientStream) Close(options ...yarpc.StreamOption) error {
+	return c.stream.Close(context.Background())
+}
+
+// ServerStream is a protobuf-specific server stream.
+type ServerStream struct {
+	ctx    context.Context
+	stream *transport.ServerStream
+	codec  *codec
+}
+
+// Context returns the context of the stream.
+func (s *ServerStream) Context() context.Context {
+	return s.ctx
+}
+
+// Receive will receive a protobuf message from the server stream.
+func (s *ServerStream) Receive(newMessage func() proto.Message, options ...yarpc.StreamOption) (proto.Message, error) {
+	return readFromStream(context.Background(), s.stream, newMessage, s.codec)
+}
+
+// Send will send a protobuf message to the server stream.
+func (s *ServerStream) Send(message proto.Message, options ...yarpc.StreamOption) error {
+	return writeToStream(context.Background(), s.stream, message, s.codec)
+}

--- a/encoding/protobuf/v2/protobuf_test.go
+++ b/encoding/protobuf/v2/protobuf_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2022 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package v2
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/yarpc/yarpcerrors"
+)
+
+func TestCastError(t *testing.T) {
+	assert.Equal(t, yarpcerrors.CodeInternal, yarpcerrors.FromError(CastError(nil, nil)).Code())
+}
+
+func TestClientBuilderOptions(t *testing.T) {
+	assert.Nil(t, ClientBuilderOptions(nil, reflect.StructField{Tag: `service:"keyvalue"`}))
+	assert.Equal(t, []ClientOption{UseJSON}, ClientBuilderOptions(nil, reflect.StructField{Tag: `service:"keyvalue" proto:"json"`}))
+}
+
+func TestUniqueLowercaseStrings(t *testing.T) {
+	tests := []struct {
+		give []string
+		want []string
+	}{
+		{
+			give: []string{"foo", "bar", "baz"},
+			want: []string{"foo", "bar", "baz"},
+		},
+		{
+			give: []string{"foo", "BAR", "bAz"},
+			want: []string{"foo", "bar", "baz"},
+		},
+		{
+			give: []string{"foo", "BAR", "bAz", "bar"},
+			want: []string{"foo", "bar", "baz"},
+		},
+	}
+	for _, tt := range tests {
+		got := uniqueLowercaseStrings(tt.give)
+		sort.Strings(tt.want)
+		sort.Strings(got)
+		assert.Equal(t, tt.want, got)
+	}
+}

--- a/encoding/protobuf/v2/stream_unit_test.go
+++ b/encoding/protobuf/v2/stream_unit_test.go
@@ -58,7 +58,7 @@ func TestReadFromStreamDecodeError(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = readFromStream(ctx, clientStream, func() proto.Message { return nil },
-	newCodec(nil /*AnyResolver*/))
+		newCodec(nil /*AnyResolver*/))
 
 	assert.Equal(t, wantErr, err)
 }

--- a/encoding/protobuf/v2/stream_unit_test.go
+++ b/encoding/protobuf/v2/stream_unit_test.go
@@ -58,7 +58,7 @@ func TestReadFromStreamDecodeError(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = readFromStream(ctx, clientStream, func() proto.Message { return nil },
-		newCodec(nil /*AnyResolver*/))
+	newCodec(nil /*AnyResolver*/))
 
 	assert.Equal(t, wantErr, err)
 }


### PR DESCRIPTION
- [ ] Description and context for reviewers: one partner, one stranger

This diff aims to add APIs for Inbound and Outbound used by yarpc stubs(*yarpc.pb.go). Integrations test will be added later once v2 plugin is merged.