### PR TITLE
grpc: add grpcClientConnWrapper and connPoolConfig types

### DIFF
--- a/transport/grpc/client_conn_wrapper.go
+++ b/transport/grpc/client_conn_wrapper.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package grpc
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	"google.golang.org/grpc"
+)
+
+// connState is the lifecycle state of a pooled gRPC connection.
+type connState int32
+
+const (
+	// connStateActive means the connection accepts new streams.
+	connStateActive connState = iota
+	// connStateDraining means the connection is no longer accepting new
+	// streams but is waiting for in-flight streams to complete.
+	connStateDraining
+	// connStateIdle means all streams have finished; the connection is
+	// waiting for the idle timeout before being closed.
+	connStateIdle
+)
+
+// connPoolConfig holds configuration for the per-peer connection pool.
+// Values are derived from transportOptions at peer creation time.
+type connPoolConfig struct {
+	// maxConcurrentStreams is the HTTP/2 SETTINGS_MAX_CONCURRENT_STREAMS
+	// value enforced by the server (default 250).
+	maxConcurrentStreams int32
+	// scaleUpThreshold is the fraction of maxConcurrentStreams at which a
+	// new connection is opened (e.g. 0.8 → scale up at 200 active streams).
+	scaleUpThreshold float64
+	// minConnections is the minimum number of connections kept in the pool.
+	minConnections int
+	// maxConnections is the maximum number of connections allowed in the pool.
+	maxConnections int
+	// idleTimeout is how long a drained connection stays idle before it is
+	// closed and removed from the pool.
+	idleTimeout time.Duration
+}
+
+// grpcClientConnWrapper wraps a single *grpc.ClientConn with connection-pool
+// metadata.  All fields that are accessed concurrently are updated atomically.
+type grpcClientConnWrapper struct {
+	clientConn *grpc.ClientConn
+
+	// ctx is derived from the peer's context.  Cancelling it stops this
+	// connection's monitor goroutine, which in turn closes clientConn.
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	// streamCount is the number of in-flight streams on this connection.
+	streamCount int32 // accessed atomically
+	// state is the current connState of this wrapper.
+	state connState // accessed atomically
+
+	createdAt      time.Time
+	lastIdleAtNano int64 // atomic unix nanos; set when transitioning to connStateIdle
+
+	// stoppedC is closed by the connection's monitor goroutine after the
+	// underlying clientConn has been closed.
+	stoppedC chan struct{}
+}
+
+func newConnWrapper(parentCtx context.Context, clientConn *grpc.ClientConn) *grpcClientConnWrapper {
+	ctx, cancel := context.WithCancel(parentCtx)
+	return &grpcClientConnWrapper{
+		clientConn: clientConn,
+		ctx:        ctx,
+		cancel:     cancel,
+		state:      connStateActive,
+		createdAt:  time.Now(),
+		stoppedC:   make(chan struct{}),
+	}
+}
+
+// incStreamCount atomically increments the active stream count.
+func (w *grpcClientConnWrapper) incStreamCount() {
+	atomic.AddInt32(&w.streamCount, 1)
+}
+
+// decStreamCount atomically decrements the active stream count.
+func (w *grpcClientConnWrapper) decStreamCount() {
+	atomic.AddInt32(&w.streamCount, -1)
+}
+
+// getStreamCount returns the current number of active streams.
+func (w *grpcClientConnWrapper) getStreamCount() int32 {
+	return atomic.LoadInt32(&w.streamCount)
+}
+
+// getState returns the current connection state.
+func (w *grpcClientConnWrapper) getState() connState {
+	return connState(atomic.LoadInt32((*int32)(&w.state)))
+}
+
+// setState atomically updates the connection state.
+func (w *grpcClientConnWrapper) setState(s connState) {
+	atomic.StoreInt32((*int32)(&w.state), int32(s))
+}
+
+// isActive reports whether the connection is currently accepting new streams.
+func (w *grpcClientConnWrapper) isActive() bool {
+	return w.getState() == connStateActive
+}
+
+// setIdleNow records the current time as the idle start time.
+func (w *grpcClientConnWrapper) setIdleNow() {
+	atomic.StoreInt64(&w.lastIdleAtNano, time.Now().UnixNano())
+}
+
+// idleSince returns the time when this connection entered the idle state,
+// or the zero time if it has not become idle yet.
+func (w *grpcClientConnWrapper) idleSince() time.Time {
+	ns := atomic.LoadInt64(&w.lastIdleAtNano)
+	if ns == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, ns)
+}

