### PR TITLE
Feat: update transport name for http2 outbound (for yarpc metrics)

### DIFF
--- a/transport/http/constants.go
+++ b/transport/http/constants.go
@@ -22,11 +22,16 @@ package http
 
 import "time"
 
-// TransportName is the name of the transport.
-//
-// This value is what is used as transport.Request#Transport and transport.Namer
-// for Outbounds.
-const TransportName = "http"
+const (
+	// TransportName is the name of the transport.
+	//
+	// This value is what is used as transport.Request#Transport and transport.Namer
+	// for Outbounds.
+	TransportName = "http"
+
+	// TransportHTTP2Name is the name of the transport for HTTP/2.
+	TransportHTTP2Name = "http2"
+)
 
 var (
 	defaultConnTimeout          = 500 * time.Millisecond

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -263,6 +263,9 @@ type Outbound struct {
 
 // TransportName is the transport name that will be set on `transport.Request` struct.
 func (o *Outbound) TransportName() string {
+	if o.useHTTP2 {
+		return TransportHTTP2Name
+	}
 	return TransportName
 }
 

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -60,7 +60,13 @@ func TestNewOutbound(t *testing.T) {
 }
 
 func TestTransportNamer(t *testing.T) {
-	assert.Equal(t, TransportName, NewOutbound(nil).TransportName())
+	t.Run("default is http", func(t *testing.T) {
+		assert.Equal(t, TransportName, NewOutbound(nil).TransportName())
+	})
+
+	t.Run("outbound is http2", func(t *testing.T) {
+		assert.Equal(t, TransportHTTP2Name, NewOutbound(nil, UseHTTP2()).TransportName())
+	})
 }
 
 func TestNewSingleOutboundPanic(t *testing.T) {


### PR DESCRIPTION
- [X] Description and context for reviewers: one partner, one stranger
update tranport name based on outbound for http2
- [ ] Docs (package doc)

RELEASE NOTES:
update transport name based on outbound for http2 (metrics)