### PR TITLE
http: fix outbound url template leaking schema across all the outbounds

### DIFF
--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -23,6 +23,7 @@ package http
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"errors"
 	"io/ioutil"
 	"net/http"
@@ -836,4 +837,13 @@ func TestCallOneWayResponseCloseError(t *testing.T) {
 		Service: "Service",
 	})
 	require.Errorf(t, err, "Received unexpected error:code:internal message:test error")
+}
+
+func TestIsolatedSchemaChange(t *testing.T) {
+	tr := &Transport{client: &http.Client{Transport: http.DefaultTransport}}
+	plainOutbound := tr.NewOutbound(nil)
+	tlsOutbound := tr.NewOutbound(nil, OutboundTLSConfiguration(&tls.Config{}))
+	assert.NotEqual(t, plainOutbound.urlTemplate, tlsOutbound.urlTemplate)
+	assert.Equal(t, "http", plainOutbound.urlTemplate.Scheme)
+	assert.Equal(t, "https", tlsOutbound.urlTemplate.Scheme)
 }


### PR DESCRIPTION
HTTP outbounds use the shared `defaultURLTemplate` with schema set to `HTTP`. When a TLS outbound is created, it sets the schema to HTTPS in the URL template of the outbound. Since the URL templates are shared across outbounds, this schema for the outbound incorrectly is set to HTTPS. This diff fixes this bug by creating a copy of the URL template in the tls outbounds.
