### PR TITLE
Remove redundant CanonicalizeHeaderKey from metadata iteration paths

### DIFF
--- a/transport/grpc/headers.go
+++ b/transport/grpc/headers.go
@@ -147,8 +147,7 @@ func metadataToTransportRequest(md metadata.MD) (*transport.Request, error) {
 		default:
 			return nil, yarpcerrors.InvalidArgumentErrorf("header has more than one value: %s:%v", header, values)
 		}
-		header = transport.CanonicalizeHeaderKey(header)
-		// skip routing header
+		// gRPC metadata keys are already lowercase.
 		if routingHeaders[header] {
 			continue
 		}
@@ -223,7 +222,7 @@ func getApplicationHeaders(md metadata.MD) (transport.Headers, error) {
 	}
 	headers := transport.NewHeadersWithCapacity(md.Len())
 	for header, values := range md {
-		header = transport.CanonicalizeHeaderKey(header)
+		// gRPC metadata keys are already lowercase.
 		if isReserved(header) {
 			continue
 		}

--- a/transport/grpc/headers.go
+++ b/transport/grpc/headers.go
@@ -145,8 +145,7 @@ func metadataToTransportRequest(md metadata.MD) (*transport.Request, error) {
 		default:
 			return nil, yarpcerrors.InvalidArgumentErrorf("header has more than one value: %s:%v", header, values)
 		}
-		header = transport.CanonicalizeHeaderKey(header)
-		// skip routing header
+		// gRPC metadata keys are already lowercase.
 		if routingHeaders[header] {
 			continue
 		}
@@ -221,7 +220,7 @@ func getApplicationHeaders(md metadata.MD) (transport.Headers, error) {
 	}
 	headers := transport.NewHeadersWithCapacity(md.Len())
 	for header, values := range md {
-		header = transport.CanonicalizeHeaderKey(header)
+		// gRPC metadata keys are already lowercase.
 		if isReserved(header) {
 			continue
 		}

--- a/transport/grpc/headers_test.go
+++ b/transport/grpc/headers_test.go
@@ -253,7 +253,7 @@ func TestGetApplicationHeaders(t *testing.T) {
 				"rpc-service":         []string{"foo"}, // reserved header
 				"test-header-empty":   []string{},      // no value
 				"test-header-valid-1": []string{"test-value-1"},
-				"test-Header-Valid-2": []string{"test-value-2"},
+				"test-header-valid-2": []string{"test-value-2"},
 			},
 			wantHeaders: map[string]string{
 				"test-header-valid-1": "test-value-1",
@@ -389,4 +389,46 @@ func TestTransportRequestToMetadataWithRoutingHeaders(t *testing.T) {
 		// Verify custom header
 		assert.Equal(t, []string{"custom-value"}, md["custom-header"])
 	})
+}
+
+func BenchmarkMetadataToTransportRequest(b *testing.B) {
+	md := metadata.Pairs(
+		CallerHeader, "example-caller",
+		ServiceHeader, "example-service",
+		ShardKeyHeader, "example-shard-key",
+		RoutingKeyHeader, "example-routing-key",
+		RoutingDelegateHeader, "example-routing-delegate",
+		EncodingHeader, "raw",
+		CallerProcedureHeader, "example-caller-procedure",
+		"x-uber-source", "service-a",
+		"x-request-id", "abc-123",
+		"x-trace-id", "trace-456",
+		"x-custom-1", "val1",
+		"x-custom-2", "val2",
+	)
+
+	b.ResetTimer()
+	for range b.N {
+		_, _ = metadataToTransportRequest(md)
+	}
+}
+
+func BenchmarkGetApplicationHeaders(b *testing.B) {
+	md := metadata.MD{
+		"rpc-caller":    []string{"example-caller"},
+		"rpc-service":   []string{"example-service"},
+		"rpc-encoding":  []string{"raw"},
+		"x-uber-source": []string{"service-a"},
+		"x-request-id":  []string{"abc-123"},
+		"x-trace-id":    []string{"trace-456"},
+		"x-custom-1":    []string{"val1"},
+		"x-custom-2":    []string{"val2"},
+		"x-custom-3":    []string{"val3"},
+		"x-custom-4":    []string{"val4"},
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		_, _ = getApplicationHeaders(md)
+	}
 }

--- a/transport/grpc/headers_test.go
+++ b/transport/grpc/headers_test.go
@@ -253,7 +253,7 @@ func TestGetApplicationHeaders(t *testing.T) {
 				"rpc-service":         []string{"foo"}, // reserved header
 				"test-header-empty":   []string{},      // no value
 				"test-header-valid-1": []string{"test-value-1"},
-				"test-Header-Valid-2": []string{"test-value-2"},
+				"test-header-valid-2": []string{"test-value-2"},
 			},
 			wantHeaders: map[string]string{
 				"test-header-valid-1": "test-value-1",
@@ -402,5 +402,47 @@ func BenchmarkIsReserved(b *testing.B) {
 				isReserved(h)
 			}
 		})
