### PR TITLE
Added integration test for inbound and outbound with any resolver

### DIFF
--- a/encoding/protobuf/v2/inbound_test.go
+++ b/encoding/protobuf/v2/inbound_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2022 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package v2_test
 
 import (

--- a/encoding/protobuf/v2/inbound_test.go
+++ b/encoding/protobuf/v2/inbound_test.go
@@ -25,7 +25,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/api/transport/transporttest"
@@ -37,7 +36,7 @@ import (
 
 func TestInboundAnyResolver(t *testing.T) {
 	newReq := func() proto.Message { return &testpb.TestMessage{} }
-	customAnyResolver := &anyResolver{NewMessage: &testpb.TestMessage{}}
+	customAnyResolver := &testAnyResolver{NewMessage: &testpb.TestMessage{}}
 	tests := []struct {
 		name     string
 		anyURL   string
@@ -65,7 +64,7 @@ func TestInboundAnyResolver(t *testing.T) {
 				Handle: func(context.Context, proto.Message) (proto.Message, error) {
 					testMessage := &testpb.TestMessage{Value: "foo-bar-baz"}
 					any, err := anypb.New(testMessage)
-					assert.NoError(t, err)
+					require.NoError(t, err)
 					any.TypeUrl = tt.anyURL // update to custom URL
 					return any, nil
 				},

--- a/encoding/protobuf/v2/inbound_test.go
+++ b/encoding/protobuf/v2/inbound_test.go
@@ -1,0 +1,66 @@
+package v2_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/api/transport/transporttest"
+	"go.uber.org/yarpc/encoding/protobuf/internal/testpb/v2"
+	"go.uber.org/yarpc/encoding/protobuf/v2"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+func TestInboundAnyResolver(t *testing.T) {
+	newReq := func() proto.Message { return &testpb.TestMessage{} }
+	customAnyResolver := &anyResolver{NewMessage: &testpb.TestMessage{}}
+	tests := []struct {
+		name     string
+		anyURL   string
+		resolver v2.AnyResolver
+	}{
+		{
+			name:   "nothing custom",
+			anyURL: "uber.yarpc.encoding.protobuf.TestMessage",
+		},
+		{
+			name:     "custom resolver",
+			anyURL:   "uber.yarpc.encoding.protobuf.TestMessage",
+			resolver: customAnyResolver,
+		},
+		{
+			name:     "custom resolver, custom URL",
+			anyURL:   "foo.bar.baz",
+			resolver: customAnyResolver,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := v2.NewUnaryHandler(v2.UnaryHandlerParams{
+				Handle: func(context.Context, proto.Message) (proto.Message, error) {
+					testMessage := &testpb.TestMessage{Value: "foo-bar-baz"}
+					any, err := anypb.New(testMessage)
+					assert.NoError(t, err)
+					any.TypeUrl = tt.anyURL // update to custom URL
+					return any, nil
+				},
+				NewRequest:  newReq,
+				AnyResolver: tt.resolver,
+			})
+
+			req := &transport.Request{
+				Encoding: v2.Encoding,
+				Body:     bytes.NewReader(nil),
+			}
+
+			var resw transporttest.FakeResponseWriter
+			err := handler.Handle(context.Background(), req, &resw)
+			require.NoError(t, err)
+		})
+	}
+}

--- a/encoding/protobuf/v2/marshal.go
+++ b/encoding/protobuf/v2/marshal.go
@@ -64,7 +64,7 @@ type codec struct {
 func newCodec(anyResolver AnyResolver) *codec {
 	return &codec{
 		jsonMarshaler:   &protojson.MarshalOptions{Resolver: anyResolver},
-		jsonUnmarshaler: &protojson.UnmarshalOptions{Resolver: anyResolver},
+		jsonUnmarshaler: &protojson.UnmarshalOptions{Resolver: anyResolver, DiscardUnknown: true},
 	}
 }
 

--- a/encoding/protobuf/v2/outbound_test.go
+++ b/encoding/protobuf/v2/outbound_test.go
@@ -1,10 +1,28 @@
+// Copyright (c) 2022 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package v2_test
 
 import (
 	"context"
 	"errors"
-	"google.golang.org/protobuf/reflect/protoreflect"
-	"google.golang.org/protobuf/runtime/protoimpl"
 	"io/ioutil"
 	"testing"
 
@@ -15,6 +33,8 @@ import (
 	"go.uber.org/yarpc/encoding/protobuf/v2"
 	"go.uber.org/yarpc/yarpctest"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/runtime/protoimpl"
 	"google.golang.org/protobuf/types/known/anypb"
 )
 

--- a/encoding/protobuf/v2/outbound_test.go
+++ b/encoding/protobuf/v2/outbound_test.go
@@ -1,0 +1,111 @@
+package v2_test
+
+import (
+	"context"
+	"errors"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/runtime/protoimpl"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/encoding/protobuf/internal/testpb/v2"
+	"go.uber.org/yarpc/encoding/protobuf/v2"
+	"go.uber.org/yarpc/yarpctest"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+func TestOutboundAnyResolver(t *testing.T) {
+	const testValue = "foo-bar-baz"
+	newReq := func() proto.Message { return &testpb.TestMessage{} }
+	customAnyResolver := &anyResolver{NewMessage: &testpb.TestMessage{}}
+	tests := []struct {
+		name     string
+		anyURL   string
+		resolver v2.AnyResolver
+		wantErr  bool
+	}{
+		{
+			name:   "nothing custom",
+			anyURL: "uber.yarpc.encoding.protobuf.TestMessage",
+		},
+		{
+			name:     "custom resolver",
+			anyURL:   "uber.yarpc.encoding.protobuf.TestMessage",
+			resolver: customAnyResolver,
+		},
+		{
+			name:     "custom resolver, custom URL",
+			anyURL:   "foo.bar.baz",
+			resolver: customAnyResolver,
+		},
+		{
+			name:    "custom URL, no resolver",
+			anyURL:  "foo.bar.baz",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			trans := yarpctest.NewFakeTransport()
+			// outbound that echos the body back
+			out := trans.NewOutbound(nil, yarpctest.OutboundCallOverride(
+				yarpctest.OutboundCallable(func(ctx context.Context, req *transport.Request) (*transport.Response, error) {
+					return &transport.Response{Body: ioutil.NopCloser(req.Body)}, nil
+				}),
+			))
+
+			client := v2.NewClient(v2.ClientParams{
+				ClientConfig: &transport.OutboundConfig{
+					Outbounds: transport.Outbounds{
+						Unary: out,
+					},
+				},
+				AnyResolver: tt.resolver,
+				Options:     []v2.ClientOption{v2.UseJSON},
+			})
+
+			testMessage := &testpb.TestMessage{Value: testValue}
+
+			// convert to an Any so that the marshaller will use the custom resolver
+			anyMsg, err := anypb.New(testMessage)
+			require.NoError(t, err)
+			anyMsg.TypeUrl = tt.anyURL // update to custom URL
+
+			gotMessage, err := client.Call(context.Background(), "", anyMsg, newReq)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.True(t, proto.Equal(testMessage, gotMessage)) // we expect the actual type behind the Any
+			}
+		})
+	}
+}
+
+type anyResolver struct {
+	NewMessage proto.Message
+}
+
+func (r anyResolver) FindMessageByName(message protoreflect.FullName) (protoreflect.MessageType, error) {
+	return r.FindMessageByURL(string(message))
+}
+
+func (r anyResolver) FindMessageByURL(url string) (protoreflect.MessageType, error) {
+	if r.NewMessage == nil {
+		return nil, errors.New("test resolver is not initialized")
+	}
+	return protoimpl.X.MessageTypeOf(r.NewMessage), nil
+}
+
+func (r anyResolver) FindExtensionByName(field protoreflect.FullName) (protoreflect.ExtensionType, error) {
+	return nil, nil
+}
+
+func (r anyResolver) FindExtensionByNumber(message protoreflect.FullName, field protoreflect.FieldNumber) (protoreflect.ExtensionType, error) {
+	return nil, nil
+}


### PR DESCRIPTION
This PR aims to add integration for inbound and outbound with anyresolver. The test simulates (un)marshalling with anytypes provided no resolver and resolver.

