### PR TITLE
Preparing release v1.64.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Added
+- tchannel: add TLS support for the inbound. Supports accepting
+  TLS and plaintext connections on the same port.
 
 ## [1.63.0] - 2022-08-17
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - tchannel: add TLS support for the inbound. Supports accepting
   TLS and plaintext connections on the same port.
+### Changed
+- protoc-gen-yarpc-go: expose service reflection metadata.
 
 ## [1.63.0] - 2022-08-17
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- No changes yet.
+
 ## [1.63.0] - 2022-08-17
 ### Added
 - http - add TLS support for the inbound. Supports accepting
@@ -1429,6 +1432,7 @@ This release requires regeneration of ThriftRW code.
 ## 0.1.0 - 2016-08-31
 
 - Initial release.
+[Unreleased]: https://github.com/yarpc/yarpc-go/compare/v1.63.0...HEAD
 [1.63.0]: https://github.com/yarpc/yarpc-go/compare/v1.62.0...v1.63.0
 [1.62.0]: https://github.com/yarpc/yarpc-go/compare/v1.61.0...v1.62.0
 [1.61.0]: https://github.com/yarpc/yarpc-go/compare/v1.60.0...v1.61.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.64.0] - 2022-09-12
 ### Added
 - tchannel: add TLS support for the inbound. Supports accepting
   TLS and plaintext connections on the same port.
@@ -1436,7 +1436,7 @@ This release requires regeneration of ThriftRW code.
 ## 0.1.0 - 2016-08-31
 
 - Initial release.
-[Unreleased]: https://github.com/yarpc/yarpc-go/compare/v1.63.0...HEAD
+[1.64.0]: https://github.com/yarpc/yarpc-go/compare/v1.63.0...v1.64.0
 [1.63.0]: https://github.com/yarpc/yarpc-go/compare/v1.62.0...v1.63.0
 [1.62.0]: https://github.com/yarpc/yarpc-go/compare/v1.61.0...v1.62.0
 [1.61.0]: https://github.com/yarpc/yarpc-go/compare/v1.60.0...v1.61.0

--- a/encoding/protobuf/internal/testpb/test.pb.yarpc.go
+++ b/encoding/protobuf/internal/testpb/test.pb.yarpc.go
@@ -213,12 +213,18 @@ func NewFxTestYARPCProcedures() interface{} {
 				Server:      params.Server,
 				AnyResolver: params.AnyResolver,
 			}),
-			ReflectionMeta: reflection.ServerMeta{
-				ServiceName:     "uber.yarpc.encoding.protobuf.Test",
-				FileDescriptors: yarpcFileDescriptorClosurefc320162ebaf2b25,
-			},
+			ReflectionMeta: TestReflectionMeta,
 		}
 	}
+}
+
+// TestReflectionMeta is the reflection server metadata
+// required for using the gRPC reflection protocol with YARPC.
+//
+// See https://github.com/grpc/grpc/blob/master/doc/server-reflection.md.
+var TestReflectionMeta = reflection.ServerMeta{
+	ServiceName:     "uber.yarpc.encoding.protobuf.Test",
+	FileDescriptors: yarpcFileDescriptorClosurefc320162ebaf2b25,
 }
 
 type _TestYARPCCaller struct {

--- a/encoding/protobuf/internal/testpb/testpb_test.go
+++ b/encoding/protobuf/internal/testpb/testpb_test.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2022 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package testpb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServerReflectionMeta(t *testing.T) {
+	assert.Equal(t, "uber.yarpc.encoding.protobuf.Test", TestReflectionMeta.ServiceName)
+	assert.NotNil(t, TestReflectionMeta.FileDescriptors)
+}

--- a/encoding/protobuf/protoc-gen-yarpc-go/internal/lib/lib.go
+++ b/encoding/protobuf/protoc-gen-yarpc-go/internal/lib/lib.go
@@ -300,12 +300,18 @@ func NewFx{{$service.GetName}}YARPCProcedures() interface{} {
 				Server:      params.Server,
 				AnyResolver: params.AnyResolver,
 			}),
-			ReflectionMeta: reflection.ServerMeta{
-				ServiceName: "{{trimPrefixPeriod $service.FQSN}}",
-				FileDescriptors: {{ fileDescriptorClosureVarName .File }},
-			},
+			ReflectionMeta: {{$service.GetName}}ReflectionMeta,
 		}
 	}
