### PR TITLE
Log when inbound encoding handler's ResponseWriter does not implement ApplicationErrorMetaSetter

### DIFF
--- a/api/transport/transporttest/reqres.go
+++ b/api/transport/transporttest/reqres.go
@@ -237,3 +237,28 @@ func (fw *FakeResponseWriter) Write(s []byte) (int, error) {
 func (fw *FakeResponseWriter) SetApplicationErrorMeta(applicationErrorMeta *transport.ApplicationErrorMeta) {
 	fw.ApplicationErrorMeta = applicationErrorMeta
 }
+
+// FakeNonApplicationErrorMetaSetter is a ResponseWriter that also
+// implements ApplicationErrorMetaSetter
+type FakeNonApplicationErrorMetaSetter struct {
+	IsApplicationError bool
+	Headers            transport.Headers
+	Body               bytes.Buffer
+}
+
+// AddHeaders for FakeNonApplicationErrorMetaSetter.
+func (fw *FakeNonApplicationErrorMetaSetter) AddHeaders(h transport.Headers) {
+	for k, v := range h.OriginalItems() {
+		fw.Headers = fw.Headers.With(k, v)
+	}
+}
+
+// SetApplicationError for FakeNonApplicationErrorMetaSetter.
+func (fw *FakeNonApplicationErrorMetaSetter) SetApplicationError() {
+	fw.IsApplicationError = true
+}
+
+// Write for FakeNonApplicationErrorMetaSetter.
+func (fw *FakeNonApplicationErrorMetaSetter) Write(s []byte) (int, error) {
+	return fw.Body.Write(s)
+}

--- a/encoding/thrift/inbound_nowire.go
+++ b/encoding/thrift/inbound_nowire.go
@@ -29,10 +29,13 @@ import (
 	"go.uber.org/thriftrw/wire"
 	encodingapi "go.uber.org/yarpc/api/encoding"
 	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/observabilitylogger"
 	"go.uber.org/yarpc/pkg/errors"
+	"go.uber.org/zap"
 )
 
 var _emptyResponse = NoWireResponse{}
+var _loggedMissingAppErrMetaSetter bool
 
 // NoWireCall contains all of the required objects needed for an underlying
 // Handle needs to unpack any given request.
@@ -94,6 +97,13 @@ func (t thriftNoWireHandler) Handle(ctx context.Context, treq *transport.Request
 				Name:    res.ApplicationErrorName,
 				Code:    res.ApplicationErrorCode,
 			})
+		} else if logger := observabilitylogger.FromContext(ctx); logger != nil {
+			if !_loggedMissingAppErrMetaSetter {
+				_loggedMissingAppErrMetaSetter = true
+				logger.Warn("ResponseWriter does not implement ApplicationErrorMetaSetter; application error metadata will not be propagated to transport",
+					zap.Stack("stacktrace"),
+				)
+			}
 		}
 	}
 

--- a/encoding/thrift/inbound_nowire_test.go
+++ b/encoding/thrift/inbound_nowire_test.go
@@ -33,7 +33,11 @@ import (
 	"go.uber.org/thriftrw/thrifttest/streamtest"
 	"go.uber.org/thriftrw/wire"
 	"go.uber.org/yarpc/api/transport/transporttest"
+	"go.uber.org/yarpc/internal/observabilitylogger"
 	"go.uber.org/yarpc/internal/testtime"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 const _body = "decoded"
@@ -220,29 +224,80 @@ func TestDecodeNoWireRequestExpectEncodingsError(t *testing.T) {
 }
 
 func TestDecodeNoWireAppliationError(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
+	t.Run("rw implements ApplicationErrorMetaSetter", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
 
-	env := streamtest.NewMockEnveloper(mockCtrl)
-	env.EXPECT().EnvelopeType().Return(wire.Reply).Times(1)
-	env.EXPECT().Encode(gomock.Any()).Return(nil).Times(1)
+		env := streamtest.NewMockEnveloper(mockCtrl)
+		env.EXPECT().EnvelopeType().Return(wire.Reply).Times(1)
+		env.EXPECT().Encode(gomock.Any()).Return(nil).Times(1)
 
-	br := &bodyReader{}
-	h := thriftNoWireHandler{
-		Handler: &responseHandler{
-			t:        t,
-			reqBody:  br,
-			body:     env,
-			appError: true,
-		},
-		RequestReader: binary.Default,
-	}
+		br := &bodyReader{}
+		h := thriftNoWireHandler{
+			Handler: &responseHandler{
+				t:        t,
+				reqBody:  br,
+				body:     env,
+				appError: true,
+			},
+			RequestReader: binary.Default,
+		}
 
-	ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
-	defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
+		defer cancel()
 
-	req := request()
-	rw := new(transporttest.FakeResponseWriter)
-	require.NoError(t, h.Handle(ctx, req, rw))
-	assert.True(t, rw.IsApplicationError)
+		req := request()
+		rw := new(transporttest.FakeResponseWriter)
+		require.NoError(t, h.Handle(ctx, req, rw))
+		assert.True(t, rw.IsApplicationError)
+	})
+
+	t.Run("rw does not implement ApplicationErrorMetaSetter", func(t *testing.T) {
+		// Reset the package-level atomic between test runs.
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		env := streamtest.NewMockEnveloper(mockCtrl)
+		env.EXPECT().EnvelopeType().Return(wire.Reply).Times(2)
+		env.EXPECT().Encode(gomock.Any()).Return(nil).Times(2)
+		br := &bodyReader{}
+		h := thriftNoWireHandler{
+			Handler: &responseHandler{
+				t:        t,
+				reqBody:  br,
+				body:     env,
+				appError: true,
+			},
+			RequestReader: binary.Default,
+		}
+
+		_loggedMissingAppErrMetaSetter = false
+		// Set up an observed logger to capture log entries.
+		core, logs := observer.New(zapcore.WarnLevel)
+		logger := zap.New(core)
+		ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
+		defer cancel()
+
+		ctx = observabilitylogger.WithLogger(ctx, logger)
+		req := request()
+		rw := new(transporttest.FakeNonApplicationErrorMetaSetter)
+		// First call: handler succeeds, warning is logged.
+		require.NoError(t, h.Handle(ctx, req, rw))
+		require.Equal(t, 1, logs.Len())
+		entry := logs.All()[0]
+		assert.Equal(t, zapcore.WarnLevel, entry.Level)
+		assert.Contains(t, entry.Message, "ApplicationErrorMetaSetter")
+		// Check logged fields.
+		fieldMap := make(map[string]string)
+		for _, f := range entry.Context {
+			if f.Type == zapcore.StringType {
+				fieldMap[f.Key] = f.String
+			}
+		}
+		assert.NotEmpty(t, fieldMap["stacktrace"])
+
+		// Second call: no additional log (atomic.Bool already flipped).
+		require.NoError(t, h.Handle(ctx, req, rw))
+		assert.Equal(t, 1, logs.Len(), "should not log a second time")
+	})
 }

