### PR TITLE
Expose error message if the error is yarpcerror and has its own message

### DIFF
--- a/encoding/protobuf/observability_test.go
+++ b/encoding/protobuf/observability_test.go
@@ -48,8 +48,8 @@ const (
 	_serverName = "callee"
 
 	// from observability middleware
-	_errorInbound  = "Error handling inbound request."
-	_errorOutbound = "Error making outbound call."
+	_errorInbound  = "Error handling inbound request. Error: my message"
+	_errorOutbound = "Error making outbound call. Error: my message"
 )
 
 func TestProtobufErrorDetailObservability(t *testing.T) {

--- a/encoding/protobuf/v2/observability_test.go
+++ b/encoding/protobuf/v2/observability_test.go
@@ -45,8 +45,8 @@ import (
 
 const (
 	// from observability middleware
-	_errorInbound  = "Error handling inbound request."
-	_errorOutbound = "Error making outbound call."
+	_errorInbound  = "Error handling inbound request. Error: my message"
+	_errorOutbound = "Error making outbound call. Error: my message"
 )
 
 func TestProtobufErrorDetailObservability(t *testing.T) {

--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -41,10 +41,11 @@ const (
 	_errorCodeLogKey    = "errorCode"
 	_errorDetailsLogKey = "errorDetails"
 
-	_successfulInbound  = "Handled inbound request."
-	_successfulOutbound = "Made outbound call."
-	_errorInbound       = "Error handling inbound request."
-	_errorOutbound      = "Error making outbound call."
+	_successfulInbound        = "Handled inbound request."
+	_successfulOutbound       = "Made outbound call."
+	_errorInbound             = "Error handling inbound request."
+	_errorOutbound            = "Error making outbound call."
+	_errorWithOriginalMessage = "%s Error: %s"
 
 	_successStreamOpen  = "Successfully created stream"
 	_successStreamClose = "Successfully closed stream"
@@ -162,9 +163,15 @@ func (c call) endLogs(
 		}
 		ce = c.edge.logger.Check(c.levels.success, msg)
 	} else {
+
 		msg := _errorInbound
 		if c.direction != _directionInbound {
 			msg = _errorOutbound
+		}
+
+		// expose error message if the error is yarpcerror and has its own message
+		if status, ok := err.(*yarpcerrors.Status); ok && status.Message() != "" {
+			msg = fmt.Sprintf(_errorWithOriginalMessage, msg, status.Message())
 		}
 
 		var lvl zapcore.Level

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -405,8 +405,8 @@ func TestMiddlewareLoggingWithApplicationErrorConfiguration(t *testing.T) {
 			err:             yErrNoDetails,
 			applicationErr:  true, // always true for Protobuf handler errors
 			wantErrLevel:    zapcore.ErrorLevel,
-			wantInboundMsg:  "Error handling inbound request.",
-			wantOutboundMsg: "Error making outbound call.",
+			wantInboundMsg:  "Error handling inbound request. Error: fail",
+			wantOutboundMsg: "Error making outbound call. Error: fail",
 			wantFields: []zapcore.Field{
 				zap.Duration("latency", 0),
 				zap.Bool("successful", false),
@@ -424,8 +424,8 @@ func TestMiddlewareLoggingWithApplicationErrorConfiguration(t *testing.T) {
 			wantErrLevel:          zapcore.ErrorLevel,
 			applicationErrDetails: appErrDetails,
 			applicationErrName:    "MyErrMessageName",
-			wantInboundMsg:        "Error handling inbound request.",
-			wantOutboundMsg:       "Error making outbound call.",
+			wantInboundMsg:        "Error handling inbound request. Error: fail",
+			wantOutboundMsg:       "Error making outbound call. Error: fail",
 			wantFields: []zapcore.Field{
 				zap.Duration("latency", 0),
 				zap.Bool("successful", false),
@@ -443,8 +443,8 @@ func TestMiddlewareLoggingWithApplicationErrorConfiguration(t *testing.T) {
 			err:             yErrWithDetails,
 			applicationErr:  true, // always true for Protobuf handler errors
 			wantErrLevel:    zapcore.WarnLevel,
-			wantInboundMsg:  "Error handling inbound request.",
-			wantOutboundMsg: "Error making outbound call.",
+			wantInboundMsg:  "Error handling inbound request. Error: fail",
+			wantOutboundMsg: "Error making outbound call. Error: fail",
 			wantFields: []zapcore.Field{
 				zap.Duration("latency", 0),
 				zap.Bool("successful", false),
@@ -762,8 +762,8 @@ func TestMiddlewareLoggingWithServerErrorConfiguration(t *testing.T) {
 			err:             yErrNoDetails,
 			applicationErr:  true, // always true for Protobuf handler errors
 			wantErrLevel:    zapcore.WarnLevel,
-			wantInboundMsg:  "Error handling inbound request.",
-			wantOutboundMsg: "Error making outbound call.",
+			wantInboundMsg:  "Error handling inbound request. Error: fail",
+			wantOutboundMsg: "Error making outbound call. Error: fail",
 			wantFields: []zapcore.Field{
 				zap.Duration("latency", 0),
 				zap.Bool("successful", false),
@@ -781,8 +781,8 @@ func TestMiddlewareLoggingWithServerErrorConfiguration(t *testing.T) {
 			wantErrLevel:          zapcore.WarnLevel,
 			applicationErrDetails: appErrDetails,
 			applicationErrName:    "MyErrMessageName",
-			wantInboundMsg:        "Error handling inbound request.",
-			wantOutboundMsg:       "Error making outbound call.",
+			wantInboundMsg:        "Error handling inbound request. Error: fail",
+			wantOutboundMsg:       "Error making outbound call. Error: fail",
 			wantFields: []zapcore.Field{
 				zap.Duration("latency", 0),
 				zap.Bool("successful", false),
@@ -800,8 +800,8 @@ func TestMiddlewareLoggingWithServerErrorConfiguration(t *testing.T) {
 			err:             yErrWithDetails,
 			applicationErr:  true, // always true for Protobuf handler errors
 			wantErrLevel:    zapcore.WarnLevel,
-			wantInboundMsg:  "Error handling inbound request.",
-			wantOutboundMsg: "Error making outbound call.",
+			wantInboundMsg:  "Error handling inbound request. Error: fail",
+			wantOutboundMsg: "Error making outbound call. Error: fail",
 			wantFields: []zapcore.Field{
 				zap.Duration("latency", 0),
 				zap.Bool("successful", false),
@@ -817,8 +817,8 @@ func TestMiddlewareLoggingWithServerErrorConfiguration(t *testing.T) {
 			err:             yServerErrInternal,
 			applicationErr:  true, // always true for Protobuf handler errors
 			wantErrLevel:    zapcore.ErrorLevel,
-			wantInboundMsg:  "Error handling inbound request.",
-			wantOutboundMsg: "Error making outbound call.",
+			wantInboundMsg:  "Error handling inbound request. Error: internal",
+			wantOutboundMsg: "Error making outbound call. Error: internal",
 			wantFields: []zapcore.Field{
 				zap.Duration("latency", 0),
 				zap.Bool("successful", false),


### PR DESCRIPTION
- Internal monitoring service uMonitor exposes `message` logging field at the front, and the uMonitor log explorer is dominated by "_Error handling inbound request._" and "_Error making outbound call._" for many services who didn't mute yarpc logging. [EXAMPLE](https://umonitor.uberinternal.com/services/users/logs?q=level%3A%22error%22%20%7C%20%40table%3Alevel%2Cmessage)
- Although `yarpc.error` field has `error code + message`, this field is not exposed on the front at first sight. Also having error message only in 'yarpc.error' field makes it hard to cluster yarpc errors with other logs as it does not have the actual error message in the 'message' field. [EXAMPLE - see filter on the left side](https://umonitor.uberinternal.com/services/users/logs?filters=level&filters=message&q=level%3A%22error%22%20%7C%20%40table%3Alevel%2Cmessage)
- Hence this change appends the original error message that the application intended to the base error message string.