### PR TITLE
Changed release approach to trunk-based model

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,4 @@
 - [ ] Description and context for reviewers: one partner, one stranger
 - [ ] Docs (package doc)
-- [ ] Entry in CHANGELOG.md
+
+RELEASE NOTES:

--- a/CHANGELOG_ARCHIVED.md
+++ b/CHANGELOG_ARCHIVED.md
@@ -1,12 +1,18 @@
 # Changelog
+
+Version 1.75.4 was the last one that used git-flow release management and the last one
+that required manually complied list of changes in a changelog.
+
+Changelog is archived, please don't update it anymore.
+
+To specify changes for the next release, please use `RELEASE NOTES:` in a PR summary.
+
+# Archive
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
-
-=======
-## [Unreleased]
-- No changes yet.
 
 ## [1.75.4] - 2025-01-30
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing
+
+We welcome contributions from the community. Here are some guidelines to make it easier for everyone.
+
+## Default branch renaming
+
+For a long time, we had two protected branches: master and dev. Latter was used as default one.
+We also used git-flow to manage our releases.
+
+One Feb 10, 2025 `master` was renamed to `archived-releases`, and `dev` was renamed to `main`.
+
+Moreover, we stopped using git-flow and switched to a trunk-based development model. In realm of this repo,
+we use feature branches for development, pull requests to merge changes to main, and release branches for
+cutting new releases. I.e. no tags are created on main branch.
+
+If your local copy still has a `dev` branch, please use following commands to rename it to `main`:
+
+```
+git checkout dev
+git branch -m dev main
+git fetch origin
+git branch -u origin/main main
+git remote set-head origin -a
+```
+
+## Creating a Pull Request
+
+Please use `RELEASE NOTES:` in a PR summary to write all significant changes that you've made.
+This section will be used later to compile a release notes.
+
+Please use `N/a` if there are no release notes.
+
+## Development
+
+### Setup
+
+To start developing with yarpc-go, make a fork via the Github UI, and clone it locally:
+
+```
+git clone https://github.com/{github-username}/yarpc-go.git go.uber.org/yarpc
+```
+
+### Running Tests
+
+To run tests into a pre-configured docker container, run the following command:
+```
+make test
+```
+
+To run tests locally, run the following command:
+```
+SUPPRESS_DOCKER=1 make test
+```
+
+Happy development!

--- a/README.md
+++ b/README.md
@@ -40,31 +40,6 @@ APIs can break at any time. The intention here is to validate these APIs and ite
 by working closely with internal customers. Once stable, their contents will be moved out of
 the containing `x` package and their APIs will be locked.
 
-
-## Development
-
-### Setup
-
-To start developing with yarpc-go, run the following command to setup your environment:
-
-```
-git clone https://github.com/yarpc/yarpc-go.git go.uber.org/yarpc
-```
-
-### Running Tests
-
-To run tests into a pre-configured docker container, run the following command:
-```
-make test
-```
-
-To run tests locally, run the following command:
-```
-SUPPRESS_DOCKER=1 make test
-```
-
-Happy development!
-
 [doc-img]: https://pkg.go.dev/badge/go.uber.org/yarpc.svg
 [doc]: https://pkg.go.dev/go.uber.org/yarpc
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
-Release process
+# Release process
 ===============
 
 > **NOTE**: Don't do any of this before validating with a test service. Check
@@ -6,7 +6,17 @@ Release process
 
 This document outlines how to create a release of yarpc-go.
 
-Prerequisites
+## Process description
+
+We're using trunk-based development model. It means, all the development is done in feature branches,
+and changes are merged to `main` branch via pull requests.
+
+When it's time to cut a new release, we create a release branch from `main`, update `version.go`,
+and tag the release.
+
+We don't use tags on `main` branch, and we never merge release branches back to `main`.
+
+## Prerequisites
 -------------
 
 Make sure you have `gh` installed.
