### PR TITLE
Export traced stream wrappers and implement header interfaces

### DIFF
--- a/internal/tracinginterceptor/interceptor.go
+++ b/internal/tracinginterceptor/interceptor.go
@@ -186,17 +186,29 @@ func (i *Interceptor) HandleStream(s *transport.ServerStream, h transport.Stream
 		Headers:   req.Meta.Headers,
 		Transport: req.Meta.Transport,
 	}
-
 	extractOpenTracingSpan := &transport.ExtractOpenTracingSpan{
 		ParentSpanContext: parentSpanCtx,
 		Tracer:            i.tracer,
-		TransportName:     s.Request().Meta.Transport,
+		TransportName:     req.Meta.Transport,
 		StartTime:         time.Now(),
 		ExtraTags:         commonTracingTags,
 	}
 	_, span := extractOpenTracingSpan.Do(s.Context(), transportRequest)
+	if span == nil {
+		return h.HandleStream(s)
+	}
 	defer span.Finish()
-	err := h.HandleStream(s)
+
+	tracedRaw := &tracedServerStream{
+		serverStream: s,
+		span:         span,
+	}
+	wrapped, err := transport.NewServerStream(tracedRaw)
+	if err != nil {
+		span.LogFields(logFieldEventError, log.String("message", "Failed to wrap the traced server stream"))
+		return err
+	}
+	err = h.HandleStream(wrapped)
 	return updateSpanWithErrorDetails(span, err != nil, nil, err)
 }
 