--- a/transport/grpc/client_conn_wrapper_test.go
+++ b/transport/grpc/client_conn_wrapper_test.go
@@ -1,0 +1,193 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package grpc
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// newTestConnWrapper creates a grpcClientConnWrapper backed by a real (but
+// non-connected) *grpc.ClientConn suitable for unit tests.
+func newTestConnWrapper(t *testing.T) *grpcClientConnWrapper {
+	t.Helper()
+	cc, err := grpc.NewClient("passthrough:///localhost:0", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cc.Close() })
+	return newConnWrapper(context.Background(), cc)
+}
+
+// TestNewConnWrapper verifies that newConnWrapper initialises all fields
+// correctly.
+func TestNewConnWrapper(t *testing.T) {
+	before := time.Now()
+	w := newTestConnWrapper(t)
+	after := time.Now()
+
+	assert.NotNil(t, w.clientConn)
+	assert.NotNil(t, w.ctx)
+	assert.NotNil(t, w.cancel)
+	assert.NotNil(t, w.stoppedC)
+	assert.Equal(t, connStateActive, w.getState())
+	assert.Equal(t, int32(0), w.getStreamCount())
+	assert.False(t, w.createdAt.Before(before), "createdAt should be >= before")
+	assert.False(t, w.createdAt.After(after), "createdAt should be <= after")
+}
+
+// TestConnStateConstants verifies the iota ordering that the rest of the pool
+// logic depends on.
+func TestConnStateConstants(t *testing.T) {
+	assert.Equal(t, connState(0), connStateActive)
+	assert.Equal(t, connState(1), connStateDraining)
+	assert.Equal(t, connState(2), connStateIdle)
+}
+
+// TestGetSetState verifies that setState and getState round-trip correctly for
+// all defined states.
+func TestGetSetState(t *testing.T) {
+	w := newTestConnWrapper(t)
+
+	for _, s := range []connState{connStateActive, connStateDraining, connStateIdle} {
+		w.setState(s)
+		assert.Equal(t, s, w.getState())
+	}
+}
+
+// TestIsActive verifies isActive returns true only when state is connStateActive.
+func TestIsActive(t *testing.T) {
+	w := newTestConnWrapper(t)
+
+	assert.True(t, w.isActive(), "newly created wrapper should be active")
+
+	w.setState(connStateDraining)
+	assert.False(t, w.isActive())
+
+	w.setState(connStateIdle)
+	assert.False(t, w.isActive())
+
+	w.setState(connStateActive)
+	assert.True(t, w.isActive())
+}
+
+// TestStreamCountIncDec verifies incStreamCount, decStreamCount, and
+// getStreamCount.
+func TestStreamCountIncDec(t *testing.T) {
+	w := newTestConnWrapper(t)
+
+	assert.Equal(t, int32(0), w.getStreamCount())
+
+	w.incStreamCount()
+	assert.Equal(t, int32(1), w.getStreamCount())
+
+	w.incStreamCount()
+	w.incStreamCount()
+	assert.Equal(t, int32(3), w.getStreamCount())
+
+	w.decStreamCount()
+	assert.Equal(t, int32(2), w.getStreamCount())
+
+	w.decStreamCount()
+	w.decStreamCount()
+	assert.Equal(t, int32(0), w.getStreamCount())
+}
+
+// TestStreamCountConcurrent verifies that inc/dec are safe under concurrent
+// access.
+func TestStreamCountConcurrent(t *testing.T) {
+	w := newTestConnWrapper(t)
+
+	const goroutines = 100
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 2)
+
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			w.incStreamCount()
+		}()
+		go func() {
+			defer wg.Done()
+			w.decStreamCount()
+		}()
+	}
+
+	wg.Wait()
+	assert.Equal(t, int32(0), w.getStreamCount())
+}
+
+// TestSetIdleNow verifies that setIdleNow records a timestamp and idleSince
+// returns it.
+func TestSetIdleNow(t *testing.T) {
+	w := newTestConnWrapper(t)
+
+	// Before setIdleNow, idleSince should return the zero time.
+	assert.True(t, w.idleSince().IsZero(), "idleSince should be zero before setIdleNow")
+
+	before := time.Now()
+	w.setIdleNow()
+	after := time.Now()
+
+	idle := w.idleSince()
+	assert.False(t, idle.IsZero())
+	assert.False(t, idle.Before(before.Truncate(time.Nanosecond)), "idleSince should be >= before")
+	assert.False(t, idle.After(after), "idleSince should be <= after")
+}
+
+// TestIdleSinceZeroBeforeSet verifies the zero-value branch in idleSince.
+func TestIdleSinceZeroBeforeSet(t *testing.T) {
+	w := newTestConnWrapper(t)
+	assert.Equal(t, time.Time{}, w.idleSince())
+}
+
+// TestContextCancelledOnCancel verifies that the context derived inside
+// newConnWrapper is cancelled when cancel() is called.
+func TestContextCancelledOnCancel(t *testing.T) {
+	w := newTestConnWrapper(t)
+
+	require.NoError(t, w.ctx.Err(), "context should not be cancelled initially")
+
+	w.cancel()
+
+	assert.ErrorIs(t, w.ctx.Err(), context.Canceled)
+}
+
+// TestContextInheritsParentCancellation verifies that cancelling the parent
+// context also cancels the wrapper's context.
+func TestContextInheritsParentCancellation(t *testing.T) {
+	parent, cancel := context.WithCancel(context.Background())
+
+	cc, err := grpc.NewClient("passthrough:///localhost:0", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cc.Close() })
+
+	w := newConnWrapper(parent, cc)
+
+	require.NoError(t, w.ctx.Err())
+	cancel()
+	assert.ErrorIs(t, w.ctx.Err(), context.Canceled)
+}

