### PR TITLE
Add zstd compression support

### DIFF
--- a/compressor/benchmark_test.go
+++ b/compressor/benchmark_test.go
@@ -1,0 +1,251 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package compressor_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/api/transport"
+	yarpcgzip "go.uber.org/yarpc/compressor/gzip"
+	yarpczstd "go.uber.org/yarpc/compressor/zstd"
+)
+
+type compressorFactory struct {
+	name string
+	new  func() transport.Compressor
+}
+
+var compressors = []compressorFactory{
+	{"gzip", func() transport.Compressor { return yarpcgzip.New() }},
+	{"zstd", func() transport.Compressor { return yarpczstd.New() }},
+}
+
+type payload struct {
+	name string
+	data []byte
+}
+
+// makePayloads builds payloads that approximate what the compressor sees in
+// production: serialized protocol buffer and JSON bytes produced by YARPC
+// encodings before they hit the wire.
+//
+// Sizes are chosen to match the tiers used by other benchmarks in the repo
+// (encoding/protobuf/codec_bench_test.go, encoding/thrift/benchmark_test.go).
+func makePayloads() []payload {
+	return []payload{
+		{"proto-350B", makeProtoLike(350)},
+		{"proto-10KB", makeProtoLike(10 * 1024)},
+		{"proto-1MB", makeProtoLike(1024 * 1024)},
+		{"json-10KB", makeJSON(10 * 1024)},
+		{"random-1KB", makeRandom(1024)},
+	}
+}
+
+// Pools of realistic field values that provide moderate entropy — higher than
+// strings.Repeat("x", N) but lower than fully random a-z.  Real protobuf
+// messages contain UUIDs, service names, status strings, and addresses that
+// repeat across fields and across messages in a batch.
+var (
+	sampleStrings = []string{
+		"user-service", "payment-gateway", "order-processor",
+		"550e8400-e29b-41d4-a716-446655440000",
+		"7c9e6679-7425-40de-944b-e07fc1f90ae7",
+		"https://internal.example.com/api/v2/users",
+		"https://internal.example.com/api/v2/orders",
+		"REQUEST_COMPLETED", "REQUEST_FAILED", "REQUEST_PENDING",
+		"us-east-1", "us-west-2", "eu-west-1",
+		"john.doe@example.com", "jane.smith@example.com",
+		"192.168.1.100:8080", "10.0.0.42:9090",
+		"error: context deadline exceeded",
+		"error: connection refused",
+		`{"retry": true, "attempt": 3, "backoff_ms": 500}`,
+	}
+)
+
+// makeProtoLike builds a byte slice that approximates serialized protobuf wire
+// format.  It mixes length-delimited string fields (wire type 2) drawn from
+// realistic value pools with varint integer fields (wire type 0), producing the
+// same byte patterns proto.Marshal emits for messages with mixed field types.
+func makeProtoLike(targetSize int) []byte {
+	rng := rand.New(rand.NewSource(42))
+	var buf bytes.Buffer
+
+	fieldNum := byte(1)
+	for buf.Len() < targetSize {
+		remaining := targetSize - buf.Len()
+		if remaining <= 2 {
+			break
+		}
+
+		if rng.Intn(4) == 0 {
+			// ~25% varint integer fields (wire type 0).
+			buf.WriteByte(fieldNum << 3) // wire type 0 = varint
+			writeVarint(&buf, uint64(rng.Int63n(1<<32)))
+		} else {
+			// ~75% string fields (wire type 2) drawn from sample pool.
+			s := sampleStrings[rng.Intn(len(sampleStrings))]
+
+			// Occasionally duplicate the value to simulate repeated/list
+			// fields in a batch response.
+			reps := 1
+			if rng.Intn(5) == 0 {
+				reps = 2 + rng.Intn(4)
+			}
+
+			content := ""
+			for r := 0; r < reps; r++ {
+				content += s
+			}
+			if len(content) > remaining-3 {
+				content = content[:remaining-3]
+			}
+
+			buf.WriteByte(fieldNum<<3 | 0x02)
+			writeVarint(&buf, uint64(len(content)))
+			buf.WriteString(content)
+		}
+
+		fieldNum++
+		if fieldNum > 15 {
+			fieldNum = 1
+		}
+	}
+
+	return buf.Bytes()
+}
+
+func writeVarint(buf *bytes.Buffer, v uint64) {
+	for v >= 0x80 {
+		buf.WriteByte(byte(v&0x7f) | 0x80)
+		v >>= 7
+	}
+	buf.WriteByte(byte(v))
+}
+
+// makeJSON builds a JSON object that approximates serialized JSON-encoded YARPC
+// messages: nested objects with string keys and varied string/number values.
+func makeJSON(targetSize int) []byte {
+	rng := rand.New(rand.NewSource(99))
+	obj := make(map[string]interface{})
+
+	keys := []string{
+		"request_id", "service", "method", "caller", "status",
+		"error_message", "endpoint", "region", "user_email",
+		"trace_id", "span_id", "duration_ms", "retry_count",
+	}
+
+	for i := 0; ; i++ {
+		key := keys[i%len(keys)]
+		if i >= len(keys) {
+			key = fmt.Sprintf("%s_%d", key, i/len(keys))
+		}
+
+		if i%4 == 0 {
+			obj[key] = rng.Int63n(1 << 32)
+		} else {
+			obj[key] = sampleStrings[rng.Intn(len(sampleStrings))]
+		}
+
+		data, _ := json.Marshal(obj)
+		if len(data) >= targetSize {
+			return data
+		}
+	}
+}
+
+func makeRandom(size int) []byte {
+	rng := rand.New(rand.NewSource(7))
+	buf := make([]byte, size)
+	rng.Read(buf)
+	return buf
+}
+
+func compress(b *testing.B, c transport.Compressor, data []byte) []byte {
+	b.Helper()
+	var buf bytes.Buffer
+	w, err := c.Compress(&buf)
+	require.NoError(b, err)
+	_, err = w.Write(data)
+	require.NoError(b, err)
+	require.NoError(b, w.Close())
+	return buf.Bytes()
+}
+
+func BenchmarkCompress(b *testing.B) {
+	payloads := makePayloads()
+
+	for _, cf := range compressors {
+		for _, p := range payloads {
+			c := cf.new()
+			b.Run(fmt.Sprintf("%s/%s", cf.name, p.name), func(b *testing.B) {
+				b.SetBytes(int64(len(p.data)))
+				b.ReportAllocs()
+
+				sample := compress(b, c, p.data)
+				ratio := float64(len(sample)) / float64(len(p.data))
+
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					var buf bytes.Buffer
+					w, err := c.Compress(&buf)
+					require.NoError(b, err)
+					_, err = w.Write(p.data)
+					require.NoError(b, err)
+					require.NoError(b, w.Close())
+				}
+				b.StopTimer()
+				b.ReportMetric(ratio, "ratio")
+			})
+		}
+	}
+}
+
+func BenchmarkDecompress(b *testing.B) {
+	payloads := makePayloads()
+
+	for _, cf := range compressors {
+		for _, p := range payloads {
+			c := cf.new()
+			compressed := compress(b, c, p.data)
+
+			b.Run(fmt.Sprintf("%s/%s", cf.name, p.name), func(b *testing.B) {
+				b.SetBytes(int64(len(p.data)))
+				b.ReportAllocs()
+				b.ResetTimer()
+
+				for i := 0; i < b.N; i++ {
+					r, err := c.Decompress(bytes.NewReader(compressed))
+					require.NoError(b, err)
+					_, err = io.Copy(io.Discard, r)
+					require.NoError(b, err)
+					r.Close()
+				}
+			})
+		}
+	}
+}
+

