### PR TITLE
Add custom multiaddress resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 =======
 ## [Unreleased]
+### Added
+- Added multiaddress passthrough resolver
 ### Fixed
 - Return correct error code for ctx Cancelled error in http outbound.
 - Make tchannel outbound satisfy Namer interface

--- a/pkg/multiaddrpassthrough/multiaddrpassthrough.go
+++ b/pkg/multiaddrpassthrough/multiaddrpassthrough.go
@@ -22,7 +22,6 @@ package multiaddrpassthrough
 
 import (
 	"errors"
-	"net"
 	"strings"
 
 	"google.golang.org/grpc/resolver"
@@ -32,7 +31,7 @@ func init() {
 	resolver.Register(&multiaddrPassthroughBuilder{})
 }
 
-const _scheme = "multi-addr-passthrough"
+const Scheme = "multi-addr-passthrough"
 
 var (
 	errMissingAddr     = errors.New("missing address")
@@ -65,7 +64,7 @@ func (*multiaddrPassthroughBuilder) Build(target resolver.Target, cc resolver.Cl
 }
 
 func (*multiaddrPassthroughBuilder) Scheme() string {
-	return _scheme
+	return Scheme
 }
 
 // ResolveNow is a noop for the multi address passthrough resolver.
@@ -75,16 +74,11 @@ func (*multiaddrPassthroughResolver) ResolveNow(resolver.ResolveNowOptions) {}
 func (*multiaddrPassthroughResolver) Close() {}
 
 func parseTarget(target resolver.Target) ([]resolver.Address, error) {
-	endpoints := strings.Split(target.URL.Path, "/")
+	endpoints := strings.Split(target.Endpoint, "/")
 	addresses := make([]resolver.Address, 0, len(endpoints))
 
 	for _, endpoint := range endpoints {
 		if len(endpoint) > 0 {
-			_, _, err := net.SplitHostPort(endpoint)
-			if err != nil {
-				return nil, errInvaildEndpoint
-			}
-
 			addresses = append(addresses, resolver.Address{Addr: endpoint})
 		}
 	}

--- a/pkg/multiaddrpassthrough/multiaddrpassthrough.go
+++ b/pkg/multiaddrpassthrough/multiaddrpassthrough.go
@@ -31,6 +31,7 @@ func init() {
 	resolver.Register(&multiaddrPassthroughBuilder{})
 }
 
+// Scheme is the scheme for the multi address passthrough resolver.
 const Scheme = "multi-addr-passthrough"
 
 var (

--- a/pkg/multiaddrpassthrough/multiaddrpassthrough.go
+++ b/pkg/multiaddrpassthrough/multiaddrpassthrough.go
@@ -1,0 +1,73 @@
+package multiaddrpassthrough
+
+import (
+	"errors"
+	"net"
+	"strings"
+
+	"google.golang.org/grpc/resolver"
+)
+
+func init() {
+	resolver.Register(&multiaddrPassthroughBuilder{})
+}
+
+const _scheme = "multi-addr-passthrough"
+
+var (
+	errMissingAddr     = errors.New("missing address")
+	errInvaildEndpoint = errors.New("specified endpoint is invalid")
+)
+
+type multiaddrPassthroughBuilder struct{}
+type multiaddrPassthroughResolver struct{}
+
+func NewBuilder() resolver.Builder {
+	return &multiaddrPassthroughBuilder{}
+}
+
+// Build creates and starts a multi address passthrough resolver.
+// It expects the target to be a list of addresses on the format:
+// multi-addr-passthrough:///192.168.0.1:2345/127.0.0.1:5678
+func (*multiaddrPassthroughBuilder) Build(target resolver.Target, cc resolver.ClientConn, _ resolver.BuildOptions) (resolver.Resolver, error) {
+	addresses, err := parseTarget(target)
+	if err != nil {
+		return nil, err
+	}
+
+	err = cc.UpdateState(resolver.State{Addresses: addresses})
+	if err != nil {
+		return nil, err
+	}
+
+	return &multiaddrPassthroughResolver{}, nil
+}
+
+func (*multiaddrPassthroughBuilder) Scheme() string {
+	return _scheme
+}
+
+func (*multiaddrPassthroughResolver) ResolveNow(resolver.ResolveNowOptions) {}
+
+func (*multiaddrPassthroughResolver) Close() {}
+
+func parseTarget(target resolver.Target) ([]resolver.Address, error) {
+	endpoints := strings.Split(target.URL.Path, "/")
+	addresses := make([]resolver.Address, 0, len(endpoints))
+
+	for _, endpoint := range endpoints {
+		if len(endpoint) > 0 {
+			_, _, err := net.SplitHostPort(endpoint)
+			if err != nil {
+				return nil, errInvaildEndpoint
+			}
+
+			addresses = append(addresses, resolver.Address{Addr: endpoint})
+		}
+	}
+
+	if len(addresses) == 0 {
+		return nil, errMissingAddr
+	}
+	return addresses, nil
+}

--- a/pkg/multiaddrpassthrough/multiaddrpassthrough.go
+++ b/pkg/multiaddrpassthrough/multiaddrpassthrough.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2024 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package multiaddrpassthrough
 
 import (

--- a/pkg/multiaddrpassthrough/multiaddrpassthrough.go
+++ b/pkg/multiaddrpassthrough/multiaddrpassthrough.go
@@ -22,6 +22,7 @@ var (
 type multiaddrPassthroughBuilder struct{}
 type multiaddrPassthroughResolver struct{}
 
+// NewBuilder creates a new multi address passthrough resolver builder.
 func NewBuilder() resolver.Builder {
 	return &multiaddrPassthroughBuilder{}
 }
@@ -46,9 +47,9 @@ func (*multiaddrPassthroughBuilder) Build(target resolver.Target, cc resolver.Cl
 func (*multiaddrPassthroughBuilder) Scheme() string {
 	return _scheme
 }
-
+// ResolveNow is a noop for multi address passthrough resolver.
 func (*multiaddrPassthroughResolver) ResolveNow(resolver.ResolveNowOptions) {}
-
+// Close is a noop for multi address passthrough resolver.
 func (*multiaddrPassthroughResolver) Close() {}
 
 func parseTarget(target resolver.Target) ([]resolver.Address, error) {

--- a/pkg/multiaddrpassthrough/multiaddrpassthrough.go
+++ b/pkg/multiaddrpassthrough/multiaddrpassthrough.go
@@ -31,12 +31,10 @@ func init() {
 	resolver.Register(&multiaddrPassthroughBuilder{})
 }
 
-// Scheme is the scheme for the multi address passthrough resolver.
 const Scheme = "multi-addr-passthrough"
 
 var (
-	errMissingAddr     = errors.New("missing address")
-	errInvaildEndpoint = errors.New("specified endpoint is invalid")
+	errMissingAddr = errors.New("missing address")
 )
 
 type multiaddrPassthroughBuilder struct{}
@@ -75,7 +73,7 @@ func (*multiaddrPassthroughResolver) ResolveNow(resolver.ResolveNowOptions) {}
 func (*multiaddrPassthroughResolver) Close() {}
 
 func parseTarget(target resolver.Target) ([]resolver.Address, error) {
-	endpoints := strings.Split(target.Endpoint, "/")
+	endpoints := strings.Split(target.URL.Path, "/")
 	addresses := make([]resolver.Address, 0, len(endpoints))
 
 	for _, endpoint := range endpoints {

--- a/pkg/multiaddrpassthrough/multiaddrpassthrough.go
+++ b/pkg/multiaddrpassthrough/multiaddrpassthrough.go
@@ -22,6 +22,7 @@ var (
 type multiaddrPassthroughBuilder struct{}
 type multiaddrPassthroughResolver struct{}
 
+// NewBuilder creates a new multi address passthrough resolver builder.
 func NewBuilder() resolver.Builder {
 	return &multiaddrPassthroughBuilder{}
 }
@@ -47,8 +48,10 @@ func (*multiaddrPassthroughBuilder) Scheme() string {
 	return _scheme
 }
 
+// ResolveNow is a noop for the multi address passthrough resolver.
 func (*multiaddrPassthroughResolver) ResolveNow(resolver.ResolveNowOptions) {}
 
+// Close is a noop for the multi address passthrough resolver.
 func (*multiaddrPassthroughResolver) Close() {}
 
 func parseTarget(target resolver.Target) ([]resolver.Address, error) {

--- a/pkg/multiaddrpassthrough/multiaddrpassthrough.go
+++ b/pkg/multiaddrpassthrough/multiaddrpassthrough.go
@@ -22,7 +22,6 @@ var (
 type multiaddrPassthroughBuilder struct{}
 type multiaddrPassthroughResolver struct{}
 
-// NewBuilder creates a new multi address passthrough resolver builder.
 func NewBuilder() resolver.Builder {
 	return &multiaddrPassthroughBuilder{}
 }
@@ -47,9 +46,9 @@ func (*multiaddrPassthroughBuilder) Build(target resolver.Target, cc resolver.Cl
 func (*multiaddrPassthroughBuilder) Scheme() string {
 	return _scheme
 }
-// ResolveNow is a noop for multi address passthrough resolver.
+
 func (*multiaddrPassthroughResolver) ResolveNow(resolver.ResolveNowOptions) {}
-// Close is a noop for multi address passthrough resolver.
+
 func (*multiaddrPassthroughResolver) Close() {}
 
 func parseTarget(target resolver.Target) ([]resolver.Address, error) {

--- a/pkg/multiaddrpassthrough/multiaddrpassthrough_test.go
+++ b/pkg/multiaddrpassthrough/multiaddrpassthrough_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/serviceconfig"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 var _ resolver.ClientConn = (*testClientConn)(nil)

--- a/pkg/multiaddrpassthrough/multiaddrpassthrough_test.go
+++ b/pkg/multiaddrpassthrough/multiaddrpassthrough_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2024 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package multiaddrpassthrough
 
 import (

--- a/pkg/multiaddrpassthrough/multiaddrpassthrough_test.go
+++ b/pkg/multiaddrpassthrough/multiaddrpassthrough_test.go
@@ -32,8 +32,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/serviceconfig"
 )

--- a/pkg/multiaddrpassthrough/multiaddrpassthrough_test.go
+++ b/pkg/multiaddrpassthrough/multiaddrpassthrough_test.go
@@ -1,0 +1,210 @@
+package multiaddrpassthrough
+
+import (
+	"context"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	rpb "google.golang.org/grpc/reflection/grpc_reflection_v1alpha"
+	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/serviceconfig"
+)
+
+var _ resolver.ClientConn = (*testClientConn)(nil)
+
+func TestParseTarget(t *testing.T) {
+
+	tests := []struct {
+		msg       string
+		target    resolver.Target
+		addrsWant []resolver.Address
+		errWant   string
+	}{
+		{
+			msg:       "Single IPv4",
+			target:    resolver.Target{URL: url.URL{Path: "1.2.3.4:1234"}},
+			addrsWant: []resolver.Address{{Addr: "1.2.3.4:1234"}},
+		}, {
+			msg:       "Single IPv4, leading slash",
+			target:    resolver.Target{URL: url.URL{Path: "/1.2.3.4:1234"}},
+			addrsWant: []resolver.Address{{Addr: "1.2.3.4:1234"}},
+		},
+		{
+			msg:       "Single IPv6",
+			target:    resolver.Target{URL: url.URL{Path: "[2607:f8b0:400a:801::1001]:9000"}},
+			addrsWant: []resolver.Address{{Addr: "[2607:f8b0:400a:801::1001]:9000"}},
+		},
+		{
+			msg:    "Testing multiple IPv4s",
+			target: resolver.Target{URL: url.URL{Path: "1.2.3.4:1234/5.6.7.8:1234"}},
+			addrsWant: []resolver.Address{
+				{Addr: "1.2.3.4:1234"},
+				{Addr: "5.6.7.8:1234"},
+			},
+		},
+		{
+			msg:    "Mixed IPv6 and IPv4",
+			target: resolver.Target{URL: url.URL{Path: "[2607:f8b0:400a:801::1001]:9000/[2607:f8b0:400a:801::1002]:2345/127.0.0.1:4567"}},
+			addrsWant: []resolver.Address{
+				{Addr: "[2607:f8b0:400a:801::1001]:9000"},
+				{Addr: "[2607:f8b0:400a:801::1002]:2345"},
+				{Addr: "127.0.0.1:4567"},
+			},
+		},
+		{
+			msg:     "Empty target",
+			target:  resolver.Target{URL: url.URL{Path: ""}},
+			errWant: errMissingAddr.Error(),
+		},
+		{
+			msg:    "Localhost",
+			target: resolver.Target{URL: url.URL{Path: "localhost:1000"}},
+			addrsWant: []resolver.Address{
+				{Addr: "localhost:1000"},
+			},
+		},
+		{
+			msg:     "Invalid IPv4",
+			target:  resolver.Target{URL: url.URL{Path: "999.1.1.1"}},
+			errWant: errInvaildEndpoint.Error(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			gotAddr, gotErr := parseTarget(tt.target)
+
+			if gotErr != nil {
+				assert.EqualError(t, gotErr, tt.errWant)
+			}
+			assert.ElementsMatch(t, gotAddr, tt.addrsWant)
+		})
+	}
+}
+
+func TestBuild(t *testing.T) {
+	tests := []struct {
+		msg        string
+		target     resolver.Target
+		watAddress []resolver.Address
+		wantErr    string
+	}{
+		{
+			msg:        "IPv6",
+			target:     resolver.Target{URL: url.URL{Path: "[2001:db8::1]:http"}},
+			watAddress: []resolver.Address{{Addr: "[2001:db8::1]:http"}},
+		},
+		{
+			msg:     "Invalid target",
+			target:  resolver.Target{URL: url.URL{Path: "127.0.0.1"}},
+			wantErr: errInvaildEndpoint.Error(),
+		},
+		{
+			msg:     "Empty target",
+			target:  resolver.Target{URL: url.URL{Path: ""}},
+			wantErr: errMissingAddr.Error(),
+		},
+	}
+
+	builder := &multiaddrPassthroughBuilder{}
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+
+			cc := &testClientConn{target: tt.target.URL.Host}
+			gotResolver, gotError := builder.Build(tt.target, cc, resolver.BuildOptions{})
+			if tt.wantErr != "" {
+				assert.EqualError(t, gotError, tt.wantErr)
+			} else {
+				assert.ElementsMatch(t, cc.State.Addresses, tt.watAddress)
+				gotResolver.Close()
+			}
+		})
+	}
+}
+
+func TestClientConnectionIntegration(t *testing.T) {
+	dest := "127.0.0.1:3456"
+	wantAddr := []resolver.Address{{Addr: dest}}
+
+	b := NewBuilder()
+
+	cc := &testClientConn{}
+	_, err := b.Build(resolver.Target{URL: url.URL{Path: dest}}, cc, resolver.BuildOptions{})
+	assert.ElementsMatch(t, cc.State.Addresses, wantAddr, "Client connection received the wrong list of addresses")
+	require.NoError(t, err, "unexpected error building the resolver")
+}
+
+func TestGRPCIntegration(t *testing.T) {
+	dest := "127.0.0.1:3456/192.168.1.1:6789"
+
+	b := NewBuilder()
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	_, err := grpc.DialContext(ctx, b.Scheme()+":///"+dest, grpc.WithInsecure())
+	assert.NoError(t, err)
+}
+
+type testClientConn struct {
+	target string
+	State  resolver.State
+	mu     sync.Mutex
+	addrs  []resolver.Address // protected by mu
+	t      *testing.T
+}
+
+func (t *testClientConn) ParseServiceConfig(string) *serviceconfig.ParseResult {
+	return nil
+}
+
+func (t *testClientConn) ReportError(error) {
+}
+
+func (t *testClientConn) UpdateState(state resolver.State) error {
+	t.State = state
+	return nil
+}
+
+func (t *testClientConn) NewAddress(addrs []resolver.Address) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.addrs = addrs
+}
+
+func (t *testClientConn) getAddress() []resolver.Address {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.addrs
+}
+
+// This shouldn't be called by our code since we don't support this.
+func (t *testClientConn) NewServiceConfig(serviceConfig string) {
+	assert.Fail(t.t, "unexpected call to NewServiceConfig")
+	return
+}
+
+type dummyReflectionServer struct {
+	md        metadata.MD
+	returnErr error
+}
+
+func (s *dummyReflectionServer) Reset() {
+	s.md = nil
+}
+
+func (s *dummyReflectionServer) ServerReflectionInfo(r rpb.ServerReflection_ServerReflectionInfoServer) error {
+	if s.returnErr != nil {
+		return s.returnErr
+	}
+
+	if md, ok := metadata.FromIncomingContext(r.Context()); ok {
+		s.md = md
+	}
+	return assert.AnError
+}


### PR DESCRIPTION
In grpc-go, the default passthrough resolver only allows for a single IP address to be specified.

This resolver has the same functionality as the default one but allows for multiple addresses. 