### PR TITLE
Reapply "Renamed tchannel caller-procedure header (#2246)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 =======
 ## [Unreleased]
-- No changes yet.
+### Changed
+- tchannel: Renamed caller-procedure header from `$rpc$-caller-procedure` to `rpc-caller-procedure`.
 
 ## [1.73.0] - 2024-05-31
 - Upgraded go version to 1.21, set toolchain version.

--- a/transport/tchannel/header.go
+++ b/transport/tchannel/header.go
@@ -33,6 +33,8 @@ import (
 )
 
 const (
+	/** Response headers **/
+
 	// ErrorCodeHeaderKey is the response header key for the error code.
 	ErrorCodeHeaderKey = "$rpc$-error-code"
 	// ErrorNameHeaderKey is the response header key for the error name.
@@ -48,8 +50,11 @@ const (
 	ApplicationErrorDetailsHeaderKey = "$rpc$-application-error-details"
 	// ApplicationErrorCodeHeaderKey is the response header key for the application error code.
 	ApplicationErrorCodeHeaderKey = "$rpc$-application-error-code"
+
+	/** Request headers **/
+
 	// CallerProcedureHeader is the header key for the procedure of the caller making the request.
-	CallerProcedureHeader = "$rpc$-caller-procedure"
+	CallerProcedureHeader = "rpc-caller-procedure"
 )
 
 var _reservedHeaderKeys = map[string]struct{}{
@@ -60,6 +65,7 @@ var _reservedHeaderKeys = map[string]struct{}{
 	ApplicationErrorNameHeaderKey:    {},
 	ApplicationErrorDetailsHeaderKey: {},
 	ApplicationErrorCodeHeaderKey:    {},
+	CallerProcedureHeader:            {},
 }
 
 func isReservedHeaderKey(key string) bool {


### PR DESCRIPTION
We don't want to loss this changes, as eventually they have to be landed anyway.

Revert changes of #2276 (reapplying changes from #2246).

TODO: Changelog