### PR TITLE
Revert setting caller value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 =======
 ## [Unreleased]
 - Upgraded go version to 1.21, set toolchain version.
+- Reverted rpc-caller-procedure value setting.
 
 ## [1.72.1] - 2024-03-14
 - tchannel: Renamed caller-procedure header from `$rpc$-caller-procedure` to `rpc-caller-procedure`.

--- a/internal/firstoutboundmiddleware/middleware.go
+++ b/internal/firstoutboundmiddleware/middleware.go
@@ -26,7 +26,6 @@ package firstoutboundmiddleware
 import (
 	"context"
 
-	"go.uber.org/yarpc/api/encoding"
 	"go.uber.org/yarpc/api/middleware"
 	"go.uber.org/yarpc/api/transport"
 )
@@ -74,12 +73,6 @@ func update(ctx context.Context, req *transport.Request, out transport.Outbound)
 	if namer, ok := out.(transport.Namer); ok {
 		req.Transport = namer.TransportName()
 	}
-
-	// Update the caller procedure to the current procedure making this request
-	call := encoding.CallFromContext(ctx)
-	if call != nil {
-		req.CallerProcedure = call.Procedure()
-	}
 }
 
 func updateStream(ctx context.Context, req *transport.StreamRequest, out transport.Outbound) {
@@ -91,11 +84,5 @@ func updateStream(ctx context.Context, req *transport.StreamRequest, out transpo
 	// requests to a different outbound type.
 	if namer, ok := out.(transport.Namer); ok {
 		req.Meta.Transport = namer.TransportName()
-	}
-
-	// Update the caller procedure to the current procedure making this request
-	call := encoding.CallFromContext(ctx)
-	if call != nil {
-		req.Meta.CallerProcedure = call.Procedure()
 	}
 }

--- a/internal/firstoutboundmiddleware/middleware_test.go
+++ b/internal/firstoutboundmiddleware/middleware_test.go
@@ -54,7 +54,7 @@ func TestFirstOutboundMidleware(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, "fake", string(req.Transport))
-		assert.Equal(t, "ABC", string(req.CallerProcedure))
+		assert.Equal(t, "", string(req.CallerProcedure))
 	})
 
 	t.Run("oneway", func(t *testing.T) {
@@ -66,7 +66,7 @@ func TestFirstOutboundMidleware(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, "fake", string(req.Transport))
-		assert.Equal(t, "ABC", string(req.CallerProcedure))
+		assert.Equal(t, "", string(req.CallerProcedure))
 	})
 
 	t.Run("stream", func(t *testing.T) {
@@ -78,6 +78,6 @@ func TestFirstOutboundMidleware(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, "fake", string(streamReq.Meta.Transport))
-		assert.Equal(t, "ABC", string(streamReq.Meta.CallerProcedure))
+		assert.Equal(t, "", string(streamReq.Meta.CallerProcedure))
 	})
 }


### PR DESCRIPTION
Based on #2255

Reverting changes from #2240, because currently there are no safety way go propagate this value. #2246 broke forward-compatibility, so it should be deployed first.