### PR TITLE
Renamed headerCallerProcedureToRequest to transportHeadersToRequest

### DIFF
--- a/transport/tchannel/handler.go
+++ b/transport/tchannel/handler.go
@@ -182,9 +182,7 @@ func (h handler) callHandler(ctx context.Context, call inboundCall, responseWrit
 		return errors.RequestHeadersDecodeError(treq, err)
 	}
 
-	// callerProcedure is a rpc header but recevied in application headers, so moving this header to transprotRequest
-	// by updating treq.CallerProcedure.
-	treq = headerCallerProcedureToRequest(treq, &headers)
+	transportHeadersToRequest(treq, headers)
 	treq.Headers = headers
 
 	if tcall, ok := call.(tchannelCall); ok {

--- a/transport/tchannel/header.go
+++ b/transport/tchannel/header.go
@@ -177,15 +177,13 @@ func decodeHeaders(r io.Reader) (transport.Headers, error) {
 	return headers, reader.Err()
 }
 
-// headerCallerProcedureToRequest copies callerProcedure from headers to req.CallerProcedure
-// and then deletes it from headers.
-func headerCallerProcedureToRequest(req *transport.Request, headers *transport.Headers) *transport.Request {
+// transportHeadersToRequest copies custom (which are not part of tchannel protocol) transport header values to request
+// and then deletes them from headers list.
+func transportHeadersToRequest(req *transport.Request, headers transport.Headers) {
 	if callerProcedure, ok := headers.Get(CallerProcedureHeader); ok {
 		req.CallerProcedure = callerProcedure
 		headers.Del(CallerProcedureHeader)
-		return req
 	}
-	return req
 }
 
 // requestToTransportHeaders adds custom (which are not part of tchannel protocol) transport headers from request.
@@ -197,7 +195,9 @@ func requestToTransportHeaders(req *transport.Request, reqHeaders map[string]str
 	if reqHeaders == nil {
 		reqHeaders = make(map[string]string)
 	}
+
 	reqHeaders[CallerProcedureHeader] = req.CallerProcedure
+
 	return reqHeaders
 }
 

--- a/transport/tchannel/header_test.go
+++ b/transport/tchannel/header_test.go
@@ -134,8 +134,8 @@ func TestMoveCallerProcedureToRequest(t *testing.T) {
 	} {
 		t.Run(tt.desc, func(t *testing.T) {
 			headers := transport.HeadersFromMap(tt.headers)
-			treq := headerCallerProcedureToRequest(&tt.treq, &headers)
-			assert.Equal(t, tt.expectedTreq, *treq)
+			transportHeadersToRequest(&tt.treq, headers)
+			assert.Equal(t, tt.expectedTreq, tt.treq)
 			assert.Equal(t, transport.HeadersFromMap(tt.expectedHeaders), headers)
 		})
 	}

--- a/transport/tchannel/outbound.go
+++ b/transport/tchannel/outbound.go
@@ -153,10 +153,10 @@ func callWithPeer(ctx context.Context, req *transport.Request, peer *tchannel.Pe
 		req.Procedure,
 		&callOptions,
 	)
-
 	if err != nil {
 		return nil, err
 	}
+
 	reqHeaders := getHeaderMap(req.Headers, headerCase)
 
 	reqHeaders = requestToTransportHeaders(req, reqHeaders)


### PR DESCRIPTION
headerCallerProcedureToRequest was dedicated to one particular header, transportHeadersToRequest dedicated to all the potential headers that should be parsed from transport.