### PR TITLE
Cleaned up io.Reader creation in unit tests

### DIFF
--- a/encoding/json/inbound_test.go
+++ b/encoding/json/inbound_test.go
@@ -21,12 +21,11 @@
 package json
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
-	"io"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -63,7 +62,7 @@ func TestHandleStructSuccess(t *testing.T) {
 	err := handler.Handle(context.Background(), &transport.Request{
 		Procedure: "simpleCall",
 		Encoding:  "json",
-		Body:      jsonBody(`{"name": "foo", "attributes": {"bar": 42}}`),
+		Body:      strings.NewReader(`{"name": "foo", "attributes": {"bar": 42}}`),
 	}, resw)
 	require.NoError(t, err)
 
@@ -90,7 +89,7 @@ func TestHandleMapSuccess(t *testing.T) {
 	err := handler.Handle(context.Background(), &transport.Request{
 		Procedure: "foo",
 		Encoding:  "json",
-		Body:      jsonBody(`{"foo": 42, "bar": ["a", "b", "c"]}`),
+		Body:      strings.NewReader(`{"foo": 42, "bar": ["a", "b", "c"]}`),
 	}, resw)
 	require.NoError(t, err)
 
@@ -110,7 +109,7 @@ func TestHandleInterfaceEmptySuccess(t *testing.T) {
 	err := handler.Handle(context.Background(), &transport.Request{
 		Procedure: "foo",
 		Encoding:  "json",
-		Body:      jsonBody(`["a", "b", "c"]`),
+		Body:      strings.NewReader(`["a", "b", "c"]`),
 	}, resw)
 	require.NoError(t, err)
 
@@ -132,7 +131,7 @@ func TestHandleSuccessWithResponseHeaders(t *testing.T) {
 	err := handler.Handle(context.Background(), &transport.Request{
 		Procedure: "simpleCall",
 		Encoding:  "json",
-		Body:      jsonBody(`{"name": "foo", "attributes": {"bar": 42}}`),
+		Body:      strings.NewReader(`{"name": "foo", "attributes": {"bar": 42}}`),
 	}, resw)
 	require.NoError(t, err)
 
@@ -157,7 +156,7 @@ func TestHandleBothResponseError(t *testing.T) {
 	err := handler.Handle(context.Background(), &transport.Request{
 		Procedure: "simpleCall",
 		Encoding:  "json",
-		Body:      jsonBody(`{"name": "foo", "attributes": {"bar": 42}}`),
+		Body:      strings.NewReader(`{"name": "foo", "attributes": {"bar": 42}}`),
 	}, resw)
 	require.Equal(t, errors.New("bar"), err)
 
@@ -165,8 +164,4 @@ func TestHandleBothResponseError(t *testing.T) {
 	require.NoError(t, json.Unmarshal(resw.Body.Bytes(), &response))
 
 	assert.Equal(t, simpleResponse{Success: true}, response)
-}
-
-func jsonBody(s string) io.Reader {
-	return bytes.NewReader([]byte(s))
 }

--- a/encoding/json/outbound_test.go
+++ b/encoding/json/outbound_test.go
@@ -21,11 +21,11 @@
 package json
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"io"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -123,12 +123,11 @@ func TestCall(t *testing.T) {
 						Procedure: tt.procedure,
 						Encoding:  Encoding,
 						Headers:   transport.HeadersFromMap(tt.headers),
-						Body:      bytes.NewReader([]byte(tt.encodedRequest)),
+						Body:      strings.NewReader(tt.encodedRequest),
 					}),
 			).Return(
 				&transport.Response{
-					Body: io.NopCloser(
-						bytes.NewReader([]byte(tt.encodedResponse))),
+					Body:    io.NopCloser(strings.NewReader(tt.encodedResponse)),
 					Headers: transport.HeadersFromMap(tt.wantHeaders),
 				}, tt.responseErr)
 		}
@@ -229,7 +228,7 @@ func TestCallOneway(t *testing.T) {
 					Procedure: tt.procedure,
 					Encoding:  Encoding,
 					Headers:   transport.HeadersFromMap(tt.headers),
-					Body:      bytes.NewReader([]byte(tt.encodedRequest)),
+					Body:      strings.NewReader(tt.encodedRequest),
 				})
 
 			if tt.wantErr != "" {

--- a/encoding/protobuf/marshal_test.go
+++ b/encoding/protobuf/marshal_test.go
@@ -21,7 +21,7 @@
 package protobuf
 
 import (
-	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,7 +31,7 @@ import (
 
 func TestUnhandledEncoding(t *testing.T) {
 	assert.Equal(t, yarpcerrors.CodeInternal,
-		yarpcerrors.FromError(unmarshal(transport.Encoding("foo"), bytes.NewReader([]byte("foo")), nil, newCodec(nil))).Code())
+		yarpcerrors.FromError(unmarshal(transport.Encoding("foo"), strings.NewReader("foo"), nil, newCodec(nil))).Code())
 	_, _, err := marshal(transport.Encoding("foo"), nil, newCodec(nil))
 	assert.Equal(t, yarpcerrors.CodeInternal, yarpcerrors.FromError(err).Code())
 }

--- a/encoding/protobuf/v2/marshal_test.go
+++ b/encoding/protobuf/v2/marshal_test.go
@@ -21,7 +21,7 @@
 package v2
 
 import (
-	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,7 +31,7 @@ import (
 
 func TestUnhandledEncoding(t *testing.T) {
 	assert.Equal(t, yarpcerrors.CodeInternal,
-		yarpcerrors.FromError(unmarshal(transport.Encoding("foo"), bytes.NewReader([]byte("foo")), nil, newCodec(nil))).Code())
+		yarpcerrors.FromError(unmarshal(transport.Encoding("foo"), strings.NewReader("foo"), nil, newCodec(nil))).Code())
 	_, _, err := marshal(transport.Encoding("foo"), nil, newCodec(nil))
 	assert.Equal(t, yarpcerrors.CodeInternal, yarpcerrors.FromError(err).Code())
 }

--- a/encoding/thrift/envelope_test.go
+++ b/encoding/thrift/envelope_test.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"math/rand"
 	"reflect"
+	"strings"
 	"testing"
 	"testing/quick"
 	"time"
@@ -85,7 +86,7 @@ func TestDisableEnveloperEncode(t *testing.T) {
 
 func TestDisableEnveloperNoWireRead(t *testing.T) {
 	cont := "some buffered contents"
-	buf := bytes.NewBuffer([]byte(cont))
+	buf := strings.NewReader(cont)
 	evnw := disableEnvelopingNoWireProtocol{Protocol: binary.Default, Type: wire.Call}
 	sr := evnw.Reader(buf)
 	evh, err := sr.ReadEnvelopeBegin()

--- a/encoding/thrift/inbound_test.go
+++ b/encoding/thrift/inbound_test.go
@@ -22,11 +22,11 @@
 package thrift
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -440,7 +440,7 @@ func request() *transport.Request {
 		Service:   "service",
 		Encoding:  "thrift",
 		Procedure: "MyService::someMethod",
-		Body:      bytes.NewReader([]byte("irrelevant")),
+		Body:      strings.NewReader("irrelevant"),
 	}
 }
 

--- a/encoding/thrift/multiplex_test.go
+++ b/encoding/thrift/multiplex_test.go
@@ -140,7 +140,7 @@ func TestMultiplexedDecode(t *testing.T) {
 					SeqID: 42,
 				}, nil)
 
-			gotEnvelope, err := proto.DecodeEnveloped(bytes.NewReader([]byte{}))
+			gotEnvelope, err := proto.DecodeEnveloped(bytes.NewReader(nil))
 			if assert.NoError(t, err) {
 				assert.Equal(t, tt.wantName, gotEnvelope.Name)
 			}

--- a/encoding/thrift/outbound_nowire_test.go
+++ b/encoding/thrift/outbound_nowire_test.go
@@ -21,11 +21,11 @@
 package thrift
 
 import (
-	"bytes"
 	"context"
 	"encoding/binary"
 	"errors"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -173,10 +173,10 @@ func TestNoWireClientCall(t *testing.T) {
 						Service:   "service",
 						Encoding:  Encoding,
 						Procedure: "MyService::someMethod",
-						Body:      bytes.NewReader([]byte(tt.wantRequestBody)),
+						Body:      strings.NewReader(tt.wantRequestBody),
 					}),
 				).Return(&transport.Response{
-					Body: readCloser{bytes.NewReader([]byte(tt.giveResponseBody))},
+					Body: io.NopCloser(strings.NewReader(tt.giveResponseBody)),
 				}, nil)
 			}
 
@@ -281,7 +281,7 @@ func TestNoWireClientOneway(t *testing.T) {
 							Service:   "service",
 							Encoding:  Encoding,
 							Procedure: "MyService::someMethod",
-							Body:      bytes.NewReader([]byte(tt.wantRequestBody)),
+							Body:      strings.NewReader(tt.wantRequestBody),
 						}),
 					).Return(nil, errors.New("oneway outbound error"))
 				} else {
@@ -291,7 +291,7 @@ func TestNoWireClientOneway(t *testing.T) {
 							Service:   "service",
 							Encoding:  Encoding,
 							Procedure: "MyService::someMethod",
-							Body:      bytes.NewReader([]byte(tt.wantRequestBody)),
+							Body:      strings.NewReader(tt.wantRequestBody),
 						}),
 					).Return(&successAck{}, nil)
 				}

