### PR TITLE
Add component tag to tracing spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Added multiaddress passthrough resolver
+- Added component tag to tracing spans
 ### Fixed
 - Return correct error code for ctx Cancelled error in http outbound.
 - Make tchannel outbound satisfy Namer interface

--- a/tracing.go
+++ b/tracing.go
@@ -30,4 +30,5 @@ import (
 var OpentracingTags = opentracing.Tags{
 	"yarpc.version": Version,
 	"go.version":    runtime.Version(),
+	"component":     "yarpc-go",
 }


### PR DESCRIPTION
This PR is making a tiny change to add span component tag to tracing spans. According to the [OpenTracing sematic conventions](https://github.com/opentracing/specification/blob/master/semantic_conventions.md), the component tag indicates the library that created the spans. 
> The software package, framework, library, or module that generated the associated Span. E.g., "grpc", "django", "JDBI".

Internally at Uber, It is quite useful for the tracing team to understand the distribution of span creation among libraries in order to optimize the operational cost.
