### PR TITLE
Log original context deadline on errors (#2184)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+### Added
+- logging: Original context deadline if available is logged under `deadline` field.
 
 ## [1.66.0] - 2022-10-10
 ### Added

--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -64,7 +64,7 @@ const (
 type call struct {
 	edge    *edge
 	extract ContextExtractor
-	fields  [9]zapcore.Field
+	fields  [10]zapcore.Field
 
 	started   time.Time
 	ctx       context.Context
@@ -227,6 +227,9 @@ func (c call) endLogs(
 	fields = append(fields, zap.Duration("latency", elapsed))
 	fields = append(fields, zap.Bool("successful", err == nil && !isApplicationError))
 	fields = append(fields, c.extract(c.ctx))
+	if deadlineTime, ok := c.ctx.Deadline(); ok {
+		fields = append(fields, zap.Duration("deadline", deadlineTime.Sub(c.started)))
+	}
 
 	if appErrBitWithNoError { // Thrift exception
 		fields = append(fields, zap.String(_error, "application_error"))


### PR DESCRIPTION
Log original context deadline, if available, which is particularly useful on failed calls where the caller has supplied an unreasonably short deadline.
