### PR TITLE
Enable `rpc-caller-procedure` via outbound middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 =======
 ## [Unreleased]
 - Removed gonum.org/v1/gonum dependency.
+- Enable rpc-caller-procedure via yarpc outbound middleware.
 
 ## [1.71.0] - 2023-12-14
 - tchannel: optional transport-level config to allow reusing a buffer for reading a tchannel response body.
@@ -17,7 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.70.4] - 2023-08-31
 - logging: fix logged error in observability middleware when fields of transport.Request is in the tagsBlocklist
 - `go.mod`: update minimum requirements to go1.21 instead of go1.14 and update `golang.org/x/net v0.7.0` to v0.14.0
-- middleware stack usage: remove ~2KB of stack usage from the rpc handler function, 
+- middleware stack usage: remove ~2KB of stack usage from the rpc handler function,
   so that it decreases the chance of needing more stack. It can improve the
   performance of the application.
 

--- a/internal/firstoutboundmiddleware/middleware.go
+++ b/internal/firstoutboundmiddleware/middleware.go
@@ -26,6 +26,7 @@ package firstoutboundmiddleware
 import (
 	"context"
 
+	"go.uber.org/yarpc/api/encoding"
 	"go.uber.org/yarpc/api/middleware"
 	"go.uber.org/yarpc/api/transport"
 )
@@ -73,6 +74,12 @@ func update(ctx context.Context, req *transport.Request, out transport.Outbound)
 	if namer, ok := out.(transport.Namer); ok {
 		req.Transport = namer.TransportName()
 	}
+
+	// Update the caller procedure to the current procedure making this request
+	call := encoding.CallFromContext(ctx)
+	if call != nil {
+		req.CallerProcedure = call.Procedure()
+	}
 }
 
 func updateStream(ctx context.Context, req *transport.StreamRequest, out transport.Outbound) {
@@ -84,5 +91,11 @@ func updateStream(ctx context.Context, req *transport.StreamRequest, out transpo
 	// requests to a different outbound type.
 	if namer, ok := out.(transport.Namer); ok {
 		req.Meta.Transport = namer.TransportName()
+	}
+
+	// Update the caller procedure to the current procedure making this request
+	call := encoding.CallFromContext(ctx)
+	if call != nil {
+		req.Meta.CallerProcedure = call.Procedure()
 	}
 }

--- a/internal/firstoutboundmiddleware/middleware_test.go
+++ b/internal/firstoutboundmiddleware/middleware_test.go
@@ -54,7 +54,7 @@ func TestFirstOutboundMidleware(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, "fake", string(req.Transport))
-		assert.Equal(t, "", string(req.CallerProcedure))
+		assert.Equal(t, "ABC", string(req.CallerProcedure))
 	})
 
 	t.Run("oneway", func(t *testing.T) {
@@ -66,7 +66,7 @@ func TestFirstOutboundMidleware(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, "fake", string(req.Transport))
-		assert.Equal(t, "", string(req.CallerProcedure))
+		assert.Equal(t, "ABC", string(req.CallerProcedure))
 	})
 
 	t.Run("stream", func(t *testing.T) {
@@ -78,6 +78,6 @@ func TestFirstOutboundMidleware(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, "fake", string(streamReq.Meta.Transport))
-		assert.Equal(t, "", string(streamReq.Meta.CallerProcedure))
+		assert.Equal(t, "ABC", string(streamReq.Meta.CallerProcedure))
 	})
 }


### PR DESCRIPTION
- [x] Description and context for reviewers: one partner, one stranger

Enable setting `rpc-caller-procedure` via populating the `CallerProcedure` field in the yarpc outbound middleware.

This PR reverts a [previous commit](https://github.com/yarpc/yarpc-go/commit/664b170d5b2dc57ab58afa5a283ae741e76593a5) where the caller procedure was disabled. The fix has been landed and we can now safely populate the new field.

Fixes https://github.com/yarpc/yarpc-go/issues/2231

- [n/a] Docs (package doc)
- [x] Entry in CHANGELOG.md

