### PR TITLE
Preparing release v1.73.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 =======
 ## [Unreleased]
-- No changes yet.
+### Added
+- `OriginalHeader` accessor in `encoding.Call` to get an original header value for a request from context object with zero-copy, as opposed to accessing it via `OriginalHeaders()`
 
 ## [1.73.1] - 2024-08-26
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 =======
+## [Unreleased]
+- No changes yet.
+
 ## [1.73.1] - 2024-08-26
 ### Changed
 - Updated most of the dependencies in go.mod to a newer versions.
@@ -1512,6 +1515,7 @@ This release requires regeneration of ThriftRW code.
 ## 0.1.0 - 2016-08-31
 
 - Initial release.
+[Unreleased]: https://github.com/yarpc/yarpc-go/compare/v1.73.1...HEAD
 [1.73.1]: https://github.com/yarpc/yarpc-go/compare/v1.73.0...1.73.1
 [1.73.0]: https://github.com/yarpc/yarpc-go/compare/v1.72.1...1.73.0
 [1.72.1]: https://github.com/yarpc/yarpc-go/compare/v1.72.0...1.72.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 =======
-## [Unreleased]
+## [1.73.2] - 2024-09-09
 ### Added
 - `OriginalHeader` accessor in `encoding.Call` to get an original header value for a request from context object with zero-copy, as opposed to accessing it via `OriginalHeaders()`
 
@@ -1516,7 +1516,7 @@ This release requires regeneration of ThriftRW code.
 ## 0.1.0 - 2016-08-31
 
 - Initial release.
-[Unreleased]: https://github.com/yarpc/yarpc-go/compare/v1.73.1...HEAD
+[1.73.2]: https://github.com/yarpc/yarpc-go/compare/v1.73.1...1.73.2
 [1.73.1]: https://github.com/yarpc/yarpc-go/compare/v1.73.0...1.73.1
 [1.73.0]: https://github.com/yarpc/yarpc-go/compare/v1.72.1...1.73.0
 [1.72.1]: https://github.com/yarpc/yarpc-go/compare/v1.72.0...1.72.1

--- a/api/encoding/call.go
+++ b/api/encoding/call.go
@@ -110,6 +110,21 @@ func (c *Call) Header(k string) string {
 	return ""
 }
 
