### PR TITLE
Vitalii/release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 =======
+## [Unreleased]
+- No changes yet.
+
 ## [1.72.0] - 2024-02-21
 - Removed gonum.org/v1/gonum dependency.
 - Enable rpc-caller-procedure via yarpc outbound middleware.
@@ -1497,6 +1500,7 @@ This release requires regeneration of ThriftRW code.
 ## 0.1.0 - 2016-08-31
 
 - Initial release.
+[Unreleased]: https://github.com/yarpc/yarpc-go/compare/v1.72.0...HEAD
 [1.72.0]: https://github.com/yarpc/yarpc-go/compare/v1.71.0...v1.72.0
 [1.71.0]: https://github.com/yarpc/yarpc-go/compare/v1.70.4...v1.71.0
 [1.70.4]: https://github.com/yarpc/yarpc-go/compare/v1.70.3...v1.70.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 =======
-## [Unreleased]
-- No changes yet.
+## [1.72.1] - 2024-03-14
+- tchannel: Renamed caller-procedure header from `$rpc$-caller-procedure` to `rpc-caller-procedure`.
 
 ## [1.72.0] - 2024-02-21
 - Removed gonum.org/v1/gonum dependency.
@@ -1500,7 +1500,7 @@ This release requires regeneration of ThriftRW code.
 ## 0.1.0 - 2016-08-31
 
 - Initial release.
-[Unreleased]: https://github.com/yarpc/yarpc-go/compare/v1.72.0...HEAD
+[1.72.1]: https://github.com/yarpc/yarpc-go/compare/v1.72.0...1.72.1
 [1.72.0]: https://github.com/yarpc/yarpc-go/compare/v1.71.0...v1.72.0
 [1.71.0]: https://github.com/yarpc/yarpc-go/compare/v1.70.4...v1.71.0
 [1.70.4]: https://github.com/yarpc/yarpc-go/compare/v1.70.3...v1.70.4

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -36,6 +36,7 @@ Releasing
     it.
 
     ```
+    git fetch origin dev
     git fetch origin master
     git checkout origin/master
     git checkout -B $(whoami)/release
@@ -68,7 +69,7 @@ Releasing
 
     ```
     sed -i '' -e "s/^const Version =.*/const Version = \"$VERSION\"/" version.go