@@ -25,135 +35,70 @@ gh auth login
 ? How would you like to authenticate GitHub CLI? Login with a web browser
 ```
 
-Releasing
----------
+## Releasing
 
-1.  Set up some environment variables for use later.
+- Decide what's the next version number. It should be a semver-compatible string.
+Usually, we increase minor version number for new features, and patch version number for bug fixes.
 
-    ```
-    # This is the version being released.
-    VERSION=1.0.0
+I.e. 1.2.0 -> 1.3.0 for new features, and 1.2.0 -> 1.2.1 for bug fixes.
 
-    # This is the branch from which $VERSION will be released.
-    # This is almost always dev.
-    BRANCH=dev
-    ```
+You may get last release version by running:
 
-    **If you are copying/pasting commands, make sure you actually set the right
-    value for VERSION above.**
+  ```
+    gh release list --exclude-drafts --exclude-pre-releases --json "tagName" | jq -r '.[0].tagName'
+  ```
 
-2. Call release preparation helper.
+- Set environment variable with the version you want to release.
 
-   ```
-   ./etc/bin/release-step-1.sh $VERSION $BRANCH
-   ```
-   
-    This script will:
-    * Create a release branch from the specified branch.
-    * Update CHANGELOG.md with the new version and date.
-    * Update version.go with the new version.
-    * Commit the changes and push the branch to GitHub.
-    * Open a pull request for the release.
+  ```
+  VERSION=1.0.0
+  ```
 
-3.  Land the pull request after approval as a **merge commit**. To do this,
-    select **Create a merge commit** from the pull-down next to the merge
-    button and click **Merge pull request**. Make sure you delete that branch
-    after it has been merged with **Delete Branch**.
+- Compile release notes.
 
-4.  Once the change has been landed, run second script.
+  ```
+  ./etc/bin/release/cmd-format-release-notes.sh \
+        $(git log --pretty=format:"%H" \
+              $(git merge-base main \
+                  $(gh release list --exclude-drafts --exclude-pre-releases --json "isLatest,tagName" | \
+                       jq -r '.[] | select( .isLatest ) | .tagName') \
+               )..HEAD) | tee /tmp/yarpc-release-notes.txt
+  ```
 
-   ```
-   ./etc/bin/release-step-2.sh $VERSION $BRANCH
-   ```
-
-   This script will:
-   * Tag the release.
-   * Push the tag to GitHub.
-   * Create a release on GitHub.
-      * (This will open a browser window with the release page. Copy the changelog entries into the release description.)
-   * Switch version and CHANGELOG.md back to development mode.
-   * Commit the changes and push them to GitHub.
-   * Open a pull request for the development changes.
-
-5. Send pull request to a peer review.
-
-# Manual release
-
-If the above steps fail, you can manually release yarpc-go by following the
-steps below.
-
-(For the sake of simplicity, we will assume that changes are merged to branch `dev`,
-release should be done to branch `master`, and new version is 1.0.0.)
-
-1.  Create a release branch from `dev`.
+- Please format release notes:
 
     ```
-    git checkout dev
-    git pull
-    git checkout -B prepare-release
-    ```
-    
-2.  Update `CHANGELOG.md` with the new version and date.
-
-    ```
-    - ## [Unreleased]
-    + ## [1.0.0] - 2025-01-01
-    
-    - [Unreleased]: https://github.com/yarpc/yarpc-go/compare/v0.0.9...HEAD
-    + [1.75.4]: https://github.com/yarpc/yarpc-go/compare/v0.0.9...v1.0.0
-    ```
-    
-3.  Update `version.go` with the new version.
-
-    ```
-    - const Version = "0.0.9"
-    + const Version = "1.0.0"
-    ```
-    
-4.  Commit the changes and push the branch to GitHub.
-
-    ```
-    git add CHANGELOG.md version.go
-    git commit -m "Preparing release v1.0.0"
-    gh pr create --base master --title "Preparing release v1.0.0" --web
+      nano /tmp/yarpc-release-notes.txt
+      
+      # for vim users
+      vim /tmp/yarpc-release-notes.txt
     ```
 
-5.  Land the pull request after approval as a **merge commit**.
 
-6.  After the change has been landed, pull the changes locally and tag the release.
-
-    ```
-    git checkout master
-    git pull
-    gh release create "v1.0.0" --latest --target master --title "v1.0.0"
-    ```
-    
-Use the changelog entries as the release description.
-
-7. Merging release back to dev branch via pull request.
+- Create a release branch from the specified branch.
 
     ```
