### PR TITLE
Fix empty transport name in outbound request for tchannel channel outbound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Fixed
 - Return correct error code for ctx Cancelled error in http outbound.
+- Make tchannel outbound satisfy Namer interface
 
 ## [1.73.2] - 2024-09-09
 ### Added

--- a/transport/tchannel/channel_outbound.go
+++ b/transport/tchannel/channel_outbound.go
@@ -33,6 +33,7 @@ import (
 )
 
 var (
+	_ transport.Namer                      = (*ChannelOutbound)(nil)
 	_ transport.UnaryOutbound              = (*ChannelOutbound)(nil)
 	_ introspection.IntrospectableOutbound = (*ChannelOutbound)(nil)
 )
@@ -72,6 +73,12 @@ type ChannelOutbound struct {
 	addr string
 
 	once *lifecycle.Once
+}
+
+// TransportName is the transport name that will be set on `transport.Request`
+// struct.
+func (o *ChannelOutbound) TransportName() string {
+	return TransportName
 }
 
 // Transports returns the underlying TChannel Transport for this outbound.

--- a/transport/tchannel/channel_outbound_test.go
+++ b/transport/tchannel/channel_outbound_test.go
@@ -514,3 +514,9 @@ func TestChannelOutboundNoRequest(t *testing.T) {
 		})
 	}
 }
+
+func TestChannelOutboundTransportName(t *testing.T) {
+	ct, err := NewChannelTransport(ServiceName("myclient"))
+	require.NoError(t, err)
+	assert.Equal(t, TransportName, ct.NewOutbound().TransportName())
+}


### PR DESCRIPTION
Fixing #2293 