### PR TITLE
Feat: Add http2 server support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 =======
 ## [Unreleased]
+### Added
+- HTTP2 server support for the HTTP inbound.
+  - The HTTP inbound now supports HTTP2 connections as well by default.
+  - Inbound config option to disable HTTP2 server support (this will only allow HTTP1.1 connections).
 ### Changed
 - Updated grpc-go to v1.59.0
 

--- a/internal/integrationtest/util_test.go
+++ b/internal/integrationtest/util_test.go
@@ -30,7 +30,7 @@ import (
 	"go.uber.org/yarpc/transport/http"
 )
 
-var spec = integrationtest.TransportSpec{
+var http1spec = integrationtest.TransportSpec{
 	Identify: hostport.Identify,
 	NewServerTransport: func(t *testing.T, addr string) peer.Transport {
 		return http.NewTransport()
@@ -42,7 +42,8 @@ var spec = integrationtest.TransportSpec{
 		return x.(*http.Transport).NewOutbound(pc)
 	},
 	NewInbound: func(x peer.Transport, addr string) transport.Inbound {
-		return x.(*http.Transport).NewInbound(addr)
+		// disable http2
+		return x.(*http.Transport).NewInbound(addr, http.DisableHTTP2(true))
 	},
 	Addr: func(x peer.Transport, ib transport.Inbound) string {
 		return ib.(*http.Inbound).Addr().String()
@@ -50,5 +51,30 @@ var spec = integrationtest.TransportSpec{
 }
 
 func TestIntegrationWithHTTP(t *testing.T) {
-	spec.Test(t)
+	http1spec.Test(t)
+}
+
+var http2spec = integrationtest.TransportSpec{
+	Identify: hostport.Identify,
+	NewServerTransport: func(t *testing.T, addr string) peer.Transport {
+		return http.NewTransport()
+	},
+	NewClientTransport: func(t *testing.T) peer.Transport {
+		// TODO: will update this once we add client support
+		return http.NewTransport()
+	},
+	NewUnaryOutbound: func(x peer.Transport, pc peer.Chooser) transport.UnaryOutbound {
+		return x.(*http.Transport).NewOutbound(pc)
+	},
+	NewInbound: func(x peer.Transport, addr string) transport.Inbound {
+		// we don't disable http2
+		return x.(*http.Transport).NewInbound(addr)
+	},
+	Addr: func(x peer.Transport, ib transport.Inbound) string {
+		return ib.(*http.Inbound).Addr().String()
+	},
+}
+
+func TestIntegrationWithHTTP2(t *testing.T) {
+	http2spec.Test(t)
 }

--- a/transport/http/config.go
+++ b/transport/http/config.go
@@ -174,8 +174,8 @@ type InboundConfig struct {
 	ShutdownTimeout *time.Duration `config:"shutdownTimeout"`
 	// TLS configuration of the inbound.
 	TLSConfig TLSConfig `config:"tls"`
-	// UseHTTP2 configure to accept http2 requests. This field is optional. Default is true.
-	UseHTTP2 *bool `config:"useHTTP2"`
+	// DisableHTTP2 configure to reject http2 requests.
+	DisableHTTP2 bool `config:"disableHTTP2"`
 }
 
 // TLSConfig specifies the TLS configuration of the HTTP inbound.
@@ -204,9 +204,7 @@ func (ts *transportSpec) buildInbound(ic *InboundConfig, t transport.Transport, 
 		inboundOptions = append(inboundOptions, ShutdownTimeout(*ic.ShutdownTimeout))
 	}
 
-	if ic.UseHTTP2 != nil {
-		inboundOptions = append(inboundOptions, InboundUseHTTP2(*ic.UseHTTP2))
-	}
+	inboundOptions = append(inboundOptions, DisableHTTP2(ic.DisableHTTP2))
 
 	return t.(*Transport).NewInbound(ic.Address, inboundOptions...), nil
 }

--- a/transport/http/config.go
+++ b/transport/http/config.go
@@ -174,6 +174,8 @@ type InboundConfig struct {
 	ShutdownTimeout *time.Duration `config:"shutdownTimeout"`
 	// TLS configuration of the inbound.
 	TLSConfig TLSConfig `config:"tls"`
+	// HttpVersion specifies the HTTP version that the inbound should accept.
+	HttpVersion *httpVersion `config:"httpVersion"`
 }
 
 // TLSConfig specifies the TLS configuration of the HTTP inbound.
@@ -200,6 +202,10 @@ func (ts *transportSpec) buildInbound(ic *InboundConfig, t transport.Transport, 
 			return nil, fmt.Errorf("shutdownTimeout must not be negative, got: %q", ic.ShutdownTimeout)
 		}
 		inboundOptions = append(inboundOptions, ShutdownTimeout(*ic.ShutdownTimeout))
+	}
+
+	if ic.HttpVersion != nil {
+		inboundOptions = append(inboundOptions, InboundHttpVersion(*ic.HttpVersion))
 	}
 
 	return t.(*Transport).NewInbound(ic.Address, inboundOptions...), nil

--- a/transport/http/config.go
+++ b/transport/http/config.go
@@ -175,7 +175,7 @@ type InboundConfig struct {
 	// TLS configuration of the inbound.
 	TLSConfig TLSConfig `config:"tls"`
 	// HttpVersion specifies the HTTP version that the inbound should accept.
-	HttpVersion *httpVersion `config:"httpVersion"`
+	HTTPVersion *httpVersion `config:"httpVersion"`
 }
 
 // TLSConfig specifies the TLS configuration of the HTTP inbound.
@@ -204,8 +204,8 @@ func (ts *transportSpec) buildInbound(ic *InboundConfig, t transport.Transport, 
 		inboundOptions = append(inboundOptions, ShutdownTimeout(*ic.ShutdownTimeout))
 	}
 
-	if ic.HttpVersion != nil {
-		inboundOptions = append(inboundOptions, InboundHttpVersion(*ic.HttpVersion))
+	if ic.HTTPVersion != nil {
+		inboundOptions = append(inboundOptions, InboundHTTPVersion(*ic.HTTPVersion))
 	}
 
 	return t.(*Transport).NewInbound(ic.Address, inboundOptions...), nil

--- a/transport/http/config.go
+++ b/transport/http/config.go
@@ -174,8 +174,8 @@ type InboundConfig struct {
 	ShutdownTimeout *time.Duration `config:"shutdownTimeout"`
 	// TLS configuration of the inbound.
 	TLSConfig TLSConfig `config:"tls"`
-	// HttpVersion specifies the HTTP version that the inbound should accept.
-	HTTPVersion *httpVersion `config:"httpVersion"`
+	// UseHTTP2 configure to accept http2 requests. This field is optional. Default is true.
+	UseHTTP2 *bool `config:"useHTTP2"`
 }
 
 // TLSConfig specifies the TLS configuration of the HTTP inbound.
@@ -204,8 +204,8 @@ func (ts *transportSpec) buildInbound(ic *InboundConfig, t transport.Transport, 
 		inboundOptions = append(inboundOptions, ShutdownTimeout(*ic.ShutdownTimeout))
 	}
 
-	if ic.HTTPVersion != nil {
-		inboundOptions = append(inboundOptions, InboundHTTPVersion(*ic.HTTPVersion))
+	if ic.UseHTTP2 != nil {
+		inboundOptions = append(inboundOptions, InboundUseHTTP2(*ic.UseHTTP2))
 	}
 
 	return t.(*Transport).NewInbound(ic.Address, inboundOptions...), nil

--- a/transport/http/config_test.go
+++ b/transport/http/config_test.go
@@ -244,10 +244,16 @@ func TestTransportSpec(t *testing.T) {
 			wantErrors: []string{`shutdownTimeout must not be negative, got: "-1s"`},
 		},
 		{
-			desc:        "useHTTP2 false",
-			cfg:         attrs{"address": ":8080", "shutdownTimeout": "0s"},
+			desc:        "useHTTP2 false as cfg",
+			cfg:         attrs{"address": ":8080", "useHTTP2": false},
+			opts:        []Option{},
+			wantInbound: &wantInbound{Address: ":8080", ShutdownTimeout: defaultShutdownTimeout, UseHTTP2: &useHTTP2False},
+		},
+		{
+			desc:        "useHTTP2 false as option",
+			cfg:         attrs{"address": ":8080"},
 			opts:        []Option{InboundUseHTTP2(false)},
-			wantInbound: &wantInbound{Address: ":8080", ShutdownTimeout: 0, UseHTTP2: &useHTTP2False},
+			wantInbound: &wantInbound{Address: ":8080", ShutdownTimeout: defaultShutdownTimeout, UseHTTP2: &useHTTP2False},
 		},
 	}
 

--- a/transport/http/inbound.go
+++ b/transport/http/inbound.go
@@ -47,7 +47,7 @@ type httpVersion int
 
 const (
 	// it only accepts http1 request
-	version1 httpVersion = iota
+	_ httpVersion = iota
 	// it accepts both http1 & http2 request
 	version2
 )
@@ -141,8 +141,8 @@ func InboundTLSMode(mode yarpctls.Mode) InboundOption {
 	}
 }
 
-// InboundHttpVersion specifies the HTTP version that the inbound should accept.
-func InboundHttpVersion(version httpVersion) InboundOption {
+// InboundHTTPVersion specifies the HTTP version that the inbound should accept.
+func InboundHTTPVersion(version httpVersion) InboundOption {
 	return func(i *Inbound) {
 		i.httpVersion = version
 	}

--- a/transport/http/inbound.go
+++ b/transport/http/inbound.go
@@ -46,7 +46,9 @@ import (
 type httpVersion int
 
 const (
+	// it only accepts http1 request
 	version1 httpVersion = iota
+	// it accepts both http1 & http2 request
 	version2
 )
 
@@ -136,6 +138,13 @@ func InboundTLSConfiguration(tlsConfig *tls.Config) InboundOption {
 func InboundTLSMode(mode yarpctls.Mode) InboundOption {
 	return func(i *Inbound) {
 		i.tlsMode = mode
+	}
+}
+
+// InboundHttpVersion specifies the HTTP version that the inbound should accept.
+func InboundHttpVersion(version httpVersion) InboundOption {
+	return func(i *Inbound) {
+		i.httpVersion = version
 	}
 }
 

--- a/transport/http/inbound.go
+++ b/transport/http/inbound.go
@@ -30,8 +30,6 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/net/http2"
-
 	"github.com/opentracing/opentracing-go"
 	"go.uber.org/yarpc/api/transport"
 	yarpctls "go.uber.org/yarpc/api/transport/tls"
@@ -41,6 +39,8 @@ import (
 	"go.uber.org/yarpc/transport/internal/tls/muxlistener"
 	"go.uber.org/yarpc/yarpcerrors"
 	"go.uber.org/zap"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
 )
 
 type httpVersion int
@@ -246,6 +246,7 @@ func (i *Inbound) start() error {
 	}
 	if i.httpVersion == version2 {
 		h2s := &http2.Server{}
+		server.Handler = h2c.NewHandler(server.Handler, h2s)
 		err := http2.ConfigureServer(server, h2s)
 		if err != nil {
 			return fmt.Errorf("failed to configure HTTP/2 server: %w", err)

--- a/transport/http/inbound.go
+++ b/transport/http/inbound.go
@@ -43,15 +43,6 @@ import (
 	"golang.org/x/net/http2/h2c"
 )
 
-type httpVersion int
-
-const (
-	// it only accepts http1 request
-	_ httpVersion = iota
-	// it accepts both http1 & http2 request
-	version2
-)
-
 const (
 	// We want a value that's around 5 seconds, but slightly higher than how
 	// long a successful HTTP shutdown can take.


### PR DESCRIPTION
- [X] Description and context for reviewers: one partner, one stranger
  - Add http2 server support - version2 accept both http1 and http2 request. So all existing inbounds should work as expected. 
  - Add config that can be used to override this 
  - [Test Checklist ](https://docs.google.com/document/d/1mYfH0DmC3Rg61oSV5ulzCVUJsXrHEOuTY4TOfrcTmWM/edit?usp=sharing)
- [X] Entry in CHANGELOG.md
