### PR TITLE
Improve stack usage of all the Handle functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 =======
 ## [Unreleased]
-- No changes yet.
+- middleware stack usage: remove ~2KB of stack usage from the rpc handler function, 
+  so that it decreases the chance of needing more stack. It can improve the
+  performance of the application.
 
 ## [1.70.3] - 2023-06-27
 - tls-outbounds: spiffe ids field has been made optional field. Outbounds

--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -64,7 +64,6 @@ const (
 type call struct {
 	edge    *edge
 	extract ContextExtractor
-	fields  [10]zapcore.Field
 
 	started   time.Time
 	ctx       context.Context
@@ -222,7 +221,7 @@ func (c call) endLogs(
 		return
 	}
 
-	fields := c.fields[:0]
+	fields := make([]zapcore.Field, 0, 9+len(extraLogFields))
 	fields = append(fields, zap.String("rpcType", c.rpcType.String()))
 	fields = append(fields, zap.Duration("latency", elapsed))
 	fields = append(fields, zap.Bool("successful", err == nil && !isApplicationError))


### PR DESCRIPTION
- [X] Description and context for reviewers: one partner, one stranger
- [X] Docs (package doc)
- [X] Entry in CHANGELOG.md

TLDR; Reduce stack usage from the rpc handler function from 2520 bytes to 608 bytes.

**UPDATE:**
We decided to keep the methods with value receivers which increased stack usage a bit (~200 bytes), but still gave us ~1.9KB savings. The only change done was to remove the [10]zap.Field from the call struct and allocate that directly in the method that was using it.

**Original description**
Currently one of our services has the following stack trace:
```
10920
200 google.golang.org/grpc.(*Server).serveStreams.func1.2
888 google.golang.org/grpc.(*Server).handleStream
1000 google.golang.org/grpc.(*Server).processStreamingRPC
728 go.uber.org/yarpc/transport/grpc.(*handler).handle
496 go.uber.org/yarpc/transport/grpc.(*handler).handleUnary
544 go.uber.org/yarpc/transport/grpc.(*handler).handleUnaryBeforeErrorConversion
256 go.uber.org/yarpc/transport/grpc.(*handler).callUnary
544 go.uber.org/yarpc/api/transport.InvokeUnaryHandler
104 go.uber.org/yarpc/api/middleware.unaryHandlerWithMiddleware.Handle
160 go.uber.org/yarpc/internal/inboundmiddleware.unaryChain.Handle
136 go.uber.org/yarpc/internal/inboundmiddleware.unaryChainExec.Handle
2520 go.uber.org/yarpc/internal/observability.(*Middleware).Handle                  # We're fixing this one
136 go.uber.org/yarpc/internal/inboundmiddleware.unaryChainExec.Handle
... (omitting for privacy)
```

We noticed that the Handle function is consuming 2.5KB of stack usage. Although, it is preferred to use stack vs heap, >2KB seems like a problem. This could negatively impact an application if it frequently causes stack expansion. Additionally, it requires more memory to hold it.

The problem was with the *call* struct:

```
type call struct {
	edge    *edge
	extract ContextExtractor
        fields  [10]zapcore.Field

	started   time.Time
	ctx       context.Context
	req       *transport.Request
	rpcType   transport.Type
	direction directionName

	levels *levels
}
```

After calling unsafe.Sizeof(call{}), it shows that it consumes 736 bytes. In this case the compiler decided to give stack space for 3 copies of call:

1. The local variable of Handle().
2. The return value from call{}.
3. One for passing the call to the defer or calling any method on call.

This looks somewhat inefficient so we decided to fix it, to have only one copy at the Handle() level. The required changes were:

1. All methods for "call" must use pointer receiver to avoid allocating stack space.
2. begin() function can receive a pointer to the stack allocated call{} coming from Handle() (in this way we eliminate the copy for the return value).
3. Remove the [10]zap.Field from call{}. These fields are then stored in a buffer which cause the stack allocated at Handle() to be escaped to the heap.
4. Fix all Handle() functions (stream, unary, etc) to follow the same process.

After these changes we can quickly see the differences from the assembly:

From
```
TEXT go.uber.org/yarpc/internal/observability.(*Middleware).Handle(SB) gofile../home/user/go/go-no-monorepo/src/go.uber.org/yarpc/internal/observability/middleware.go
  middleware.go:183     0x62dd4                 4881ec88090000                  SUBQ $0x988, SP
--
TEXT go.uber.org/yarpc/internal/observability.(*Middleware).HandleOneway(SB) gofile../home/user/go/go-no-monorepo/src/go.uber.org/yarpc/internal/observability/middleware.go
  middleware.go:235     0x6374a                 4881ec680c0000                  SUBQ $0xc68, SP
--
TEXT go.uber.org/yarpc/internal/observability.(*Middleware).HandleStream(SB) gofile../home/user/go/go-no-monorepo/src/go.uber.org/yarpc/internal/observability/middleware.go
  middleware.go:255     0x63f15                 4881ec38090000                  SUBQ $0x938, SP
```

To
```
TEXT go.uber.org/yarpc/internal/observability.(*Middleware).Handle(SB) gofile../home/user/go/go-no-monorepo/src/go.uber.org/yarpc/internal/observability/middleware.go
  middleware.go:183     0x5c728                 4881ec50010000                  SUBQ $0x150, SP
--
TEXT go.uber.org/yarpc/internal/observability.(*Middleware).HandleOneway(SB) gofile../home/user/go/go-no-monorepo/src/go.uber.org/yarpc/internal/observability/middleware.go
  middleware.go:241     0x5cf29                 4881ec50010000                  SUBQ $0x150, SP
--
TEXT go.uber.org/yarpc/internal/observability.(*Middleware).HandleStream(SB) gofile../home/user/go/go-no-monorepo/src/go.uber.org/yarpc/internal/observability/middleware.go
  middleware.go:263     0x5d553                 4881ec28010000                  SUBQ $0x128, SP
```

Finally our application reports:

```
8824
200 google.golang.org/grpc.(*Server).serveStreams.func1.2
888 google.golang.org/grpc.(*Server).handleStream
1000 google.golang.org/grpc.(*Server).processStreamingRPC
728 go.uber.org/yarpc/transport/grpc.(*handler).handle
496 go.uber.org/yarpc/transport/grpc.(*handler).handleUnary
544 go.uber.org/yarpc/transport/grpc.(*handler).handleUnaryBeforeErrorConversion
256 go.uber.org/yarpc/transport/grpc.(*handler).callUnary
544 go.uber.org/yarpc/api/transport.InvokeUnaryHandler
104 go.uber.org/yarpc/api/middleware.unaryHandlerWithMiddleware.Handle
160 go.uber.org/yarpc/internal/inboundmiddleware.unaryChain.Handle
136 go.uber.org/yarpc/internal/inboundmiddleware.unaryChainExec.Handle
424 go.uber.org/yarpc/internal/observability.(*Middleware).Handle
136 go.uber.org/yarpc/internal/inboundmiddleware.unaryChainExec.Handle
...
```

424 vs the original 2520.

