### PR TITLE
grpc: apply compression only on outbounds with compression enabled

### DIFF
--- a/transport/grpc/config.go
+++ b/transport/grpc/config.go
@@ -192,7 +192,6 @@ func (c OutboundConfig) dialOptions(kit *yarpcconfig.Kit, tlsConfigProvider yarp
 	if err != nil {
 		return nil, err
 	}
-	opts = append(opts, Compressor(kit.Compressor(c.Compressor)))
 
 	keepaliveOpts, err := c.Keepalive.dialOptions()
 	if err != nil {
@@ -375,8 +374,7 @@ func (t *transportSpec) buildOutbound(outboundConfig *OutboundConfig, tr transpo
 		return nil, newTransportCastError(tr)
 	}
 
-	outboundOpts := newOutboundOptions(t.OutboundOptions)
-	dialOpts, err := outboundConfig.dialOptions(kit, outboundOpts.tlsConfigProvider)
+	dialOpts, err := outboundConfig.dialOptions(kit, newOutboundOptions(t.OutboundOptions).tlsConfigProvider)
 	if err != nil {
 		return nil, err
 	}
@@ -397,7 +395,9 @@ func (t *transportSpec) buildOutbound(outboundConfig *OutboundConfig, tr transpo
 		}
 	}
 
-	return trans.NewOutbound(chooser, t.OutboundOptions...), nil
+	outboundOpts := []OutboundOption{OutboundCompressor(kit.Compressor(outboundConfig.Compressor))}
+	outboundOpts = append(outboundOpts, t.OutboundOptions...)
+	return trans.NewOutbound(chooser, outboundOpts...), nil
 }
 
 func newTransportCastError(tr transport.Transport) error {

--- a/transport/grpc/options.go
+++ b/transport/grpc/options.go
@@ -212,6 +212,16 @@ func OutboundTLSConfigProvider(provider yarpctls.OutboundTLSConfigProvider) Outb
 	}
 }
 
+// OutboundCompressor returns an OutboundOption that applies compressorion
+// for requests in the outbound.
+func OutboundCompressor(compressor transport.Compressor) OutboundOption {
+	return func(outboundOptions *outboundOptions) {
+		if compressor != nil {
+			outboundOptions.compressor = compressor.Name()
+		}
+	}
+}
+
 // DialOption is an option that influences grpc.Dial.
 type DialOption func(*dialOptions)
 
@@ -323,6 +333,7 @@ func newInboundOptions(options []InboundOption) *inboundOptions {
 }
 
 type outboundOptions struct {
+	compressor        string
 	tlsConfigProvider yarpctls.OutboundTLSConfigProvider
 }
 

--- a/transport/grpc/outbound.go
+++ b/transport/grpc/outbound.go
@@ -178,6 +178,9 @@ func (o *Outbound) invoke(
 	if responseMD != nil {
 		callOptions = []grpc.CallOption{grpc.Trailer(responseMD)}
 	}
+	if o.options.compressor != "" {
+		callOptions = append(callOptions, grpc.UseCompressor(o.options.compressor))
+	}
 	apiPeer, onFinish, err := o.peerChooser.Choose(ctx, request)
 	if err != nil {
 		return err


### PR DESCRIPTION
When multiple outbounds exist for the same host port, compression is incorrectly enabled for all even though just one outbound has compression enabled. This happens as yarpc maintains at most one connection to any host port, multiple outbounds share the same connection which has compression enabled for all the RPCs.

This PR fixes it by disabling connection level compression (dial option) and enabling compression per RPC call by passing the grpc call option in the outbound call.

- [X] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [X] Entry in CHANGELOG.md
