### PR TITLE
[1/2 tchannel refactoring] Extracted response writer to dedicated file.

### DIFF
--- a/transport/tchannel/channel_transport.go
+++ b/transport/tchannel/channel_transport.go
@@ -139,7 +139,13 @@ func (t *ChannelTransport) start() error {
 		for s := range services {
 			sc := t.ch.GetSubChannel(s)
 			existing := sc.GetHandlers()
-			sc.SetHandler(handler{existing: existing, router: t.router, tracer: t.tracer, logger: t.logger, newResponseWriter: t.newResponseWriter})
+			sc.SetHandler(handler{
+				existing:          existing,
+				router:            t.router,
+				tracer:            t.tracer,
+				logger:            t.logger,
+				newResponseWriter: t.newResponseWriter,
+			})
 		}
 	}
 

--- a/transport/tchannel/handler_test.go
+++ b/transport/tchannel/handler_test.go
@@ -56,7 +56,7 @@ func TestHandlerErrors(t *testing.T) {
 		format            tchannel.Format
 		headers           []byte
 		wantHeaders       map[string]string
-		newResponseWriter func(inboundCallResponse, tchannel.Format, headerCase) responseWriter
+		newResponseWriter responseWriterConstructor
 		recorder          recorder
 		wantLogLevel      zapcore.Level
 		wantLogMessage    string
@@ -181,7 +181,7 @@ func TestHandlerFailures(t *testing.T) {
 		sendCall          *fakeInboundCall
 		expectCall        func(*transporttest.MockUnaryHandler)
 		wantStatus        tchannel.SystemErrCode // expected status
-		newResponseWriter func(inboundCallResponse, tchannel.Format, headerCase) responseWriter
+		newResponseWriter responseWriterConstructor
 		recorder          recorder
 		wantLogLevel      zapcore.Level
 		wantLogMessage    string
@@ -806,7 +806,7 @@ func TestTruncatedHeader(t *testing.T) {
 }
 
 func TestRpcServiceHeader(t *testing.T) {
-	hw := &handlerWriter{}
+	hw := &responseWriterImpl{}
 	h := handler{
 		headerCase: canonicalizedHeaderCase,
 		newResponseWriter: func(inboundCallResponse, tchannel.Format, headerCase) responseWriter {

--- a/transport/tchannel/header.go
+++ b/transport/tchannel/header.go
@@ -188,8 +188,8 @@ func headerCallerProcedureToRequest(req *transport.Request, headers *transport.H
 	return req
 }
 
-// requestCallerProcedureToHeader add callerProcedure header as an application header.
-func requestCallerProcedureToHeader(req *transport.Request, reqHeaders map[string]string) map[string]string {
+// requestToTransportHeaders adds custom (which are not part of tchannel protocol) transport headers from request.
+func requestToTransportHeaders(req *transport.Request, reqHeaders map[string]string) map[string]string {
 	if req.CallerProcedure == "" {
 		return reqHeaders
 	}
@@ -227,7 +227,7 @@ func encodeHeaders(hs map[string]string) []byte {
 	return out
 }
 
-func headerMap(hs transport.Headers, headerCase headerCase) map[string]string {
+func getHeaderMap(hs transport.Headers, headerCase headerCase) map[string]string {
 	switch headerCase {
 	case originalHeaderCase:
 		return hs.OriginalItems()

--- a/transport/tchannel/header_test.go
+++ b/transport/tchannel/header_test.go
@@ -100,7 +100,7 @@ func TestAddCallerProcedureHeader(t *testing.T) {
 		},
 	} {
 		t.Run(tt.desc, func(t *testing.T) {
-			headers := requestCallerProcedureToHeader(&tt.treq, tt.headers)
+			headers := requestToTransportHeaders(&tt.treq, tt.headers)
 			assert.Equal(t, tt.expectedHeaders, headers)
 		})
 	}

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -157,10 +157,9 @@ func callWithPeer(ctx context.Context, req *transport.Request, peer *tchannel.Pe
 	if err != nil {
 		return nil, err
 	}
-	reqHeaders := headerMap(req.Headers, headerCase)
+	reqHeaders := getHeaderMap(req.Headers, headerCase)
 
-	// for tchannel, callerProcedure is added to application headers.
-	reqHeaders = requestCallerProcedureToHeader(req, reqHeaders)
+	reqHeaders = requestToTransportHeaders(req, reqHeaders)
 
 	// baggage headers are transport implementation details that are stripped out (and stored in the context). Users don't interact with it
 	tracingBaggage := tchannel.InjectOutboundSpan(call.Response(), nil)

--- a/transport/tchannel/response_writer.go
+++ b/transport/tchannel/response_writer.go
@@ -1,0 +1,149 @@
+// Copyright (c) 2024 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tchannel
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/uber/tchannel-go"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/bufferpool"
+)
+
+type responseWriterConstructor func(inboundCallResponse, tchannel.Format, headerCase) responseWriter
+
+type responseWriterImpl struct {
+	failedWith       error
+	format           tchannel.Format
+	headers          transport.Headers
+	buffer           *bufferpool.Buffer
+	response         inboundCallResponse
+	applicationError bool
+	headerCase       headerCase
+}
+
+func newHandlerWriter(response inboundCallResponse, format tchannel.Format, headerCase headerCase) responseWriter {
+	return &responseWriterImpl{
+		response:   response,
+		format:     format,
+		headerCase: headerCase,
+	}
+}
+
+func (w *responseWriterImpl) AddHeaders(h transport.Headers) {
+	for k, v := range h.OriginalItems() {
+		if isReservedHeaderKey(k) {
+			w.failedWith = appendError(w.failedWith, fmt.Errorf("cannot use reserved header key: %s", k))
+			return
+		}
+		w.addHeader(k, v)
+	}
+}
+
+func (w *responseWriterImpl) AddSystemHeader(key, value string) {
+	w.addHeader(key, value)
+}
+
+func (w *responseWriterImpl) addHeader(key, value string) {
+	w.headers = w.headers.With(key, value)
+}
+
+func (w *responseWriterImpl) SetApplicationError() {
+	w.applicationError = true
+}
+
+func (w *responseWriterImpl) SetApplicationErrorMeta(applicationErrorMeta *transport.ApplicationErrorMeta) {
+	if applicationErrorMeta == nil {
+		return
+	}
+	if applicationErrorMeta.Code != nil {
+		w.AddSystemHeader(ApplicationErrorCodeHeaderKey, strconv.Itoa(int(*applicationErrorMeta.Code)))
+	}
+	if applicationErrorMeta.Name != "" {
+		w.AddSystemHeader(ApplicationErrorNameHeaderKey, applicationErrorMeta.Name)
+	}
+	if applicationErrorMeta.Details != "" {
+		w.AddSystemHeader(ApplicationErrorDetailsHeaderKey, truncateAppErrDetails(applicationErrorMeta.Details))
+	}
+}
+
+func truncateAppErrDetails(val string) string {
+	if len(val) <= _maxAppErrDetailsHeaderLen {
+		return val
+	}
+	stripIndex := _maxAppErrDetailsHeaderLen - len(_truncatedHeaderMessage)
+	return val[:stripIndex] + _truncatedHeaderMessage
+}
+
+func (w *responseWriterImpl) IsApplicationError() bool {
+	return w.applicationError
+}
+
+func (w *responseWriterImpl) Write(s []byte) (int, error) {
+	if w.failedWith != nil {
+		return 0, w.failedWith
+	}
+
+	if w.buffer == nil {
+		w.buffer = bufferpool.Get()
+	}
+
+	n, err := w.buffer.Write(s)
+	if err != nil {
+		w.failedWith = appendError(w.failedWith, err)
+	}
+	return n, err
+}
+
+func (w *responseWriterImpl) Close() error {
+	retErr := w.failedWith
+	if w.IsApplicationError() {
+		if err := w.response.SetApplicationError(); err != nil {
+			retErr = appendError(retErr, fmt.Errorf("SetApplicationError() failed: %v", err))
+		}
+	}
+
+	headers := getHeaderMap(w.headers, w.headerCase)
+	retErr = appendError(retErr, writeHeaders(w.format, headers, nil, w.response.Arg2Writer))
+
+	// Arg3Writer must be opened and closed regardless of if there is data
+	// However, if there is a system error, we do not want to do this
+	bodyWriter, err := w.response.Arg3Writer()
+	if err != nil {
+		return appendError(retErr, err)
+	}
+	defer func() { retErr = appendError(retErr, bodyWriter.Close()) }()
+	if w.buffer != nil {
+		if _, err := w.buffer.WriteTo(bodyWriter); err != nil {
+			return appendError(retErr, err)
+		}
+	}
+
+	return retErr
+}
+
+func (w *responseWriterImpl) ReleaseBuffer() {
+	if w.buffer != nil {
+		bufferpool.Put(w.buffer)
+		w.buffer = nil
+	}
+}

--- a/transport/tchannel/tchannel_utils_test.go
+++ b/transport/tchannel/tchannel_utils_test.go
@@ -171,9 +171,9 @@ func (fr *faultyResponseRecorder) SendSystemError(err error) error {
 
 // faultyHandlerWriter mocks a responseWriter.Close() error to test logging behaviour
 // inside tchannel.Handle.
-type faultyHandlerWriter struct{ handlerWriter }
+type faultyHandlerWriter struct{ responseWriterImpl }
 
-func newFaultyHandlerWriter(response inboundCallResponse, format tchannel.Format, headerCase headerCase) responseWriter {
+func newFaultyHandlerWriter(inboundCallResponse, tchannel.Format, headerCase) responseWriter {
 	return &faultyHandlerWriter{}
 }
 

--- a/transport/tchannel/transport.go
+++ b/transport/tchannel/transport.go
@@ -68,7 +68,7 @@ type Transport struct {
 	addr              string
 	listener          net.Listener
 	dialer            func(ctx context.Context, network, hostPort string) (net.Conn, error)
-	newResponseWriter func(inboundCallResponse, tchannel.Format, headerCase) responseWriter
+	newResponseWriter responseWriterConstructor
 
 	connTimeout         time.Duration
 	connectorsGroup     sync.WaitGroup


### PR DESCRIPTION
Extracted response writer to dedicated file, introduced constructor type and simplified interface.

This PR is part of header handling changes (https://github.com/yarpc/yarpc-go/issues/2265). This refactoring was extracted from tchannel PR to make review easier.