-    make verifyversion SUPPRESS_DOCKER=1
+    SUPPRESS_DOCKER=1 make verifyversion
     ```
 
 6.  Create a commit for the release.

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/readonlystoreclient/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/readonlystoreclient/client.go
@@ -27,7 +27,7 @@ type Interface interface {
 
 // New builds a new client for the ReadOnlyStore service.
 //
-// 	client := readonlystoreclient.New(dispatcher.ClientConfig("readonlystore"))
+//	client := readonlystoreclient.New(dispatcher.ClientConfig("readonlystore"))
 func New(c transport.ClientConfig, opts ...thrift.ClientOption) Interface {
 	return client{
 		c: thrift.New(thrift.Config{

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/readonlystorefx/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/readonlystorefx/client.go
@@ -35,10 +35,10 @@ type Result struct {
 // Client provides a ReadOnlyStore client to an Fx application using the given name
 // for routing.
 //
-// 	fx.Provide(
-// 		readonlystorefx.Client("..."),
-// 		newHandler,
-// 	)
+//	fx.Provide(
+//		readonlystorefx.Client("..."),
+//		newHandler,
+//	)
 func Client(name string, opts ...thrift.ClientOption) interface{} {
 	return func(p Params) Result {
 		cc := p.Provider.ClientConfig(name)

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/readonlystorefx/doc.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/readonlystorefx/doc.go
@@ -4,27 +4,27 @@
 // Package readonlystorefx provides better integration for Fx for services
 // implementing or calling ReadOnlyStore.
 //
-// Clients
+// # Clients
 //
 // If you are making requests to ReadOnlyStore, use the Client function to inject a
 // ReadOnlyStore client into your container.
 //
-// 	fx.Provide(readonlystorefx.Client("..."))
+//	fx.Provide(readonlystorefx.Client("..."))
 //
-// Servers
+// # Servers
 //
 // If you are implementing ReadOnlyStore, provide a readonlystoreserver.Interface into
 // the container and use the Server function.
 //
 // Given,
 //
-// 	func NewReadOnlyStoreHandler() readonlystoreserver.Interface
+//	func NewReadOnlyStoreHandler() readonlystoreserver.Interface
 //
 // You can do the following to have the procedures of ReadOnlyStore made available
 // to an Fx application.
 //
-// 	fx.Provide(
-// 		NewReadOnlyStoreHandler,
-// 		readonlystorefx.Server(),
-// 	)
+//	fx.Provide(
+//		NewReadOnlyStoreHandler,
+//		readonlystorefx.Server(),
+//	)
 package readonlystorefx

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/readonlystorefx/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/readonlystorefx/server.go
@@ -31,12 +31,12 @@ type ServerResult struct {
 // Server provides procedures for ReadOnlyStore to an Fx application. It expects a
 // readonlystorefx.Interface to be present in the container.
 //
-// 	fx.Provide(
-// 		func(h *MyReadOnlyStoreHandler) readonlystoreserver.Interface {
-// 			return h
-// 		},
-// 		readonlystorefx.Server(),
-// 	)
+//	fx.Provide(
+//		func(h *MyReadOnlyStoreHandler) readonlystoreserver.Interface {
+//			return h
+//		},
+//		readonlystorefx.Server(),
+//	)
 func Server(opts ...thrift.RegisterOption) interface{} {
 	return func(p ServerParams) ServerResult {
 		procedures := readonlystoreserver.New(p.Handler, opts...)

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/readonlystoreserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/readonlystoreserver/server.go
@@ -27,8 +27,8 @@ type Interface interface {
 // New prepares an implementation of the ReadOnlyStore service for
 // registration.
 //
-// 	handler := ReadOnlyStoreHandler{}
-// 	dispatcher.Register(readonlystoreserver.New(handler))
+//	handler := ReadOnlyStoreHandler{}
+//	dispatcher.Register(readonlystoreserver.New(handler))
 func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 	h := handler{impl}
 	service := thrift.Service{

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/readonlystoretest/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/readonlystoretest/client.go
@@ -25,8 +25,8 @@ type _MockClientRecorder struct {
 
 // Build a new mock client for service ReadOnlyStore.
 //
-// 	mockCtrl := gomock.NewController(t)
-// 	client := readonlystoretest.NewMockClient(mockCtrl)
+//	mockCtrl := gomock.NewController(t)
+//	client := readonlystoretest.NewMockClient(mockCtrl)
 //
 // Use EXPECT() to set expectations on the mock.
 func NewMockClient(ctrl *gomock.Controller) *MockClient {
@@ -45,8 +45,8 @@ func (m *MockClient) EXPECT() *_MockClientRecorder {
 // call will fail if the mock does not expect this call. Use EXPECT to expect
 // a call to this function.
 //
-// 	client.EXPECT().Integer(gomock.Any(), ...).Return(...)
-// 	... := client.Integer(...)
+//	client.EXPECT().Integer(gomock.Any(), ...).Return(...)
+//	... := client.Integer(...)
 func (m *MockClient) Integer(
 	ctx context.Context,
 	_Key *string,
@@ -78,8 +78,8 @@ func (mr *_MockClientRecorder) Integer(
 // call will fail if the mock does not expect this call. Use EXPECT to expect
 // a call to this function.
 //
-// 	client.EXPECT().Healthy(gomock.Any(), ...).Return(...)
-// 	... := client.Healthy(...)
+//	client.EXPECT().Healthy(gomock.Any(), ...).Return(...)
+//	... := client.Healthy(...)
 func (m *MockClient) Healthy(
 	ctx context.Context,
 	opts ...yarpc.CallOption,

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storeclient/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storeclient/client.go
@@ -40,7 +40,7 @@ type Interface interface {
 
 // New builds a new client for the Store service.
 //
-// 	client := storeclient.New(dispatcher.ClientConfig("store"))
+//	client := storeclient.New(dispatcher.ClientConfig("store"))
 func New(c transport.ClientConfig, opts ...thrift.ClientOption) Interface {
 	return client{
 		c: thrift.New(thrift.Config{

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storefx/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storefx/client.go
@@ -35,10 +35,10 @@ type Result struct {
 // Client provides a Store client to an Fx application using the given name
 // for routing.
 //
-// 	fx.Provide(
-// 		storefx.Client("..."),
-// 		newHandler,
-// 	)
+//	fx.Provide(
+//		storefx.Client("..."),
+//		newHandler,
+//	)
 func Client(name string, opts ...thrift.ClientOption) interface{} {
 	return func(p Params) Result {
 		cc := p.Provider.ClientConfig(name)

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storefx/doc.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storefx/doc.go
@@ -4,27 +4,27 @@
 // Package storefx provides better integration for Fx for services
 // implementing or calling Store.
 //
-// Clients
+// # Clients
 //
 // If you are making requests to Store, use the Client function to inject a
 // Store client into your container.
 //
-// 	fx.Provide(storefx.Client("..."))
+//	fx.Provide(storefx.Client("..."))
 //
-// Servers
+// # Servers
 //
 // If you are implementing Store, provide a storeserver.Interface into
 // the container and use the Server function.
 //
 // Given,
 //
-// 	func NewStoreHandler() storeserver.Interface
+//	func NewStoreHandler() storeserver.Interface
 //
 // You can do the following to have the procedures of Store made available
 // to an Fx application.
 //
-// 	fx.Provide(
-// 		NewStoreHandler,
-// 		storefx.Server(),
-// 	)
+//	fx.Provide(
+//		NewStoreHandler,
+//		storefx.Server(),
+//	)
 package storefx

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storefx/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storefx/server.go
@@ -31,12 +31,12 @@ type ServerResult struct {
 // Server provides procedures for Store to an Fx application. It expects a
 // storefx.Interface to be present in the container.
 //
-// 	fx.Provide(
-// 		func(h *MyStoreHandler) storeserver.Interface {
-// 			return h
-// 		},
-// 		storefx.Server(),
-// 	)
+//	fx.Provide(
+//		func(h *MyStoreHandler) storeserver.Interface {
+//			return h
+//		},
+//		storefx.Server(),
+//	)
 func Server(opts ...thrift.RegisterOption) interface{} {
 	return func(p ServerParams) ServerResult {
 		procedures := storeserver.New(p.Handler, opts...)

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storeserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storeserver/server.go
@@ -38,8 +38,8 @@ type Interface interface {
 // New prepares an implementation of the Store service for
 // registration.
 //
-// 	handler := StoreHandler{}
-// 	dispatcher.Register(storeserver.New(handler))
+//	handler := StoreHandler{}
+//	dispatcher.Register(storeserver.New(handler))
 func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 	h := handler{impl}
 	service := thrift.Service{

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storetest/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storetest/client.go
@@ -26,8 +26,8 @@ type _MockClientRecorder struct {
 
 // Build a new mock client for service Store.
 //
-// 	mockCtrl := gomock.NewController(t)
-// 	client := storetest.NewMockClient(mockCtrl)
+//	mockCtrl := gomock.NewController(t)
+//	client := storetest.NewMockClient(mockCtrl)
 //
 // Use EXPECT() to set expectations on the mock.
 func NewMockClient(ctrl *gomock.Controller) *MockClient {
@@ -46,8 +46,8 @@ func (m *MockClient) EXPECT() *_MockClientRecorder {
 // call will fail if the mock does not expect this call. Use EXPECT to expect
 // a call to this function.
 //
-// 	client.EXPECT().CompareAndSwap(gomock.Any(), ...).Return(...)
-// 	... := client.CompareAndSwap(...)
+//	client.EXPECT().CompareAndSwap(gomock.Any(), ...).Return(...)
+//	... := client.CompareAndSwap(...)
 func (m *MockClient) CompareAndSwap(
 	ctx context.Context,
 	_Request *atomic.CompareAndSwap,
@@ -77,8 +77,8 @@ func (mr *_MockClientRecorder) CompareAndSwap(
 // call will fail if the mock does not expect this call. Use EXPECT to expect
 // a call to this function.
 //
-// 	client.EXPECT().Forget(gomock.Any(), ...).Return(...)
-// 	... := client.Forget(...)
+//	client.EXPECT().Forget(gomock.Any(), ...).Return(...)
+//	... := client.Forget(...)
 func (m *MockClient) Forget(
 	ctx context.Context,
 	_Key *string,
@@ -110,8 +110,8 @@ func (mr *_MockClientRecorder) Forget(
 // call will fail if the mock does not expect this call. Use EXPECT to expect
 // a call to this function.
 //
-// 	client.EXPECT().Increment(gomock.Any(), ...).Return(...)
-// 	... := client.Increment(...)
+//	client.EXPECT().Increment(gomock.Any(), ...).Return(...)
+//	... := client.Increment(...)
 func (m *MockClient) Increment(
 	ctx context.Context,
 	_Key *string,
@@ -143,8 +143,8 @@ func (mr *_MockClientRecorder) Increment(
 // call will fail if the mock does not expect this call. Use EXPECT to expect
 // a call to this function.
 //
-// 	client.EXPECT().Integer(gomock.Any(), ...).Return(...)
-// 	... := client.Integer(...)
+//	client.EXPECT().Integer(gomock.Any(), ...).Return(...)
+//	... := client.Integer(...)
 func (m *MockClient) Integer(
 	ctx context.Context,
 	_Key *string,
@@ -176,8 +176,8 @@ func (mr *_MockClientRecorder) Integer(
 // call will fail if the mock does not expect this call. Use EXPECT to expect
 // a call to this function.
 //
-// 	client.EXPECT().Healthy(gomock.Any(), ...).Return(...)
-// 	... := client.Healthy(...)
+//	client.EXPECT().Healthy(gomock.Any(), ...).Return(...)
+//	... := client.Healthy(...)
 func (m *MockClient) Healthy(
 	ctx context.Context,
 	opts ...yarpc.CallOption,

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/baseserviceclient/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/baseserviceclient/client.go
@@ -23,7 +23,7 @@ type Interface interface {
 
 // New builds a new client for the BaseService service.
 //
-// 	client := baseserviceclient.New(dispatcher.ClientConfig("baseservice"))
+//	client := baseserviceclient.New(dispatcher.ClientConfig("baseservice"))
 func New(c transport.ClientConfig, opts ...thrift.ClientOption) Interface {
 	return client{
 		c: thrift.New(thrift.Config{

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/baseservicefx/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/baseservicefx/client.go
@@ -35,10 +35,10 @@ type Result struct {
 // Client provides a BaseService client to an Fx application using the given name
 // for routing.
 //
-// 	fx.Provide(
-// 		baseservicefx.Client("..."),
-// 		newHandler,
-// 	)
+//	fx.Provide(
+//		baseservicefx.Client("..."),
+//		newHandler,
+//	)
 func Client(name string, opts ...thrift.ClientOption) interface{} {
 	return func(p Params) Result {
 		cc := p.Provider.ClientConfig(name)

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/baseservicefx/doc.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/baseservicefx/doc.go
@@ -4,27 +4,27 @@
 // Package baseservicefx provides better integration for Fx for services
 // implementing or calling BaseService.
 //
-// Clients
+// # Clients
 //
 // If you are making requests to BaseService, use the Client function to inject a
 // BaseService client into your container.
 //
-// 	fx.Provide(baseservicefx.Client("..."))
+//	fx.Provide(baseservicefx.Client("..."))
 //
-// Servers
+// # Servers
 //
 // If you are implementing BaseService, provide a baseserviceserver.Interface into
 // the container and use the Server function.
 //
 // Given,
 //
-// 	func NewBaseServiceHandler() baseserviceserver.Interface
+//	func NewBaseServiceHandler() baseserviceserver.Interface
 //
 // You can do the following to have the procedures of BaseService made available
 // to an Fx application.
 //
-// 	fx.Provide(
-// 		NewBaseServiceHandler,
-// 		baseservicefx.Server(),
-// 	)
+//	fx.Provide(
+//		NewBaseServiceHandler,
+//		baseservicefx.Server(),
+//	)
 package baseservicefx

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/baseservicefx/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/baseservicefx/server.go
@@ -31,12 +31,12 @@ type ServerResult struct {
 // Server provides procedures for BaseService to an Fx application. It expects a
 // baseservicefx.Interface to be present in the container.
 //
-// 	fx.Provide(
-// 		func(h *MyBaseServiceHandler) baseserviceserver.Interface {
-// 			return h
-// 		},
-// 		baseservicefx.Server(),
-// 	)
+//	fx.Provide(
+//		func(h *MyBaseServiceHandler) baseserviceserver.Interface {
+//			return h
+//		},
+//		baseservicefx.Server(),
+//	)
 func Server(opts ...thrift.RegisterOption) interface{} {
 	return func(p ServerParams) ServerResult {
 		procedures := baseserviceserver.New(p.Handler, opts...)

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/baseserviceserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/baseserviceserver/server.go
@@ -23,8 +23,8 @@ type Interface interface {
 // New prepares an implementation of the BaseService service for
 // registration.
 //
-// 	handler := BaseServiceHandler{}
-// 	dispatcher.Register(baseserviceserver.New(handler))
+//	handler := BaseServiceHandler{}
+//	dispatcher.Register(baseserviceserver.New(handler))
 func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 	h := handler{impl}
 	service := thrift.Service{

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/baseservicetest/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/baseservicetest/client.go
@@ -25,8 +25,8 @@ type _MockClientRecorder struct {
 
 // Build a new mock client for service BaseService.
 //
-// 	mockCtrl := gomock.NewController(t)
-// 	client := baseservicetest.NewMockClient(mockCtrl)
+//	mockCtrl := gomock.NewController(t)
+//	client := baseservicetest.NewMockClient(mockCtrl)
 //
 // Use EXPECT() to set expectations on the mock.
 func NewMockClient(ctrl *gomock.Controller) *MockClient {
@@ -45,8 +45,8 @@ func (m *MockClient) EXPECT() *_MockClientRecorder {
 // call will fail if the mock does not expect this call. Use EXPECT to expect
 // a call to this function.
 //
-// 	client.EXPECT().Healthy(gomock.Any(), ...).Return(...)
-// 	... := client.Healthy(...)
+//	client.EXPECT().Healthy(gomock.Any(), ...).Return(...)
+//	... := client.Healthy(...)
 func (m *MockClient) Healthy(
 	ctx context.Context,
 	opts ...yarpc.CallOption,

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/emptyserviceclient/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/emptyserviceclient/client.go
@@ -16,7 +16,7 @@ type Interface interface {
 
 // New builds a new client for the EmptyService service.
 //
-// 	client := emptyserviceclient.New(dispatcher.ClientConfig("emptyservice"))
+//	client := emptyserviceclient.New(dispatcher.ClientConfig("emptyservice"))
 func New(c transport.ClientConfig, opts ...thrift.ClientOption) Interface {
 	return client{
 		c: thrift.New(thrift.Config{

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/emptyservicefx/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/emptyservicefx/client.go
@@ -35,10 +35,10 @@ type Result struct {
 // Client provides a EmptyService client to an Fx application using the given name
 // for routing.
 //
-// 	fx.Provide(
-// 		emptyservicefx.Client("..."),
-// 		newHandler,
-// 	)
+//	fx.Provide(
+//		emptyservicefx.Client("..."),
+//		newHandler,
+//	)
 func Client(name string, opts ...thrift.ClientOption) interface{} {
 	return func(p Params) Result {
 		cc := p.Provider.ClientConfig(name)

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/emptyservicefx/doc.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/emptyservicefx/doc.go
@@ -4,27 +4,27 @@
 // Package emptyservicefx provides better integration for Fx for services
 // implementing or calling EmptyService.
 //
-// Clients
+// # Clients
 //
 // If you are making requests to EmptyService, use the Client function to inject a
 // EmptyService client into your container.
 //
-// 	fx.Provide(emptyservicefx.Client("..."))
+//	fx.Provide(emptyservicefx.Client("..."))
 //
-// Servers
+// # Servers
 //
 // If you are implementing EmptyService, provide a emptyserviceserver.Interface into
 // the container and use the Server function.
 //
 // Given,
 //
-// 	func NewEmptyServiceHandler() emptyserviceserver.Interface
+//	func NewEmptyServiceHandler() emptyserviceserver.Interface
 //
 // You can do the following to have the procedures of EmptyService made available
 // to an Fx application.
 //
-// 	fx.Provide(
-// 		NewEmptyServiceHandler,
-// 		emptyservicefx.Server(),
-// 	)
+//	fx.Provide(
+//		NewEmptyServiceHandler,
+//		emptyservicefx.Server(),
+//	)
 package emptyservicefx

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/emptyservicefx/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/emptyservicefx/server.go
@@ -31,12 +31,12 @@ type ServerResult struct {
 // Server provides procedures for EmptyService to an Fx application. It expects a
 // emptyservicefx.Interface to be present in the container.
 //
-// 	fx.Provide(
-// 		func(h *MyEmptyServiceHandler) emptyserviceserver.Interface {
-// 			return h
-// 		},
-// 		emptyservicefx.Server(),
-// 	)
+//	fx.Provide(
+//		func(h *MyEmptyServiceHandler) emptyserviceserver.Interface {
+//			return h
+//		},
+//		emptyservicefx.Server(),
+//	)
 func Server(opts ...thrift.RegisterOption) interface{} {
 	return func(p ServerParams) ServerResult {
 		procedures := emptyserviceserver.New(p.Handler, opts...)

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/emptyserviceserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/emptyserviceserver/server.go
@@ -15,8 +15,8 @@ type Interface interface {
 // New prepares an implementation of the EmptyService service for
 // registration.
 //
-// 	handler := EmptyServiceHandler{}
-// 	dispatcher.Register(emptyserviceserver.New(handler))
+//	handler := EmptyServiceHandler{}
+//	dispatcher.Register(emptyserviceserver.New(handler))
 func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 
 	service := thrift.Service{

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/emptyservicetest/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/emptyservicetest/client.go
@@ -23,8 +23,8 @@ type _MockClientRecorder struct {
 
 // Build a new mock client for service EmptyService.
 //
-// 	mockCtrl := gomock.NewController(t)
-// 	client := emptyservicetest.NewMockClient(mockCtrl)
+//	mockCtrl := gomock.NewController(t)
+//	client := emptyservicetest.NewMockClient(mockCtrl)
 //
 // Use EXPECT() to set expectations on the mock.
 func NewMockClient(ctrl *gomock.Controller) *MockClient {

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendemptyclient/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendemptyclient/client.go
@@ -26,7 +26,7 @@ type Interface interface {
 
 // New builds a new client for the ExtendEmpty service.
 //
-// 	client := extendemptyclient.New(dispatcher.ClientConfig("extendempty"))
+//	client := extendemptyclient.New(dispatcher.ClientConfig("extendempty"))
 func New(c transport.ClientConfig, opts ...thrift.ClientOption) Interface {
 	return client{
 		c: thrift.New(thrift.Config{

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendemptyfx/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendemptyfx/client.go
@@ -35,10 +35,10 @@ type Result struct {
 // Client provides a ExtendEmpty client to an Fx application using the given name
 // for routing.
 //
-// 	fx.Provide(
-// 		extendemptyfx.Client("..."),
-// 		newHandler,
-// 	)
+//	fx.Provide(
+//		extendemptyfx.Client("..."),
+//		newHandler,
+//	)
 func Client(name string, opts ...thrift.ClientOption) interface{} {
 	return func(p Params) Result {
 		cc := p.Provider.ClientConfig(name)

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendemptyfx/doc.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendemptyfx/doc.go
@@ -4,27 +4,27 @@
 // Package extendemptyfx provides better integration for Fx for services
 // implementing or calling ExtendEmpty.
 //
-// Clients
+// # Clients
 //
 // If you are making requests to ExtendEmpty, use the Client function to inject a
 // ExtendEmpty client into your container.
 //
-// 	fx.Provide(extendemptyfx.Client("..."))
+//	fx.Provide(extendemptyfx.Client("..."))
 //
-// Servers
+// # Servers
 //
 // If you are implementing ExtendEmpty, provide a extendemptyserver.Interface into
 // the container and use the Server function.
 //
 // Given,
 //
-// 	func NewExtendEmptyHandler() extendemptyserver.Interface
+//	func NewExtendEmptyHandler() extendemptyserver.Interface
 //
 // You can do the following to have the procedures of ExtendEmpty made available
 // to an Fx application.
 //
-// 	fx.Provide(
-// 		NewExtendEmptyHandler,
-// 		extendemptyfx.Server(),
-// 	)
+//	fx.Provide(
+//		NewExtendEmptyHandler,
+//		extendemptyfx.Server(),
+//	)
 package extendemptyfx

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendemptyfx/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendemptyfx/server.go
@@ -31,12 +31,12 @@ type ServerResult struct {
 // Server provides procedures for ExtendEmpty to an Fx application. It expects a
 // extendemptyfx.Interface to be present in the container.
 //
-// 	fx.Provide(
-// 		func(h *MyExtendEmptyHandler) extendemptyserver.Interface {
-// 			return h
-// 		},
-// 		extendemptyfx.Server(),
-// 	)
+//	fx.Provide(
+//		func(h *MyExtendEmptyHandler) extendemptyserver.Interface {
+//			return h
+//		},
+//		extendemptyfx.Server(),
+//	)
 func Server(opts ...thrift.RegisterOption) interface{} {
 	return func(p ServerParams) ServerResult {
 		procedures := extendemptyserver.New(p.Handler, opts...)

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendemptyserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendemptyserver/server.go
@@ -26,8 +26,8 @@ type Interface interface {
 // New prepares an implementation of the ExtendEmpty service for
 // registration.
 //
-// 	handler := ExtendEmptyHandler{}
-// 	dispatcher.Register(extendemptyserver.New(handler))
+//	handler := ExtendEmptyHandler{}
+//	dispatcher.Register(extendemptyserver.New(handler))
 func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 	h := handler{impl}
 	service := thrift.Service{

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendemptytest/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendemptytest/client.go
@@ -25,8 +25,8 @@ type _MockClientRecorder struct {
 
 // Build a new mock client for service ExtendEmpty.
 //
-// 	mockCtrl := gomock.NewController(t)
-// 	client := extendemptytest.NewMockClient(mockCtrl)
+//	mockCtrl := gomock.NewController(t)
+//	client := extendemptytest.NewMockClient(mockCtrl)
 //
 // Use EXPECT() to set expectations on the mock.
 func NewMockClient(ctrl *gomock.Controller) *MockClient {
@@ -45,8 +45,8 @@ func (m *MockClient) EXPECT() *_MockClientRecorder {
 // call will fail if the mock does not expect this call. Use EXPECT to expect
 // a call to this function.
 //
-// 	client.EXPECT().Hello(gomock.Any(), ...).Return(...)
-// 	... := client.Hello(...)
+//	client.EXPECT().Hello(gomock.Any(), ...).Return(...)
+//	... := client.Hello(...)
 func (m *MockClient) Hello(
 	ctx context.Context,
 	opts ...yarpc.CallOption,

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendonlyclient/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendonlyclient/client.go
@@ -18,7 +18,7 @@ type Interface interface {
 
 // New builds a new client for the ExtendOnly service.
 //
-// 	client := extendonlyclient.New(dispatcher.ClientConfig("extendonly"))
+//	client := extendonlyclient.New(dispatcher.ClientConfig("extendonly"))
 func New(c transport.ClientConfig, opts ...thrift.ClientOption) Interface {
 	return client{
 		c: thrift.New(thrift.Config{

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendonlyfx/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendonlyfx/client.go
@@ -35,10 +35,10 @@ type Result struct {
 // Client provides a ExtendOnly client to an Fx application using the given name
 // for routing.
 //
-// 	fx.Provide(
-// 		extendonlyfx.Client("..."),
-// 		newHandler,
-// 	)
+//	fx.Provide(
+//		extendonlyfx.Client("..."),
+//		newHandler,
+//	)
 func Client(name string, opts ...thrift.ClientOption) interface{} {
 	return func(p Params) Result {
 		cc := p.Provider.ClientConfig(name)

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendonlyfx/doc.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendonlyfx/doc.go
@@ -4,27 +4,27 @@
 // Package extendonlyfx provides better integration for Fx for services
 // implementing or calling ExtendOnly.
 //
-// Clients
+// # Clients
 //
 // If you are making requests to ExtendOnly, use the Client function to inject a
 // ExtendOnly client into your container.
 //
-// 	fx.Provide(extendonlyfx.Client("..."))
+//	fx.Provide(extendonlyfx.Client("..."))
 //
-// Servers
+// # Servers
 //
 // If you are implementing ExtendOnly, provide a extendonlyserver.Interface into
 // the container and use the Server function.
 //
 // Given,
 //
-// 	func NewExtendOnlyHandler() extendonlyserver.Interface
+//	func NewExtendOnlyHandler() extendonlyserver.Interface
 //
 // You can do the following to have the procedures of ExtendOnly made available
 // to an Fx application.
 //
-// 	fx.Provide(
-// 		NewExtendOnlyHandler,
-// 		extendonlyfx.Server(),
-// 	)
+//	fx.Provide(
+//		NewExtendOnlyHandler,
+//		extendonlyfx.Server(),
+//	)
 package extendonlyfx

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendonlyfx/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendonlyfx/server.go
@@ -31,12 +31,12 @@ type ServerResult struct {
 // Server provides procedures for ExtendOnly to an Fx application. It expects a
 // extendonlyfx.Interface to be present in the container.
 //
-// 	fx.Provide(
-// 		func(h *MyExtendOnlyHandler) extendonlyserver.Interface {
-// 			return h
-// 		},
-// 		extendonlyfx.Server(),
-// 	)
+//	fx.Provide(
+//		func(h *MyExtendOnlyHandler) extendonlyserver.Interface {
+//			return h
+//		},
+//		extendonlyfx.Server(),
+//	)
 func Server(opts ...thrift.RegisterOption) interface{} {
 	return func(p ServerParams) ServerResult {
 		procedures := extendonlyserver.New(p.Handler, opts...)

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendonlyserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendonlyserver/server.go
@@ -17,8 +17,8 @@ type Interface interface {
 // New prepares an implementation of the ExtendOnly service for
 // registration.
 //
-// 	handler := ExtendOnlyHandler{}
-// 	dispatcher.Register(extendonlyserver.New(handler))
+//	handler := ExtendOnlyHandler{}
+//	dispatcher.Register(extendonlyserver.New(handler))
 func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 
 	service := thrift.Service{

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendonlytest/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendonlytest/client.go
@@ -25,8 +25,8 @@ type _MockClientRecorder struct {
 
 // Build a new mock client for service ExtendOnly.
 //
-// 	mockCtrl := gomock.NewController(t)
-// 	client := extendonlytest.NewMockClient(mockCtrl)
+//	mockCtrl := gomock.NewController(t)
+//	client := extendonlytest.NewMockClient(mockCtrl)
 //
 // Use EXPECT() to set expectations on the mock.
 func NewMockClient(ctrl *gomock.Controller) *MockClient {
@@ -45,8 +45,8 @@ func (m *MockClient) EXPECT() *_MockClientRecorder {
 // call will fail if the mock does not expect this call. Use EXPECT to expect
 // a call to this function.
 //
-// 	client.EXPECT().Healthy(gomock.Any(), ...).Return(...)
-// 	... := client.Healthy(...)
+//	client.EXPECT().Healthy(gomock.Any(), ...).Return(...)
+//	... := client.Healthy(...)
 func (m *MockClient) Healthy(
 	ctx context.Context,
 	opts ...yarpc.CallOption,

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/barclient/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/barclient/client.go
@@ -18,7 +18,7 @@ type Interface interface {
 
 // New builds a new client for the Bar service.
 //
-// 	client := barclient.New(dispatcher.ClientConfig("bar"))
+//	client := barclient.New(dispatcher.ClientConfig("bar"))
 func New(c transport.ClientConfig, opts ...thrift.ClientOption) Interface {
 	return client{
 		c: thrift.New(thrift.Config{

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/barfx/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/barfx/client.go
@@ -35,10 +35,10 @@ type Result struct {
 // Client provides a Bar client to an Fx application using the given name
 // for routing.
 //
-// 	fx.Provide(
-// 		barfx.Client("..."),
-// 		newHandler,
-// 	)
+//	fx.Provide(
+//		barfx.Client("..."),
+//		newHandler,
+//	)
 func Client(name string, opts ...thrift.ClientOption) interface{} {
 	return func(p Params) Result {
 		cc := p.Provider.ClientConfig(name)

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/barfx/doc.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/barfx/doc.go
@@ -4,27 +4,27 @@
 // Package barfx provides better integration for Fx for services
 // implementing or calling Bar.
 //
-// Clients
+// # Clients
 //
 // If you are making requests to Bar, use the Client function to inject a
 // Bar client into your container.
 //
-// 	fx.Provide(barfx.Client("..."))
+//	fx.Provide(barfx.Client("..."))
 //
-// Servers
+// # Servers
 //
 // If you are implementing Bar, provide a barserver.Interface into
 // the container and use the Server function.
 //
 // Given,
 //
-// 	func NewBarHandler() barserver.Interface
+//	func NewBarHandler() barserver.Interface
 //
 // You can do the following to have the procedures of Bar made available
 // to an Fx application.
 //
-// 	fx.Provide(
-// 		NewBarHandler,
-// 		barfx.Server(),
-// 	)
+//	fx.Provide(
+//		NewBarHandler,
+//		barfx.Server(),
+//	)
 package barfx

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/barfx/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/barfx/server.go
@@ -31,12 +31,12 @@ type ServerResult struct {
 // Server provides procedures for Bar to an Fx application. It expects a
 // barfx.Interface to be present in the container.
 //
-// 	fx.Provide(
-// 		func(h *MyBarHandler) barserver.Interface {
-// 			return h
-// 		},
-// 		barfx.Server(),
-// 	)
+//	fx.Provide(
+//		func(h *MyBarHandler) barserver.Interface {
+//			return h
+//		},
+//		barfx.Server(),
+//	)
 func Server(opts ...thrift.RegisterOption) interface{} {
 	return func(p ServerParams) ServerResult {
 		procedures := barserver.New(p.Handler, opts...)

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/barserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/barserver/server.go
@@ -17,8 +17,8 @@ type Interface interface {
 // New prepares an implementation of the Bar service for
 // registration.
 //
-// 	handler := BarHandler{}
-// 	dispatcher.Register(barserver.New(handler))
+//	handler := BarHandler{}
+//	dispatcher.Register(barserver.New(handler))
 func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 
 	service := thrift.Service{

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/bartest/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/bartest/client.go
@@ -25,8 +25,8 @@ type _MockClientRecorder struct {
 
 // Build a new mock client for service Bar.
 //
-// 	mockCtrl := gomock.NewController(t)
-// 	client := bartest.NewMockClient(mockCtrl)
+//	mockCtrl := gomock.NewController(t)
+//	client := bartest.NewMockClient(mockCtrl)
 //
 // Use EXPECT() to set expectations on the mock.
 func NewMockClient(ctrl *gomock.Controller) *MockClient {
@@ -45,8 +45,8 @@ func (m *MockClient) EXPECT() *_MockClientRecorder {
 // call will fail if the mock does not expect this call. Use EXPECT to expect
 // a call to this function.
 //
-// 	client.EXPECT().Name(gomock.Any(), ...).Return(...)
-// 	... := client.Name(...)
+//	client.EXPECT().Name(gomock.Any(), ...).Return(...)
+//	... := client.Name(...)
 func (m *MockClient) Name(
 	ctx context.Context,
 	opts ...yarpc.CallOption,

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/fooclient/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/fooclient/client.go
@@ -18,7 +18,7 @@ type Interface interface {
 
 // New builds a new client for the Foo service.
 //
-// 	client := fooclient.New(dispatcher.ClientConfig("foo"))
+//	client := fooclient.New(dispatcher.ClientConfig("foo"))
 func New(c transport.ClientConfig, opts ...thrift.ClientOption) Interface {
 	return client{
 		c: thrift.New(thrift.Config{

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/foofx/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/foofx/client.go
@@ -35,10 +35,10 @@ type Result struct {
 // Client provides a Foo client to an Fx application using the given name
 // for routing.
 //
-// 	fx.Provide(
-// 		foofx.Client("..."),
-// 		newHandler,
-// 	)
+//	fx.Provide(
+//		foofx.Client("..."),
+//		newHandler,
+//	)
 func Client(name string, opts ...thrift.ClientOption) interface{} {
 	return func(p Params) Result {
 		cc := p.Provider.ClientConfig(name)

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/foofx/doc.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/foofx/doc.go
@@ -4,27 +4,27 @@
 // Package foofx provides better integration for Fx for services
 // implementing or calling Foo.
 //
-// Clients
+// # Clients
 //
 // If you are making requests to Foo, use the Client function to inject a
 // Foo client into your container.
 //
-// 	fx.Provide(foofx.Client("..."))
+//	fx.Provide(foofx.Client("..."))
 //
-// Servers
+// # Servers
 //
 // If you are implementing Foo, provide a fooserver.Interface into
 // the container and use the Server function.
 //
 // Given,
 //
-// 	func NewFooHandler() fooserver.Interface
+//	func NewFooHandler() fooserver.Interface
 //
 // You can do the following to have the procedures of Foo made available
 // to an Fx application.
 //
-// 	fx.Provide(
-// 		NewFooHandler,
-// 		foofx.Server(),
-// 	)
+//	fx.Provide(
+//		NewFooHandler,
+//		foofx.Server(),
+//	)
 package foofx

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/foofx/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/foofx/server.go
@@ -31,12 +31,12 @@ type ServerResult struct {
 // Server provides procedures for Foo to an Fx application. It expects a
 // foofx.Interface to be present in the container.
 //
-// 	fx.Provide(
-// 		func(h *MyFooHandler) fooserver.Interface {
-// 			return h
-// 		},
-// 		foofx.Server(),
-// 	)
+//	fx.Provide(
+//		func(h *MyFooHandler) fooserver.Interface {
+//			return h
+//		},
+//		foofx.Server(),
+//	)
 func Server(opts ...thrift.RegisterOption) interface{} {
 	return func(p ServerParams) ServerResult {
 		procedures := fooserver.New(p.Handler, opts...)

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/fooserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/fooserver/server.go
@@ -17,8 +17,8 @@ type Interface interface {
 // New prepares an implementation of the Foo service for
 // registration.
 //
-// 	handler := FooHandler{}
-// 	dispatcher.Register(fooserver.New(handler))
+//	handler := FooHandler{}
+//	dispatcher.Register(fooserver.New(handler))
 func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 
 	service := thrift.Service{

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/footest/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/footest/client.go
@@ -25,8 +25,8 @@ type _MockClientRecorder struct {
 
 // Build a new mock client for service Foo.
 //
-// 	mockCtrl := gomock.NewController(t)
-// 	client := footest.NewMockClient(mockCtrl)
+//	mockCtrl := gomock.NewController(t)
+//	client := footest.NewMockClient(mockCtrl)
 //
 // Use EXPECT() to set expectations on the mock.
 func NewMockClient(ctrl *gomock.Controller) *MockClient {
@@ -45,8 +45,8 @@ func (m *MockClient) EXPECT() *_MockClientRecorder {
 // call will fail if the mock does not expect this call. Use EXPECT to expect
 // a call to this function.
 //
-// 	client.EXPECT().Name(gomock.Any(), ...).Return(...)
-// 	... := client.Name(...)
+//	client.EXPECT().Name(gomock.Any(), ...).Return(...)
+//	... := client.Name(...)
 func (m *MockClient) Name(
 	ctx context.Context,
 	opts ...yarpc.CallOption,

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/nameclient/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/nameclient/client.go
@@ -23,7 +23,7 @@ type Interface interface {
 
 // New builds a new client for the Name service.
 //
-// 	client := nameclient.New(dispatcher.ClientConfig("name"))
+//	client := nameclient.New(dispatcher.ClientConfig("name"))
 func New(c transport.ClientConfig, opts ...thrift.ClientOption) Interface {
 	return client{
 		c: thrift.New(thrift.Config{

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/namefx/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/namefx/client.go
@@ -35,10 +35,10 @@ type Result struct {
 // Client provides a Name client to an Fx application using the given name
 // for routing.
 //
-// 	fx.Provide(
-// 		namefx.Client("..."),
-// 		newHandler,
-// 	)
+//	fx.Provide(
+//		namefx.Client("..."),
+//		newHandler,
+//	)
 func Client(name string, opts ...thrift.ClientOption) interface{} {
 	return func(p Params) Result {
 		cc := p.Provider.ClientConfig(name)

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/namefx/doc.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/namefx/doc.go
@@ -4,27 +4,27 @@
 // Package namefx provides better integration for Fx for services
 // implementing or calling Name.
 //
-// Clients
+// # Clients
 //
 // If you are making requests to Name, use the Client function to inject a
 // Name client into your container.
 //
-// 	fx.Provide(namefx.Client("..."))
+//	fx.Provide(namefx.Client("..."))
 //
-// Servers
+// # Servers
 //
 // If you are implementing Name, provide a nameserver.Interface into
 // the container and use the Server function.
 //
 // Given,
 //
-// 	func NewNameHandler() nameserver.Interface
+//	func NewNameHandler() nameserver.Interface
 //
 // You can do the following to have the procedures of Name made available
 // to an Fx application.
 //
-// 	fx.Provide(
-// 		NewNameHandler,
-// 		namefx.Server(),
-// 	)
+//	fx.Provide(
+//		NewNameHandler,
+//		namefx.Server(),
+//	)
 package namefx

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/namefx/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/namefx/server.go
@@ -31,12 +31,12 @@ type ServerResult struct {
 // Server provides procedures for Name to an Fx application. It expects a
 // namefx.Interface to be present in the container.
 //
-// 	fx.Provide(
-// 		func(h *MyNameHandler) nameserver.Interface {
-// 			return h
-// 		},
-// 		namefx.Server(),
-// 	)
+//	fx.Provide(
+//		func(h *MyNameHandler) nameserver.Interface {
+//			return h
+//		},
+//		namefx.Server(),
+//	)
 func Server(opts ...thrift.RegisterOption) interface{} {
 	return func(p ServerParams) ServerResult {
 		procedures := nameserver.New(p.Handler, opts...)

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/nameserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/nameserver/server.go
@@ -23,8 +23,8 @@ type Interface interface {
 // New prepares an implementation of the Name service for
 // registration.
 //
-// 	handler := NameHandler{}
-// 	dispatcher.Register(nameserver.New(handler))
+//	handler := NameHandler{}
+//	dispatcher.Register(nameserver.New(handler))
 func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 	h := handler{impl}
 	service := thrift.Service{

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/nametest/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/nametest/client.go
@@ -25,8 +25,8 @@ type _MockClientRecorder struct {
 
 // Build a new mock client for service Name.
 //
-// 	mockCtrl := gomock.NewController(t)
-// 	client := nametest.NewMockClient(mockCtrl)
+//	mockCtrl := gomock.NewController(t)
+//	client := nametest.NewMockClient(mockCtrl)
 //
 // Use EXPECT() to set expectations on the mock.
 func NewMockClient(ctrl *gomock.Controller) *MockClient {
@@ -45,8 +45,8 @@ func (m *MockClient) EXPECT() *_MockClientRecorder {
 // call will fail if the mock does not expect this call. Use EXPECT to expect
 // a call to this function.
 //
-// 	client.EXPECT().Name(gomock.Any(), ...).Return(...)
-// 	... := client.Name(...)
+//	client.EXPECT().Name(gomock.Any(), ...).Return(...)
+//	... := client.Name(...)
 func (m *MockClient) Name(
 	ctx context.Context,
 	opts ...yarpc.CallOption,

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/weather/weatherclient/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/weather/weatherclient/client.go
@@ -24,7 +24,7 @@ type Interface interface {
 
 // New builds a new client for the Weather service.
 //
-// 	client := weatherclient.New(dispatcher.ClientConfig("weather"))
+//	client := weatherclient.New(dispatcher.ClientConfig("weather"))
 func New(c transport.ClientConfig, opts ...thrift.ClientOption) Interface {
 	return client{
 		c: thrift.New(thrift.Config{

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/weather/weatherfx/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/weather/weatherfx/client.go
@@ -35,10 +35,10 @@ type Result struct {
 // Client provides a Weather client to an Fx application using the given name
 // for routing.
 //
-// 	fx.Provide(
-// 		weatherfx.Client("..."),
-// 		newHandler,
-// 	)
+//	fx.Provide(
+//		weatherfx.Client("..."),
+//		newHandler,
+//	)
 func Client(name string, opts ...thrift.ClientOption) interface{} {
 	return func(p Params) Result {
 		cc := p.Provider.ClientConfig(name)

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/weather/weatherfx/doc.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/weather/weatherfx/doc.go
@@ -4,27 +4,27 @@
 // Package weatherfx provides better integration for Fx for services
 // implementing or calling Weather.
 //
-// Clients
+// # Clients
 //
 // If you are making requests to Weather, use the Client function to inject a
 // Weather client into your container.
 //
-// 	fx.Provide(weatherfx.Client("..."))
+//	fx.Provide(weatherfx.Client("..."))
 //
-// Servers
+// # Servers
 //
 // If you are implementing Weather, provide a weatherserver.Interface into
 // the container and use the Server function.
 //
 // Given,
 //
-// 	func NewWeatherHandler() weatherserver.Interface
+//	func NewWeatherHandler() weatherserver.Interface
 //
 // You can do the following to have the procedures of Weather made available
 // to an Fx application.
 //
-// 	fx.Provide(
-// 		NewWeatherHandler,
-// 		weatherfx.Server(),
-// 	)
+//	fx.Provide(
+//		NewWeatherHandler,
+//		weatherfx.Server(),
+//	)
 package weatherfx

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/weather/weatherfx/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/weather/weatherfx/server.go
@@ -31,12 +31,12 @@ type ServerResult struct {
 // Server provides procedures for Weather to an Fx application. It expects a
 // weatherfx.Interface to be present in the container.
 //
-// 	fx.Provide(
-// 		func(h *MyWeatherHandler) weatherserver.Interface {
-// 			return h
-// 		},
-// 		weatherfx.Server(),
-// 	)
+//	fx.Provide(
+//		func(h *MyWeatherHandler) weatherserver.Interface {
+//			return h
+//		},
+//		weatherfx.Server(),
+//	)
 func Server(opts ...thrift.RegisterOption) interface{} {
 	return func(p ServerParams) ServerResult {
 		procedures := weatherserver.New(p.Handler, opts...)

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/weather/weatherserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/weather/weatherserver/server.go
@@ -23,8 +23,8 @@ type Interface interface {
 // New prepares an implementation of the Weather service for
 // registration.
 //
-// 	handler := WeatherHandler{}
-// 	dispatcher.Register(weatherserver.New(handler))
+//	handler := WeatherHandler{}
+//	dispatcher.Register(weatherserver.New(handler))
 func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 	h := handler{impl}
 	service := thrift.Service{

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/weather/weathertest/client.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/weather/weathertest/client.go
@@ -25,8 +25,8 @@ type _MockClientRecorder struct {
 
 // Build a new mock client for service Weather.
 //
-// 	mockCtrl := gomock.NewController(t)
-// 	client := weathertest.NewMockClient(mockCtrl)
+//	mockCtrl := gomock.NewController(t)
+//	client := weathertest.NewMockClient(mockCtrl)
 //
 // Use EXPECT() to set expectations on the mock.
 func NewMockClient(ctrl *gomock.Controller) *MockClient {
@@ -45,8 +45,8 @@ func (m *MockClient) EXPECT() *_MockClientRecorder {
 // call will fail if the mock does not expect this call. Use EXPECT to expect
 // a call to this function.
 //
-// 	client.EXPECT().Check(gomock.Any(), ...).Return(...)
-// 	... := client.Check(...)
+//	client.EXPECT().Check(gomock.Any(), ...).Return(...)
+//	... := client.Check(...)
 func (m *MockClient) Check(
 	ctx context.Context,
 	opts ...yarpc.CallOption,

--- a/etc/make/local.mk
+++ b/etc/make/local.mk
@@ -138,6 +138,7 @@ lint: basiclint generatenodiff nogogenerate verifyversion verifycodecovignores #
 
 .PHONY: test
 test: $(THRIFTRW) __eval_chunked_packages ## run chunked tests
+	go mod vendor
 	PATH=$(BIN):$$PATH go test -race $(CHUNKED_PACKAGES)
 
 .PHONY: cover

--- a/transport/grpc/integration_test.go
+++ b/transport/grpc/integration_test.go
@@ -211,7 +211,12 @@ func TestYARPCMaxMsgSize(t *testing.T) {
 	t.Run("too big", func(t *testing.T) {
 		te := testEnvOptions{}
 		te.do(t, func(t *testing.T, e *testEnv) {
-			assert.Equal(t, yarpcerrors.CodeResourceExhausted, yarpcerrors.FromError(e.SetValueYARPC(context.Background(), "foo", value)).Code())
+			ctx, cancel := context.WithTimeout(context.Background(), testtime.Second*5)
+			defer cancel()
+
+			err := e.SetValueYARPC(ctx, "foo", value)
+
+			assert.Equal(t, yarpcerrors.CodeResourceExhausted.String(), yarpcerrors.FromError(err).Code().String())
 		})
 	})
 	t.Run("just right", func(t *testing.T) {
@@ -224,8 +229,11 @@ func TestYARPCMaxMsgSize(t *testing.T) {
 			},
 		}
 		te.do(t, func(t *testing.T, e *testEnv) {
-			if assert.NoError(t, e.SetValueYARPC(context.Background(), "foo", value)) {
-				getValue, err := e.GetValueYARPC(context.Background(), "foo")
+			ctx, cancel := context.WithTimeout(context.Background(), testtime.Second*5)
+			defer cancel()
+
+			if assert.NoError(t, e.SetValueYARPC(ctx, "foo", value)) {
+				getValue, err := e.GetValueYARPC(ctx, "foo")
 				assert.NoError(t, err)
 				assert.Equal(t, value, getValue)
 			}

--- a/transport/tchannel/header.go
+++ b/transport/tchannel/header.go
@@ -33,6 +33,8 @@ import (
 )
 
 const (
+	/** Response headers **/
+
 	// ErrorCodeHeaderKey is the response header key for the error code.
 	ErrorCodeHeaderKey = "$rpc$-error-code"
 	// ErrorNameHeaderKey is the response header key for the error name.
@@ -48,8 +50,11 @@ const (
 	ApplicationErrorDetailsHeaderKey = "$rpc$-application-error-details"
 	// ApplicationErrorCodeHeaderKey is the response header key for the application error code.
 	ApplicationErrorCodeHeaderKey = "$rpc$-application-error-code"
+
+	/** Request headers **/
+
 	// CallerProcedureHeader is the header key for the procedure of the caller making the request.
-	CallerProcedureHeader = "$rpc$-caller-procedure"
+	CallerProcedureHeader = "rpc-caller-procedure"
 )
 
 var _reservedHeaderKeys = map[string]struct{}{
@@ -60,6 +65,7 @@ var _reservedHeaderKeys = map[string]struct{}{
 	ApplicationErrorNameHeaderKey:    {},
 	ApplicationErrorDetailsHeaderKey: {},
 	ApplicationErrorCodeHeaderKey:    {},
+	CallerProcedureHeader:            {},
 }
 
 func isReservedHeaderKey(key string) bool {

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package yarpc // import "go.uber.org/yarpc"
 
 // Version is the current version of YARPC.
-const Version = "1.72.0"
+const Version = "1.73.0-dev"

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package yarpc // import "go.uber.org/yarpc"
 
 // Version is the current version of YARPC.
-const Version = "1.73.0-dev"
+const Version = "1.72.1"


### PR DESCRIPTION
- tchannel: Renamed caller-procedure header from `$rpc$-caller-procedure` to `rpc-caller-procedure`.