### PR TITLE
Fix bogus check on yarpctest.Call

### DIFF
--- a/yarpctest/context_test.go
+++ b/yarpctest/context_test.go
@@ -55,7 +55,7 @@ func TestContextWithCall(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			ctx := yarpctest.ContextWithCall(context.Background(), &yarpctest.Call{
+			testCall := &yarpctest.Call{
 				Caller:          "caller",
 				Service:         "service",
 				Transport:       "transport",
@@ -67,7 +67,8 @@ func TestContextWithCall(t *testing.T) {
 				RoutingDelegate: "routingdelegate",
 				ResponseHeaders: tt.resHeaders,
 				CallerProcedure: "callerProcedure",
-			})
+			}
+			ctx := yarpctest.ContextWithCall(context.Background(), testCall)
 			call := yarpc.CallFromContext(ctx)
 
 			assert.Equal(t, "caller", call.Caller())
@@ -83,7 +84,7 @@ func TestContextWithCall(t *testing.T) {
 			assert.Equal(t, "callerProcedure", call.CallerProcedure())
 
 			assert.NoError(t, call.WriteResponseHeader("baz", "qux"))
-			assert.Equal(t, tt.wantResHeaders, tt.resHeaders)
+			assert.Equal(t, tt.wantResHeaders, testCall.ResponseHeaders)
 		})
 	}
 


### PR DESCRIPTION
The test was on the given values rather than expected and processed ones
Use the unexported state to verify proper behavior

RELEASE NOTES:
Improve unit test on yarpctest.Call