### PR TITLE
tls-testing: expose server and client tls config

### DIFF
--- a/transport/internal/tls/muxlistener/listener_test.go
+++ b/transport/internal/tls/muxlistener/listener_test.go
@@ -49,18 +49,8 @@ func TestNewListenerOnDisabled(t *testing.T) {
 
 func TestMux(t *testing.T) {
 	scenario := testscenario.Create(t, time.Minute, time.Minute)
-	serverTlsConfig := &tls.Config{
-		GetCertificate: func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
-			return &tls.Certificate{
-				Certificate: [][]byte{scenario.ServerCert.Raw},
-				Leaf:        scenario.ServerCert,
-				PrivateKey:  scenario.ServerKey,
-			}, nil
-		},
-		MinVersion: tls.VersionTLS13,
-		ClientAuth: tls.RequireAndVerifyClientCert,
-		ClientCAs:  scenario.CAs,
-	}
+	serverTlsConfig := scenario.ServerTLSConfig()
+	serverTlsConfig.MinVersion = tls.VersionTLS13
 
 	tests := []struct {
 		desc            string


### PR DESCRIPTION
Expose server and client `*tls.Config` boilerplate to avoid duplicating code across tests. Addresses review comment: https://github.com/yarpc/yarpc-go/pull/2166#discussion_r982666191