+	}
+}
+
+func BenchmarkMetadataToTransportRequest(b *testing.B) {
+	md := metadata.Pairs(
+		CallerHeader, "example-caller",
+		ServiceHeader, "example-service",
+		ShardKeyHeader, "example-shard-key",
+		RoutingKeyHeader, "example-routing-key",
+		RoutingDelegateHeader, "example-routing-delegate",
+		EncodingHeader, "raw",
+		CallerProcedureHeader, "example-caller-procedure",
+		"x-uber-source", "service-a",
+		"x-request-id", "abc-123",
+		"x-trace-id", "trace-456",
+		"x-custom-1", "val1",
+		"x-custom-2", "val2",
+	)
+
+	b.ResetTimer()
+	for range b.N {
+		_, _ = metadataToTransportRequest(md)
+	}
+}
+
+func BenchmarkGetApplicationHeaders(b *testing.B) {
+	md := metadata.MD{
+		"rpc-caller":    []string{"example-caller"},
+		"rpc-service":   []string{"example-service"},
+		"rpc-encoding":  []string{"raw"},
+		"x-uber-source": []string{"service-a"},
+		"x-request-id":  []string{"abc-123"},
+		"x-trace-id":    []string{"trace-456"},
+		"x-custom-1":    []string{"val1"},
+		"x-custom-2":    []string{"val2"},
+		"x-custom-3":    []string{"val3"},
+		"x-custom-4":    []string{"val4"},
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		_, _ = getApplicationHeaders(md)
 	}
 }


### PR DESCRIPTION
## Description

- Remove redundant `transport.CanonicalizeHeaderKey` calls from `metadataToTransportRequest` and `getApplicationHeaders` in `transport/grpc/headers.go`. gRPC metadata keys are guaranteed lowercase by HTTP/2 spec and grpc-go implementation.

## Problem

Both functions call `CanonicalizeHeaderKey` (`strings.ToLower`) on every key while iterating `metadata.MD`, but these keys are already guaranteed lowercase — making the calls redundant CPU work.

## Safety — three independent guarantees:

1. **HTTP/2 spec** (RFC 7540 §8.1.2): header names MUST be lowercase
2. **grpc-go PR #4416** (v1.39): `FromIncomingContext` explicitly lowercases all keys — https://github.com/grpc/grpc-go/pull/4416
3. **yarpc-go** uses grpc-go v1.67.3, well past v1.39

## Benchmark

`count=6, AMD EPYC 9B45`:

| Benchmark | Before (main) | After (this PR) | Change |
|---|---|---|---|
| MetadataToTransportRequest | 984.8 ns/op | 907.7 ns/op | **-7.83%** (p=0.002) |
| GetApplicationHeaders | 992.0 ns/op | 895.9 ns/op | **-9.69%** (p=0.002) |

## Test plan

Ran `go test ./transport/grpc/...` and the new benchmarks locally (count=6).

- [x] All gRPC header tests pass
- [x] Benchmarks added and run with count=6

RELEASE NOTES: N/a

---

**Update (2026-07-26):** rebased onto current `main`. One positional conflict in `transport/grpc/headers_test.go`: main's newly-added `BenchmarkIsReserved` and this PR's benchmarks were both appended at the same location — resolved by keeping both functions.

