### PR TITLE
Feat: expose Headers API (canonicalised request headers) via call

### DIFF
--- a/api/encoding/call.go
+++ b/api/encoding/call.go
@@ -111,6 +111,21 @@ func (c *Call) Header(k string) string {
 	return ""
 }
 
+// Headers returns a copy of the canonicalized request headers provided with the request.
+// Deprecated: Use [HeadersAll] instead.
+func (c *Call) Headers() map[string]string {
+	if c == nil {
+		return nil
+	}
+
+	items := c.md.Headers().Items()
+	h := make(map[string]string, len(items))
+	for k, v := range items {
+		h[k] = v
+	}
+	return h
+}
+
 // OriginalHeader returns the value of the given request header provided with the
 // request. The getter is suitable for transport like TChannel that hides
 // certain headers by default eg: the ones starting with $

--- a/api/encoding/call_test.go
+++ b/api/encoding/call_test.go
@@ -89,6 +89,8 @@ func TestReadFromRequest(t *testing.T) {
 	assert.Equal(t, "Bar", call.OriginalHeader("Foo"))
 	assert.Equal(t, map[string]string{"Foo": "Bar", "foo": "bar"}, call.OriginalHeaders())
 	assert.Equal(t, call.OriginalHeaders(), maps.Collect(call.OriginalHeadersAll()), "OriginalHeadersAll should match OriginalHeaders")
+	assert.Equal(t, map[string]string{"foo": "bar"}, call.Headers())
+	assert.Equal(t, call.Headers(), maps.Collect(call.HeadersAll()), "HeadersAll should match Headers")
 
 	assert.Equal(t, "cp", call.CallerProcedure())
 	assert.Len(t, call.HeaderNames(), 1)

--- a/call.go
+++ b/call.go
@@ -186,6 +186,9 @@ func (c *Call) CallerProcedure() string {
 	return (*encoding.Call)(c).CallerProcedure()
 }
 
+// Headers returns a copy of the canonicalized request headers provided with the request.
+func (c *Call) Headers() map[string]string { return (*encoding.Call)(c).Headers() }
+
 // StreamOption defines options that may be passed in at streaming function
 // call sites.
 //

--- a/call_test.go
+++ b/call_test.go
@@ -77,6 +77,7 @@ func TestCallFromContext(t *testing.T) {
 	assert.Equal(t, "bar", call.OriginalHeader("foo"))
 	assert.Equal(t, "Bar", call.OriginalHeader("Foo"))
 	assert.Equal(t, map[string]string{"Foo": "Bar", "foo": "bar"}, call.OriginalHeaders())
+	assert.Equal(t, map[string]string{"foo": "bar"}, call.Headers()) // Headers are case insensitive
 	assert.Equal(t, []string{"foo"}, call.HeaderNames())
 	assert.Equal(t, "one", call.ShardKey())
 	assert.Equal(t, "two", call.RoutingKey())


### PR DESCRIPTION
- [X] Description and context for reviewers: one partner, one stranger
  - Feat: expose Headers API (canonicalised request headers) via call

RELEASE NOTES: Feat: expose Headers API (canonicalised request headers) via call