--- a/compressor/benchmark_test.go
+++ b/compressor/benchmark_test.go
@@ -1,0 +1,250 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package compressor_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/api/transport"
+	yarpcgzip "go.uber.org/yarpc/compressor/gzip"
+	yarpczstd "go.uber.org/yarpc/compressor/zstd"
+)
+
+type compressorFactory struct {
+	name string
+	new  func() transport.Compressor
+}
+
+var compressors = []compressorFactory{
+	{"gzip", func() transport.Compressor { return yarpcgzip.New() }},
+	{"zstd", func() transport.Compressor { return yarpczstd.New() }},
+}
+
+type payload struct {
+	name string
+	data []byte
+}
+
+// makePayloads builds payloads that approximate what the compressor sees in
+// production: serialized protocol buffer and JSON bytes produced by YARPC
+// encodings before they hit the wire.
+//
+// Sizes are chosen to match the tiers used by other benchmarks in the repo
+// (encoding/protobuf/codec_bench_test.go, encoding/thrift/benchmark_test.go).
+func makePayloads() []payload {
+	return []payload{
+		{"proto-350B", makeProtoLike(350)},
+		{"proto-10KB", makeProtoLike(10 * 1024)},
+		{"proto-1MB", makeProtoLike(1024 * 1024)},
+		{"json-10KB", makeJSON(10 * 1024)},
+		{"random-1KB", makeRandom(1024)},
+	}
+}
+
+// Pools of realistic field values that provide moderate entropy — higher than
+// strings.Repeat("x", N) but lower than fully random a-z.  Real protobuf
+// messages contain UUIDs, service names, status strings, and addresses that
+// repeat across fields and across messages in a batch.
+var (
+	sampleStrings = []string{
+		"user-service", "payment-gateway", "order-processor",
+		"550e8400-e29b-41d4-a716-446655440000",
+		"7c9e6679-7425-40de-944b-e07fc1f90ae7",
+		"https://internal.example.com/api/v2/users",
+		"https://internal.example.com/api/v2/orders",
+		"REQUEST_COMPLETED", "REQUEST_FAILED", "REQUEST_PENDING",
+		"us-east-1", "us-west-2", "eu-west-1",
+		"john.doe@example.com", "jane.smith@example.com",
+		"192.168.1.100:8080", "10.0.0.42:9090",
+		"error: context deadline exceeded",
+		"error: connection refused",
+		`{"retry": true, "attempt": 3, "backoff_ms": 500}`,
+	}
+)
+
+// makeProtoLike builds a byte slice that approximates serialized protobuf wire
+// format.  It mixes length-delimited string fields (wire type 2) drawn from
+// realistic value pools with varint integer fields (wire type 0), producing the
+// same byte patterns proto.Marshal emits for messages with mixed field types.
+func makeProtoLike(targetSize int) []byte {
+	rng := rand.New(rand.NewSource(42))
+	var buf bytes.Buffer
+
+	fieldNum := byte(1)
+	for buf.Len() < targetSize {
+		remaining := targetSize - buf.Len()
+		if remaining <= 2 {
+			break
+		}
+
+		if rng.Intn(4) == 0 {
+			// ~25% varint integer fields (wire type 0).
+			buf.WriteByte(fieldNum << 3) // wire type 0 = varint
+			writeVarint(&buf, uint64(rng.Int63n(1<<32)))
+		} else {
+			// ~75% string fields (wire type 2) drawn from sample pool.
+			s := sampleStrings[rng.Intn(len(sampleStrings))]
+
+			// Occasionally duplicate the value to simulate repeated/list
+			// fields in a batch response.
+			reps := 1
+			if rng.Intn(5) == 0 {
+				reps = 2 + rng.Intn(4)
+			}
+
+			content := ""
+			for r := 0; r < reps; r++ {
+				content += s
+			}
+			if len(content) > remaining-3 {
+				content = content[:remaining-3]
+			}
+
+			buf.WriteByte(fieldNum<<3 | 0x02)
+			writeVarint(&buf, uint64(len(content)))
+			buf.WriteString(content)
+		}
+
+		fieldNum++
+		if fieldNum > 15 {
+			fieldNum = 1
+		}
+	}
+
+	return buf.Bytes()
+}
+
+func writeVarint(buf *bytes.Buffer, v uint64) {
+	for v >= 0x80 {
+		buf.WriteByte(byte(v&0x7f) | 0x80)
+		v >>= 7
+	}
+	buf.WriteByte(byte(v))
+}
+
+// makeJSON builds a JSON object that approximates serialized JSON-encoded YARPC
+// messages: nested objects with string keys and varied string/number values.
+func makeJSON(targetSize int) []byte {
+	rng := rand.New(rand.NewSource(99))
+	obj := make(map[string]interface{})
+
+	keys := []string{
+		"request_id", "service", "method", "caller", "status",
+		"error_message", "endpoint", "region", "user_email",
+		"trace_id", "span_id", "duration_ms", "retry_count",
+	}
+
+	for i := 0; ; i++ {
+		key := keys[i%len(keys)]
+		if i >= len(keys) {
+			key = fmt.Sprintf("%s_%d", key, i/len(keys))
+		}
+
+		if i%4 == 0 {
+			obj[key] = rng.Int63n(1 << 32)
+		} else {
+			obj[key] = sampleStrings[rng.Intn(len(sampleStrings))]
+		}
+
+		data, _ := json.Marshal(obj)
+		if len(data) >= targetSize {
+			return data
+		}
+	}
+}
+
+func makeRandom(size int) []byte {
+	rng := rand.New(rand.NewSource(7))
+	buf := make([]byte, size)
+	rng.Read(buf)
+	return buf
+}
+
+func compress(b *testing.B, c transport.Compressor, data []byte) []byte {
+	b.Helper()
+	var buf bytes.Buffer
+	w, err := c.Compress(&buf)
+	require.NoError(b, err)
+	_, err = w.Write(data)
+	require.NoError(b, err)
+	require.NoError(b, w.Close())
+	return buf.Bytes()
+}
+
+func BenchmarkCompress(b *testing.B) {
+	payloads := makePayloads()
+
+	for _, cf := range compressors {
+		for _, p := range payloads {
+			c := cf.new()
+			b.Run(fmt.Sprintf("%s/%s", cf.name, p.name), func(b *testing.B) {
+				b.SetBytes(int64(len(p.data)))
+				b.ReportAllocs()
+
+				sample := compress(b, c, p.data)
+				ratio := float64(len(sample)) / float64(len(p.data))
+
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					var buf bytes.Buffer
+					w, err := c.Compress(&buf)
+					require.NoError(b, err)
+					_, err = w.Write(p.data)
+					require.NoError(b, err)
+					require.NoError(b, w.Close())
+				}
+				b.StopTimer()
+				b.ReportMetric(ratio, "ratio")
+			})
+		}
+	}
+}
+
+func BenchmarkDecompress(b *testing.B) {
+	payloads := makePayloads()
+
+	for _, cf := range compressors {
+		for _, p := range payloads {
+			c := cf.new()
+			compressed := compress(b, c, p.data)
+
+			b.Run(fmt.Sprintf("%s/%s", cf.name, p.name), func(b *testing.B) {
+				b.SetBytes(int64(len(p.data)))
+				b.ReportAllocs()
+				b.ResetTimer()
+
+				for i := 0; i < b.N; i++ {
+					r, err := c.Decompress(bytes.NewReader(compressed))
+					require.NoError(b, err)
+					_, err = io.Copy(io.Discard, r)
+					require.NoError(b, err)
+					r.Close()
+				}
+			})
+		}
+	}
+}

