### PR TITLE
Fix layout of Outbounds table on debug page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 =======
 ## [Unreleased]
-- No changes yet.
+### Fixed
+- Columns in the HTML Outbounds table on the debug page now properly line up
+  with header rows.
 
 ## [1.75.3] - 2024-12-04
 ### Added

--- a/x/debug/debug.go
+++ b/x/debug/debug.go
@@ -142,6 +142,7 @@ var (
 			<th></th>
 			<th></th>
 			<th></th>
+			<th></th>
 			<th>Name</th>
 			<th>State</th>
 			<th>Peers</th>


### PR DESCRIPTION
The two header rows on the HTML table for Outbounds on the debug page
now have the same number of cells.

This will make the columns line up properly.

- [x] Description and context for reviewers: one partner, one stranger
- [x] Docs (package doc)
- [x] Entry in CHANGELOG.md