--- a/internal/observability/middleware.go
+++ b/internal/observability/middleware.go
@@ -26,6 +26,7 @@ import (
 
 	"go.uber.org/net/metrics"
 	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/internal/observabilitylogger"
 	"go.uber.org/yarpc/yarpcerrors"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -185,6 +186,7 @@ func (m *Middleware) Handle(ctx context.Context, req *transport.Request, w trans
 	defer m.handlePanicForCall(call, transport.Unary)
 
 	wrappedWriter := newWriter(w)
+	ctx = observabilitylogger.WithLogger(ctx, call.edge.logger)
 	err := h.Handle(ctx, req, wrappedWriter)
 	ctxErr := ctxErrOverride(ctx, req)
 

--- a/internal/observabilitylogger/logger.go
+++ b/internal/observabilitylogger/logger.go
@@ -1,0 +1,22 @@
+package observabilitylogger
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+)
+
+type loggerKey struct{}
+
+// WithLogger attaches the logger to the context
+func WithLogger(ctx context.Context, logger *zap.Logger) context.Context {
+	return context.WithValue(ctx, loggerKey{}, logger)
+}
+
+// FromContext gets the logger from the context
+func FromContext(ctx context.Context) *zap.Logger {
+	if l, ok := ctx.Value(loggerKey{}).(*zap.Logger); ok {
+		return l
+	}
+	return nil
+}

--- a/internal/observabilitylogger/logger.go
+++ b/internal/observabilitylogger/logger.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package observabilitylogger
 
 import (

--- a/internal/observabilitylogger/logger_test.go
+++ b/internal/observabilitylogger/logger_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package observabilitylogger
 
 import (

--- a/internal/observabilitylogger/logger_test.go
+++ b/internal/observabilitylogger/logger_test.go
@@ -1,0 +1,26 @@
+package observabilitylogger
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestFromContext_NoLogger(t *testing.T) {
+	ctx := context.Background()
+	assert.Nil(t, FromContext(ctx))
+}
+func TestWithLogger_RoundTrip(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+	ctx := WithLogger(context.Background(), logger)
+	got := FromContext(ctx)
+	require.NotNil(t, got)
+	assert.Equal(t, logger, got)
+}
+func TestFromContext_WrongType(t *testing.T) {
+	ctx := context.WithValue(context.Background(), loggerKey{}, "not a logger")
+	assert.Nil(t, FromContext(ctx))
+}


### PR DESCRIPTION
[X] Description and context for reviewers: one partner, one stranger 
 - Currently, custom middlewares that do not implement the ApplicationErrorMetaSetter interface are causing silent failures with AppErrorMeta propagation. This change adds a log at thrift inbound layer, which sits just before service code. If the received ResponseWriter does not implement ApplicationErrorMetaSetter, simply log the stack trace to observe the custom middlewares in the chain. 

A logger, taken from observability middleware is propagated through context for the thrift handler to have access to it.

<img width="681" height="687" alt="Screenshot 2026-04-02 at 11 18 12" src="https://github.com/user-attachments/assets/f16edbf9-b97b-4114-9816-1c2d9f162b31" />

Test diff: [https://code.uberinternal.com/D22895705](https://code.uberinternal.com/D22895705)

RELEASE NOTES: Optional logging when inbound encoding handler's ResponseWriter does not implement ApplicationErrorMetaSetter

