### PR TITLE
Add ReadHeaderTimeout to config and HTTP InboundOptions

### DIFF
--- a/transport/http/config.go
+++ b/transport/http/config.go
@@ -164,6 +164,7 @@ func (ts *transportSpec) buildTransport(tc *TransportConfig, k *yarpcconfig.Kit)
 //	         - x-foo
 //	         - x-bar
 //		      shutdownTimeout: 5s
+//	       readHeaderTimeout: 5s
 //	       readTimeout: 10s
 //	       writeTimeout: 10s
 type InboundConfig struct {
@@ -172,6 +173,8 @@ type InboundConfig struct {
 	// The additional headers, starting with x, that should be
 	// propagated to handlers. This field is optional.
 	GrabHeaders []string `config:"grabHeaders"`
+	// ReadHeaderTimeout value set on the http.Server
+	ReadHeaderTimeout *time.Duration `config:"readHeaderTimeout"`
 	// ReadTimeout value set on the http.Server
 	ReadTimeout *time.Duration `config:"readTimeout"`
 	// WriteTimeout value set on the http.Server
@@ -208,6 +211,13 @@ func (ts *transportSpec) buildInbound(ic *InboundConfig, t transport.Transport, 
 			return nil, fmt.Errorf("shutdownTimeout must not be negative, got: %q", ic.ShutdownTimeout)
 		}
 		inboundOptions = append(inboundOptions, ShutdownTimeout(*ic.ShutdownTimeout))
+	}
+
+	if ic.ReadHeaderTimeout != nil {
+		if *ic.ReadHeaderTimeout < 0 {
+			return nil, fmt.Errorf("readHeaderTimeout must not be negative, got: %q", ic.ReadHeaderTimeout)
+		}
+		inboundOptions = append(inboundOptions, ReadHeaderTimeout(*ic.ReadHeaderTimeout))
 	}
 
 	if ic.ReadTimeout != nil {

--- a/transport/http/config_test.go
+++ b/transport/http/config_test.go
@@ -75,15 +75,16 @@ func TestTransportSpec(t *testing.T) {
 	}
 
 	type wantInbound struct {
-		Address         string
-		Mux             *http.ServeMux
-		MuxPattern      string
-		GrabHeaders     map[string]struct{}
-		ShutdownTimeout time.Duration
-		TLSMode         yarpctls.Mode
-		DisableHTTP2    bool
-		ReadTimeout     time.Duration
-		WriteTimeout    time.Duration
+		Address           string
+		Mux               *http.ServeMux
+		MuxPattern        string
+		GrabHeaders       map[string]struct{}
+		ShutdownTimeout   time.Duration
+		TLSMode           yarpctls.Mode
+		DisableHTTP2      bool
+		ReadHeaderTimeout time.Duration
+		ReadTimeout       time.Duration
+		WriteTimeout      time.Duration
 	}
 
 	type inboundTest struct {
@@ -260,6 +261,17 @@ func TestTransportSpec(t *testing.T) {
 			cfg:         attrs{"address": ":8080"},
 			opts:        []Option{},
 			wantInbound: &wantInbound{Address: ":8080", ShutdownTimeout: defaultShutdownTimeout, DisableHTTP2: false},
+		},
+		{
+			desc:        "readHeaderTimeout",
+			cfg:         attrs{"address": ":8080", "readHeaderTimeout": "5s"},
+			opts:        []Option{},
+			wantInbound: &wantInbound{Address: ":8080", ShutdownTimeout: defaultShutdownTimeout, ReadHeaderTimeout: 5 * time.Second},
+		},
+		{
+			desc:       "readHeaderTimeout err",
+			cfg:        attrs{"address": ":8080", "readHeaderTimeout": "-1s"},
+			wantErrors: []string{`readHeaderTimeout must not be negative, got: "-1s"`},
 		},
 		{
 			desc:        "ReadTimeout/WriteTimeout",
@@ -609,6 +621,7 @@ func TestTransportSpec(t *testing.T) {
 				assert.Equal(t, "foo", ib.transport.serviceName, "service name must match")
 				assert.Equal(t, want.TLSMode, ib.tlsMode, "tlsMode should match")
 				assert.Equal(t, want.DisableHTTP2, ib.disableHTTP2, "disableHTTP2 should match")
+				assert.Equal(t, want.ReadHeaderTimeout, ib.server.ReadHeaderTimeout, "ReadHeaderTimeout should match")
 				assert.Equal(t, want.WriteTimeout, ib.server.WriteTimeout, "WriteTimeout should match")
 				assert.Equal(t, want.ReadTimeout, ib.server.ReadTimeout, "ReadTimeout should match")
 			}

--- a/transport/http/inbound.go
+++ b/transport/http/inbound.go
@@ -136,6 +136,13 @@ func DisableHTTP2(flag bool) InboundOption {
 	}
 }
 
+// ReadHeaderTimeout returns an InboundOption that sets the http.Server ReadHeaderTimeout
+func ReadHeaderTimeout(timeout time.Duration) InboundOption {
+	return func(i *Inbound) {
+		i.server.ReadHeaderTimeout = timeout
+	}
+}
+
 // ReadTimeout returns an InboundOption that sets the http.Server ReadTimeout
 func ReadTimeout(timeout time.Duration) InboundOption {
 	return func(i *Inbound) {

--- a/transport/http/inbound_test.go
+++ b/transport/http/inbound_test.go
@@ -460,6 +460,13 @@ func TestInboundWithHTTPVersion(t *testing.T) {
 }
 
 func TestInboundWithTimeouts(t *testing.T) {
+	t.Run("ReadHeaderTimeout", func(t *testing.T) {
+		testTransport := NewTransport()
+		inbound := testTransport.NewInbound("127.0.0.1:8888", ReadHeaderTimeout(5*time.Second))
+
+		require.Equal(t, 5*time.Second, inbound.server.ReadHeaderTimeout)
+	})
+
 	t.Run("WriteTimeout", func(t *testing.T) {
 		testTransport := NewTransport()
 		inbound := testTransport.NewInbound("127.0.0.1:8888", WriteTimeout(5*time.Second))


### PR DESCRIPTION
- [x] Description and context for reviewers: one partner, one stranger

This PR adds support for `ReadHeaderTimeout` configuration in the HTTP transport inbound. The `ReadHeaderTimeout` setting allows users to configure the maximum duration for reading request headers on the HTTP server, which helps prevent slow header attacks and improves server security.

**Implementation Details:**
- Added `ReadHeaderTimeout` field to `InboundConfig` struct with YAML config support (`readHeaderTimeout`)
- Added `ReadHeaderTimeout()` inbound option function that sets the `http.Server.ReadHeaderTimeout` field
- Added validation to ensure `ReadHeaderTimeout` is not negative
- Maintains backward compatibility - the timeout is optional and defaults to Go's http.Server default (no timeout)

**Usage Examples:**

YAML configuration:
```yaml
inbounds:
  http:
    address: ":8080"
    readHeaderTimeout: 5s
```

This enhancement improves server security by preventing slow header attacks where malicious clients send headers very slowly to tie up server resources.

- [x] Docs (package doc)

Updated configuration example to include the new `readHeaderTimeout` option.

RELEASE NOTES:

Added ReadHeaderTimeout support for HTTP inbound transport - allows configuring maximum duration for reading request headers to prevent slow header attacks.

