### PR TITLE
grpc outbound to return read-only body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 =======
 ## [Unreleased]
-- No changes yet.
+- grpc: returned outbound response body is no longer writable.
 
 ## [1.70.4] - 2023-08-31
 - logging: fix logged error in observability middleware when fields of transport.Request is in the tagsBlocklist

--- a/transport/grpc/outbound.go
+++ b/transport/grpc/outbound.go
@@ -127,7 +127,7 @@ func (o *Outbound) Call(ctx context.Context, request *transport.Request) (*trans
 		return nil, err
 	}
 	return &transport.Response{
-		Body:                 ioutil.NopCloser(bytes.NewBuffer(responseBody)),
+		Body:                 ioutil.NopCloser(bytes.NewReader(responseBody)),
 		BodySize:             len(responseBody),
 		Headers:              responseHeaders,
 		ApplicationError:     metadataToIsApplicationError(responseMD),


### PR DESCRIPTION
If the response body returned by grpc transport is a `bytes.Buffer` object, callers can use its Write methods to modify its contents. This is not desirable. 

This PR fixes it by returning a `bytes.Reader` instead of a `bytes.Buffer`, making the returned response body read-only.