### PR TITLE
[WIP] Wrong func argument is internal error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 - Upgraded go version to 1.21, set toolchain version.
 - Reverted rpc-caller-procedure value setting.
+- errors: encoding/decoding (marshalling/unmarshalling) errors are now returned as CodeInternal (13) instead of CodeInvalidArgument (3).
 
 ## [1.72.1] - 2024-03-14
 - tchannel: Renamed caller-procedure header from `$rpc$-caller-procedure` to `rpc-caller-procedure`.

--- a/api/encoding/call.go
+++ b/api/encoding/call.go
@@ -49,7 +49,7 @@ func CallFromContext(ctx context.Context) *Call {
 // WriteResponseHeader writes headers to the response of this call.
 func (c *Call) WriteResponseHeader(k, v string) error {
 	if c == nil {
-		return yarpcerrors.InvalidArgumentErrorf(
+		return yarpcerrors.InternalErrorf(
 			"failed to write response header: " +
 				"Call was nil, make sure CallFromContext was called with a request context")
 	}

--- a/api/transport/stream.go
+++ b/api/transport/stream.go
@@ -44,7 +44,7 @@ type ServerStreamOption interface {
 // supports stream headers.
 func NewServerStream(s Stream, options ...ServerStreamOption) (*ServerStream, error) {
 	if s == nil {
-		return nil, yarpcerrors.InvalidArgumentErrorf("non-nil stream is required")
+		return nil, yarpcerrors.InternalErrorf("non-nil stream is required")
 	}
 	return &ServerStream{stream: s}, nil
 }
@@ -107,7 +107,7 @@ type ClientStreamOption interface {
 // supports stream headers.
 func NewClientStream(s StreamCloser, options ...ClientStreamOption) (*ClientStream, error) {
 	if s == nil {
-		return nil, yarpcerrors.InvalidArgumentErrorf("non-nil stream with close is required")
+		return nil, yarpcerrors.InternalErrorf("non-nil stream with close is required")
 	}
 	return &ClientStream{stream: s}, nil
 }

--- a/internal/crossdock/client/errorshttpclient/behavior.go
+++ b/internal/crossdock/client/errorshttpclient/behavior.go
@@ -283,7 +283,7 @@ func Run(t crossdock.T) {
 				"Context-TTL-MS": "100",
 			},
 			body:       "{}",
-			wantStatus: 400,
+			wantStatus: 500,
 			wantBodyContains: `failed to encode "json" response ` +
 				`body for procedure "bad-response" of service "yarpc-test" ` +
 				`from caller "yarpc-test":`,

--- a/internal/crossdock/client/errorstchclient/behavior.go
+++ b/internal/crossdock/client/errorstchclient/behavior.go
@@ -131,7 +131,7 @@ func Run(t crossdock.T) {
 					return
 				}
 				code := tchannel.GetSystemErrorCode(err)
-				assert.Equal(tchannel.ErrCodeBadRequest, code, "bad-response must produce unexpected error")
+				assert.Equal(tchannel.ErrCodeUnexpected, code, "bad-response must produce unexpected error")
 				assert.Contains(err.Error(), `failed to encode "json"`, "must mention failure to encode JSON in error message")
 			},
 		},

--- a/peer/direct/direct.go
+++ b/peer/direct/direct.go
@@ -57,7 +57,7 @@ func New(cfg Configuration, transport peer.Transport, opts ...ChooserOption) (*C
 	}
 
 	if transport == nil {
-		return nil, yarpcerrors.InvalidArgumentErrorf("%q chooser requires non-nil transport", name)
+		return nil, yarpcerrors.InternalErrorf("%q chooser requires non-nil transport", name)
 	}
 	return &Chooser{
 		transport: transport,

--- a/pkg/errors/client.go
+++ b/pkg/errors/client.go
@@ -29,28 +29,28 @@ import (
 )
 
 // RequestBodyEncodeError builds a YARPC error with code
-// yarpcerrors.CodeInvalidArgument that represents a failure to encode
+// yarpcerrors.CodeInternal that represents a failure to encode
 // the request body.
 func RequestBodyEncodeError(req *transport.Request, err error) error {
 	return newClientEncodingError(req, false /*isResponse*/, false /*isHeader*/, err)
 }
 
 // ResponseBodyDecodeError builds a YARPC error with code
-// yarpcerrors.CodeInvalidArgument that represents a failure to decode
+// yarpcerrors.CodeInternal that represents a failure to decode
 // the response body.
 func ResponseBodyDecodeError(req *transport.Request, err error) error {
 	return newClientEncodingError(req, true /*isResponse*/, false /*isHeader*/, err)
 }
 
 // RequestHeadersEncodeError builds a YARPC error with code
-// yarpcerrors.CodeInvalidArgument that represents a failure to
+// yarpcerrors.CodeInternal that represents a failure to
 // encode the request headers.
 func RequestHeadersEncodeError(req *transport.Request, err error) error {
 	return newClientEncodingError(req, false /*isResponse*/, true /*isHeader*/, err)
 }
 
 // ResponseHeadersDecodeError builds a YARPC error with code
-// yarpcerrors.CodeInvalidArgument that represents a failure to
+// yarpcerrors.CodeInternal that represents a failure to
 // decode the response headers.
 func ResponseHeadersDecodeError(req *transport.Request, err error) error {
 	return newClientEncodingError(req, true /*isResponse*/, true /*isHeader*/, err)
@@ -71,5 +71,5 @@ func newClientEncodingError(req *transport.Request, isResponse bool, isHeader bo
 	parts = append(parts,
 		fmt.Sprintf("for procedure %q of service %q: %v",
 			req.Procedure, req.Service, err))
-	return yarpcerrors.Newf(yarpcerrors.CodeInvalidArgument, strings.Join(parts, " "))
+	return yarpcerrors.Newf(yarpcerrors.CodeInternal, strings.Join(parts, " "))
 }

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -32,15 +32,16 @@ import (
 func TestWrapHandlerError(t *testing.T) {
 	assert.Nil(t, WrapHandlerError(nil, "foo", "bar"))
 	assert.Equal(t, yarpcerrors.CodeInvalidArgument, yarpcerrors.FromError(WrapHandlerError(yarpcerrors.Newf(yarpcerrors.CodeInvalidArgument, ""), "foo", "bar")).Code())
+	assert.Equal(t, yarpcerrors.CodeInternal, yarpcerrors.FromError(WrapHandlerError(yarpcerrors.Newf(yarpcerrors.CodeInternal, ""), "foo", "bar")).Code())
 	assert.Equal(t, yarpcerrors.CodeUnknown, yarpcerrors.FromError(WrapHandlerError(errors.New(""), "foo", "bar")).Code())
 }
 
 func TestExpectEncodings(t *testing.T) {
-	assert.Error(t, ExpectEncodings(&transport.Request{}, "foo"))
+	assertError(t, ExpectEncodings(&transport.Request{}, "foo"), yarpcerrors.CodeInvalidArgument, "request", "encoding")
 	assert.NoError(t, ExpectEncodings(&transport.Request{Encoding: "foo"}, "foo"))
 	assert.NoError(t, ExpectEncodings(&transport.Request{Encoding: "foo"}, "foo", "bar"))
-	assert.Error(t, ExpectEncodings(&transport.Request{Encoding: "foo"}, "bar"))
-	assert.Error(t, ExpectEncodings(&transport.Request{Encoding: "foo"}, "bar", "baz"))
+	assertError(t, ExpectEncodings(&transport.Request{Encoding: "foo"}, "bar"), yarpcerrors.CodeInvalidArgument, "request", "encoding")
+	assertError(t, ExpectEncodings(&transport.Request{Encoding: "foo"}, "bar", "baz"), yarpcerrors.CodeInvalidArgument, "request", "encoding")
 }
 
 func TestEncodeErrors(t *testing.T) {
@@ -51,12 +52,12 @@ func TestEncodeErrors(t *testing.T) {
 	}{
 		{
 			errorFunc:     RequestBodyEncodeError,
-			expectedCode:  yarpcerrors.CodeInvalidArgument,
+			expectedCode:  yarpcerrors.CodeInternal,
 			expectedWords: []string{"request", "body", "encode"},
 		},
 		{
 			errorFunc:     RequestHeadersEncodeError,
-			expectedCode:  yarpcerrors.CodeInvalidArgument,
+			expectedCode:  yarpcerrors.CodeInternal,
 			expectedWords: []string{"request", "headers", "encode"},
 		},
 		{
@@ -71,22 +72,22 @@ func TestEncodeErrors(t *testing.T) {
 		},
 		{
 			errorFunc:     ResponseBodyEncodeError,
-			expectedCode:  yarpcerrors.CodeInvalidArgument,
+			expectedCode:  yarpcerrors.CodeInternal,
 			expectedWords: []string{"response", "body", "encode"},
 		},
 		{
 			errorFunc:     ResponseHeadersEncodeError,
-			expectedCode:  yarpcerrors.CodeInvalidArgument,
+			expectedCode:  yarpcerrors.CodeInternal,
 			expectedWords: []string{"response", "headers", "encode"},
 		},
 		{
 			errorFunc:     ResponseBodyDecodeError,
-			expectedCode:  yarpcerrors.CodeInvalidArgument,
+			expectedCode:  yarpcerrors.CodeInternal,
 			expectedWords: []string{"response", "body", "decode"},
 		},
 		{
 			errorFunc:     ResponseHeadersDecodeError,
-			expectedCode:  yarpcerrors.CodeInvalidArgument,
+			expectedCode:  yarpcerrors.CodeInternal,
 			expectedWords: []string{"response", "headers", "decode"},
 		},
 	}

--- a/transport/grpc/outbound.go
+++ b/transport/grpc/outbound.go
@@ -108,7 +108,7 @@ func (o *Outbound) Chooser() peer.Chooser {
 // Call implements transport.UnaryOutbound#Call.
 func (o *Outbound) Call(ctx context.Context, request *transport.Request) (*transport.Response, error) {
 	if request == nil {
-		return nil, yarpcerrors.InvalidArgumentErrorf("request for grpc outbound was nil")
+		return nil, yarpcerrors.InternalErrorf("request for grpc outbound was nil")
 	}
 	if err := validateRequest(request); err != nil {
 		return nil, err

--- a/transport/grpc/outbound_test.go
+++ b/transport/grpc/outbound_test.go
@@ -54,7 +54,7 @@ func TestNoRequest(t *testing.T) {
 	out := tran.NewSingleOutbound("localhost:0")
 
 	_, err := out.Call(context.Background(), nil)
-	assert.Equal(t, yarpcerrors.InvalidArgumentErrorf("request for grpc outbound was nil"), err)
+	assert.Equal(t, yarpcerrors.InternalErrorf("request for grpc outbound was nil"), err)
 }
 
 func TestCallWithInvalidHeaderValue(t *testing.T) {

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -265,7 +265,7 @@ func (o *Outbound) IsRunning() bool {
 // Call makes a HTTP request
 func (o *Outbound) Call(ctx context.Context, treq *transport.Request) (*transport.Response, error) {
 	if treq == nil {
-		return nil, yarpcerrors.InvalidArgumentErrorf("request for http unary outbound was nil")
+		return nil, yarpcerrors.InternalErrorf("request for http unary outbound was nil")
 	}
 
 	return o.call(ctx, treq)
@@ -274,7 +274,7 @@ func (o *Outbound) Call(ctx context.Context, treq *transport.Request) (*transpor
 // CallOneway makes a oneway request
 func (o *Outbound) CallOneway(ctx context.Context, treq *transport.Request) (transport.Ack, error) {
 	if treq == nil {
-		return nil, yarpcerrors.InvalidArgumentErrorf("request for http oneway outbound was nil")
+		return nil, yarpcerrors.InternalErrorf("request for http oneway outbound was nil")
 	}
 
 	// res is used to close the response body to avoid memory/connection leak

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -651,10 +651,10 @@ func TestNoRequest(t *testing.T) {
 	out := tran.NewSingleOutbound("localhost:0")
 
 	_, err := out.Call(context.Background(), nil)
-	assert.Equal(t, yarpcerrors.InvalidArgumentErrorf("request for http unary outbound was nil"), err)
+	assert.Equal(t, yarpcerrors.InternalErrorf("request for http unary outbound was nil"), err)
 
 	_, err = out.CallOneway(context.Background(), nil)
-	assert.Equal(t, yarpcerrors.InvalidArgumentErrorf("request for http oneway outbound was nil"), err)
+	assert.Equal(t, yarpcerrors.InternalErrorf("request for http oneway outbound was nil"), err)
 }
 
 func TestOutboundNoDeadline(t *testing.T) {

--- a/transport/tchannel/channel_outbound.go
+++ b/transport/tchannel/channel_outbound.go
@@ -104,7 +104,7 @@ func (o *ChannelOutbound) IsRunning() bool {
 // Call sends an RPC over this TChannel outbound.
 func (o *ChannelOutbound) Call(ctx context.Context, req *transport.Request) (*transport.Response, error) {
 	if req == nil {
-		return nil, yarpcerrors.InvalidArgumentErrorf("request for tchannel channel outbound was nil")
+		return nil, yarpcerrors.InternalErrorf("request for tchannel channel outbound was nil")
 	}
 	if err := o.once.WaitUntilRunning(ctx); err != nil {
 		return nil, intyarpcerrors.AnnotateWithInfo(yarpcerrors.FromError(err), "error waiting for tchannel channel outbound to start for service: %s", req.Service)

--- a/transport/tchannel/channel_outbound_test.go
+++ b/transport/tchannel/channel_outbound_test.go
@@ -510,7 +510,7 @@ func TestChannelOutboundNoRequest(t *testing.T) {
 			require.NoError(t, err)
 
 			_, err = out.Call(context.Background(), nil)
-			assert.Equal(t, yarpcerrors.InvalidArgumentErrorf("request for tchannel channel outbound was nil"), err)
+			assert.Equal(t, yarpcerrors.InternalErrorf("request for tchannel channel outbound was nil"), err)
 		})
 	}
 }

--- a/transport/tchannel/handler_test.go
+++ b/transport/tchannel/handler_test.go
@@ -306,7 +306,7 @@ func TestHandlerFailures(t *testing.T) {
 						"serialization derp",
 					)))
 			},
-			wantStatus:        tchannel.ErrCodeBadRequest,
+			wantStatus:        tchannel.ErrCodeUnexpected,
 			newResponseWriter: newHandlerWriter,
 			recorder:          newResponseRecorder(),
 			wantLogLevel:      zapcore.ErrorLevel,
@@ -391,7 +391,7 @@ func TestHandlerFailures(t *testing.T) {
 				arg2:    nil,
 				arg3:    []byte{0x00},
 			},
-			wantStatus:        tchannel.ErrCodeBadRequest,
+			wantStatus:        tchannel.ErrCodeBadRequest, // This is an actual error for request, but we're testing problem with response writing
 			newResponseWriter: newHandlerWriter,
 			recorder:          newFaultyResponseRecorder(),
 			wantLogLevel:      zapcore.ErrorLevel,

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -102,7 +102,7 @@ func (o *Outbound) Chooser() peer.Chooser {
 // Call sends an RPC over this TChannel outbound.
 func (o *Outbound) Call(ctx context.Context, req *transport.Request) (*transport.Response, error) {
 	if req == nil {
-		return nil, yarpcerrors.InvalidArgumentErrorf("request for tchannel outbound was nil")
+		return nil, yarpcerrors.InternalErrorf("request for tchannel outbound was nil")
 	}
 	if err := o.once.WaitUntilRunning(ctx); err != nil {
 		return nil, intyarpcerrors.AnnotateWithInfo(yarpcerrors.FromError(err), "error waiting for tchannel outbound to start for service: %s", req.Service)

--- a/transport/tchannel/outbound_test.go
+++ b/transport/tchannel/outbound_test.go
@@ -462,7 +462,7 @@ func TestOutboundNoRequest(t *testing.T) {
 	defer out.Stop()
 	defer trans.Stop()
 	_, err := out.Call(context.Background(), nil)
-	wantErr := yarpcerrors.InvalidArgumentErrorf("request for tchannel outbound was nil")
+	wantErr := yarpcerrors.InternalErrorf("request for tchannel outbound was nil")
 	assert.EqualError(t, err, wantErr.Error())
 }
 


### PR DESCRIPTION
Depends on #2251

Invalid argument passed to a function doesn't mean that we should return InvalidArgument error. For those cases we should return InternalError, because client can't fix this problem by changing request.