### PR TITLE
Revert "Renamed tchannel caller-procedure header (#2246)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 - Upgraded go version to 1.21, set toolchain version.
 - Reverted rpc-caller-procedure value setting.
+- Reverted header renaming for tchannel: caller-procedure header changed back from `rpc-caller-procedure` to `$rpc$-caller-procedure`.
 
 ## [1.72.1] - 2024-03-14
 - tchannel: Renamed caller-procedure header from `$rpc$-caller-procedure` to `rpc-caller-procedure`.

--- a/transport/tchannel/header.go
+++ b/transport/tchannel/header.go
@@ -33,8 +33,6 @@ import (
 )
 
 const (
-	/** Response headers **/
-
 	// ErrorCodeHeaderKey is the response header key for the error code.
 	ErrorCodeHeaderKey = "$rpc$-error-code"
 	// ErrorNameHeaderKey is the response header key for the error name.
@@ -50,11 +48,8 @@ const (
 	ApplicationErrorDetailsHeaderKey = "$rpc$-application-error-details"
 	// ApplicationErrorCodeHeaderKey is the response header key for the application error code.
 	ApplicationErrorCodeHeaderKey = "$rpc$-application-error-code"
-
-	/** Request headers **/
-
 	// CallerProcedureHeader is the header key for the procedure of the caller making the request.
-	CallerProcedureHeader = "rpc-caller-procedure"
+	CallerProcedureHeader = "$rpc$-caller-procedure"
 )
 
 var _reservedHeaderKeys = map[string]struct{}{
@@ -65,7 +60,6 @@ var _reservedHeaderKeys = map[string]struct{}{
 	ApplicationErrorNameHeaderKey:    {},
 	ApplicationErrorDetailsHeaderKey: {},
 	ApplicationErrorCodeHeaderKey:    {},
-	CallerProcedureHeader:            {},
 }
 
 func isReservedHeaderKey(key string) bool {


### PR DESCRIPTION
Renaming is a breaking change, and despite this header is not in use, we want to land this change with extra care in the future.

PR reverts changes from #2246.