### PR TITLE
Classify 3XX http status code as InvalidArgument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- yarpcerrors: classify http 3XX statusCode as InvalidArgument.
+- yarpcerrors: classify http 304 as StatusOk and other 3XX statusCode as InvalidArgument.
 
 ## [1.69.1] - 2023-1-24
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No changes yet.
+- yarpcerrors: classify http 3XX statusCode as InvalidArgument.
 
 ## [1.69.1] - 2023-1-24
 ### Changed

--- a/transport/http/codes.go
+++ b/transport/http/codes.go
@@ -47,6 +47,7 @@ var (
 	// _statusCodeToCodes maps HTTP status codes to a slice of their corresponding Codes.
 	_statusCodeToCodes = map[int][]yarpcerrors.Code{
 		200: {yarpcerrors.CodeOK},
+		304: {yarpcerrors.CodeOK},
 		400: {
 			yarpcerrors.CodeInvalidArgument,
 			yarpcerrors.CodeFailedPrecondition,
@@ -81,13 +82,13 @@ var (
 // If the Code is >=400 and < 500, yarpcerrors.CodeInvalidArgument is returned.
 // Else, yarpcerrors.CodeUnknown is returned.
 func statusCodeToBestCode(statusCode int) yarpcerrors.Code {
-	// The class of 3XX status code indicates the client must take additional action to complete the request.
-	// In this sense, it is client's fault to have requested the resources in the first place.
-	if statusCode >= 300 && statusCode < 400 {
-		return yarpcerrors.CodeInvalidArgument
-	}
 	codes, ok := _statusCodeToCodes[statusCode]
 	if !ok || len(codes) == 0 {
+		// The class of 3XX status code indicates the client must take additional action to complete the request.
+		// In this sense, it is client's fault to have requested the resources in the first place.
+		if statusCode >= 300 && statusCode < 400 {
+			return yarpcerrors.CodeInvalidArgument
+		}
 		if statusCode >= 400 && statusCode < 500 {
 			return yarpcerrors.CodeInvalidArgument
 		}

--- a/transport/http/codes.go
+++ b/transport/http/codes.go
@@ -77,9 +77,15 @@ var (
 //
 // If one Code maps to the given HTTP status code, that Code is returned.
 // If more than one Code maps to the given HTTP status Code, one Code is returned.
+// If the Code is >=300 and < 400, yarpcerrors.CodeInvalidArgument is returned.
 // If the Code is >=400 and < 500, yarpcerrors.CodeInvalidArgument is returned.
 // Else, yarpcerrors.CodeUnknown is returned.
 func statusCodeToBestCode(statusCode int) yarpcerrors.Code {
+	// The class of 3XX status code indicates the client must take additional action to complete the request.
+	// In this sense, it is client's fault to have requested the resources in the first place.
+	if statusCode >= 300 && statusCode < 400 {
+		return yarpcerrors.CodeInvalidArgument
+	}
 	codes, ok := _statusCodeToCodes[statusCode]
 	if !ok || len(codes) == 0 {
 		if statusCode >= 400 && statusCode < 500 {

--- a/transport/http/codes_test.go
+++ b/transport/http/codes_test.go
@@ -49,6 +49,11 @@ func TestUnspecifiedCodes(t *testing.T) {
 		want yarpcerrors.Code
 	}{
 		{
+			name: "code temporary redirection",
+			give: 307, // test for an x in range: [400, 500)
+			want: yarpcerrors.CodeInvalidArgument,
+		},
+		{
 			name: "code invalid argument",
 			give: 450, // test for an x in range: [400, 500)
 			want: yarpcerrors.CodeInvalidArgument,

--- a/transport/http/codes_test.go
+++ b/transport/http/codes_test.go
@@ -49,8 +49,13 @@ func TestUnspecifiedCodes(t *testing.T) {
 		want yarpcerrors.Code
 	}{
 		{
+			name: "code not modified",
+			give: 304,
+			want: yarpcerrors.CodeOK,
+		},
+		{
 			name: "code temporary redirection",
-			give: 307, // test for an x in range: [400, 500)
+			give: 307, // test for an x in range: [300, 400)
 			want: yarpcerrors.CodeInvalidArgument,
 		},
 		{


### PR DESCRIPTION
- [x] Description and context for reviewers: one partner, one stranger
Currently 3XX is marked as unknown and classified as server error. This
impacts the server SLA calculation. This diff adds support to classify
it as InvalidArgument, a type of client error.
- [x] Docs (package doc)
- [x] Entry in CHANGELOG.md