### PR TITLE
Add a lock guarding the headers in Call sruct

### DIFF
--- a/api/encoding/inbound_call.go
+++ b/api/encoding/inbound_call.go
@@ -22,6 +22,7 @@ package encoding
 
 import (
 	"context"
+	"sync"
 
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/inboundcall"
@@ -34,6 +35,8 @@ import (
 // incoming request on the Context and send response headers through
 // WriteResponseHeader.
 type InboundCall struct {
+	// guards resHeaders so InboundCall should not be passed by copying, only by pointer!
+	lock                   sync.Mutex
 	resHeaders             []keyValuePair
 	req                    *transport.Request
 	disableResponseHeaders bool
@@ -101,9 +104,11 @@ func (ic *InboundCall) ReadFromRequestMeta(reqMeta *transport.RequestMeta) error
 // ResponseWriter.
 func (ic *InboundCall) WriteToResponse(resw transport.ResponseWriter) error {
 	var headers transport.Headers
+	ic.lock.Lock()
 	for _, h := range ic.resHeaders {
 		headers = headers.With(h.k, h.v)
 	}
+	ic.lock.Unlock()
 
 	if headers.Len() > 0 {
 		resw.AddHeaders(headers)
@@ -161,6 +166,8 @@ func (ic *inboundCallMetadata) WriteResponseHeader(k, v string) error {
 	if ic.disableResponseHeaders {
 		return yarpcerrors.InvalidArgumentErrorf("call does not support setting response headers")
 	}
+	ic.lock.Lock()
 	ic.resHeaders = append(ic.resHeaders, keyValuePair{k: k, v: v})
+	ic.lock.Unlock()
 	return nil
 }

--- a/call_test.go
+++ b/call_test.go
@@ -83,3 +83,12 @@ func TestCallFromContext(t *testing.T) {
 	assert.Equal(t, "three", call.RoutingDelegate())
 	assert.Equal(t, "four", call.CallerProcedure())
 }
+
+func TestRealCallTheadSafety(t *testing.T) {
+	ctx, _ := encoding.NewInboundCall(context.Background())
+	call := yarpc.CallFromContext(ctx)
+	go func() {
+		_ = call.WriteResponseHeader("test", "test")
+	}()
+	_ = call.WriteResponseHeader("test", "test")
+}


### PR DESCRIPTION
Add a test checking for the proper guard of the Call object

Should fix https://github.com/yarpc/yarpc-go/issues/2357