+}
+
+// {{$service.GetName}}ReflectionMeta is the reflection server metadata
+// required for using the gRPC reflection protocol with YARPC.
+//
+// See https://github.com/grpc/grpc/blob/master/doc/server-reflection.md.
+var {{$service.GetName}}ReflectionMeta = reflection.ServerMeta{
+	ServiceName: "{{trimPrefixPeriod $service.FQSN}}",
+	FileDescriptors: {{ fileDescriptorClosureVarName .File }},
 }
 
 type _{{$service.GetName}}YARPCCaller struct {

--- a/internal/crossdock/crossdockpb/crossdock.pb.yarpc.go
+++ b/internal/crossdock/crossdockpb/crossdock.pb.yarpc.go
@@ -187,12 +187,18 @@ func NewFxEchoYARPCProcedures() interface{} {
 				Server:      params.Server,
 				AnyResolver: params.AnyResolver,
 			}),
-			ReflectionMeta: reflection.ServerMeta{
-				ServiceName:     "uber.yarpc.internal.crossdock.Echo",
-				FileDescriptors: yarpcFileDescriptorClosure6acfd671bab786d8,
-			},
+			ReflectionMeta: EchoReflectionMeta,
 		}
 	}
+}
+
+// EchoReflectionMeta is the reflection server metadata
+// required for using the gRPC reflection protocol with YARPC.
+//
+// See https://github.com/grpc/grpc/blob/master/doc/server-reflection.md.
+var EchoReflectionMeta = reflection.ServerMeta{
+	ServiceName:     "uber.yarpc.internal.crossdock.Echo",
+	FileDescriptors: yarpcFileDescriptorClosure6acfd671bab786d8,
 }
 
 type _EchoYARPCCaller struct {

--- a/internal/examples/protobuf/examplepb/example.pb.yarpc.go
+++ b/internal/examples/protobuf/examplepb/example.pb.yarpc.go
@@ -199,12 +199,18 @@ func NewFxKeyValueYARPCProcedures() interface{} {
 				Server:      params.Server,
 				AnyResolver: params.AnyResolver,
 			}),
-			ReflectionMeta: reflection.ServerMeta{
-				ServiceName:     "uber.yarpc.internal.examples.protobuf.example.KeyValue",
-				FileDescriptors: yarpcFileDescriptorClosure43929dec9f67b739,
-			},
+			ReflectionMeta: KeyValueReflectionMeta,
 		}
 	}
+}
+
+// KeyValueReflectionMeta is the reflection server metadata
+// required for using the gRPC reflection protocol with YARPC.
+//
+// See https://github.com/grpc/grpc/blob/master/doc/server-reflection.md.
+var KeyValueReflectionMeta = reflection.ServerMeta{
+	ServiceName:     "uber.yarpc.internal.examples.protobuf.example.KeyValue",
+	FileDescriptors: yarpcFileDescriptorClosure43929dec9f67b739,
 }
 
 type _KeyValueYARPCCaller struct {
@@ -502,12 +508,18 @@ func NewFxFooYARPCProcedures() interface{} {
 				Server:      params.Server,
 				AnyResolver: params.AnyResolver,
 			}),
-			ReflectionMeta: reflection.ServerMeta{
-				ServiceName:     "uber.yarpc.internal.examples.protobuf.example.Foo",
-				FileDescriptors: yarpcFileDescriptorClosure43929dec9f67b739,
-			},
+			ReflectionMeta: FooReflectionMeta,
 		}
 	}
+}
+
+// FooReflectionMeta is the reflection server metadata
+// required for using the gRPC reflection protocol with YARPC.
+//
+// See https://github.com/grpc/grpc/blob/master/doc/server-reflection.md.
+var FooReflectionMeta = reflection.ServerMeta{
+	ServiceName:     "uber.yarpc.internal.examples.protobuf.example.Foo",
+	FileDescriptors: yarpcFileDescriptorClosure43929dec9f67b739,
 }
 
 type _FooYARPCCaller struct {

--- a/internal/examples/streaming/stream.pb.yarpc.go
+++ b/internal/examples/streaming/stream.pb.yarpc.go
@@ -261,12 +261,18 @@ func NewFxHelloYARPCProcedures() interface{} {
 				Server:      params.Server,
 				AnyResolver: params.AnyResolver,
 			}),
-			ReflectionMeta: reflection.ServerMeta{
-				ServiceName:     "uber.yarpc.internal.examples.streaming.Hello",
-				FileDescriptors: yarpcFileDescriptorClosure45d12c3ddf34baf8,
-			},
+			ReflectionMeta: HelloReflectionMeta,
 		}
 	}
