### PR TITLE
Add `AddHeader` for transport 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
-
+### Added
+- added `AddHeader` as a shorthand to add a single response header.
 
 ## [1.60.0] - 2022-02-03
 ### Added

--- a/transport/grpc/headers.go
+++ b/transport/grpc/headers.go
@@ -184,15 +184,20 @@ func metadataToApplicationErrorMeta(responseMD metadata.MD) *transport.Applicati
 // addApplicationHeaders adds the headers to md.
 func addApplicationHeaders(md metadata.MD, headers transport.Headers) error {
 	for header, value := range headers.Items() {
-		header = transport.CanonicalizeHeaderKey(header)
-		if isReserved(header) {
-			return yarpcerrors.InvalidArgumentErrorf("cannot use reserved header in application headers: %s", header)
-		}
-		if err := addToMetadata(md, header, value); err != nil {
+		if err := addApplicationHeader(md, header, value); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// addApplicationHeaders adds the header pair 'key': 'value' to 'md'.
+func addApplicationHeader(md metadata.MD, key, value string) error {
+	key = transport.CanonicalizeHeaderKey(key)
+	if isReserved(key) {
+		return yarpcerrors.InvalidArgumentErrorf("cannot use reserved header in application headers: %s", key)
+	}
+	return addToMetadata(md, key, value)
 }
 
 // getApplicationHeaders returns the headers from md without any reserved headers.

--- a/transport/grpc/response_writer.go
+++ b/transport/grpc/response_writer.go
@@ -61,6 +61,13 @@ func (r *responseWriter) AddHeaders(headers transport.Headers) {
 	r.headerErr = multierr.Combine(r.headerErr, addApplicationHeaders(r.md, headers))
 }
 
+func (r *responseWriter) AddHeader(key, value string) {
+	if r.md == nil {
+		r.md = metadata.New(nil)
+	}
+	r.headerErr = multierr.Combine(r.headerErr, addApplicationHeader(r.md, key, value))
+}
+
 func (r *responseWriter) SetApplicationError() {
 	r.AddSystemHeader(ApplicationErrorHeader, ApplicationErrorHeaderValue)
 }

--- a/transport/grpc/response_writer.go
+++ b/transport/grpc/response_writer.go
@@ -88,7 +88,7 @@ func (r *responseWriter) AddSystemHeader(key string, value string) {
 	if r.md == nil {
 		r.md = metadata.New(nil)
 	}
-	r.headerErr = multierr.Combine(r.headerErr, addToMetadata(r.md, key, value))
+	r.headerErr = multierr.Append(r.headerErr, addToMetadata(r.md, key, value))
 }
 
 func (r *responseWriter) Bytes() []byte {

--- a/transport/grpc/response_writer.go
+++ b/transport/grpc/response_writer.go
@@ -58,14 +58,14 @@ func (r *responseWriter) AddHeaders(headers transport.Headers) {
 	if r.md == nil {
 		r.md = metadata.New(nil)
 	}
-	r.headerErr = multierr.Combine(r.headerErr, addApplicationHeaders(r.md, headers))
+	r.headerErr = multierr.Append(r.headerErr, addApplicationHeaders(r.md, headers))
 }
 
 func (r *responseWriter) AddHeader(key, value string) {
 	if r.md == nil {
 		r.md = metadata.New(nil)
 	}
-	r.headerErr = multierr.Combine(r.headerErr, addApplicationHeader(r.md, key, value))
+	r.headerErr = multierr.Append(r.headerErr, addApplicationHeader(r.md, key, value))
 }
 
 func (r *responseWriter) SetApplicationError() {

--- a/transport/grpc/response_writer_test.go
+++ b/transport/grpc/response_writer_test.go
@@ -1,8 +1,10 @@
 package grpc
 
 import (
+	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/yarpc/api/transport"
 )
 
@@ -11,33 +13,85 @@ func Benchmark_ResponseWriter_AddHeaders(b *testing.B) {
 		rw := newResponseWriter()
 		for i := 0; i < b.N; i++ {
 			rw.AddHeaders(transport.NewHeadersWithCapacity(1).With(
-				"abc", "",
+				"foo"+strconv.Itoa(i), "bar",
 			))
 		}
+		assert.NoError(b, rw.headerErr)
+	})
+
+	b.Run("lowercase no-value", func(b *testing.B) {
+		rw := newResponseWriter()
+		for i := 0; i < b.N; i++ {
+			rw.AddHeaders(transport.NewHeadersWithCapacity(1).With(
+				"foo", "",
+			))
+		}
+		assert.NoError(b, rw.headerErr)
 	})
 
 	b.Run("titlecase", func(b *testing.B) {
 		rw := newResponseWriter()
 		for i := 0; i < b.N; i++ {
 			rw.AddHeaders(transport.NewHeadersWithCapacity(1).With(
-				"Abc", "",
+				"Foo"+strconv.Itoa(i), "bar",
 			))
 		}
+		assert.NoError(b, rw.headerErr)
 	})
+
+	b.Run("titlecase no-value", func(b *testing.B) {
+		rw := newResponseWriter()
+		for i := 0; i < b.N; i++ {
+			rw.AddHeaders(transport.NewHeadersWithCapacity(1).With(
+				"Foo", "",
+			))
+		}
+		assert.NoError(b, rw.headerErr)
+	})
+}
+
+func Test_addHeaders(t *testing.T) {
+	// t.Run("No ")
+	rw := newResponseWriter()
+	for i := 0; i < 10; i++ {
+		rw.AddHeaders(transport.NewHeadersWithCapacity(1).With(
+			"foo", "bar",
+		))
+	}
+	assert.NoError(t, rw.headerErr)
+
 }
 
 func Benchmark_ResponseWriter_AddHeader(b *testing.B) {
 	b.Run("lowercase", func(b *testing.B) {
 		rw := newResponseWriter()
 		for i := 0; i < b.N; i++ {
-			rw.AddHeader("abc", "")
+			rw.AddHeader("foo"+strconv.Itoa(i), "bar")
 		}
+		assert.NoError(b, rw.headerErr)
+	})
+
+	b.Run("lowercase no-value", func(b *testing.B) {
+		rw := newResponseWriter()
+		for i := 0; i < b.N; i++ {
+			rw.AddHeader("foo", "")
+		}
+		assert.NoError(b, rw.headerErr)
 	})
 
 	b.Run("titlecase", func(b *testing.B) {
 		rw := newResponseWriter()
 		for i := 0; i < b.N; i++ {
-			rw.AddHeader("Abc", "")
+			rw.AddHeader("Foo"+strconv.Itoa(i), "bar")
 		}
+		assert.NoError(b, rw.headerErr)
+	})
+
+	b.Run("titlecase no-value", func(b *testing.B) {
+		rw := newResponseWriter()
+		for i := 0; i < b.N; i++ {
+			rw.AddHeader("Foo", "")
+		}
+		assert.NoError(b, rw.headerErr)
 	})
 }

--- a/transport/grpc/response_writer_test.go
+++ b/transport/grpc/response_writer_test.go
@@ -1,0 +1,43 @@
+package grpc
+
+import (
+	"testing"
+
+	"go.uber.org/yarpc/api/transport"
+)
+
+func Benchmark_ResponseWriter_AddHeaders(b *testing.B) {
+	b.Run("lowercase", func(b *testing.B) {
+		rw := newResponseWriter()
+		for i := 0; i < b.N; i++ {
+			rw.AddHeaders(transport.NewHeadersWithCapacity(1).With(
+				"abc", "",
+			))
+		}
+	})
+
+	b.Run("titlecase", func(b *testing.B) {
+		rw := newResponseWriter()
+		for i := 0; i < b.N; i++ {
+			rw.AddHeaders(transport.NewHeadersWithCapacity(1).With(
+				"Abc", "",
+			))
+		}
+	})
+}
+
+func Benchmark_ResponseWriter_AddHeader(b *testing.B) {
+	b.Run("lowercase", func(b *testing.B) {
+		rw := newResponseWriter()
+		for i := 0; i < b.N; i++ {
+			rw.AddHeader("abc", "")
+		}
+	})
+
+	b.Run("titlecase", func(b *testing.B) {
+		rw := newResponseWriter()
+		for i := 0; i < b.N; i++ {
+			rw.AddHeader("Abc", "")
+		}
+	})
+}

--- a/transport/http/handler.go
+++ b/transport/http/handler.go
@@ -270,6 +270,10 @@ func (rw *responseWriter) AddHeaders(h transport.Headers) {
 	applicationHeaders.ToHTTPHeaders(h, rw.w.Header())
 }
 
+func (rw *responseWriter) AddHeader(k, v string) {
+	applicationHeaders.ToHTTPHeader(rw.w.Header(), k, v)
+}
+
 func (rw *responseWriter) SetApplicationError() {
 	rw.w.Header().Set(ApplicationStatusHeader, ApplicationErrorStatus)
 }

--- a/transport/http/handler_test.go
+++ b/transport/http/handler_test.go
@@ -460,7 +460,7 @@ func Benchmark_ResponseWriter_AddHeaders(b *testing.B) {
 		rw := newResponseWriter(recorder)
 		for i := 0; i < b.N; i++ {
 			rw.AddHeaders(transport.NewHeadersWithCapacity(1).With(
-				"abc", "",
+				"foo", "bar",
 			))
 		}
 	})
@@ -470,7 +470,17 @@ func Benchmark_ResponseWriter_AddHeaders(b *testing.B) {
 		rw := newResponseWriter(recorder)
 		for i := 0; i < b.N; i++ {
 			rw.AddHeaders(transport.NewHeadersWithCapacity(1).With(
-				"Abc", "",
+				"Foo", "bar",
+			))
+		}
+	})
+
+	b.Run("titlecase with rpc-header prefix", func(b *testing.B) {
+		recorder := httptest.NewRecorder()
+		rw := newResponseWriter(recorder)
+		for i := 0; i < b.N; i++ {
+			rw.AddHeaders(transport.NewHeadersWithCapacity(1).With(
+				"Rpc-Header-Foo", "bar",
 			))
 		}
 	})
@@ -481,7 +491,7 @@ func Benchmark_ResponseWriter_AddHeader(b *testing.B) {
 		recorder := httptest.NewRecorder()
 		rw := newResponseWriter(recorder)
 		for i := 0; i < b.N; i++ {
-			rw.AddHeader("abc", "")
+			rw.AddHeader("foo", "bar")
 		}
 	})
 
