### PR TITLE
[Yarpc-Go] Implement Metrics Tag Decorator

### DIFF
--- a/api/metrics/metricstagdecorator/metricstagdecorator.go
+++ b/api/metrics/metricstagdecorator/metricstagdecorator.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2025 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package metricstagdecorator
+
+import (
+	"context"
+)
+
+// MetricsTagDecorator is used for adding custom tags to YARPC metrics.
+type MetricsTagDecorator interface {
+	ProvideTags(ctx context.Context) map[string]string
+}

--- a/config.go
+++ b/config.go
@@ -28,6 +28,7 @@ import (
 	"github.com/uber-go/tally"
 	"go.uber.org/net/metrics"
 	"go.uber.org/net/metrics/tallypush"
+	"go.uber.org/yarpc/api/metrics/metricstagdecorator"
 	"go.uber.org/yarpc/api/middleware"
 	"go.uber.org/yarpc/internal/observability"
 	"go.uber.org/zap"
@@ -157,6 +158,8 @@ type MetricsConfig struct {
 	// TagsBlocklist enlists tags' keys that should be suppressed from all the metrics
 	// emitted from w/in YARPC middleware.
 	TagsBlocklist []string
+	// MetricsTagsDecorators populates yarpc metrics scope with custom tags.
+	MetricsTagsDecorators []metricstagdecorator.MetricsTagDecorator
 }
 
 func (c MetricsConfig) scope(name string, logger *zap.Logger) (*metrics.Scope, context.CancelFunc) {

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -103,10 +103,11 @@ func addObservingMiddleware(cfg Config, meter *metrics.Scope, logger *zap.Logger
 	}
 
 	observer := observability.NewMiddleware(observability.Config{
-		Logger:              logger,
-		Scope:               meter,
-		ContextExtractor:    extractor,
-		MetricTagsBlocklist: cfg.Metrics.TagsBlocklist,
+		Logger:                logger,
+		Scope:                 meter,
+		ContextExtractor:      extractor,
+		MetricTagsBlocklist:   cfg.Metrics.TagsBlocklist,
+		MetricsTagsDecorators: cfg.Metrics.MetricsTagsDecorators,
 		Levels: observability.LevelsConfig{
 			Default: observability.DirectionalLevelsConfig{
 				Success:          cfg.Logging.Levels.Success,

--- a/internal/observability/middleware.go
+++ b/internal/observability/middleware.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 
 	"go.uber.org/net/metrics"
+	"go.uber.org/yarpc/api/metrics/metricstagdecorator"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/yarpcerrors"
 	"go.uber.org/zap"
@@ -99,6 +100,9 @@ type Config struct {
 
 	// Levels specify log levels for various classes of requests.
 	Levels LevelsConfig
+
+	// MetricsTagDecorators populates yarpc metrics scope with custom tags.
+	MetricsTagsDecorators []metricstagdecorator.MetricsTagDecorator
 }
 
 // LevelsConfig specifies log level overrides for inbound traffic, outbound
@@ -147,7 +151,7 @@ type DirectionalLevelsConfig struct {
 // NewMiddleware constructs an observability middleware with the provided
 // configuration.
 func NewMiddleware(cfg Config) *Middleware {
-	m := &Middleware{newGraph(cfg.Scope, cfg.Logger, cfg.ContextExtractor, cfg.MetricTagsBlocklist)}
+	m := &Middleware{newGraph(cfg.Scope, cfg.Logger, cfg.ContextExtractor, cfg.MetricTagsBlocklist, cfg.MetricsTagsDecorators)}
 
 	// Apply the default levels
 	applyLogLevelsConfig(&m.graph.inboundLevels, &cfg.Levels.Default)

--- a/internal/sampledlogger/sampledlogger.go
+++ b/internal/sampledlogger/sampledlogger.go
@@ -1,0 +1,89 @@
+package sampledlogger
+
+import (
+	"sync/atomic"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+type SampledLogger struct {
+	logger      *zap.Logger
+	logInterval time.Duration
+	lastLogTime atomic.Value
+}
+
+// NewSampledLogger creates a new SampledLogger with custom interval and zap.Logger.
+func NewSampledLogger(interval time.Duration, logger *zap.Logger) *SampledLogger {
+	return &SampledLogger{
+		logger:      logger,
+		logInterval: interval,
+	}
+}
+
+// NewDefaultSampledLogger creates a SampledLogger with zap.NewNop() and 5-minute interval.
+func NewDefaultSampledLogger() *SampledLogger {
+	return NewSampledLogger(5*time.Minute, zap.NewNop())
+}
+
+// log performs rate-limited logging for the given level and message.
+func (sl *SampledLogger) log(level zapcore.Level, msg string, fields ...zap.Field) {
+	now := time.Now()
+	last := sl.lastLogTime.Load().(time.Time)
+
+	if last.IsZero() || now.Sub(last) > sl.logInterval {
+		switch level {
+		case zapcore.DebugLevel:
+			sl.logger.Debug(msg, fields...)
+		case zapcore.InfoLevel:
+			sl.logger.Info(msg, fields...)
+		case zapcore.WarnLevel:
+			sl.logger.Warn(msg, fields...)
+		case zapcore.ErrorLevel:
+			sl.logger.Error(msg, fields...)
+		case zapcore.DPanicLevel:
+			sl.logger.DPanic(msg, fields...)
+		case zapcore.PanicLevel:
+			sl.logger.Panic(msg, fields...)
+		case zapcore.FatalLevel:
+			sl.logger.Fatal(msg, fields...)
+		}
+		sl.lastLogTime.Store(now)
+	}
+}
+
+// Debug logs a debug-level message with rate limiting.
+func (sl *SampledLogger) Debug(msg string, fields ...zap.Field) {
+	sl.log(zapcore.DebugLevel, msg, fields...)
+}
+
+// Info logs an info-level message with rate limiting.
+func (sl *SampledLogger) Info(msg string, fields ...zap.Field) {
+	sl.log(zapcore.InfoLevel, msg, fields...)
+}
+
+// Warn logs a warn-level message with rate limiting.
+func (sl *SampledLogger) Warn(msg string, fields ...zap.Field) {
+	sl.log(zapcore.WarnLevel, msg, fields...)
+}
+
+// Error logs an error-level message with rate limiting.
+func (sl *SampledLogger) Error(msg string, fields ...zap.Field) {
+	sl.log(zapcore.ErrorLevel, msg, fields...)
+}
+
+// DPanic logs a DPanic-level message with rate limiting.
+func (sl *SampledLogger) DPanic(msg string, fields ...zap.Field) {
+	sl.log(zapcore.DPanicLevel, msg, fields...)
+}
+
+// Panic logs a panic-level message with rate limiting.
+func (sl *SampledLogger) Panic(msg string, fields ...zap.Field) {
+	sl.log(zapcore.PanicLevel, msg, fields...)
+}
+
+// Fatal logs a fatal-level message with rate limiting.
+func (sl *SampledLogger) Fatal(msg string, fields ...zap.Field) {
+	sl.log(zapcore.FatalLevel, msg, fields...)
+}


### PR DESCRIPTION
- [x] Description and context for reviewers: one partner, one stranger
This PR introduces a Metric Tag Decorator interface that allows service owners to add custom tags to the inbound and outbound metrics emitted by YARPC-Go.
The main motivation for this change is to support adding a custom tenancy tag to YARPC metrics.
To prevent high cardinality issues, this tag is opt-in. By default, the tenancy tag is set to dropped, but service owners can override it by providing implementation of the TenancyTagDecorator interface.

- [x] Docs (package doc)
ERD : https://docs.google.com/document/d/1ceTSRSYCaRO5yDXQ6FFgyfloxrIHWrD6_CXVWdi00VU/edit?usp=sharing

RELEASE NOTES:
Implementing MetricsTagsDecorator which would allows teams to add custom tags to Yarpc inbound / outbound metrics
