### PR TITLE
Remove redundant CanonicalizeHeaderKey call from isReserved

### DIFF
--- a/transport/grpc/headers.go
+++ b/transport/grpc/headers.go
@@ -103,10 +103,8 @@ var (
 // TODO: there are way too many repeat calls to strings.ToLower
 // Note that these calls are done indirectly, primarily through
 // transport.CanonicalizeHeaderKey
-
+// NOTE: Callers must pass canonical (lowercase) keys.
 func isReserved(header string) bool {
-	header = transport.CanonicalizeHeaderKey(header)
-	// exempt routing headers from isReserved check
 	if routingHeaders[header] {
 		return false
 	}

--- a/transport/grpc/headers_test.go
+++ b/transport/grpc/headers_test.go
@@ -390,3 +390,17 @@ func TestTransportRequestToMetadataWithRoutingHeaders(t *testing.T) {
 		assert.Equal(t, []string{"custom-value"}, md["custom-header"])
 	})
 }
+
+func BenchmarkIsReserved(b *testing.B) {
+	headers := []string{
+		"rpc-caller", "rpc-service", "rpc-encoding",
+		"x-uber-source", "x-custom-header", "content-type",
+	}
+	for _, h := range headers {
+		b.Run(h, func(b *testing.B) {
+			for range b.N {
+				isReserved(h)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Remove the redundant `transport.CanonicalizeHeaderKey` call inside `isReserved()` in `transport/grpc/headers.go`. Both callers (`addApplicationHeaders` and `getApplicationHeaders`) already lowercase the key on the preceding line, making the call inside `isReserved` a provable duplicate.

## Problem

`isReserved()` calls `transport.CanonicalizeHeaderKey` (`strings.ToLower`) on every invocation, but both of its callers already call `CanonicalizeHeaderKey` on the header key immediately before passing it to `isReserved`. This results in the same string being scanned twice per header on every gRPC request path (inbound, outbound, and response).

```
addApplicationHeaders:
  header = transport.CanonicalizeHeaderKey(header)  // line 208
  if isReserved(header) {                           // line 209 → calls CanonicalizeHeaderKey AGAIN

getApplicationHeaders (client response):
  header = transport.CanonicalizeHeaderKey(header)  // line 226
  if isReserved(header) {                           // line 227 → calls CanonicalizeHeaderKey AGAIN
```

## Safety

This is a **duplicate-in-stack removal** — no external invariants are relied upon:

- Both call sites visibly lowercase the key on the preceding line within the same function
- There are no other callers of `isReserved` in production code
- Test callers (`TestIsReserved`) pass lowercase string literals, which are unaffected
- All existing tests pass

## Benchmark

`BenchmarkIsReserved` (count=6, AMD EPYC 9B45):

| | Before (main) | After (this PR) | Change |
|---|---|---|---|
| geomean | 14.39 ns/op | 6.50 ns/op | **-54.87%** (p=0.002) |

## Test plan

- [x] `go test ./transport/grpc/...` — all header tests pass (`TestIsReserved`, `TestGetApplicationHeaders`, `TestMetadataToTransportRequest`, `TestTransportRequestToMetadata`, `TestRoutingHeaders*`)
- [x] `BenchmarkIsReserved` added and run with count=6

RELEASE NOTES: Remove redundant CanonicalizeHeaderKey call from isReserved