### PR TITLE
Feat: client per outbound (previously it was per transport) for http

### DIFF
--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -149,7 +149,6 @@ func createHTTP1Client(o *Outbound) *http.Client {
 }
 
 func createHTTP1TLSClient(o *Outbound) *http.Client {
-	h1transport := o.transport.h1Transport.Clone()
 	tlsDialer := dialer.NewTLSDialer(dialer.Params{
 		Config:        o.tlsConfig,
 		Meter:         o.transport.meter,
@@ -157,9 +156,9 @@ func createHTTP1TLSClient(o *Outbound) *http.Client {
 		ServiceName:   o.transport.serviceName,
 		TransportName: TransportName,
 		Dest:          o.destServiceName,
-		Dialer:        h1transport.DialContext,
+		Dialer:        o.transport.h1Transport.DialContext,
 	})
-
+	h1transport := o.transport.h1Transport.Clone()
 	h1transport.DialTLSContext = tlsDialer.DialContext
 	// Create a copy of the url template to avoid scheme changes impacting
 	// other outbounds as the base url template is shared across http

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -865,7 +865,7 @@ func TestCallOneWayResponseCloseError(t *testing.T) {
 
 func TestIsolatedSchemaChange(t *testing.T) {
 	tr := &Transport{
-		h1Transport: defaultH1Transport(&defaultTransportOptions),
+		h1Transport: buildH1Transport(&defaultTransportOptions),
 	}
 	plainOutbound := tr.NewOutbound(nil)
 	tlsOutbound := tr.NewOutbound(nil, OutboundTLSConfiguration(&tls.Config{}))

--- a/transport/http/transport.go
+++ b/transport/http/transport.go
@@ -280,11 +280,11 @@ func (o *transportOptions) newTransport() *Transport {
 		meter:                    o.meter,
 		serviceName:              o.serviceName,
 		ouboundTLSConfigProvider: o.outboundTLSConfigProvider,
-		h1Transport:              defaultH1Transport(o),
+		h1Transport:              buildH1Transport(o),
 	}
 }
 
-func defaultH1Transport(options *transportOptions) *http.Transport {
+func buildH1Transport(options *transportOptions) *http.Transport {
 	dialContext := options.dialContext
 	if dialContext == nil {
 		dialContext = (&net.Dialer{
@@ -310,7 +310,7 @@ func defaultH1Transport(options *transportOptions) *http.Transport {
 
 func buildHTTPClient(options *transportOptions) *http.Client {
 	return &http.Client{
-		Transport: defaultH1Transport(options),
+		Transport: buildH1Transport(options),
 	}
 }
 

--- a/transport/http/transport_test.go
+++ b/transport/http/transport_test.go
@@ -276,10 +276,10 @@ func TestTransport(t *testing.T) {
 	}
 }
 
-func TestTransportClient(t *testing.T) {
+func TestH1Transport(t *testing.T) {
 	transport := NewTransport()
 
-	assert.NotNil(t, transport.client)
+	assert.NotNil(t, transport.h1Transport)
 }
 
 func TestTransportClientOpaqueOptions(t *testing.T) {
@@ -295,7 +295,7 @@ func TestTransportClientOpaqueOptions(t *testing.T) {
 		ResponseHeaderTimeout(1*time.Second),
 	)
 
-	assert.NotNil(t, transport.client)
+	assert.NotNil(t, transport.h1Transport)
 }
 
 func TestDialContext(t *testing.T) {


### PR DESCRIPTION
- [X] Description and context for reviewers: one partner, one stranger
 - Update transport and outbound to create client per outbound (previously it was per transport) for http. This will be required for http2 client support which is control by outbound based on outbound config
- [X] Entry in CHANGELOG.md

RELEASE NOTES:
Create client per outbound (previously it was per transport) for http
