### PR TITLE
[10/n] tlsmux: HTTP inbound integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Added
+- http - add TLS support for the inbound. Supports accepting
+  TLS and plaintext connections on the same port.
 
 ## [1.62.0] - 2022-07-27
 ### Added

--- a/transport/http/config_test.go
+++ b/transport/http/config_test.go
@@ -453,6 +453,7 @@ func TestTransportSpec(t *testing.T) {
 					assert.Empty(t, ib.grabHeaders)
 				}
 				assert.Equal(t, want.ShutdownTimeout, ib.shutdownTimeout, "shutdownTimeout should match")
+				assert.Equal(t, "foo", ib.transport.serviceName, "service name must match")
 				assert.Equal(t, want.TLSMode, ib.tlsMode, "tlsMode should match")
 			}
 		}

--- a/transport/http/config_test.go
+++ b/transport/http/config_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	yarpctls "go.uber.org/yarpc/api/transport/tls"
 	"go.uber.org/yarpc/yarpcconfig"
 )
 
@@ -61,6 +62,7 @@ func TestTransportSpec(t *testing.T) {
 		MuxPattern      string
 		GrabHeaders     map[string]struct{}
 		ShutdownTimeout time.Duration
+		TLSMode         yarpctls.Mode
 	}
 
 	type inboundTest struct {
@@ -153,6 +155,27 @@ func TestTransportSpec(t *testing.T) {
 			desc:        "simple inbound",
 			cfg:         attrs{"address": ":8080"},
 			wantInbound: &wantInbound{Address: ":8080", ShutdownTimeout: defaultShutdownTimeout},
+		},
+		{
+			desc: "inbound tls",
+			cfg: attrs{
+				"address": ":8080",
+				"tls": attrs{
+					"mode": "permissive",
+				},
+			},
+			wantInbound: &wantInbound{Address: ":8080", ShutdownTimeout: defaultShutdownTimeout, TLSMode: yarpctls.Permissive},
+		},
+		{
+			desc: "inbound tls mode overridden by inbound option",
+			cfg: attrs{
+				"address": ":8080",
+				"tls": attrs{
+					"mode": "enforced",
+				},
+			},
+			opts:        []Option{InboundTLSMode(yarpctls.Permissive)},
+			wantInbound: &wantInbound{Address: ":8080", ShutdownTimeout: defaultShutdownTimeout, TLSMode: yarpctls.Permissive},
 		},
 		{
 			desc: "simple inbound with grab headers",
@@ -430,6 +453,7 @@ func TestTransportSpec(t *testing.T) {
 					assert.Empty(t, ib.grabHeaders)
 				}
 				assert.Equal(t, want.ShutdownTimeout, ib.shutdownTimeout, "shutdownTimeout should match")
+				assert.Equal(t, want.TLSMode, ib.tlsMode, "tlsMode should match")
 			}
 		}
 

--- a/transport/http/integration_test.go
+++ b/transport/http/integration_test.go
@@ -46,7 +46,7 @@ func TestInboundTLS(t *testing.T) {
 
 	scenario := tlsscenario.Create(t, time.Minute, time.Minute)
 	serverTLSConfig := &tls.Config{
-		GetCertificate: func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
+		GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
 			return &tls.Certificate{
 				Certificate: [][]byte{scenario.ServerCert.Raw},
 				Leaf:        scenario.ServerCert,
@@ -57,7 +57,7 @@ func TestInboundTLS(t *testing.T) {
 		ClientCAs:  scenario.CAs,
 	}
 	clientTLSConfig := &tls.Config{
-		GetClientCertificate: func(_ *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+		GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
 			return &tls.Certificate{
 				Certificate: [][]byte{scenario.ClientCert.Raw},
 				Leaf:        scenario.ClientCert,

--- a/transport/http/transport.go
+++ b/transport/http/transport.go
@@ -269,6 +269,7 @@ func (o *transportOptions) newTransport() *Transport {
 		tracer:              o.tracer,
 		logger:              logger,
 		meter:               o.meter,
+		serviceName:         o.serviceName,
 	}
 }
 

--- a/transport/http/transport.go
+++ b/transport/http/transport.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/opentracing/opentracing-go"
+	"go.uber.org/net/metrics"
 	backoffapi "go.uber.org/yarpc/api/backoff"
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
@@ -53,6 +54,8 @@ type transportOptions struct {
 	tracer                opentracing.Tracer
 	buildClient           func(*transportOptions) *http.Client
 	logger                *zap.Logger
+	meter                 *metrics.Scope
+	serviceName           string
 }
 
 var defaultTransportOptions = transportOptions{
@@ -216,6 +219,23 @@ func Logger(logger *zap.Logger) TransportOption {
 	}
 }
 
+// Meter sets a meter to use for internal transport metrics.
+//
+// The default is to not emit any metrics.
+func Meter(meter *metrics.Scope) TransportOption {
+	return func(options *transportOptions) {
+		options.meter = meter
+	}
+}
+
+// ServiceName sets the name of the service used in transport logging
+// and metrics.
+func ServiceName(name string) TransportOption {
+	return func(options *transportOptions) {
+		options.serviceName = name
+	}
+}
+
 // Hidden option to override the buildHTTPClient function. This is used only
 // for testing.
 func buildClient(f func(*transportOptions) *http.Client) TransportOption {
@@ -248,6 +268,7 @@ func (o *transportOptions) newTransport() *Transport {
 		peers:               make(map[string]*httpPeer),
 		tracer:              o.tracer,
 		logger:              logger,
+		meter:               o.meter,
 	}
 }
 
@@ -293,8 +314,10 @@ type Transport struct {
 	innocenceWindow     time.Duration
 	jitter              func(int64) int64
 
-	tracer opentracing.Tracer
-	logger *zap.Logger
+	tracer      opentracing.Tracer
+	logger      *zap.Logger
+	meter       *metrics.Scope
+	serviceName string
 }
 
 var _ transport.Transport = (*Transport)(nil)


### PR DESCRIPTION
- [X] Description and context for reviewers: one partner, one stranger
- [X] Entry in CHANGELOG.md

Integrate HTTP inbound with `tlsmux` to support TLS inbound. Applications can set up HTTP secure inbound by passing the TLS mode either via configuration `tls.Mode` or passing the inbound option `InboundTLSMode`. The TLS configuration for inbound can be passed using the `InboundTLSConfiguration` transport option.

Two new transport options are exposed:
* `Meter` - accept meter used for transport metrics
* `ServiceName` - accept name of the service used in transport metrics and logging