+}
+
+// HelloReflectionMeta is the reflection server metadata
+// required for using the gRPC reflection protocol with YARPC.
+//
+// See https://github.com/grpc/grpc/blob/master/doc/server-reflection.md.
+var HelloReflectionMeta = reflection.ServerMeta{
+	ServiceName:     "uber.yarpc.internal.examples.streaming.Hello",
+	FileDescriptors: yarpcFileDescriptorClosure45d12c3ddf34baf8,
 }
 
 type _HelloYARPCCaller struct {

--- a/internal/prototest/examplepb/example.pb.yarpc.go
+++ b/internal/prototest/examplepb/example.pb.yarpc.go
@@ -199,12 +199,18 @@ func NewFxKeyValueYARPCProcedures() interface{} {
 				Server:      params.Server,
 				AnyResolver: params.AnyResolver,
 			}),
-			ReflectionMeta: reflection.ServerMeta{
-				ServiceName:     "uber.yarpc.internal.examples.protobuf.example.KeyValue",
-				FileDescriptors: yarpcFileDescriptorClosurebab15b635bbc13f7,
-			},
+			ReflectionMeta: KeyValueReflectionMeta,
 		}
 	}
+}
+
+// KeyValueReflectionMeta is the reflection server metadata
+// required for using the gRPC reflection protocol with YARPC.
+//
+// See https://github.com/grpc/grpc/blob/master/doc/server-reflection.md.
+var KeyValueReflectionMeta = reflection.ServerMeta{
+	ServiceName:     "uber.yarpc.internal.examples.protobuf.example.KeyValue",
+	FileDescriptors: yarpcFileDescriptorClosurebab15b635bbc13f7,
 }
 
 type _KeyValueYARPCCaller struct {
@@ -502,12 +508,18 @@ func NewFxFooYARPCProcedures() interface{} {
 				Server:      params.Server,
 				AnyResolver: params.AnyResolver,
 			}),
-			ReflectionMeta: reflection.ServerMeta{
-				ServiceName:     "uber.yarpc.internal.examples.protobuf.example.Foo",
-				FileDescriptors: yarpcFileDescriptorClosurebab15b635bbc13f7,
-			},
+			ReflectionMeta: FooReflectionMeta,
 		}
 	}
+}
+
+// FooReflectionMeta is the reflection server metadata
+// required for using the gRPC reflection protocol with YARPC.
+//
+// See https://github.com/grpc/grpc/blob/master/doc/server-reflection.md.
+var FooReflectionMeta = reflection.ServerMeta{
+	ServiceName:     "uber.yarpc.internal.examples.protobuf.example.Foo",
+	FileDescriptors: yarpcFileDescriptorClosurebab15b635bbc13f7,
 }
 
 type _FooYARPCCaller struct {
@@ -885,12 +897,18 @@ func NewFxTestMessageNameParityYARPCProcedures() interface{} {
 				Server:      params.Server,
 				AnyResolver: params.AnyResolver,
 			}),
-			ReflectionMeta: reflection.ServerMeta{
-				ServiceName:     "uber.yarpc.internal.examples.protobuf.example.TestMessageNameParity",
-				FileDescriptors: yarpcFileDescriptorClosurebab15b635bbc13f7,
-			},
+			ReflectionMeta: TestMessageNameParityReflectionMeta,
 		}
 	}
+}
+
+// TestMessageNameParityReflectionMeta is the reflection server metadata
+// required for using the gRPC reflection protocol with YARPC.
+//
+// See https://github.com/grpc/grpc/blob/master/doc/server-reflection.md.
+var TestMessageNameParityReflectionMeta = reflection.ServerMeta{
+	ServiceName:     "uber.yarpc.internal.examples.protobuf.example.TestMessageNameParity",
+	FileDescriptors: yarpcFileDescriptorClosurebab15b635bbc13f7,
 }
 
 type _TestMessageNameParityYARPCCaller struct {

--- a/transport/tchannel/tchannel_integration_test.go
+++ b/transport/tchannel/tchannel_integration_test.go
@@ -21,8 +21,11 @@
 package tchannel_test
 
 import (
+	"bytes"
 	"context"
+	"crypto/tls"
 	"errors"
+	"io"
 	"net"
 	"testing"
 	"time"
@@ -31,7 +34,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc/api/peer/peertest"
 	"go.uber.org/yarpc/api/transport"
+	yarpctls "go.uber.org/yarpc/api/transport/tls"
 	"go.uber.org/yarpc/peer"
+	"go.uber.org/yarpc/transport/internal/tlsscenario"
 	"go.uber.org/yarpc/transport/tchannel"
 	"go.uber.org/yarpc/x/yarpctest"
 	"go.uber.org/yarpc/x/yarpctest/api"
@@ -97,4 +102,101 @@ func TestDialerOption(t *testing.T) {
 	_, err = out.Call(ctx, &transport.Request{Service: "bar-service"})
 	require.Error(t, err, "expected dialer error")
 	assert.Contains(t, err.Error(), customDialerErr.Error())
+}
+
+func TestInboundTLS(t *testing.T) {
+	scenario := tlsscenario.Create(t, time.Minute, time.Minute)
+	serverCreds := &tls.Config{
+		GetCertificate: func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			return &tls.Certificate{
+				Certificate: [][]byte{scenario.ServerCert.Raw},
+				Leaf:        scenario.ServerCert,
+				PrivateKey:  scenario.ServerKey,
+			}, nil
+		},
+		ClientAuth: tls.RequireAndVerifyClientCert,
+		ClientCAs:  scenario.CAs,
+	}
+	clientCreds := &tls.Config{
+		GetClientCertificate: func(_ *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			return &tls.Certificate{
+				Certificate: [][]byte{scenario.ClientCert.Raw},
+				Leaf:        scenario.ClientCert,
+				PrivateKey:  scenario.ClientKey,
+			}, nil
+		},
+		RootCAs: scenario.CAs,
+	}
+
+	tests := []struct {
+		desc        string
+		isClientTLS bool
+	}{
+		{desc: "plaintext_client_permissive_tls_inbound"},
+		{desc: "tls_client_permissive_tls_inbound", isClientTLS: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			options := []tchannel.TransportOption{
+				tchannel.InboundTLSConfiguration(serverCreds),
+				tchannel.InboundTLSMode(yarpctls.Permissive),
+				tchannel.ServiceName("test-svc"),
+			}
+			if tt.isClientTLS {
+				tchannel.Dialer(func(ctx context.Context, network, hostPort string) (net.Conn, error) {
+					return tls.Dial(network, hostPort, clientCreds)
+				})
+			}
+			tr, err := tchannel.NewTransport(options...)
+			require.NoError(t, err)
+			inbound := tr.NewInbound()
+			inbound.SetRouter(testRouter{proc: transport.Procedure{HandlerSpec: transport.NewUnaryHandlerSpec(testServer{})}})
+
+			require.NoError(t, tr.Start())
+			defer tr.Stop()
+			require.NoError(t, inbound.Start())
+			defer inbound.Stop()
+
+			outbound := tr.NewSingleOutbound(tr.ListenAddr())
+			require.NoError(t, outbound.Start())
+			defer outbound.Stop()
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+			defer cancel()
+
+			res, err := outbound.Call(ctx, &transport.Request{
+				Service:   "test-svc-1",
+				Procedure: "test-proc",
+				Body:      bytes.NewReader([]byte("hello")),
+			})
+			require.NoError(t, err)
+
+			resBody, err := io.ReadAll(res.Body)
+			require.NoError(t, err)
+			assert.Equal(t, "hello", string(resBody))
+		})
+	}
+}
+
+type testRouter struct {
+	proc transport.Procedure
+}
+
+func (t testRouter) Procedures() []transport.Procedure {
+	return []transport.Procedure{t.proc}
+}
+
+func (t testRouter) Choose(ctx context.Context, req *transport.Request) (transport.HandlerSpec, error) {
+	return t.proc.HandlerSpec, nil
+}
+
+type testServer struct{}
+
+func (testServer) Handle(ctx context.Context, req *transport.Request, resw transport.ResponseWriter) error {
+	data, err := io.ReadAll(req.Body)
+	if err != nil {
+		return err
+	}
+	resw.Write(data)
+	return nil
 }

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package yarpc // import "go.uber.org/yarpc"
 
 // Version is the current version of YARPC.
-const Version = "1.63.0"
+const Version = "1.64.0-dev"

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package yarpc // import "go.uber.org/yarpc"
 
 // Version is the current version of YARPC.
-const Version = "1.64.0-dev"
+const Version = "1.64.0"


### PR DESCRIPTION
# Changelog

### Added
- tchannel: add TLS support for the inbound. Supports accepting
  TLS and plaintext connections on the same port.
### Changed
- protoc-gen-yarpc-go: expose service reflection metadata.