### PR TITLE
Change inbound client error log level from Error to Warning

### DIFF
--- a/config.go
+++ b/config.go
@@ -61,7 +61,7 @@ type DirectionalLogLevelConfig struct {
 	// Level at which client errors are logged.
 	// All Thrift exceptions are considered application errors if
 	// they are not annotated with the option rpc.code.
-	// Defaults to ErrorLevel.
+	// Defaults to WarnLevel for inbound requests, ErrorLevel for outbound requests.
 	ClientError *zapcore.Level
 	// Level at which server errors are logged.
 	// Defaults to ErrorLevel.
@@ -92,7 +92,7 @@ type LogLevelConfig struct {
 	// Level at which client errors are logged.
 	// All Thrift exceptions are considered application errors if
 	// they are not annotated with the option rpc.code.
-	// Defaults to ErrorLevel.
+	// Defaults to WarnLevel for inbound requests, ErrorLevel for outbound requests.
 	// Can be overridden by Inbound.ApplicationError or
 	// Outbound.ApplicationError for inbound or outbound requests.
 	ClientError *zapcore.Level

--- a/internal/observability/graph.go
+++ b/internal/observability/graph.go
@@ -176,7 +176,7 @@ func newGraph(meter *metrics.Scope, logger *zap.Logger, extract ContextExtractor
 			failure:          zapcore.ErrorLevel,
 			applicationError: zapcore.ErrorLevel,
 			serverError:      zapcore.ErrorLevel,
-			clientError:      zapcore.ErrorLevel,
+			clientError:      zapcore.WarnLevel,
 		},
 		outboundLevels: levels{
 			success:          zapcore.DebugLevel,

--- a/internal/observability/middleware.go
+++ b/internal/observability/middleware.go
@@ -140,7 +140,7 @@ type DirectionalLevelsConfig struct {
 	// All Thrift exceptions are considered application errors if
 	// there are not annotated with the option rpc.code.
 	//
-	// Defaults to ErrorLevel.
+	// Defaults to WarnLevel for inbound requests, ErrorLevel for outbound requests.
 	ClientError *zapcore.Level
 }
 

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -124,7 +124,7 @@ func TestNewMiddlewareLogLevels(t *testing.T) {
 		t.Run("ClientError", func(t *testing.T) {
 			t.Run("default", func(t *testing.T) {
 				m := NewMiddleware(Config{})
-				assert.Equal(t, zapcore.ErrorLevel, m.graph.inboundLevels.clientError)
+				assert.Equal(t, zapcore.WarnLevel, m.graph.inboundLevels.clientError)
 				assert.False(t, m.graph.inboundLevels.useApplicationErrorFailureLevels)
 			})
 
@@ -1937,7 +1937,7 @@ func TestUnaryInboundApplicationErrors(t *testing.T) {
 
 	expected := observer.LoggedEntry{
 		Entry: zapcore.Entry{
-			Level:   zapcore.ErrorLevel,
+			Level:   zapcore.WarnLevel,
 			Message: "Error handling inbound request.",
 		},
 		Context: expectedFields,


### PR DESCRIPTION
- Updated default log level for inbound client errors from ErrorLevel to WarnLevel
- Outbound client errors remain at ErrorLevel (unchanged)
- Updated documentation comments to reflect new defaults
- Updated tests to expect WarnLevel for inbound client error logging
- Maintains backward compatibility through configuration overrides

This change reduces log noise for client-side errors on inbound requests while preserving error-level logging for outbound client errors.

- [x] Description and context for reviewers
Client errors on inbound requests (invalid args, auth failures) were creating log noise at ERROR level. This changes them to WARNING while keeping outbound client errors at ERROR level to distinguish client-side issues from server-side issues needing immediate attention.

- [x] Docs (package doc)
Users can override via config:
```yaml
yarpc:
  logging:
    levels:
      inbound:
        clientError: error  # Restore ERROR level if needed
```

RELEASE NOTES:
Changed default log level for inbound client errors from ERROR to WARNING to reduce log noise. Outbound client errors remain at ERROR level. Users can override this behavior through configuration if needed.