### PR TITLE
Add a custom grcp-go resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 =======
 ## [Unreleased]
+### Added
+- Added multiaddress passthrough resolver
 ### Fixed
 - Return correct error code for ctx Cancelled error in http outbound.
 - Make tchannel outbound satisfy Namer interface

--- a/pkg/multiaddrpassthrough/multiaddrpassthrough.go
+++ b/pkg/multiaddrpassthrough/multiaddrpassthrough.go
@@ -1,0 +1,78 @@
+package multiaddrpassthrough
+
+import (
+	"errors"
+	"net"
+	"strings"
+
+	"google.golang.org/grpc/resolver"
+)
+
+func init() {
+	resolver.Register(&multiaddrPassthroughBuilder{})
+}
+
+const _scheme = "multi-addr-passthrough"
+
+var errMissingAddr = errors.New("missing address")
+
+type multiaddrPassthroughBuilder struct{}
+
+// Build creates and starts a multi address passthrough resolver.
+// It expects the target to be a list of addresses on the format:
+// multi-addr-passthrough:///192.168.0.1:2345/127.0.0.1:5678
+func (*multiaddrPassthroughBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOptions) (resolver.Resolver, error) {
+	addresses, err := parseTarget(target)
+	if err != nil {
+		return nil, err
+	}
+
+	r := &multiaddrPassthroughResolver{
+		addresses: addresses,
+		cc:        cc,
+	}
+
+	err = r.start()
+	if err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+func (*multiaddrPassthroughBuilder) Scheme() string {
+	return _scheme
+}
+
+type multiaddrPassthroughResolver struct {
+	addresses []resolver.Address
+	cc        resolver.ClientConn
+}
+
+func (r *multiaddrPassthroughResolver) start() error {
+	return r.cc.UpdateState(resolver.State{Addresses: r.addresses})
+}
+
+func (*multiaddrPassthroughResolver) ResolveNow(resolver.ResolveNowOptions) {}
+
+func (*multiaddrPassthroughResolver) Close() {}
+
+func parseTarget(target resolver.Target) ([]resolver.Address, error) {
+	addresses := []resolver.Address{}
+	endpoints := strings.Split(target.URL.Host, "/")
+
+	for _, endpoint := range endpoints {
+		if endpoint == "" {
+			return nil, errMissingAddr
+		}
+
+		host, port, err := net.SplitHostPort(endpoint)
+		if err != nil {
+			return nil, err
+		}
+
+		addresses = append(addresses, resolver.Address{Addr: net.JoinHostPort(host, port), Type: resolver.Backend})
+	}
+
+	return addresses, nil
+}

--- a/pkg/multiaddrpassthrough/multiaddrpassthrough.go
+++ b/pkg/multiaddrpassthrough/multiaddrpassthrough.go
@@ -18,9 +18,13 @@ var errMissingAddr = errors.New("missing address")
 
 type multiaddrPassthroughBuilder struct{}
 
+func NewBuilder() resolver.Builder {
+	return &multiaddrPassthroughBuilder{}
+}
+
 // Build creates and starts a multi address passthrough resolver.
 // It expects the target to be a list of addresses on the format:
-// multi-addr-passthrough:///192.168.0.1:2345/127.0.0.1:5678
+// 192.168.0.1:2345/127.0.0.1:5678
 func (*multiaddrPassthroughBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOptions) (resolver.Resolver, error) {
 	addresses, err := parseTarget(target)
 	if err != nil {

--- a/pkg/multiaddrpassthrough/multiaddrpassthrough_test.go
+++ b/pkg/multiaddrpassthrough/multiaddrpassthrough_test.go
@@ -1,0 +1,158 @@
+package multiaddrpassthrough
+
+import (
+	"net/url"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/serviceconfig"
+)
+
+var _ resolver.ClientConn = (*testClientConn)(nil)
+
+type testClientConn struct {
+	target  string
+	State   resolver.State
+	mu      sync.Mutex
+	addrs   []resolver.Address // protected by mu
+	updates int                // protected by mu
+	t       *testing.T
+}
+
+func (t *testClientConn) ParseServiceConfig(string) *serviceconfig.ParseResult {
+	return nil
+}
+
+func (t *testClientConn) ReportError(error) {
+}
+
+func (t *testClientConn) UpdateState(state resolver.State) error {
+	t.State = state
+	return nil
+}
+
+func (t *testClientConn) NewAddress(addrs []resolver.Address) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.addrs = addrs
+	t.updates++
+}
+
+func (t *testClientConn) getAddress() ([]resolver.Address, int) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.addrs, t.updates
+}
+
+// This shouldn't be called by our code since we don't support this.
+func (t *testClientConn) NewServiceConfig(serviceConfig string) {
+	assert.Fail(t.t, "unexpected call to NewServiceConfig")
+	return
+}
+
+func TestParseTarget(t *testing.T) {
+
+	tests := []struct {
+		msg       string
+		target    resolver.Target
+		addrsWant []resolver.Address
+		errWant   error
+	}{
+		{
+			msg:       "Single IPv4",
+			target:    resolver.Target{URL: url.URL{Host: "1.2.3.4:1234"}},
+			addrsWant: []resolver.Address{{Addr: "1.2.3.4:1234"}},
+		},
+		{
+			msg:       "Single IPv6",
+			target:    resolver.Target{URL: url.URL{Host: "[2607:f8b0:400a:801::1001]:9000"}},
+			addrsWant: []resolver.Address{{Addr: "[2607:f8b0:400a:801::1001]:9000"}},
+		},
+		{
+			msg:    "Testing multiple IPv4s",
+			target: resolver.Target{URL: url.URL{Host: "1.2.3.4:1234/5.6.7.8:1234"}},
+			addrsWant: []resolver.Address{
+				{Addr: "1.2.3.4:1234"},
+				{Addr: "5.6.7.8:1234"},
+			},
+		},
+		{
+			msg:    "Mixed IPv6 and IPv4",
+			target: resolver.Target{URL: url.URL{Host: "[2607:f8b0:400a:801::1001]:9000/[2607:f8b0:400a:801::1002]:2345/127.0.0.1:4567"}},
+			addrsWant: []resolver.Address{
+				{Addr: "[2607:f8b0:400a:801::1001]:9000"},
+				{Addr: "[2607:f8b0:400a:801::1002]:2345"},
+				{Addr: "127.0.0.1:4567"},
+			},
+		},
+		{
+			msg:     "Empty target",
+			target:  resolver.Target{URL: url.URL{Host: ""}},
+			errWant: errMissingAddr,
+		},
+		{
+			msg:    "Localhost",
+			target: resolver.Target{URL: url.URL{Host: "localhost:1000"}},
+			addrsWant: []resolver.Address{
+				{Addr: "localhost:1000"},
+			},
+		},
+		{
+			msg:    "IPv4 missing port",
+			target: resolver.Target{URL: url.URL{Host: "999.1.1.1"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			gotAddr, gotErr := parseTarget(tt.target)
+
+			if tt.errWant != nil {
+				assert.EqualError(t, gotErr, tt.errWant.Error())
+			}
+			assert.ElementsMatch(t, tt.addrsWant, gotAddr)
+		})
+	}
+}
+
+func TestBuild(t *testing.T) {
+	tests := []struct {
+		msg        string
+		target     resolver.Target
+		watAddress []resolver.Address
+		wantErr    string
+	}{
+		{
+			msg:        "IPv6",
+			target:     resolver.Target{URL: url.URL{Host: "[2001:db8::1]:http"}},
+			watAddress: []resolver.Address{{Addr: "[2001:db8::1]:http"}},
+		},
+		{
+			msg:     "Empty address",
+			target:  resolver.Target{URL: url.URL{Host: "127.0.0.1:12345/"}},
+			wantErr: errMissingAddr.Error(),
+		},
+		{
+			msg:     "Empty target",
+			target:  resolver.Target{URL: url.URL{Host: ""}},
+			wantErr: errMissingAddr.Error(),
+		},
+	}
+
+	builder := &multiaddrPassthroughBuilder{}
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+
+			cc := &testClientConn{target: tt.target.URL.Host}
+			gotResolver, gotError := builder.Build(tt.target, cc, resolver.BuildOptions{})
+			if tt.wantErr != "" {
+				assert.EqualError(t, gotError, tt.wantErr)
+			} else {
+				assert.ElementsMatch(t, cc.State.Addresses, tt.watAddress)
+				gotResolver.Close()
+			}
+		})
+	}
+}


### PR DESCRIPTION

In grpc-go, the default passthrough resolver only allows for a single IP address to be specified.

This resolver has the same functionality as the default one but allows for multiple addresses.