--- a/transport/grpc/config.go
+++ b/transport/grpc/config.go
@@ -70,6 +70,13 @@ func TransportSpec(opts ...Option) yarpcconfig.TransportSpec {
 //	        max: 30s
 //	    clientMaxHeaderListSize: 1024
 //	    serverMaxHeaderListSize: 2048
+//	    clientConnectionPool:
+//	      dynamicScalingEnabled: true
+//	      maxConcurrentStreams: 250
+//	      scaleUpThreshold: 0.8
+//	      minConnections: 1
+//	      maxConnections: 10
+//	      idleTimeout: 5m
 //
 // All parameters of TransportConfig are optional. This section
 // may be omitted in the transports section.
@@ -88,6 +95,52 @@ type TransportConfig struct {
 	// incoming streams.
 	// See: https://pkg.go.dev/google.golang.org/grpc#NumStreamWorkers
 	NumStreamWorkers uint32 `config:"numStreamWorkers"`
+	// ClientConnectionPool configures the per-peer gRPC connection pool that
+	// enables dynamic scaling beyond the HTTP/2 250-stream-per-connection limit.
+	ClientConnectionPool ClientConnectionPoolConfig `config:"clientConnectionPool"`
+}
+
+// ClientConnectionPoolConfig configures the dynamic gRPC connection pool for all
+// peers on this transport.
+//
+//	transports:
+//	  grpc:
+//	    clientConnectionPool:
+//	      dynamicScalingEnabled: true   # enable background auto-scaling
+//	      maxConcurrentStreams: 250     # assumed server HTTP/2 stream limit
+//	      scaleUpThreshold: 0.8         # open a new conn at 80% utilization
+//	      minConnections: 1             # minimum connections per peer
+//	      maxConnections: 10            # maximum connections per peer
+//	      idleTimeout: 5m               # close idle connections after this duration
+type ClientConnectionPoolConfig struct {
+	// DynamicScalingEnabled enables the background connection scaling monitor.
+	// When true, YARPC automatically opens and drains connections based on
+	// stream utilization.  Disabled by default to allow controlled rollout.
+	DynamicScalingEnabled bool `config:"dynamicScalingEnabled"`
+
+	// MaxConcurrentStreams is the assumed HTTP/2 SETTINGS_MAX_CONCURRENT_STREAMS
+	// value enforced by the server.  YARPC uses this to decide when to open an
+	// additional connection.  Defaults to 250 (Go's net/http2 default).
+	MaxConcurrentStreams int32 `config:"maxConcurrentStreams"`
+
+	// ScaleUpThreshold is the fraction of MaxConcurrentStreams at which a
+	// new connection is opened (e.g. 0.8 → scale up at 200 active streams).
+	// Must be in the range (0, 1].  Defaults to 0.8.
+	ScaleUpThreshold float64 `config:"scaleUpThreshold"`
+
+	// MinConnections is the minimum number of connections kept per peer.
+	// Connections are pre-established up to this count at peer creation time.
+	// Defaults to 1.
+	MinConnections int `config:"minConnections"`
+
+	// MaxConnections is the maximum number of connections allowed per peer.
+	// Defaults to 5.
+	MaxConnections int `config:"maxConnections"`
+
+	// IdleTimeout is how long a fully-drained connection stays idle before
+	// YARPC closes it.
+	// Defaults to 15 minutes.
+	IdleTimeout time.Duration `config:"idleTimeout"`
 }
 
 // InboundConfig configures a gRPC Inbound.
@@ -342,12 +395,57 @@ func (t *transportSpec) buildTransport(transportConfig *TransportConfig, kit *ya
 	if transportConfig.NumStreamWorkers > 0 {
 		options = append(options, NumStreamWorkers(transportConfig.NumStreamWorkers))
 	}
+	// Connection pool options — only apply non-zero values so that
+	// programmatic TransportOption defaults set by the caller are not
+	// silently overridden by the zero value of an omitted YAML field.
+	cp := transportConfig.ClientConnectionPool
+	if cp.MinConnections < 0 {
+		return nil, fmt.Errorf("clientConnectionPool.minConnections must be non-negative, got %d", cp.MinConnections)
+	}
+	if cp.MaxConnections < 0 {
+		return nil, fmt.Errorf("clientConnectionPool.maxConnections must be non-negative, got %d", cp.MaxConnections)
+	}
+	if cp.MaxConcurrentStreams < 0 {
+		return nil, fmt.Errorf("clientConnectionPool.maxConcurrentStreams must be non-negative, got %d", cp.MaxConcurrentStreams)
+	}
+	if cp.ScaleUpThreshold < 0 || cp.ScaleUpThreshold > 1 {
+		return nil, fmt.Errorf("clientConnectionPool.scaleUpThreshold must be in [0, 1], got %v", cp.ScaleUpThreshold)
+	}
+	if cp.IdleTimeout < 0 {
+		return nil, fmt.Errorf("clientConnectionPool.idleTimeout must be non-negative, got %v", cp.IdleTimeout)
+	}
+	options = append(options, WithDynamicConnectionScaling(cp.DynamicScalingEnabled))
+	if cp.MaxConcurrentStreams > 0 {
+		options = append(options, MaxConcurrentStreams(cp.MaxConcurrentStreams))
+	}
+	if cp.ScaleUpThreshold > 0 {
+		options = append(options, ScaleUpThreshold(cp.ScaleUpThreshold))
+	}
+	if cp.MinConnections > 0 {
+		options = append(options, MinConnections(cp.MinConnections))
+	}
+	if cp.MaxConnections > 0 {
+		options = append(options, MaxConnections(cp.MaxConnections))
+	}
+	if cp.IdleTimeout > 0 {
+		options = append(options, ConnIdleTimeout(cp.IdleTimeout))
+	}
 	backoffStrategy, err := transportConfig.Backoff.Strategy()
 	if err != nil {
 		return nil, err
 	}
 	options = append(options, BackoffStrategy(backoffStrategy), ServiceName(kit.ServiceName()))
-	return newTransport(newTransportOptions(options)), nil
+	opts := newTransportOptions(options)
+	if opts.clientConnPoolMaxConnections < opts.clientConnPoolMinConnections {
+		return nil, fmt.Errorf("clientConnectionPool.maxConnections (%d) must be >= minConnections (%d)", opts.clientConnPoolMaxConnections, opts.clientConnPoolMinConnections)
+	}
+	if opts.clientConnPoolScaleUpThreshold <= 0 || opts.clientConnPoolScaleUpThreshold > 1 {
+		return nil, fmt.Errorf("clientConnectionPool.scaleUpThreshold must be in (0, 1], got %v", opts.clientConnPoolScaleUpThreshold)
+	}
+	if opts.clientConnPoolMaxConcurrentStreams < 1 {
+		return nil, fmt.Errorf("clientConnectionPool.maxConcurrentStreams must be at least 1, got %d", opts.clientConnPoolMaxConcurrentStreams)
+	}
+	return newTransport(opts), nil
 }
 
 func (t *transportSpec) buildInbound(inboundConfig *InboundConfig, tr transport.Transport, _ *yarpcconfig.Kit) (transport.Inbound, error) {

--- a/transport/grpc/config_test.go
+++ b/transport/grpc/config_test.go
@@ -552,6 +552,99 @@ func TestTransportSpec(t *testing.T) {
 			},
 			wantErrors: []string{"outbound TLS enforced but outbound TLS config provider is nil"},
 		},
+		{
+			desc: "negative minConnections",
+			transportCfg: attrs{
+				"clientConnectionPool": attrs{
+					"minConnections": "-1",
+				},
+			},
+			outboundCfg: attrs{
+				"myservice": attrs{
+					TransportName: attrs{"address": "localhost:54580"},
+				},
+			},
+			wantErrors: []string{"clientConnectionPool.minConnections must be non-negative"},
+		},
+		{
+			desc: "negative maxConnections",
+			transportCfg: attrs{
+				"clientConnectionPool": attrs{
+					"maxConnections": "-1",
+				},
+			},
+			outboundCfg: attrs{
+				"myservice": attrs{
+					TransportName: attrs{"address": "localhost:54581"},
+				},
+			},
+			wantErrors: []string{"clientConnectionPool.maxConnections must be non-negative"},
+		},
+		{
+			desc: "maxConnections less than minConnections",
+			transportCfg: attrs{
+				"clientConnectionPool": attrs{
+					"minConnections": "5",
+					"maxConnections": "2",
+				},
+			},
+			outboundCfg: attrs{
+				"myservice": attrs{
+					TransportName: attrs{"address": "localhost:54582"},
+				},
+			},
+			wantErrors: []string{"clientConnectionPool.maxConnections (2) must be >= minConnections (5)"},
+		},
+		{
+			desc: "minConnections exceeds default maxConnections",
+			transportCfg: attrs{
+				"clientConnectionPool": attrs{
+					"minConnections": "10",
+				},
+			},
+			outboundCfg: attrs{
+				"myservice": attrs{
+					TransportName: attrs{"address": "localhost:54583"},
+				},
+			},
+			wantErrors: []string{"clientConnectionPool.maxConnections (5) must be >= minConnections (10)"},
+		},
+		{
+			desc: "scaleUpThreshold out of range",
+			transportCfg: attrs{
+				"clientConnectionPool": attrs{
+					"scaleUpThreshold": "1.5",
+				},
+			},
+			outboundCfg: attrs{
+				"myservice": attrs{
+					TransportName: attrs{"address": "localhost:54584"},
+				},
+			},
+			wantErrors: []string{"clientConnectionPool.scaleUpThreshold must be in [0, 1]"},
+		},
+		{
+			desc: "valid connection pool config",
+			transportCfg: attrs{
+				"clientConnectionPool": attrs{
+					"minConnections":       "2",
+					"maxConnections":       "8",
+					"scaleUpThreshold":     "0.7",
+					"maxConcurrentStreams": "200",
+					"idleTimeout":          "10m",
+				},
+			},
+			outboundCfg: attrs{
+				"myservice": attrs{
+					TransportName: attrs{"address": "localhost:54585"},
+				},
+			},
+			wantOutbounds: map[string]wantOutbound{
+				"myservice": {
+					Address: "localhost:54585",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/transport/grpc/options.go
+++ b/transport/grpc/options.go
@@ -25,6 +25,7 @@ import (
 	"crypto/tls"
 	"math"
 	"net"
+	"time"
 
 	opentracing "github.com/opentracing/opentracing-go"
 	"go.uber.org/net/metrics"
@@ -53,6 +54,13 @@ const (
 	// receive sizes to 64MB.
 	defaultServerMaxRecvMsgSize = 1024 * 1024 * 64
 	defaultClientMaxRecvMsgSize = 1024 * 1024 * 64
+	// Client connection pool defaults.
+	// defaultClientConnPoolMaxConcurrentStreams matches Go's net/http2 server default (SETTINGS_MAX_CONCURRENT_STREAMS = 250).
+	defaultClientConnPoolMaxConcurrentStreams int32         = 250
+	defaultClientConnPoolScaleUpThreshold     float64       = 0.8
+	defaultClientConnPoolMinConnections       int           = 1
+	defaultClientConnPoolMaxConnections       int           = 5
+	defaultClientConnPoolIdleTimeout          time.Duration = 15 * time.Minute
 )
 
 // Option is an interface shared by TransportOption, InboundOption, and OutboundOption
@@ -204,6 +212,81 @@ func ClientMaxHeaderListSize(clientMaxHeaderListSize uint32) TransportOption {
 	}
 }
 
+// MaxConcurrentStreams sets the assumed HTTP/2 SETTINGS_MAX_CONCURRENT_STREAMS
+// value enforced by the server.  YARPC uses this value to decide when to open
+// an additional connection to a peer.
+//
+// The gRPC client does not expose the server-advertised limit, so this must be
+// configured manually.  The default is 250, which matches Go's net/http2 server
+// default.
+func MaxConcurrentStreams(n int32) TransportOption {
+	return func(transportOptions *transportOptions) {
+		transportOptions.clientConnPoolMaxConcurrentStreams = n
+	}
+}
+
+// ScaleUpThreshold sets the fraction of MaxConcurrentStreams at which YARPC
+// opens an additional connection to a peer.  For example, a value of 0.8 means
+// a new connection is opened when any existing connection carries more than
+// 80% of its stream budget.
+//
+// The default is 0.8.
+func ScaleUpThreshold(f float64) TransportOption {
+	return func(transportOptions *transportOptions) {
+		transportOptions.clientConnPoolScaleUpThreshold = f
+	}
+}
+
+// MinConnections sets the minimum number of connections YARPC maintains to
+// each peer.  Connections are pre-established up to this count when the peer
+// is first retained.
+//
+// The default is 1.
+func MinConnections(n int) TransportOption {
+	return func(transportOptions *transportOptions) {
+		transportOptions.clientConnPoolMinConnections = n
+	}
+}
+
+// MaxConnections sets the maximum number of connections YARPC may open to a
+// single peer.
+//
+// The default is 5.
+func MaxConnections(n int) TransportOption {
+	return func(transportOptions *transportOptions) {
+		transportOptions.clientConnPoolMaxConnections = n
+	}
+}
+
+// ConnIdleTimeout sets how long a fully-drained connection remains idle before
+// YARPC closes it and removes it from the pool.
+//
+// The default is 15 minutes.
+func ConnIdleTimeout(d time.Duration) TransportOption {
+	return func(transportOptions *transportOptions) {
+		transportOptions.clientConnPoolIdleTimeout = d
+	}
+}
+
+// WithDynamicConnectionScaling enables or disables automatic gRPC connection
+// pool scaling based on stream utilization.
+//
+// When enabled, YARPC monitors stream usage on each pooled connection and
+// automatically opens new connections when any connection exceeds
+// ScaleUpThreshold, and drains connections when aggregate utilization drops
+// low enough to consolidate load onto fewer connections.
+//
+// Because YARPC is an open-source project, Flipr/ObjectConfig based rollout is handled
+// externally: set this option to true only after validating the change in a
+// controlled environment.
+//
+// The default is false (disabled).
+func WithDynamicConnectionScaling(enabled bool) TransportOption {
+	return func(transportOptions *transportOptions) {
+		transportOptions.clientConnPoolDynamicScalingEnabled = enabled
+	}
+}
+
 // InboundOption is an option for an inbound.
 type InboundOption func(*inboundOptions)
 
@@ -337,6 +420,13 @@ type transportOptions struct {
 	unaryOutboundInterceptor  []interceptor.UnaryOutbound
 	streamInboundInterceptor  interceptor.StreamInbound
 	streamOutboundInterceptor []interceptor.StreamOutbound
+	// Client connection pool options.
+	clientConnPoolMaxConcurrentStreams  int32
+	clientConnPoolScaleUpThreshold      float64
+	clientConnPoolMinConnections        int
+	clientConnPoolMaxConnections        int
+	clientConnPoolIdleTimeout           time.Duration
+	clientConnPoolDynamicScalingEnabled bool
 }
 
 func newTransportOptions(options []TransportOption) *transportOptions {
@@ -346,6 +436,12 @@ func newTransportOptions(options []TransportOption) *transportOptions {
 		serverMaxSendMsgSize: defaultServerMaxSendMsgSize,
 		clientMaxRecvMsgSize: defaultClientMaxRecvMsgSize,
 		clientMaxSendMsgSize: defaultClientMaxSendMsgSize,
+		// Client connection pool defaults.
+		clientConnPoolMaxConcurrentStreams: defaultClientConnPoolMaxConcurrentStreams,
+		clientConnPoolScaleUpThreshold:     defaultClientConnPoolScaleUpThreshold,
+		clientConnPoolMinConnections:       defaultClientConnPoolMinConnections,
+		clientConnPoolMaxConnections:       defaultClientConnPoolMaxConnections,
+		clientConnPoolIdleTimeout:          defaultClientConnPoolIdleTimeout,
 	}
 	for _, option := range options {
 		option(transportOptions)


### PR DESCRIPTION
Introduces the core data structures for the gRPC connection pool:

- grpcClientConnWrapper: wraps a *grpc.ClientConn with atomic stream count, connState (Active/Draining/Idle), per-connection context for independent lifecycle management, and idle timestamp tracking
- connPoolConfig: captures pool settings (maxConcurrentStreams, scaleUpThreshold, minConnections, maxConnections, idleTimeout)

No behaviour change — existing code is untouched. Subsequent PRs will wire these types into grpcPeer and add the scaling monitor.

