### PR TITLE
[gRPC] accept custom header list sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 - No changes yet.
+### Added
+- grpc - option to set custom maximum header list size.
 
 
 ## [1.60.0] - 2022-02-03

--- a/internal/prototest/example/example.go
+++ b/internal/prototest/example/example.go
@@ -84,6 +84,10 @@ func (k *KeyValueYARPCServer) GetValue(ctx context.Context, request *examplepb.G
 
 // SetValue implements SetValue.
 func (k *KeyValueYARPCServer) SetValue(ctx context.Context, request *examplepb.SetValueRequest) (*examplepb.SetValueResponse, error) {
+	call := yarpc.CallFromContext(ctx)
+	if val := call.Header("test-header"); val != "" {
+		call.WriteResponseHeader("test-header", val)
+	}
 	if request == nil {
 		return nil, errRequestNil
 	}

--- a/internal/prototest/example/example.go
+++ b/internal/prototest/example/example.go
@@ -86,7 +86,7 @@ func (k *KeyValueYARPCServer) GetValue(ctx context.Context, request *examplepb.G
 func (k *KeyValueYARPCServer) SetValue(ctx context.Context, request *examplepb.SetValueRequest) (*examplepb.SetValueResponse, error) {
 	call := yarpc.CallFromContext(ctx)
 	if val := call.Header("test-header"); val != "" {
-		call.WriteResponseHeader("test-header", val)
+		_ = call.WriteResponseHeader("test-header", val)
 	}
 	if request == nil {
 		return nil, errRequestNil

--- a/transport/grpc/config.go
+++ b/transport/grpc/config.go
@@ -66,15 +66,19 @@ func TransportSpec(opts ...Option) yarpcconfig.TransportSpec {
 //        exponential:
 //          first: 10ms
 //          max: 30s
+//      clientMaxHeaderListSize: 1024
+//      serverMaxHeaderListSize: 2048
 //
 // All parameters of TransportConfig are optional. This section
 // may be omitted in the transports section.
 type TransportConfig struct {
-	ServerMaxRecvMsgSize int                 `config:"serverMaxRecvMsgSize"`
-	ServerMaxSendMsgSize int                 `config:"serverMaxSendMsgSize"`
-	ClientMaxRecvMsgSize int                 `config:"clientMaxRecvMsgSize"`
-	ClientMaxSendMsgSize int                 `config:"clientMaxSendMsgSize"`
-	Backoff              yarpcconfig.Backoff `config:"backoff"`
+	ServerMaxRecvMsgSize    int                 `config:"serverMaxRecvMsgSize"`
+	ServerMaxSendMsgSize    int                 `config:"serverMaxSendMsgSize"`
+	ServerMaxHeaderListSize uint32              `config:"serverMaxHeaderListSize"`
+	ClientMaxRecvMsgSize    int                 `config:"clientMaxRecvMsgSize"`
+	ClientMaxSendMsgSize    int                 `config:"clientMaxSendMsgSize"`
+	ClientMaxHeaderListSize uint32              `config:"clientMaxHeaderListSize"`
+	Backoff                 yarpcconfig.Backoff `config:"backoff"`
 }
 
 // InboundConfig configures a gRPC Inbound.
@@ -279,6 +283,12 @@ func (t *transportSpec) buildTransport(transportConfig *TransportConfig, _ *yarp
 	}
 	if transportConfig.ClientMaxSendMsgSize > 0 {
 		options = append(options, ClientMaxSendMsgSize(transportConfig.ClientMaxSendMsgSize))
+	}
+	if transportConfig.ServerMaxHeaderListSize > 0 {
+		options = append(options, ServerMaxHeaderListSize(transportConfig.ServerMaxHeaderListSize))
+	}
+	if transportConfig.ClientMaxHeaderListSize > 0 {
+		options = append(options, ClientMaxHeaderListSize(transportConfig.ClientMaxHeaderListSize))
 	}
 	backoffStrategy, err := transportConfig.Backoff.Strategy()
 	if err != nil {

--- a/transport/grpc/config.go
+++ b/transport/grpc/config.go
@@ -72,11 +72,13 @@ func TransportSpec(opts ...Option) yarpcconfig.TransportSpec {
 // All parameters of TransportConfig are optional. This section
 // may be omitted in the transports section.
 type TransportConfig struct {
-	ServerMaxRecvMsgSize    int                 `config:"serverMaxRecvMsgSize"`
-	ServerMaxSendMsgSize    int                 `config:"serverMaxSendMsgSize"`
+	ServerMaxRecvMsgSize int `config:"serverMaxRecvMsgSize"`
+	ServerMaxSendMsgSize int `config:"serverMaxSendMsgSize"`
+	ClientMaxRecvMsgSize int `config:"clientMaxRecvMsgSize"`
+	ClientMaxSendMsgSize int `config:"clientMaxSendMsgSize"`
+	// GRPC header lise size options accept uint32 param.
+	// see: https://pkg.go.dev/google.golang.org/grpc#WithMaxHeaderListSize
 	ServerMaxHeaderListSize uint32              `config:"serverMaxHeaderListSize"`
-	ClientMaxRecvMsgSize    int                 `config:"clientMaxRecvMsgSize"`
-	ClientMaxSendMsgSize    int                 `config:"clientMaxSendMsgSize"`
 	ClientMaxHeaderListSize uint32              `config:"clientMaxHeaderListSize"`
 	Backoff                 yarpcconfig.Backoff `config:"backoff"`
 }

--- a/transport/grpc/config_test.go
+++ b/transport/grpc/config_test.go
@@ -93,10 +93,10 @@ func TestTransportSpec(t *testing.T) {
 		Address                 string
 		ServerMaxRecvMsgSize    int
 		ServerMaxSendMsgSize    int
-		ServerMaxHeaderListSize int
+		ServerMaxHeaderListSize uint32
 		ClientMaxRecvMsgSize    int
 		ClientMaxSendMsgSize    int
-		ClientMaxHeaderListSize int
+		ClientMaxHeaderListSize uint32
 		TLS                     bool
 	}
 

--- a/transport/grpc/config_test.go
+++ b/transport/grpc/config_test.go
@@ -90,12 +90,14 @@ func TestTransportSpec(t *testing.T) {
 	type attrs map[string]interface{}
 
 	type wantInbound struct {
-		Address              string
-		ServerMaxRecvMsgSize int
-		ServerMaxSendMsgSize int
-		ClientMaxRecvMsgSize int
-		ClientMaxSendMsgSize int
-		TLS                  bool
+		Address                 string
+		ServerMaxRecvMsgSize    int
+		ServerMaxSendMsgSize    int
+		ServerMaxHeaderListSize int
+		ClientMaxRecvMsgSize    int
+		ClientMaxSendMsgSize    int
+		ClientMaxHeaderListSize int
+		TLS                     bool
 	}
 
 	type wantOutbound struct {
@@ -221,18 +223,22 @@ func TestTransportSpec(t *testing.T) {
 		{
 			desc: "inbound and transport with message size options",
 			transportCfg: attrs{
-				"serverMaxRecvMsgSize": "1024",
-				"serverMaxSendMsgSize": "2048",
-				"clientMaxRecvMsgSize": "4096",
-				"clientMaxSendMsgSize": "8192",
+				"serverMaxRecvMsgSize":    "1024",
+				"serverMaxSendMsgSize":    "2048",
+				"serverMaxHeaderListSize": "32768",
+				"clientMaxRecvMsgSize":    "4096",
+				"clientMaxSendMsgSize":    "8192",
+				"clientMaxHeaderListSize": "16384",
 			},
 			inboundCfg: attrs{"address": ":54571"},
 			wantInbound: &wantInbound{
-				Address:              ":54571",
-				ServerMaxRecvMsgSize: 1024,
-				ServerMaxSendMsgSize: 2048,
-				ClientMaxRecvMsgSize: 4096,
-				ClientMaxSendMsgSize: 8192,
+				Address:                 ":54571",
+				ServerMaxRecvMsgSize:    1024,
+				ServerMaxSendMsgSize:    2048,
+				ServerMaxHeaderListSize: 32768,
+				ClientMaxRecvMsgSize:    4096,
+				ClientMaxSendMsgSize:    8192,
+				ClientMaxHeaderListSize: 16384,
 			},
 		},
 		{
@@ -479,6 +485,18 @@ func TestTransportSpec(t *testing.T) {
 					assert.Equal(t, tt.wantInbound.ClientMaxSendMsgSize, inbound.t.options.clientMaxSendMsgSize)
 				} else {
 					assert.Equal(t, defaultClientMaxSendMsgSize, inbound.t.options.clientMaxSendMsgSize)
+				}
+				if tt.wantInbound.ClientMaxHeaderListSize > 0 {
+					require.NotNil(t, inbound.t.options.clientMaxHeaderListSize)
+					assert.Equal(t, tt.wantInbound.ClientMaxHeaderListSize, *inbound.t.options.clientMaxHeaderListSize)
+				} else {
+					assert.Nil(t, inbound.t.options.clientMaxHeaderListSize)
+				}
+				if tt.wantInbound.ServerMaxHeaderListSize > 0 {
+					require.NotNil(t, inbound.t.options.serverMaxHeaderListSize)
+					assert.Equal(t, tt.wantInbound.ServerMaxHeaderListSize, *inbound.t.options.serverMaxHeaderListSize)
+				} else {
+					assert.Nil(t, inbound.t.options.serverMaxHeaderListSize)
 				}
 				assert.Equal(t, tt.wantInbound.TLS, inbound.options.creds != nil)
 			} else {

--- a/transport/grpc/inbound.go
+++ b/transport/grpc/inbound.go
@@ -122,6 +122,10 @@ func (i *Inbound) start() error {
 		serverOptions = append(serverOptions, grpc.Creds(i.options.creds))
 	}
 
+	if i.t.options.serverMaxHeaderListSize != nil {
+		serverOptions = append(serverOptions, grpc.MaxHeaderListSize(*i.t.options.serverMaxHeaderListSize))
+	}
+
 	server := grpc.NewServer(serverOptions...)
 
 	go func() {

--- a/transport/grpc/integration_test.go
+++ b/transport/grpc/integration_test.go
@@ -510,7 +510,7 @@ func TestGRPCHeaderListSize(t *testing.T) {
 			te.do(t, func(t *testing.T, e *testEnv) {
 				var resHeaders map[string]string
 				// Setting longer timeout as CI timesout on large payloads.
-				ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+				ctx, cancel := context.WithTimeout(context.Background(), time.Second*15)
 				defer cancel()
 
 				err := e.SetValueYARPC(ctx, "foo", "bar", yarpc.ResponseHeaders(&resHeaders), yarpc.WithHeader("test-header", string(headerVal)))

--- a/transport/grpc/integration_test.go
+++ b/transport/grpc/integration_test.go
@@ -492,8 +492,8 @@ func TestGRPCHeaderListSize(t *testing.T) {
 		},
 		{
 			desc:       "allow_large_header_size",
-			headerSize: 1024 * 1024 * 18, // 18MB
-			options:    []TransportOption{ServerMaxHeaderListSize(1024 * 1024 * 19), ClientMaxHeaderListSize(1024 * 1024 * 19)},
+			headerSize: 1024 * 1024 * 1, // 1MB
+			options:    []TransportOption{ServerMaxHeaderListSize(1024 * 1024 * 2), ClientMaxHeaderListSize(1024 * 1024 * 2)},
 		},
 	}
 

--- a/transport/grpc/integration_test.go
+++ b/transport/grpc/integration_test.go
@@ -492,8 +492,8 @@ func TestGRPCHeaderListSize(t *testing.T) {
 		},
 		{
 			desc:       "allow_large_header_size",
-			headerSize: 1024 * 1024 * 18, // 18MB
-			options:    []TransportOption{ServerMaxHeaderListSize(1024 * 1024 * 19), ClientMaxHeaderListSize(1024 * 1024 * 19)},
+			headerSize: 1024 * 1024, // 1MB
+			options:    []TransportOption{ServerMaxHeaderListSize(1024 * 1024), ClientMaxHeaderListSize(1024 * 1024)},
 		},
 	}
 

--- a/transport/grpc/options.go
+++ b/transport/grpc/options.go
@@ -39,10 +39,11 @@ const (
 	// defensive programming
 	// these are copied from grpc-go but we set them explicitly here
 	// in case these change in grpc-go so that yarpc stays consistent
-	defaultServerMaxRecvMsgSize = 1024 * 1024 * 4
-	defaultServerMaxSendMsgSize = math.MaxInt32
-	defaultClientMaxRecvMsgSize = 1024 * 1024 * 4
-	defaultClientMaxSendMsgSize = math.MaxInt32
+	defaultServerMaxRecvMsgSize    = 1024 * 1024 * 4
+	defaultServerMaxSendMsgSize    = math.MaxInt32
+	defaultClientMaxRecvMsgSize    = 1024 * 1024 * 4
+	defaultClientMaxSendMsgSize    = math.MaxInt32
+	defaultServerMaxHeaderListSize = 1024 * 1024 * 16
 )
 
 // Option is an interface shared by TransportOption, InboundOption, and OutboundOption
@@ -108,6 +109,16 @@ func ServerMaxSendMsgSize(serverMaxSendMsgSize int) TransportOption {
 	}
 }
 
+// ServerMaxHeaderListSize returns a transport option for configuring maximum
+// header list size the server must accept.
+//
+// The default is 16MB (gRPC default).
+func ServerMaxHeaderListSize(serverMaxHeaderListSize uint32) TransportOption {
+	return func(transportOptions *transportOptions) {
+		transportOptions.serverMaxHeaderListSize = &serverMaxHeaderListSize
+	}
+}
+
 // ClientMaxRecvMsgSize is the maximum message size the client can receive.
 //
 // The default is 4MB.
@@ -123,6 +134,16 @@ func ClientMaxRecvMsgSize(clientMaxRecvMsgSize int) TransportOption {
 func ClientMaxSendMsgSize(clientMaxSendMsgSize int) TransportOption {
 	return func(transportOptions *transportOptions) {
 		transportOptions.clientMaxSendMsgSize = clientMaxSendMsgSize
+	}
+}
+
+// ClientMaxHeaderListSize returns a transport option for configuring maximum
+// header list size the client must accept.
+//
+// The default is 16MB (gRPC default).
+func ClientMaxHeaderListSize(clientMaxHeaderListSize uint32) TransportOption {
+	return func(transportOptions *transportOptions) {
+		transportOptions.clientMaxHeaderListSize = &clientMaxHeaderListSize
 	}
 }
 
@@ -190,13 +211,15 @@ func KeepaliveParams(params keepalive.ClientParameters) DialOption {
 }
 
 type transportOptions struct {
-	backoffStrategy      backoff.Strategy
-	tracer               opentracing.Tracer
-	logger               *zap.Logger
-	serverMaxRecvMsgSize int
-	serverMaxSendMsgSize int
-	clientMaxRecvMsgSize int
-	clientMaxSendMsgSize int
+	backoffStrategy         backoff.Strategy
+	tracer                  opentracing.Tracer
+	logger                  *zap.Logger
+	serverMaxRecvMsgSize    int
+	serverMaxSendMsgSize    int
+	clientMaxRecvMsgSize    int
+	clientMaxSendMsgSize    int
+	serverMaxHeaderListSize *uint32
+	clientMaxHeaderListSize *uint32
 }
 
 func newTransportOptions(options []TransportOption) *transportOptions {

--- a/transport/grpc/options.go
+++ b/transport/grpc/options.go
@@ -39,11 +39,10 @@ const (
 	// defensive programming
 	// these are copied from grpc-go but we set them explicitly here
 	// in case these change in grpc-go so that yarpc stays consistent
-	defaultServerMaxRecvMsgSize    = 1024 * 1024 * 4
-	defaultServerMaxSendMsgSize    = math.MaxInt32
-	defaultClientMaxRecvMsgSize    = 1024 * 1024 * 4
-	defaultClientMaxSendMsgSize    = math.MaxInt32
-	defaultServerMaxHeaderListSize = 1024 * 1024 * 16
+	defaultServerMaxRecvMsgSize = 1024 * 1024 * 4
+	defaultServerMaxSendMsgSize = math.MaxInt32
+	defaultClientMaxRecvMsgSize = 1024 * 1024 * 4
+	defaultClientMaxSendMsgSize = math.MaxInt32
 )
 
 // Option is an interface shared by TransportOption, InboundOption, and OutboundOption

--- a/transport/grpc/peer.go
+++ b/transport/grpc/peer.go
@@ -50,6 +50,10 @@ func (t *Transport) newPeer(address string, options *dialOptions) (*grpcPeer, er
 		),
 	}, options.grpcOptions()...)
 
+	if t.options.clientMaxHeaderListSize != nil {
+		dialOptions = append(dialOptions, grpc.WithMaxHeaderListSize(*t.options.clientMaxHeaderListSize))
+	}
+
 	clientConn, err := grpc.Dial(address, dialOptions...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- [X] Description and context for reviewers: one partner, one stranger
- [X] Entry in CHANGELOG.md

Expose transport options to set gRPC maximum header list size for the client and server. Max header sizes are also configurable through config YAML:

```
yarpc:
  transports:
    grpc:
      clientMaxHeaderListSize: 1024
      serverMaxHeaderListSize: 2048
```