### PR TITLE
Preserve tracing headers unprefixed in headerMapper

### DIFF
--- a/internal/crossdock/client/headers/behavior.go
+++ b/internal/crossdock/client/headers/behavior.go
@@ -122,6 +122,8 @@ func Run(t crossdock.T) {
 		gotHeaders, err := caller.Call(tt.give)
 		if checks.NoError(err, "%v: call failed", tt.desc) {
 			internal.RemoveVariableMapKeys(gotHeaders)
+			// Remove system-injected tracing header before comparing with expected application headers.
+			delete(gotHeaders, "uber-trace-id")
 
 			// assert.Equal doesn't work with nil maps
 			if len(tt.want) == 0 {

--- a/transport/http/constants.go
+++ b/transport/http/constants.go
@@ -158,6 +158,6 @@ var (
 
 // Tracing header keys that must be preserved in HTTP headers.
 const (
-	UberTraceIDHeader = "uber-trace-id"
-	UberCtxHeader     = "uberctx-"
+	UberTraceContextHeaderKey  = "uber-trace-id"
+	UberBaggageHeaderKeyPrefix = "uberctx-"
 )

--- a/transport/http/constants.go
+++ b/transport/http/constants.go
@@ -155,3 +155,9 @@ var (
 		_http2SchemePseudoHeader,
 	}
 )
+
+// Tracing header keys that must be preserved in HTTP headers.
+const (
+	UberTraceIDHeader = "uber-trace-id"
+	UberCtxHeader     = "uberctx-"
+)

--- a/transport/http/header.go
+++ b/transport/http/header.go
@@ -96,13 +96,22 @@ func (hm headerMapper) deleteHTTP2PseudoHeadersIfNeeded(from transport.Headers) 
 	return from
 }
 
+// hasPrefixFold reports whether s begins with prefix, performing an
+// ASCII case‐insensitive comparison without allocating.
+func hasPrefixFold(s, prefix string) bool {
+	if len(s) < len(prefix) {
+		return false
+	}
+	return strings.EqualFold(s[:len(prefix)], prefix)
+}
+
 // isTracingHeader returns true for the handful of YARPC/OpenTracing headers
 // that must go over the wire unprefixed.
 func isTracingHeader(k string) bool {
-	if k == strings.ToLower(UberTraceIDHeader) {
+	if strings.EqualFold(k, UberTraceContextHeaderKey) {
 		return true
 	}
-	if strings.HasPrefix(k, strings.ToLower(UberCtxHeader)) {
+	if hasPrefixFold(k, UberBaggageHeaderKeyPrefix) {
 		return true
 	}
 	return false

--- a/transport/http/header.go
+++ b/transport/http/header.go
@@ -61,18 +61,16 @@ func (hm headerMapper) ToHTTPHeaders(from transport.Headers, to http.Header) htt
 //
 // If 'to' is nil, a new map will be assigned.
 func (hm headerMapper) FromHTTPHeaders(from http.Header, to transport.Headers) transport.Headers {
-	prefixLower := strings.ToLower(hm.Prefix)
 	for origKey, vals := range from {
-		lowerKey := strings.ToLower(origKey)
 		switch {
-		case strings.HasPrefix(lowerKey, prefixLower):
-			suffix := lowerKey[len(prefixLower):]
+		case hasPrefixFold(origKey, hm.Prefix):
+			suffix := origKey[len(hm.Prefix):]
 			for _, v := range vals {
 				to = to.With(suffix, v)
 			}
 		case isTracingHeader(origKey):
 			for _, v := range vals {
-				to = to.With(lowerKey, v)
+				to = to.With(origKey, v)
 			}
 		}
 		// Note: undefined behavior for multiple occurrences of the same header

--- a/transport/http/header.go
+++ b/transport/http/header.go
@@ -75,6 +75,7 @@ func (hm headerMapper) FromHTTPHeaders(from http.Header, to transport.Headers) t
 				to = to.With(lowerKey, v)
 			}
 		}
+		// Note: undefined behavior for multiple occurrences of the same header
 	}
 	return to
 }

--- a/transport/http/header.go
+++ b/transport/http/header.go
@@ -45,7 +45,7 @@ func (hm headerMapper) ToHTTPHeaders(from transport.Headers, to http.Header) htt
 		to = make(http.Header, from.Len())
 	}
 	for key, val := range from.Items() {
-		if isTracingHeader(strings.ToLower(key)) {
+		if isTracingHeader(key) {
 			to.Add(key, val)
 		} else {
 			to.Add(hm.Prefix+key, val)
@@ -70,7 +70,7 @@ func (hm headerMapper) FromHTTPHeaders(from http.Header, to transport.Headers) t
 			for _, v := range vals {
 				to = to.With(suffix, v)
 			}
-		case isTracingHeader(lowerKey):
+		case isTracingHeader(origKey):
 			for _, v := range vals {
 				to = to.With(lowerKey, v)
 			}

--- a/transport/http/header_test.go
+++ b/transport/http/header_test.go
@@ -1,19 +1,18 @@
-// header_test.go
 // Copyright (c) 2025 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software are
+// copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
 //
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
 //
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF NONINFRINGEMENT,
-// FITNESS FOR A PARTICULAR PURPOSE AND MERCHANTABILITY. IN NO EVENT SHALL THE
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
@@ -29,7 +28,7 @@ import (
 	"go.uber.org/yarpc/api/transport"
 )
 
-func TestHeaderMapper_ToAndFromHTTPHeaders(t *testing.T) {
+func TestHTTPHeaders(t *testing.T) {
 	tests := []struct {
 		name         string
 		transHeaders transport.Headers
@@ -78,3 +77,6 @@ func TestHeaderMapper_ToAndFromHTTPHeaders(t *testing.T) {
 		assert.Equal(t, tt.transHeaders.Items(), gotTrans.Items(), "%s: FromHTTPHeaders", tt.name)
 	}
 }
+
+// TODO(abg): Test handling of duplicate HTTP headers when
+// https://github.com/yarpc/yarpc/issues/21 is resolved.


### PR DESCRIPTION
RELEASE NOTES:
This change updates our HTTP transport’s headerMapper so that OpenTracing headers (uber-trace-id and any uberctx-* baggage) are passed through without the usual Rpc-Header- prefix. We:

Introduce an isTracingHeader helper to identify those keys.
Special-case them in both ToHTTPHeaders and FromHTTPHeaders so they remain unprefixed.
Add a round-trip unit test covering application headers, tracing headers, and a mix of both to prevent regressions.
