### PR TITLE
[GRPC-Conn-Pooling] add grpcClientConnWrapper and connPoolConfig types

### DIFF
--- a/transport/grpc/client_conn_wrapper.go
+++ b/transport/grpc/client_conn_wrapper.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package grpc
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	"google.golang.org/grpc"
+)
+
+// connState is the lifecycle state of a pooled gRPC connection.
+type connState int32
+
+const (
+	// connStateActive means the connection accepts new streams.
+	connStateActive connState = iota
+	// connStateDraining means the connection is no longer accepting new
+	// streams but is waiting for in-flight streams to complete.
+	connStateDraining
+	// connStateIdle means all streams have finished; the connection is
+	// waiting for the idle timeout before being closed.
+	connStateIdle
+)
+
+// connPoolConfig holds configuration for the per-peer connection pool.
+// Values are derived from transportOptions at peer creation time.
+type connPoolConfig struct {
+	// maxConcurrentStreams is the HTTP/2 SETTINGS_MAX_CONCURRENT_STREAMS
+	// value enforced by the server (default 250).
+	maxConcurrentStreams int32
+	// scaleUpThreshold is the fraction of maxConcurrentStreams at which a
+	// new connection is opened (e.g. 0.8 → scale up at 200 active streams).
+	scaleUpThreshold float64
+	// minConnections is the minimum number of connections kept in the pool.
+	minConnections int
+	// maxConnections is the maximum number of connections allowed in the pool.
+	maxConnections int
+	// idleTimeout is how long a drained connection stays idle before it is
+	// closed and removed from the pool.
+	idleTimeout time.Duration
+}
+
+// grpcClientConnWrapper wraps a single *grpc.ClientConn with connection-pool
+// metadata.  All fields that are accessed concurrently are updated atomically.
+type grpcClientConnWrapper struct {
+	clientConn *grpc.ClientConn
+
+	// ctx is derived from the peer's context.  Cancelling it stops this
+	// connection's monitor goroutine, which in turn closes clientConn.
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	// streamCount is the number of in-flight streams on this connection.
+	streamCount int32 // accessed atomically
+	// state is the current connState of this wrapper.
+	state connState // accessed atomically
+
+	createdAt      time.Time
+	lastIdleAtNano int64 // atomic unix nanos; set when transitioning to connStateIdle
+
+	// stoppedC is closed by the connection's monitor goroutine after the
+	// underlying clientConn has been closed.
+	stoppedC chan struct{}
+}
+
+func newConnWrapper(parentCtx context.Context, clientConn *grpc.ClientConn) *grpcClientConnWrapper {
+	ctx, cancel := context.WithCancel(parentCtx)
+	return &grpcClientConnWrapper{
+		clientConn: clientConn,
+		ctx:        ctx,
+		cancel:     cancel,
+		state:      connStateActive,
+		createdAt:  time.Now(),
+		stoppedC:   make(chan struct{}),
+	}
+}
+
+// incStreamCount atomically increments the active stream count.
+func (w *grpcClientConnWrapper) incStreamCount() {
+	atomic.AddInt32(&w.streamCount, 1)
+}
+
+// decStreamCount atomically decrements the active stream count.
+func (w *grpcClientConnWrapper) decStreamCount() {
+	atomic.AddInt32(&w.streamCount, -1)
+}
+
+// getStreamCount returns the current number of active streams.
+func (w *grpcClientConnWrapper) getStreamCount() int32 {
+	return atomic.LoadInt32(&w.streamCount)
+}
+
+// getState returns the current connection state.
+func (w *grpcClientConnWrapper) getState() connState {
+	return connState(atomic.LoadInt32((*int32)(&w.state)))
+}
+
+// setState atomically updates the connection state.
+func (w *grpcClientConnWrapper) setState(s connState) {
+	atomic.StoreInt32((*int32)(&w.state), int32(s))
+}
+
+// isActive reports whether the connection is currently accepting new streams.
+func (w *grpcClientConnWrapper) isActive() bool {
+	return w.getState() == connStateActive
+}
+
+// setIdleNow records the current time as the idle start time.
+func (w *grpcClientConnWrapper) setIdleNow() {
+	atomic.StoreInt64(&w.lastIdleAtNano, time.Now().UnixNano())
+}
+
+// idleSince returns the time when this connection entered the idle state,
+// or the zero time if it has not become idle yet.
+func (w *grpcClientConnWrapper) idleSince() time.Time {
+	ns := atomic.LoadInt64(&w.lastIdleAtNano)
+	if ns == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, ns)
+}

