### PR TITLE
Replace fmt.Sprintf with string concatenation in toFullMethod

### DIFF
--- a/transport/grpc/util.go
+++ b/transport/grpc/util.go
@@ -21,7 +21,6 @@
 package grpc
 
 import (
-	"fmt"
 	"net/url"
 
 	"go.uber.org/yarpc/pkg/procedure"
@@ -54,7 +53,7 @@ func toFullMethod(serviceName string, methodName string) string {
 	if serviceName == "" {
 		serviceName = defaultServiceName
 	}
-	return fmt.Sprintf("/%s/%s", serviceName, methodName)
+	return "/" + serviceName + "/" + methodName
 }
 
 func procedureToName(serviceName string, methodName string) (string, error) {

--- a/transport/grpc/util_test.go
+++ b/transport/grpc/util_test.go
@@ -85,3 +85,9 @@ func TestProcedureToNameInvalidNames(t *testing.T) {
 	_, err = procedureToName("foo", "%%A")
 	require.Error(t, err)
 }
+
+func BenchmarkToFullMethod(b *testing.B) {
+	for range b.N {
+		_ = toFullMethod("MyService", "MyMethod")
+	}
+}


### PR DESCRIPTION
## Summary

- Replace `fmt.Sprintf("/%s/%s", ...)` with string concatenation `"/" + serviceName + "/" + methodName` in `toFullMethod`.

## Why

`fmt.Sprintf` parses format strings, boxes arguments, type-switches, and uses a sync.Pool buffer. String concatenation compiles to a single `runtime.concatstrings` — knows all lengths upfront, allocates once.

## Benchmark

`count=6, AMD EPYC 9B45`:

| Metric | Before (main) | After (this PR) | Change |
|---|---|---|---|
| ns/op | 70.13 | 13.07 | **-81.36%** (p=0.002) |
| B/op | 40 | 0 | **-100%** |
| allocs/op | 2 | 0 | **-100%** |

## Test plan

- [x] All gRPC util tests pass
- [x] `BenchmarkToFullMethod` added and run with count=6

RELEASE NOTES: Replace fmt.Sprintf with string concatenation in toFullMethod