### PR TITLE
yarpcconfig: expose outbound name in kit

### DIFF
--- a/yarpcconfig/builder.go
+++ b/yarpcconfig/builder.go
@@ -111,26 +111,29 @@ func (b *builder) Build() (yarpc.Config, error) {
 		var err error
 
 		var ob transport.Outbounds
+		outboundServiceName := ccname
 		if c.Service != ccname {
 			ob.ServiceName = c.Service
+			outboundServiceName = c.Service
 		}
 
+		kit := b.kit.withOutboundName(outboundServiceName)
 		if o := c.Unary; o != nil {
-			ob.Unary, err = buildUnaryOutbound(o, transports[o.TransportSpec.Name], b.kit)
+			ob.Unary, err = buildUnaryOutbound(o, transports[o.TransportSpec.Name], kit)
 			if err != nil {
 				errs = multierr.Append(errs, fmt.Errorf(`failed to configure unary outbound for %q: %v`, ccname, err))
 				continue
 			}
 		}
 		if o := c.Oneway; o != nil {
-			ob.Oneway, err = buildOnewayOutbound(o, transports[o.TransportSpec.Name], b.kit)
+			ob.Oneway, err = buildOnewayOutbound(o, transports[o.TransportSpec.Name], kit)
 			if err != nil {
 				errs = multierr.Append(errs, fmt.Errorf(`failed to configure oneway outbound for %q: %v`, ccname, err))
 				continue
 			}
 		}
 		if o := c.Stream; o != nil {
-			ob.Stream, err = buildStreamOutbound(o, transports[o.TransportSpec.Name], b.kit)
+			ob.Stream, err = buildStreamOutbound(o, transports[o.TransportSpec.Name], kit)
 			if err != nil {
 				errs = multierr.Append(errs, fmt.Errorf(`failed to configure stream outbound for %q: %v`, ccname, err))
 				continue

--- a/yarpcconfig/builder.go
+++ b/yarpcconfig/builder.go
@@ -111,13 +111,11 @@ func (b *builder) Build() (yarpc.Config, error) {
 		var err error
 
 		var ob transport.Outbounds
-		outboundServiceName := ccname
 		if c.Service != ccname {
 			ob.ServiceName = c.Service
-			outboundServiceName = c.Service
 		}
 
-		kit := b.kit.withOutboundName(outboundServiceName)
+		kit := b.kit.withOutboundName(c.Service)
 		if o := c.Unary; o != nil {
 			ob.Unary, err = buildUnaryOutbound(o, transports[o.TransportSpec.Name], kit)
 			if err != nil {

--- a/yarpcconfig/configurator_test.go
+++ b/yarpcconfig/configurator_test.go
@@ -1053,7 +1053,7 @@ func TestConfigurator(t *testing.T) {
 					BuildUnaryOutbound(
 						&outboundConfig{Address: "localhost:4040"},
 						transport,
-						kitMatcher{ServiceName: "foo"}).
+						kitMatcher{ServiceName: "foo", OutboundServiceName: "bar"}).
 					Return(outbound, nil)
 
 				tt.specs = []TransportSpec{tchan.Spec()}
@@ -1103,7 +1103,7 @@ func TestConfigurator(t *testing.T) {
 					BuildOnewayOutbound(
 						&outboundConfig{Queue: "requests"},
 						transport,
-						kitMatcher{ServiceName: "foo"}).
+						kitMatcher{ServiceName: "foo", OutboundServiceName: "bar"}).
 					Return(outbound, nil)
 
 				tt.specs = []TransportSpec{redis.Spec()}
@@ -1153,7 +1153,7 @@ func TestConfigurator(t *testing.T) {
 					BuildStreamOutbound(
 						&outboundConfig{Queue: "requests"},
 						transport,
-						kitMatcher{ServiceName: "foo"}).
+						kitMatcher{ServiceName: "foo", OutboundServiceName: "bar"}).
 					Return(outbound, nil)
 
 				tt.specs = []TransportSpec{redis.Spec()}
@@ -1206,13 +1206,13 @@ func TestConfigurator(t *testing.T) {
 
 				outcfg := outboundConfig{URL: "http://localhost:8080/yarpc"}
 				http.EXPECT().
-					BuildUnaryOutbound(&outcfg, transport, kitMatcher{ServiceName: "foo"}).
+					BuildUnaryOutbound(&outcfg, transport, kitMatcher{ServiceName: "foo", OutboundServiceName: "baz"}).
 					Return(unary, nil)
 				http.EXPECT().
-					BuildOnewayOutbound(&outcfg, transport, kitMatcher{ServiceName: "foo"}).
+					BuildOnewayOutbound(&outcfg, transport, kitMatcher{ServiceName: "foo", OutboundServiceName: "baz"}).
 					Return(oneway, nil)
 				http.EXPECT().
-					BuildStreamOutbound(&outcfg, transport, kitMatcher{ServiceName: "foo"}).
+					BuildStreamOutbound(&outcfg, transport, kitMatcher{ServiceName: "foo", OutboundServiceName: "baz"}).
 					Return(stream, nil)
 
 				tt.specs = []TransportSpec{http.Spec()}
@@ -1331,26 +1331,26 @@ func TestConfigurator(t *testing.T) {
 					BuildUnaryOutbound(
 						httpOutboundConfig{URL: "http://localhost:8080/yarpc/v1"},
 						httpTransport,
-						kitMatcher{ServiceName: "myservice"}).
+						kitMatcher{ServiceName: "myservice", OutboundServiceName: "foo"}).
 					Return(httpUnary, nil)
 				http.EXPECT().
 					BuildOnewayOutbound(
 						httpOutboundConfig{URL: "http://localhost:8081/yarpc/v2"},
 						httpTransport,
-						kitMatcher{ServiceName: "myservice"}).
+						kitMatcher{ServiceName: "myservice", OutboundServiceName: "foo"}).
 					Return(httpOneway, nil)
 				http.EXPECT().
 					BuildStreamOutbound(
 						httpOutboundConfig{URL: "http://localhost:8081/yarpc/v3"},
 						httpTransport,
-						kitMatcher{ServiceName: "myservice"}).
+						kitMatcher{ServiceName: "myservice", OutboundServiceName: "foo"}).
 					Return(httpStream, nil)
 
 				redis.EXPECT().
 					BuildOnewayOutbound(
 						redisOutboundConfig{Queue: "requests"},
 						redisTransport,
-						kitMatcher{ServiceName: "myservice"}).
+						kitMatcher{ServiceName: "myservice", OutboundServiceName: "bar"}).
 					Return(redisOneway, nil)
 
 				tt.specs = []TransportSpec{http.Spec(), redis.Spec()}
@@ -1567,26 +1567,26 @@ func TestConfigurator(t *testing.T) {
 					BuildUnaryOutbound(
 						outboundConfig{URL: "http://localhost:8080/bar"},
 						transport,
-						kitMatcher{ServiceName: "foo"}).
+						kitMatcher{ServiceName: "foo", OutboundServiceName: "bar"}).
 					Return(unary, nil)
 				http.EXPECT().
 					BuildOnewayOutbound(
 						outboundConfig{URL: "http://localhost:8080/bar"},
 						transport,
-						kitMatcher{ServiceName: "foo"}).
+						kitMatcher{ServiceName: "foo", OutboundServiceName: "bar"}).
 					Return(oneway, nil)
 
 				http.EXPECT().
 					BuildUnaryOutbound(
 						outboundConfig{URL: "http://localhost:8081/bar"},
 						transport,
-						kitMatcher{ServiceName: "foo"}).
+						kitMatcher{ServiceName: "foo", OutboundServiceName: "bar"}).
 					Return(unaryStaging, nil)
 				http.EXPECT().
 					BuildOnewayOutbound(
 						outboundConfig{URL: "http://localhost:8081/bar"},
 						transport,
-						kitMatcher{ServiceName: "foo"}).
+						kitMatcher{ServiceName: "foo", OutboundServiceName: "bar"}).
 					Return(onewayStaging, nil)
 
 				tt.specs = []TransportSpec{http.Spec()}
@@ -1646,7 +1646,8 @@ func TestConfigurator(t *testing.T) {
 					BuildTransport(transportConfig{ServerAddress: "127.0.0.1:6379"}, kit).
 					Return(transport, nil)
 				redis.EXPECT().
-					BuildOnewayOutbound(outboundConfig{QueueName: "/myservice/inbound"}, transport, kit).
+					BuildOnewayOutbound(outboundConfig{QueueName: "/myservice/inbound"}, transport,
+						kitMatcher{ServiceName: "foo", OutboundServiceName: "myservice"}).
 					Return(oneway, nil)
 
 				tt.specs = []TransportSpec{redis.Spec()}

--- a/yarpcconfig/kit.go
+++ b/yarpcconfig/kit.go
@@ -38,6 +38,10 @@ type Kit struct {
 
 	name string
 
+	// outboundName is the name of the outbound. It is set in the Kit used for
+	// building outbound.
+	outboundName string
+
 	// Used to resolve interpolated variables.
 	resolver interpolate.VariableResolver
 
@@ -52,9 +56,20 @@ func (k *Kit) withTransportSpec(spec *compiledTransportSpec) *Kit {
 	return &newK
 }
 
+// Returns a shallow copy of this Kit with outbound name set to given value.
+func (k *Kit) withOutboundName(name string) *Kit {
+	newK := *k
+	newK.outboundName = name
+	return &newK
+}
+
 // ServiceName returns the name of the service for which components are being
 // built.
 func (k *Kit) ServiceName() string { return k.name }
+
+// OutboundServiceName returns the name of the service for which outbound is
+// being built.
+func (k *Kit) OutboundServiceName() string { return k.outboundName }
 
 var _typeOfKit = reflect.TypeOf((*Kit)(nil))
 

--- a/yarpcconfig/kit_test.go
+++ b/yarpcconfig/kit_test.go
@@ -39,4 +39,9 @@ func TestKitWithTransportSpec(t *testing.T) {
 	child.name = "bar"
 	assert.Equal(t, "foo", root.ServiceName())
 	assert.Equal(t, "bar", child.ServiceName())
+
+	childOutbound := root.withOutboundName("test-outbound")
+	assert.Equal(t, "test-outbound", childOutbound.OutboundServiceName())
+	assert.Equal(t, "foo", childOutbound.ServiceName())
+	assert.Empty(t, root.outboundName, "outbound name must be empty")
 }

--- a/yarpcconfig/mock_transport_spec_test.go
+++ b/yarpcconfig/mock_transport_spec_test.go
@@ -146,7 +146,8 @@ func (r *_transportSpecRecorder) BuildStreamOutbound(cfg interface{}, t transpor
 
 // kitMatcher matches attributes of a kit
 type kitMatcher struct {
-	ServiceName string
+	ServiceName         string
+	OutboundServiceName string
 }
 
 func (m kitMatcher) Matches(x interface{}) bool {
@@ -155,9 +156,9 @@ func (m kitMatcher) Matches(x interface{}) bool {
 		return false
 	}
 
-	return k.ServiceName() == m.ServiceName
+	return k.ServiceName() == m.ServiceName && k.OutboundServiceName() == m.OutboundServiceName
 }
 
 func (m kitMatcher) String() string {
-	return fmt.Sprintf("kit{name: %q}", m.ServiceName)
+	return fmt.Sprintf("kit{name: %q, outboundName: %q}", m.ServiceName, m.OutboundServiceName)
 }


### PR DESCRIPTION
Transport outbound builders do not have access to the name of the outbound service. Unary, oneway and stream outbound builders have function signatures like:
```go
func buildOutbound(outboundConfig *OutboundConfig, tr transport.Transport, kit *yarpcconfig.Kit) (*Outbound, error)
```
None of the above params contain outbound service name.

This pull request adds the name of the outbound service in `yarpcconfig.Kit` while building outbound, which can be accessed by the outbound builders.

For reviewers, start with `yarpcconfig/kit.go` then go to `yarpcconfig/builder.go`