-    git checkout dev
-    git pull
-    git checkout -B return-to-development
-    git merge origin/master
+    git checkout -b release/v$VERSION
     ```
 
-8.  Switch version and `CHANGELOG.md` back to development mode in a new branch.
+- Update version.go with the new version.
 
     ```
-    + ## [Unreleased]
-    + - No changes yet.
-    
-    + [Unreleased]: https://github.com/yarpc/yarpc-go/compare/v1.0.0...HEAD
-    ```
-    
-9. Commit the changes and push the branch to GitHub.
-
-    ```
-    git add CHANGELOG.md version.go
-    git commit -m "Return to development"
-    gh pr create --base dev --title "Return to development" --web
+    ./etc/bin/release/cmd-update-version.sh $VERSION
     ```
 
-10. Land the pull request after approval **without** merge commit.
+- Commit this change and push the branch to GitHub.
+
+    ```
+    git add version.go
+    git commit -s -m "Prepare release v$VERSION"
+    ```
+
+- Cut a new release, using the release notes from the previous step.
+
+    ```
+    git push origin release/v$VERSION
+    gh release create v$VERSION --latest --target release/v$VERSION --title v$VERSION --notes-file /tmp/yarpc-release-notes.txt
+    ```
+
+- Done, no need to merge the release branch back to main.

--- a/etc/bin/release/cmd-format-release-notes.sh
+++ b/etc/bin/release/cmd-format-release-notes.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "${0}")/lib.sh"
+
+formatReleaseNotes "$@"

--- a/etc/bin/release/cmd-update-version.sh
+++ b/etc/bin/release/cmd-update-version.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "${0}")/lib.sh"
+
+set_version "${1}"

--- a/etc/bin/release/lib.sh
+++ b/etc/bin/release/lib.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+set -euo pipefail
+
+
+parsePRIDFromCommit() {
+  local commit="$1"
+
+  local regexp="\(#([0-9]+)\)$" # (#1234)
+  local subject=$(git log -1 --pretty=format:"%s" "${commit}")
+
+  if [[ "${subject}" =~ ${regexp} ]]; then
+    echo "${BASH_REMATCH[1]}"
+  fi
+}
+
+parsePRReleaseNoteFromText() {
+  txt="$1"
+  release_note_regex="RELEASE NOTES:(.+)$"
+
+  if [[ "${txt}" =~ ${release_note_regex} ]]; then
+    echo "${BASH_REMATCH[1]}"
+  fi
+}
+
+parsePRReleaseNoteFromRemote() {
+  local pr_id="$1"
+
+  local body=$(gh pr view "${pr_id}" --json "body" | jq -r '.body')
+
+  if [[ "${body}" == "" ]]; then
+    return
+  fi
+
+  parsePRReleaseNoteFromText "${body}"
+}
+
+formatReleaseNotes() {
+  local release_note_regex="RELEASE NOTES: (.+)$"
+
+  local commits="$@"
+  local release_notes=""
+
+  for commit in $@; do
+    local pr_id=$(parsePRIDFromCommit "${commit}")
+
+    if [[ "${pr_id}" == "" ]]; then
+      continue
+    fi
+
+    local release_note=$(parsePRReleaseNoteFromRemote "${pr_id}")
+
+    if [[ "${release_note}" == "" ]]; then
+      continue
+    fi
+
+    release_notes="${release_notes}\n${release_note} (#${pr_id})"
+  done
+
+  echo -e "${release_notes}"
+}
+
+# $1: new version
+set_version() {
+  sed -i '' -e "s/^const Version =.*/const Version = \"${1}\"/" version.go
+}

--- a/etc/make/docker.mk
+++ b/etc/make/docker.mk
@@ -60,10 +60,6 @@ errcheck: deps ## check errcheck
 verifycodecovignores: deps ## check verifycodecovignores
 	PATH=$$PATH:$(BIN) docker run $(DOCKER_RUN_FLAGS) $(DOCKER_IMAGE) make verifycodecovignores
 
-.PHONY: verifyversion
-verifyversion: deps ## verify the version in the changelog is the same as in version.go
-	PATH=$$PATH:$(BIN) docker run $(DOCKER_RUN_FLAGS) $(DOCKER_IMAGE) make verifyversion
-
 .PHONY: basiclint
 basiclint: deps ## run gofmt govet golint staticcheck errcheck
 	PATH=$$PATH:$(BIN) docker run $(DOCKER_RUN_FLAGS) $(DOCKER_IMAGE) make basiclint

--- a/etc/make/local.mk
+++ b/etc/make/local.mk
@@ -124,22 +124,6 @@ goimports-fix: $(GOIMPORTS) __eval_packages __eval_go_files
 	$(eval TARGET_FILES := $(shell PATH=$(BIN):$$PATH goimports -l $(GO_FILES) | $(FILTER_LINT)))
 	@PATH=$(BIN):$$PATH goimports -w $(TARGET_FILES)
 
-.PHONY: verifyversion
-verifyversion: ## verify the version in the changelog is the same as in version.go
-	@echo "verifyversion"
-	$(eval CHANGELOG_VERSION := $(shell perl -ne '/^## \[(\S+?)\]/ && print "v$$1\n"' CHANGELOG.md | head -n1))
-	$(eval INTHECODE_VERSION := $(shell perl -ne '/^const Version.*"([^"]+)".*$$/ && print "v$$1\n"' version.go))
-	@if [ "$(INTHECODE_VERSION)" = "$(CHANGELOG_VERSION)" ]; then \
-		echo "yarpc-go: $(CHANGELOG_VERSION)"; \
-	elif [ "$(CHANGELOG_VERSION)" = "vUnreleased" ]; then \
-		echo "yarpc-go (development): $(INTHECODE_VERSION)"; \
-	else \
-		echo "Version number in version.go does not match CHANGELOG.md"; \
-		echo "version.go: $(INTHECODE_VERSION)"; \
-		echo "CHANGELOG : $(CHANGELOG_VERSION)"; \
-		exit 1; \
-	fi
-
 .PHONY: verifycodecovignores
 verifycodecovignores: ## verify that .codecov.yml contains all .nocover packages
 	@echo "verifycodecovignores"
@@ -156,7 +140,7 @@ verifycodecovignores: ## verify that .codecov.yml contains all .nocover packages
 basiclint: gofmt govet golint staticcheck errcheck goimports # run gofmt govet golint staticcheck errcheck
 
 .PHONY: lint
-lint: basiclint generatenodiff nogogenerate verifyversion verifycodecovignores ## run all linters
+lint: basiclint generatenodiff nogogenerate verifycodecovignores ## run all linters
 
 .PHONY: test
 test: $(THRIFTRW) __eval_chunked_packages ## run chunked tests

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package yarpc // import "go.uber.org/yarpc"
 
 // Version is the current version of YARPC.
-const Version = "1.76.0-dev"
+const Version = "1.0.0-dev"


### PR DESCRIPTION
We're switching from the gitflow approach (with dev/master branches) to a trunk-based development model.

We renamed master to `archived-releases`, and `dev` to `main`. Releases now live in a dedicated branches, and no more "back to development" is needed.

More details are in [CONTRIBUTING.md](https://github.com/yarpc/yarpc-go/compare/changing-release-approach?expand=1#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055).

RELEASE NOTES: N/a