### PR TITLE
[GRPC-Conn-Pool] Add connection pool config, options, and validation

### DIFF
--- a/transport/grpc/config.go
+++ b/transport/grpc/config.go
@@ -70,6 +70,13 @@ func TransportSpec(opts ...Option) yarpcconfig.TransportSpec {
 //	        max: 30s
 //	    clientMaxHeaderListSize: 1024
 //	    serverMaxHeaderListSize: 2048
+//	    clientConnectionPool:
+//	      dynamicScalingEnabled: true
+//	      maxConcurrentStreams: 250
+//	      scaleUpThreshold: 0.8
+//	      minConnections: 1
+//	      maxConnections: 10
+//	      idleTimeout: 5m
 //
 // All parameters of TransportConfig are optional. This section
 // may be omitted in the transports section.
@@ -88,6 +95,52 @@ type TransportConfig struct {
 	// incoming streams.
 	// See: https://pkg.go.dev/google.golang.org/grpc#NumStreamWorkers
 	NumStreamWorkers uint32 `config:"numStreamWorkers"`
+	// ClientConnectionPool configures the per-peer gRPC connection pool that
+	// enables dynamic scaling beyond the HTTP/2 250-stream-per-connection limit.
+	ClientConnectionPool ClientConnectionPoolConfig `config:"clientConnectionPool"`
+}
+
+// ClientConnectionPoolConfig configures the dynamic gRPC connection pool for all
+// peers on this transport.
+//
+//	transports:
+//	  grpc:
+//	    clientConnectionPool:
+//	      dynamicScalingEnabled: true   # enable background auto-scaling
+//	      maxConcurrentStreams: 250     # assumed server HTTP/2 stream limit
+//	      scaleUpThreshold: 0.8         # open a new conn at 80% utilization
+//	      minConnections: 1             # minimum connections per peer
+//	      maxConnections: 10            # maximum connections per peer
+//	      idleTimeout: 5m               # close idle connections after this duration
+type ClientConnectionPoolConfig struct {
+	// DynamicScalingEnabled enables the background connection scaling monitor.
+	// When true, YARPC automatically opens and drains connections based on
+	// stream utilization.  Disabled by default to allow controlled rollout.
+	DynamicScalingEnabled bool `config:"dynamicScalingEnabled"`
+
+	// MaxConcurrentStreams is the assumed HTTP/2 SETTINGS_MAX_CONCURRENT_STREAMS
+	// value enforced by the server.  YARPC uses this to decide when to open an
+	// additional connection.  Defaults to 250 (Go's net/http2 default).
+	MaxConcurrentStreams int32 `config:"maxConcurrentStreams"`
+
+	// ScaleUpThreshold is the fraction of MaxConcurrentStreams at which a
+	// new connection is opened (e.g. 0.8 → scale up at 200 active streams).
+	// Must be in the range (0, 1].  Defaults to 0.8.
+	ScaleUpThreshold float64 `config:"scaleUpThreshold"`
+
+	// MinConnections is the minimum number of connections kept per peer.
+	// Connections are pre-established up to this count at peer creation time.
+	// Defaults to 1.
+	MinConnections int `config:"minConnections"`
+
+	// MaxConnections is the maximum number of connections allowed per peer.
+	// Defaults to 5.
+	MaxConnections int `config:"maxConnections"`
+
+	// IdleTimeout is how long a fully-drained connection stays idle before
+	// YARPC closes it.
+	// Defaults to 15 minutes.
+	IdleTimeout time.Duration `config:"idleTimeout"`
 }
 
 // InboundConfig configures a gRPC Inbound.
@@ -342,12 +395,57 @@ func (t *transportSpec) buildTransport(transportConfig *TransportConfig, kit *ya
 	if transportConfig.NumStreamWorkers > 0 {
 		options = append(options, NumStreamWorkers(transportConfig.NumStreamWorkers))
 	}
+	// Connection pool options — only apply non-zero values so that
+	// programmatic TransportOption defaults set by the caller are not
+	// silently overridden by the zero value of an omitted YAML field.
+	cp := transportConfig.ClientConnectionPool
+	if cp.MinConnections < 0 {
+		return nil, fmt.Errorf("clientConnectionPool.minConnections must be non-negative, got %d", cp.MinConnections)
+	}
+	if cp.MaxConnections < 0 {
+		return nil, fmt.Errorf("clientConnectionPool.maxConnections must be non-negative, got %d", cp.MaxConnections)
+	}
+	if cp.MaxConcurrentStreams < 0 {
+		return nil, fmt.Errorf("clientConnectionPool.maxConcurrentStreams must be non-negative, got %d", cp.MaxConcurrentStreams)
+	}
+	if cp.ScaleUpThreshold < 0 || cp.ScaleUpThreshold > 1 {
+		return nil, fmt.Errorf("clientConnectionPool.scaleUpThreshold must be in [0, 1], got %v", cp.ScaleUpThreshold)
+	}
+	if cp.IdleTimeout < 0 {
+		return nil, fmt.Errorf("clientConnectionPool.idleTimeout must be non-negative, got %v", cp.IdleTimeout)
+	}
+	options = append(options, WithDynamicConnectionScaling(cp.DynamicScalingEnabled))
+	if cp.MaxConcurrentStreams > 0 {
+		options = append(options, MaxConcurrentStreams(cp.MaxConcurrentStreams))
+	}
+	if cp.ScaleUpThreshold > 0 {
+		options = append(options, ScaleUpThreshold(cp.ScaleUpThreshold))
+	}
+	if cp.MinConnections > 0 {
+		options = append(options, MinConnections(cp.MinConnections))
+	}
+	if cp.MaxConnections > 0 {
+		options = append(options, MaxConnections(cp.MaxConnections))
+	}
+	if cp.IdleTimeout > 0 {
+		options = append(options, ConnIdleTimeout(cp.IdleTimeout))
+	}
 	backoffStrategy, err := transportConfig.Backoff.Strategy()
 	if err != nil {
 		return nil, err
 	}
 	options = append(options, BackoffStrategy(backoffStrategy), ServiceName(kit.ServiceName()))
-	return newTransport(newTransportOptions(options)), nil
+	opts := newTransportOptions(options)
+	if opts.clientConnPoolMaxConnections < opts.clientConnPoolMinConnections {
+		return nil, fmt.Errorf("clientConnectionPool.maxConnections (%d) must be >= minConnections (%d)", opts.clientConnPoolMaxConnections, opts.clientConnPoolMinConnections)
+	}
+	if opts.clientConnPoolScaleUpThreshold <= 0 || opts.clientConnPoolScaleUpThreshold > 1 {
+		return nil, fmt.Errorf("clientConnectionPool.scaleUpThreshold must be in (0, 1], got %v", opts.clientConnPoolScaleUpThreshold)
+	}
+	if opts.clientConnPoolMaxConcurrentStreams < 1 {
+		return nil, fmt.Errorf("clientConnectionPool.maxConcurrentStreams must be at least 1, got %d", opts.clientConnPoolMaxConcurrentStreams)
+	}
+	return newTransport(opts), nil
 }
 
 func (t *transportSpec) buildInbound(inboundConfig *InboundConfig, tr transport.Transport, _ *yarpcconfig.Kit) (transport.Inbound, error) {

--- a/transport/grpc/config_test.go
+++ b/transport/grpc/config_test.go
@@ -552,6 +552,99 @@ func TestTransportSpec(t *testing.T) {
 			},
 			wantErrors: []string{"outbound TLS enforced but outbound TLS config provider is nil"},
 		},
+		{
+			desc: "negative minConnections",
+			transportCfg: attrs{
+				"clientConnectionPool": attrs{
+					"minConnections": "-1",
+				},
+			},
+			outboundCfg: attrs{
+				"myservice": attrs{
+					TransportName: attrs{"address": "localhost:54580"},
+				},
+			},
+			wantErrors: []string{"clientConnectionPool.minConnections must be non-negative"},
+		},
+		{
+			desc: "negative maxConnections",
+			transportCfg: attrs{
+				"clientConnectionPool": attrs{
+					"maxConnections": "-1",
+				},
+			},
+			outboundCfg: attrs{
+				"myservice": attrs{
+					TransportName: attrs{"address": "localhost:54581"},
+				},
+			},
+			wantErrors: []string{"clientConnectionPool.maxConnections must be non-negative"},
+		},
+		{
+			desc: "maxConnections less than minConnections",
+			transportCfg: attrs{
+				"clientConnectionPool": attrs{
+					"minConnections": "5",
+					"maxConnections": "2",
+				},
+			},
+			outboundCfg: attrs{
+				"myservice": attrs{
+					TransportName: attrs{"address": "localhost:54582"},
+				},
+			},
+			wantErrors: []string{"clientConnectionPool.maxConnections (2) must be >= minConnections (5)"},
+		},
+		{
+			desc: "minConnections exceeds default maxConnections",
+			transportCfg: attrs{
+				"clientConnectionPool": attrs{
+					"minConnections": "10",
+				},
+			},
+			outboundCfg: attrs{
+				"myservice": attrs{
+					TransportName: attrs{"address": "localhost:54583"},
+				},
+			},
+			wantErrors: []string{"clientConnectionPool.maxConnections (5) must be >= minConnections (10)"},
+		},
+		{
+			desc: "scaleUpThreshold out of range",
+			transportCfg: attrs{
+				"clientConnectionPool": attrs{
+					"scaleUpThreshold": "1.5",
+				},
+			},
+			outboundCfg: attrs{
+				"myservice": attrs{
+					TransportName: attrs{"address": "localhost:54584"},
+				},
+			},
+			wantErrors: []string{"clientConnectionPool.scaleUpThreshold must be in [0, 1]"},
+		},
+		{
+			desc: "valid connection pool config",
+			transportCfg: attrs{
+				"clientConnectionPool": attrs{
+					"minConnections":       "2",
+					"maxConnections":       "8",
+					"scaleUpThreshold":     "0.7",
+					"maxConcurrentStreams": "200",
+					"idleTimeout":          "10m",
+				},
+			},
+			outboundCfg: attrs{
+				"myservice": attrs{
+					TransportName: attrs{"address": "localhost:54585"},
+				},
+			},
+			wantOutbounds: map[string]wantOutbound{
+				"myservice": {
+					Address: "localhost:54585",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/transport/grpc/options.go
+++ b/transport/grpc/options.go
@@ -25,6 +25,7 @@ import (
 	"crypto/tls"
 	"math"
 	"net"
+	"time"
 
 	opentracing "github.com/opentracing/opentracing-go"
 	"go.uber.org/net/metrics"
@@ -53,6 +54,13 @@ const (
 	// receive sizes to 64MB.
 	defaultServerMaxRecvMsgSize = 1024 * 1024 * 64
 	defaultClientMaxRecvMsgSize = 1024 * 1024 * 64
+	// Client connection pool defaults.
+	// defaultClientConnPoolMaxConcurrentStreams matches Go's net/http2 server default (SETTINGS_MAX_CONCURRENT_STREAMS = 250).
+	defaultClientConnPoolMaxConcurrentStreams int32         = 250
+	defaultClientConnPoolScaleUpThreshold     float64       = 0.8
+	defaultClientConnPoolMinConnections       int           = 1
+	defaultClientConnPoolMaxConnections       int           = 5
+	defaultClientConnPoolIdleTimeout          time.Duration = 15 * time.Minute
 )
 
 // Option is an interface shared by TransportOption, InboundOption, and OutboundOption
@@ -204,6 +212,81 @@ func ClientMaxHeaderListSize(clientMaxHeaderListSize uint32) TransportOption {
 	}
 }
 
+// MaxConcurrentStreams sets the assumed HTTP/2 SETTINGS_MAX_CONCURRENT_STREAMS
+// value enforced by the server.  YARPC uses this value to decide when to open
+// an additional connection to a peer.
+//
+// The gRPC client does not expose the server-advertised limit, so this must be
+// configured manually.  The default is 250, which matches Go's net/http2 server
+// default.
+func MaxConcurrentStreams(n int32) TransportOption {
+	return func(transportOptions *transportOptions) {
+		transportOptions.clientConnPoolMaxConcurrentStreams = n
+	}
+}
+
+// ScaleUpThreshold sets the fraction of MaxConcurrentStreams at which YARPC
+// opens an additional connection to a peer.  For example, a value of 0.8 means
+// a new connection is opened when any existing connection carries more than
+// 80% of its stream budget.
+//
+// The default is 0.8.
+func ScaleUpThreshold(f float64) TransportOption {
+	return func(transportOptions *transportOptions) {
+		transportOptions.clientConnPoolScaleUpThreshold = f
+	}
+}
+
+// MinConnections sets the minimum number of connections YARPC maintains to
+// each peer.  Connections are pre-established up to this count when the peer
+// is first retained.
+//
+// The default is 1.
+func MinConnections(n int) TransportOption {
+	return func(transportOptions *transportOptions) {
+		transportOptions.clientConnPoolMinConnections = n
+	}
+}
+
+// MaxConnections sets the maximum number of connections YARPC may open to a
+// single peer.
+//
+// The default is 5.
+func MaxConnections(n int) TransportOption {
+	return func(transportOptions *transportOptions) {
+		transportOptions.clientConnPoolMaxConnections = n
+	}
+}
+
+// ConnIdleTimeout sets how long a fully-drained connection remains idle before
+// YARPC closes it and removes it from the pool.
+//
+// The default is 15 minutes.
+func ConnIdleTimeout(d time.Duration) TransportOption {
+	return func(transportOptions *transportOptions) {
+		transportOptions.clientConnPoolIdleTimeout = d
+	}
+}
+
+// WithDynamicConnectionScaling enables or disables automatic gRPC connection
+// pool scaling based on stream utilization.
+//
+// When enabled, YARPC monitors stream usage on each pooled connection and
+// automatically opens new connections when any connection exceeds
+// ScaleUpThreshold, and drains connections when aggregate utilization drops
+// low enough to consolidate load onto fewer connections.
+//
+// Because YARPC is an open-source project, Flipr/ObjectConfig based rollout is handled
+// externally: set this option to true only after validating the change in a
+// controlled environment.
+//
+// The default is false (disabled).
+func WithDynamicConnectionScaling(enabled bool) TransportOption {
+	return func(transportOptions *transportOptions) {
+		transportOptions.clientConnPoolDynamicScalingEnabled = enabled
+	}
+}
+
 // InboundOption is an option for an inbound.
 type InboundOption func(*inboundOptions)
 
@@ -337,6 +420,13 @@ type transportOptions struct {
 	unaryOutboundInterceptor  []interceptor.UnaryOutbound
 	streamInboundInterceptor  interceptor.StreamInbound
 	streamOutboundInterceptor []interceptor.StreamOutbound
+	// Client connection pool options.
+	clientConnPoolMaxConcurrentStreams  int32
+	clientConnPoolScaleUpThreshold      float64
+	clientConnPoolMinConnections        int
+	clientConnPoolMaxConnections        int
+	clientConnPoolIdleTimeout           time.Duration
+	clientConnPoolDynamicScalingEnabled bool
 }
 
 func newTransportOptions(options []TransportOption) *transportOptions {
@@ -346,6 +436,12 @@ func newTransportOptions(options []TransportOption) *transportOptions {
 		serverMaxSendMsgSize: defaultServerMaxSendMsgSize,
 		clientMaxRecvMsgSize: defaultClientMaxRecvMsgSize,
 		clientMaxSendMsgSize: defaultClientMaxSendMsgSize,
+		// Client connection pool defaults.
+		clientConnPoolMaxConcurrentStreams: defaultClientConnPoolMaxConcurrentStreams,
+		clientConnPoolScaleUpThreshold:     defaultClientConnPoolScaleUpThreshold,
+		clientConnPoolMinConnections:       defaultClientConnPoolMinConnections,
+		clientConnPoolMaxConnections:       defaultClientConnPoolMaxConnections,
+		clientConnPoolIdleTimeout:          defaultClientConnPoolIdleTimeout,
 	}
 	for _, option := range options {
 		option(transportOptions)


### PR DESCRIPTION
## Summary

- Add `ClientConnectionPoolConfig` to `TransportConfig` with YAML support for connection pool tuning (`minConnections`, `maxConnections`, `maxConcurrentStreams`, `scaleUpThreshold`, `idleTimeout`, `dynamicScalingEnabled`).
- Add corresponding `TransportOption` functions and defaults in `options.go`.
- Validate connection pool parameters in `buildTransport` at two stages: bounds checks on raw YAML config (negative values, out-of-range threshold), and cross-field checks on resolved options with defaults applied (`maxConnections >= minConnections`).

## Test plan

Tested via unit tests.

## JIRA
https://t3.uberinternal.com/browse/RPC-9620