### PR TITLE
Fixed panic when error details contain unmarshallable message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 =======
 ## [Unreleased]
 - grpc: returned outbound response body is no longer writable.
+- Fixed panic when error details list contains message that cannot be unmarshalled.
 
 ## [1.70.4] - 2023-08-31
 - logging: fix logged error in observability middleware when fields of transport.Request is in the tagsBlocklist

--- a/encoding/protobuf/error.go
+++ b/encoding/protobuf/error.go
@@ -170,25 +170,29 @@ func createStatusWithDetail(pberr *pberror, encoding transport.Encoding, codec *
 }
 
 func setApplicationErrorMeta(pberr *pberror, resw transport.ResponseWriter) {
-	applicationErroMetaSetter, ok := resw.(transport.ApplicationErrorMetaSetter)
+	applicationErrorMetaSetter, ok := resw.(transport.ApplicationErrorMetaSetter)
 	if !ok {
 		return
 	}
 
-	decodedDetails := GetErrorDetails(pberr)
-	var appErrName string
-	if len(decodedDetails) > 0 { // only grab the first name since this will be emitted with metrics
-		appErrName = messageNameWithoutPackage(proto.MessageName(
-			decodedDetails[0].(proto.Message)),
-		)
-	}
+	var (
+		decodedDetails = GetErrorDetails(pberr)
 
-	details := make([]string, 0, len(decodedDetails))
+		appErrName string
+		details    = make([]string, 0, len(decodedDetails))
+	)
+
 	for _, detail := range decodedDetails {
-		details = append(details, protobufMessageToString(detail.(proto.Message)))
+		if m, ok := detail.(proto.Message); ok {
+			if appErrName == "" {
+				// only grab the first name since this will be emitted with metrics
+				appErrName = messageNameWithoutPackage(proto.MessageName(m))
+			}
+			details = append(details, protobufMessageToString(detail.(proto.Message)))
+		}
 	}
 
-	applicationErroMetaSetter.SetApplicationErrorMeta(&transport.ApplicationErrorMeta{
+	applicationErrorMetaSetter.SetApplicationErrorMeta(&transport.ApplicationErrorMeta{
 		Name:    appErrName,
 		Details: fmt.Sprintf(_errDetailsFmt, strings.Join(details, " , ")),
 	})
@@ -198,7 +202,8 @@ func setApplicationErrorMeta(pberr *pberror, resw transport.ResponseWriter) {
 // name.
 //
 // For example:
-//  uber.foo.bar.TypeName -> TypeName
+//
+//	uber.foo.bar.TypeName -> TypeName
 func messageNameWithoutPackage(messageName string) string {
 	if i := strings.LastIndex(messageName, "."); i >= 0 {
 		return messageName[i+1:]


### PR DESCRIPTION
GetErrorDetails may return both proto.Message and std error objects, while setApplicationErrorMeta expects to see only proto.Message object. As a result it may lead to panic while casting std error to proto.Message.

New unit-test proofs that panic exist without fix. There is no panic with presented fix.

Output of the new test against the code without fix:
```
> GOTOOLCHAIN=go1.21.0 go test -v -run=TestSetApplicationErrorMeta .
=== RUN   TestSetApplicationErrorMeta
--- FAIL: TestSetApplicationErrorMeta (0.00s)
panic: interface conversion: *errors.errorString is not proto.Message: missing method ProtoMessage [recovered]
        panic: interface conversion: *errors.errorString is not proto.Message: missing method ProtoMessage

goroutine 35 [running]:
testing.tRunner.func1.2({0x1734b00, 0xc0000bcff0})
        /Users/vitalii/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.21.0.darwin-amd64/src/testing/testing.go:1545 +0x238
testing.tRunner.func1()
        /Users/vitalii/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.21.0.darwin-amd64/src/testing/testing.go:1548 +0x397
panic({0x1734b00?, 0xc0000bcff0?})
        /Users/vitalii/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.21.0.darwin-amd64/src/runtime/panic.go:914 +0x21f
go.uber.org/yarpc/encoding/protobuf.setApplicationErrorMeta(0xc0000ba210?, {0x191dc60?, 0xc0000ce230?})
        /Users/vitalii/go/src/github.com/biosvs/yarpc-go/encoding/protobuf/error.go:182 +0xa5
go.uber.org/yarpc/encoding/protobuf.TestSetApplicationErrorMeta(0x0?)
        /Users/vitalii/go/src/github.com/biosvs/yarpc-go/encoding/protobuf/error_test.go:286 +0x237
testing.tRunner(0xc0000a2b60, 0x18620a0)
        /Users/vitalii/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.21.0.darwin-amd64/src/testing/testing.go:1595 +0xff
created by testing.(*T).Run in goroutine 1
        /Users/vitalii/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.21.0.darwin-amd64/src/testing/testing.go:1648 +0x3ad
FAIL    go.uber.org/yarpc/encoding/protobuf     0.358s
FAIL
```