### PR TITLE
Preparing release v1.72.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 =======
-## [Unreleased]
-- No changes yet.
+## [1.72.1] - 2024-03-14
+- tchannel: Renamed caller-procedure header from `$rpc$-caller-procedure` to `rpc-caller-procedure`.
 
 ## [1.72.0] - 2024-02-21
 - Removed gonum.org/v1/gonum dependency.
@@ -1500,7 +1500,7 @@ This release requires regeneration of ThriftRW code.
 ## 0.1.0 - 2016-08-31
 
 - Initial release.
-[Unreleased]: https://github.com/yarpc/yarpc-go/compare/v1.72.0...HEAD
+[1.72.1]: https://github.com/yarpc/yarpc-go/compare/v1.72.0...1.72.1
 [1.72.0]: https://github.com/yarpc/yarpc-go/compare/v1.71.0...v1.72.0
 [1.71.0]: https://github.com/yarpc/yarpc-go/compare/v1.70.4...v1.71.0
 [1.70.4]: https://github.com/yarpc/yarpc-go/compare/v1.70.3...v1.70.4

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -68,7 +68,7 @@ Releasing
 
     ```
     sed -i '' -e "s/^const Version =.*/const Version = \"$VERSION\"/" version.go
-    make verifyversion SUPPRESS_DOCKER=1
+    SUPPRESS_DOCKER=1 make verifyversion
     ```
 
 6.  Create a commit for the release.
@@ -81,7 +81,7 @@ Releasing
 7.  Make a pull request with these changes against `master`.
 
     ```
-    hub pull-request -b master --push
+    git push && hub pull-request --push --browse -b master
     ```
 
 8.  Land the pull request after approval as a **merge commit**. To do this,

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package yarpc // import "go.uber.org/yarpc"
 
 // Version is the current version of YARPC.
-const Version = "1.73.0-dev"
+const Version = "1.72.1"


### PR DESCRIPTION
- tchannel: Renamed caller-procedure header from `$rpc$-caller-procedure` to `rpc-caller-procedure`.