### PR TITLE
Tighten checks in case ResponseHeaders are disabled

### DIFF
--- a/api/encoding/call_test.go
+++ b/api/encoding/call_test.go
@@ -156,4 +156,5 @@ func TestDisabledResponseHeaders(t *testing.T) {
 	assert.Len(t, call.HeaderNames(), 1)
 
 	assert.Error(t, call.WriteResponseHeader("foo", "bar"))
+	assert.Nil(t, icall.resHeaders)
 }


### PR DESCRIPTION
Verify no response headers are set when they are disabled
Shorten test code as go compiler can deduce type

RELEASE NOTES:
Improve InboundCall unit tests
