### PR TITLE
[1/3 header changes][metrics + grpc] Emit metrics for new headers handling behaviour. Hide actual changes under feature flag.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 - Upgraded go version to 1.21, set toolchain version.
 - Reverted rpc-caller-procedure value setting.
+- Preparation for the new header handling behavior.
+
+Starting from one of the next releases, following behaviour changes will be applied:
+- Any inbound header with the prefix `rpc-` will be treated as a reserved header and will be ignored
+(i.e. not forwarded to an application code) in both tchannel and grpc.
+Currently, unknown headers with the prefix `rpc-` are forwarded to the application code in both transports.
+- Any attempt to set request/response header with the prefix `rpc-` will result in an error in tchannel.
+Currently, the same behavior is applied only to the grpc transport, while tchannel allows setting such headers.
+
+As an intermediate step, the `reserved_headers_stripped` and `reserved_headers_error` metrics
+with `"component": "yarpc-header-migration"` constant tag and with `source` and `dest` variable tags
+will be emitted to help to identify the edges that are affected by the changes.
 
 ## [1.72.1] - 2024-03-14
 - tchannel: Renamed caller-procedure header from `$rpc$-caller-procedure` to `rpc-caller-procedure`.

--- a/docs/headers-handling.md
+++ b/docs/headers-handling.md
@@ -1,0 +1,95 @@
+# Headers handling
+
+YARPC has a single unified API for getting and setting headers across three L7 protocols, although implementations may vary by a lot.
+
+This document describes details of headers handling in Yarpc.
+
+# Existing behaviour
+
+Important to note that HTTP standard (for both plain HTTP and gRPC) supports multiple values for the same header.
+Yarpc doesn't support this feature, uses only one value for each header. Sending two headers with the same name will result in undefined behaviour.
+
+Another important note is, HTTP/gRPC header is case insensitive, but TChannel header is case sensitive. This is why we have an OriginalHeaders method on the call object (derived from `yarpc.CallFromContext(ctx)`).
+
+## HTTP
+
+### Outbound - Request (writing via req.Headers.With)
+
+All application headers are prepended with an 'Rpc-Header' prefix.
+
+### Inbound - Request (Parsing)
+
+Predefined list of headers is read and stripped from the inbound request.
+
+Headers with prefix 'Rpc-Header-' will be forwarded to the application handler (without prefix).
+
+Only headers explicitly specified in the config will be passed to the application code as is. If header name doesn't have 'x-' prefix, 'header %s does not begin with 'x-'' message is returned.
+
+### Inbound - Response (Writing)
+
+All application headers are prepended with an 'Rpc-Header' prefix.
+
+### Outbound - Response (Parsing)
+
+Headers with prefix 'Rpc-Header-' will be forwarded to the application handler (without prefix).
+
+## TChannel
+
+### Outbound - Request (writing via req.Headers.With)
+
+Headers with any name may be added.
+
+### Inbound - Request (Parsing)
+
+A single header (`rpc-caller-procedure`) is read and stripped from the inbound request.
+
+All other headers are forwarded as is to the application handler.
+
+### Inbound - Response (Writing)
+
+Attempting to add a header with a name listed as [reserved by yarpc](../transport/tchannel/header.go#L60) leads to an error "cannot use reserved header key".
+
+### Outbound - Response (Parsing)
+
+Headers with the names listed as reserved are deleted. All other headers are forwarded to the application handler as is.
+
+## GRPC
+
+### Outbound - Request (writing via req.Headers.With)
+
+Attempting to add headers with some of reserved names or with already set values lead to 'duplicate key' error.
+
+Attempting to add headers with 'rpc-' prefix leads to 'cannot use reserved header in application headers' error.
+
+### Inbound - Request (Parsing)
+
+Predefined list of headers is read and stripped from the inbound request.
+
+All other headers are forwarded as is to the application handler.
+
+### Inbound - Response (Writing)
+
+Attempting to add headers with some of reserved names or already set values lead to 'duplicate key' error.
+
+Attempting to add headers with 'rpc-' prefix leads to 'cannot use reserved header in application headers' error.
+
+### Outbound - Response (Parsing)
+
+Headers with 'rpc-' prefix will be omitted from forwarding to the application handler.
+
+# New behaviour
+
+This behaviour implemented, but hidden behind the feature flag. Following metrics may be used to check affected edges:
+
+Names: `grpc_reserved_headers_stripped`, `grpc_reserved_headers_error` with `"component": "yarpc-header-migration"` constant tag,
+`source` and `dest` variable tags.
+
+## HTTP, TChannel, GRPC
+
+### Outbound - Request (writing via req.Headers.With) and Inbound - Response (Writing)
+
+Attempting to add a header with a 'prc-' or '$rpc$-' prefixes leads to an error "cannot use reserved header key".
+
+### Inbound - Request (Parsing) and Outbound - Response (Parsing)
+
+Unparsed headers with 'rpc-' or '$rpc$-' prefixes ignored, i.e. not forwarded to the application handler.

--- a/internal/observability/reserved_headers.go
+++ b/internal/observability/reserved_headers.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2024 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package observability
+
+import (
+	"go.uber.org/net/metrics"
+)
+
+type (
+	// ReservedHeaderMetrics is a collection of metrics for reserved headers.
+	ReservedHeaderMetrics struct {
+		strippedVec *metrics.CounterVector
+		errorVec    *metrics.CounterVector
+	}
+
+	// ReservedHeaderEdgeMetrics is a wrapper for ReservedHeaderMetrics that has source and dest.
+	ReservedHeaderEdgeMetrics struct {
+		m            *ReservedHeaderMetrics
+		source, dest string
+	}
+)
+
+// NewReserveHeaderMetrics creates a new ReservedHeaderMetrics.
+func NewReserveHeaderMetrics(scope *metrics.Scope, transport string) *ReservedHeaderMetrics {
+	return &ReservedHeaderMetrics{
+		strippedVec: registerReservedHeaderStripped(scope, transport),
+		errorVec:    registerReservedHeaderError(scope, transport),
+	}
+}
+
+// IncStripped increments the stripped metric.
+func (m *ReservedHeaderMetrics) IncStripped(source, dest string) {
+	if m != nil {
+		incHeaderVecMetric(m.strippedVec, source, dest)
+	}
+}
+
+// IncError increments the error metric.
+func (m *ReservedHeaderMetrics) IncError(source, dest string) {
+	if m != nil {
+		incHeaderVecMetric(m.errorVec, source, dest)
+	}
+}
+
+// With returns a ReservedHeaderEdgeMetrics with source and dest.
+func (m *ReservedHeaderMetrics) With(source, dest string) ReservedHeaderEdgeMetrics {
+	return ReservedHeaderEdgeMetrics{
+		m:      m,
+		source: source,
+		dest:   dest,
+	}
+}
+
+// IncStripped increments the stripped metric.
+func (m *ReservedHeaderEdgeMetrics) IncStripped() {
+	m.m.IncStripped(m.source, m.dest)
+}
+
+// IncError increments the error metric.
+func (m *ReservedHeaderEdgeMetrics) IncError() {
+	m.m.IncError(m.source, m.dest)
+}
+
+func registerReservedHeaderStripped(scope *metrics.Scope, transport string) *metrics.CounterVector {
+	v, _ := scope.CounterVector(metrics.Spec{
+		Name:      transport + "_reserved_headers_stripped",
+		Help:      "Total number of reserved headers being stripped.",
+		ConstTags: map[string]string{"component": "yarpc-header-migration"},
+		VarTags:   []string{"source", "dest"},
+	})
+	return v
+}
+
+func registerReservedHeaderError(scope *metrics.Scope, transport string) *metrics.CounterVector {
+	v, _ := scope.CounterVector(metrics.Spec{
+		Name:      transport + "_reserved_headers_error",
+		Help:      "Total number of reserved headers led to error.",
+		ConstTags: map[string]string{"component": "yarpc-header-migration"},
+		VarTags:   []string{"source", "dest"},
+	})
+	return v
+}
+
+func incHeaderVecMetric(vector *metrics.CounterVector, source, dest string) {
+	if vector != nil {
+		if counter, err := vector.Get("source", source, "dest", dest); err == nil {
+			counter.Inc()
+		}
+	}
+}

--- a/internal/observability/reserved_headers_test.go
+++ b/internal/observability/reserved_headers_test.go
@@ -1,0 +1,132 @@
+// Copyright (c) 2024 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package observability
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/net/metrics"
+)
+
+func TestReservedHeaderMetrics(t *testing.T) {
+	t.Run("nil-scope", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			m := NewReserveHeaderMetrics(nil, "test")
+
+			m.IncStripped("", "")
+			m.IncError("", "")
+		})
+	})
+
+	t.Run("empty-source-dest", func(t *testing.T) {
+		root := metrics.New()
+		m := NewReserveHeaderMetrics(root.Scope(), "test")
+
+		m.IncStripped("", "")
+		m.IncError("", "")
+
+		assertTuples(t, root.Snapshot().Counters, []tuple{
+			{"test_reserved_headers_stripped", "default", "default", 1},
+			{"test_reserved_headers_error", "default", "default", 1},
+		})
+	})
+
+	t.Run("inc-header-metric", func(t *testing.T) {
+		root := metrics.New()
+		m := NewReserveHeaderMetrics(root.Scope(), "test")
+
+		m.IncStripped("source", "dest")
+		m.IncError("source", "dest")
+
+		m.IncStripped("source", "dest")
+		m.IncStripped("source", "dest-2")
+		m.IncStripped("source-2", "dest-2")
+
+		assertTuples(t, root.Snapshot().Counters, []tuple{
+			{"test_reserved_headers_stripped", "source", "dest", 2},
+			{"test_reserved_headers_stripped", "source", "dest-2", 1},
+			{"test_reserved_headers_stripped", "source-2", "dest-2", 1},
+			{"test_reserved_headers_error", "source", "dest", 1},
+		})
+	})
+}
+
+func TestReservedHeaderMetricsWith(t *testing.T) {
+	root := metrics.New()
+	m := NewReserveHeaderMetrics(root.Scope(), "test")
+
+	e := m.With("source", "dest")
+	assert.Same(t, m, e.m)
+	assert.Equal(t, "source", e.source)
+	assert.Equal(t, "dest", e.dest)
+}
+
+func TestEmptyEdgeMetrics(t *testing.T) {
+	assert.NotPanics(t, func() {
+		e := ReservedHeaderEdgeMetrics{}
+		e.IncStripped()
+		e.IncError()
+	})
+}
+
+func TestReservedHeaderEdgeMetricsIncs(t *testing.T) {
+	root := metrics.New()
+	m := NewReserveHeaderMetrics(root.Scope(), "test")
+
+	e1 := m.With("source", "dest")
+
+	e1.IncStripped()
+	e1.IncError()
+	e1.IncError()
+
+	assertTuples(t, root.Snapshot().Counters, []tuple{
+		{"test_reserved_headers_stripped", "source", "dest", 1},
+		{"test_reserved_headers_error", "source", "dest", 2},
+	})
+
+	e2 := m.With("source", "dest-2")
+	e2.IncStripped()
+	e2.IncStripped()
+	e2.IncError()
+
+	assertTuples(t, root.Snapshot().Counters, []tuple{
+		{"test_reserved_headers_stripped", "source", "dest", 1},
+		{"test_reserved_headers_stripped", "source", "dest-2", 2},
+		{"test_reserved_headers_error", "source", "dest", 2},
+		{"test_reserved_headers_error", "source", "dest-2", 1},
+	})
+}
+
+type tuple struct {
+	name, tag1, tag2 string
+	value            int64
+}
+
+func assertTuples(t *testing.T, snapshots []metrics.Snapshot, expected []tuple) {
+	actual := make([]tuple, 0, len(snapshots))
+
+	for _, c := range snapshots {
+		actual = append(actual, tuple{c.Name, c.Tags["source"], c.Tags["dest"], c.Value})
+	}
+
+	assert.ElementsMatch(t, expected, actual)
+}

