### PR TITLE
tls: refactor mux listener into tls package

### DIFF
--- a/transport/grpc/inbound.go
+++ b/transport/grpc/inbound.go
@@ -29,7 +29,7 @@ import (
 	yarpctls "go.uber.org/yarpc/api/transport/tls"
 	"go.uber.org/yarpc/api/x/introspection"
 	"go.uber.org/yarpc/pkg/lifecycle"
-	"go.uber.org/yarpc/transport/internal/tlsmux"
+	"go.uber.org/yarpc/transport/internal/tls/muxlistener"
 	"go.uber.org/yarpc/yarpcerrors"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -130,7 +130,7 @@ func (i *Inbound) start() error {
 			return errors.New("gRPC TLS enabled but configuration not provided")
 		}
 
-		listener = tlsmux.NewListener(tlsmux.Config{
+		listener = muxlistener.NewListener(muxlistener.Config{
 			Listener:      listener,
 			TLSConfig:     i.options.tlsConfig.Clone(),
 			Logger:        i.t.options.logger,

--- a/transport/http/inbound.go
+++ b/transport/http/inbound.go
@@ -35,7 +35,7 @@ import (
 	"go.uber.org/yarpc/api/x/introspection"
 	intnet "go.uber.org/yarpc/internal/net"
 	"go.uber.org/yarpc/pkg/lifecycle"
-	"go.uber.org/yarpc/transport/internal/tlsmux"
+	"go.uber.org/yarpc/transport/internal/tls/muxlistener"
 	"go.uber.org/yarpc/yarpcerrors"
 	"go.uber.org/zap"
 )
@@ -241,7 +241,7 @@ func (i *Inbound) start() error {
 			return errors.New("HTTP TLS enabled but configuration not provided")
 		}
 
-		listener = tlsmux.NewListener(tlsmux.Config{
+		listener = muxlistener.NewListener(muxlistener.Config{
 			Listener:      listener,
 			TLSConfig:     i.tlsConfig,
 			ServiceName:   i.transport.serviceName,

--- a/transport/internal/tls/muxlistener/conn_sniffer.go
+++ b/transport/internal/tls/muxlistener/conn_sniffer.go
@@ -18,14 +18,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package tlsmux
+package muxlistener
 
 import (
 	"bytes"
 	"net"
 )
 
-// connSniffer wraps the connection and enables tlsmux to sniff inital bytes from the
+// connSniffer wraps the connection and enables muxlistener to sniff inital bytes from the
 // connection efficiently.
 type connSniffer struct {
 	net.Conn

--- a/transport/internal/tls/muxlistener/conn_sniffer_test.go
+++ b/transport/internal/tls/muxlistener/conn_sniffer_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package tlsmux
+package muxlistener
 
 import (
 	"bytes"

--- a/transport/internal/tls/muxlistener/listener.go
+++ b/transport/internal/tls/muxlistener/listener.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package tlsmux
+package muxlistener
 
 import (
 	"context"

--- a/transport/internal/tls/muxlistener/listener_test.go
+++ b/transport/internal/tls/muxlistener/listener_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package tlsmux_test
+package muxlistener_test
 
 import (
 	"crypto/tls"
@@ -33,7 +33,7 @@ import (
 	"go.uber.org/goleak"
 	"go.uber.org/net/metrics"
 	yarpctls "go.uber.org/yarpc/api/transport/tls"
-	"go.uber.org/yarpc/transport/internal/tlsmux"
+	"go.uber.org/yarpc/transport/internal/tls/muxlistener"
 	"go.uber.org/yarpc/transport/internal/tlsscenario"
 	"go.uber.org/zap"
 )
@@ -43,7 +43,7 @@ func TestNewListenerOnDisabled(t *testing.T) {
 	require.NoError(t, err)
 	defer lis.Close()
 
-	gotLis := tlsmux.NewListener(tlsmux.Config{Listener: lis, Mode: yarpctls.Disabled})
+	gotLis := muxlistener.NewListener(muxlistener.Config{Listener: lis, Mode: yarpctls.Disabled})
 	assert.Equal(t, lis, gotLis)
 }
 
@@ -173,7 +173,7 @@ func TestMux(t *testing.T) {
 			require.NoError(t, err, "unexpected error on listening")
 
 			root := metrics.New()
-			muxLis := tlsmux.NewListener(tlsmux.Config{
+			muxLis := muxlistener.NewListener(muxlistener.Config{
 				Listener:      lis,
 				TLSConfig:     serverTlsConfig,
 				Meter:         root.Scope(),
@@ -267,7 +267,7 @@ func TestConcurrentConnections(t *testing.T) {
 	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err, "unexpected error on listening")
 
-	muxLis := tlsmux.NewListener(tlsmux.Config{
+	muxLis := muxlistener.NewListener(muxlistener.Config{
 		Listener:      lis,
 		TLSConfig:     serverTlsConfig,
 		Meter:         metrics.New().Scope(),

--- a/transport/internal/tls/muxlistener/observer.go
+++ b/transport/internal/tls/muxlistener/observer.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package tlsmux
+package muxlistener
 
 import (
 	"crypto/tls"

--- a/transport/internal/tls/muxlistener/observer_test.go
+++ b/transport/internal/tls/muxlistener/observer_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package tlsmux
+package muxlistener
 
 import (
 	"crypto/tls"

--- a/transport/internal/tls/muxlistener/tls_checker.go
+++ b/transport/internal/tls/muxlistener/tls_checker.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package tlsmux
+package muxlistener
 
 import "io"
 

--- a/transport/internal/tls/muxlistener/tls_checker_test.go
+++ b/transport/internal/tls/muxlistener/tls_checker_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package tlsmux
+package muxlistener
 
 import (
 	"bytes"

--- a/transport/tchannel/transport.go
+++ b/transport/tchannel/transport.go
@@ -37,7 +37,7 @@ import (
 	"go.uber.org/yarpc/api/transport"
 	yarpctls "go.uber.org/yarpc/api/transport/tls"
 	"go.uber.org/yarpc/pkg/lifecycle"
-	"go.uber.org/yarpc/transport/internal/tlsmux"
+	"go.uber.org/yarpc/transport/internal/tls/muxlistener"
 	"go.uber.org/zap"
 )
 
@@ -273,7 +273,7 @@ func (t *Transport) start() error {
 			return errors.New("tchannel TLS enabled but configuration not provided")
 		}
 
-		listener = tlsmux.NewListener(tlsmux.Config{
+		listener = muxlistener.NewListener(muxlistener.Config{
 			Listener:      listener,
 			TLSConfig:     t.inboundTLSConfig,
 			ServiceName:   t.name,


### PR DESCRIPTION
- [X] Description and context for reviewers: one partner, one stranger

Refactor the internal `tlsmux` package into `tls/muxlistener`. Going forward`tls` internal package will hold all the sub-packages related to inbound and outbound tls.

