### PR TITLE
Fix span tagging for application error in GO YARPC/gRPC

### DIFF
--- a/api/transport/propagation.go
+++ b/api/transport/propagation.go
@@ -130,7 +130,7 @@ func UpdateSpanWithErr(span opentracing.Span, err error) error {
 // The error message is intentionally omitted to prevent exposing
 // personally identifiable information (PII) in tracing systems.
 // Returns the given error
-func UpdateSpanWithApplicationErr(span opentracing.Span, err error, errCode yarpcerrors.Code) error {
+func UpdateSpanWithApplicationErr(span opentracing.Span, err error, errCode yarpcerrors.Code) {
 	if err != nil {
 		span.SetTag("error", true)
 		span.SetTag(TracingTagStatusCode, errCode)

--- a/api/transport/propagation.go
+++ b/api/transport/propagation.go
@@ -130,7 +130,7 @@ func UpdateSpanWithErr(span opentracing.Span, err error) error {
 // The error message is intentionally omitted to prevent exposing
 // personally identifiable information (PII) in tracing systems.
 // Returns the given error
-func UpdateSpanWithoutErrMsg(span opentracing.Span, err error, errCode yarpcerrors.Code) error {
+func UpdateSpanWithoutErrMsg(span opentracing.Span, err error, errCode yarpcerrors.Code) {
 	if err != nil {
 		span.SetTag("error", true)
 		span.SetTag(TracingTagStatusCode, errCode)
@@ -138,5 +138,4 @@ func UpdateSpanWithoutErrMsg(span opentracing.Span, err error, errCode yarpcerro
 			opentracinglog.String("event", "error"),
 		)
 	}
-	return err
 }

--- a/api/transport/propagation.go
+++ b/api/transport/propagation.go
@@ -22,12 +22,12 @@ package transport
 
 import (
 	"context"
-	"go.uber.org/yarpc/yarpcerrors"
 	"time"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	opentracinglog "github.com/opentracing/opentracing-go/log"
+	"go.uber.org/yarpc/yarpcerrors"
 )
 
 // CreateOpenTracingSpan creates a new context with a started span
@@ -39,7 +39,7 @@ type CreateOpenTracingSpan struct {
 }
 
 const (
-	//TracingTagStatusCode is the span tag key for the YAPRC status code.
+	// TracingTagStatusCode is the span tag key for the YAPRC status code.
 	TracingTagStatusCode = "rpc.yarpc.status_code"
 )
 
@@ -126,11 +126,11 @@ func UpdateSpanWithErr(span opentracing.Span, err error) error {
 	return err
 }
 
-// UpdateSpanWithoutErrMsg sets the error tag and status code on a span.
+// UpdateSpanWithApplicationErr sets the error tag and status code on a span for application error.
 // The error message is intentionally omitted to prevent exposing
 // personally identifiable information (PII) in tracing systems.
 // Returns the given error
-func UpdateSpanWithoutErrMsg(span opentracing.Span, err error, errCode yarpcerrors.Code) {
+func UpdateSpanWithApplicationErr(span opentracing.Span, err error, errCode yarpcerrors.Code) error {
 	if err != nil {
 		span.SetTag("error", true)
 		span.SetTag(TracingTagStatusCode, errCode)
@@ -138,4 +138,5 @@ func UpdateSpanWithoutErrMsg(span opentracing.Span, err error, errCode yarpcerro
 			opentracinglog.String("event", "error"),
 		)
 	}
+	return err
 }

--- a/api/transport/propagation.go
+++ b/api/transport/propagation.go
@@ -138,5 +138,4 @@ func UpdateSpanWithApplicationErr(span opentracing.Span, err error, errCode yarp
 			opentracinglog.String("event", "error"),
 		)
 	}
-	return err
 }

--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -137,7 +137,7 @@ func (c call) endWithAppError(
 	extraLogFields ...zap.Field) {
 	elapsed := _timeNow().Sub(c.started)
 	// Emit application error to span tag if applicable
-	c.emitSpanErrorTags(res)
+	c.emitSpanErrorTag(res)
 	c.endLogs(elapsed, res.err, res.isApplicationError, res.applicationErrorMeta, extraLogFields...)
 	c.endStats(elapsed, res)
 }
@@ -508,8 +508,8 @@ func errToMetricString(err error) string {
 	return "unknown_internal_yarpc"
 }
 
-// emitSpanErrorTags sets the error information as tags on the current span
-func (c call) emitSpanErrorTags(res callResult) {
+// emitSpanErrorTag sets the error information as tags on the current span
+func (c call) emitSpanErrorTag(res callResult) {
 	if span := opentracing.SpanFromContext(c.ctx); span != nil {
 		transport.UpdateSpanWithoutErrMsg(span, res.err, yarpcerrors.FromError(res.err).Code())
 	}

--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -504,7 +504,8 @@ func (c call) emitSpanErrorTag(res callResult) {
 	if span := opentracing.SpanFromContext(c.ctx); span != nil {
 		// emit application error to span tag if applicable
 		if res.isApplicationError {
-			transport.UpdateSpanWithoutErrMsg(span, res.err, yarpcerrors.FromError(res.err).Code())
+			transport.UpdateSpanWithoutErrMsg(span,
+				res.err, yarpcerrors.FromError(res.err).Code())
 		}
 	}
 }

--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -502,6 +502,7 @@ func (c call) logStreamEvent(err error, success bool, succMsg, errMsg string, ex
 // emitSpanErrorTag sets the error information as tags on the current span
 func (c call) emitSpanErrorTag(res callResult) {
 	if span := opentracing.SpanFromContext(c.ctx); span != nil {
+		// emit application error to span tag if applicable
 		if res.isApplicationError {
 			transport.UpdateSpanWithoutErrMsg(span, res.err, yarpcerrors.FromError(res.err).Code())
 		}

--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -499,6 +499,15 @@ func (c call) logStreamEvent(err error, success bool, succMsg, errMsg string, ex
 	ce.Write(fields...)
 }
 
+// emitSpanErrorTag sets the error information as tags on the current span
+func (c call) emitSpanErrorTag(res callResult) {
+	if span := opentracing.SpanFromContext(c.ctx); span != nil {
+		if res.isApplicationError {
+			transport.UpdateSpanWithoutErrMsg(span, res.err, yarpcerrors.FromError(res.err).Code())
+		}
+	}
+}
+
 // inteded for metric tags, this returns the yarpcerrors.Status error code name
 // or "unknown_internal_yarpc"
 func errToMetricString(err error) string {
@@ -506,11 +515,4 @@ func errToMetricString(err error) string {
 		return yarpcerrors.FromError(err).Code().String()
 	}
 	return "unknown_internal_yarpc"
-}
-
-// emitSpanErrorTag sets the error information as tags on the current span
-func (c call) emitSpanErrorTag(res callResult) {
-	if span := opentracing.SpanFromContext(c.ctx); span != nil {
-		transport.UpdateSpanWithoutErrMsg(span, res.err, yarpcerrors.FromError(res.err).Code())
-	}
 }


### PR DESCRIPTION
Fix span tagging for application error in GO YARPC/gRPC
- In https://github.com/yarpc/yarpc-go/pull/2282/files we captured invokeErr
- In addition to the invokeErr, in this PR we also emit application errors to span tags
- The error message is intentionally omitted to prevent exposing personally identifiable information (PII) in tracing systems.