### PR TITLE
classify 422 http status as InvalidArgument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 =======
 ## [Unreleased]
-- No changes yet.
+- yarpcerrors: classify http 422 as InvalidArgument.
 
 ## [1.70.1] - 2023-03-31
 ### Fixed
 - yarpcerrors: classify http 304 as StatusOk and other 3XX statusCode as InvalidArgument.
 - yarpcerrors: classify tchannel BusyError to yarpc ResourceExchausted error
-- yarpcerrors: classify http 422 as InvalidArgument.
 
 ## [1.70.0] - 2023-02-16
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 - yarpcerrors: classify http 304 as StatusOk and other 3XX statusCode as InvalidArgument.
 - yarpcerrors: classify tchannel BusyError to yarpc ResourceExchausted error
+- yarpcerrors: classify http 422 as InvalidArgument.
 
 ## [1.69.1] - 2023-1-24
 ### Changed

--- a/transport/http/codes.go
+++ b/transport/http/codes.go
@@ -60,6 +60,7 @@ var (
 			yarpcerrors.CodeAborted,
 			yarpcerrors.CodeAlreadyExists,
 		},
+		422: {yarpcerrors.CodeInvalidArgument},
 		429: {yarpcerrors.CodeResourceExhausted},
 		499: {yarpcerrors.CodeCancelled},
 		500: {

--- a/transport/http/codes_test.go
+++ b/transport/http/codes_test.go
@@ -59,6 +59,11 @@ func TestUnspecifiedCodes(t *testing.T) {
 			want: yarpcerrors.CodeInvalidArgument,
 		},
 		{
+			name: "code unprocessable context",
+			give: 422,
+			want: yarpcerrors.CodeInvalidArgument,
+		},
+		{
 			name: "code invalid argument",
 			give: 450, // test for an x in range: [400, 500)
 			want: yarpcerrors.CodeInvalidArgument,


### PR DESCRIPTION
- [x] Description and context for reviewers: one partner, one stranger
Currently 422 is marked as unknown and classified as server error. This
impacts the server SLA calculation. This diff adds support to classify
it as InvalidArgument, a type of client error.
- [x] Entry in CHANGELOG.md