### PR TITLE
Document that Call's WriteResponseHeader is not goroutine safe

### DIFF
--- a/call.go
+++ b/call.go
@@ -110,6 +110,8 @@ func CallFromContext(ctx context.Context) *Call {
 }
 
 // WriteResponseHeader writes headers to the response of this call.
+// Calling this method may mutate the underlying struct.
+// The current implementation is not safe for concurrent use by multiple goroutines.
 func (c *Call) WriteResponseHeader(k, v string) error {
 	return (*encoding.Call)(c).WriteResponseHeader(k, v)
 }


### PR DESCRIPTION
Since the InboundCall crosses many layers and is available to many go routines it may seem it is safe for goroutine usage. The write API currently is not. This is a problem in a scenario when one does fan out and sets response headers in some of the started go routines. In the worst case this may cause a nil pointer de-reference:
  https://go.dev/play/p/wTUPi2wkxH_B
This is due to the fact that slice resizing is not go routine safe.

- [x] Description and context for reviewers: one partner, one stranger
- [x] Docs (package doc)

RELEASE NOTES:
Call attention to InboundCall's WriteResponseHeader limitations