@@ -489,7 +499,15 @@ func Benchmark_ResponseWriter_AddHeader(b *testing.B) {
 		recorder := httptest.NewRecorder()
 		rw := newResponseWriter(recorder)
 		for i := 0; i < b.N; i++ {
-			rw.AddHeader("Abc", "")
+			rw.AddHeader("Foo", "bar")
+		}
+	})
+
+	b.Run("titlecase with rpc-header prefix", func(b *testing.B) {
+		recorder := httptest.NewRecorder()
+		rw := newResponseWriter(recorder)
+		for i := 0; i < b.N; i++ {
+			rw.AddHeader("Rpc-Header-Foo", "bar")
 		}
 	})
 }

--- a/transport/http/handler_test.go
+++ b/transport/http/handler_test.go
@@ -434,6 +434,7 @@ func TestResponseWriter(t *testing.T) {
 		"shard-key": "123",
 	})
 	writer.AddHeaders(headers)
+	writer.AddHeader("partition-key", "321")
 
 	writer.SetApplicationErrorMeta(&transport.ApplicationErrorMeta{
 		Details: appErrDetails,
@@ -447,6 +448,7 @@ func TestResponseWriter(t *testing.T) {
 
 	assert.Equal(t, "bar", recorder.Header().Get("rpc-header-foo"))
 	assert.Equal(t, "123", recorder.Header().Get("rpc-header-shard-key"))
+	assert.Equal(t, "321", recorder.Header().Get("rpc-header-partition-key"))
 	assert.Equal(t, "hello", recorder.Body.String())
 
 	assert.Equal(t, appErrDetails, recorder.Header().Get(_applicationErrorDetailsHeader))

--- a/transport/http/handler_test.go
+++ b/transport/http/handler_test.go
@@ -454,6 +454,46 @@ func TestResponseWriter(t *testing.T) {
 	assert.Equal(t, strconv.Itoa(int(appErrCode)), recorder.Header().Get(_applicationErrorCodeHeader))
 }
 
+func Benchmark_ResponseWriter_AddHeaders(b *testing.B) {
+	b.Run("lowercase", func(b *testing.B) {
+		recorder := httptest.NewRecorder()
+		rw := newResponseWriter(recorder)
+		for i := 0; i < b.N; i++ {
+			rw.AddHeaders(transport.NewHeadersWithCapacity(1).With(
+				"abc", "",
+			))
+		}
+	})
+
+	b.Run("titlecase", func(b *testing.B) {
+		recorder := httptest.NewRecorder()
+		rw := newResponseWriter(recorder)
+		for i := 0; i < b.N; i++ {
+			rw.AddHeaders(transport.NewHeadersWithCapacity(1).With(
+				"Abc", "",
+			))
+		}
+	})
+}
+
+func Benchmark_ResponseWriter_AddHeader(b *testing.B) {
+	b.Run("lowercase", func(b *testing.B) {
+		recorder := httptest.NewRecorder()
+		rw := newResponseWriter(recorder)
+		for i := 0; i < b.N; i++ {
+			rw.AddHeader("abc", "")
+		}
+	})
+
+	b.Run("titlecase", func(b *testing.B) {
+		recorder := httptest.NewRecorder()
+		rw := newResponseWriter(recorder)
+		for i := 0; i < b.N; i++ {
+			rw.AddHeader("Abc", "")
+		}
+	})
+}
+
 func TestTruncatedHeader(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/transport/http/header.go
+++ b/transport/http/header.go
@@ -50,6 +50,20 @@ func (hm headerMapper) ToHTTPHeaders(from transport.Headers, to http.Header) htt
 	return to
 }
 
+// toHTTPHeader adds a key, value header pair into a transport header.
+//
+// The header pair: 'key': 'value' is written to 'to'. The final header collection
+// is returned.
+//
+// If 'to' is nil, a new map will be assigned.
+func (hm headerMapper) ToHTTPHeader(to http.Header, key, value string) http.Header {
+	if to == nil {
+		to = make(http.Header, 1)
+	}
+	to.Add(hm.Prefix+transport.CanonicalizeHeaderKey(key), value)
+	return to
+}
+
 // fromHTTPHeaders converts HTTP headers to application headers.
 //
 // Headers are read from 'from' and written to 'to'. The final header collection

--- a/transport/http/header.go
+++ b/transport/http/header.go
@@ -44,8 +44,11 @@ func (hm headerMapper) ToHTTPHeaders(from transport.Headers, to http.Header) htt
 	if to == nil {
 		to = make(http.Header, from.Len())
 	}
-	for k, v := range from.Items() {
-		to.Add(hm.Prefix+k, v)
+	for k, v := range from.OriginalItems() {
+		if !strings.HasPrefix(k, hm.Prefix) {
+			k = hm.Prefix + k
+		}
+		to.Add(k, v)
 	}
 	return to
 }
@@ -60,7 +63,10 @@ func (hm headerMapper) ToHTTPHeader(to http.Header, key, value string) http.Head
 	if to == nil {
 		to = make(http.Header, 1)
 	}
-	to.Add(hm.Prefix+transport.CanonicalizeHeaderKey(key), value)
+	if !strings.HasPrefix(key, hm.Prefix) {
+		key = hm.Prefix + key
+	}
+	to.Add(key, value)
 	return to
 }
 

--- a/transport/http/header.go
+++ b/transport/http/header.go
@@ -44,11 +44,9 @@ func (hm headerMapper) ToHTTPHeaders(from transport.Headers, to http.Header) htt
 	if to == nil {
 		to = make(http.Header, from.Len())
 	}
+	// We use the original header-key, if the key is written in a MIME canoicalized form we save an allocation.
 	for k, v := range from.OriginalItems() {
-		if !strings.HasPrefix(k, hm.Prefix) {
-			k = hm.Prefix + k
-		}
-		to.Add(k, v)
+		hm.ToHTTPHeader(to, k, v)
 	}
 	return to
 }

--- a/transport/http/header_test.go
+++ b/transport/http/header_test.go
@@ -50,12 +50,34 @@ func TestHTTPHeaders(t *testing.T) {
 				"Rpc-Header-Foo-Bar": []string{"hello"},
 			},
 		},
