### PR TITLE
Added support for optional fields in proto3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - tchannel: optional transport-level config to allow reusing a buffer for reading a tchannel response body.
 - grpc: returned outbound response body is no longer writable.
 - Fixed panic when error details list contains message that cannot be unmarshalled.
+- Plugin v2: use v2 of internal libraries; indicate "optional" field support in the plugin response.
 
 ## [1.70.4] - 2023-08-31
 - logging: fix logged error in observability middleware when fields of transport.Request is in the tagsBlocklist

--- a/encoding/protobuf/protoc-gen-yarpc-go-v2/internal/lib/lib.go
+++ b/encoding/protobuf/protoc-gen-yarpc-go-v2/internal/lib/lib.go
@@ -32,7 +32,7 @@ import (
 	"strings"
 	"text/template"
 
-	"go.uber.org/yarpc/internal/protoplugin"
+	protoplugin "go.uber.org/yarpc/internal/protoplugin-v2"
 )
 
 const tmpl = `{{$packagePath := .GoPackage.Path}}{{$packageName := .GoPackage.Name}}

--- a/encoding/protobuf/protoc-gen-yarpc-go-v2/main.go
+++ b/encoding/protobuf/protoc-gen-yarpc-go-v2/main.go
@@ -33,7 +33,7 @@ import (
 	"os"
 
 	"go.uber.org/yarpc/encoding/protobuf/protoc-gen-yarpc-go-v2/internal/lib"
-	"go.uber.org/yarpc/internal/protoplugin"
+	protoplugin "go.uber.org/yarpc/internal/protoplugin-v2"
 )
 
 func main() {

--- a/internal/protoplugin-v2/runner.go
+++ b/internal/protoplugin-v2/runner.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/golang/protobuf/protoc-gen-go/plugin"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/pluginpb"
 )
 
 type runner struct {
@@ -104,7 +105,10 @@ func (r *runner) Run(request *plugin_go.CodeGeneratorRequest) *plugin_go.CodeGen
 }
 
 func newResponseFiles(files []*plugin_go.CodeGeneratorResponse_File) *plugin_go.CodeGeneratorResponse {
-	return &plugin_go.CodeGeneratorResponse{File: files}
+	return &plugin_go.CodeGeneratorResponse{
+		File:              files,
+		SupportedFeatures: proto.Uint64(uint64(pluginpb.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL)),
+	}
 }
 
 func newResponseError(err error) *plugin_go.CodeGeneratorResponse {


### PR DESCRIPTION
1. main.go of the plugin v2 used internal libraries from the v1, fixed.
2. Indicates support of "optional fields" in plugin response. Doesn't affect generated yarpc code.