### PR TITLE
Fix span error tagging in GO YARPC/gRPC

### DIFF
--- a/api/transport/propagation.go
+++ b/api/transport/propagation.go
@@ -37,6 +37,12 @@ type CreateOpenTracingSpan struct {
 	ExtraTags     opentracing.Tags
 }
 
+const (
+	_rpcYarpcStatusCode = "rpc.yarpc.status_code"
+	_rpcYarpcComponent  = "component"
+	_yarpc              = "yarpc"
+)
+
 // Do creates a new context that has a reference to the started span.
 // This should be called before a Outbound makes a call
 func (c *CreateOpenTracingSpan) Do(
@@ -112,10 +118,14 @@ func (e *ExtractOpenTracingSpan) Do(
 
 // UpdateSpanWithErr sets the error tag on a span, if an error is given.
 // Returns the given error
-func UpdateSpanWithErr(span opentracing.Span, err error) error {
+// Please refer here for the numeric status code of the yarpc reques
+// https://github.com/yarpc/yarpc-go/blob/dev/yarpcerrors/codes.go#L29
+func UpdateSpanWithErr(span opentracing.Span, err error, errCode int) error {
 	if err != nil {
 		span.SetTag("error", true)
 		span.LogFields(opentracinglog.String("event", err.Error()))
+		span.SetTag(_rpcYarpcStatusCode, errCode)
+		span.SetTag(_rpcYarpcComponent, _yarpc)
 	}
 	return err
 }

--- a/transport/grpc/handler.go
+++ b/transport/grpc/handler.go
@@ -149,7 +149,7 @@ func (h *handler) handleStream(
 	stream := newServerStream(ctx, &transport.StreamRequest{Meta: transportRequest.ToRequestMeta()}, serverStream)
 	tServerStream, err := transport.NewServerStream(stream)
 	if err != nil {
-		return err
+		return transport.UpdateSpanWithErr(span, err, 2)
 	}
 	apperr := transport.InvokeStreamHandler(transport.StreamInvokeRequest{
 		Stream:  tServerStream,
@@ -157,7 +157,7 @@ func (h *handler) handleStream(
 		Logger:  h.logger,
 	})
 	apperr = handlerErrorToGRPCError(apperr, nil)
-	return transport.UpdateSpanWithErr(span, apperr)
+	return transport.UpdateSpanWithErr(span, apperr, 2)
 }
 
 func (h *handler) handleUnary(
@@ -230,7 +230,7 @@ func (h *handler) handleUnaryBeforeErrorConversion(
 	defer span.Finish()
 
 	err := h.callUnary(ctx, transportRequest, handler, responseWriter)
-	return transport.UpdateSpanWithErr(span, err)
+	return transport.UpdateSpanWithErr(span, err, 2)
 }
 
 func (h *handler) callUnary(ctx context.Context, transportRequest *transport.Request, unaryHandler transport.UnaryHandler, responseWriter *responseWriter) error {

--- a/transport/grpc/stream.go
+++ b/transport/grpc/stream.go
@@ -174,7 +174,7 @@ func (cs *clientStream) Headers() (transport.Headers, error) {
 
 func (cs *clientStream) closeWithErr(err error) error {
 	if !cs.closed.Swap(true) {
-		err = transport.UpdateSpanWithErr(cs.span, err)
+		err = transport.UpdateSpanWithErr(cs.span, err, 2)
 		cs.span.Finish()
 		cs.release(err)
 	}

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -328,7 +328,7 @@ func (o *Outbound) call(ctx context.Context, treq *transport.Request) (*transpor
 		}
 		return nil, transport.UpdateSpanWithErr(span,
 			yarpcerrors.InternalErrorf("service name sent from the request "+
-				"does not match the service name received in the response, sent %q, got: %q", treq.Service, resSvcName))
+				"does not match the service name received in the response, sent %q, got: %q", treq.Service, resSvcName), 1)
 	}
 
 	tres := &transport.Response{


### PR DESCRIPTION
* Created span earlier and added missing span error tag 
* Added span tag for gRPC status code(based on https://github.com/yarpc/yarpc-go/blob/dev/yarpcerrors/codes.go#L29)
* Added span tag for component