### PR TITLE
Chore: remove useHTTP2 config support for http outbound

### DIFF
--- a/transport/http/config.go
+++ b/transport/http/config.go
@@ -284,12 +284,6 @@ type OutboundConfig struct {
 	//      spiffe-ids:
 	//        - destination-id
 	TLS OutboundTLSConfig `config:"tls"`
-	// UseHTTP2 configure to send http2 requests.
-	//
-	// http:
-	// 		url: "http://localhost:8080/yarpc"
-	// 		useHTTP2: true
-	UseHTTP2 bool `config:"useHTTP2"`
 }
 
 // OutboundTLSConfig configures TLS for the HTTP outbound.
@@ -340,10 +334,6 @@ func (ts *transportSpec) buildOutbound(oc *OutboundConfig, t transport.Transport
 		return nil, err
 	}
 	opts = append(option, opts...)
-
-	if oc.UseHTTP2 {
-		opts = append(opts, UseHTTP2())
-	}
 
 	// Special case where the URL implies the single peer.
 	if oc.Empty() {

--- a/transport/http/config_test.go
+++ b/transport/http/config_test.go
@@ -538,23 +538,6 @@ func TestTransportSpec(t *testing.T) {
 				},
 			},
 		},
-		{
-			desc: "enable http2 outbound with outbound cfg",
-			cfg: attrs{
-				"myservice": attrs{
-					TransportName: attrs{
-						"url":      "http://localhost/yarpc",
-						"useHTTP2": true,
-					},
-				},
-			},
-			wantOutbounds: map[string]wantOutbound{
-				"myservice": {
-					URLTemplate: "http://localhost/yarpc",
-					UseHTTP2:    true,
-				},
-			},
-		},
 	}
 
 	runTest := func(t *testing.T, trans transportTest, inbound inboundTest, outbound outboundTest) {


### PR DESCRIPTION
- [X] Description and context for reviewers: one partner, one stranger

RELEASE NOTES:
- remove useHTTP2 config support for http outbound