### PR TITLE
Move & Export logic to get server/client fault type under yarpcerrors

### DIFF
--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -3565,7 +3565,7 @@ func TestStreamingMetrics(t *testing.T) {
 				// so we don't have create a sorting implementation, manually place the
 				// first two expected counter snapshots, based on the error fault.
 				counters := make([]metrics.Snapshot, 0, 10)
-				if faultFromCode(yarpcerrors.FromError(tt.err).Code()) == clientFault {
+				if yarpcerrors.GetFaultTypeFromCode(yarpcerrors.FromError(tt.err).Code()) == yarpcerrors.ClientFault {
 					counters = append(counters,
 						metrics.Snapshot{Name: "caller_failures", Tags: errTags, Value: 1},
 						metrics.Snapshot{Name: "calls", Tags: successTags, Value: 1},

--- a/yarpcerrors/yarpcerrorclassifier.go
+++ b/yarpcerrors/yarpcerrorclassifier.go
@@ -18,46 +18,44 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package observability
-
-import (
-	"go.uber.org/yarpc/yarpcerrors"
-)
-
-// TODO(apeatsbond): This code may be worth exporting in the yarpcerrors
-// package.
+package yarpcerrors
 
 type fault int
 
 const (
-	unknownFault fault = iota
-	clientFault
-	serverFault
+	UnknownFault fault = iota
+	ClientFault
+	ServerFault
 )
 
-// determine whether the status code is a client, server or indeterminate fault based on a YARPC Code.
-func faultFromCode(code yarpcerrors.Code) fault {
-	switch code {
-	case yarpcerrors.CodeCancelled,
-		yarpcerrors.CodeInvalidArgument,
-		yarpcerrors.CodeNotFound,
-		yarpcerrors.CodeAlreadyExists,
-		yarpcerrors.CodePermissionDenied,
-		yarpcerrors.CodeFailedPrecondition,
-		yarpcerrors.CodeAborted,
-		yarpcerrors.CodeOutOfRange,
-		yarpcerrors.CodeUnauthenticated,
-		yarpcerrors.CodeUnimplemented,
-		yarpcerrors.CodeResourceExhausted:
-		return clientFault
+// GetFaultTypeFromError determines whether the error is a client, server or indeterminate fault based on a YARPC Code.
+func GetFaultTypeFromError(err error) fault {
+	return GetFaultTypeFromCode(FromError(err).Code())
+}
 
-	case yarpcerrors.CodeUnknown,
-		yarpcerrors.CodeDeadlineExceeded,
-		yarpcerrors.CodeInternal,
-		yarpcerrors.CodeUnavailable,
-		yarpcerrors.CodeDataLoss:
-		return serverFault
+// GetFaultTypeFromCode determines whether the status code is a client, server or indeterminate fault based on a YARPC Code.
+func GetFaultTypeFromCode(code Code) fault {
+	switch code {
+	case CodeCancelled,
+		CodeInvalidArgument,
+		CodeNotFound,
+		CodeAlreadyExists,
+		CodePermissionDenied,
+		CodeFailedPrecondition,
+		CodeAborted,
+		CodeOutOfRange,
+		CodeUnauthenticated,
+		CodeUnimplemented,
+		CodeResourceExhausted:
+		return ClientFault
+
+	case CodeUnknown,
+		CodeDeadlineExceeded,
+		CodeInternal,
+		CodeUnavailable,
+		CodeDataLoss:
+		return ServerFault
 	}
 
-	return unknownFault
+	return UnknownFault
 }

--- a/yarpcerrors/yarpcerrorclassifier_test.go
+++ b/yarpcerrors/yarpcerrorclassifier_test.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2022 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpcerrors
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGetFaultTypeFromErrorForClientErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "invalid argument",
+			err:  InvalidArgumentErrorf("test"),
+		},
+		{
+			name: "cancelled",
+			err:  CancelledErrorf("test"),
+		},
+		{
+			name: "not found",
+			err:  NotFoundErrorf("test"),
+		},
+		{
+			name: "already exists",
+			err:  AlreadyExistsErrorf("test"),
+		},
+		{
+			name: "permission denied",
+			err:  PermissionDeniedErrorf("test"),
+		},
+		{
+			name: "resource exhausted",
+			err:  ResourceExhaustedErrorf("test"),
+		},
+		{
+			name: "failed precondition",
+			err:  FailedPreconditionErrorf("test"),
+		},
+		{
+			name: "aborted",
+			err:  AbortedErrorf("test"),
+		},
+		{
+			name: "out of range",
+			err:  OutOfRangeErrorf("test"),
+		},
+		{
+			name: "unimplemented",
+			err:  UnimplementedErrorf("test"),
+		},
+		{
+			name: "unauthenticated",
+			err:  UnauthenticatedErrorf("test"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, ClientFault, GetFaultTypeFromError(tt.err))
+		})
+	}
+}
+
+func TestGetFaultTypeFromErrorForServerErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "unknown",
+			err:  UnknownErrorf("test"),
+		},
+		{
+			name: "deadline exceeded",
+			err:  DeadlineExceededErrorf("test"),
+		},
+		{
+			name: "internal",
+			err:  InternalErrorf("test"),
+		},
+		{
+			name: "unavailable",
+			err:  UnavailableErrorf("test"),
+		},
+		{
+			name: "data loss",
+			err:  DataLossErrorf("test"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, ServerFault, GetFaultTypeFromError(tt.err))
+		})
+	}
+}


### PR DESCRIPTION
We have currently duplicated the logic that classifies client and server error types because we want to have a decorator that classifies yarpc exception to client vs server and emit metrics. Based on these metrics, alarms are configured.

Exposing the Server / Error types allows to avoid code duplication and allows others to follow a similar approach 