### PR TITLE
[WIP][protoc-gen-yarpc-go] replaces instances of deprecated ioutil package…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 =======
 ## [Unreleased]
-- No changes yet.
+- protoc-gen-yarpc-go & protoc-gen-yarpc-go-v2: remove references to
+  deprecated ioutil package from code generator.
 
 ## [1.71.0] - 2023-12-14
 - tchannel: optional transport-level config to allow reusing a buffer for reading a tchannel response body.

--- a/encoding/protobuf/internal/testpb/test.pb.yarpc.go
+++ b/encoding/protobuf/internal/testpb/test.pb.yarpc.go
@@ -25,7 +25,7 @@ package testpb
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"reflect"
 
 	"github.com/gogo/protobuf/jsonpb"
@@ -38,7 +38,7 @@ import (
 	"go.uber.org/yarpc/encoding/protobuf/reflection"
 )
 
-var _ = ioutil.NopCloser
+var _ = io.NopCloser
 
 // TestYARPCClient is the YARPC client-side interface for the Test service.
 type TestYARPCClient interface {

--- a/encoding/protobuf/internal/testpb/v2/test.pb.yarpc.go
+++ b/encoding/protobuf/internal/testpb/v2/test.pb.yarpc.go
@@ -25,7 +25,7 @@ package testpb
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"reflect"
 
 	"go.uber.org/fx"
@@ -37,7 +37,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-var _ = ioutil.NopCloser
+var _ = io.NopCloser
 
 // TestYARPCClient is the YARPC client-side interface for the Test service.
 type TestYARPCClient interface {

--- a/encoding/protobuf/outbound_test.go
+++ b/encoding/protobuf/outbound_test.go
@@ -22,7 +22,7 @@ package protobuf_test
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/gogo/protobuf/jsonpb"
@@ -76,7 +76,7 @@ func TestOutboundAnyResolver(t *testing.T) {
 			// outbound that echos the body back
 			out := trans.NewOutbound(nil, yarpctest.OutboundCallOverride(
 				yarpctest.OutboundCallable(func(ctx context.Context, req *transport.Request) (*transport.Response, error) {
-					return &transport.Response{Body: ioutil.NopCloser(req.Body)}, nil
+					return &transport.Response{Body: io.NopCloser(req.Body)}, nil
 				}),
 			))
 

--- a/encoding/protobuf/protoc-gen-yarpc-go-v2/internal/lib/lib.go
+++ b/encoding/protobuf/protoc-gen-yarpc-go-v2/internal/lib/lib.go
@@ -47,7 +47,7 @@ import (
 	{{range $i := .Imports}}{{if not $i.Standard}}{{$i | printf "%s\n"}}{{end}}{{end}}
 ){{end}}
 
-{{if ne (len .Services) 0}}var _ = ioutil.NopCloser{{end}}
+{{if ne (len .Services) 0}}var _ = io.NopCloser{{end}}
 
 {{range $service := .Services}}
 // {{$service.GetName}}YARPCClient is the YARPC client-side interface for the {{$service.GetName}} service.
@@ -619,7 +619,7 @@ var Runner = protoplugin.NewRunner(
 	checkTemplateInfo,
 	[]string{
 		"context",
-		"io/ioutil",
+		"io",
 		"reflect",
 		"go.uber.org/yarpc/encoding/protobuf/v2",
 		"google.golang.org/protobuf/proto",

--- a/encoding/protobuf/protoc-gen-yarpc-go/internal/lib/lib.go
+++ b/encoding/protobuf/protoc-gen-yarpc-go/internal/lib/lib.go
@@ -47,7 +47,7 @@ import (
 	{{range $i := .Imports}}{{if not $i.Standard}}{{$i | printf "%s\n"}}{{end}}{{end}}
 ){{end}}
 
-{{if ne (len .Services) 0}}var _ = ioutil.NopCloser{{end}}
+{{if ne (len .Services) 0}}var _ = io.NopCloser{{end}}
 
 {{range $service := .Services}}
 // {{$service.GetName}}YARPCClient is the YARPC client-side interface for the {{$service.GetName}} service.
@@ -625,7 +625,7 @@ var Runner = protoplugin.NewRunner(
 	checkTemplateInfo,
 	[]string{
 		"context",
-		"io/ioutil",
+		"io",
 		"reflect",
 		"github.com/gogo/protobuf/jsonpb",
 		"github.com/gogo/protobuf/proto",

--- a/encoding/protobuf/stream_unit_test.go
+++ b/encoding/protobuf/stream_unit_test.go
@@ -23,7 +23,7 @@ package protobuf
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
@@ -44,7 +44,7 @@ func TestReadFromStreamDecodeError(t *testing.T) {
 
 	stream := transporttest.NewMockStreamCloser(mockCtrl)
 	stream.EXPECT().ReceiveMessage(ctx).Return(&transport.StreamMessage{
-		Body: ioutil.NopCloser(readErr{err: wantErr}),
+		Body: io.NopCloser(readErr{err: wantErr}),
 	}, nil)
 	stream.EXPECT().Request().Return(
 		&transport.StreamRequest{

--- a/encoding/protobuf/testing/benchmark_test.go
+++ b/encoding/protobuf/testing/benchmark_test.go
@@ -21,7 +21,7 @@
 package testing
 
 import (
-	"io/ioutil"
+	"io"
 	"net"
 	"testing"
 
@@ -36,7 +36,7 @@ import (
 )
 
 func init() {
-	grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, ioutil.Discard))
+	grpclog.SetLoggerV2(grpclog.NewLoggerV2(io.Discard, io.Discard, io.Discard))
 }
 
 func BenchmarkIntegrationYARPC(b *testing.B) {

--- a/encoding/protobuf/v2/outbound_test.go
+++ b/encoding/protobuf/v2/outbound_test.go
@@ -23,7 +23,7 @@ package v2_test
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -75,7 +75,7 @@ func TestOutboundWithAnyResolver(t *testing.T) {
 			// outbound that echos the body back
 			out := trans.NewOutbound(nil, yarpctest.OutboundCallOverride(
 				yarpctest.OutboundCallable(func(ctx context.Context, req *transport.Request) (*transport.Response, error) {
-					return &transport.Response{Body: ioutil.NopCloser(req.Body)}, nil
+					return &transport.Response{Body: io.NopCloser(req.Body)}, nil
 				}),
 			))
 
@@ -114,7 +114,7 @@ func TestOutboundWithKnownProtoMsg(t *testing.T) {
 		// outbound that echos the body back
 		out := trans.NewOutbound(nil, yarpctest.OutboundCallOverride(
 			yarpctest.OutboundCallable(func(ctx context.Context, req *transport.Request) (*transport.Response, error) {
-				return &transport.Response{Body: ioutil.NopCloser(req.Body)}, nil
+				return &transport.Response{Body: io.NopCloser(req.Body)}, nil
 			}),
 		))
 
@@ -142,7 +142,7 @@ func TestOutboundWithAnyProtobufMsg(t *testing.T) {
 		// outbound that echos the body back
 		out := trans.NewOutbound(nil, yarpctest.OutboundCallOverride(
 			yarpctest.OutboundCallable(func(ctx context.Context, req *transport.Request) (*transport.Response, error) {
-				return &transport.Response{Body: ioutil.NopCloser(req.Body)}, nil
+				return &transport.Response{Body: io.NopCloser(req.Body)}, nil
 			}),
 		))
 

--- a/encoding/protobuf/v2/stream_unit_test.go
+++ b/encoding/protobuf/v2/stream_unit_test.go
@@ -23,7 +23,7 @@ package v2
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -44,7 +44,7 @@ func TestReadFromStreamDecodeError(t *testing.T) {
 
 	stream := transporttest.NewMockStreamCloser(mockCtrl)
 	stream.EXPECT().ReceiveMessage(ctx).Return(&transport.StreamMessage{
-		Body: ioutil.NopCloser(readErr{err: wantErr}),
+		Body: io.NopCloser(readErr{err: wantErr}),
 	}, nil)
 	stream.EXPECT().Request().Return(
 		&transport.StreamRequest{


### PR DESCRIPTION
… with io

- [x] Description and context for reviewers:
This commit replaces instances of deprecated `ioutil` package methods with `io` package counterpart
from the code generators protoc-gen-yarpc-go & protoc-gen-yarpc-go-v2. 
For eg:
```
- ioutil.NopCloser
+ io.NopCloser
```
[Ref](https://pkg.go.dev/io/ioutil#NopCloser) ioutil.NopCloser simply call io.NopCloser.
- [n/a] Docs (package doc)
- [x] Entry in CHANGELOG.md
