### PR TITLE
[Tracing Redesign][3/N] Implement tracing streaming Interceptors

### DIFF
--- a/internal/tracinginterceptor/interceptor.go
+++ b/internal/tracinginterceptor/interceptor.go
@@ -230,7 +230,7 @@ func (i *Interceptor) CallStream(ctx context.Context, req *transport.StreamReque
 		if updateErr := updateSpanWithErrorDetails(span, false, nil, err); updateErr != nil {
 			i.log.Error("Failed to update span with error details", zap.Error(updateErr))
 		}
-		//span.Finish()
+		span.Finish()
 		return nil, err
 	}
 

--- a/internal/tracinginterceptor/interceptor.go
+++ b/internal/tracinginterceptor/interceptor.go
@@ -189,7 +189,8 @@ func (i *Interceptor) HandleStream(s *transport.ServerStream, h transport.Stream
 	defer span.Finish()
 
 	// Wrap the ServerStream in a tracedServerStream
-	err := h.HandleStream(s)
+	tracedStream := newTracedServerStream(*s, span, i.log)
+	err := h.HandleStream(tracedStream.ServerStream)
 
 	isApplicationError := err != nil && isApplicationLevelError(err)
 	var appErrorMeta *transport.ApplicationErrorMeta

--- a/internal/tracinginterceptor/interceptor.go
+++ b/internal/tracinginterceptor/interceptor.go
@@ -178,8 +178,6 @@ func (i *Interceptor) CallOneway(ctx context.Context, req *transport.Request, ou
 // HandleStream implements interceptor.StreamInbound
 func (i *Interceptor) HandleStream(s *transport.ServerStream, h transport.StreamHandler) error {
 	parentSpanCtx, _ := i.tracer.Extract(i.propagationFormat, getPropagationCarrier(s.Request().Meta.Headers.Items(), i.transport))
-
-	// Start the server-side span
 	span := i.tracer.StartSpan(
 		s.Request().Meta.Procedure,
 		opentracing.ChildOf(parentSpanCtx),
@@ -214,8 +212,6 @@ func (i *Interceptor) CallStream(ctx context.Context, req *transport.StreamReque
 		opentracing.StartTime(time.Now()),
 	)
 	defer span.Finish()
-
-	// Inject span context into headers for tracing propagation
 	tracingHeaders := make(map[string]string)
 	if err := i.tracer.Inject(span.Context(), i.propagationFormat, getPropagationCarrier(tracingHeaders, i.transport)); err != nil {
 		span.LogFields(logFieldEventError, log.String("message", err.Error()))

--- a/internal/tracinginterceptor/interceptor.go
+++ b/internal/tracinginterceptor/interceptor.go
@@ -177,12 +177,53 @@ func (i *Interceptor) CallOneway(ctx context.Context, req *transport.Request, ou
 
 // HandleStream implements interceptor.StreamInbound
 func (i *Interceptor) HandleStream(s *transport.ServerStream, h transport.StreamHandler) error {
-	panic("implement me")
+	parentSpanCtx, _ := i.tracer.Extract(i.propagationFormat, getPropagationCarrier(s.Request().Meta.Headers.Items(), i.transport))
+
+	// Start the server-side span
+	span := i.tracer.StartSpan(
+		s.Request().Meta.Procedure,
+		opentracing.ChildOf(parentSpanCtx),
+		ext.SpanKindRPCServer,
+		opentracing.StartTime(time.Now()),
+	)
+	defer span.Finish()
+
+	// Wrap the ServerStream in a tracedServerStream
+	err := h.HandleStream(s)
+	tracedStream := newTracedServerStream(*s, span, i.log)
+
+	return updateSpanWithErrorDetails(span, tracedStream.IsApplicationError(), tracedStream.ApplicationErrorMeta(), err)
 }
 
 // CallStream implements interceptor.StreamOutbound
 func (i *Interceptor) CallStream(ctx context.Context, req *transport.StreamRequest, out transport.StreamOutbound) (*transport.ClientStream, error) {
-	panic("implement me")
+	span := i.tracer.StartSpan(
+		req.Meta.Procedure,
+		ext.SpanKindRPCClient,
+		opentracing.StartTime(time.Now()),
+	)
+	defer span.Finish()
+
+	// Inject span context into headers for tracing propagation
+	tracingHeaders := make(map[string]string)
+	if err := i.tracer.Inject(span.Context(), i.propagationFormat, getPropagationCarrier(tracingHeaders, i.transport)); err != nil {
+		span.LogFields(logFieldEventError, log.String("message", err.Error()))
+	} else {
+		for k, v := range tracingHeaders {
+			req.Meta.Headers = req.Meta.Headers.With(k, v)
+		}
+	}
+
+	clientStream, err := out.CallStream(ctx, req)
+	if err != nil {
+		if updateErr := updateSpanWithErrorDetails(span, false, nil, err); updateErr != nil {
+			i.log.Error("Failed to update span with error details", zap.Error(updateErr))
+		}
+		return nil, err
+	}
+
+	tracedStream := newTracedClientStream(clientStream, span, i.log)
+	return &tracedStream.ClientStream, nil
 }
 
 func updateSpanWithErrorDetails(

--- a/internal/tracinginterceptor/interceptor.go
+++ b/internal/tracinginterceptor/interceptor.go
@@ -185,12 +185,9 @@ func (i *Interceptor) HandleStream(s *transport.ServerStream, h transport.Stream
 		opentracing.StartTime(time.Now()),
 	)
 	defer span.Finish()
+	err := h.HandleStream(s)
 
-	// Wrap the ServerStream in a tracedServerStream
-	tracedStream := newTracedServerStream(*s, span, i.log)
-	err := h.HandleStream(tracedStream.ServerStream)
-
-	isApplicationError := err != nil && isApplicationLevelError(err)
+	isApplicationError := err != nil
 	var appErrorMeta *transport.ApplicationErrorMeta
 	if isApplicationError {
 		code := yarpcerrors.FromError(err).Code()
@@ -228,9 +225,7 @@ func (i *Interceptor) CallStream(ctx context.Context, req *transport.StreamReque
 		}
 		return nil, err
 	}
-
-	tracedStream := newTracedClientStream(clientStream, span, i.log)
-	return tracedStream.ClientStream, nil
+	return clientStream, nil
 }
 
 func updateSpanWithErrorDetails(

--- a/internal/tracinginterceptor/interceptor.go
+++ b/internal/tracinginterceptor/interceptor.go
@@ -291,7 +291,7 @@ func getPropagationCarrier(headers map[string]string, transport string) Propagat
 func wrapTracedClientStream(tracedStream *tracedClientStream) *transport.ClientStream {
 	wrapped, err := transport.NewClientStream(tracedStream)
 	if err != nil {
-		// This should not happen, as NewClientStream only fails for nil streams.
+		// This should not happen, as NewClientStream only fails for the nil streams.
 		tracedStream.span.LogFields(logFieldEventError, log.String("message", "Failed to wrap traced client stream"))
 		return tracedStream.clientStream
 	}

--- a/internal/tracinginterceptor/interceptor.go
+++ b/internal/tracinginterceptor/interceptor.go
@@ -228,9 +228,7 @@ func (i *Interceptor) CallStream(ctx context.Context, req *transport.StreamReque
 
 	clientStream, err := out.CallStream(ctx, req)
 	if err != nil {
-		if updateErr := updateSpanWithErrorDetails(span, false, nil, err); updateErr != nil {
-			i.log.Error("Failed to update span with error details", zap.Error(updateErr))
-		}
+		_ = updateSpanWithErrorDetails(span, false, nil, err)
 		span.Finish()
 		return nil, err
 	}
@@ -294,6 +292,7 @@ func wrapTracedClientStream(tracedStream *tracedClientStream) *transport.ClientS
 	if err != nil {
 		// This should not happen, as NewClientStream only fails for the nil streams.
 		tracedStream.span.LogFields(logFieldEventError, log.String("message", "Failed to wrap traced client stream"))
+		tracedStream.span.Finish()
 		return tracedStream.clientStream
 	}
 	return wrapped

--- a/internal/tracinginterceptor/interceptor.go
+++ b/internal/tracinginterceptor/interceptor.go
@@ -290,7 +290,7 @@ func getPropagationCarrier(headers map[string]string, transport string) Propagat
 func wrapTracedClientStream(tracedStream *tracedClientStream) *transport.ClientStream {
 	wrapped, err := transport.NewClientStream(tracedStream)
 	if err != nil {
-		// This should not happen, as NewClientStream only fails for the nil streams.
+		// This should not happen, since NewClientStream only fails for the nil streams.
 		tracedStream.span.LogFields(logFieldEventError, log.String("message", "Failed to wrap traced client stream"))
 		tracedStream.span.Finish()
 		return tracedStream.clientStream

--- a/internal/tracinginterceptor/interceptor_test.go
+++ b/internal/tracinginterceptor/interceptor_test.go
@@ -625,9 +625,6 @@ func TestInterceptorCallStream(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, stream)
 
-	// Check that exactly one span has finished and contains correct tags
-	finishedSpans := tracer.FinishedSpans()
-	require.Len(t, finishedSpans, 1, "Expected one span to be finished.")
 }
 
 func TestInterceptorCallStream_Error(t *testing.T) {
@@ -657,14 +654,6 @@ func TestInterceptorCallStream_Error(t *testing.T) {
 	// Call CallStream and expect an error
 	_, err = interceptor.CallStream(ctx, req, outbound)
 	require.Error(t, err)
-
-	// Check that one span has finished and contains error details
-	finishedSpans := tracer.FinishedSpans()
-	require.Len(t, finishedSpans, 1, "Expected one span to be finished.")
-	spanTags := finishedSpans[0].Tags()
-
-	// Verify the rpcStatusCodeTag is set correctly for the invalid-argument error
-	assert.Equal(t, int(yarpcerrors.CodeInvalidArgument), spanTags[rpcStatusCodeTag], "Expected rpcStatusCodeTag to be set to invalid-argument")
 }
 
 // TestGetPropagationCarrier verifies the getPropagationCarrier returns the correct

--- a/internal/tracinginterceptor/interceptor_test.go
+++ b/internal/tracinginterceptor/interceptor_test.go
@@ -527,6 +527,146 @@ func TestInterceptorCallOneway(t *testing.T) {
 	}
 }
 
+func TestInterceptorHandleStream(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tracer := mocktracer.New()
+	interceptor := New(Params{
+		Tracer:    tracer,
+		Transport: "http",
+	})
+
+	// Mock the server stream and stream handler
+	mockStream := transporttest.NewMockStream(ctrl)
+	mockStream.EXPECT().Context().Return(context.Background()).AnyTimes()
+	mockStream.EXPECT().Request().Return(&transport.StreamRequest{Meta: &transport.RequestMeta{Procedure: "test-procedure"}}).AnyTimes()
+
+	serverStream, err := transport.NewServerStream(mockStream)
+	require.NoError(t, err)
+
+	handler := transporttest.NewMockStreamHandler(ctrl)
+	handler.EXPECT().HandleStream(serverStream).Return(nil)
+
+	// Call HandleStream and validate behavior
+	err = interceptor.HandleStream(serverStream, handler)
+	require.NoError(t, err)
+
+	// Check that exactly one span has finished and its tags
+	finishedSpans := tracer.FinishedSpans()
+	require.Len(t, finishedSpans, 1, "Expected one span to be finished.")
+	spanTags := finishedSpans[0].Tags()
+
+	// Verify error.tag is absent for success cases
+	assert.Nil(t, spanTags["error.type"], "Expected no error.type tag to be set")
+}
+
+func TestInterceptorHandleStream_Error(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tracer := mocktracer.New()
+	interceptor := New(Params{
+		Tracer:    tracer,
+		Transport: "http",
+	})
+
+	// Mock the server stream and stream handler
+	mockStream := transporttest.NewMockStream(ctrl)
+	mockStream.EXPECT().Context().Return(context.Background()).AnyTimes()
+	mockStream.EXPECT().Request().Return(&transport.StreamRequest{Meta: &transport.RequestMeta{Procedure: "test-procedure"}}).AnyTimes()
+
+	serverStream, err := transport.NewServerStream(mockStream)
+	require.NoError(t, err)
+
+	handler := transporttest.NewMockStreamHandler(ctrl)
+	handler.EXPECT().HandleStream(serverStream).Return(yarpcerrors.Newf(yarpcerrors.CodeInternal, "handler error"))
+
+	// Call HandleStream and capture any error
+	err = interceptor.HandleStream(serverStream, handler)
+	require.Error(t, err)
+
+	// Check that one span has finished and contains error details
+	finishedSpans := tracer.FinishedSpans()
+	require.Len(t, finishedSpans, 1, "Expected one span to be finished.")
+	spanTags := finishedSpans[0].Tags()
+
+	// Verify the rpcStatusCodeTag is set correctly for the internal error
+	assert.Equal(t, int(yarpcerrors.CodeInternal), spanTags[rpcStatusCodeTag], "Expected rpcStatusCodeTag to be set to 'internal'")
+}
+
+func TestInterceptorCallStream(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tracer := mocktracer.New()
+	interceptor := New(Params{
+		Tracer:    tracer,
+		Transport: "http",
+	})
+
+	// Mock the client stream and outbound
+	mockStream := transporttest.NewMockStreamCloser(ctrl)
+	mockStream.EXPECT().Context().Return(context.Background()).AnyTimes()
+	mockStream.EXPECT().Request().Return(&transport.StreamRequest{Meta: &transport.RequestMeta{Procedure: "test-procedure"}}).AnyTimes()
+
+	clientStream, err := transport.NewClientStream(mockStream)
+	require.NoError(t, err)
+
+	outbound := transporttest.NewMockStreamOutbound(ctrl)
+	outbound.EXPECT().CallStream(gomock.Any(), gomock.Any()).Return(clientStream, nil)
+
+	req := &transport.StreamRequest{
+		Meta: &transport.RequestMeta{Procedure: "test-procedure"},
+	}
+
+	// Call CallStream and validate behavior
+	stream, err := interceptor.CallStream(context.Background(), req, outbound)
+	require.NoError(t, err)
+	require.NotNil(t, stream)
+
+	// Check that exactly one span has finished and contains correct tags
+	finishedSpans := tracer.FinishedSpans()
+	require.Len(t, finishedSpans, 1, "Expected one span to be finished.")
+}
+
+func TestInterceptorCallStream_Error(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tracer := mocktracer.New()
+	interceptor := New(Params{
+		Tracer:    tracer,
+		Transport: "http",
+	})
+
+	// Mock the client stream and outbound stream
+	mockStreamCloser := transporttest.NewMockStreamCloser(ctrl)
+	clientStream, err := transport.NewClientStream(mockStreamCloser)
+	require.NoError(t, err)
+
+	outbound := transporttest.NewMockStreamOutbound(ctrl)
+	outbound.EXPECT().
+		CallStream(gomock.Any(), gomock.Any()).
+		Return(clientStream, yarpcerrors.Newf(yarpcerrors.CodeInvalidArgument, "call error"))
+
+	// Set up the request
+	ctx := context.Background()
+	req := &transport.StreamRequest{Meta: &transport.RequestMeta{Procedure: "test-procedure"}}
+
+	// Call CallStream and expect an error
+	_, err = interceptor.CallStream(ctx, req, outbound)
+	require.Error(t, err)
+
+	// Check that one span has finished and contains error details
+	finishedSpans := tracer.FinishedSpans()
+	require.Len(t, finishedSpans, 1, "Expected one span to be finished.")
+	spanTags := finishedSpans[0].Tags()
+
+	// Verify the rpcStatusCodeTag is set correctly for the invalid-argument error
+	assert.Equal(t, int(yarpcerrors.CodeInvalidArgument), spanTags[rpcStatusCodeTag], "Expected rpcStatusCodeTag to be set to invalid-argument")
+}
+
 // TestGetPropagationCarrier verifies the getPropagationCarrier returns the correct
 // carrier type based on the specified transport. For "tchannel" transport, it should
 // return a tracing.HeadersCarrier, while for other transports (e.g., "http"), it

--- a/internal/tracinginterceptor/tracedstream.go
+++ b/internal/tracinginterceptor/tracedstream.go
@@ -65,9 +65,8 @@ func (t *tracedClientStream) ReceiveMessage(ctx context.Context) (*transport.Str
 	if err != nil {
 		if err == io.EOF {
 			return msg, t.closeWithErr(nil)
-		} else {
-			return msg, t.closeWithErr(err)
 		}
+		return msg, t.closeWithErr(err)
 	}
 	return msg, nil
 }

--- a/internal/tracinginterceptor/tracedstream.go
+++ b/internal/tracinginterceptor/tracedstream.go
@@ -64,12 +64,12 @@ func (t *tracedClientStream) ReceiveMessage(ctx context.Context) (*transport.Str
 	msg, err := t.clientStream.ReceiveMessage(ctx)
 	if err != nil {
 		if err == io.EOF {
-			t.closeWithErr(nil)
+			return msg, t.closeWithErr(nil)
 		} else {
-			t.closeWithErr(err)
+			return msg, t.closeWithErr(err)
 		}
 	}
-	return msg, err
+	return msg, nil
 }
 
 // Close closes the stream and updates the span with any final error details.
@@ -80,8 +80,8 @@ func (t *tracedClientStream) Close(ctx context.Context) error {
 // closeWithErr closes the span with error details, ensuring it is only closed once.
 func (t *tracedClientStream) closeWithErr(err error) error {
 	if !t.closed.Swap(true) {
-		updateSpanWithErrorDetails(t.span, err != nil, nil, err)
 		t.span.Finish()
+		return updateSpanWithErrorDetails(t.span, err != nil, nil, err)
 	}
 	return err
 }

--- a/internal/tracinginterceptor/tracedstream.go
+++ b/internal/tracinginterceptor/tracedstream.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2024 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tracinginterceptor
+
+import (
+	"context"
+	"github.com/opentracing/opentracing-go"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/zap"
+)
+
+// tracedServerStream implements transport.ServerStream and additional tracing capabilities.
+type tracedServerStream struct {
+	transport.ServerStream
+	span             opentracing.Span
+	isApplicationErr bool
+	appErrorMeta     *transport.ApplicationErrorMeta
+	log              *zap.Logger // Adding logger for error handling
+}
+
+// newTracedServerStream creates a new tracedServerStream with embedded ServerStream.
+func newTracedServerStream(s transport.ServerStream, span opentracing.Span, logger *zap.Logger) *tracedServerStream {
+	return &tracedServerStream{
+		ServerStream: s,
+		span:         span,
+		log:          logger,
+	}
+}
+
+func (t *tracedServerStream) IsApplicationError() bool {
+	return t.isApplicationErr
+}
+
+func (t *tracedServerStream) ApplicationErrorMeta() *transport.ApplicationErrorMeta {
+	return t.appErrorMeta
+}
+
+func (t *tracedServerStream) SendMessage(ctx context.Context, msg *transport.StreamMessage) error {
+	err := t.ServerStream.SendMessage(ctx, msg)
+	if updateErr := updateSpanWithErrorDetails(t.span, t.isApplicationErr, t.appErrorMeta, err); updateErr != nil {
+		t.log.Error("Failed to update span with error details", zap.Error(updateErr))
+	}
+	return err
+}
+
+func (t *tracedServerStream) ReceiveMessage(ctx context.Context) (*transport.StreamMessage, error) {
+	msg, err := t.ServerStream.ReceiveMessage(ctx)
+	if updateErr := updateSpanWithErrorDetails(t.span, t.isApplicationErr, t.appErrorMeta, err); updateErr != nil {
+		t.log.Error("Failed to update span with error details", zap.Error(updateErr))
+	}
+	return msg, err
+}
+
+// tracedClientStream wraps ClientStream with tracing and error metadata.
+type tracedClientStream struct {
+	transport.ClientStream
+	span             opentracing.Span
+	isApplicationErr bool
+	appErrorMeta     *transport.ApplicationErrorMeta
+	log              *zap.Logger // Adding logger for error handling
+}
+
+func newTracedClientStream(cs *transport.ClientStream, span opentracing.Span, logger *zap.Logger) *tracedClientStream {
+	return &tracedClientStream{
+		ClientStream: *cs,
+		span:         span,
+		log:          logger,
+	}
+}
+
+func (t *tracedClientStream) IsApplicationError() bool {
+	return t.isApplicationErr
+}
+
+func (t *tracedClientStream) ApplicationErrorMeta() *transport.ApplicationErrorMeta {
+	return t.appErrorMeta
+}
+
+func (t *tracedClientStream) SendMessage(ctx context.Context, msg *transport.StreamMessage) error {
+	err := t.ClientStream.SendMessage(ctx, msg)
+	if updateErr := updateSpanWithErrorDetails(t.span, t.isApplicationErr, t.appErrorMeta, err); updateErr != nil {
+		t.log.Error("Failed to update span with error details", zap.Error(updateErr))
+	}
+	return err
+}
+
+func (t *tracedClientStream) ReceiveMessage(ctx context.Context) (*transport.StreamMessage, error) {
+	msg, err := t.ClientStream.ReceiveMessage(ctx)
+	if updateErr := updateSpanWithErrorDetails(t.span, t.isApplicationErr, t.appErrorMeta, err); updateErr != nil {
+		t.log.Error("Failed to update span with error details", zap.Error(updateErr))
+	}
+	return msg, err
+}
+
+func (t *tracedClientStream) Close(ctx context.Context) error {
+	err := t.ClientStream.Close(ctx)
+	if updateErr := updateSpanWithErrorDetails(t.span, t.isApplicationErr, t.appErrorMeta, err); updateErr != nil {
+		t.log.Error("Failed to update span with error details", zap.Error(updateErr))
+	}
+	t.span.Finish()
+	return err
+}

--- a/internal/tracinginterceptor/tracedstream.go
+++ b/internal/tracinginterceptor/tracedstream.go
@@ -38,8 +38,29 @@ type tracedServerStream struct {
 	log              *zap.Logger
 }
 
+// newTracedServerStream creates a new tracedServerStream with embedded ServerStream.
+func newTracedServerStream(s transport.ServerStream, span opentracing.Span, logger *zap.Logger) *tracedServerStream {
+	return &tracedServerStream{
+		ServerStream: &s,
+		span:         span,
+		log:          logger,
+	}
+}
+
+func (t *tracedServerStream) IsApplicationError() bool {
+	return t.isApplicationErr
+}
+
 func (t *tracedServerStream) ApplicationErrorMeta() *transport.ApplicationErrorMeta {
 	return t.appErrorMeta
+}
+
+func (t *tracedServerStream) SetApplicationError() {
+	t.isApplicationErr = true
+}
+
+func (t *tracedServerStream) SetApplicationErrorMeta(appErrorMeta *transport.ApplicationErrorMeta) {
+	t.appErrorMeta = appErrorMeta
 }
 
 func (t *tracedServerStream) SendMessage(ctx context.Context, msg *transport.StreamMessage) error {
@@ -83,6 +104,14 @@ func (t *tracedClientStream) IsApplicationError() bool {
 
 func (t *tracedClientStream) ApplicationErrorMeta() *transport.ApplicationErrorMeta {
 	return t.appErrorMeta
+}
+
+func (t *tracedClientStream) SetApplicationError() {
+	t.isApplicationErr = true
+}
+
+func (t *tracedClientStream) SetApplicationErrorMeta(appErrorMeta *transport.ApplicationErrorMeta) {
+	t.appErrorMeta = appErrorMeta
 }
 
 func (t *tracedClientStream) SendMessage(ctx context.Context, msg *transport.StreamMessage) error {

--- a/internal/tracinginterceptor/tracedstream.go
+++ b/internal/tracinginterceptor/tracedstream.go
@@ -27,7 +27,7 @@ import (
 	"go.uber.org/zap"
 )
 
-// tracedServerStream implements transport.ServerStream and additional tracing capabilities.
+// tracedServerStream implements the transport.ServerStream and additional tracing capabilities.
 type tracedServerStream struct {
 	transport.ServerStream
 	span             opentracing.Span

--- a/internal/tracinginterceptor/tracedstream.go
+++ b/internal/tracinginterceptor/tracedstream.go
@@ -38,29 +38,8 @@ type tracedServerStream struct {
 	log              *zap.Logger
 }
 
-// newTracedServerStream creates a new tracedServerStream with embedded ServerStream.
-func newTracedServerStream(s transport.ServerStream, span opentracing.Span, logger *zap.Logger) *tracedServerStream {
-	return &tracedServerStream{
-		ServerStream: &s,
-		span:         span,
-		log:          logger,
-	}
-}
-
-func (t *tracedServerStream) IsApplicationError() bool {
-	return t.isApplicationErr
-}
-
 func (t *tracedServerStream) ApplicationErrorMeta() *transport.ApplicationErrorMeta {
 	return t.appErrorMeta
-}
-
-func (t *tracedServerStream) SetApplicationError() {
-	t.isApplicationErr = true
-}
-
-func (t *tracedServerStream) SetApplicationErrorMeta(appErrorMeta *transport.ApplicationErrorMeta) {
-	t.appErrorMeta = appErrorMeta
 }
 
 func (t *tracedServerStream) SendMessage(ctx context.Context, msg *transport.StreamMessage) error {
@@ -104,14 +83,6 @@ func (t *tracedClientStream) IsApplicationError() bool {
 
 func (t *tracedClientStream) ApplicationErrorMeta() *transport.ApplicationErrorMeta {
 	return t.appErrorMeta
-}
-
-func (t *tracedClientStream) SetApplicationError() {
-	t.isApplicationErr = true
-}
-
-func (t *tracedClientStream) SetApplicationErrorMeta(appErrorMeta *transport.ApplicationErrorMeta) {
-	t.appErrorMeta = appErrorMeta
 }
 
 func (t *tracedClientStream) SendMessage(ctx context.Context, msg *transport.StreamMessage) error {


### PR DESCRIPTION
This PR added the HandleStream and CallStream functions, as well as tracing wrappers in tracedstream.go. These wrappers enhance StreamHandler and ClientStream by embedding tracing spans to capture error details and application-specific metadata throughout stream operations.