--- a/internal/tracinginterceptor/tracedstream.go
+++ b/internal/tracinginterceptor/tracedstream.go
@@ -22,6 +22,7 @@ package tracinginterceptor
 
 import (
 	"context"
+	"errors"
 	"io"
 
 	"github.com/opentracing/opentracing-go"
@@ -30,28 +31,29 @@ import (
 )
 
 var (
-	_ transport.StreamCloser = (*tracedClientStream)(nil)
+	_ transport.StreamCloser        = (*tracedClientStream)(nil)
+	_ transport.StreamHeadersReader = (*tracedClientStream)(nil)
+	_ transport.StreamHeadersSender = (*tracedServerStream)(nil)
 )
 
+// tracedClientStream wraps the transport.ClientStream to add tracing.
 type tracedClientStream struct {
 	clientStream *transport.ClientStream
 	span         opentracing.Span
 	closed       atomic.Bool
 }
 
-// Context returns the context for the traced client stream.
-// This method delegates to the underlying clientStream's Context method,
-// allowing access to the context associated with the stream.
+// Context returns the context associated with the client stream.
 func (t *tracedClientStream) Context() context.Context {
 	return t.clientStream.Context()
 }
 
-// Request returns the metadata about the request.
+// Request returns the initial StreamRequest metadata for the client stream.
 func (t *tracedClientStream) Request() *transport.StreamRequest {
 	return t.clientStream.Request()
 }
 
-// SendMessage sends a message over the stream. If an error occurs, it closes the span with error details.
+// SendMessage delegates to the underlying stream's SendMessage and updates the span on error.
 func (t *tracedClientStream) SendMessage(ctx context.Context, msg *transport.StreamMessage) error {
 	if err := t.clientStream.SendMessage(ctx, msg); err != nil {
 		return t.closeWithErr(err)
@@ -59,28 +61,92 @@ func (t *tracedClientStream) SendMessage(ctx context.Context, msg *transport.Str
 	return nil
 }
 
-// ReceiveMessage receives a message from the stream. If an error occurs or EOF is reached, it closes the span.
+// ReceiveMessage delegates to the underlying stream's ReceiveMessage and updates the span on error or EOF.
 func (t *tracedClientStream) ReceiveMessage(ctx context.Context) (*transport.StreamMessage, error) {
 	msg, err := t.clientStream.ReceiveMessage(ctx)
 	if err != nil {
-		if err == io.EOF {
-			return msg, t.closeWithErr(nil)
-		}
-		return msg, t.closeWithErr(err)
+		return nil, t.closeWithErr(err)
 	}
 	return msg, nil
 }
 
-// Close closes the stream and updates the span with any final error details.
+// Close closes the client stream and updates the span with any final error.
 func (t *tracedClientStream) Close(ctx context.Context) error {
 	return t.closeWithErr(t.clientStream.Close(ctx))
 }
 
-// closeWithErr closes the span with error details, ensuring it is only closed once.
+// Headers implements transport.StreamHeadersReader.
+// It reads the initial stream response headers and updates the span on error.
+func (t *tracedClientStream) Headers() (transport.Headers, error) {
+	headers, err := t.clientStream.Headers()
+	if err != nil {
+		return headers, t.closeWithErr(err)
+	}
+	return headers, nil
+}
+
+// closeWithErr finishes the span once and tags it if there was an error.
 func (t *tracedClientStream) closeWithErr(err error) error {
-	if !t.closed.Swap(true) {
+	if !t.closed.Swap(true) && t.span != nil {
 		t.span.Finish()
-		return updateSpanWithErrorDetails(t.span, err != nil, nil, err)
+		// treat EOF as non-error; everything else is an error
+		isErr := err != nil && !errors.Is(err, io.EOF)
+		// updateSpanWithErrorDetails will tag the span appropriately and return the original error
+		_ = updateSpanWithErrorDetails(t.span, isErr, nil, err)
+	}
+	return err
+}
+
+// tracedServerStream wraps a transport.ServerStream to add tracing.
+type tracedServerStream struct {
+	serverStream *transport.ServerStream
+	span         opentracing.Span
+	closed       atomic.Bool
+}
+
+// Context returns the context associated with the server stream.
+func (t *tracedServerStream) Context() context.Context {
+	return t.serverStream.Context()
+}
+
+// Request returns the initial StreamRequest metadata for the server stream.
+func (t *tracedServerStream) Request() *transport.StreamRequest {
+	return t.serverStream.Request()
+}
+
+// SendMessage delegates to the underlying stream's SendMessage and updates the span on error.
+func (t *tracedServerStream) SendMessage(ctx context.Context, msg *transport.StreamMessage) error {
+	if err := t.serverStream.SendMessage(ctx, msg); err != nil {
+		return t.closeWithErr(err)
+	}
+	return nil
+}
+
+// ReceiveMessage delegates to the underlying stream's ReceiveMessage and updates the span on error or EOF.
+func (t *tracedServerStream) ReceiveMessage(ctx context.Context) (*transport.StreamMessage, error) {
+	msg, err := t.serverStream.ReceiveMessage(ctx)
+	if err != nil {
+		return nil, t.closeWithErr(err)
+	}
+	return msg, nil
+}
+
+// SendHeaders implements transport.StreamHeadersSender.
+func (t *tracedServerStream) SendHeaders(h transport.Headers) error {
+	if err := t.serverStream.SendHeaders(h); err != nil {
+		return t.closeWithErr(err)
+	}
+	return nil
+}
+
+// closeWithErr finishes the span once and tags it if there was an error.
+func (t *tracedServerStream) closeWithErr(err error) error {
+	if !t.closed.Swap(true) && t.span != nil {
+		t.span.Finish()
+		// treat EOF as non-error; everything else is an error
+		isErr := err != nil && !errors.Is(err, io.EOF)
+		// updateSpanWithErrorDetails will tag the span appropriately and return the original error
+		_ = updateSpanWithErrorDetails(t.span, isErr, nil, err)
 	}
 	return err
 }

--- a/internal/tracinginterceptor/tracedstream_test.go
+++ b/internal/tracinginterceptor/tracedstream_test.go
@@ -1,0 +1,257 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software are
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF TORT, TORT OR OTHERWISE, ARISING FROM,
+// THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package tracinginterceptor
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/opentracing/opentracing-go/mocktracer"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/yarpc/api/transport"
+)
+
+type mockClientStream struct {
+	ctx        context.Context
+	req        *transport.StreamRequest
+	sendMsg    func(context.Context, *transport.StreamMessage) error
+	receiveMsg func(context.Context) (*transport.StreamMessage, error)
+	close      func(context.Context) error
+	headers    func() (transport.Headers, error)
+}
+
+func (m *mockClientStream) Context() context.Context {
+	return m.ctx
+}
+
+func (m *mockClientStream) Request() *transport.StreamRequest {
+	return m.req
+}
+
+func (m *mockClientStream) SendMessage(ctx context.Context, msg *transport.StreamMessage) error {
+	return m.sendMsg(ctx, msg)
+}
+
+func (m *mockClientStream) ReceiveMessage(ctx context.Context) (*transport.StreamMessage, error) {
+	return m.receiveMsg(ctx)
+}
+
+func (m *mockClientStream) Close(ctx context.Context) error {
+	return m.close(ctx)
+}
+
+func (m *mockClientStream) Headers() (transport.Headers, error) {
+	return m.headers()
+}
+
+type mockServerStream struct {
+	ctx         context.Context
+	req         *transport.StreamRequest
+	sendMsg     func(context.Context, *transport.StreamMessage) error
+	receiveMsg  func(context.Context) (*transport.StreamMessage, error)
+	sendHeaders func(transport.Headers) error
+}
+
+func (m *mockServerStream) Context() context.Context {
+	return m.ctx
+}
+
+func (m *mockServerStream) Request() *transport.StreamRequest {
+	return m.req
+}
+
+func (m *mockServerStream) SendMessage(ctx context.Context, msg *transport.StreamMessage) error {
+	return m.sendMsg(ctx, msg)
+}
+
+func (m *mockServerStream) ReceiveMessage(ctx context.Context) (*transport.StreamMessage, error) {
+	return m.receiveMsg(ctx)
+}
+
+func (m *mockServerStream) SendHeaders(h transport.Headers) error {
+	return m.sendHeaders(h)
+}
+
+func TestTracedClientStream(t *testing.T) {
+	tracer := mocktracer.New()
+	span := tracer.StartSpan("test")
+	ctx := context.Background()
+
+	clientStream := &mockClientStream{
+		ctx: ctx,
+		req: &transport.StreamRequest{
+			Meta: &transport.RequestMeta{
+				Caller:    "test-caller",
+				Service:   "test-service",
+				Procedure: "test-procedure",
+			},
+		},
+		sendMsg: func(ctx context.Context, msg *transport.StreamMessage) error {
+			return nil
+		},
+		receiveMsg: func(ctx context.Context) (*transport.StreamMessage, error) {
+			return &transport.StreamMessage{}, nil
+		},
+		close: func(ctx context.Context) error {
+			return nil
+		},
+		headers: func() (transport.Headers, error) {
+			return transport.Headers{}, nil
+		},
+	}
+
+	clientStreamWrapper, err := transport.NewClientStream(clientStream)
+	assert.NoError(t, err)
+
+	tracedStream := &tracedClientStream{
+		clientStream: clientStreamWrapper,
+		span:         span,
+	}
+
+	// Test successful SendMessage
+	err = tracedStream.SendMessage(ctx, &transport.StreamMessage{})
+	assert.NoError(t, err)
+
+	// Test successful ReceiveMessage
+	msg, err := tracedStream.ReceiveMessage(ctx)
+	assert.NoError(t, err)
+	assert.NotNil(t, msg)
+
+	// Test successful Close
+	err = tracedStream.Close(ctx)
+	assert.NoError(t, err)
+
+	// Test successful Headers
+	headers, err := tracedStream.Headers()
+	assert.NoError(t, err)
+	assert.NotNil(t, headers)
+
+	// Test error cases
+	clientStream.sendMsg = func(ctx context.Context, msg *transport.StreamMessage) error {
+		return errors.New("send error")
+	}
+	err = tracedStream.SendMessage(ctx, &transport.StreamMessage{})
+	assert.Error(t, err)
+
+	clientStream.receiveMsg = func(ctx context.Context) (*transport.StreamMessage, error) {
+		return nil, errors.New("receive error")
+	}
+	msg, err = tracedStream.ReceiveMessage(ctx)
+	assert.Error(t, err)
+	assert.Nil(t, msg)
+
+	clientStream.close = func(ctx context.Context) error {
+		return errors.New("close error")
+	}
+	err = tracedStream.Close(ctx)
+	assert.Error(t, err)
+
+	clientStream.headers = func() (transport.Headers, error) {
+		return transport.Headers{}, errors.New("headers error")
+	}
+	headers, err = tracedStream.Headers()
+	assert.Error(t, err)
+	assert.NotNil(t, headers)
+
+	// Test EOF handling
+	clientStream.receiveMsg = func(ctx context.Context) (*transport.StreamMessage, error) {
+		return nil, io.EOF
+	}
+	msg, err = tracedStream.ReceiveMessage(ctx)
+	assert.Equal(t, io.EOF, err)
+	assert.Nil(t, msg)
+}
+
+func TestTracedServerStream(t *testing.T) {
+	tracer := mocktracer.New()
+	span := tracer.StartSpan("test")
+	ctx := context.Background()
+
+	serverStream := &mockServerStream{
+		ctx: ctx,
+		req: &transport.StreamRequest{
+			Meta: &transport.RequestMeta{
+				Caller:    "test-caller",
+				Service:   "test-service",
+				Procedure: "test-procedure",
+			},
+		},
+		sendMsg: func(ctx context.Context, msg *transport.StreamMessage) error {
+			return nil
+		},
+		receiveMsg: func(ctx context.Context) (*transport.StreamMessage, error) {
+			return &transport.StreamMessage{}, nil
+		},
+		sendHeaders: func(h transport.Headers) error {
+			return nil
+		},
+	}
+
+	serverStreamWrapper, err := transport.NewServerStream(serverStream)
+	assert.NoError(t, err)
+
+	tracedStream := &tracedServerStream{
+		serverStream: serverStreamWrapper,
+		span:         span,
+	}
+
+	// Test successful SendMessage
+	err = tracedStream.SendMessage(ctx, &transport.StreamMessage{})
+	assert.NoError(t, err)
+
+	// Test successful ReceiveMessage
+	msg, err := tracedStream.ReceiveMessage(ctx)
+	assert.NoError(t, err)
+	assert.NotNil(t, msg)
+
+	// Test successful SendHeaders
+	err = tracedStream.SendHeaders(transport.Headers{})
+	assert.NoError(t, err)
+
+	// Test error cases
+	serverStream.sendMsg = func(ctx context.Context, msg *transport.StreamMessage) error {
+		return errors.New("send error")
+	}
+	err = tracedStream.SendMessage(ctx, &transport.StreamMessage{})
+	assert.Error(t, err)
+
+	serverStream.receiveMsg = func(ctx context.Context) (*transport.StreamMessage, error) {
+		return nil, errors.New("receive error")
+	}
+	msg, err = tracedStream.ReceiveMessage(ctx)
+	assert.Error(t, err)
+	assert.Nil(t, msg)
+
+	serverStream.sendHeaders = func(h transport.Headers) error {
+		return errors.New("headers error")
+	}
+	err = tracedStream.SendHeaders(transport.Headers{})
+	assert.Error(t, err)
+
+	// Test EOF handling
+	serverStream.receiveMsg = func(ctx context.Context) (*transport.StreamMessage, error) {
+		return nil, io.EOF
+	}
+	msg, err = tracedStream.ReceiveMessage(ctx)
+	assert.Equal(t, io.EOF, err)
+	assert.Nil(t, msg)
+}


### PR DESCRIPTION
RELEASE NOTES: Export TracedClientStream/TracedServerStream, implement the missing Headers() and SendHeaders() methods with compile-time interface assertions, and add GoDoc comments for all exported methods.
