### PR TITLE
Renamed tchannel caller-procedure header

### DIFF
--- a/transport/tchannel/header.go
+++ b/transport/tchannel/header.go
@@ -33,6 +33,8 @@ import (
 )
 
 const (
+	/** Response headers **/
+
 	// ErrorCodeHeaderKey is the response header key for the error code.
 	ErrorCodeHeaderKey = "$rpc$-error-code"
 	// ErrorNameHeaderKey is the response header key for the error name.
@@ -48,8 +50,11 @@ const (
 	ApplicationErrorDetailsHeaderKey = "$rpc$-application-error-details"
 	// ApplicationErrorCodeHeaderKey is the response header key for the application error code.
 	ApplicationErrorCodeHeaderKey = "$rpc$-application-error-code"
+
+	/** Request headers **/
+
 	// CallerProcedureHeader is the header key for the procedure of the caller making the request.
-	CallerProcedureHeader = "$rpc$-caller-procedure"
+	CallerProcedureHeader = "rpc-caller-procedure"
 )
 
 var _reservedHeaderKeys = map[string]struct{}{
@@ -60,6 +65,7 @@ var _reservedHeaderKeys = map[string]struct{}{
 	ApplicationErrorNameHeaderKey:    {},
 	ApplicationErrorDetailsHeaderKey: {},
 	ApplicationErrorCodeHeaderKey:    {},
+	CallerProcedureHeader:            {},
 }
 
 func isReservedHeaderKey(key string) bool {


### PR DESCRIPTION
None of existing _request_ headers in tchannel have $ in a header filed name. This sign causes problems, so let's get rid of it.