### PR TITLE
Fix: Update transport name for inbound metrics for http2

### DIFF
--- a/transport/http/handler.go
+++ b/transport/http/handler.go
@@ -105,12 +105,17 @@ func (h handler) callHandler(responseWriter *responseWriter, req *http.Request, 
 		return yarpcerrors.Newf(yarpcerrors.CodeNotFound, "request method was %s but only %s is allowed", req.Method, http.MethodPost)
 	}
 
+	transportName := TransportName
+	if req.ProtoMajor == 2 {
+		transportName = TransportHTTP2Name
+	}
+
 	treq := &transport.Request{
 		Caller:          popHeader(req.Header, CallerHeader),
 		Service:         service,
 		Procedure:       procedure,
 		Encoding:        transport.Encoding(popHeader(req.Header, EncodingHeader)),
-		Transport:       TransportName,
+		Transport:       transportName,
 		ShardKey:        popHeader(req.Header, ShardKeyHeader),
 		RoutingKey:      popHeader(req.Header, RoutingKeyHeader),
 		RoutingDelegate: popHeader(req.Header, RoutingDelegateHeader),


### PR DESCRIPTION
- [X] Description and context for reviewers: one partner, one stranger
  - Update transport name to http2 based on proto major check for request - this will fix/tag http2 transport name for inbound metrics

RELEASE NOTES: Update transport name for inbound metrics for http2
