### PR TITLE
protoc-gen-yarpc-go: expose service reflection meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - tchannel: add TLS support for the inbound. Supports accepting
   TLS and plaintext connections on the same port.
+### Changed
+- protoc-gen-yarpc-go: expose service reflection metadata.
 
 ## [1.63.0] - 2022-08-17
 ### Added

--- a/encoding/protobuf/internal/testpb/test.pb.yarpc.go
+++ b/encoding/protobuf/internal/testpb/test.pb.yarpc.go
@@ -213,12 +213,18 @@ func NewFxTestYARPCProcedures() interface{} {
 				Server:      params.Server,
 				AnyResolver: params.AnyResolver,
 			}),
-			ReflectionMeta: reflection.ServerMeta{
-				ServiceName:     "uber.yarpc.encoding.protobuf.Test",
-				FileDescriptors: yarpcFileDescriptorClosurefc320162ebaf2b25,
-			},
+			ReflectionMeta: TestReflectionMeta,
 		}
 	}
+}
+
+// TestReflectionMeta is the reflection server metadata
+// required for using the gRPC reflection protocol with YARPC.
+//
+// See https://github.com/grpc/grpc/blob/master/doc/server-reflection.md.
+var TestReflectionMeta = reflection.ServerMeta{
+	ServiceName:     "uber.yarpc.encoding.protobuf.Test",
+	FileDescriptors: yarpcFileDescriptorClosurefc320162ebaf2b25,
 }
 
 type _TestYARPCCaller struct {

--- a/encoding/protobuf/internal/testpb/testpb_test.go
+++ b/encoding/protobuf/internal/testpb/testpb_test.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2022 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package testpb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServerReflectionMeta(t *testing.T) {
+	assert.Equal(t, "uber.yarpc.encoding.protobuf.Test", TestReflectionMeta.ServiceName)
+	assert.NotNil(t, TestReflectionMeta.FileDescriptors)
+}

--- a/encoding/protobuf/protoc-gen-yarpc-go/internal/lib/lib.go
+++ b/encoding/protobuf/protoc-gen-yarpc-go/internal/lib/lib.go
@@ -300,12 +300,18 @@ func NewFx{{$service.GetName}}YARPCProcedures() interface{} {
 				Server:      params.Server,
 				AnyResolver: params.AnyResolver,
 			}),
-			ReflectionMeta: reflection.ServerMeta{
-				ServiceName: "{{trimPrefixPeriod $service.FQSN}}",
-				FileDescriptors: {{ fileDescriptorClosureVarName .File }},
-			},
+			ReflectionMeta: {{$service.GetName}}ReflectionMeta,
 		}
 	}
+}
+
+// {{$service.GetName}}ReflectionMeta is the reflection server metadata
+// required for using the gRPC reflection protocol with YARPC.
+//
+// See https://github.com/grpc/grpc/blob/master/doc/server-reflection.md.
+var {{$service.GetName}}ReflectionMeta = reflection.ServerMeta{
+	ServiceName: "{{trimPrefixPeriod $service.FQSN}}",
+	FileDescriptors: {{ fileDescriptorClosureVarName .File }},
 }
 
 type _{{$service.GetName}}YARPCCaller struct {

--- a/internal/crossdock/crossdockpb/crossdock.pb.yarpc.go
+++ b/internal/crossdock/crossdockpb/crossdock.pb.yarpc.go
@@ -187,12 +187,18 @@ func NewFxEchoYARPCProcedures() interface{} {
 				Server:      params.Server,
 				AnyResolver: params.AnyResolver,
 			}),
-			ReflectionMeta: reflection.ServerMeta{
-				ServiceName:     "uber.yarpc.internal.crossdock.Echo",
-				FileDescriptors: yarpcFileDescriptorClosure6acfd671bab786d8,
-			},
+			ReflectionMeta: EchoReflectionMeta,
 		}
 	}
+}
+
+// EchoReflectionMeta is the reflection server metadata
+// required for using the gRPC reflection protocol with YARPC.
+//
+// See https://github.com/grpc/grpc/blob/master/doc/server-reflection.md.
+var EchoReflectionMeta = reflection.ServerMeta{
+	ServiceName:     "uber.yarpc.internal.crossdock.Echo",
+	FileDescriptors: yarpcFileDescriptorClosure6acfd671bab786d8,
 }
 
 type _EchoYARPCCaller struct {

--- a/internal/examples/protobuf/examplepb/example.pb.yarpc.go
+++ b/internal/examples/protobuf/examplepb/example.pb.yarpc.go
@@ -199,12 +199,18 @@ func NewFxKeyValueYARPCProcedures() interface{} {
 				Server:      params.Server,
 				AnyResolver: params.AnyResolver,
 			}),
-			ReflectionMeta: reflection.ServerMeta{
-				ServiceName:     "uber.yarpc.internal.examples.protobuf.example.KeyValue",
-				FileDescriptors: yarpcFileDescriptorClosure43929dec9f67b739,
-			},
+			ReflectionMeta: KeyValueReflectionMeta,
 		}
 	}
+}
+
+// KeyValueReflectionMeta is the reflection server metadata
+// required for using the gRPC reflection protocol with YARPC.
+//
+// See https://github.com/grpc/grpc/blob/master/doc/server-reflection.md.
+var KeyValueReflectionMeta = reflection.ServerMeta{
+	ServiceName:     "uber.yarpc.internal.examples.protobuf.example.KeyValue",
+	FileDescriptors: yarpcFileDescriptorClosure43929dec9f67b739,
 }
 
 type _KeyValueYARPCCaller struct {
@@ -502,12 +508,18 @@ func NewFxFooYARPCProcedures() interface{} {
 				Server:      params.Server,
 				AnyResolver: params.AnyResolver,
 			}),
