### PR TITLE
Added goimports linter

### DIFF
--- a/compressor/grpc/grpc_test.go
+++ b/compressor/grpc/grpc_test.go
@@ -23,8 +23,8 @@ package yarpcgrpccompressor_test
 import (
 	"testing"
 
-	"go.uber.org/yarpc/compressor/grpc"
-	"go.uber.org/yarpc/compressor/gzip"
+	yarpcgrpccompressor "go.uber.org/yarpc/compressor/grpc"
+	yarpcgzip "go.uber.org/yarpc/compressor/gzip"
 	"google.golang.org/grpc/encoding"
 )
 

--- a/compressor/gzip/gzip_test.go
+++ b/compressor/gzip/gzip_test.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/yarpc/compressor/gzip"
+	yarpcgzip "go.uber.org/yarpc/compressor/gzip"
 )
 
 // This should be compressible:

--- a/compressor/snappy/snappy_test.go
+++ b/compressor/snappy/snappy_test.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/yarpc/compressor/snappy"
+	yarpcsnappy "go.uber.org/yarpc/compressor/snappy"
 )
 
 // This should be compressible:

--- a/encoding/protobuf/v2/error.go
+++ b/encoding/protobuf/v2/error.go
@@ -23,7 +23,6 @@ package v2
 import (
 	"errors"
 	"fmt"
-	"google.golang.org/protobuf/encoding/prototext"
 	"strings"
 
 	"github.com/golang/protobuf/ptypes/any"
@@ -32,6 +31,7 @@ import (
 	"go.uber.org/yarpc/yarpcerrors"
 	rpc_status "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 )

--- a/encoding/protobuf/v2/error_external_test.go
+++ b/encoding/protobuf/v2/error_external_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/yarpc/encoding/protobuf/v2"
+	v2 "go.uber.org/yarpc/encoding/protobuf/v2"
 	"go.uber.org/yarpc/yarpcerrors"
 	"google.golang.org/protobuf/proto"
 )

--- a/encoding/protobuf/v2/error_integration_test.go
+++ b/encoding/protobuf/v2/error_integration_test.go
@@ -33,7 +33,7 @@ import (
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/json"
 	"go.uber.org/yarpc/encoding/protobuf/internal/testpb/v2"
-	"go.uber.org/yarpc/encoding/protobuf/v2"
+	v2 "go.uber.org/yarpc/encoding/protobuf/v2"
 	"go.uber.org/yarpc/encoding/raw"
 	"go.uber.org/yarpc/transport/grpc"
 	"go.uber.org/yarpc/yarpcerrors"

--- a/encoding/protobuf/v2/inbound_test.go
+++ b/encoding/protobuf/v2/inbound_test.go
@@ -29,7 +29,7 @@ import (
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/api/transport/transporttest"
 	"go.uber.org/yarpc/encoding/protobuf/internal/testpb/v2"
-	"go.uber.org/yarpc/encoding/protobuf/v2"
+	v2 "go.uber.org/yarpc/encoding/protobuf/v2"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 )

--- a/encoding/protobuf/v2/marshal.go
+++ b/encoding/protobuf/v2/marshal.go
@@ -21,14 +21,15 @@
 package v2
 
 import (
+	"io"
+	"sync"
+
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/bufferpool"
 	"go.uber.org/yarpc/yarpcerrors"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoregistry"
-	"io"
-	"sync"
 )
 
 var (

--- a/encoding/protobuf/v2/observability_test.go
+++ b/encoding/protobuf/v2/observability_test.go
@@ -33,7 +33,7 @@ import (
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/protobuf/internal/testpb/v2"
-	"go.uber.org/yarpc/encoding/protobuf/v2"
+	v2 "go.uber.org/yarpc/encoding/protobuf/v2"
 	"go.uber.org/yarpc/internal/testutils"
 	"go.uber.org/yarpc/transport/grpc"
 	"go.uber.org/yarpc/yarpcerrors"

--- a/encoding/protobuf/v2/outbound_test.go
+++ b/encoding/protobuf/v2/outbound_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/protobuf/internal/testpb/v2"
-	"go.uber.org/yarpc/encoding/protobuf/v2"
+	v2 "go.uber.org/yarpc/encoding/protobuf/v2"
 	"go.uber.org/yarpc/yarpctest"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"

--- a/encoding/protobuf/v2/stream_test.go
+++ b/encoding/protobuf/v2/stream_test.go
@@ -31,7 +31,7 @@ import (
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/protobuf/internal/testpb/v2"
-	"go.uber.org/yarpc/encoding/protobuf/v2"
+	v2 "go.uber.org/yarpc/encoding/protobuf/v2"
 	"go.uber.org/yarpc/internal/clientconfig"
 	"go.uber.org/yarpc/peer"
 	"go.uber.org/yarpc/peer/hostport"

--- a/etc/make/deps.mk
+++ b/etc/make/deps.mk
@@ -18,6 +18,7 @@ RAGEL_VERSION := 6.10
 ERRCHECK_VERSION := 1.7.0
 GOLINT_VERSION := 0.0.0-20210508222113-6edffad5e616
 STATICHCHECK_VERSION := 0.4.7
+GOIMPORTS_VERSION := 0.24.0
 
 THRIFT_OS := $(UNAME_OS)
 PROTOC_OS := $(UNAME_OS)
@@ -89,6 +90,10 @@ $(BIN)/staticcheck:
 	@mkdir -p $(BIN)
 	GOBIN=$(BIN) go install "honnef.co/go/tools/cmd/staticcheck@v$(STATICHCHECK_VERSION)"
 
+$(BIN)/goimports:
+	@mkdir -p $(BIN)
+	GOBIN=$(BIN) go install "golang.org/x/tools/cmd/goimports@v$(GOIMPORTS_VERSION)"
+
 define generatedeprule
 GEN_BINS += $(BIN)/$(shell basename $1)
 endef
@@ -112,6 +117,7 @@ THRIFTRW = $(BIN)/thriftrw
 GOLINT = $(BIN)/golint
 ERRCHECK = $(BIN)/errcheck
 STATICCHECK = $(BIN)/staticcheck
+GOIMPORTS = $(BIN)/goimports
 
 .PHONY: predeps
 predeps: $(THRIFT) $(PROTOC) $(RAGEL)

--- a/internal/protoplugin-v2/generator.go
+++ b/internal/protoplugin-v2/generator.go
@@ -28,7 +28,7 @@ import (
 	"path"
 	"text/template"
 
-	"github.com/golang/protobuf/protoc-gen-go/plugin"
+	plugin_go "github.com/golang/protobuf/protoc-gen-go/plugin"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/internal/protoplugin-v2/multi_runner.go
+++ b/internal/protoplugin-v2/multi_runner.go
@@ -25,7 +25,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/golang/protobuf/protoc-gen-go/plugin"
+	plugin_go "github.com/golang/protobuf/protoc-gen-go/plugin"
 	"go.uber.org/multierr"
 )
 

--- a/internal/protoplugin-v2/multi_runner_test.go
+++ b/internal/protoplugin-v2/multi_runner_test.go
@@ -24,7 +24,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/golang/protobuf/protoc-gen-go/plugin"
+	plugin_go "github.com/golang/protobuf/protoc-gen-go/plugin"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/multierr"
 	"google.golang.org/protobuf/proto"

--- a/internal/protoplugin-v2/protoplugin.go
+++ b/internal/protoplugin-v2/protoplugin.go
@@ -33,7 +33,7 @@ import (
 	"text/template"
 
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
-	"github.com/golang/protobuf/protoc-gen-go/plugin"
+	plugin_go "github.com/golang/protobuf/protoc-gen-go/plugin"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/internal/protoplugin-v2/registry.go
+++ b/internal/protoplugin-v2/registry.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
-	"github.com/golang/protobuf/protoc-gen-go/plugin"
+	plugin_go "github.com/golang/protobuf/protoc-gen-go/plugin"
 )
 
 type registry struct {

--- a/internal/protoplugin-v2/runner.go
+++ b/internal/protoplugin-v2/runner.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/golang/protobuf/protoc-gen-go/plugin"
+	plugin_go "github.com/golang/protobuf/protoc-gen-go/plugin"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/pluginpb"
 )

--- a/internal/protoplugin/generator.go
+++ b/internal/protoplugin/generator.go
@@ -29,7 +29,7 @@ import (
 	"text/template"
 
 	"github.com/gogo/protobuf/proto"
-	"github.com/gogo/protobuf/protoc-gen-gogo/plugin"
+	plugin_go "github.com/gogo/protobuf/protoc-gen-gogo/plugin"
 )
 
 var (

--- a/internal/protoplugin/multi_runner.go
+++ b/internal/protoplugin/multi_runner.go
@@ -25,7 +25,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/gogo/protobuf/protoc-gen-gogo/plugin"
+	plugin_go "github.com/gogo/protobuf/protoc-gen-gogo/plugin"
 	"go.uber.org/multierr"
 )
 

--- a/internal/protoplugin/multi_runner_test.go
+++ b/internal/protoplugin/multi_runner_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
-	"github.com/gogo/protobuf/protoc-gen-gogo/plugin"
+	plugin_go "github.com/gogo/protobuf/protoc-gen-gogo/plugin"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/multierr"
 )

--- a/internal/protoplugin/protoplugin.go
+++ b/internal/protoplugin/protoplugin.go
@@ -46,7 +46,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/protoc-gen-gogo/descriptor"
 	gogogen "github.com/gogo/protobuf/protoc-gen-gogo/generator"
-	"github.com/gogo/protobuf/protoc-gen-gogo/plugin"
+	plugin_go "github.com/gogo/protobuf/protoc-gen-gogo/plugin"
 )
 
 // Do is a helper function for protobuf plugins.

--- a/internal/protoplugin/registry.go
+++ b/internal/protoplugin/registry.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 
 	"github.com/gogo/protobuf/protoc-gen-gogo/descriptor"
-	"github.com/gogo/protobuf/protoc-gen-gogo/plugin"
+	plugin_go "github.com/gogo/protobuf/protoc-gen-gogo/plugin"
 )
 
 type registry struct {

--- a/internal/protoplugin/runner.go
+++ b/internal/protoplugin/runner.go
@@ -25,7 +25,7 @@ import (
 	"text/template"
 
 	"github.com/gogo/protobuf/proto"
-	"github.com/gogo/protobuf/protoc-gen-gogo/plugin"
+	plugin_go "github.com/gogo/protobuf/protoc-gen-gogo/plugin"
 )
 
 type runner struct {

--- a/transport/grpc/globals_for_test.go
+++ b/transport/grpc/globals_for_test.go
@@ -21,7 +21,7 @@
 package grpc
 
 import (
-	"go.uber.org/yarpc/compressor/grpc"
+	yarpcgrpccompressor "go.uber.org/yarpc/compressor/grpc"
 	"go.uber.org/yarpc/yarpcconfig"
 	"google.golang.org/grpc/encoding"
 )

--- a/yarpcerrors/yarpcerrorclassifier_test.go
+++ b/yarpcerrors/yarpcerrorclassifier_test.go
@@ -21,8 +21,9 @@
 package yarpcerrors
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetFaultTypeFromErrorForClientErrors(t *testing.T) {


### PR DESCRIPTION
- Added goimports linter
- Applied new rules to the codebase

All the auto generated files are excluded. 
For the goimports-fix target, the tool is running twice, as it was the simplest solution to preserve only one list of exclusions.