### PR TITLE
Upgrade to go 1.25

### DIFF
--- a/.buildkite/pipeline-default.yml
+++ b/.buildkite/pipeline-default.yml
@@ -64,7 +64,7 @@ steps:
       - docker-compose#v3.13.0:
           run: yarpc-go-1.21
 
-  - name: ":go: 1.22 test - %n"
+  - name: ":go: 1.25 test - %n"
     parallelism: 6
     plugins:
       - kubernetes:
@@ -77,9 +77,9 @@ steps:
                 - |-
                   make codecov
       - docker-compose#v3.13.0:
-          run: yarpc-go-1.22
+          run: yarpc-go-1.25
 
-  - name: ":go: 1.22 crossdock"
+  - name: ":go: 1.25 crossdock"
     plugins:
       - kubernetes:
           <<: *kubernetes
@@ -91,9 +91,9 @@ steps:
                 - |-
                   make crossdock-codecov
       - docker-compose#v3.13.0:
-          run: yarpc-go-1.22
+          run: yarpc-go-1.25
 
-  - name: ":go: 1.22 lint"
+  - name: ":go: 1.25 lint"
     plugins:
       - kubernetes:
           <<: *kubernetes
@@ -105,9 +105,9 @@ steps:
                 - |-
                   make lint
       - docker-compose#v3.13.0:
-          run: yarpc-go-1.22
+          run: yarpc-go-1.25
 
-  - name: ":go: 1.22 examples"
+  - name: ":go: 1.25 examples"
     plugins:
       - kubernetes:
           <<: *kubernetes
@@ -119,4 +119,4 @@ steps:
                 - |-
                   make examples
       - docker-compose#v3.13.0:
-          run: yarpc-go-1.22
+          run: yarpc-go-1.25

--- a/Dockerfile.1.25
+++ b/Dockerfile.1.25
@@ -1,0 +1,24 @@
+FROM golang:1.25
+
+ENV SUPPRESS_DOCKER 1
+WORKDIR /yarpc
+RUN apt-get update -yq && apt-get install -yq jq unzip netcat-openbsd
+ADD dockerdeps.mk /yarpc/
+ADD etc/make/base.mk etc/make/deps.mk /yarpc/etc/make/
+RUN make -f dockerdeps.mk predeps
+ADD etc/bin/vendor-build.sh /yarpc/etc/bin/
+
+# Download and cache dependencies in the image so that we're not constantly
+# re-downloading them locally.
+
+ADD tools_test.go go.mod go.sum /yarpc/
+RUN go mod download
+
+ADD internal/examples/go.mod /yarpc/internal/examples/
+RUN cd /yarpc/internal/examples && go mod download
+
+ADD internal/crossdock/go.mod /yarpc/internal/crossdock/
+RUN cd /yarpc/internal/crossdock && go mod download
+
+RUN make -f dockerdeps.mk deps
+ADD . /yarpc/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,3 +48,27 @@ services:
       - BUILDKITE_PROJECT_SLUG
       - BUILDKITE_REPO
       - GO111MODULE=on
+
+  yarpc-go-1.25:
+    build:
+      context: .
+      dockerfile: Dockerfile.1.25
+    environment:
+      - TEST_TIME_SCALE=5
+      - THIS_CHUNK=${BUILDKITE_PARALLEL_JOB}
+      - TOTAL_CHUNKS=${BUILDKITE_PARALLEL_JOB_COUNT}
+      - CODECOV_TOKEN
+      - CI=true
+      - BUILDKITE
+      - BUILDKITE_AGENT_ID
+      - BUILDKITE_BRANCH
+      - BUILDKITE_BUILD_NUMBER
+      - BUILDKITE_BUILD_URL
+      - BUILDKITE_COMMIT
+      - BUILDKITE_JOB_ID
+      - BUILDKITE_PROJECT_SLUG
+      - BUILDKITE_REPO
+      - GO111MODULE=on
+      - SSH_AUTH_SOCK=/ssh-agent
+    volumes:
+      - /ssh-agent:/ssh-agent

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module go.uber.org/yarpc
 
-go 1.21
-
-toolchain go1.22.2
+go 1.25.1
 
 require (
 	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13


### PR DESCRIPTION
This PR upgrades the go version for `yarpc-go`. 

We are currently running [v1.22](https://go.dev/doc/go1.22), which is pretty old. The current latest stable version is [v1.25](https://go.dev/doc/go1.25), and we should upgrade to get the latest features onto `yarpc-go`. 

Have deployed this version [here](https://code.uberinternal.com/D20392429) to ensure all tests pass. 