--- a/internal/examples/thrift-keyvalue/keyvalue/client/cache.go
+++ b/internal/examples/thrift-keyvalue/keyvalue/client/cache.go
@@ -63,7 +63,7 @@ func (c *cacheOutboundMiddleware) Call(ctx context.Context, request *transport.R
 	if err != nil {
 		return nil, err
 	}
-	request.Body = io.NopCloser(bytes.NewReader(body))
+	request.Body = bytes.NewReader(body)
 
 	if v, ok := data[string(body)]; ok {
 		fmt.Println("cache hit")

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -21,7 +21,6 @@
 package observability
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -3469,7 +3468,7 @@ func TestStreamingMetrics(t *testing.T) {
 			&fakeStream{
 				request: req,
 				receiveMsg: &transport.StreamMessage{
-					Body:     readCloser{bytes.NewReader([]byte("Foobar"))},
+					Body:     io.NopCloser(strings.NewReader("Foobar")),
 					BodySize: 6,
 				},
 			},
@@ -3480,7 +3479,7 @@ func TestStreamingMetrics(t *testing.T) {
 				err := stream.SendMessage(
 					context.Background(),
 					&transport.StreamMessage{
-						Body:     readCloser{bytes.NewReader([]byte("test"))},
+						Body:     io.NopCloser(strings.NewReader("test")),
 						BodySize: 4,
 					},
 				)
@@ -3819,14 +3818,6 @@ func TestNewWriterIsEmpty(t *testing.T) {
 	require.NotNil(t, w, "writer must not be nil")
 	assert.Equal(t, writer{}, *w,
 		"expected empty writer, fields were likely not cleared in the pool")
-}
-
-type readCloser struct {
-	*bytes.Reader
-}
-
-func (r readCloser) Close() error {
-	return nil
 }
 
 func BenchmarkMiddlewareHandle(b *testing.B) {

--- a/serialize/serialize_test.go
+++ b/serialize/serialize_test.go
@@ -23,6 +23,7 @@ package serialize
 import (
 	"bytes"
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -79,7 +80,7 @@ func TestDeserializationFailure(t *testing.T) {
 		Caller:    "Caller",
 		Service:   "ServiceName",
 		Procedure: "Procedure",
-		Body:      bytes.NewReader([]byte("someBODY")),
+		Body:      strings.NewReader("someBODY"),
 	}
 
 	marshalledReq, err := ToBytes(tracer, spanContext, req)

--- a/transport/grpc/integration_test.go
+++ b/transport/grpc/integration_test.go
@@ -1039,7 +1039,7 @@ func TestYARPCErrorsConverted(t *testing.T) {
 			Service:   "service",
 			Encoding:  "encoding",
 			Procedure: "no procedure",
-			Body:      bytes.NewBufferString("foo-body"),
+			Body:      strings.NewReader("foo-body"),
 		})
 
 		require.Error(t, err)

--- a/transport/grpc/outbound_test.go
+++ b/transport/grpc/outbound_test.go
@@ -21,9 +21,9 @@
 package grpc
 
 import (
-	"bytes"
 	"context"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -334,7 +334,7 @@ func TestCallServiceMatch(t *testing.T) {
 			req := &transport.Request{
 				Service:   "Service",
 				Procedure: "Hello",
-				Body:      bytes.NewReader([]byte("world")),
+				Body:      strings.NewReader("world"),
 			}
 			_, err = out.Call(ctx, req)
 			if tt.wantErr {

--- a/transport/http/handler_test.go
+++ b/transport/http/handler_test.go
@@ -83,7 +83,7 @@ func TestHandlerSuccess(t *testing.T) {
 				RoutingKey:      "routekey",
 				RoutingDelegate: "routedelegate",
 				CallerProcedure: "callerprocedure",
-				Body:            bytes.NewReader([]byte("Nyuck Nyuck")),
+				Body:            strings.NewReader("Nyuck Nyuck"),
 			},
 		),
 		gomock.Any(),
@@ -98,7 +98,7 @@ func TestHandlerSuccess(t *testing.T) {
 	req := &http.Request{
 		Method: "POST",
 		Header: headers,
-		Body:   io.NopCloser(bytes.NewReader([]byte("Nyuck Nyuck"))),
+		Body:   io.NopCloser(strings.NewReader("Nyuck Nyuck")),
 	}
 	rw := httptest.NewRecorder()
 	httpHandler.ServeHTTP(rw, req)
@@ -190,7 +190,7 @@ func TestHandlerHeaders(t *testing.T) {
 					Encoding:  transport.Encoding(tt.giveEncoding),
 					Procedure: "hello",
 					Headers:   transport.HeadersFromMap(tt.wantHeaders),
-					Body:      bytes.NewReader([]byte("world")),
+					Body:      strings.NewReader("world"),
 				}),
 			gomock.Any(),
 		).Return(nil)
@@ -209,7 +209,7 @@ func TestHandlerHeaders(t *testing.T) {
 		req := &http.Request{
 			Method: "POST",
 			Header: headers,
-			Body:   io.NopCloser(bytes.NewReader([]byte("world"))),
+			Body:   io.NopCloser(strings.NewReader("world")),
 		}
 		rw := httptest.NewRecorder()
 		httpHandler.ServeHTTP(rw, req)
@@ -293,7 +293,7 @@ func TestHandlerFailures(t *testing.T) {
 	for _, tt := range tests {
 		req := tt.req
 		if req.Body == nil {
-			req.Body = io.NopCloser(bytes.NewReader([]byte{}))
+			req.Body = io.NopCloser(bytes.NewReader(nil))
 		}
 
 		reg := transporttest.NewMockRouter(mockCtrl)
@@ -335,7 +335,7 @@ func TestHandlerInternalFailure(t *testing.T) {
 	request := http.Request{
 		Method: "POST",
 		Header: headers,
-		Body:   io.NopCloser(bytes.NewReader([]byte{})),
+		Body:   io.NopCloser(bytes.NewReader(nil)),
 	}
 
 	rpcHandler := transporttest.NewMockUnaryHandler(mockCtrl)
@@ -348,7 +348,7 @@ func TestHandlerInternalFailure(t *testing.T) {
 				Transport: "http",
 				Encoding:  raw.Encoding,
 				Procedure: "hello",
-				Body:      bytes.NewReader([]byte{}),
+				Body:      bytes.NewReader(nil),
 			},
 		),
 		gomock.Any(),

--- a/transport/http/inbound_test.go
+++ b/transport/http/inbound_test.go
@@ -21,7 +21,6 @@
 package http
 
 import (
-	"bytes"
 	"context"
 	"crypto/tls"
 	"fmt"
@@ -29,6 +28,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strings"
 	"syscall"
 	"testing"
 
@@ -159,7 +159,7 @@ func TestInboundMux(t *testing.T) {
 		Service:   "bar",
 		Procedure: "hello",
 		Encoding:  raw.Encoding,
-		Body:      bytes.NewReader([]byte("derp")),
+		Body:      strings.NewReader("derp"),
 	})
 
 	if assert.Error(t, err, "RPC call to / should have failed") {
@@ -184,7 +184,7 @@ func TestInboundMux(t *testing.T) {
 		Service:   "bar",
 		Procedure: "hello",
 		Encoding:  raw.Encoding,
-		Body:      bytes.NewReader([]byte("derp")),
+		Body:      strings.NewReader("derp"),
 	})
 
 	if assert.NoError(t, err, "expected rpc request to succeed") {

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -21,7 +21,6 @@
 package http
 
 import (
-	"bytes"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -30,6 +29,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -180,7 +180,7 @@ func TestCallWithHTTP2(t *testing.T) {
 			Service:   "service",
 			Encoding:  raw.Encoding,
 			Procedure: "hello",
-			Body:      bytes.NewReader([]byte("world")),
+			Body:      strings.NewReader("world"),
 		})
 		require.NoError(t, err)
 		t.Cleanup(func() {
@@ -257,7 +257,7 @@ func TestCallWithHTTP2(t *testing.T) {
 			Service:   "service",
 			Encoding:  raw.Encoding,
 			Procedure: "hello",
-			Body:      bytes.NewReader([]byte("world")),
+			Body:      strings.NewReader("world"),
 		})
 		require.NoError(t, err)
 		t.Cleanup(func() {
@@ -311,7 +311,7 @@ func TestCallWithHTTP2(t *testing.T) {
 			Service:   "service",
 			Encoding:  raw.Encoding,
 			Procedure: "hello",
-			Body:      bytes.NewReader([]byte("world")),
+			Body:      strings.NewReader("world"),
 		})
 		require.Error(t, err, "expected failure")
 		require.Nil(t, res, "expected no response")
@@ -358,7 +358,7 @@ func TestCallSuccess(t *testing.T) {
 		Service:   "service",
 		Encoding:  raw.Encoding,
 		Procedure: "hello",
-		Body:      bytes.NewReader([]byte("world")),
+		Body:      strings.NewReader("world"),
 	})
 	require.NoError(t, err)
 	defer res.Body.Close()
@@ -413,7 +413,7 @@ func TestCallOneWaySuccessWithBody(t *testing.T) {
 		Service:   "service",
 		Encoding:  raw.Encoding,
 		Procedure: "hello",
-		Body:      bytes.NewReader([]byte("world")),
+		Body:      strings.NewReader("world"),
 	})
 	require.NoError(t, err)
 	require.NotNil(t, ack)
@@ -458,7 +458,7 @@ func TestCallOneWaySuccess(t *testing.T) {
 		Service:   "service",
 		Encoding:  raw.Encoding,
 		Procedure: "hello",
-		Body:      bytes.NewReader([]byte("world")),
+		Body:      strings.NewReader("world"),
 	})
 	require.NoError(t, err)
 	require.NotNil(t, ack)
@@ -479,7 +479,7 @@ func TestCallOneWayFailWithoutDeadline(t *testing.T) {
 		Service:   "service",
 		Encoding:  raw.Encoding,
 		Procedure: "hello",
-		Body:      bytes.NewReader([]byte("world")),
+		Body:      strings.NewReader("world"),
 	})
 	require.Error(t, err)
 	require.Nil(t, ack)
@@ -502,7 +502,7 @@ func TestCallOneWayFailWithCtxCancelled(t *testing.T) {
 		Service:   "service",
 		Encoding:  raw.Encoding,
 		Procedure: "hello",
-		Body:      bytes.NewReader([]byte("world")),
+		Body:      strings.NewReader("world"),
 	})
 	require.Error(t, err)
 	assert.Equal(t, yarpcerrors.CodeCancelled, yarpcerrors.FromError(err).Code())
@@ -597,7 +597,7 @@ func TestOutboundHeaders(t *testing.T) {
 			Encoding:  raw.Encoding,
 			Headers:   tt.headers,
 			Procedure: "hello",
-			Body:      bytes.NewReader([]byte("world")),
+			Body:      strings.NewReader("world"),
 		})
 
 		if !assert.NoError(t, err, "%v: call failed", tt.desc) {
@@ -677,7 +677,7 @@ func TestOutboundApplicationError(t *testing.T) {
 			Service:   "service",
 			Encoding:  raw.Encoding,
 			Procedure: "hello",
-			Body:      bytes.NewReader([]byte("world")),
+			Body:      strings.NewReader("world"),
 		})
 
 		assert.Equal(t, res.ApplicationError, tt.appError, "%v: application status", tt.desc)
@@ -732,7 +732,7 @@ func TestCallFailures(t *testing.T) {
 			Service:   "service",
 			Encoding:  raw.Encoding,
 			Procedure: "wat",
-			Body:      bytes.NewReader([]byte("huh")),
+			Body:      strings.NewReader("huh"),
 		})
 		assert.Error(t, err, "expected failure")
 		for _, msg := range tt.messages {
@@ -802,7 +802,7 @@ func TestCallWithoutStarting(t *testing.T) {
 			Service:   "service",
 			Encoding:  raw.Encoding,
 			Procedure: "foo",
-			Body:      bytes.NewReader([]byte("sup")),
+			Body:      strings.NewReader("sup"),
 		},
 	)
 

--- a/transport/http/roundtrip_test.go
+++ b/transport/http/roundtrip_test.go
@@ -21,11 +21,11 @@
 package http
 
 import (
-	"bytes"
 	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -69,7 +69,7 @@ func TestRoundTripSuccess(t *testing.T) {
 	defer out.Stop()
 
 	// create request
-	hreq := httptest.NewRequest("GET", echoServer.URL, bytes.NewReader([]byte(giveBody)))
+	hreq := httptest.NewRequest("GET", echoServer.URL, strings.NewReader(giveBody))
 	hreq.Header.Add(headerKey, headerVal)
 
 	// add deadline

--- a/transport/internal/tls/muxlistener/tls_checker_test.go
+++ b/transport/internal/tls/muxlistener/tls_checker_test.go
@@ -25,6 +25,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -33,7 +34,7 @@ import (
 
 func TestIsTLSClientHelloRecord(t *testing.T) {
 	t.Run("non_tls", func(t *testing.T) {
-		isTLS, err := isTLSClientHelloRecord(bytes.NewBuffer([]byte("testtls")))
+		isTLS, err := isTLSClientHelloRecord(strings.NewReader("testtls"))
 		assert.NoError(t, err, "unexpected error")
 		assert.False(t, isTLS, "unexpected tls")
 	})

--- a/transport/roundtrip_test.go
+++ b/transport/roundtrip_test.go
@@ -21,11 +21,11 @@
 package transport_test
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -254,7 +254,7 @@ func TestSimpleRoundTrip(t *testing.T) {
 					Procedure: testProcedure,
 					Encoding:  raw.Encoding,
 					Headers:   tt.requestHeaders,
-					Body:      bytes.NewBufferString(tt.requestBody),
+					Body:      strings.NewReader(tt.requestBody),
 				})
 
 				handler := unaryHandlerFunc(func(_ context.Context, r *transport.Request, w transport.ResponseWriter) error {
@@ -286,7 +286,7 @@ func TestSimpleRoundTrip(t *testing.T) {
 						Procedure: testProcedure,
 						Encoding:  raw.Encoding,
 						Headers:   tt.requestHeaders,
-						Body:      bytes.NewBufferString(tt.requestBody),
+						Body:      strings.NewReader(tt.requestBody),
 					})
 
 					if tt.wantError != nil {
@@ -297,7 +297,7 @@ func TestSimpleRoundTrip(t *testing.T) {
 					} else {
 						responseMatcher := transporttest.NewResponseMatcher(t, &transport.Response{
 							Headers: tt.responseHeaders,
-							Body:    io.NopCloser(bytes.NewReader([]byte(tt.responseBody))),
+							Body:    io.NopCloser(strings.NewReader(tt.responseBody)),
 						})
 
 						if assert.NoError(t, err, "%T: call failed", trans) {
@@ -342,7 +342,7 @@ func TestSimpleRoundTripOneway(t *testing.T) {
 				Procedure: testProcedureOneway,
 				Encoding:  raw.Encoding,
 				Headers:   tt.requestHeaders,
-				Body:      bytes.NewReader([]byte(tt.requestBody)),
+				Body:      strings.NewReader(tt.requestBody),
 			})
 
 			handlerDone := make(chan struct{})
@@ -372,7 +372,7 @@ func TestSimpleRoundTripOneway(t *testing.T) {
 					Procedure: testProcedureOneway,
 					Encoding:  raw.Encoding,
 					Headers:   tt.requestHeaders,
-					Body:      bytes.NewReader([]byte(tt.requestBody)),
+					Body:      strings.NewReader(tt.requestBody),
 				})
 
 				select {

--- a/transport/tchannel/channel_inbound_test.go
+++ b/transport/tchannel/channel_inbound_test.go
@@ -232,7 +232,7 @@ func TestChannelInboundSubServices(t *testing.T) {
 				Service:   tt.service,
 				Procedure: tt.procedure,
 				Encoding:  raw.Encoding,
-				Body:      bytes.NewReader([]byte{}),
+				Body:      bytes.NewReader(nil),
 			},
 		)
 		if !assert.NoError(t, err, "failed to make call") {

--- a/transport/tchannel/channel_outbound_test.go
+++ b/transport/tchannel/channel_outbound_test.go
@@ -21,8 +21,8 @@
 package tchannel
 
 import (
-	"bytes"
 	"io"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -136,7 +136,7 @@ func TestChannelOutboundHeaders(t *testing.T) {
 							Encoding:  raw.Encoding,
 							Procedure: "hello",
 							Headers:   tt.headers,
-							Body:      bytes.NewReader([]byte("world")),
+							Body:      strings.NewReader("world"),
 						},
 					)
 					if tt.wantError != "" {
@@ -231,7 +231,7 @@ func TestChannelCallSuccess(t *testing.T) {
 							Service:   "service",
 							Encoding:  raw.Encoding,
 							Procedure: "hello",
-							Body:      bytes.NewReader([]byte("world")),
+							Body:      strings.NewReader("world"),
 						},
 					)
 
@@ -331,7 +331,7 @@ func TestChannelCallFailures(t *testing.T) {
 							Service:   "service",
 							Encoding:  raw.Encoding,
 							Procedure: tt.procedure,
-							Body:      bytes.NewReader([]byte("sup")),
+							Body:      strings.NewReader("sup"),
 						},
 					)
 
@@ -393,7 +393,7 @@ func TestChannelCallError(t *testing.T) {
 					Service:   "service",
 					Encoding:  raw.Encoding,
 					Procedure: "hello",
-					Body:      bytes.NewReader([]byte("world")),
+					Body:      strings.NewReader("world"),
 				},
 			)
 
@@ -492,7 +492,7 @@ func TestChannelCallWithoutStarting(t *testing.T) {
 					Service:   "service",
 					Encoding:  raw.Encoding,
 					Procedure: "foo",
-					Body:      bytes.NewReader([]byte("sup")),
+					Body:      strings.NewReader("sup"),
 				},
 			)
 

--- a/transport/tchannel/error_external_test.go
+++ b/transport/tchannel/error_external_test.go
@@ -21,10 +21,10 @@
 package tchannel_test
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -69,7 +69,7 @@ func TestResponseErrorMetaIntegration(t *testing.T) {
 	defer cancel()
 	_, err = client.Call(ctx, &transport.Request{
 		Service: "foo",
-		Body:    bytes.NewBufferString("bar"),
+		Body:    strings.NewReader("bar"),
 	})
 	require.Error(t, err, "expected call failure")
 

--- a/transport/tchannel/handler_test.go
+++ b/transport/tchannel/handler_test.go
@@ -134,7 +134,7 @@ func TestHandlerErrors(t *testing.T) {
 					ShardKey:        "shard",
 					RoutingKey:      "routekey",
 					RoutingDelegate: "routedelegate",
-					Body:            bytes.NewReader([]byte("world")),
+					Body:            strings.NewReader("world"),
 				}),
 			gomock.Any(),
 		).Return(nil)

--- a/transport/tchannel/inbound_test.go
+++ b/transport/tchannel/inbound_test.go
@@ -24,6 +24,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -122,7 +123,7 @@ func TestInboundSubServices(t *testing.T) {
 				Service:   tt.service,
 				Procedure: tt.procedure,
 				Encoding:  raw.Encoding,
-				Body:      bytes.NewReader([]byte{}),
+				Body:      bytes.NewReader(nil),
 			},
 		)
 		if !assert.NoError(t, err, "failed to make call") {
@@ -238,7 +239,7 @@ func TestInboundWithNativeHandlers(t *testing.T) {
 				Service:   tt.service,
 				Procedure: tt.procedure,
 				Encoding:  raw.Encoding,
-				Body:      bytes.NewReader([]byte{}),
+				Body:      bytes.NewReader(nil),
 			},
 		)
 		require.NoError(t, err, "failed to make call")
@@ -289,7 +290,7 @@ func TestArbitraryInboundServiceOutboundCallerName(t *testing.T) {
 					Service:   tt.service,
 					Encoding:  raw.Encoding,
 					Procedure: "procedure",
-					Body:      bytes.NewReader([]byte(tt.msg)),
+					Body:      strings.NewReader(tt.msg),
 				},
 			)
 			if !assert.NoError(t, err, "call success") {

--- a/transport/tchannel/outbound_channel_test.go
+++ b/transport/tchannel/outbound_channel_test.go
@@ -21,8 +21,8 @@
 package tchannel
 
 import (
-	"bytes"
 	"net"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -88,7 +88,7 @@ func TestOutboundChannel(t *testing.T) {
 			Service:   "service",
 			Encoding:  raw.Encoding,
 			Procedure: "hello",
-			Body:      bytes.NewBufferString("body"),
+			Body:      strings.NewReader("body"),
 		},
 	)
 	require.NoError(t, err, "failed to make call")

--- a/transport/tchannel/outbound_test.go
+++ b/transport/tchannel/outbound_test.go
@@ -23,6 +23,7 @@ package tchannel
 import (
 	"bytes"
 	"io"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -127,7 +128,7 @@ func TestOutboundHeaders(t *testing.T) {
 					Encoding:  raw.Encoding,
 					Procedure: "hello",
 					Headers:   transport.HeadersFromMap(tt.giveHeaders),
-					Body:      bytes.NewBufferString("body"),
+					Body:      strings.NewReader("body"),
 				},
 			)
 
@@ -183,7 +184,7 @@ func TestCallSuccess(t *testing.T) {
 			Service:   "service",
 			Encoding:  raw.Encoding,
 			Procedure: "hello",
-			Body:      bytes.NewBufferString("world"),
+			Body:      strings.NewReader("world"),
 		},
 	)
 
@@ -317,7 +318,7 @@ func TestCallFailures(t *testing.T) {
 					Service:   "service",
 					Encoding:  raw.Encoding,
 					Procedure: tt.procedure,
-					Body:      bytes.NewReader([]byte("sup")),
+					Body:      strings.NewReader("sup"),
 				},
 			)
 
@@ -448,7 +449,7 @@ func TestCallWithoutStarting(t *testing.T) {
 			Service:   "service",
 			Encoding:  raw.Encoding,
 			Procedure: "foo",
-			Body:      bytes.NewReader([]byte("sup")),
+			Body:      strings.NewReader("sup"),
 		},
 	)
 

--- a/transport/tchannel/tchannel_integration_test.go
+++ b/transport/tchannel/tchannel_integration_test.go
@@ -21,7 +21,6 @@
 package tchannel_test
 
 import (
-	"bytes"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -149,7 +148,7 @@ func TestInboundTLS(t *testing.T) {
 			res, err := outbound.Call(ctx, &transport.Request{
 				Service:   "test-svc-1",
 				Procedure: "test-proc",
-				Body:      bytes.NewReader([]byte("hello")),
+				Body:      strings.NewReader("hello"),
 			})
 			require.NoError(t, err)
 

--- a/x/yarpctest/api/request_unary.go
+++ b/x/yarpctest/api/request_unary.go
@@ -49,7 +49,7 @@ func NewRequestOpts() RequestOpts {
 			Caller:   "unknown",
 			Encoding: transport.Encoding("raw"),
 			Headers:  transport.NewHeaders(),
-			Body:     bytes.NewBufferString(""),
+			Body:     bytes.NewReader(nil),
 		},
 		WantResponse: &transport.Response{
 			Headers: transport.NewHeaders(),

--- a/x/yarpctest/request_unary.go
+++ b/x/yarpctest/request_unary.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -192,7 +193,7 @@ func matchResponse(actualResp *transport.Response, expectedResp *transport.Respo
 // Body sets the body on a request to the raw representation of the msg field.
 func Body(msg string) api.RequestOption {
 	return api.RequestOptionFunc(func(opts *api.RequestOpts) {
-		opts.GiveRequest.Body = bytes.NewBufferString(msg)
+		opts.GiveRequest.Body = strings.NewReader(msg)
 	})
 }
 
@@ -224,7 +225,7 @@ func WantError(errMsg string) api.RequestOption {
 // request.
 func WantRespBody(body string) api.RequestOption {
 	return api.RequestOptionFunc(func(opts *api.RequestOpts) {
-		opts.WantResponse.Body = io.NopCloser(bytes.NewBufferString(body))
+		opts.WantResponse.Body = io.NopCloser(strings.NewReader(body))
 	})
 }
 

--- a/x/yarpctest/stream.go
+++ b/x/yarpctest/stream.go
@@ -21,8 +21,8 @@
 package yarpctest
 
 import (
-	"bytes"
 	"io"
+	"strings"
 
 	"go.uber.org/yarpc/x/yarpctest/types"
 )
@@ -31,7 +31,7 @@ import (
 func SendStreamMsg(sendMsg string) *types.SendStreamMsg {
 	return &types.SendStreamMsg{
 		BodyFunc: func() io.ReadCloser {
-			return io.NopCloser(bytes.NewBufferString(sendMsg))
+			return io.NopCloser(strings.NewReader(sendMsg))
 		},
 	}
 }
@@ -41,7 +41,7 @@ func SendStreamMsg(sendMsg string) *types.SendStreamMsg {
 func SendStreamMsgAndExpectError(sendMsg string, wantErrMsgs ...string) *types.SendStreamMsg {
 	return &types.SendStreamMsg{
 		BodyFunc: func() io.ReadCloser {
-			return io.NopCloser(bytes.NewBufferString(sendMsg))
+			return io.NopCloser(strings.NewReader(sendMsg))
 		},
 		WantErrMsgs: wantErrMsgs,
 	}
@@ -68,7 +68,7 @@ func (r readErr) Read(p []byte) (n int, err error) {
 
 // RecvStreamMsg waits to receive a message on a client stream.
 func RecvStreamMsg(wantMsg string) *types.RecvStreamMsg {
-	return &types.RecvStreamMsg{WantBody: bytes.NewBufferString(wantMsg).Bytes()}
+	return &types.RecvStreamMsg{WantBody: []byte(wantMsg)}
 }
 
 // RecvStreamErr waits to receive a message on a client stream.  It expects

--- a/yarpctest/recorder/recorder.go
+++ b/yarpctest/recorder/recorder.go
@@ -341,7 +341,7 @@ func (r *Recorder) requestToRequestRecord(request *transport.Request) requestRec
 	if err != nil {
 		r.logger.Fatal(err)
 	}
-	request.Body = io.NopCloser(bytes.NewReader(requestBody))
+	request.Body = bytes.NewReader(requestBody)
 	return requestRecord{
 		Caller:          request.Caller,
 		Service:         request.Service,

--- a/yarpctest/recorder/recorder_test.go
+++ b/yarpctest/recorder/recorder_test.go
@@ -24,10 +24,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"math/rand"
 	"os"
 	"path"
+	"strings"
 	"testing"
 	"time"
 
@@ -96,7 +96,7 @@ func (r *randomGenerator) Request() transport.Request {
 		ShardKey:        r.Atom(),
 		RoutingKey:      r.Atom(),
 		RoutingDelegate: r.Atom(),
-		Body:            io.NopCloser(bytes.NewReader(bodyData)),
+		Body:            bytes.NewReader(bodyData),
 	}
 }
 
@@ -160,7 +160,7 @@ func TestHash(t *testing.T) {
 
 	// Body
 	r = request
-	request.Body = io.NopCloser(bytes.NewReader([]byte(rgen.Atom())))
+	request.Body = strings.NewReader(rgen.Atom())
 	requestRecord = recorder.requestToRequestRecord(&r)
 	assert.NotEqual(t, recorder.hashRequestRecord(&requestRecord), referenceHash)
 }


### PR DESCRIPTION
Made some clean up:
- bytes.NewReader([]byte()) -> strings.NewReader
- bytes.NewReaderString() -> strings.NewReader
- Removed custom io.NopCloser implementations
- Removed unnecessary casts to io.NopCloser

RELEASE NOTES: N/a
