### PR TITLE
Test cases demoing thread unsafety of prod and mock call implementations

### DIFF
--- a/call_test.go
+++ b/call_test.go
@@ -83,3 +83,12 @@ func TestCallFromContext(t *testing.T) {
 	assert.Equal(t, "three", call.RoutingDelegate())
 	assert.Equal(t, "four", call.CallerProcedure())
 }
+
+func TestRealCallTheadSafety(t *testing.T) {
+	ctx, _ := encoding.NewInboundCall(context.Background())
+	call := yarpc.CallFromContext(ctx)
+	go func() {
+		_ = call.WriteResponseHeader("test", "test")
+	}()
+	_ = call.WriteResponseHeader("test", "test")
+}

--- a/yarpctest/context_test.go
+++ b/yarpctest/context_test.go
@@ -88,3 +88,12 @@ func TestContextWithCall(t *testing.T) {
 	}
 
 }
+
+func TestMockCallTheadSafety(t *testing.T) {
+	ctx := yarpctest.ContextWithCall(context.Background(), &yarpctest.Call{ResponseHeaders: make(map[string]string)})
+	call := yarpc.CallFromContext(ctx)
+	go func() {
+		_ = call.WriteResponseHeader("test", "test")
+	}()
+	_ = call.WriteResponseHeader("test", "test")
+}


### PR DESCRIPTION
This pull request is not targeted to be merged as is

Rather it is providing test cases demoing the problem. It should be viewed together with ticket: 


To check:

Prod - run:
go test -race

Mock - run:
cd yarpctest
go test -race

- [ ] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)

RELEASE NOTES:
