### PR TITLE
Feat: Add HTTP2 client support (without TLS)

### DIFF
--- a/internal/integrationtest/util_test.go
+++ b/internal/integrationtest/util_test.go
@@ -64,7 +64,7 @@ var http2spec = integrationtest.TransportSpec{
 		return http.NewTransport()
 	},
 	NewUnaryOutbound: func(x peer.Transport, pc peer.Chooser) transport.UnaryOutbound {
-		return x.(*http.Transport).NewOutbound(pc)
+		return x.(*http.Transport).NewOutbound(pc, http.UseHTTP2())
 	},
 	NewInbound: func(x peer.Transport, addr string) transport.Inbound {
 		// we don't disable http2

--- a/transport/http/config.go
+++ b/transport/http/config.go
@@ -264,6 +264,12 @@ type OutboundConfig struct {
 	//      spiffe-ids:
 	//        - destination-id
 	TLS OutboundTLSConfig `config:"tls"`
+	// UseHTTP2 configure to send http2 requests.
+	//
+	// http:
+	// 		url: "http://localhost:8080/yarpc"
+	// 		useHTTP2: true
+	UseHTTP2 bool `config:"useHTTP2"`
 }
 
 // OutboundTLSConfig configures TLS for the HTTP outbound.
@@ -314,6 +320,10 @@ func (ts *transportSpec) buildOutbound(oc *OutboundConfig, t transport.Transport
 		return nil, err
 	}
 	opts = append(option, opts...)
+
+	if oc.UseHTTP2 {
+		opts = append(opts, UseHTTP2())
+	}
 
 	// Special case where the URL implies the single peer.
 	if oc.Empty() {

--- a/transport/http/config_test.go
+++ b/transport/http/config_test.go
@@ -100,6 +100,7 @@ func TestTransportSpec(t *testing.T) {
 		URLTemplate string
 		Headers     http.Header
 		TLSConfig   bool
+		UseHTTP2    bool
 	}
 
 	type outboundTest struct {
@@ -512,6 +513,40 @@ func TestTransportSpec(t *testing.T) {
 			},
 			wantErrors: []string{"outbound TLS enforced but outbound TLS config provider is nil"},
 		},
+		{
+			desc: "enable http2 outbound with options",
+			cfg: attrs{
+				"myservice": attrs{
+					TransportName: attrs{
+						"url": "http://localhost/yarpc",
+					},
+				},
+			},
+			opts: []Option{UseHTTP2()},
+			wantOutbounds: map[string]wantOutbound{
+				"myservice": {
+					URLTemplate: "http://localhost/yarpc",
+					UseHTTP2:    true,
+				},
+			},
+		},
+		{
+			desc: "enable http2 outbound with outbound cfg",
+			cfg: attrs{
+				"myservice": attrs{
+					TransportName: attrs{
+						"url":      "http://localhost/yarpc",
+						"useHTTP2": true,
+					},
+				},
+			},
+			wantOutbounds: map[string]wantOutbound{
+				"myservice": {
+					URLTemplate: "http://localhost/yarpc",
+					UseHTTP2:    true,
+				},
+			},
+		},
 	}
 
 	runTest := func(t *testing.T, trans transportTest, inbound inboundTest, outbound outboundTest) {
@@ -597,6 +632,7 @@ func TestTransportSpec(t *testing.T) {
 				assert.Equal(t, want.Headers, ob.headers, "outbound headers should match")
 				assert.Equal(t, svc, ob.destServiceName, "outbound destination service name must match")
 				assert.Equal(t, want.TLSConfig, ob.tlsConfig != nil, "unexpected outbound tls config")
+				assert.Equal(t, want.UseHTTP2, ob.useHTTP2, "UseHTTP2 should match")
 			}
 
 		}

--- a/transport/http/constants.go
+++ b/transport/http/constants.go
@@ -29,9 +29,12 @@ import "time"
 const TransportName = "http"
 
 var (
-	defaultConnTimeout     = 500 * time.Millisecond
-	defaultInnocenceWindow = 5 * time.Second
-	defaultIdleConnTimeout = 15 * time.Minute
+	defaultConnTimeout          = 500 * time.Millisecond
+	defaultInnocenceWindow      = 5 * time.Second
+	defaultIdleConnTimeout      = 15 * time.Minute
+	defaultDialerTimeout        = 30 * time.Second
+	defaultHTTP2PingTimeout     = 10 * time.Second
+	defaultHTTP2ReadIdleTimeout = 15 * time.Second
 )
 
 // HTTP headers used in requests and responses to send YARPC metadata.

--- a/transport/http/transport_test.go
+++ b/transport/http/transport_test.go
@@ -276,10 +276,11 @@ func TestTransport(t *testing.T) {
 	}
 }
 
-func TestH1Transport(t *testing.T) {
+func TestDefaultTransportInitialisation(t *testing.T) {
 	transport := NewTransport()
 
 	assert.NotNil(t, transport.h1Transport)
+	assert.NotNil(t, transport.h2Transport)
 }
 
 func TestTransportClientOpaqueOptions(t *testing.T) {
@@ -296,6 +297,7 @@ func TestTransportClientOpaqueOptions(t *testing.T) {
 	)
 
 	assert.NotNil(t, transport.h1Transport)
+	assert.NotNil(t, transport.h2Transport)
 }
 
 func TestDialContext(t *testing.T) {


### PR DESCRIPTION
- [X] Description and context for reviewers: one partner, one stranger
  - Added Config support to useHTTP2 in outbounds
  - Updated Outbound to support HTTP2 client based on config
- [X] Entry in CHANGELOG.md

RELEASE NOTES: 
- HTTP2 client support for the HTTP outbound.
  - Client/Peer will use http2.Transport based on the outbound configuration.
  - Added `useHTTP2` option to the HTTP outbound configuration to enable HTTP2 client support.