### PR TITLE
[11/n] tlsmux: TChannel inbound integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Added
+- tchannel: add TLS support for the inbound. Supports accepting
+  TLS and plaintext connections on the same port.
 
 ## [1.63.0] - 2022-08-17
 ### Added

--- a/transport/tchannel/tchannel_integration_test.go
+++ b/transport/tchannel/tchannel_integration_test.go
@@ -21,8 +21,11 @@
 package tchannel_test
 
 import (
+	"bytes"
 	"context"
+	"crypto/tls"
 	"errors"
+	"io"
 	"net"
 	"testing"
 	"time"
@@ -31,7 +34,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc/api/peer/peertest"
 	"go.uber.org/yarpc/api/transport"
+	yarpctls "go.uber.org/yarpc/api/transport/tls"
 	"go.uber.org/yarpc/peer"
+	"go.uber.org/yarpc/transport/internal/tlsscenario"
 	"go.uber.org/yarpc/transport/tchannel"
 	"go.uber.org/yarpc/x/yarpctest"
 	"go.uber.org/yarpc/x/yarpctest/api"
@@ -97,4 +102,101 @@ func TestDialerOption(t *testing.T) {
 	_, err = out.Call(ctx, &transport.Request{Service: "bar-service"})
 	require.Error(t, err, "expected dialer error")
 	assert.Contains(t, err.Error(), customDialerErr.Error())
+}
+
+func TestInboundTLS(t *testing.T) {
+	scenario := tlsscenario.Create(t, time.Minute, time.Minute)
+	serverCreds := &tls.Config{
+		GetCertificate: func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			return &tls.Certificate{
+				Certificate: [][]byte{scenario.ServerCert.Raw},
+				Leaf:        scenario.ServerCert,
+				PrivateKey:  scenario.ServerKey,
+			}, nil
+		},
+		ClientAuth: tls.RequireAndVerifyClientCert,
+		ClientCAs:  scenario.CAs,
+	}
+	clientCreds := &tls.Config{
+		GetClientCertificate: func(_ *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			return &tls.Certificate{
+				Certificate: [][]byte{scenario.ClientCert.Raw},
+				Leaf:        scenario.ClientCert,
+				PrivateKey:  scenario.ClientKey,
+			}, nil
+		},
+		RootCAs: scenario.CAs,
+	}
+
+	tests := []struct {
+		desc        string
+		isClientTLS bool
+	}{
+		{desc: "plaintext_client_permissive_tls_inbound"},
+		{desc: "tls_client_permissive_tls_inbound", isClientTLS: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			options := []tchannel.TransportOption{
+				tchannel.InboundTLSConfiguration(serverCreds),
+				tchannel.InboundTLSMode(yarpctls.Permissive),
+				tchannel.ServiceName("test-svc"),
+			}
+			if tt.isClientTLS {
+				tchannel.Dialer(func(ctx context.Context, network, hostPort string) (net.Conn, error) {
+					return tls.Dial(network, hostPort, clientCreds)
+				})
+			}
+			tr, err := tchannel.NewTransport(options...)
+			require.NoError(t, err)
+			inbound := tr.NewInbound()
+			inbound.SetRouter(testRouter{proc: transport.Procedure{HandlerSpec: transport.NewUnaryHandlerSpec(testServer{})}})
+
+			require.NoError(t, tr.Start())
+			defer tr.Stop()
+			require.NoError(t, inbound.Start())
+			defer inbound.Stop()
+
+			outbound := tr.NewSingleOutbound(tr.ListenAddr())
+			require.NoError(t, outbound.Start())
+			defer outbound.Stop()
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+			defer cancel()
+
+			res, err := outbound.Call(ctx, &transport.Request{
+				Service:   "test-svc-1",
+				Procedure: "test-proc",
+				Body:      bytes.NewReader([]byte("hello")),
+			})
+			require.NoError(t, err)
+
+			resBody, err := io.ReadAll(res.Body)
+			require.NoError(t, err)
+			assert.Equal(t, "hello", string(resBody))
+		})
+	}
+}
+
+type testRouter struct {
+	proc transport.Procedure
+}
+
+func (t testRouter) Procedures() []transport.Procedure {
+	return []transport.Procedure{t.proc}
+}
+
+func (t testRouter) Choose(ctx context.Context, req *transport.Request) (transport.HandlerSpec, error) {
+	return t.proc.HandlerSpec, nil
+}
+
+type testServer struct{}
+
+func (testServer) Handle(ctx context.Context, req *transport.Request, resw transport.ResponseWriter) error {
+	data, err := io.ReadAll(req.Body)
+	if err != nil {
+		return err
+	}
+	resw.Write(data)
+	return nil
 }


### PR DESCRIPTION
- [X] Description and context for reviewers: one partner, one stranger
- [X] Entry in CHANGELOG.md

Integrate TChannel inbound with tlsmux to support TLS inbound. Applications can set up TChannel secure inbound by passing the TLS mode either via configuration tls.Mode or pass the inbound option `InboundTLSMode`. The TLS configuration for inbound can be passed using the `InboundTLSConfiguration` transport option.