### PR TITLE
Add OriginalHeader accessor in encoding.Call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 =======
 ## [Unreleased]
-- No changes yet.
+### Added
+- `OriginalHeader` accessor in `encoding.Call` to get an original header value for a request from context object with zero-copy, as opposed to accessing it via `OriginalHeaders()`
 
 ## [1.73.1] - 2024-08-26
 ### Changed

--- a/api/encoding/call.go
+++ b/api/encoding/call.go
@@ -110,6 +110,21 @@ func (c *Call) Header(k string) string {
 	return ""
 }
 
+// OriginalHeader returns the value of the given request header provided with the
+// request. The getter is suitable for transport like TChannel that hides
+// certain headers by default eg: the ones starting with $
+func (c *Call) OriginalHeader(k string) string {
+	if c == nil {
+		return ""
+	}
+
+	if v, ok := c.md.Headers().OriginalItems()[k]; ok {
+		return v
+	}
+
+	return ""
+}
+
 // OriginalHeaders returns a copy of the given request headers provided with the request.
 // The header key are not canonicalized and suitable for case-sensitive transport like TChannel.
 func (c *Call) OriginalHeaders() map[string]string {

--- a/api/encoding/call_test.go
+++ b/api/encoding/call_test.go
@@ -43,6 +43,7 @@ func TestNilCall(t *testing.T) {
 	assert.Equal(t, "", call.RoutingDelegate())
 	assert.Equal(t, "", call.CallerProcedure())
 	assert.Equal(t, "", call.Header("foo"))
+	assert.Equal(t, "", call.OriginalHeader("foo"))
 	assert.Empty(t, call.HeaderNames())
 	assert.Nil(t, call.OriginalHeaders())
 
@@ -76,6 +77,8 @@ func TestReadFromRequest(t *testing.T) {
 	assert.Equal(t, "rk", call.RoutingKey())
 	assert.Equal(t, "rd", call.RoutingDelegate())
 	assert.Equal(t, "bar", call.Header("foo"))
+	assert.Equal(t, "bar", call.OriginalHeader("foo"))
+	assert.Equal(t, "Bar", call.OriginalHeader("Foo"))
 	assert.Equal(t, map[string]string{"Foo": "Bar", "foo": "bar"}, call.OriginalHeaders())
 	assert.Equal(t, "cp", call.CallerProcedure())
 	assert.Len(t, call.HeaderNames(), 1)
@@ -113,6 +116,8 @@ func TestReadFromRequestMeta(t *testing.T) {
 	assert.Equal(t, "rd", call.RoutingDelegate())
 	assert.Equal(t, "cp", call.CallerProcedure())
 	assert.Equal(t, "bar", call.Header("foo"))
+	assert.Equal(t, "bar", call.OriginalHeader("foo"))
+	assert.Equal(t, "Bar", call.OriginalHeader("Foo"))
 	assert.Equal(t, map[string]string{"Foo": "Bar", "foo": "bar"}, call.OriginalHeaders())
 	assert.Len(t, call.HeaderNames(), 1)
 

--- a/call.go
+++ b/call.go
@@ -145,6 +145,13 @@ func (c *Call) Header(k string) string {
 	return (*encoding.Call)(c).Header(k)
 }
 
+// OriginalHeader returns the value of the given request header provided with the
+// request. The getter is suitable for transport like TChannel that hides
+// certain headers by default eg: the ones starting with $
+func (c *Call) OriginalHeader(k string) string {
+	return (*encoding.Call)(c).OriginalHeader(k)
+}
+
 // OriginalHeaders returns a copy of the given request headers provided with the request.
 // The header key are not canonicalized and suitable for case-sensitive transport like TChannel.
 func (c *Call) OriginalHeaders() map[string]string {

--- a/call_test.go
+++ b/call_test.go
@@ -74,6 +74,7 @@ func TestCallFromContext(t *testing.T) {
 	assert.Equal(t, transport.Encoding("baz"), call.Encoding())
 	assert.Equal(t, "hello", call.Procedure())
 	assert.Equal(t, "bar", call.Header("foo"))
+	assert.Equal(t, "Bar", call.OriginalHeader("Foo"))
 	assert.Equal(t, map[string]string{"Foo": "Bar", "foo": "bar"}, call.OriginalHeaders())
 	assert.Equal(t, []string{"foo"}, call.HeaderNames())
 	assert.Equal(t, "one", call.ShardKey())

--- a/call_test.go
+++ b/call_test.go
@@ -74,6 +74,7 @@ func TestCallFromContext(t *testing.T) {
 	assert.Equal(t, transport.Encoding("baz"), call.Encoding())
 	assert.Equal(t, "hello", call.Procedure())
 	assert.Equal(t, "bar", call.Header("foo"))
+	assert.Equal(t, "bar", call.OriginalHeader("foo"))
 	assert.Equal(t, "Bar", call.OriginalHeader("Foo"))
 	assert.Equal(t, map[string]string{"Foo": "Bar", "foo": "bar"}, call.OriginalHeaders())
 	assert.Equal(t, []string{"foo"}, call.HeaderNames())


### PR DESCRIPTION
### Description
This change adds a new accessor `OriginalHeader(k string) string` to `encoding.Call`. The new accessor makes it possible to efficiently fetch the value of a single original header, without having to copy over the entire header map as in `OriginalHeaders() map[string]string`.

This implementation ensures that the underlying header map can't be modified, keeping the behaviour consistent with the `OriginalHeaders() map[string]string` implementation.

It is useful for transport like TChannel, which skip headers with prefix `$` eg: `$tracing-foo` when being queried via `Header(k string) string`, but those headers are still accessible via `OriginalHeaders() map[string]string`.

### Testing
Updated unit tests