-			ReflectionMeta: reflection.ServerMeta{
-				ServiceName:     "uber.yarpc.internal.examples.protobuf.example.Foo",
-				FileDescriptors: yarpcFileDescriptorClosure43929dec9f67b739,
-			},
+			ReflectionMeta: FooReflectionMeta,
 		}
 	}
+}
+
+// FooReflectionMeta is the reflection server metadata
+// required for using the gRPC reflection protocol with YARPC.
+//
+// See https://github.com/grpc/grpc/blob/master/doc/server-reflection.md.
+var FooReflectionMeta = reflection.ServerMeta{
+	ServiceName:     "uber.yarpc.internal.examples.protobuf.example.Foo",
+	FileDescriptors: yarpcFileDescriptorClosure43929dec9f67b739,
 }
 
 type _FooYARPCCaller struct {

--- a/internal/examples/streaming/stream.pb.yarpc.go
+++ b/internal/examples/streaming/stream.pb.yarpc.go
@@ -261,12 +261,18 @@ func NewFxHelloYARPCProcedures() interface{} {
 				Server:      params.Server,
 				AnyResolver: params.AnyResolver,
 			}),
-			ReflectionMeta: reflection.ServerMeta{
-				ServiceName:     "uber.yarpc.internal.examples.streaming.Hello",
-				FileDescriptors: yarpcFileDescriptorClosure45d12c3ddf34baf8,
-			},
+			ReflectionMeta: HelloReflectionMeta,
 		}
 	}
+}
+
+// HelloReflectionMeta is the reflection server metadata
+// required for using the gRPC reflection protocol with YARPC.
+//
+// See https://github.com/grpc/grpc/blob/master/doc/server-reflection.md.
+var HelloReflectionMeta = reflection.ServerMeta{
+	ServiceName:     "uber.yarpc.internal.examples.streaming.Hello",
+	FileDescriptors: yarpcFileDescriptorClosure45d12c3ddf34baf8,
 }
 
 type _HelloYARPCCaller struct {

--- a/internal/prototest/examplepb/example.pb.yarpc.go
+++ b/internal/prototest/examplepb/example.pb.yarpc.go
@@ -199,12 +199,18 @@ func NewFxKeyValueYARPCProcedures() interface{} {
 				Server:      params.Server,
 				AnyResolver: params.AnyResolver,
 			}),
-			ReflectionMeta: reflection.ServerMeta{
-				ServiceName:     "uber.yarpc.internal.examples.protobuf.example.KeyValue",
-				FileDescriptors: yarpcFileDescriptorClosurebab15b635bbc13f7,
-			},
+			ReflectionMeta: KeyValueReflectionMeta,
 		}
 	}
+}
+
+// KeyValueReflectionMeta is the reflection server metadata
+// required for using the gRPC reflection protocol with YARPC.
+//
+// See https://github.com/grpc/grpc/blob/master/doc/server-reflection.md.
+var KeyValueReflectionMeta = reflection.ServerMeta{
+	ServiceName:     "uber.yarpc.internal.examples.protobuf.example.KeyValue",
+	FileDescriptors: yarpcFileDescriptorClosurebab15b635bbc13f7,
 }
 
 type _KeyValueYARPCCaller struct {
@@ -502,12 +508,18 @@ func NewFxFooYARPCProcedures() interface{} {
 				Server:      params.Server,
 				AnyResolver: params.AnyResolver,
 			}),
-			ReflectionMeta: reflection.ServerMeta{
-				ServiceName:     "uber.yarpc.internal.examples.protobuf.example.Foo",
-				FileDescriptors: yarpcFileDescriptorClosurebab15b635bbc13f7,
-			},
+			ReflectionMeta: FooReflectionMeta,
 		}
 	}
+}
+
+// FooReflectionMeta is the reflection server metadata
+// required for using the gRPC reflection protocol with YARPC.
+//
+// See https://github.com/grpc/grpc/blob/master/doc/server-reflection.md.
+var FooReflectionMeta = reflection.ServerMeta{
+	ServiceName:     "uber.yarpc.internal.examples.protobuf.example.Foo",
+	FileDescriptors: yarpcFileDescriptorClosurebab15b635bbc13f7,
 }
 
 type _FooYARPCCaller struct {
@@ -885,12 +897,18 @@ func NewFxTestMessageNameParityYARPCProcedures() interface{} {
 				Server:      params.Server,
 				AnyResolver: params.AnyResolver,
 			}),
-			ReflectionMeta: reflection.ServerMeta{
-				ServiceName:     "uber.yarpc.internal.examples.protobuf.example.TestMessageNameParity",
-				FileDescriptors: yarpcFileDescriptorClosurebab15b635bbc13f7,
-			},
+			ReflectionMeta: TestMessageNameParityReflectionMeta,
 		}
 	}
+}
+
+// TestMessageNameParityReflectionMeta is the reflection server metadata
+// required for using the gRPC reflection protocol with YARPC.
+//
+// See https://github.com/grpc/grpc/blob/master/doc/server-reflection.md.
+var TestMessageNameParityReflectionMeta = reflection.ServerMeta{
+	ServiceName:     "uber.yarpc.internal.examples.protobuf.example.TestMessageNameParity",
+	FileDescriptors: yarpcFileDescriptorClosurebab15b635bbc13f7,
 }
 
 type _TestMessageNameParityYARPCCaller struct {


### PR DESCRIPTION
- [X] Description and context for reviewers: one partner, one stranger
- [X] Entry in CHANGELOG.md

Currently, service reflection metadata is available only through the fx result which is unusable by non-fx users. This change exposes server reflection meta for each proto service.