### PR TITLE
Optimize header.Get access for happy path access

### DIFF
--- a/api/transport/header.go
+++ b/api/transport/header.go
@@ -126,7 +126,20 @@ func (h Headers) Del(k string) {
 
 // Get retrieves the value associated with the given header name.
 func (h Headers) Get(k string) (string, bool) {
-	v, ok := h.items[CanonicalizeHeaderKey(k)]
+	// Assume the passed in header is already canonical as a happy
+	// path optimization.
+	if v, ok := h.items[k]; ok {
+		return v, ok
+	}
+
+	// If the header is missing, fallback to the expensive path.
+	canonical := CanonicalizeHeaderKey(k)
+	// Avoid map lookup if the header turns out to be canonical.
+	if k == canonical {
+		return "", false
+	}
+	// Passed in header was non-canonical, try again.
+	v, ok := h.items[canonical]
 	return v, ok
 }
 

--- a/api/transport/header_test.go
+++ b/api/transport/header_test.go
@@ -21,6 +21,8 @@
 package transport
 
 import (
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -496,6 +498,62 @@ func TestDelWithHeaderCaseMapping(t *testing.T) {
 
 			assert.Equal(t, tt.expectedItems, header.Items())
 			assert.Equal(t, tt.expectedOriginalItems, header.OriginalItems())
+		})
+	}
+}
+
+func BenchmarkHeaderGet(b *testing.B) {
+	var (
+		presentKey = "uberctx-x-uber-can-fail-open"
+		missingKey = "uberctx-x-uber-can-fail-missing"
+		headers    = HeadersFromMap(map[string]string{
+			presentKey: "Bar",
+		})
+	)
+
+	for i := range 50 {
+		headers = headers.With(strconv.Itoa(i), strconv.Itoa(i))
+	}
+
+	tests := []struct {
+		name string
+		give string
+		want string
+		ok   bool
+	}{
+		{
+			name: "canonical",
+			give: presentKey,
+			want: "Bar",
+			ok:   true,
+		},
+		{
+			name: "noncanonical",
+			give: strings.ToUpper(presentKey),
+			want: "Bar",
+			ok:   true,
+		},
+		{
+			name: "missing-canonical",
+			give: missingKey,
+		},
+		{
+			name: "missing-noncanonical",
+			give: strings.ToUpper(missingKey),
+		},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			var (
+				s  string
+				ok bool
+			)
+			for range b.N {
+				s, ok = headers.Get(tt.give)
+			}
+			assert.Equal(b, tt.want, s)
+			assert.Equal(b, tt.ok, ok)
 		})
 	}
 }


### PR DESCRIPTION
We observe header access being a very high cost across the fleet. Looking at profiles, we observe that `CanonicalizeHeaderKey` is around 50% of the cost, even for well behaving callers. This is unfortunate.

This PR offers two benefits:
- raw optimization (see below)
- but also removes the `CanonicalizeHeaderKey` path from the "good callers". From now on, we'll now that if we see `CanonicalizeHeaderKey` in profiles (on the write path) the caller is not setting the right headers and it should be fixed.

Optimization itself stems from the fact that we're guaranteed for the `items` to contain well-formed headers.
We can then be `optimistic` and assume that caller is passing in a well formatted string and skip this path entirely. This reduces the cost by half.

All in all, we have 4 cases:
- header-present, request well formatted: 50% win
- header-present, request badly formatted - one more map lookup
- header-missing, request well formatted - one extra if/else, trivial cost increase
- header-missing, request badly formatted - one more map lookup

All current tests remain unchanged.

The primary question is how many callers are well-behaved, and it's hard to say for certain - the profiles don't show for certain (we always canonicalize today), after this PR we'll be able to see, however:
- we spot checked most application frameworks (glue, middlewares, jaeger) - those should be the bulk of it and they're all doing the right thing
- we only need 10% of callers to be well-behaved for this PR to be wel behaved
- most people have a static list of headers they care about, it should be easy to fix

Expected win is a few thousand cores.

The increase in errors seems basically within error range, depending on the benchmark run I get between 0 to 5% degradation. (memory and allock benchmarks are unchanged)

```
cpu: Apple M2 Max
                                  │  before50   │               after50                │
                                  │   sec/op    │    sec/op     vs base                │
HeaderGet/canonical-12              27.55n ± 1%    13.77n ± 1%  -50.04% (p=0.000 n=20)
HeaderGet/noncanonical-12           90.83n ± 1%    96.30n ± 0%   +6.01% (p=0.000 n=20)
HeaderGet/missing-canonical-12      31.30n ± 1%    30.43n ± 1%   -2.75% (p=0.000 n=20)
HeaderGet/missing-noncanonical-12   95.72n ± 1%   103.80n ± 1%   +8.44% (p=0.000 n=20)
```

```
pkg: go.uber.org/yarpc/api/transport
cpu: Apple M2 Max
                                  │    sec/op    │    sec/op      vs base               │
HeaderGet/canonical-12              27.57n ± ∞ ¹    13.79n ± ∞ ¹  -49.98% (p=0.008 n=5)
HeaderGet/noncanonical-12           89.86n ± ∞ ¹    96.49n ± ∞ ¹   +7.38% (p=0.008 n=5)
HeaderGet/missing-canonical-12      28.80n ± ∞ ¹    30.41n ± ∞ ¹   +5.59% (p=0.008 n=5)
HeaderGet/missing-noncanonical-12   93.75n ± ∞ ¹   100.50n ± ∞ ¹   +7.20% (p=0.008 n=5)
geomean                             50.86n          44.91n        -11.70%
```
```
                                  │    sec/op    │    sec/op      vs base               │
HeaderGet/canonical-12              28.09n ± ∞ ¹    13.79n ± ∞ ¹  -50.91% (p=0.008 n=5)
HeaderGet/noncanonical-12           92.21n ± ∞ ¹    96.49n ± ∞ ¹   +4.64% (p=0.008 n=5)
HeaderGet/missing-canonical-12      30.34n ± ∞ ¹    30.41n ± ∞ ¹        ~ (p=0.198 n=5)
HeaderGet/missing-noncanonical-12   95.80n ± ∞ ¹   100.50n ± ∞ ¹   +4.91% (p=0.008 n=5)
geomean                             52.38n          44.91n        -14.27%
¹ need >= 6 samples for confidence interval at level 0.95
```

- [ ] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)

RELEASE NOTES:
