### PR TITLE
encoding/protobuf: Update BuildProcedures slice capacity hint

### DIFF
--- a/encoding/protobuf/protobuf.go
+++ b/encoding/protobuf/protobuf.go
@@ -76,7 +76,7 @@ type BuildProceduresStreamHandlerParams struct {
 
 // BuildProcedures builds the transport.Procedures.
 func BuildProcedures(params BuildProceduresParams) []transport.Procedure {
-	procedures := make([]transport.Procedure, 0, 2*(len(params.UnaryHandlerParams)+len(params.OnewayHandlerParams)))
+	procedures := make([]transport.Procedure, 0, 2*(len(params.UnaryHandlerParams)+len(params.OnewayHandlerParams)+len(params.StreamHandlerParams)))
 	for _, unaryHandlerParams := range params.UnaryHandlerParams {
 		procedures = append(
 			procedures,

--- a/encoding/protobuf/v2/protobuf.go
+++ b/encoding/protobuf/v2/protobuf.go
@@ -65,7 +65,7 @@ type BuildProceduresStreamHandlerParams struct {
 
 // BuildProcedures builds the transport.Procedures.
 func BuildProcedures(params BuildProceduresParams) []transport.Procedure {
-	procedures := make([]transport.Procedure, 0, 2*(len(params.UnaryHandlerParams)+len(params.OnewayHandlerParams)))
+	procedures := make([]transport.Procedure, 0, 2*(len(params.UnaryHandlerParams)+len(params.OnewayHandlerParams)+len(params.StreamHandlerParams)))
 	for _, unaryHandlerParams := range params.UnaryHandlerParams {
 		procedures = append(
 			procedures,


### PR DESCRIPTION
Updates the slice capacity hint in `BuildProcedures` to also include
the `StreamHandlerParams` which are passed in.