+		{
+			ApplicationHeaderPrefix,
+			transport.HeadersFromMap(map[string]string{
+				"Rpc-Header-Foo":     "bar",
+				"Rpc-Header-Foo-Bar": "hello",
+			}),
+			transport.HeadersFromMap(map[string]string{
+				"Foo":     "bar",
+				"Foo-Bar": "hello",
+			}),
+			http.Header{
+				"Rpc-Header-Foo":     []string{"bar"},
+				"Rpc-Header-Foo-Bar": []string{"hello"},
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		m := headerMapper{tt.prefix}
 		assert.Equal(t, tt.fromTransport, m.FromHTTPHeaders(tt.http, transport.Headers{}))
 		assert.Equal(t, tt.http, m.ToHTTPHeaders(tt.toTransport, nil))
+
+		m = headerMapper{tt.prefix}
+		var res http.Header
+		for k, v := range tt.toTransport.OriginalItems() {
+			res = m.ToHTTPHeader(res, k, v)
+		}
+		assert.Equal(t, tt.http, res)
 	}
 }
 

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -271,7 +271,7 @@ func newHandlerWriter(response inboundCallResponse, format tchannel.Format, head
 }
 
 func (hw *handlerWriter) AddHeaders(h transport.Headers) {
-	for k, v := range h.OriginalItems() {
+	for k, v := range h.Items() {
 		hw.AddHeader(k, v)
 	}
 }

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -271,6 +271,7 @@ func newHandlerWriter(response inboundCallResponse, format tchannel.Format, head
 }
 
 func (hw *handlerWriter) AddHeaders(h transport.Headers) {
+	// We use the lowercased keys in the headers, that will save us an allocation.
 	for k, v := range h.Items() {
 		hw.AddHeader(k, v)
 	}

--- a/transport/tchannel/handler_test.go
+++ b/transport/tchannel/handler_test.go
@@ -648,6 +648,42 @@ func TestResponseWriterEmptyBodyHeaders(t *testing.T) {
 	assert.False(t, res.applicationError, "application error must be false")
 }
 
+func Benchmark_ResponseWriter_AddHeaders(b *testing.B) {
+	b.Run("lowercase", func(b *testing.B) {
+		rw := newHandlerWriter(nil, tchannel.Raw, canonicalizedHeaderCase)
+		for i := 0; i < b.N; i++ {
+			rw.AddHeaders(transport.NewHeadersWithCapacity(1).With(
+				"abc", "",
+			))
+		}
+	})
+
+	b.Run("titlecase", func(b *testing.B) {
+		rw := newHandlerWriter(nil, tchannel.Raw, canonicalizedHeaderCase)
+		for i := 0; i < b.N; i++ {
+			rw.AddHeaders(transport.NewHeadersWithCapacity(1).With(
+				"Abc", "",
+			))
+		}
+	})
+}
+
+func Benchmark_ResponseWriter_AddHeader(b *testing.B) {
+	b.Run("lowercase", func(b *testing.B) {
+		rw := newHandlerWriter(nil, tchannel.Raw, canonicalizedHeaderCase)
+		for i := 0; i < b.N; i++ {
+			rw.AddHeader("abc", "")
+		}
+	})
+
+	b.Run("titlecase", func(b *testing.B) {
+		rw := newHandlerWriter(nil, tchannel.Raw, canonicalizedHeaderCase)
+		for i := 0; i < b.N; i++ {
+			rw.AddHeader("Abc", "")
+		}
+	})
+}
+
 func TestGetSystemError(t *testing.T) {
 	tests := []struct {
 		giveErr  error

--- a/transport/tchannel/handler_test.go
+++ b/transport/tchannel/handler_test.go
@@ -653,7 +653,7 @@ func Benchmark_ResponseWriter_AddHeaders(b *testing.B) {
 		rw := newHandlerWriter(nil, tchannel.Raw, canonicalizedHeaderCase)
 		for i := 0; i < b.N; i++ {
 			rw.AddHeaders(transport.NewHeadersWithCapacity(1).With(
-				"abc", "",
+				"foo", "bar",
 			))
 		}
 	})
@@ -662,7 +662,7 @@ func Benchmark_ResponseWriter_AddHeaders(b *testing.B) {
 		rw := newHandlerWriter(nil, tchannel.Raw, canonicalizedHeaderCase)
 		for i := 0; i < b.N; i++ {
 			rw.AddHeaders(transport.NewHeadersWithCapacity(1).With(
-				"Abc", "",
+				"Foo", "bar",
 			))
 		}
 	})
@@ -672,14 +672,14 @@ func Benchmark_ResponseWriter_AddHeader(b *testing.B) {
 	b.Run("lowercase", func(b *testing.B) {
 		rw := newHandlerWriter(nil, tchannel.Raw, canonicalizedHeaderCase)
 		for i := 0; i < b.N; i++ {
-			rw.AddHeader("abc", "")
+			rw.AddHeader("foo", "bar")
 		}
 	})
 
 	b.Run("titlecase", func(b *testing.B) {
 		rw := newHandlerWriter(nil, tchannel.Raw, canonicalizedHeaderCase)
 		for i := 0; i < b.N; i++ {
-			rw.AddHeader("Abc", "")
+			rw.AddHeader("Foo", "bar")
 		}
 	})
 }


### PR DESCRIPTION
- [X] Description and context for reviewers: one partner, one stranger
Trying to address #2119. I have introduced a `AddHeader` method as a shorthand to add a response header.
This PR also includes various benchmarks on `AddHeader(s)`, which has been used to remove some allocations.

The only outside facing change this PR comes with is that if an http header has `Rpc-Header-` as a prefix, like `Rpc-Header-Foo` we now don't add another `Rpc-Header-` as a prefix. (See tests in `transport/http/header_test.go`).

Benchmark results for `AddHeaders` pre vs post change:
```
name                                                         old time/op    new time/op    delta
pkg:go.uber.org/yarpc/transport/grpc goos:darwin goarch:amd64
_ResponseWriter_AddHeaders/lowercase                           1.14µs ± 2%    1.12µs ±10%      ~     (p=0.251 n=9+10)
_ResponseWriter_AddHeaders/lowercase_no-value                   165ns ± 2%     103ns ±11%   -37.37%  (p=0.000 n=9+9)
_ResponseWriter_AddHeaders/titlecase                           1.21µs ± 3%    1.18µs ±11%      ~     (p=0.280 n=10+10)
_ResponseWriter_AddHeaders/titlecase_no-value                   192ns ± 4%     149ns ±15%   -22.46%  (p=0.000 n=10+10)
pkg:go.uber.org/yarpc/transport/http goos:darwin goarch:amd64
_ResponseWriter_AddHeaders/lowercase                            345ns ±14%     394ns ±10%   +14.29%  (p=0.000 n=10+10)
_ResponseWriter_AddHeaders/titlecase                            357ns ± 9%     326ns ±11%    -8.69%  (p=0.021 n=9+10)
_ResponseWriter_AddHeaders/titlecase_with_rpc-header_prefix     413ns ± 4%     312ns ±15%   -24.46%  (p=0.000 n=10+10)
pkg:go.uber.org/yarpc/transport/tchannel goos:darwin goarch:amd64
_ResponseWriter_AddHeaders/lowercase                            124ns ±10%     131ns ± 3%    +5.37%  (p=0.021 n=10+9)
_ResponseWriter_AddHeaders/titlecase                            209ns ± 9%     187ns ± 9%   -10.54%  (p=0.000 n=10+10)

name                                                         old alloc/op   new alloc/op   delta
pkg:go.uber.org/yarpc/transport/grpc goos:darwin goarch:amd64
_ResponseWriter_AddHeaders/lowercase                             264B ± 0%      232B ± 0%   -12.12%  (p=0.000 n=10+10)
_ResponseWriter_AddHeaders/lowercase_no-value                   32.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
_ResponseWriter_AddHeaders/titlecase                             279B ± 0%      247B ± 0%   -11.47%  (p=0.000 n=10+10)
_ResponseWriter_AddHeaders/titlecase_no-value                   35.0B ± 0%      3.0B ± 0%   -91.43%  (p=0.000 n=10+10)
pkg:go.uber.org/yarpc/transport/http goos:darwin goarch:amd64
_ResponseWriter_AddHeaders/lowercase                             117B ±10%      122B ± 7%      ~     (p=0.090 n=10+10)
_ResponseWriter_AddHeaders/titlecase                             119B ± 6%      107B ± 7%   -10.17%  (p=0.000 n=9+10)
_ResponseWriter_AddHeaders/titlecase_with_rpc-header_prefix      172B ± 8%      102B ± 8%   -40.82%  (p=0.000 n=10+10)
pkg:go.uber.org/yarpc/transport/tchannel goos:darwin goarch:amd64
_ResponseWriter_AddHeaders/lowercase                            0.00B          0.00B           ~     (all equal)
_ResponseWriter_AddHeaders/titlecase                            9.00B ± 0%     3.00B ± 0%   -66.67%  (p=0.000 n=10+10)

name                                                         old allocs/op  new allocs/op  delta
pkg:go.uber.org/yarpc/transport/grpc goos:darwin goarch:amd64
_ResponseWriter_AddHeaders/lowercase                             4.00 ± 0%      3.00 ± 0%   -25.00%  (p=0.000 n=10+10)
_ResponseWriter_AddHeaders/lowercase_no-value                    1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
_ResponseWriter_AddHeaders/titlecase                             5.00 ± 0%      4.00 ± 0%   -20.00%  (p=0.000 n=10+10)
_ResponseWriter_AddHeaders/titlecase_no-value                    2.00 ± 0%      1.00 ± 0%   -50.00%  (p=0.000 n=10+10)
pkg:go.uber.org/yarpc/transport/http goos:darwin goarch:amd64
_ResponseWriter_AddHeaders/lowercase                             2.00 ± 0%      2.00 ± 0%      ~     (all equal)
_ResponseWriter_AddHeaders/titlecase                             3.00 ± 0%      2.00 ± 0%   -33.33%  (p=0.000 n=10+10)
_ResponseWriter_AddHeaders/titlecase_with_rpc-header_prefix      3.00 ± 0%      1.00 ± 0%   -66.67%  (p=0.000 n=10+10)
pkg:go.uber.org/yarpc/transport/tchannel goos:darwin goarch:amd64
_ResponseWriter_AddHeaders/lowercase                             0.00           0.00           ~     (all equal)
_ResponseWriter_AddHeaders/titlecase                             3.00 ± 0%      1.00 ± 0%   -66.67%  (p=0.000 n=10+10)
```

Benchmarks on `AddHeader`:
```
name                                                         time/op
pkg:go.uber.org/yarpc/transport/grpc goos:darwin goarch:amd64
_ResponseWriter_AddHeader/lowercase                          1.04µs ± 8%
_ResponseWriter_AddHeader/lowercase_no-value                 17.9ns ± 7%
_ResponseWriter_AddHeader/titlecase                          1.05µs ±10%
_ResponseWriter_AddHeader/titlecase_no-value                 39.3ns ±11%
pkg:go.uber.org/yarpc/transport/http goos:darwin goarch:amd64
_ResponseWriter_AddHeader/lowercase                           259ns ± 5%
_ResponseWriter_AddHeader/titlecase                           161ns ± 7%
_ResponseWriter_AddHeader/titlecase_with_rpc-header_prefix    114ns ±10%
pkg:go.uber.org/yarpc/transport/tchannel goos:darwin goarch:amd64
_ResponseWriter_AddHeader/lowercase                          47.6ns ±11%
_ResponseWriter_AddHeader/titlecase                           105ns ± 5%

name                                                         alloc/op
pkg:go.uber.org/yarpc/transport/grpc goos:darwin goarch:amd64
_ResponseWriter_AddHeader/lowercase                            232B ± 0%
_ResponseWriter_AddHeader/lowercase_no-value                  0.00B     
_ResponseWriter_AddHeader/titlecase                            247B ± 0%
_ResponseWriter_AddHeader/titlecase_no-value                  3.00B ± 0%
pkg:go.uber.org/yarpc/transport/http goos:darwin goarch:amd64
_ResponseWriter_AddHeader/lowercase                            121B ± 8%
_ResponseWriter_AddHeader/titlecase                            106B ± 8%
_ResponseWriter_AddHeader/titlecase_with_rpc-header_prefix    91.0B ±12%
pkg:go.uber.org/yarpc/transport/tchannel goos:darwin goarch:amd64
_ResponseWriter_AddHeader/lowercase                           0.00B     
_ResponseWriter_AddHeader/titlecase                           6.00B ± 0%

name                                                         allocs/op
pkg:go.uber.org/yarpc/transport/grpc goos:darwin goarch:amd64
_ResponseWriter_AddHeader/lowercase                            3.00 ± 0%
_ResponseWriter_AddHeader/lowercase_no-value                   0.00     
_ResponseWriter_AddHeader/titlecase                            4.00 ± 0%
_ResponseWriter_AddHeader/titlecase_no-value                   1.00 ± 0%
pkg:go.uber.org/yarpc/transport/http goos:darwin goarch:amd64
_ResponseWriter_AddHeader/lowercase                            2.00 ± 0%
_ResponseWriter_AddHeader/titlecase                            1.00 ± 0%
_ResponseWriter_AddHeader/titlecase_with_rpc-header_prefix     0.00     
pkg:go.uber.org/yarpc/transport/tchannel goos:darwin goarch:amd64
_ResponseWriter_AddHeader/lowercase                            0.00     
_ResponseWriter_AddHeader/titlecase                            2.00 ± 0%
```

- [X] Docs (package doc)
Nothing has changed.
- [X] Entry in CHANGELOG.md