+// OriginalHeader returns the value of the given request header provided with the
+// request. The getter is suitable for transport like TChannel that hides
+// certain headers by default eg: the ones starting with $
+func (c *Call) OriginalHeader(k string) string {
+	if c == nil {
+		return ""
+	}
+
+	if v, ok := c.md.Headers().OriginalItems()[k]; ok {
+		return v
+	}
+
+	return ""
+}
+
 // OriginalHeaders returns a copy of the given request headers provided with the request.
 // The header key are not canonicalized and suitable for case-sensitive transport like TChannel.
 func (c *Call) OriginalHeaders() map[string]string {

--- a/api/encoding/call_test.go
+++ b/api/encoding/call_test.go
@@ -43,6 +43,7 @@ func TestNilCall(t *testing.T) {
 	assert.Equal(t, "", call.RoutingDelegate())
 	assert.Equal(t, "", call.CallerProcedure())
 	assert.Equal(t, "", call.Header("foo"))
+	assert.Equal(t, "", call.OriginalHeader("foo"))
 	assert.Empty(t, call.HeaderNames())
 	assert.Nil(t, call.OriginalHeaders())
 
@@ -76,6 +77,8 @@ func TestReadFromRequest(t *testing.T) {
 	assert.Equal(t, "rk", call.RoutingKey())
 	assert.Equal(t, "rd", call.RoutingDelegate())
 	assert.Equal(t, "bar", call.Header("foo"))
+	assert.Equal(t, "bar", call.OriginalHeader("foo"))
+	assert.Equal(t, "Bar", call.OriginalHeader("Foo"))
 	assert.Equal(t, map[string]string{"Foo": "Bar", "foo": "bar"}, call.OriginalHeaders())
 	assert.Equal(t, "cp", call.CallerProcedure())
 	assert.Len(t, call.HeaderNames(), 1)
@@ -113,6 +116,8 @@ func TestReadFromRequestMeta(t *testing.T) {
 	assert.Equal(t, "rd", call.RoutingDelegate())
 	assert.Equal(t, "cp", call.CallerProcedure())
 	assert.Equal(t, "bar", call.Header("foo"))
+	assert.Equal(t, "bar", call.OriginalHeader("foo"))
+	assert.Equal(t, "Bar", call.OriginalHeader("Foo"))
 	assert.Equal(t, map[string]string{"Foo": "Bar", "foo": "bar"}, call.OriginalHeaders())
 	assert.Len(t, call.HeaderNames(), 1)
 

--- a/call.go
+++ b/call.go
@@ -145,6 +145,13 @@ func (c *Call) Header(k string) string {
 	return (*encoding.Call)(c).Header(k)
 }
 
+// OriginalHeader returns the value of the given request header provided with the
+// request. The getter is suitable for transport like TChannel that hides
+// certain headers by default eg: the ones starting with $
+func (c *Call) OriginalHeader(k string) string {
+	return (*encoding.Call)(c).OriginalHeader(k)
+}
+
 // OriginalHeaders returns a copy of the given request headers provided with the request.
 // The header key are not canonicalized and suitable for case-sensitive transport like TChannel.
 func (c *Call) OriginalHeaders() map[string]string {

--- a/call_test.go
+++ b/call_test.go
@@ -74,6 +74,7 @@ func TestCallFromContext(t *testing.T) {
 	assert.Equal(t, transport.Encoding("baz"), call.Encoding())
 	assert.Equal(t, "hello", call.Procedure())
 	assert.Equal(t, "bar", call.Header("foo"))
+	assert.Equal(t, "Bar", call.OriginalHeader("Foo"))
 	assert.Equal(t, map[string]string{"Foo": "Bar", "foo": "bar"}, call.OriginalHeaders())
 	assert.Equal(t, []string{"foo"}, call.HeaderNames())
 	assert.Equal(t, "one", call.ShardKey())

--- a/call_test.go
+++ b/call_test.go
@@ -74,6 +74,7 @@ func TestCallFromContext(t *testing.T) {
 	assert.Equal(t, transport.Encoding("baz"), call.Encoding())
 	assert.Equal(t, "hello", call.Procedure())
 	assert.Equal(t, "bar", call.Header("foo"))
+	assert.Equal(t, "bar", call.OriginalHeader("foo"))
 	assert.Equal(t, "Bar", call.OriginalHeader("Foo"))
 	assert.Equal(t, map[string]string{"Foo": "Bar", "foo": "bar"}, call.OriginalHeaders())
 	assert.Equal(t, []string{"foo"}, call.HeaderNames())

--- a/compressor/grpc/grpc_test.go
+++ b/compressor/grpc/grpc_test.go
@@ -23,8 +23,8 @@ package yarpcgrpccompressor_test
 import (
 	"testing"
 
-	"go.uber.org/yarpc/compressor/grpc"
-	"go.uber.org/yarpc/compressor/gzip"
+	yarpcgrpccompressor "go.uber.org/yarpc/compressor/grpc"
+	yarpcgzip "go.uber.org/yarpc/compressor/gzip"
 	"google.golang.org/grpc/encoding"
 )
 

--- a/compressor/gzip/gzip_test.go
+++ b/compressor/gzip/gzip_test.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/yarpc/compressor/gzip"
+	yarpcgzip "go.uber.org/yarpc/compressor/gzip"
 )
 
 // This should be compressible:

--- a/compressor/snappy/snappy_test.go
+++ b/compressor/snappy/snappy_test.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/yarpc/compressor/snappy"
+	yarpcsnappy "go.uber.org/yarpc/compressor/snappy"
 )
 
 // This should be compressible:

--- a/encoding/protobuf/v2/error.go
+++ b/encoding/protobuf/v2/error.go
@@ -23,7 +23,6 @@ package v2
 import (
 	"errors"
 	"fmt"
-	"google.golang.org/protobuf/encoding/prototext"
 	"strings"
 
 	"github.com/golang/protobuf/ptypes/any"
@@ -32,6 +31,7 @@ import (
 	"go.uber.org/yarpc/yarpcerrors"
 	rpc_status "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 )

--- a/encoding/protobuf/v2/error_external_test.go
+++ b/encoding/protobuf/v2/error_external_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/yarpc/encoding/protobuf/v2"
+	v2 "go.uber.org/yarpc/encoding/protobuf/v2"
 	"go.uber.org/yarpc/yarpcerrors"
 	"google.golang.org/protobuf/proto"
 )

--- a/encoding/protobuf/v2/error_integration_test.go
+++ b/encoding/protobuf/v2/error_integration_test.go
@@ -33,7 +33,7 @@ import (
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/json"
 	"go.uber.org/yarpc/encoding/protobuf/internal/testpb/v2"
-	"go.uber.org/yarpc/encoding/protobuf/v2"
+	v2 "go.uber.org/yarpc/encoding/protobuf/v2"
 	"go.uber.org/yarpc/encoding/raw"
 	"go.uber.org/yarpc/transport/grpc"
 	"go.uber.org/yarpc/yarpcerrors"

--- a/encoding/protobuf/v2/inbound_test.go
+++ b/encoding/protobuf/v2/inbound_test.go
@@ -29,7 +29,7 @@ import (
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/api/transport/transporttest"
 	"go.uber.org/yarpc/encoding/protobuf/internal/testpb/v2"
-	"go.uber.org/yarpc/encoding/protobuf/v2"
+	v2 "go.uber.org/yarpc/encoding/protobuf/v2"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 )

--- a/encoding/protobuf/v2/marshal.go
+++ b/encoding/protobuf/v2/marshal.go
@@ -21,14 +21,15 @@
 package v2
 
 import (
+	"io"
+	"sync"
+
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/bufferpool"
 	"go.uber.org/yarpc/yarpcerrors"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoregistry"
-	"io"
-	"sync"
 )
 
 var (

--- a/encoding/protobuf/v2/observability_test.go
+++ b/encoding/protobuf/v2/observability_test.go
@@ -33,7 +33,7 @@ import (
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/protobuf/internal/testpb/v2"
-	"go.uber.org/yarpc/encoding/protobuf/v2"
+	v2 "go.uber.org/yarpc/encoding/protobuf/v2"
 	"go.uber.org/yarpc/internal/testutils"
 	"go.uber.org/yarpc/transport/grpc"
 	"go.uber.org/yarpc/yarpcerrors"

--- a/encoding/protobuf/v2/outbound_test.go
+++ b/encoding/protobuf/v2/outbound_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/protobuf/internal/testpb/v2"
-	"go.uber.org/yarpc/encoding/protobuf/v2"
+	v2 "go.uber.org/yarpc/encoding/protobuf/v2"
 	"go.uber.org/yarpc/yarpctest"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"

--- a/encoding/protobuf/v2/stream_test.go
+++ b/encoding/protobuf/v2/stream_test.go
@@ -31,7 +31,7 @@ import (
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/protobuf/internal/testpb/v2"
-	"go.uber.org/yarpc/encoding/protobuf/v2"
+	v2 "go.uber.org/yarpc/encoding/protobuf/v2"
 	"go.uber.org/yarpc/internal/clientconfig"
 	"go.uber.org/yarpc/peer"
 	"go.uber.org/yarpc/peer/hostport"

--- a/etc/make/deps.mk
+++ b/etc/make/deps.mk
@@ -18,6 +18,7 @@ RAGEL_VERSION := 6.10
 ERRCHECK_VERSION := 1.7.0
 GOLINT_VERSION := 0.0.0-20210508222113-6edffad5e616
 STATICHCHECK_VERSION := 0.4.7
+GOIMPORTS_VERSION := 0.24.0
 
 THRIFT_OS := $(UNAME_OS)
 PROTOC_OS := $(UNAME_OS)
@@ -89,6 +90,10 @@ $(BIN)/staticcheck:
 	@mkdir -p $(BIN)
 	GOBIN=$(BIN) go install "honnef.co/go/tools/cmd/staticcheck@v$(STATICHCHECK_VERSION)"
 
+$(BIN)/goimports:
+	@mkdir -p $(BIN)
+	GOBIN=$(BIN) go install "golang.org/x/tools/cmd/goimports@v$(GOIMPORTS_VERSION)"
+
 define generatedeprule
 GEN_BINS += $(BIN)/$(shell basename $1)
 endef
@@ -112,6 +117,7 @@ THRIFTRW = $(BIN)/thriftrw
 GOLINT = $(BIN)/golint
 ERRCHECK = $(BIN)/errcheck
 STATICCHECK = $(BIN)/staticcheck
+GOIMPORTS = $(BIN)/goimports
 
 .PHONY: predeps
 predeps: $(THRIFT) $(PROTOC) $(RAGEL)

--- a/internal/protoplugin-v2/generator.go
+++ b/internal/protoplugin-v2/generator.go
@@ -28,7 +28,7 @@ import (
 	"path"
 	"text/template"
 
-	"github.com/golang/protobuf/protoc-gen-go/plugin"
+	plugin_go "github.com/golang/protobuf/protoc-gen-go/plugin"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/internal/protoplugin-v2/multi_runner.go
+++ b/internal/protoplugin-v2/multi_runner.go
@@ -25,7 +25,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/golang/protobuf/protoc-gen-go/plugin"
+	plugin_go "github.com/golang/protobuf/protoc-gen-go/plugin"
 	"go.uber.org/multierr"
 )
 

--- a/internal/protoplugin-v2/multi_runner_test.go
+++ b/internal/protoplugin-v2/multi_runner_test.go
@@ -24,7 +24,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/golang/protobuf/protoc-gen-go/plugin"
+	plugin_go "github.com/golang/protobuf/protoc-gen-go/plugin"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/multierr"
 	"google.golang.org/protobuf/proto"

--- a/internal/protoplugin-v2/protoplugin.go
+++ b/internal/protoplugin-v2/protoplugin.go
@@ -33,7 +33,7 @@ import (
 	"text/template"
 
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
-	"github.com/golang/protobuf/protoc-gen-go/plugin"
+	plugin_go "github.com/golang/protobuf/protoc-gen-go/plugin"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/internal/protoplugin-v2/registry.go
+++ b/internal/protoplugin-v2/registry.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
-	"github.com/golang/protobuf/protoc-gen-go/plugin"
+	plugin_go "github.com/golang/protobuf/protoc-gen-go/plugin"
 )
 
 type registry struct {

--- a/internal/protoplugin-v2/runner.go
+++ b/internal/protoplugin-v2/runner.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/golang/protobuf/protoc-gen-go/plugin"
+	plugin_go "github.com/golang/protobuf/protoc-gen-go/plugin"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/pluginpb"
 )

--- a/internal/protoplugin/generator.go
+++ b/internal/protoplugin/generator.go
@@ -29,7 +29,7 @@ import (
 	"text/template"
 
 	"github.com/gogo/protobuf/proto"
-	"github.com/gogo/protobuf/protoc-gen-gogo/plugin"
+	plugin_go "github.com/gogo/protobuf/protoc-gen-gogo/plugin"
 )
 
 var (

--- a/internal/protoplugin/multi_runner.go
+++ b/internal/protoplugin/multi_runner.go
@@ -25,7 +25,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/gogo/protobuf/protoc-gen-gogo/plugin"
+	plugin_go "github.com/gogo/protobuf/protoc-gen-gogo/plugin"
 	"go.uber.org/multierr"
 )
 

--- a/internal/protoplugin/multi_runner_test.go
+++ b/internal/protoplugin/multi_runner_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
-	"github.com/gogo/protobuf/protoc-gen-gogo/plugin"
+	plugin_go "github.com/gogo/protobuf/protoc-gen-gogo/plugin"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/multierr"
 )

--- a/internal/protoplugin/protoplugin.go
+++ b/internal/protoplugin/protoplugin.go
@@ -46,7 +46,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/protoc-gen-gogo/descriptor"
 	gogogen "github.com/gogo/protobuf/protoc-gen-gogo/generator"
-	"github.com/gogo/protobuf/protoc-gen-gogo/plugin"
+	plugin_go "github.com/gogo/protobuf/protoc-gen-gogo/plugin"
 )
 
 // Do is a helper function for protobuf plugins.

--- a/internal/protoplugin/registry.go
+++ b/internal/protoplugin/registry.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 
 	"github.com/gogo/protobuf/protoc-gen-gogo/descriptor"
-	"github.com/gogo/protobuf/protoc-gen-gogo/plugin"
+	plugin_go "github.com/gogo/protobuf/protoc-gen-gogo/plugin"
 )
 
 type registry struct {

--- a/internal/protoplugin/runner.go
+++ b/internal/protoplugin/runner.go
@@ -25,7 +25,7 @@ import (
 	"text/template"
 
 	"github.com/gogo/protobuf/proto"
-	"github.com/gogo/protobuf/protoc-gen-gogo/plugin"
+	plugin_go "github.com/gogo/protobuf/protoc-gen-gogo/plugin"
 )
 
 type runner struct {

--- a/transport/grpc/globals_for_test.go
+++ b/transport/grpc/globals_for_test.go
@@ -21,7 +21,7 @@
 package grpc
 
 import (
-	"go.uber.org/yarpc/compressor/grpc"
+	yarpcgrpccompressor "go.uber.org/yarpc/compressor/grpc"
 	"go.uber.org/yarpc/yarpcconfig"
 	"google.golang.org/grpc/encoding"
 )

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package yarpc // import "go.uber.org/yarpc"
 
 // Version is the current version of YARPC.
-const Version = "1.73.1"
+const Version = "1.74.0-dev"

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package yarpc // import "go.uber.org/yarpc"
 
 // Version is the current version of YARPC.
-const Version = "1.74.0-dev"
+const Version = "1.73.2"

--- a/yarpcerrors/yarpcerrorclassifier_test.go
+++ b/yarpcerrors/yarpcerrorclassifier_test.go
@@ -21,8 +21,9 @@
 package yarpcerrors
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetFaultTypeFromErrorForClientErrors(t *testing.T) {


### PR DESCRIPTION
Added `OriginalHeader` accessor in `encoding.Call` to get an original header value for a request from context object with zero-copy, as opposed to accessing it via `OriginalHeaders()`
