### PR TITLE
Add ReadTimeout & WriteTimeout for HTTP InboundOptions

### DIFF
--- a/transport/http/config_test.go
+++ b/transport/http/config_test.go
@@ -82,6 +82,8 @@ func TestTransportSpec(t *testing.T) {
 		ShutdownTimeout time.Duration
 		TLSMode         yarpctls.Mode
 		DisableHTTP2    bool
+		ReadTimeout     time.Duration
+		WriteTimeout    time.Duration
 	}
 
 	type inboundTest struct {
@@ -258,6 +260,12 @@ func TestTransportSpec(t *testing.T) {
 			cfg:         attrs{"address": ":8080"},
 			opts:        []Option{},
 			wantInbound: &wantInbound{Address: ":8080", ShutdownTimeout: defaultShutdownTimeout, DisableHTTP2: false},
+		},
+		{
+			desc:        "ReadTimeout/WriteTimeout",
+			cfg:         attrs{"address": ":8080", "readTimeout": "1s", "writeTimeout": "10s"},
+			opts:        []Option{},
+			wantInbound: &wantInbound{Address: ":8080", ShutdownTimeout: defaultShutdownTimeout, ReadTimeout: time.Second, WriteTimeout: 10 * time.Second},
 		},
 	}
 
@@ -618,6 +626,8 @@ func TestTransportSpec(t *testing.T) {
 				assert.Equal(t, "foo", ib.transport.serviceName, "service name must match")
 				assert.Equal(t, want.TLSMode, ib.tlsMode, "tlsMode should match")
 				assert.Equal(t, want.DisableHTTP2, ib.disableHTTP2, "disableHTTP2 should match")
+				assert.Equal(t, want.WriteTimeout, ib.server.WriteTimeout, "WriteTimeout should match")
+				assert.Equal(t, want.ReadTimeout, ib.server.ReadTimeout, "ReadTimeout should match")
 			}
 		}
 

--- a/transport/http/inbound.go
+++ b/transport/http/inbound.go
@@ -136,12 +136,14 @@ func DisableHTTP2(flag bool) InboundOption {
 	}
 }
 
+// ReadTimeout returns an InboundOption that sets the http.Server ReadTimeout
 func ReadTimeout(timeout time.Duration) InboundOption {
 	return func(i *Inbound) {
 		i.server.ReadTimeout = timeout
 	}
 }
 
+// WriteTimeout returns an InboundOption that sets the http.Server WriteTimeout
 func WriteTimeout(timeout time.Duration) InboundOption {
 	return func(i *Inbound) {
 		i.server.WriteTimeout = timeout

--- a/transport/http/inbound_test.go
+++ b/transport/http/inbound_test.go
@@ -31,6 +31,7 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+	"time"
 
 	"golang.org/x/net/http2"
 
@@ -455,6 +456,22 @@ func TestInboundWithHTTPVersion(t *testing.T) {
 		res, err := client.Get("http://127.0.0.1:8888/health")
 		require.Error(t, err, "expected error making request")
 		require.Nil(t, res, "expected response to be nil")
+	})
+}
+
+func TestInboundWithTimeouts(t *testing.T) {
+	t.Run("WriteTimeout", func(t *testing.T) {
+		testTransport := NewTransport()
+		inbound := testTransport.NewInbound("127.0.0.1:8888", WriteTimeout(5*time.Second))
+
+		require.Equal(t, 5*time.Second, inbound.server.WriteTimeout)
+	})
+
+	t.Run("ReadTimeout", func(t *testing.T) {
+		testTransport := NewTransport()
+		inbound := testTransport.NewInbound("127.0.0.1:8888", ReadTimeout(5*time.Second))
+
+		require.Equal(t, 5*time.Second, inbound.server.ReadTimeout)
 	})
 }
 


### PR DESCRIPTION
## What
Add Read & Write timeout options to the HTTP Inbound

## Why?
Some users that want to migrate to the http fallbackhandler already set these timeouts.  We're maintaining parity

RELEASE NOTES: Add Read & Write timeout options to the HTTP Inbound