### PR TITLE
grpc: update default max receive message sizes to 64MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - http - add TLS support for the inbound. Supports accepting
   TLS and plaintext connections on the same port.
+### Changed
+- grpc - set default client and server maximum receive message
+  sizes to 64MB from earlier 4MB.
 
 ## [1.62.0] - 2022-07-27
 ### Added

--- a/transport/grpc/config_test.go
+++ b/transport/grpc/config_test.go
@@ -472,7 +472,7 @@ func TestTransportSpec(t *testing.T) {
 				if tt.wantInbound.ServerMaxRecvMsgSize > 0 {
 					assert.Equal(t, tt.wantInbound.ServerMaxRecvMsgSize, inbound.t.options.serverMaxRecvMsgSize)
 				} else {
-					assert.Equal(t, defaultServerMaxRecvMsgSize, inbound.t.options.serverMaxRecvMsgSize)
+					assert.Equal(t, 1024*1024*64, inbound.t.options.serverMaxRecvMsgSize)
 				}
 				if tt.wantInbound.ServerMaxSendMsgSize > 0 {
 					assert.Equal(t, tt.wantInbound.ServerMaxSendMsgSize, inbound.t.options.serverMaxSendMsgSize)
@@ -482,7 +482,7 @@ func TestTransportSpec(t *testing.T) {
 				if tt.wantInbound.ClientMaxRecvMsgSize > 0 {
 					assert.Equal(t, tt.wantInbound.ClientMaxRecvMsgSize, inbound.t.options.clientMaxRecvMsgSize)
 				} else {
-					assert.Equal(t, defaultClientMaxRecvMsgSize, inbound.t.options.clientMaxRecvMsgSize)
+					assert.Equal(t, 1024*1024*64, inbound.t.options.clientMaxRecvMsgSize)
 				}
 				if tt.wantInbound.ClientMaxSendMsgSize > 0 {
 					assert.Equal(t, tt.wantInbound.ClientMaxSendMsgSize, inbound.t.options.clientMaxSendMsgSize)

--- a/transport/grpc/options.go
+++ b/transport/grpc/options.go
@@ -42,10 +42,12 @@ const (
 	// defensive programming
 	// these are copied from grpc-go but we set them explicitly here
 	// in case these change in grpc-go so that yarpc stays consistent
-	defaultServerMaxRecvMsgSize = 1024 * 1024 * 4
 	defaultServerMaxSendMsgSize = math.MaxInt32
-	defaultClientMaxRecvMsgSize = 1024 * 1024 * 4
 	defaultClientMaxSendMsgSize = math.MaxInt32
+	// Overriding default server and client maximum request and response
+	// receive sizes to 64MB.
+	defaultServerMaxRecvMsgSize = 1024 * 1024 * 64
+	defaultClientMaxRecvMsgSize = 1024 * 1024 * 64
 )
 
 // Option is an interface shared by TransportOption, InboundOption, and OutboundOption


### PR DESCRIPTION
- [X] Description and context for reviewers: one partner, one stranger
- [X] Entry in CHANGELOG.md

Updates client and server default maximum receive message sizes to 64MB from the earlier 4MB. Earlier maximum size was very restrictive and sometimes impacted production traffic for a very few requests with large request/response sizes. Bump in size should provide a cushion to such request/response payloads.