### PR TITLE
Preparing relase v1.65.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.65.0] - 2022-09-26
 ### Added
 - protoc-gen-yarpc-go-v2: Added new yarpc proto plugin `protoc-gen-yarpc-go-v2`. `protoc-gen-yarpc-go-v2`
   generated yarpc protobuf code is compatible with golang protobuf v2 apis.
@@ -1441,7 +1441,7 @@ This release requires regeneration of ThriftRW code.
 ## 0.1.0 - 2016-08-31
 
 - Initial release.
-[Unreleased]: https://github.com/yarpc/yarpc-go/compare/v1.64.0...HEAD
+[1.65.0]: https://github.com/yarpc/yarpc-go/compare/v1.64.0...v1.65.0
 [1.64.0]: https://github.com/yarpc/yarpc-go/compare/v1.63.0...v1.64.0
 [1.63.0]: https://github.com/yarpc/yarpc-go/compare/v1.62.0...v1.63.0
 [1.62.0]: https://github.com/yarpc/yarpc-go/compare/v1.61.0...v1.62.0

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package yarpc // import "go.uber.org/yarpc"
 
 // Version is the current version of YARPC.
-const Version = "1.65.0-dev"
+const Version = "1.65.0"


### PR DESCRIPTION
**Changelog**

_Added_
- protoc-gen-yarpc-go-v2: Added new yarpc proto plugin `protoc-gen-yarpc-go-v2`. `protoc-gen-yarpc-go-v2`
  generated yarpc protobuf code is compatible with golang protobuf v2 apis.