--- a/compressor/zstd/zstd.go
+++ b/compressor/zstd/zstd.go
@@ -1,0 +1,229 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package yarpczstd provides a YARPC binding for Zstandard compression.
+package yarpczstd
+
+import (
+	"io"
+	"sync"
+
+	"github.com/klauspost/compress/zstd"
+	"go.uber.org/yarpc/api/transport"
+)
+
+const _name = "zstd"
+
+// Concurrency=1 means encoding and decoding happen in the calling goroutine
+// with no background workers. With concurrency > 1 the zstd library spawns
+// internal worker goroutines per encoder/decoder; because we pool those
+// objects via sync.Pool, the workers would persist for the pool's lifetime.
+const _defaultConcurrency = 1
+
+// Option is an option argument for the Zstd compressor constructor, New.
+type Option interface {
+	apply(*Compressor)
+}
+
+// Level sets the compression level for the compressor.
+// This is a shorthand for EncoderOptions(zstd.WithEncoderLevel(level)).
+func Level(level zstd.EncoderLevel) Option {
+	return encoderOptionsOption{opts: []zstd.EOption{zstd.WithEncoderLevel(level)}}
+}
+
+// EncoderOptions passes raw zstd encoder options through to the underlying
+// encoder.
+func EncoderOptions(opts ...zstd.EOption) Option {
+	return encoderOptionsOption{opts: opts}
+}
+
+type encoderOptionsOption struct {
+	opts []zstd.EOption
+}
+
+func (o encoderOptionsOption) apply(c *Compressor) {
+	c.encoderOptions = append(c.encoderOptions, o.opts...)
+}
+
+// DecoderOptions passes raw zstd decoder options through to the underlying
+// decoder.
+func DecoderOptions(opts ...zstd.DOption) Option {
+	return decoderOptionsOption{opts: opts}
+}
+
+type decoderOptionsOption struct {
+	opts []zstd.DOption
+}
+
+func (o decoderOptionsOption) apply(c *Compressor) {
+	c.decoderOptions = append(c.decoderOptions, o.opts...)
+}
+
+// New returns a Zstandard compression strategy, suitable for configuring
+// an outbound dialer.
+//
+// The compressor needs to be adapted and registered to be compatible
+// with the gRPC compressor system.
+// Since gRPC requires global registration of compressors, you must arrange for
+// the compressor to be registered in your application initialization.
+// The adapter converts an io.Reader into an io.ReadCloser so that reading EOF
+// will implicitly trigger Close, a behavior gRPC-go relies upon to reuse
+// readers.
+//
+//	import (
+//	    "google.golang.org/grpc/encoding"
+//	    "go.uber.org/yarpc/compressor/grpc"
+//	    "go.uber.org/yarpc/compressor/zstd"
+//	)
+//
+//	var ZstdCompressor = yarpczstd.New(yarpczstd.Level(zstd.SpeedDefault))
+//
+//	func init() {
+//	    zc := yarpcgrpccompressor.New(ZstdCompressor)
+//	    encoding.RegisterCompressor(zc)
+//	}
+//
+// If you are constructing your YARPC clients directly through the API,
+// create a gRPC dialer with the Compressor option.
+//
+//	trans := grpc.NewTransport()
+//	dialer := trans.NewDialer(grpc.Compressor(ZstdCompressor))
+//	peers := roundrobin.New(dialer)
+//	outbound := trans.NewOutbound(peers)
+//
+// If you are using the YARPC configurator to create YARPC objects
+// using config files, you will also need to register the compressor
+// with your configurator.
+//
+//	configurator := yarpcconfig.New()
+//	configurator.MustRegisterCompressor(ZstdCompressor)
+//
+// Then, using the compression strategy for outbound requests
+// on a particular client, just set the compressor to zstd.
+//
+//	outbounds:
+//	  theirsecureservice:
+//	    grpc:
+//	      address: ":443"
+//	      tls:
+//	        enabled: true
+//	      compressor: zstd
+func New(opts ...Option) *Compressor {
+	c := &Compressor{}
+	for _, opt := range opts {
+		opt.apply(c)
+	}
+	// Prepend defaults so user options win (last option wins in zstd).
+	c.encoderOptions = append(
+		[]zstd.EOption{zstd.WithEncoderConcurrency(_defaultConcurrency)},
+		c.encoderOptions...,
+	)
+	c.decoderOptions = append(
+		[]zstd.DOption{zstd.WithDecoderConcurrency(_defaultConcurrency)},
+		c.decoderOptions...,
+	)
+	return c
+}
+
+// Compressor represents the zstd compression strategy.
+type Compressor struct {
+	encoderOptions []zstd.EOption
+	decoderOptions []zstd.DOption
+	encoders       sync.Pool
+	decoders       sync.Pool
+}
+
+var _ transport.Compressor = (*Compressor)(nil)
+
+// Name is zstd.
+func (*Compressor) Name() string {
+	return _name
+}
+
+// Compress creates a zstd compressor.
+func (c *Compressor) Compress(w io.Writer) (io.WriteCloser, error) {
+	if cw, got := c.encoders.Get().(*writer); got {
+		cw.encoder.Reset(w)
+		return cw, nil
+	}
+
+	enc, err := zstd.NewWriter(w, c.encoderOptions...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &writer{
+		encoder: enc,
+		pool:    &c.encoders,
+	}, nil
+}
+
+type writer struct {
+	encoder *zstd.Encoder
+	pool    *sync.Pool
+}
+
+var _ io.WriteCloser = (*writer)(nil)
+
+func (w *writer) Write(buf []byte) (int, error) {
+	return w.encoder.Write(buf)
+}
+
+func (w *writer) Close() error {
+	defer w.pool.Put(w)
+	return w.encoder.Close()
+}
+
+// Decompress creates a zstd decompressor.
+func (c *Compressor) Decompress(r io.Reader) (io.ReadCloser, error) {
+	if dr, got := c.decoders.Get().(*reader); got {
+		if err := dr.decoder.Reset(r); err != nil {
+			c.decoders.Put(dr)
+			return nil, err
+		}
+		return dr, nil
+	}
+
+	dec, err := zstd.NewReader(r, c.decoderOptions...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &reader{
+		decoder: dec,
+		pool:    &c.decoders,
+	}, nil
+}
+
+type reader struct {
+	decoder *zstd.Decoder
+	pool    *sync.Pool
+}
+
+var _ io.ReadCloser = (*reader)(nil)
+
+func (r *reader) Read(buf []byte) (int, error) {
+	return r.decoder.Read(buf)
+}
+
+func (r *reader) Close() error {
+	r.pool.Put(r)
+	return nil
+}

--- a/compressor/zstd/zstd.go
+++ b/compressor/zstd/zstd.go
@@ -1,0 +1,235 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package yarpczstd provides a YARPC binding for Zstandard compression.
+package yarpczstd
+
+import (
+	"errors"
+	"io"
+	"sync"
+
+	"github.com/klauspost/compress/zstd"
+	"go.uber.org/yarpc/api/transport"
+)
+
+const _name = "zstd"
+
+// Concurrency=1 means encoding and decoding happen in the calling goroutine
+// with no background workers. With concurrency > 1 the zstd library spawns
+// internal worker goroutines per encoder/decoder; because we pool those
+// objects via sync.Pool, the workers would persist for the pool's lifetime.
+const _defaultConcurrency = 1
+
+// Option is an option argument for the Zstd compressor constructor, New.
+type Option interface {
+	apply(*Compressor)
+}
+
+// Level sets the compression level for the compressor.
+// This is a shorthand for EncoderOptions(zstd.WithEncoderLevel(level)).
+func Level(level zstd.EncoderLevel) Option {
+	return encoderOptionsOption{opts: []zstd.EOption{zstd.WithEncoderLevel(level)}}
+}
+
+// EncoderOptions passes raw zstd encoder options through to the underlying
+// encoder.
+func EncoderOptions(opts ...zstd.EOption) Option {
+	return encoderOptionsOption{opts: opts}
+}
+
+type encoderOptionsOption struct {
+	opts []zstd.EOption
+}
+
+func (o encoderOptionsOption) apply(c *Compressor) {
+	c.encoderOptions = append(c.encoderOptions, o.opts...)
+}
+
+// DecoderOptions passes raw zstd decoder options through to the underlying
+// decoder.
+func DecoderOptions(opts ...zstd.DOption) Option {
+	return decoderOptionsOption{opts: opts}
+}
+
+type decoderOptionsOption struct {
+	opts []zstd.DOption
+}
+
+func (o decoderOptionsOption) apply(c *Compressor) {
+	c.decoderOptions = append(c.decoderOptions, o.opts...)
+}
+
+// New returns a Zstandard compression strategy, suitable for configuring
+// an outbound dialer.
+//
+// The compressor needs to be adapted and registered to be compatible
+// with the gRPC compressor system.
+// Since gRPC requires global registration of compressors, you must arrange for
+// the compressor to be registered in your application initialization.
+// The adapter converts an io.Reader into an io.ReadCloser so that reading EOF
+// will implicitly trigger Close, a behavior gRPC-go relies upon to reuse
+// readers.
+//
+//	import (
+//	    "google.golang.org/grpc/encoding"
+//	    "go.uber.org/yarpc/compressor/grpc"
+//	    "go.uber.org/yarpc/compressor/zstd"
+//	)
+//
+//	var ZstdCompressor = yarpczstd.New(yarpczstd.Level(zstd.SpeedDefault))
+//
+//	func init() {
+//	    zc := yarpcgrpccompressor.New(ZstdCompressor)
+//	    encoding.RegisterCompressor(zc)
+//	}
+//
+// If you are constructing your YARPC clients directly through the API,
+// create a gRPC dialer with the Compressor option.
+//
+//	trans := grpc.NewTransport()
+//	dialer := trans.NewDialer(grpc.Compressor(ZstdCompressor))
+//	peers := roundrobin.New(dialer)
+//	outbound := trans.NewOutbound(peers)
+//
+// If you are using the YARPC configurator to create YARPC objects
+// using config files, you will also need to register the compressor
+// with your configurator.
+//
+//	configurator := yarpcconfig.New()
+//	configurator.MustRegisterCompressor(ZstdCompressor)
+//
+// Then, using the compression strategy for outbound requests
+// on a particular client, just set the compressor to zstd.
+//
+//	outbounds:
+//	  theirsecureservice:
+//	    grpc:
+//	      address: ":443"
+//	      tls:
+//	        enabled: true
+//	      compressor: zstd
+func New(opts ...Option) *Compressor {
+	c := &Compressor{
+		encoderOptions: []zstd.EOption{zstd.WithEncoderConcurrency(_defaultConcurrency)},
+		decoderOptions: []zstd.DOption{zstd.WithDecoderConcurrency(_defaultConcurrency)},
+	}
+	for _, opt := range opts {
+		opt.apply(c)
+	}
+	return c
+}
+
+// Compressor represents the zstd compression strategy.
+type Compressor struct {
+	encoderOptions []zstd.EOption
+	decoderOptions []zstd.DOption
+	encoders       sync.Pool
+	decoders       sync.Pool
+}
+
+var _ transport.Compressor = (*Compressor)(nil)
+
+// Name is zstd.
+func (*Compressor) Name() string {
+	return _name
+}
+
+// Compress creates a zstd compressor.
+func (c *Compressor) Compress(w io.Writer) (io.WriteCloser, error) {
+	if cw, got := c.encoders.Get().(*writer); got {
+		cw.encoder.Reset(w)
+		cw.pool = &c.encoders
+		return cw, nil
+	}
+
+	enc, err := zstd.NewWriter(w, c.encoderOptions...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &writer{
+		encoder: enc,
+		pool:    &c.encoders,
+	}, nil
+}
+
+type writer struct {
+	encoder *zstd.Encoder
+	pool    *sync.Pool
+}
+
+var _ io.WriteCloser = (*writer)(nil)
+
+func (w *writer) Write(buf []byte) (int, error) {
+	return w.encoder.Write(buf)
+}
+
+func (w *writer) Close() error {
+	err := w.encoder.Close()
+	if w.pool != nil {
+		w.pool.Put(w)
+		w.pool = nil
+	}
+	return err
+}
+
+// Decompress creates a zstd decompressor.
+func (c *Compressor) Decompress(r io.Reader) (io.ReadCloser, error) {
+	if dr, got := c.decoders.Get().(*reader); got {
+		if err := dr.decoder.Reset(r); err != nil {
+			if !errors.Is(err, zstd.ErrDecoderClosed) {
+				c.decoders.Put(dr)
+			}
+			return nil, err
+		}
+		dr.pool = &c.decoders
+		return dr, nil
+	}
+
+	dec, err := zstd.NewReader(r, c.decoderOptions...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &reader{
+		decoder: dec,
+		pool:    &c.decoders,
+	}, nil
+}
+
+type reader struct {
+	decoder *zstd.Decoder
+	pool    *sync.Pool
+}
+
+var _ io.ReadCloser = (*reader)(nil)
+
+func (r *reader) Read(buf []byte) (int, error) {
+	return r.decoder.Read(buf)
+}
+
+func (r *reader) Close() error {
+	if r.pool != nil {
+		r.pool.Put(r)
+		r.pool = nil
+	}
+	return nil
+}

--- a/compressor/zstd/zstd_test.go
+++ b/compressor/zstd/zstd_test.go
@@ -1,0 +1,160 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpczstd_test
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	yarpczstd "go.uber.org/yarpc/compressor/zstd"
+)
+
+var quote = "Now is the time for all good men to come to the aid of their country"
+var input = []byte(quote + quote + quote)
+
+// TestCompressionPooling reuses a single Compressor across many sequential
+// round-trips to exercise encoder/decoder pool recycling. Also sanity-checks
+// that compressed output is smaller than the input.
+func TestCompressionPooling(t *testing.T) {
+	compressor := yarpczstd.New()
+	for i := 0; i < 128; i++ {
+		buf := bytes.NewBuffer(nil)
+		writer, err := compressor.Compress(buf)
+		require.NoError(t, err)
+
+		_, err = writer.Write(input)
+		require.NoError(t, err)
+		require.NoError(t, writer.Close())
+
+		assert.True(t, buf.Len() < len(input), "compressed data should be smaller than input")
+
+		str, err := compressor.Decompress(buf)
+		require.NoError(t, err)
+
+		output, err := io.ReadAll(str)
+		require.NoError(t, err)
+		require.NoError(t, str.Close())
+
+		assert.Equal(t, input, output)
+	}
+}
+
+func TestEveryCompressionLevel(t *testing.T) {
+	levels := []zstd.EncoderLevel{
+		zstd.SpeedFastest,
+		zstd.SpeedDefault,
+		zstd.SpeedBetterCompression,
+		zstd.SpeedBestCompression,
+	}
+
+	for _, level := range levels {
+		t.Run(level.String(), func(t *testing.T) {
+			compressor := yarpczstd.New(yarpczstd.Level(level))
+
+			buf := bytes.NewBuffer(nil)
+			writer, err := compressor.Compress(buf)
+			require.NoError(t, err)
+
+			_, err = writer.Write(input)
+			require.NoError(t, err)
+			require.NoError(t, writer.Close())
+
+			str, err := compressor.Decompress(buf)
+			require.NoError(t, err)
+
+			output, err := io.ReadAll(str)
+			require.NoError(t, err)
+			require.NoError(t, str.Close())
+
+			assert.Equal(t, input, output)
+		})
+	}
+}
+
+func TestZstdName(t *testing.T) {
+	assert.Equal(t, "zstd", yarpczstd.New().Name())
+}
+
+func TestRawEncoderDecoderOptions(t *testing.T) {
+	compressor := yarpczstd.New(
+		yarpczstd.Level(zstd.SpeedBestCompression),
+		yarpczstd.EncoderOptions(zstd.WithWindowSize(1<<20)),
+		yarpczstd.DecoderOptions(zstd.WithDecoderLowmem(true)),
+	)
+
+	buf := bytes.NewBuffer(nil)
+	writer, err := compressor.Compress(buf)
+	require.NoError(t, err)
+
+	_, err = writer.Write(input)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	str, err := compressor.Decompress(buf)
+	require.NoError(t, err)
+
+	output, err := io.ReadAll(str)
+	require.NoError(t, err)
+	require.NoError(t, str.Close())
+
+	assert.Equal(t, input, output)
+}
+
+func TestDecompressPoolingAfterError(t *testing.T) {
+	compressor := yarpczstd.New()
+
+	// Warm up the pool with valid data.
+	buf := bytes.NewBuffer(nil)
+	writer, err := compressor.Compress(buf)
+	require.NoError(t, err)
+	_, err = writer.Write(input)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+	validData := buf.Bytes()
+
+	r, err := compressor.Decompress(bytes.NewReader(validData))
+	require.NoError(t, err)
+	io.Copy(io.Discard, r)
+	r.Close()
+
+	// Feed invalid data — the pooled decoder should handle the error.
+	invalidData := []byte("this is not valid zstd data")
+	r, err = compressor.Decompress(bytes.NewReader(invalidData))
+	if err == nil {
+		// zstd may defer the error to Read rather than Decompress.
+		_, err = io.ReadAll(r)
+		r.Close()
+	}
+	require.Error(t, err)
+
+	// After the error, the pool should still produce working decoders.
+	r, err = compressor.Decompress(bytes.NewReader(validData))
+	require.NoError(t, err)
+	output, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+	assert.Equal(t, input, output)
+}
+

--- a/compressor/zstd/zstd_test.go
+++ b/compressor/zstd/zstd_test.go
@@ -1,0 +1,159 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpczstd_test
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	yarpczstd "go.uber.org/yarpc/compressor/zstd"
+)
+
+var quote = "Now is the time for all good men to come to the aid of their country"
+var input = []byte(quote + quote + quote)
+
+// TestCompressionPooling reuses a single Compressor across many sequential
+// round-trips to exercise encoder/decoder pool recycling. Also sanity-checks
+// that compressed output is smaller than the input.
+func TestCompressionPooling(t *testing.T) {
+	compressor := yarpczstd.New()
+	for i := 0; i < 128; i++ {
+		buf := bytes.NewBuffer(nil)
+		writer, err := compressor.Compress(buf)
+		require.NoError(t, err)
+
+		_, err = writer.Write(input)
+		require.NoError(t, err)
+		require.NoError(t, writer.Close())
+
+		assert.True(t, buf.Len() < len(input), "compressed data should be smaller than input")
+
+		str, err := compressor.Decompress(buf)
+		require.NoError(t, err)
+
+		output, err := io.ReadAll(str)
+		require.NoError(t, err)
+		require.NoError(t, str.Close())
+
+		assert.Equal(t, input, output)
+	}
+}
+
+func TestEveryCompressionLevel(t *testing.T) {
+	levels := []zstd.EncoderLevel{
+		zstd.SpeedFastest,
+		zstd.SpeedDefault,
+		zstd.SpeedBetterCompression,
+		zstd.SpeedBestCompression,
+	}
+
+	for _, level := range levels {
+		t.Run(level.String(), func(t *testing.T) {
+			compressor := yarpczstd.New(yarpczstd.Level(level))
+
+			buf := bytes.NewBuffer(nil)
+			writer, err := compressor.Compress(buf)
+			require.NoError(t, err)
+
+			_, err = writer.Write(input)
+			require.NoError(t, err)
+			require.NoError(t, writer.Close())
+
+			str, err := compressor.Decompress(buf)
+			require.NoError(t, err)
+
+			output, err := io.ReadAll(str)
+			require.NoError(t, err)
+			require.NoError(t, str.Close())
+
+			assert.Equal(t, input, output)
+		})
+	}
+}
+
+func TestZstdName(t *testing.T) {
+	assert.Equal(t, "zstd", yarpczstd.New().Name())
+}
+
+func TestRawEncoderDecoderOptions(t *testing.T) {
+	compressor := yarpczstd.New(
+		yarpczstd.Level(zstd.SpeedBestCompression),
+		yarpczstd.EncoderOptions(zstd.WithWindowSize(1<<20)),
+		yarpczstd.DecoderOptions(zstd.WithDecoderLowmem(true)),
+	)
+
+	buf := bytes.NewBuffer(nil)
+	writer, err := compressor.Compress(buf)
+	require.NoError(t, err)
+
+	_, err = writer.Write(input)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	str, err := compressor.Decompress(buf)
+	require.NoError(t, err)
+
+	output, err := io.ReadAll(str)
+	require.NoError(t, err)
+	require.NoError(t, str.Close())
+
+	assert.Equal(t, input, output)
+}
+
+func TestDecompressPoolingAfterError(t *testing.T) {
+	compressor := yarpczstd.New()
+
+	// Warm up the pool with valid data.
+	buf := bytes.NewBuffer(nil)
+	writer, err := compressor.Compress(buf)
+	require.NoError(t, err)
+	_, err = writer.Write(input)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+	validData := buf.Bytes()
+
+	r, err := compressor.Decompress(bytes.NewReader(validData))
+	require.NoError(t, err)
+	io.Copy(io.Discard, r)
+	r.Close()
+
+	// Feed invalid data — the pooled decoder should handle the error.
+	invalidData := []byte("this is not valid zstd data")
+	r, err = compressor.Decompress(bytes.NewReader(invalidData))
+	if err == nil {
+		// zstd may defer the error to Read rather than Decompress.
+		_, err = io.ReadAll(r)
+		r.Close()
+	}
+	require.Error(t, err)
+
+	// After the error, the pool should still produce working decoders.
+	r, err = compressor.Decompress(bytes.NewReader(validData))
+	require.NoError(t, err)
+	output, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+	assert.Equal(t, input, output)
+}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/golang/protobuf v1.5.4
 	github.com/golang/snappy v0.0.4
 	github.com/kisielk/errcheck v1.7.0
+	github.com/klauspost/compress v1.18.4
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,8 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/errcheck v1.7.0 h1:+SbscKmWJ5mOK/bO1zS60F5I9WwZDWOfRsC4RwfwRV0=
 github.com/kisielk/errcheck v1.7.0/go.mod h1:1kLL+jV4e+CFfueBmI1dSK2ADDyQnlrnrY/FqKluHJQ=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/klauspost/compress v1.18.4 h1:RPhnKRAQ4Fh8zU2FY/6ZFDwTVTxgJ/EMydqSTzE9a2c=
+github.com/klauspost/compress v1.18.4/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=


### PR DESCRIPTION
Adds a `zstd` compressor backed by https://github.com/klauspost/compress, following the same pattern as the existing `gzip` and `snappy` compressors.

**Why zstd over gzip?** Better compression ratio and throughput (1.5–2× faster than stdlib gzip).
**Why klauspost?** Battle-tested library already used by Loki, Thanos, and CockroachDB; widely adopted (260k dependents).

RELEASE NOTES:
- Added support for zstd compression using https://github.com/klauspost/compress.

## Benchmarks (gzip vs zstd)
goos: darwin
goarch: arm64
pkg: go.uber.org/yarpc/compressor
cpu: Apple M4 Max
BenchmarkCompress/gzip/proto-350B-16         	   69567	     16055 ns/op	  21.74 MB/s	         0.6332 ratio	     348 B/op	       3 allocs/op
BenchmarkCompress/gzip/proto-10KB-16         	   20641	     58096 ns/op	 176.30 MB/s	         0.1760 ratio	    4192 B/op	       6 allocs/op
BenchmarkCompress/gzip/proto-1MB-16          	     208	   5711855 ns/op	 183.58 MB/s	         0.1277 ratio	  524546 B/op	      13 allocs/op
BenchmarkCompress/gzip/json-10KB-16          	   21156	     56543 ns/op	 181.60 MB/s	         0.1980 ratio	    4225 B/op	       6 allocs/op
BenchmarkCompress/gzip/random-1KB-16         	   35979	     33499 ns/op	  30.57 MB/s	         1.027 ratio	    1378 B/op	       3 allocs/op
BenchmarkCompress/zstd/proto-350B-16         	  325700	      3716 ns/op	  93.92 MB/s	         0.6074 ratio	     294 B/op	       2 allocs/op
BenchmarkCompress/zstd/proto-10KB-16         	   66994	     17814 ns/op	 574.94 MB/s	         0.1825 ratio	    2364 B/op	       2 allocs/op
BenchmarkCompress/zstd/proto-1MB-16          	     693	   1707442 ns/op	 614.12 MB/s	         0.1315 ratio	  305961 B/op	       8 allocs/op
BenchmarkCompress/zstd/json-10KB-16          	   54955	     21697 ns/op	 473.24 MB/s	         0.2085 ratio	    2483 B/op	       2 allocs/op
BenchmarkCompress/zstd/random-1KB-16         	  964190	      1221 ns/op	 838.63 MB/s	         1.015 ratio	    1288 B/op	       2 allocs/op
BenchmarkDecompress/gzip/proto-350B-16       	  432679	      2762 ns/op	 126.36 MB/s	      48 B/op	       1 allocs/op
BenchmarkDecompress/gzip/proto-10KB-16       	   82290	     14414 ns/op	 710.55 MB/s	     853 B/op	      22 allocs/op
BenchmarkDecompress/gzip/proto-1MB-16        	     993	   1208413 ns/op	 867.73 MB/s	    6922 B/op	      64 allocs/op
BenchmarkDecompress/gzip/json-10KB-16        	   68367	     17568 ns/op	 584.48 MB/s	     418 B/op	      11 allocs/op
BenchmarkDecompress/gzip/random-1KB-16       	 3433684	       346.3 ns/op	2957.17 MB/s	      48 B/op	       1 allocs/op
BenchmarkDecompress/zstd/proto-350B-16       	  649257	      1839 ns/op	 189.76 MB/s	      48 B/op	       1 allocs/op
BenchmarkDecompress/zstd/proto-10KB-16       	  247582	      4837 ns/op	2117.46 MB/s	      48 B/op	       1 allocs/op
BenchmarkDecompress/zstd/proto-1MB-16        	    2446	    466867 ns/op	2245.98 MB/s	      50 B/op	       1 allocs/op
BenchmarkDecompress/zstd/json-10KB-16        	  132722	      8892 ns/op	1154.70 MB/s	      48 B/op	       1 allocs/op
BenchmarkDecompress/zstd/random-1KB-16       	 5539242	       215.9 ns/op	4743.10 MB/s	      48 B/op	       1 allocs/op
BenchmarkRoundTrip/gzip/proto-350B-16        	   62145	     19251 ns/op	  18.13 MB/s	     378 B/op	       3 allocs/op
BenchmarkRoundTrip/gzip/proto-10KB-16        	   16017	     75361 ns/op	 135.91 MB/s	    5832 B/op	      27 allocs/op
BenchmarkRoundTrip/gzip/proto-1MB-16         	     166	   7155376 ns/op	 146.54 MB/s	  569225 B/op	      78 allocs/op
BenchmarkRoundTrip/gzip/json-10KB-16         	   15658	     76132 ns/op	 134.87 MB/s	    5456 B/op	      16 allocs/op
BenchmarkRoundTrip/gzip/random-1KB-16        	   35198	     34319 ns/op	  29.84 MB/s	    1369 B/op	       3 allocs/op
BenchmarkRoundTrip/zstd/proto-350B-16        	  213946	      5617 ns/op	  62.13 MB/s	     358 B/op	       2 allocs/op
BenchmarkRoundTrip/zstd/proto-10KB-16        	   51296	     23552 ns/op	 434.87 MB/s	    2388 B/op	       2 allocs/op
BenchmarkRoundTrip/zstd/proto-1MB-16         	     508	   2332599 ns/op	 449.53 MB/s	  381733 B/op	       8 allocs/op
BenchmarkRoundTrip/zstd/json-10KB-16         	   38079	     31485 ns/op	 326.12 MB/s	    2897 B/op	       2 allocs/op
BenchmarkRoundTrip/zstd/random-1KB-16        	  820908	      1434 ns/op	 714.03 MB/s	    1453 B/op	       2 allocs/op
PASS
ok  	go.uber.org/yarpc/compressor	44.533s

### Benchmarks Summary Tables
#### Compression

| Scenario | gzip Throughput | zstd Throughput | Speedup | gzip Ratio | zstd Ratio | gzip Allocs | zstd Allocs |
|----------|----------------|----------------|---------|------------|------------|-------------|-------------|
| proto-350B | 21.74 MB/s | 93.92 MB/s | 4.3x | 0.6332 | 0.6074 | 3 | 2 |
| proto-10KB | 176.30 MB/s | 574.94 MB/s | 3.3x | 0.1760 | 0.1825 | 6 | 2 |
| proto-1MB | 183.58 MB/s | 614.12 MB/s | 3.3x | 0.1277 | 0.1315 | 13 | 8 |
| json-10KB | 181.60 MB/s | 473.24 MB/s | 2.6x | 0.1980 | 0.2085 | 6 | 2 |
| random-1KB | 30.57 MB/s | 838.63 MB/s | 27.4x | 1.027 | 1.015 | 3 | 2 |

#### Decompression

| Scenario | gzip Throughput | zstd Throughput | Speedup | gzip Allocs | zstd Allocs |
|----------|----------------|----------------|---------|-------------|-------------|
| proto-350B | 126.36 MB/s | 189.76 MB/s | 1.5x | 1 | 1 |
| proto-10KB | 710.55 MB/s | 2,117.46 MB/s | 3.0x | 22 | 1 |
| proto-1MB | 867.73 MB/s | 2,245.98 MB/s | 2.6x | 64 | 1 |
| json-10KB | 584.48 MB/s | 1,154.70 MB/s | 2.0x | 11 | 1 |
| random-1KB | 2,957.17 MB/s | 4,743.10 MB/s | 1.6x | 1 | 1 |

#### Round Trip (Compress + Decompress)

| Scenario | gzip Throughput | zstd Throughput | Speedup | gzip Allocs | zstd Allocs |
|----------|----------------|----------------|---------|-------------|-------------|
| proto-350B | 18.13 MB/s | 62.13 MB/s | 3.4x | 3 | 2 |
| proto-10KB | 135.91 MB/s | 434.87 MB/s | 3.2x | 27 | 2 |
| proto-1MB | 146.54 MB/s | 449.53 MB/s | 3.1x | 78 | 8 |
| json-10KB | 134.87 MB/s | 326.12 MB/s | 2.4x | 16 | 2 |
| random-1KB | 29.84 MB/s | 714.03 MB/s | 23.9x | 3 | 2 |

## Test plan
Internal Uber libraries release tool
