### PR TITLE
Skip redundant CanonicalizeHeaderKey in gRPC transport With() calls

### DIFF
--- a/api/transport/header.go
+++ b/api/transport/header.go
@@ -50,6 +50,10 @@ type Headers struct {
 	// into originalItems under every mapped key variant, falling back to
 	// the canonicalized key for unmapped headers.
 	headerMapping map[string][]string
+	// skipCanonicalizationOfKeys indicates that all keys passed to With()
+	// are already in canonical (lowercase) form, allowing With() to skip
+	// the CanonicalizeHeaderKey call.
+	skipCanonicalizationOfKeys bool
 }
 
 // NewHeaders builds a new Headers object.
@@ -81,7 +85,10 @@ func (h Headers) With(k, v string) Headers {
 		h.items = make(map[string]string)
 		h.originalItems = make(map[string]string)
 	}
-	canonicalizedKey := CanonicalizeHeaderKey(k)
+	canonicalizedKey := k
+	if !h.skipCanonicalizationOfKeys {
+		canonicalizedKey = CanonicalizeHeaderKey(k)
+	}
 	h.items[canonicalizedKey] = v
 
 	switch {
@@ -197,6 +204,15 @@ func (h Headers) OriginalItemsLen() int {
 // items with canonicalized keys when adding headers.
 func (h Headers) EnableOverrideOriginalItemsWithCanonicalizedKeys() Headers {
 	h.overrideOriginalItemWithCanonicalizedKey = true
+	return h
+}
+
+// SkipCanonicalizationOfKeys indicates that all keys passed to With() are
+// already in canonical (lowercase) form, allowing With() to skip the
+// CanonicalizeHeaderKey call. This is a performance optimization for
+// transports where keys are guaranteed lowercase by the protocol.
+func (h Headers) SkipCanonicalizationOfKeys() Headers {
+	h.skipCanonicalizationOfKeys = true
 	return h
 }
 

--- a/api/transport/header_test.go
+++ b/api/transport/header_test.go
@@ -263,6 +263,77 @@ func TestEnableOverrideOriginalItemsWithCanonicalizedKeys(t *testing.T) {
 	}
 }
 
+func TestSkipCanonicalizationOfKeys(t *testing.T) {
+	tests := []struct {
+		msg                   string
+		skip                  bool
+		headers               []struct{ key, val string }
+		expectedItems         map[string]string
+		expectedOriginalItems map[string]string
+	}{
+		{
+			msg:  "without skip, keys are canonicalized",
+			skip: false,
+			headers: []struct{ key, val string }{
+				{"foo-bar", "value1"},
+				{"x-custom-header", "value2"},
+				{"X-Non-Lowercase", "value3"},
+			},
+			expectedItems: map[string]string{
+				"foo-bar":         "value1",
+				"x-custom-header": "value2",
+				"x-non-lowercase": "value3",
+			},
+			expectedOriginalItems: map[string]string{
+				"foo-bar":         "value1",
+				"x-custom-header": "value2",
+				"X-Non-Lowercase": "value3",
+			},
+		},
+		{
+			msg:  "with skip, keys are used as-is (no canonicalization)",
+			skip: true,
+			headers: []struct{ key, val string }{
+				{"foo-bar", "value1"},
+				{"x-custom-header", "value2"},
+				{"X-Non-Lowercase", "value3"},
+			},
+			expectedItems: map[string]string{
+				"foo-bar":         "value1",
+				"x-custom-header": "value2",
+				"X-Non-Lowercase": "value3",
+			},
+			expectedOriginalItems: map[string]string{
+				"foo-bar":         "value1",
+				"x-custom-header": "value2",
+				"X-Non-Lowercase": "value3",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			header := NewHeaders()
+			if tt.skip {
+				header = header.SkipCanonicalizationOfKeys()
+			}
+			for _, h := range tt.headers {
+				header = header.With(h.key, h.val)
+			}
+
+			assert.Equal(t, tt.expectedItems, header.Items())
+			assert.Equal(t, tt.expectedOriginalItems, header.OriginalItems())
+
+			// Verify Get works for all expected items
+			for k, v := range tt.expectedItems {
+				got, ok := header.Get(k)
+				assert.True(t, ok, "expected key %q to exist", k)
+				assert.Equal(t, v, got, "value mismatch for %q", k)
+			}
+		})
+	}
+}
+
 func TestWithHeaderCaseMapping(t *testing.T) {
 	tests := []struct {
 		msg                   string

--- a/transport/grpc/headers.go
+++ b/transport/grpc/headers.go
@@ -113,6 +113,13 @@ func isReserved(header string) bool {
 	return strings.HasPrefix(header, "rpc-")
 }
 
+// newCanonicalHeaders returns a Headers pre-sized for capacity with
+// canonicalization skipped. Used for headers sourced from gRPC metadata,
+// whose keys are guaranteed lowercase.
+func newCanonicalHeaders(capacity int) transport.Headers {
+	return transport.NewHeadersWithCapacity(capacity).SkipCanonicalizationOfKeys()
+}
+
 // transportRequestToMetadata will populate all reserved and application headers
 // from the Request into a new MD.
 func transportRequestToMetadata(request *transport.Request) (metadata.MD, error) {
@@ -135,7 +142,7 @@ func transportRequestToMetadata(request *transport.Request) (metadata.MD, error)
 // headers into a new Request, only not setting the Body field.
 func metadataToTransportRequest(md metadata.MD) (*transport.Request, error) {
 	request := &transport.Request{
-		Headers: transport.NewHeadersWithCapacity(md.Len()),
+		Headers: newCanonicalHeaders(md.Len()),
 	}
 	for header, values := range md {
 		var value string
@@ -221,9 +228,8 @@ func getApplicationHeaders(md metadata.MD) (transport.Headers, error) {
 	if len(md) == 0 {
 		return transport.Headers{}, nil
 	}
-	headers := transport.NewHeadersWithCapacity(md.Len())
+	headers := newCanonicalHeaders(md.Len())
 	for header, values := range md {
-		header = transport.CanonicalizeHeaderKey(header)
 		if isReserved(header) {
 			continue
 		}

--- a/transport/grpc/headers_test.go
+++ b/transport/grpc/headers_test.go
@@ -30,6 +30,16 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
+// canonicalHeadersFromMap builds Headers with SkipCanonicalizationOfKeys set,
+// matching the behavior of newCanonicalHeaders used in production code.
+func canonicalHeadersFromMap(m map[string]string) transport.Headers {
+	h := newCanonicalHeaders(len(m))
+	for k, v := range m {
+		h = h.With(k, v)
+	}
+	return h
+}
+
 func TestMetadataToTransportRequest(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -61,7 +71,7 @@ func TestMetadataToTransportRequest(t *testing.T) {
 				RoutingDelegate: "example-routing-delegate",
 				Encoding:        "example-encoding",
 				CallerProcedure: "example-caller-procedure",
-				Headers: transport.HeadersFromMap(map[string]string{
+				Headers: canonicalHeadersFromMap(map[string]string{
 					"foo": "bar",
 					"baz": "bat",
 				}),
@@ -86,7 +96,7 @@ func TestMetadataToTransportRequest(t *testing.T) {
 				RoutingKey:      "example-routing-key",
 				RoutingDelegate: "example-routing-delegate",
 				Encoding:        "example-encoding",
-				Headers: transport.HeadersFromMap(map[string]string{
+				Headers: canonicalHeadersFromMap(map[string]string{
 					"foo": "bar",
 					"baz": "bat",
 				}),
@@ -112,7 +122,7 @@ func TestMetadataToTransportRequest(t *testing.T) {
 				RoutingKey:      "example-routing-key",
 				RoutingDelegate: "example-routing-delegate",
 				Encoding:        "example-encoding-override",
-				Headers: transport.HeadersFromMap(map[string]string{
+				Headers: canonicalHeadersFromMap(map[string]string{
 					"foo": "bar",
 					"baz": "bat",
 				}),
@@ -253,7 +263,7 @@ func TestGetApplicationHeaders(t *testing.T) {
 				"rpc-service":         []string{"foo"}, // reserved header
 				"test-header-empty":   []string{},      // no value
 				"test-header-valid-1": []string{"test-value-1"},
-				"test-Header-Valid-2": []string{"test-value-2"},
+				"test-header-valid-2": []string{"test-value-2"}, // gRPC metadata keys are always lowercase
 			},
 			wantHeaders: map[string]string{
 				"test-header-valid-1": "test-value-1",

--- a/transport/grpc/stream.go
+++ b/transport/grpc/stream.go
@@ -186,7 +186,7 @@ func (cs *clientStream) Headers() (transport.Headers, error) {
 	if err != nil {
 		return transport.NewHeaders(), err
 	}
-	headers := transport.NewHeadersWithCapacity(len(md))
+	headers := newCanonicalHeaders(len(md))
 	for k, vs := range md {
 		if len(vs) > 0 {
 			headers = headers.With(k, vs[0])


### PR DESCRIPTION
## Summary

- Adds `SkipCanonicalizationOfKeys()` to `transport.Headers`, which sets a flag causing `With()` to skip the `CanonicalizeHeaderKey` (`strings.ToLower`) call when keys are already canonical.
- Introduces a centralized `newCanonicalHeaders()` helper in the gRPC transport that constructs `Headers` with this flag set, used by all three sites that build Headers from gRPC metadata:
  - `metadataToTransportRequest` (headers.go)
  - `getApplicationHeaders` (headers.go)
  - `clientStream.Headers` (stream.go)
- All other callers of `With()` (application code, TChannel, HTTP, `HeadersFromMap`) keep the default behavior with canonicalization enabled.

## Safety

gRPC metadata keys are guaranteed lowercase by two independent layers:

1. **HTTP/2 spec (RFC 7540 §8.1.2)**: header field names MUST be converted to lowercase prior to encoding.
   https://httpwg.org/specs/rfc7540.html#rfc.section.8.1.2

2. **grpc-go** explicitly lowercases all metadata keys from `FromIncomingContext` via `encodeKeyValue`.
   https://github.com/grpc/grpc-go/pull/4416

## Test plan

- [x] Added `TestSkipCanonicalizationOfKeys` in `api/transport/header_test.go` covering:
  - Without skip: keys are canonicalized (control case)
  - With skip: keys used as-is including non-lowercase (demonstrates no canonicalization)
- [x] Updated `TestMetadataToTransportRequest` to use `canonicalHeadersFromMap` helper matching production behavior
- [x] Updated `TestGetApplicationHeaders` to use lowercase metadata keys (matching real gRPC behavior)
- [x] Full `api/transport` test suite passes
- [x] Full `transport/grpc` test suite passes


Made with [Cursor](https://cursor.com)