### PR TITLE
Add HTTP2 client support (without TLS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 =======
 ## [Unreleased]
+### Added
+- HTTP2 client support for the HTTP outbound.
+  - Client/Peer will use http2.Transport based on the outbound configuration.
+  - Added `useHTTP2` option to the HTTP outbound configuration to enable HTTP2 client support.
 ### Fixed
 - Columns in the HTML Outbounds table on the debug page now properly line up
   with header rows.

--- a/internal/integrationtest/util_test.go
+++ b/internal/integrationtest/util_test.go
@@ -64,7 +64,7 @@ var http2spec = integrationtest.TransportSpec{
 		return http.NewTransport()
 	},
 	NewUnaryOutbound: func(x peer.Transport, pc peer.Chooser) transport.UnaryOutbound {
-		return x.(*http.Transport).NewOutbound(pc, http.EnableHTTP2())
+		return x.(*http.Transport).NewOutbound(pc, http.UseHTTP2())
 	},
 	NewInbound: func(x peer.Transport, addr string) transport.Inbound {
 		// we don't disable http2

--- a/internal/integrationtest/util_test.go
+++ b/internal/integrationtest/util_test.go
@@ -64,7 +64,7 @@ var http2spec = integrationtest.TransportSpec{
 		return http.NewTransport()
 	},
 	NewUnaryOutbound: func(x peer.Transport, pc peer.Chooser) transport.UnaryOutbound {
-		return x.(*http.Transport).NewOutbound(pc)
+		return x.(*http.Transport).NewOutbound(pc, http.EnableHTTP2())
 	},
 	NewInbound: func(x peer.Transport, addr string) transport.Inbound {
 		// we don't disable http2

--- a/transport/http/config.go
+++ b/transport/http/config.go
@@ -94,6 +94,7 @@ func (ts *transportSpec) Spec() yarpcconfig.TransportSpec {
 //	      exponential:
 //	        first: 10ms
 //	        max: 30s
+//	    useHTTP2: true
 //
 // All parameters of TransportConfig are optional. This section may be omitted
 // in the transports section.
@@ -109,7 +110,6 @@ type TransportConfig struct {
 	ResponseHeaderTimeout time.Duration       `config:"responseHeaderTimeout"`
 	ConnTimeout           time.Duration       `config:"connTimeout"`
 	ConnBackoff           yarpcconfig.Backoff `config:"connBackoff"`
-	useHTTP2              bool                `config:"useHTTP2"`
 }
 
 func (ts *transportSpec) buildTransport(tc *TransportConfig, k *yarpcconfig.Kit) (transport.Transport, error) {
@@ -145,9 +145,6 @@ func (ts *transportSpec) buildTransport(tc *TransportConfig, k *yarpcconfig.Kit)
 	}
 	if tc.ConnTimeout > 0 {
 		options.connTimeout = tc.ConnTimeout
-	}
-	if tc.useHTTP2 {
-		options.useHTTP2 = true
 	}
 
 	strategy, err := tc.ConnBackoff.Strategy()

--- a/transport/http/config.go
+++ b/transport/http/config.go
@@ -109,7 +109,7 @@ type TransportConfig struct {
 	ResponseHeaderTimeout time.Duration       `config:"responseHeaderTimeout"`
 	ConnTimeout           time.Duration       `config:"connTimeout"`
 	ConnBackoff           yarpcconfig.Backoff `config:"connBackoff"`
-	EnableHTTP2           bool                `config:"enableHTTP2"`
+	useHTTP2              bool                `config:"useHTTP2"`
 }
 
 func (ts *transportSpec) buildTransport(tc *TransportConfig, k *yarpcconfig.Kit) (transport.Transport, error) {
@@ -146,8 +146,8 @@ func (ts *transportSpec) buildTransport(tc *TransportConfig, k *yarpcconfig.Kit)
 	if tc.ConnTimeout > 0 {
 		options.connTimeout = tc.ConnTimeout
 	}
-	if tc.EnableHTTP2 {
-		options.enableHTTP2 = true
+	if tc.useHTTP2 {
+		options.useHTTP2 = true
 	}
 
 	strategy, err := tc.ConnBackoff.Strategy()
@@ -268,12 +268,12 @@ type OutboundConfig struct {
 	//      spiffe-ids:
 	//        - destination-id
 	TLS OutboundTLSConfig `config:"tls"`
-	// EnableHTTP2 configure to enable http2 requests.
+	// UseHTTP2 configure to send http2 requests.
 	//
 	// http:
 	// 		url: "http://localhost:8080/yarpc"
-	// 		enableHTTP2: true
-	EnableHTTP2 bool `config:"enableHTTP2"`
+	// 		useHTTP2: true
+	UseHTTP2 bool `config:"useHTTP2"`
 }
 
 // OutboundTLSConfig configures TLS for the HTTP outbound.
@@ -325,8 +325,8 @@ func (ts *transportSpec) buildOutbound(oc *OutboundConfig, t transport.Transport
 	}
 	opts = append(option, opts...)
 
-	if oc.EnableHTTP2 {
-		opts = append(opts, EnableHTTP2())
+	if oc.UseHTTP2 {
+		opts = append(opts, UseHTTP2())
 	}
 
 	// Special case where the URL implies the single peer.

--- a/transport/http/config_test.go
+++ b/transport/http/config_test.go
@@ -514,23 +514,6 @@ func TestTransportSpec(t *testing.T) {
 			wantErrors: []string{"outbound TLS enforced but outbound TLS config provider is nil"},
 		},
 		{
-			desc: "enable http2 outbound with cfg",
-			cfg: attrs{
-				"myservice": attrs{
-					TransportName: attrs{
-						"url":      "http://localhost/yarpc",
-						"useHTTP2": true,
-					},
-				},
-			},
-			wantOutbounds: map[string]wantOutbound{
-				"myservice": {
-					URLTemplate: "http://localhost/yarpc",
-					UseHTTP2:    true,
-				},
-			},
-		},
-		{
 			desc: "enable http2 outbound with options",
 			cfg: attrs{
 				"myservice": attrs{
@@ -540,6 +523,23 @@ func TestTransportSpec(t *testing.T) {
 				},
 			},
 			opts: []Option{UseHTTP2()},
+			wantOutbounds: map[string]wantOutbound{
+				"myservice": {
+					URLTemplate: "http://localhost/yarpc",
+					UseHTTP2:    true,
+				},
+			},
+		},
+		{
+			desc: "enable http2 outbound with outbound cfg",
+			cfg: attrs{
+				"myservice": attrs{
+					TransportName: attrs{
+						"url":      "http://localhost/yarpc",
+						"useHTTP2": true,
+					},
+				},
+			},
 			wantOutbounds: map[string]wantOutbound{
 				"myservice": {
 					URLTemplate: "http://localhost/yarpc",
@@ -632,7 +632,7 @@ func TestTransportSpec(t *testing.T) {
 				assert.Equal(t, want.Headers, ob.headers, "outbound headers should match")
 				assert.Equal(t, svc, ob.destServiceName, "outbound destination service name must match")
 				assert.Equal(t, want.TLSConfig, ob.tlsConfig != nil, "unexpected outbound tls config")
-				assert.Equal(t, want.UseHTTP2, ob.useHTTP2, "useHTTP2 should match")
+				assert.Equal(t, want.UseHTTP2, ob.useHTTP2, "UseHTTP2 should match")
 			}
 
 		}
@@ -674,7 +674,6 @@ type wantHTTPClient struct {
 	DisableCompression    bool
 	ResponseHeaderTimeout time.Duration
 	ConnTimeout           time.Duration
-	UseHTTP2              bool
 }
 
 // useFakeBuildClient verifies the configuration we use to build an HTTP
@@ -689,7 +688,6 @@ func useFakeBuildClient(t *testing.T, want *wantHTTPClient) TransportOption {
 		assert.Equal(t, want.DisableCompression, options.disableCompression, "http.Client: DisableCompression should match")
 		assert.Equal(t, want.ResponseHeaderTimeout, options.responseHeaderTimeout, "http.Client: ResponseHeaderTimeout should match")
 		assert.Equal(t, want.ConnTimeout, options.connTimeout, "http.Client: ConnTimeout should match")
-		assert.Equal(t, want.UseHTTP2, options.useHTTP2, "http.Client: UseHTTP2 should match")
 		return buildHTTPClient(options)
 	})
 }

--- a/transport/http/config_test.go
+++ b/transport/http/config_test.go
@@ -674,6 +674,7 @@ type wantHTTPClient struct {
 	DisableCompression    bool
 	ResponseHeaderTimeout time.Duration
 	ConnTimeout           time.Duration
+	UseHTTP2              bool
 }
 
 // useFakeBuildClient verifies the configuration we use to build an HTTP
@@ -688,6 +689,7 @@ func useFakeBuildClient(t *testing.T, want *wantHTTPClient) TransportOption {
 		assert.Equal(t, want.DisableCompression, options.disableCompression, "http.Client: DisableCompression should match")
 		assert.Equal(t, want.ResponseHeaderTimeout, options.responseHeaderTimeout, "http.Client: ResponseHeaderTimeout should match")
 		assert.Equal(t, want.ConnTimeout, options.connTimeout, "http.Client: ConnTimeout should match")
+		assert.Equal(t, want.UseHTTP2, options.useHTTP2, "http.Client: UseHTTP2 should match")
 		return buildHTTPClient(options)
 	})
 }

--- a/transport/http/config_test.go
+++ b/transport/http/config_test.go
@@ -100,7 +100,7 @@ func TestTransportSpec(t *testing.T) {
 		URLTemplate string
 		Headers     http.Header
 		TLSConfig   bool
-		EnableHTTP2 bool
+		UseHTTP2    bool
 	}
 
 	type outboundTest struct {
@@ -518,15 +518,15 @@ func TestTransportSpec(t *testing.T) {
 			cfg: attrs{
 				"myservice": attrs{
 					TransportName: attrs{
-						"url":         "http://localhost/yarpc",
-						"enableHTTP2": true,
+						"url":      "http://localhost/yarpc",
+						"useHTTP2": true,
 					},
 				},
 			},
 			wantOutbounds: map[string]wantOutbound{
 				"myservice": {
 					URLTemplate: "http://localhost/yarpc",
-					EnableHTTP2: true,
+					UseHTTP2:    true,
 				},
 			},
 		},
@@ -539,11 +539,11 @@ func TestTransportSpec(t *testing.T) {
 					},
 				},
 			},
-			opts: []Option{EnableHTTP2()},
+			opts: []Option{UseHTTP2()},
 			wantOutbounds: map[string]wantOutbound{
 				"myservice": {
 					URLTemplate: "http://localhost/yarpc",
-					EnableHTTP2: true,
+					UseHTTP2:    true,
 				},
 			},
 		},
@@ -632,7 +632,7 @@ func TestTransportSpec(t *testing.T) {
 				assert.Equal(t, want.Headers, ob.headers, "outbound headers should match")
 				assert.Equal(t, svc, ob.destServiceName, "outbound destination service name must match")
 				assert.Equal(t, want.TLSConfig, ob.tlsConfig != nil, "unexpected outbound tls config")
-				assert.Equal(t, want.EnableHTTP2, ob.enableHTTP2, "enableHTTP2 should match")
+				assert.Equal(t, want.UseHTTP2, ob.useHTTP2, "useHTTP2 should match")
 			}
 
 		}

--- a/transport/http/config_test.go
+++ b/transport/http/config_test.go
@@ -100,6 +100,7 @@ func TestTransportSpec(t *testing.T) {
 		URLTemplate string
 		Headers     http.Header
 		TLSConfig   bool
+		EnableHTTP2 bool
 	}
 
 	type outboundTest struct {
@@ -512,6 +513,40 @@ func TestTransportSpec(t *testing.T) {
 			},
 			wantErrors: []string{"outbound TLS enforced but outbound TLS config provider is nil"},
 		},
+		{
+			desc: "enable http2 outbound with cfg",
+			cfg: attrs{
+				"myservice": attrs{
+					TransportName: attrs{
+						"url":         "http://localhost/yarpc",
+						"enableHTTP2": true,
+					},
+				},
+			},
+			wantOutbounds: map[string]wantOutbound{
+				"myservice": {
+					URLTemplate: "http://localhost/yarpc",
+					EnableHTTP2: true,
+				},
+			},
+		},
+		{
+			desc: "enable http2 outbound with options",
+			cfg: attrs{
+				"myservice": attrs{
+					TransportName: attrs{
+						"url": "http://localhost/yarpc",
+					},
+				},
+			},
+			opts: []Option{EnableHTTP2()},
+			wantOutbounds: map[string]wantOutbound{
+				"myservice": {
+					URLTemplate: "http://localhost/yarpc",
+					EnableHTTP2: true,
+				},
+			},
+		},
 	}
 
 	runTest := func(t *testing.T, trans transportTest, inbound inboundTest, outbound outboundTest) {
@@ -597,6 +632,7 @@ func TestTransportSpec(t *testing.T) {
 				assert.Equal(t, want.Headers, ob.headers, "outbound headers should match")
 				assert.Equal(t, svc, ob.destServiceName, "outbound destination service name must match")
 				assert.Equal(t, want.TLSConfig, ob.tlsConfig != nil, "unexpected outbound tls config")
+				assert.Equal(t, want.EnableHTTP2, ob.enableHTTP2, "enableHTTP2 should match")
 			}
 
 		}

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -188,7 +188,7 @@ func createHTTP2Client(o *Outbound) *http.Client {
 	if !ok {
 		// This should not happen as default yarpc http.Client uses
 		// http.Transport and it's not configurable by the user.
-		panic(fmt.Sprintf("failed to create http tls client, provided http.Client transport type %T is not *http.Transport", o.transport.client.Transport))
+		panic(fmt.Sprintf("failed to create http2 client, provided http.Client transport type %T is not *http.Transport", o.transport.client.Transport))
 	}
 	http2Transport := http2.Transport{
 		AllowHTTP: true,

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -72,19 +72,19 @@ func URLTemplate(template string) OutboundOption {
 	}
 }
 
-// EnableHTTP2 returns an OutboundOption that enables HTTP/2 support for the outbound.
+// UseHTTP2 returns an OutboundOption that enables HTTP/2 support for the outbound.
 // This option configures the outbound to use HTTP/2 for all outbound requests.
 //
 // Example usage:
 //
-//	outbound := http.NewOutbound(chooser, http.EnableHTTP2())
+//	outbound := http.NewOutbound(chooser, http.UseHTTP2())
 //
 // Returns:
 //
-//	OutboundOption: A function that sets the enableHTTP2 field to true in the Outbound struct.
-func EnableHTTP2() OutboundOption {
+//	OutboundOption: A function that sets the useHTTP2 field to true in the Outbound struct.
+func UseHTTP2() OutboundOption {
 	return func(o *Outbound) {
-		o.enableHTTP2 = true
+		o.useHTTP2 = true
 	}
 }
 
@@ -150,7 +150,7 @@ func (t *Transport) NewOutbound(chooser peer.Chooser, opts ...OutboundOption) *O
 
 	client := t.client
 	if o.tlsConfig != nil {
-		if o.enableHTTP2 {
+		if o.useHTTP2 {
 			client = createHTTP2TLSClient(o)
 		} else {
 			client = createTLSClient(o)
@@ -244,7 +244,7 @@ type Outbound struct {
 	client            *http.Client
 	tlsConfig         *tls.Config
 
-	enableHTTP2 bool
+	useHTTP2 bool
 }
 
 // TransportName is the transport name that will be set on `transport.Request` struct.

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -56,9 +56,11 @@ var (
 	_ transport.UnaryOutbound              = (*Outbound)(nil)
 	_ transport.OnewayOutbound             = (*Outbound)(nil)
 	_ introspection.IntrospectableOutbound = (*Outbound)(nil)
-)
 
-var defaultURLTemplate, _ = url.Parse("http://localhost")
+	defaultURLTemplate, _       = url.Parse("http://localhost")
+	defaultHTTP2PingTimeout     = 10 * time.Second
+	defaultHTTP2ReadIdleTimeout = 15 * time.Second
+)
 
 // OutboundOption customizes an HTTP Outbound.
 type OutboundOption func(*Outbound)
@@ -176,27 +178,32 @@ func createHTTP2Client(o *Outbound) *http.Client {
 		return createHTTP2TLSClient(o)
 	}
 
+	// check if transport is already http2 transport
+	if _, ok := o.transport.client.Transport.(*http2.Transport); ok {
+		return o.transport.client
+	}
+
+	// get default http1 transport from the client and use it to create http2 transport
 	http1Transport, ok := o.transport.client.Transport.(*http.Transport)
 	if !ok {
 		// This should not happen as default yarpc http.Client uses
 		// http.Transport and it's not configurable by the user.
 		panic(fmt.Sprintf("failed to create http tls client, provided http.Client transport type %T is not *http.Transport", o.transport.client.Transport))
 	}
-	http1Transport = http1Transport.Clone()
-	http2Transport, err := http2.ConfigureTransports(http1Transport)
-	if err != nil {
-		// TODO: log and default to http1 for now using it for testing
-		panic(fmt.Sprintf("failed to configure http2 transport: %v", err))
+	http2Transport := http2.Transport{
+		AllowHTTP: true,
+		DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+			return http1Transport.DialContext(ctx, network, addr)
+		},
+		DisableCompression: http1Transport.DisableCompression,
+		IdleConnTimeout:    defaultIdleConnTimeout,
+		PingTimeout:        defaultHTTP2PingTimeout,
+		ReadIdleTimeout:    defaultHTTP2ReadIdleTimeout,
 	}
-	// add http2 specific settings
-	http2Transport.AllowHTTP = true
-	http2Transport.DialTLSContext = func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
-		var d net.Dialer
-		return d.DialContext(ctx, network, addr)
-	}
-
+	// peer uses this client to make request
+	o.transport.client.Transport = &http2Transport
 	return &http.Client{
-		Transport: http2Transport,
+		Transport: &http2Transport,
 	}
 }
 

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -141,7 +141,7 @@ func TestCallSuccessWithHTTP2(t *testing.T) {
 
 	httpTransport := NewTransport()
 	defer httpTransport.Stop()
-	out := httpTransport.NewSingleOutbound(successServer.URL, EnableHTTP2())
+	out := httpTransport.NewSingleOutbound(successServer.URL, UseHTTP2())
 	require.NoError(t, out.Start(), "failed to start outbound")
 	defer out.Stop()
 

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -115,81 +115,201 @@ func TestCreateRequest(t *testing.T) {
 	}
 }
 
-func TestCallSuccessWithHTTP2(t *testing.T) {
-	handler := http.HandlerFunc(
-		func(w http.ResponseWriter, req *http.Request) {
-			defer req.Body.Close()
+func TestCallWithHTTP2(t *testing.T) {
+	t.Run("success - http2 client with http2 server", func(t *testing.T) {
+		handler := http.HandlerFunc(
+			func(w http.ResponseWriter, req *http.Request) {
+				defer req.Body.Close()
 
-			ttl := req.Header.Get(TTLMSHeader)
-			ttlms, err := strconv.Atoi(ttl)
-			assert.NoError(t, err, "can parse TTL header")
-			assert.InDelta(t, ttlms, testtime.X*1000.0, testtime.X*5.0, "ttl header within tolerance")
+				ttl := req.Header.Get(TTLMSHeader)
+				ttlms, err := strconv.Atoi(ttl)
+				assert.NoError(t, err, "can parse TTL header")
+				assert.InDelta(t, ttlms, testtime.X*1000.0, testtime.X*5.0, "ttl header within tolerance")
 
-			assert.Equal(t, "caller", req.Header.Get(CallerHeader))
-			assert.Equal(t, "service", req.Header.Get(ServiceHeader))
-			assert.Equal(t, "raw", req.Header.Get(EncodingHeader))
-			assert.Equal(t, "hello", req.Header.Get(ProcedureHeader))
+				assert.Equal(t, "caller", req.Header.Get(CallerHeader))
+				assert.Equal(t, "service", req.Header.Get(ServiceHeader))
+				assert.Equal(t, "raw", req.Header.Get(EncodingHeader))
+				assert.Equal(t, "hello", req.Header.Get(ProcedureHeader))
 
-			body, err := io.ReadAll(req.Body)
-			if assert.NoError(t, err) {
-				assert.Equal(t, []byte("world"), body)
+				body, err := io.ReadAll(req.Body)
+				if assert.NoError(t, err) {
+					assert.Equal(t, []byte("world"), body)
+				}
+
+				w.Header().Set("rpc-header-foo", "bar")
+				_, err = w.Write([]byte("great success"))
+				assert.NoError(t, err)
+			},
+		)
+		h2s := &http2.Server{
+			NewWriteScheduler: func() http2.WriteScheduler {
+				return http2.NewPriorityWriteScheduler(nil)
+			},
+			IdleTimeout: defaultIdleConnTimeout,
+		}
+		h1s := httptest.NewServer(h2c.NewHandler(handler, h2s))
+		t.Cleanup(h1s.Close)
+
+		httpTransport := NewTransport()
+		t.Cleanup(func() {
+			if err := httpTransport.Stop(); err != nil {
+				t.Logf("failed to stop transport: %v", err)
 			}
+		})
 
-			w.Header().Set("rpc-header-foo", "bar")
-			_, err = w.Write([]byte("great success"))
-			assert.NoError(t, err)
-		},
-	)
-	h2s := &http2.Server{
-		NewWriteScheduler: func() http2.WriteScheduler {
-			return http2.NewPriorityWriteScheduler(nil)
-		},
-		IdleTimeout: defaultIdleConnTimeout,
-	}
-	h1s := httptest.NewServer(h2c.NewHandler(handler, h2s))
-	t.Cleanup(h1s.Close)
+		out := httpTransport.NewSingleOutbound(h1s.URL, UseHTTP2())
+		require.NoError(t, out.Start(), "failed to start outbound")
+		t.Cleanup(func() {
+			if err := out.Stop(); err != nil {
+				t.Logf("failed to stop outbound: %v", err)
+			}
+			out.client.CloseIdleConnections()
+		})
 
-	httpTransport := NewTransport()
-	t.Cleanup(func() {
-		if err := httpTransport.Stop(); err != nil {
-			t.Logf("failed to stop transport: %v", err)
+		ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
+		t.Cleanup(cancel)
+
+		res, err := out.Call(ctx, &transport.Request{
+			Caller:    "caller",
+			Service:   "service",
+			Encoding:  raw.Encoding,
+			Procedure: "hello",
+			Body:      bytes.NewReader([]byte("world")),
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			if err := res.Body.Close(); err != nil {
+				t.Logf("failed to close response body: %v", err)
+			}
+		})
+
+		foo, ok := res.Headers.Get("foo")
+		assert.True(t, ok, "value for foo expected")
+		assert.Equal(t, "bar", foo, "foo value mismatch")
+
+		body, err := io.ReadAll(res.Body)
+		if assert.NoError(t, err) {
+			assert.Equal(t, []byte("great success"), body)
 		}
 	})
 
-	out := httpTransport.NewSingleOutbound(h1s.URL, UseHTTP2())
-	require.NoError(t, out.Start(), "failed to start outbound")
-	t.Cleanup(func() {
-		if err := out.Stop(); err != nil {
-			t.Logf("failed to stop outbound: %v", err)
+	t.Run("success - http2 disabled client with http2 server", func(t *testing.T) {
+		handler := http.HandlerFunc(
+			func(w http.ResponseWriter, req *http.Request) {
+				defer req.Body.Close()
+
+				ttl := req.Header.Get(TTLMSHeader)
+				ttlms, err := strconv.Atoi(ttl)
+				assert.NoError(t, err, "can parse TTL header")
+				assert.InDelta(t, ttlms, testtime.X*1000.0, testtime.X*5.0, "ttl header within tolerance")
+
+				assert.Equal(t, "caller", req.Header.Get(CallerHeader))
+				assert.Equal(t, "service", req.Header.Get(ServiceHeader))
+				assert.Equal(t, "raw", req.Header.Get(EncodingHeader))
+				assert.Equal(t, "hello", req.Header.Get(ProcedureHeader))
+
+				body, err := io.ReadAll(req.Body)
+				if assert.NoError(t, err) {
+					assert.Equal(t, []byte("world"), body)
+				}
+
+				w.Header().Set("rpc-header-foo", "bar")
+				_, err = w.Write([]byte("great success"))
+				assert.NoError(t, err)
+			},
+		)
+		h2s := &http2.Server{
+			NewWriteScheduler: func() http2.WriteScheduler {
+				return http2.NewPriorityWriteScheduler(nil)
+			},
+			IdleTimeout: defaultIdleConnTimeout,
 		}
-		out.client.CloseIdleConnections()
-	})
+		h1s := httptest.NewServer(h2c.NewHandler(handler, h2s))
+		t.Cleanup(h1s.Close)
 
-	ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
-	t.Cleanup(cancel)
+		httpTransport := NewTransport()
+		t.Cleanup(func() {
+			if err := httpTransport.Stop(); err != nil {
+				t.Logf("failed to stop transport: %v", err)
+			}
+		})
 
-	res, err := out.Call(ctx, &transport.Request{
-		Caller:    "caller",
-		Service:   "service",
-		Encoding:  raw.Encoding,
-		Procedure: "hello",
-		Body:      bytes.NewReader([]byte("world")),
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		if err := res.Body.Close(); err != nil {
-			t.Logf("failed to close response body: %v", err)
+		out := httpTransport.NewSingleOutbound(h1s.URL)
+		require.NoError(t, out.Start(), "failed to start outbound")
+		t.Cleanup(func() {
+			if err := out.Stop(); err != nil {
+				t.Logf("failed to stop outbound: %v", err)
+			}
+			out.client.CloseIdleConnections()
+		})
+
+		ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
+		t.Cleanup(cancel)
+
+		res, err := out.Call(ctx, &transport.Request{
+			Caller:    "caller",
+			Service:   "service",
+			Encoding:  raw.Encoding,
+			Procedure: "hello",
+			Body:      bytes.NewReader([]byte("world")),
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			if err := res.Body.Close(); err != nil {
+				t.Logf("failed to close response body: %v", err)
+			}
+		})
+
+		foo, ok := res.Headers.Get("foo")
+		assert.True(t, ok, "value for foo expected")
+		assert.Equal(t, "bar", foo, "foo value mismatch")
+
+		body, err := io.ReadAll(res.Body)
+		if assert.NoError(t, err) {
+			assert.Equal(t, []byte("great success"), body)
 		}
 	})
 
-	foo, ok := res.Headers.Get("foo")
-	assert.True(t, ok, "value for foo expected")
-	assert.Equal(t, "bar", foo, "foo value mismatch")
+	t.Run("transport failure - http2 client with http1 server", func(t *testing.T) {
+		handler := http.HandlerFunc(
+			func(w http.ResponseWriter, req *http.Request) {
+				defer req.Body.Close()
+				_, err := w.Write([]byte("great success"))
+				assert.NoError(t, err)
+			},
+		)
+		h1s := httptest.NewServer(handler)
+		t.Cleanup(h1s.Close)
 
-	body, err := io.ReadAll(res.Body)
-	if assert.NoError(t, err) {
-		assert.Equal(t, []byte("great success"), body)
-	}
+		httpTransport := NewTransport()
+		t.Cleanup(func() {
+			if err := httpTransport.Stop(); err != nil {
+				t.Logf("failed to stop transport: %v", err)
+			}
+		})
+
+		out := httpTransport.NewSingleOutbound(h1s.URL, UseHTTP2())
+		require.NoError(t, out.Start(), "failed to start outbound")
+		t.Cleanup(func() {
+			if err := out.Stop(); err != nil {
+				t.Logf("failed to stop outbound: %v", err)
+			}
+			out.client.CloseIdleConnections()
+		})
+
+		ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
+		t.Cleanup(cancel)
+
+		res, err := out.Call(ctx, &transport.Request{
+			Caller:    "caller",
+			Service:   "service",
+			Encoding:  raw.Encoding,
+			Procedure: "hello",
+			Body:      bytes.NewReader([]byte("world")),
+		})
+		require.Error(t, err, "expected failure")
+		require.Nil(t, res, "expected no response")
+	})
 }
 
 func TestCallSuccess(t *testing.T) {

--- a/transport/http/transport.go
+++ b/transport/http/transport.go
@@ -60,7 +60,7 @@ type transportOptions struct {
 	meter                     *metrics.Scope
 	serviceName               string
 	outboundTLSConfigProvider yarpctls.OutboundTLSConfigProvider
-	enableHTTP2               bool
+	useHTTP2                  bool
 }
 
 var defaultTransportOptions = transportOptions{
@@ -310,7 +310,7 @@ func buildHTTPClient(options *transportOptions) *http.Client {
 		ResponseHeaderTimeout: options.responseHeaderTimeout,
 	}
 
-	if options.enableHTTP2 {
+	if options.useHTTP2 {
 		http2Transport, err := http2.ConfigureTransports(&h1Transport)
 		if err != nil {
 			// TODO: log this error instead of panicking (for now just testing)

--- a/transport/http/transport.go
+++ b/transport/http/transport.go
@@ -249,6 +249,14 @@ func OutboundTLSConfigProvider(provider yarpctls.OutboundTLSConfigProvider) Tran
 	}
 }
 
+// UseHTTP2TransportOption returns an option that configures the transport to
+// use HTTP/2.
+func UseHTTP2TransportOption(flag bool) TransportOption {
+	return func(options *transportOptions) {
+		options.useHTTP2 = flag
+	}
+}
+
 // Hidden option to override the buildHTTPClient function. This is used only
 // for testing.
 func buildClient(f func(*transportOptions) *http.Client) TransportOption {

--- a/transport/http/transport_test.go
+++ b/transport/http/transport_test.go
@@ -298,13 +298,6 @@ func TestTransportClientOpaqueOptions(t *testing.T) {
 	assert.NotNil(t, transport.client)
 }
 
-func TestTransportClientUseHTTP2Option(t *testing.T) {
-	assert.NotPanics(t, func() {
-		NewTransport(UseHTTP2TransportOption(true))
-	}, "UseHTTP2TransportOption should not panic")
-	assert.NotNil(t, NewTransport(UseHTTP2TransportOption(true)).client.Transport, "UseHTTP2TransportOption should set the transport")
-}
-
 func TestDialContext(t *testing.T) {
 	errMsg := "my custom dialer error message"
 	dialContext := func(ctx context.Context, network, addr string) (net.Conn, error) {

--- a/transport/http/transport_test.go
+++ b/transport/http/transport_test.go
@@ -298,6 +298,13 @@ func TestTransportClientOpaqueOptions(t *testing.T) {
 	assert.NotNil(t, transport.client)
 }
 
+func TestTransportClientUseHTTP2Option(t *testing.T) {
+	assert.NotPanics(t, func() {
+		NewTransport(UseHTTP2TransportOption(true))
+	}, "UseHTTP2TransportOption should not panic")
+	assert.NotNil(t, NewTransport(UseHTTP2TransportOption(true)).client.Transport, "UseHTTP2TransportOption should set the transport")
+}
+
 func TestDialContext(t *testing.T) {
 	errMsg := "my custom dialer error message"
 	dialContext := func(ctx context.Context, network, addr string) (net.Conn, error) {

--- a/transport/http/transport_test.go
+++ b/transport/http/transport_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc/api/peer"
 	. "go.uber.org/yarpc/api/peer/peertest"
-	"go.uber.org/yarpc/internal/testtime"
 	ypeer "go.uber.org/yarpc/peer"
 	"go.uber.org/yarpc/peer/hostport"
 )
@@ -274,28 +273,6 @@ func TestTransport(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestTransportClient(t *testing.T) {
-	transport := NewTransport()
-
-	assert.NotNil(t, transport.client)
-}
-
-func TestTransportClientOpaqueOptions(t *testing.T) {
-	// Unfortunately the KeepAlive is obfuscated in the client, so we can't really
-	// assert this worked.
-	transport := NewTransport(
-		KeepAlive(testtime.Second),
-		MaxIdleConns(100),
-		MaxIdleConnsPerHost(10),
-		IdleConnTimeout(1*time.Second),
-		DisableCompression(),
-		DisableKeepAlives(),
-		ResponseHeaderTimeout(1*time.Second),
-	)
-
-	assert.NotNil(t, transport.client)
 }
 
 func TestDialContext(t *testing.T) {


### PR DESCRIPTION
- [X] Description and context for reviewers: one partner, one stranger
  - Added Config support to `useHTTP2` in outbounds
  - Updated Outbound to support HTTP2 client based on config
- [X] Entry in CHANGELOG.md
