### PR TITLE
Update custom gRPC codec name

### DIFF
--- a/transport/grpc/codec.go
+++ b/transport/grpc/codec.go
@@ -27,7 +27,14 @@ import (
 )
 
 // Name is the name registered for the customCodec.
-const Name = "yarpc"
+//
+// YARPC installs this codec to support arbitrary combinations of transports and encodings.
+// The gRPC transport will use this codec to transmit the raw message bytes without interpretation,
+// allowing YARPC to later apply the user-specified codec.
+//
+// Although this codec bypasses gRPC’s default behavior, we register it under the name "proto"
+// to maintain compatibility with external (non-YARPC) services that expect "proto" as the encoding name.
+const Name = "proto"
 
 // customCodec pass bytes to/from the wire without modification.
 type customCodec struct{}

--- a/transport/grpc/codec_test.go
+++ b/transport/grpc/codec_test.go
@@ -57,5 +57,5 @@ func TestCustomCodecUnmarshalCastError(t *testing.T) {
 }
 
 func TestCustomCodecName(t *testing.T) {
-	assert.Equal(t, "yarpc", customCodec{}.Name())
+	assert.Equal(t, "proto", customCodec{}.Name())
 }


### PR DESCRIPTION
This PR renames YARPC’s custom passthrough codec from "yarpc" to "proto" when registering it with gRPC. 

While the codec implementation remains the same (a passthrough of raw bytes), the updated name improves compatibility with services and infrastructure that expect the standard "proto" value in the content-type header (e.g., application/grpc+proto).
