### PR TITLE
tls: fix connection close on listener close

### DIFF
--- a/transport/internal/tls/muxlistener/listener.go
+++ b/transport/internal/tls/muxlistener/listener.go
@@ -138,8 +138,8 @@ func (l *listener) serve() {
 	defer func() {
 		cancel()
 		wg.Wait()
-		close(l.stoppedChan)
 		close(l.connChan)
+		close(l.stoppedChan)
 	}()
 
 	for {
@@ -167,7 +167,7 @@ func (l *listener) serveConnection(ctx context.Context, conn net.Conn, wg *sync.
 	select {
 	case l.connChan <- c:
 	case <-l.stopChan:
-		conn.Close()
+		c.Close()
 	}
 }
 


### PR DESCRIPTION
In `serveConnection`, closing the muxed connection instead of underlying `net.Conn` to properly release resources. Muxed connection can be `*tls.Conn` and should be closed properly.

Other minor change is close the `stoppedChan` in `serve` at the end as closing it will unblock read in `Close` and will effectively close the listener. This should be the last logical instruction during close.

- [x] Description and context for reviewers: one partner, one stranger
- [x] Docs (package doc)
- [] Entry in CHANGELOG.md
Minor change, skipping entry in CHANGELOG
