### PR TITLE
tls-outbounds: make spiffe ids field as optional field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 =======
 ## [Unreleased]
-- No changes yet.
+- tls-outbounds: spiffe ids field has been made optional field.
 
 ## [1.70.2] - 2023-04-11
 - yarpcerrors: classify http 422 as InvalidArgument.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 =======
 ## [Unreleased]
-- tls-outbounds: spiffe ids field has been made optional field.
+- tls-outbounds: spiffe ids field has been made optional field. Outbounds
+  will accept any server certificate issued by the internal CA with any spiffe id
+  if no spiffe id config is provided.
 
 ## [1.70.2] - 2023-04-11
 - yarpcerrors: classify http 422 as InvalidArgument.

--- a/transport/grpc/config.go
+++ b/transport/grpc/config.go
@@ -225,10 +225,6 @@ func (c OutboundTLSConfig) dialOptions(tlsConfigProvider yarpctls.OutboundTLSCon
 			return nil, errors.New("outbound TLS enforced but outbound TLS config provider is nil")
 		}
 
-		if len(c.SpiffeIDs) == 0 {
-			return nil, errors.New("outbound TLS enforced but no spiffe id is provided")
-		}
-
 		config, err := tlsConfigProvider.ClientTLSConfig(c.SpiffeIDs)
 		if err != nil {
 			return nil, err

--- a/transport/grpc/config_test.go
+++ b/transport/grpc/config_test.go
@@ -472,7 +472,7 @@ func TestTransportSpec(t *testing.T) {
 			},
 		},
 		{
-			desc: "fail TLS outbound without spiffe id",
+			desc: "TLS outbound without spiffe id",
 			outboundCfg: attrs{
 				"myservice": attrs{
 					TransportName: attrs{
@@ -483,8 +483,13 @@ func TestTransportSpec(t *testing.T) {
 					},
 				},
 			},
-			opts:       []Option{OutboundTLSConfigProvider(&fakeOutboundTLSConfigProvider{})},
-			wantErrors: []string{"outbound TLS enforced but no spiffe id is provided"},
+			opts: []Option{OutboundTLSConfigProvider(&fakeOutboundTLSConfigProvider{})},
+			wantOutbounds: map[string]wantOutbound{
+				"myservice": {
+					Address:   "localhost:54569",
+					TLSConfig: true,
+				},
+			},
 		},
 		{
 			desc: "fail TLS outbound with invalid tls mode",

--- a/transport/http/config.go
+++ b/transport/http/config.go
@@ -286,10 +286,6 @@ func (o OutboundTLSConfig) options(provider yarpctls.OutboundTLSConfigProvider) 
 		return nil, errors.New("outbound TLS enforced but outbound TLS config provider is nil")
 	}
 
-	if len(o.SpiffeIDs) == 0 {
-		return nil, errors.New("outbound TLS enforced but no spiffe id is provided")
-	}
-
 	config, err := provider.ClientTLSConfig(o.SpiffeIDs)
 	if err != nil {
 		return nil, err

--- a/transport/http/config_test.go
+++ b/transport/http/config_test.go
@@ -428,7 +428,7 @@ func TestTransportSpec(t *testing.T) {
 			},
 		},
 		{
-			desc: "fail TLS outbound without spiffe id",
+			desc: "TLS outbound without spiffe id",
 			cfg: attrs{
 				"myservice": attrs{
 					TransportName: attrs{
@@ -439,8 +439,13 @@ func TestTransportSpec(t *testing.T) {
 					},
 				},
 			},
-			opts:       []Option{OutboundTLSConfigProvider(&fakeOutboundTLSConfigProvider{})},
-			wantErrors: []string{"outbound TLS enforced but no spiffe id is provided"},
+			opts: []Option{OutboundTLSConfigProvider(&fakeOutboundTLSConfigProvider{})},
+			wantOutbounds: map[string]wantOutbound{
+				"myservice": {
+					URLTemplate: "https://localhost/yarpc",
+					TLSConfig:   true,
+				},
+			},
 		},
 		{
 			desc: "fail TLS outbound with invalid tls mode",

--- a/transport/tchannel/config.go
+++ b/transport/tchannel/config.go
@@ -114,10 +114,6 @@ func (c OutboundConfig) getPeerTransport(transport *Transport, destName string) 
 		return nil, errors.New("outbound TLS enforced but outbound TLS config provider is nil")
 	}
 
-	if len(c.TLS.SpiffeIDs) == 0 {
-		return nil, errors.New("outbound TLS enforced but no spiffe id is provided")
-	}
-
 	config, err := transport.outboundTLSConfigProvider.ClientTLSConfig(c.TLS.SpiffeIDs)
 	if err != nil {
 		return nil, err

--- a/transport/tchannel/config_test.go
+++ b/transport/tchannel/config_test.go
@@ -232,7 +232,7 @@ func TestTransportSpec(t *testing.T) {
 			wantErrors: []string{"outbound TLS enforced but outbound TLS config provider is nil"},
 		},
 		{
-			desc: "fail TLS outbound without spiffe id",
+			desc: "TLS outbound without spiffe id",
 			cfg: attrs{
 				"myservice": attrs{
 					"tchannel": attrs{
@@ -243,8 +243,8 @@ func TestTransportSpec(t *testing.T) {
 					},
 				},
 			},
-			opts:       []Option{OutboundTLSConfigProvider(&fakeOutboundTLSConfigProvider{})},
-			wantErrors: []string{"outbound TLS enforced but no spiffe id is provided"},
+			opts:          []Option{OutboundTLSConfigProvider(&fakeOutboundTLSConfigProvider{})},
+			wantOutbounds: []string{"myservice"},
 		},
 		{
 			desc: "fail TLS outbound when tls config provider returns error",


### PR DESCRIPTION
Earlier, tls outbound required at least one spiffe id as we wanted to use it to match the server id. Since managing server spiffe id across clients causes issues during the migration, this PR makes spiffe ids an optional field. Outbounds will accept any server certificate issued by the internal CA with any spiffe id if no spiffe ids configuration is provided.

- [X] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)
- [X] Entry in CHANGELOG.md