--- a/transport/grpc/handler.go
+++ b/transport/grpc/handler.go
@@ -88,7 +88,7 @@ func (h *handler) getBasicTransportRequest(ctx context.Context, streamMethod str
 	if md == nil || !ok {
 		return nil, yarpcerrors.Newf(yarpcerrors.CodeInternal, "cannot get metadata from ctx: %v", ctx)
 	}
-	transportRequest, err := metadataToTransportRequest(md)
+	transportRequest, err := metadataToInboundRequest(md, h.i.t.reservedHeaderMetric)
 	if err != nil {
 		return nil, err
 	}
@@ -181,7 +181,7 @@ func (h *handler) handleUnary(
 	transportRequest.Body = requestBuffer
 	transportRequest.BodySize = len(requestData)
 
-	responseWriter := newResponseWriter()
+	responseWriter := newResponseWriter(h.i.t.reservedHeaderMetric.With(transportRequest.Caller, transportRequest.Service))
 	defer responseWriter.Close()
 
 	// Echo accepted rpc-service in response header

--- a/transport/grpc/outbound.go
+++ b/transport/grpc/outbound.go
@@ -122,7 +122,7 @@ func (o *Outbound) Call(ctx context.Context, request *transport.Request) (*trans
 	var responseMD metadata.MD
 	invokeErr := o.invoke(ctx, request, &responseBody, &responseMD, start)
 
-	responseHeaders, err := getApplicationHeaders(responseMD)
+	responseHeaders, err := getOutboundResponseApplicationHeaders(responseMD, o.t.reservedHeaderMetric.With(request.Caller, request.Service))
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +161,7 @@ func (o *Outbound) invoke(
 	responseMD *metadata.MD,
 	start time.Time,
 ) (retErr error) {
-	md, err := transportRequestToMetadata(request)
+	md, err := outboundRequestToMetadata(request, o.t.reservedHeaderMetric.With(request.Caller, request.Service))
 	if err != nil {
 		return err
 	}
@@ -301,7 +301,7 @@ func (o *Outbound) stream(
 		return nil, err
 	}
 
-	md, err := transportRequestToMetadata(treq)
+	md, err := outboundRequestToMetadata(treq, o.t.reservedHeaderMetric.With(treq.Caller, treq.Service))
 	if err != nil {
 		return nil, err
 	}

--- a/transport/grpc/outbound_test.go
+++ b/transport/grpc/outbound_test.go
@@ -31,9 +31,11 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/net/metrics"
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/peer/peertest"
 	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/observability"
 	"go.uber.org/yarpc/yarpcerrors"
 	"google.golang.org/grpc"
 )
@@ -296,7 +298,8 @@ func TestCallServiceMatch(t *testing.T) {
 		t.Run(tt.msg, func(t *testing.T) {
 			server := grpc.NewServer(
 				grpc.UnknownServiceHandler(func(srv interface{}, stream grpc.ServerStream) error {
-					responseWriter := newResponseWriter()
+					reporter := observability.NewReserveHeaderMetrics(metrics.New().Scope(), TransportName).With("any-source", "any-dest")
+					responseWriter := newResponseWriter(reporter)
 					defer responseWriter.Close()
 
 					if tt.headerKey != "" {

--- a/transport/grpc/response_writer_test.go
+++ b/transport/grpc/response_writer_test.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2024 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package grpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/multierr"
+	"go.uber.org/net/metrics"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/observability"
+	"go.uber.org/yarpc/yarpcerrors"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestResponseWriterAddHeaders(t *testing.T) {
+	tests := map[string]struct {
+		h               transport.Headers
+		md              metadata.MD
+		expErr          error
+		expReportHeader bool
+		expMD           metadata.MD
+	}{
+		"md-is-nil": {
+			h:     transport.NewHeaders().With("foo", "bar"),
+			md:    nil,
+			expMD: metadata.Pairs("foo", "bar"),
+		},
+		"success": {
+			h:     transport.NewHeaders().With("foo", "bar"),
+			md:    metadata.Pairs(),
+			expMD: metadata.Pairs("foo", "bar"),
+		},
+		"reserved-header-used": {
+			h:      transport.NewHeaders().With("rpc-any", "any-value"),
+			md:     metadata.Pairs(),
+			expErr: yarpcerrors.InvalidArgumentErrorf("cannot use reserved header in application headers: rpc-any"),
+			expMD:  metadata.Pairs(),
+		},
+		"report-header": {
+			h:               transport.NewHeaders().With("$rpc$-any", "any-value"),
+			md:              metadata.Pairs(),
+			expMD:           metadata.Pairs("$rpc$-any", "any-value"),
+			expReportHeader: true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			root := metrics.New()
+			m := observability.NewReserveHeaderMetrics(root.Scope(), "test")
+			rw := newResponseWriter(m.With("any-source", "any-test"))
+			rw.md = tt.md
+
+			rw.AddHeaders(tt.h)
+			if tt.expErr != nil {
+				errs := multierr.Errors(rw.headerErr)
+				require.Len(t, errs, 1)
+				assert.Equal(t, tt.expErr, errs[0])
+			} else {
+				assert.NoError(t, rw.headerErr)
+			}
+			assert.Equal(t, tt.expMD, rw.md)
+
+			if tt.expReportHeader {
+				assertTuple(t, root.Snapshot().Counters, tuple{"test_reserved_headers_error", "any-source", "any-test", 1})
+			} else {
+				assertEmptyMetrics(t, root.Snapshot())
+			}
+		})
+	}
+}

--- a/transport/grpc/transport.go
+++ b/transport/grpc/transport.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 
 	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/internal/observability"
 	"go.uber.org/yarpc/pkg/lifecycle"
 )
 
@@ -35,10 +36,11 @@ var emptyDialOpts = &dialOptions{}
 // This currently does not have any additional functionality over creating
 // an Inbound or Outbound separately, but may in the future.
 type Transport struct {
-	lock          sync.Mutex
-	once          *lifecycle.Once
-	options       *transportOptions
-	addressToPeer map[string]*grpcPeer
+	lock                 sync.Mutex
+	once                 *lifecycle.Once
+	options              *transportOptions
+	addressToPeer        map[string]*grpcPeer
+	reservedHeaderMetric *observability.ReservedHeaderMetrics
 }
 
 // NewTransport returns a new Transport.
@@ -48,9 +50,10 @@ func NewTransport(options ...TransportOption) *Transport {
 
 func newTransport(transportOptions *transportOptions) *Transport {
 	return &Transport{
-		once:          lifecycle.NewOnce(),
-		options:       transportOptions,
-		addressToPeer: make(map[string]*grpcPeer),
+		once:                 lifecycle.NewOnce(),
+		options:              transportOptions,
+		addressToPeer:        make(map[string]*grpcPeer),
+		reservedHeaderMetric: observability.NewReserveHeaderMetrics(transportOptions.meter, TransportName),
 	}
 }
 

--- a/transport/tchannel/channel_transport.go
+++ b/transport/tchannel/channel_transport.go
@@ -139,7 +139,13 @@ func (t *ChannelTransport) start() error {
 		for s := range services {
 			sc := t.ch.GetSubChannel(s)
 			existing := sc.GetHandlers()
-			sc.SetHandler(handler{existing: existing, router: t.router, tracer: t.tracer, logger: t.logger, newResponseWriter: t.newResponseWriter})
+			sc.SetHandler(handler{
+				existing:          existing,
+				router:            t.router,
+				tracer:            t.tracer,
+				logger:            t.logger,
+				newResponseWriter: t.newResponseWriter,
+			})
 		}
 	}
 

--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -182,9 +182,7 @@ func (h handler) callHandler(ctx context.Context, call inboundCall, responseWrit
 		return errors.RequestHeadersDecodeError(treq, err)
 	}
 
-	// callerProcedure is a rpc header but recevied in application headers, so moving this header to transprotRequest
-	// by updating treq.CallerProcedure.
-	treq = headerCallerProcedureToRequest(treq, &headers)
+	transportHeadersToRequest(treq, headers)
 	treq.Headers = headers
 
 	if tcall, ok := call.(tchannelCall); ok {

--- a/transport/tchannel/handler_test.go
+++ b/transport/tchannel/handler_test.go
@@ -56,7 +56,7 @@ func TestHandlerErrors(t *testing.T) {
 		format            tchannel.Format
 		headers           []byte
 		wantHeaders       map[string]string
-		newResponseWriter func(inboundCallResponse, tchannel.Format, headerCase) responseWriter
+		newResponseWriter responseWriterConstructor
 		recorder          recorder
 		wantLogLevel      zapcore.Level
 		wantLogMessage    string
@@ -181,7 +181,7 @@ func TestHandlerFailures(t *testing.T) {
 		sendCall          *fakeInboundCall
 		expectCall        func(*transporttest.MockUnaryHandler)
 		wantStatus        tchannel.SystemErrCode // expected status
-		newResponseWriter func(inboundCallResponse, tchannel.Format, headerCase) responseWriter
+		newResponseWriter responseWriterConstructor
 		recorder          recorder
 		wantLogLevel      zapcore.Level
 		wantLogMessage    string
@@ -806,7 +806,7 @@ func TestTruncatedHeader(t *testing.T) {
 }
 
 func TestRpcServiceHeader(t *testing.T) {
-	hw := &handlerWriter{}
+	hw := &responseWriterImpl{}
 	h := handler{
 		headerCase: canonicalizedHeaderCase,
 		newResponseWriter: func(inboundCallResponse, tchannel.Format, headerCase) responseWriter {

--- a/transport/tchannel/header.go
+++ b/transport/tchannel/header.go
@@ -177,15 +177,13 @@ func decodeHeaders(r io.Reader) (transport.Headers, error) {
 	return headers, reader.Err()
 }
 
-// headerCallerProcedureToRequest copies callerProcedure from headers to req.CallerProcedure
-// and then deletes it from headers.
-func headerCallerProcedureToRequest(req *transport.Request, headers *transport.Headers) *transport.Request {
+// transportHeadersToRequest copies custom (which are not part of tchannel protocol) transport header values to request
+// and then deletes them from headers list.
+func transportHeadersToRequest(req *transport.Request, headers transport.Headers) {
 	if callerProcedure, ok := headers.Get(CallerProcedureHeader); ok {
 		req.CallerProcedure = callerProcedure
 		headers.Del(CallerProcedureHeader)
-		return req
 	}
-	return req
 }
 
 // requestToTransportHeaders adds custom (which are not part of tchannel protocol) transport headers from request.
@@ -197,7 +195,9 @@ func requestToTransportHeaders(req *transport.Request, reqHeaders map[string]str
 	if reqHeaders == nil {
 		reqHeaders = make(map[string]string)
 	}
+
 	reqHeaders[CallerProcedureHeader] = req.CallerProcedure
+
 	return reqHeaders
 }
 

--- a/transport/tchannel/header.go
+++ b/transport/tchannel/header.go
@@ -188,8 +188,8 @@ func headerCallerProcedureToRequest(req *transport.Request, headers *transport.H
 	return req
 }
 
-// requestCallerProcedureToHeader add callerProcedure header as an application header.
-func requestCallerProcedureToHeader(req *transport.Request, reqHeaders map[string]string) map[string]string {
+// requestToTransportHeaders adds custom (which are not part of tchannel protocol) transport headers from request.
+func requestToTransportHeaders(req *transport.Request, reqHeaders map[string]string) map[string]string {
 	if req.CallerProcedure == "" {
 		return reqHeaders
 	}
@@ -227,7 +227,7 @@ func encodeHeaders(hs map[string]string) []byte {
 	return out
 }
 
-func headerMap(hs transport.Headers, headerCase headerCase) map[string]string {
+func getHeaderMap(hs transport.Headers, headerCase headerCase) map[string]string {
 	switch headerCase {
 	case originalHeaderCase:
 		return hs.OriginalItems()

--- a/transport/tchannel/header_test.go
+++ b/transport/tchannel/header_test.go
@@ -100,7 +100,7 @@ func TestAddCallerProcedureHeader(t *testing.T) {
 		},
 	} {
 		t.Run(tt.desc, func(t *testing.T) {
-			headers := requestCallerProcedureToHeader(&tt.treq, tt.headers)
+			headers := requestToTransportHeaders(&tt.treq, tt.headers)
 			assert.Equal(t, tt.expectedHeaders, headers)
 		})
 	}

--- a/transport/tchannel/header_test.go
+++ b/transport/tchannel/header_test.go
@@ -134,8 +134,8 @@ func TestMoveCallerProcedureToRequest(t *testing.T) {
 	} {
 		t.Run(tt.desc, func(t *testing.T) {
 			headers := transport.HeadersFromMap(tt.headers)
-			treq := headerCallerProcedureToRequest(&tt.treq, &headers)
-			assert.Equal(t, tt.expectedTreq, *treq)
+			transportHeadersToRequest(&tt.treq, headers)
+			assert.Equal(t, tt.expectedTreq, tt.treq)
 			assert.Equal(t, transport.HeadersFromMap(tt.expectedHeaders), headers)
 		})
 	}

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -157,10 +157,9 @@ func callWithPeer(ctx context.Context, req *transport.Request, peer *tchannel.Pe
 	if err != nil {
 		return nil, err
 	}
-	reqHeaders := headerMap(req.Headers, headerCase)
+	reqHeaders := getHeaderMap(req.Headers, headerCase)
 
-	// for tchannel, callerProcedure is added to application headers.
-	reqHeaders = requestCallerProcedureToHeader(req, reqHeaders)
+	reqHeaders = requestToTransportHeaders(req, reqHeaders)
 
 	// baggage headers are transport implementation details that are stripped out (and stored in the context). Users don't interact with it
 	tracingBaggage := tchannel.InjectOutboundSpan(call.Response(), nil)

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -153,10 +153,10 @@ func callWithPeer(ctx context.Context, req *transport.Request, peer *tchannel.Pe
 		req.Procedure,
 		&callOptions,
 	)
-
 	if err != nil {
 		return nil, err
 	}
+
 	reqHeaders := getHeaderMap(req.Headers, headerCase)
 
 	reqHeaders = requestToTransportHeaders(req, reqHeaders)

--- a/transport/tchannel/response_writer.go
+++ b/transport/tchannel/response_writer.go
@@ -1,0 +1,149 @@
+// Copyright (c) 2024 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tchannel
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/uber/tchannel-go"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/bufferpool"
+)
+
+type responseWriterConstructor func(inboundCallResponse, tchannel.Format, headerCase) responseWriter
+
+type responseWriterImpl struct {
+	failedWith       error
+	format           tchannel.Format
+	headers          transport.Headers
+	buffer           *bufferpool.Buffer
+	response         inboundCallResponse
+	applicationError bool
+	headerCase       headerCase
+}
+
+func newHandlerWriter(response inboundCallResponse, format tchannel.Format, headerCase headerCase) responseWriter {
+	return &responseWriterImpl{
+		response:   response,
+		format:     format,
+		headerCase: headerCase,
+	}
+}
+
+func (w *responseWriterImpl) AddHeaders(h transport.Headers) {
+	for k, v := range h.OriginalItems() {
+		if isReservedHeaderKey(k) {
+			w.failedWith = appendError(w.failedWith, fmt.Errorf("cannot use reserved header key: %s", k))
+			return
+		}
+		w.addHeader(k, v)
+	}
+}
+
+func (w *responseWriterImpl) AddSystemHeader(key, value string) {
+	w.addHeader(key, value)
+}
+
+func (w *responseWriterImpl) addHeader(key, value string) {
+	w.headers = w.headers.With(key, value)
+}
+
+func (w *responseWriterImpl) SetApplicationError() {
+	w.applicationError = true
+}
+
+func (w *responseWriterImpl) SetApplicationErrorMeta(applicationErrorMeta *transport.ApplicationErrorMeta) {
+	if applicationErrorMeta == nil {
+		return
+	}
+	if applicationErrorMeta.Code != nil {
+		w.AddSystemHeader(ApplicationErrorCodeHeaderKey, strconv.Itoa(int(*applicationErrorMeta.Code)))
+	}
+	if applicationErrorMeta.Name != "" {
+		w.AddSystemHeader(ApplicationErrorNameHeaderKey, applicationErrorMeta.Name)
+	}
+	if applicationErrorMeta.Details != "" {
+		w.AddSystemHeader(ApplicationErrorDetailsHeaderKey, truncateAppErrDetails(applicationErrorMeta.Details))
+	}
+}
+
+func truncateAppErrDetails(val string) string {
+	if len(val) <= _maxAppErrDetailsHeaderLen {
+		return val
+	}
+	stripIndex := _maxAppErrDetailsHeaderLen - len(_truncatedHeaderMessage)
+	return val[:stripIndex] + _truncatedHeaderMessage
+}
+
+func (w *responseWriterImpl) IsApplicationError() bool {
+	return w.applicationError
+}
+
+func (w *responseWriterImpl) Write(s []byte) (int, error) {
+	if w.failedWith != nil {
+		return 0, w.failedWith
+	}
+
+	if w.buffer == nil {
+		w.buffer = bufferpool.Get()
+	}
+
+	n, err := w.buffer.Write(s)
+	if err != nil {
+		w.failedWith = appendError(w.failedWith, err)
+	}
+	return n, err
+}
+
+func (w *responseWriterImpl) Close() error {
+	retErr := w.failedWith
+	if w.IsApplicationError() {
+		if err := w.response.SetApplicationError(); err != nil {
+			retErr = appendError(retErr, fmt.Errorf("SetApplicationError() failed: %v", err))
+		}
+	}
+
+	headers := getHeaderMap(w.headers, w.headerCase)
+	retErr = appendError(retErr, writeHeaders(w.format, headers, nil, w.response.Arg2Writer))
+
+	// Arg3Writer must be opened and closed regardless of if there is data
+	// However, if there is a system error, we do not want to do this
+	bodyWriter, err := w.response.Arg3Writer()
+	if err != nil {
+		return appendError(retErr, err)
+	}
+	defer func() { retErr = appendError(retErr, bodyWriter.Close()) }()
+	if w.buffer != nil {
+		if _, err := w.buffer.WriteTo(bodyWriter); err != nil {
+			return appendError(retErr, err)
+		}
+	}
+
+	return retErr
+}
+
+func (w *responseWriterImpl) ReleaseBuffer() {
+	if w.buffer != nil {
+		bufferpool.Put(w.buffer)
+		w.buffer = nil
+	}
+}

--- a/transport/tchannel/tchannel_utils_test.go
+++ b/transport/tchannel/tchannel_utils_test.go
@@ -171,9 +171,9 @@ func (fr *faultyResponseRecorder) SendSystemError(err error) error {
 
 // faultyHandlerWriter mocks a responseWriter.Close() error to test logging behaviour
 // inside tchannel.Handle.
-type faultyHandlerWriter struct{ handlerWriter }
+type faultyHandlerWriter struct{ responseWriterImpl }
 
-func newFaultyHandlerWriter(response inboundCallResponse, format tchannel.Format, headerCase headerCase) responseWriter {
+func newFaultyHandlerWriter(inboundCallResponse, tchannel.Format, headerCase) responseWriter {
 	return &faultyHandlerWriter{}
 }
 

--- a/transport/tchannel/transport.go
+++ b/transport/tchannel/transport.go
@@ -68,7 +68,7 @@ type Transport struct {
 	addr              string
 	listener          net.Listener
 	dialer            func(ctx context.Context, network, hostPort string) (net.Conn, error)
-	newResponseWriter func(inboundCallResponse, tchannel.Format, headerCase) responseWriter
+	newResponseWriter responseWriterConstructor
 
 	connTimeout         time.Duration
 	connectorsGroup     sync.WaitGroup


### PR DESCRIPTION
Currently underlying implementation of headers handling wary significantly from one transport to another (docs/docs/headers-handling.md in this PR). Eventually, in one of the following releases, we want to make behaviour consistent and protective: filter inbound 'rpc-' headers, return error for attempting of 'rpc-' header setting.

Proposed changes are backward incompatible, so to identify the edges that are affected by the future changes, at first stage let's emit metrics.

Metrics: reserved_headers_stripped and reserved_headers_error metrics with "component": "yarpc-header-migration" constant tag and with source and dest variable tags

Part of https://github.com/yarpc/yarpc-go/issues/2265