--- a/transport/grpc/client_conn_wrapper_test.go
+++ b/transport/grpc/client_conn_wrapper_test.go
@@ -1,0 +1,193 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package grpc
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// newTestConnWrapper creates a grpcClientConnWrapper backed by a real (but
+// non-connected) *grpc.ClientConn suitable for unit tests.
+func newTestConnWrapper(t *testing.T) *grpcClientConnWrapper {
+	t.Helper()
+	cc, err := grpc.NewClient("passthrough:///localhost:0", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cc.Close() })
+	return newConnWrapper(context.Background(), cc)
+}
+
+// TestNewConnWrapper verifies that newConnWrapper initialises all fields
+// correctly.
+func TestNewConnWrapper(t *testing.T) {
+	before := time.Now()
+	w := newTestConnWrapper(t)
+	after := time.Now()
+
+	assert.NotNil(t, w.clientConn)
+	assert.NotNil(t, w.ctx)
+	assert.NotNil(t, w.cancel)
+	assert.NotNil(t, w.stoppedC)
+	assert.Equal(t, connStateActive, w.getState())
+	assert.Equal(t, int32(0), w.getStreamCount())
+	assert.False(t, w.createdAt.Before(before), "createdAt should be >= before")
+	assert.False(t, w.createdAt.After(after), "createdAt should be <= after")
+}
+
+// TestConnStateConstants verifies the iota ordering that the rest of the pool
+// logic depends on.
+func TestConnStateConstants(t *testing.T) {
+	assert.Equal(t, connState(0), connStateActive)
+	assert.Equal(t, connState(1), connStateDraining)
+	assert.Equal(t, connState(2), connStateIdle)
+}
+
+// TestGetSetState verifies that setState and getState round-trip correctly for
+// all defined states.
+func TestGetSetState(t *testing.T) {
+	w := newTestConnWrapper(t)
+
+	for _, s := range []connState{connStateActive, connStateDraining, connStateIdle} {
+		w.setState(s)
+		assert.Equal(t, s, w.getState())
+	}
+}
+
+// TestIsActive verifies isActive returns true only when state is connStateActive.
+func TestIsActive(t *testing.T) {
+	w := newTestConnWrapper(t)
+
+	assert.True(t, w.isActive(), "newly created wrapper should be active")
+
+	w.setState(connStateDraining)
+	assert.False(t, w.isActive())
+
+	w.setState(connStateIdle)
+	assert.False(t, w.isActive())
+
+	w.setState(connStateActive)
+	assert.True(t, w.isActive())
+}
+
+// TestStreamCountIncDec verifies incStreamCount, decStreamCount, and
+// getStreamCount.
+func TestStreamCountIncDec(t *testing.T) {
+	w := newTestConnWrapper(t)
+
+	assert.Equal(t, int32(0), w.getStreamCount())
+
+	w.incStreamCount()
+	assert.Equal(t, int32(1), w.getStreamCount())
+
+	w.incStreamCount()
+	w.incStreamCount()
+	assert.Equal(t, int32(3), w.getStreamCount())
+
+	w.decStreamCount()
+	assert.Equal(t, int32(2), w.getStreamCount())
+
+	w.decStreamCount()
+	w.decStreamCount()
+	assert.Equal(t, int32(0), w.getStreamCount())
+}
+
+// TestStreamCountConcurrent verifies that inc/dec are safe under concurrent
+// access.
+func TestStreamCountConcurrent(t *testing.T) {
+	w := newTestConnWrapper(t)
+
+	const goroutines = 100
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 2)
+
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			w.incStreamCount()
+		}()
+		go func() {
+			defer wg.Done()
+			w.decStreamCount()
+		}()
+	}
+
+	wg.Wait()
+	assert.Equal(t, int32(0), w.getStreamCount())
+}
+
+// TestSetIdleNow verifies that setIdleNow records a timestamp and idleSince
+// returns it.
+func TestSetIdleNow(t *testing.T) {
+	w := newTestConnWrapper(t)
+
+	// Before setIdleNow, idleSince should return the zero time.
+	assert.True(t, w.idleSince().IsZero(), "idleSince should be zero before setIdleNow")
+
+	before := time.Now()
+	w.setIdleNow()
+	after := time.Now()
+
+	idle := w.idleSince()
+	assert.False(t, idle.IsZero())
+	assert.False(t, idle.Before(before.Truncate(time.Nanosecond)), "idleSince should be >= before")
+	assert.False(t, idle.After(after), "idleSince should be <= after")
+}
+
+// TestIdleSinceZeroBeforeSet verifies the zero-value branch in idleSince.
+func TestIdleSinceZeroBeforeSet(t *testing.T) {
+	w := newTestConnWrapper(t)
+	assert.Equal(t, time.Time{}, w.idleSince())
+}
+
+// TestContextCancelledOnCancel verifies that the context derived inside
+// newConnWrapper is cancelled when cancel() is called.
+func TestContextCancelledOnCancel(t *testing.T) {
+	w := newTestConnWrapper(t)
+
+	require.NoError(t, w.ctx.Err(), "context should not be cancelled initially")
+
+	w.cancel()
+
+	assert.ErrorIs(t, w.ctx.Err(), context.Canceled)
+}
+
+// TestContextInheritsParentCancellation verifies that cancelling the parent
+// context also cancels the wrapper's context.
+func TestContextInheritsParentCancellation(t *testing.T) {
+	parent, cancel := context.WithCancel(context.Background())
+
+	cc, err := grpc.NewClient("passthrough:///localhost:0", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cc.Close() })
+
+	w := newConnWrapper(parent, cc)
+
+	require.NoError(t, w.ctx.Err())
+	cancel()
+	assert.ErrorIs(t, w.ctx.Err(), context.Canceled)
+}


### PR DESCRIPTION
## Summary

Introduces the core data structures for the gRPC connection pool:

- grpcClientConnWrapper: wraps a *grpc.ClientConn with atomic stream count, connState (Active/Draining/Idle), per-connection context for independent lifecycle management, and idle timestamp tracking
- connPoolConfig: captures pool settings (maxConcurrentStreams, scaleUpThreshold, minConnections, maxConnections, idleTimeout)

No behaviour change — existing code is untouched. Subsequent PRs will wire these types into grpcPeer and add the scaling monitor.

## Jira
[RPC-9626](https://t3.uberinternal.com/browse/RPC-9626)