### PR TITLE
[GRPC-Conn-Pooling] Enhance peer selection logic for multiple peers

### DIFF
--- a/transport/grpc/client_conn_wrapper.go
+++ b/transport/grpc/client_conn_wrapper.go
@@ -45,6 +45,9 @@ const (
 // connPoolConfig holds configuration for the per-peer connection pool.
 // Values are derived from transportOptions at peer creation time.
 type connPoolConfig struct {
+	// dynamicScalingEnabled gates all automatic connection-pool scaling.
+	// When false the pool is never grown or shrunk automatically.
+	dynamicScalingEnabled bool
 	// maxConcurrentStreams is the HTTP/2 SETTINGS_MAX_CONCURRENT_STREAMS
 	// value enforced by the server (default 250).
 	maxConcurrentStreams int32

--- a/transport/grpc/config_test.go
+++ b/transport/grpc/config_test.go
@@ -811,13 +811,13 @@ func TestContextDialerOptionUsage(t *testing.T) {
 	require.True(t, ok, "expected a gRPC peer")
 
 	for {
-		state := grpcPeer.clientConn.GetState()
+		state := grpcPeer.conns[0].clientConn.GetState()
 		if state == connectivity.Ready {
 			break
 		}
-		grpcPeer.clientConn.WaitForStateChange(ctx, state)
+		grpcPeer.conns[0].clientConn.WaitForStateChange(ctx, state)
 	}
-	require.Equal(t, connectivity.Ready, grpcPeer.clientConn.GetState(), "expected gRPC connection in Ready state")
+	require.Equal(t, connectivity.Ready, grpcPeer.conns[0].clientConn.GetState(), "expected gRPC connection in Ready state")
 	require.Equal(t, 1, dialContextInvoked, "counter should increment by one from dialer invocation")
 }
 

--- a/transport/grpc/outbound.go
+++ b/transport/grpc/outbound.go
@@ -215,6 +215,14 @@ func (o *Outbound) invoke(
 		}
 	}
 
+	// Pick the pool connection with the fewest active streams.
+	conn := grpcPeer.pickConn()
+	if conn == nil {
+		return yarpcerrors.UnavailableErrorf("no available connections for peer %s", grpcPeer.HostPort())
+	}
+	conn.incStreamCount()
+	defer conn.decStreamCount()
+
 	tracer := o.t.options.tracer
 	createOpenTracingSpan := &transport.CreateOpenTracingSpan{
 		Tracer:        tracer,
@@ -231,7 +239,7 @@ func (o *Outbound) invoke(
 
 	err = transport.UpdateSpanWithErr(
 		span,
-		grpcPeer.clientConn.Invoke(
+		conn.clientConn.Invoke(
 			metadata.NewOutgoingContext(ctx, md),
 			fullMethod,
 			msg,
@@ -352,6 +360,20 @@ func (o *Outbound) stream(
 		return nil, err
 	}
 
+	// Pick the pool connection with the fewest active streams.
+	conn := grpcPeer.pickConn()
+	if conn == nil {
+		onFinish(yarpcerrors.UnavailableErrorf("no available connections for peer %s", grpcPeer.HostPort()))
+		return nil, yarpcerrors.UnavailableErrorf("no available connections for peer %s", grpcPeer.HostPort())
+	}
+	conn.incStreamCount()
+	// Wrap the release callback so stream count is decremented when
+	// the stream actually closes, not when stream() returns.
+	release := func(err error) {
+		conn.decStreamCount()
+		onFinish(err)
+	}
+
 	tracer := o.t.options.tracer
 	createOpenTracingSpan := &transport.CreateOpenTracingSpan{
 		Tracer:        tracer,
@@ -363,12 +385,12 @@ func (o *Outbound) stream(
 
 	if err := tracer.Inject(span.Context(), opentracing.HTTPHeaders, mdReadWriter(md)); err != nil {
 		span.Finish()
-		onFinish(err)
+		release(err)
 		return nil, err
 	}
 
 	streamCtx := metadata.NewOutgoingContext(ctx, md)
-	clientStream, err := grpcPeer.clientConn.NewStream(
+	clientStream, err := conn.clientConn.NewStream(
 		streamCtx,
 		&grpc.StreamDesc{
 			ClientStreams: true,
@@ -378,13 +400,13 @@ func (o *Outbound) stream(
 	)
 	if err != nil {
 		span.Finish()
-		onFinish(err)
+		release(err)
 		return nil, err
 	}
-	stream := newClientStream(streamCtx, req, clientStream, span, onFinish)
+	stream := newClientStream(streamCtx, req, clientStream, span, release)
 	tClientStream, err := transport.NewClientStream(stream)
 	if err != nil {
-		onFinish(err)
+		release(err)
 		span.Finish()
 		return nil, err
 	}

--- a/transport/grpc/outbound_test.go
+++ b/transport/grpc/outbound_test.go
@@ -35,6 +35,7 @@ import (
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/yarpcerrors"
 	"google.golang.org/grpc"
+	"go.uber.org/yarpc/peer/abstractpeer"
 )
 
 // shared between Unary and Streaming InvalidHeaderValue tests.
@@ -362,4 +363,81 @@ func TestOutboundIntrospection(t *testing.T) {
 
 	require.NoError(t, o.Stop(), "could not stop outbound")
 	assert.Equal(t, "Stopped", o.Introspect().State)
+}
+
+// emptyGRPCPeer returns a *grpcPeer with no connections in the pool, so that
+// pickConn() returns nil.  Only p.Peer is set; p.t is intentionally left nil
+// because the nil-conn path returns before any transport access.
+func emptyGRPCPeer(t *testing.T) *grpcPeer {
+	t.Helper()
+	tr := NewTransport()
+	return &grpcPeer{
+		Peer: abstractpeer.NewPeer(abstractpeer.PeerIdentifier("127.0.0.1:1"), tr),
+	}
+}
+
+// TestInvokeWithNoActiveConnections verifies that DirectCall returns an
+// UnavailableError when pickConn finds no active connections.
+func TestInvokeWithNoActiveConnections(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	chooser := peertest.NewMockChooser(mockCtrl)
+	chooser.EXPECT().Start()
+	chooser.EXPECT().Stop()
+	chooser.EXPECT().Choose(gomock.Any(), gomock.Any()).Return(emptyGRPCPeer(t), func(error) {}, nil)
+
+	tran := NewTransport()
+	out := tran.NewOutbound(chooser)
+	require.NoError(t, tran.Start())
+	require.NoError(t, out.Start())
+	defer tran.Stop()
+	defer out.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	_, err := out.DirectCall(ctx, &transport.Request{
+		Caller:    "caller",
+		Service:   "service",
+		Encoding:  transport.Encoding("raw"),
+		Procedure: "procedure",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no available connections")
+}
+
+// TestStreamWithNoActiveConnections verifies that CallStream returns an
+// UnavailableError when pickConn finds no active connections.
+func TestStreamWithNoActiveConnections(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	chooser := peertest.NewMockChooser(mockCtrl)
+	chooser.EXPECT().Start()
+	chooser.EXPECT().Stop()
+	chooser.EXPECT().Choose(gomock.Any(), gomock.Any()).Return(emptyGRPCPeer(t), func(error) {}, nil)
+
+	tran := NewTransport()
+	out := tran.NewOutbound(chooser)
+	require.NoError(t, tran.Start())
+	require.NoError(t, out.Start())
+	defer tran.Stop()
+	defer out.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	_, err := out.CallStream(ctx, &transport.StreamRequest{
+		Meta: &transport.RequestMeta{
+			Caller:    "caller",
+			Service:   "service",
+			Encoding:  transport.Encoding("raw"),
+			Procedure: "procedure",
+		},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no available connections")
 }

--- a/transport/grpc/peer.go
+++ b/transport/grpc/peer.go
@@ -34,11 +34,22 @@ import (
 type grpcPeer struct {
 	*abstractpeer.Peer
 
-	t          *Transport
-	ctx        context.Context
-	cancel     context.CancelFunc
-	clientConn *grpc.ClientConn
-	stoppedC   chan struct{}
+	t        *Transport
+	ctx      context.Context
+	cancel   context.CancelFunc
+	stoppedC chan struct{}
+
+	// grpcDialOpts are stored so that additional pooled connections can be
+	// dialled with the same parameters as the initial connection.
+	grpcDialOpts []grpc.DialOption
+
+	// isScaling is set to 1 (via CAS) while a background scale-up goroutine is
+	// running.  This prevents multiple concurrent scale-up operations.
+	isScaling int32 // accessed atomically
+
+	// connWg tracks active monitorConnWrapper goroutines.
+	// stoppedC is closed once all goroutines finish after the peer is stopped.
+	connWg sync.WaitGroup
 
 	mu      sync.RWMutex
 	conns   []*grpcClientConnWrapper
@@ -58,55 +69,183 @@ func (t *Transport) newPeer(address string, options *dialOptions) (*grpcPeer, er
 	if t.options.clientMaxHeaderListSize != nil {
 		dialOptions = append(dialOptions, grpc.WithMaxHeaderListSize(*t.options.clientMaxHeaderListSize))
 	}
-	//lint:ignore SA1019 grpc.Dial is deprecated
-	clientConn, err := grpc.Dial(address, dialOptions...)
-	if err != nil {
-		return nil, err
-	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	grpcPeer := &grpcPeer{
-		Peer:       abstractpeer.NewPeer(abstractpeer.PeerIdentifier(address), t),
-		t:          t,
-		ctx:        ctx,
-		cancel:     cancel,
-		clientConn: clientConn,
-		stoppedC:   make(chan struct{}),
+	p := &grpcPeer{
+		Peer:         abstractpeer.NewPeer(abstractpeer.PeerIdentifier(address), t),
+		t:            t,
+		ctx:          ctx,
+		cancel:       cancel,
+		stoppedC:     make(chan struct{}),
+		grpcDialOpts: dialOptions,
+		poolCfg: connPoolConfig{
+			dynamicScalingEnabled: t.options.clientConnPoolDynamicScalingEnabled,
+			maxConcurrentStreams:   t.options.clientConnPoolMaxConcurrentStreams,
+			scaleUpThreshold:      t.options.clientConnPoolScaleUpThreshold,
+			minConnections:        t.options.clientConnPoolMinConnections,
+			maxConnections:        t.options.clientConnPoolMaxConnections,
+			idleTimeout:           t.options.clientConnPoolIdleTimeout,
+		},
 	}
 
-	go grpcPeer.monitorConnectionStatus()
+	// All connections are created via addConn — no special primary connection.
+	initialConnCount := 1
+	if p.poolCfg.dynamicScalingEnabled {
+		initialConnCount = p.poolCfg.minConnections
+	}
+	for i := 0; i < initialConnCount; i++ {
+		if err := p.addConn(); err != nil {
+			p.cancel()
+			return nil, err
+		}
+	}
 
-	return grpcPeer, nil
+	if p.poolCfg.dynamicScalingEnabled {
+		go p.runScalingMonitor()
+	}
+
+	// Close stoppedC once all monitorConnWrapper goroutines have finished.
+	// We acquire mu briefly after ctx is cancelled to ensure any in-flight
+	// addConn() that passed its context check has already called connWg.Add(1)
+	// before we call connWg.Wait().
+	go func() {
+		<-p.ctx.Done()
+		// Acquire mu after cancellation to ensure any addConn() call that
+		// passed its ctx.Err() check has already called connWg.Add(1).
+		// The empty critical section is intentional: we need the memory
+		// barrier, not exclusive access to any data.
+		p.mu.Lock()
+		p.mu.Unlock() //nolint:staticcheck
+		p.connWg.Wait()
+		close(p.stoppedC)
+	}()
+
+	return p, nil
 }
 
-func (p *grpcPeer) monitorConnectionStatus() {
-	p.setConnectionStatus(peer.Unavailable)
+// addConn dials a new connection to the peer's address using the same options
+// as the initial connection, appends the wrapper to the pool, and starts its
+// monitor goroutine.
+func (p *grpcPeer) addConn() error {
+	//lint:ignore SA1019 grpc.Dial is deprecated
+	clientConn, err := grpc.Dial(p.Peer.Identifier(), p.grpcDialOpts...)
+	if err != nil {
+		return err
+	}
+	w := newConnWrapper(p.ctx, clientConn)
+
+	// Hold mu while registering with connWg and appending to conns.  The
+	// lifecycle goroutine in newPeer acquires mu after ctx is cancelled so
+	// that it observes any Add(1) call that raced with cancellation.
+	p.mu.Lock()
+	if p.ctx.Err() != nil {
+		p.mu.Unlock()
+		_ = clientConn.Close()
+		return p.ctx.Err()
+	}
+	p.connWg.Add(1)
+	p.conns = append(p.conns, w)
+	p.mu.Unlock()
+
+	go p.monitorConnWrapper(w)
+	return nil
+}
+
+// monitorConnWrapper runs the per-connection health loop: it watches gRPC
+// connectivity state changes, keeps the peer status up to date, and triggers
+// reconnection when a connection goes idle.  It cleans up when the wrapper's
+// context is cancelled (i.e. when the peer is stopped or the connection is
+// evicted by the pool).
+func (p *grpcPeer) monitorConnWrapper(w *grpcClientConnWrapper) {
+	defer func() {
+		_ = w.clientConn.Close()
+		close(w.stoppedC)
+		p.removeConn(w)
+		// Recompute connection status now that this peer is gone.
+		p.recomputeConnectionStatus()
+		p.connWg.Done()
+	}()
+
 	var grpcStatus connectivity.State
 	for {
-		grpcStatus = p.clientConn.GetState()
-		yarpcStatus := grpcStatusToYARPCStatus(grpcStatus)
-		p.setConnectionStatus(yarpcStatus)
+		grpcStatus = w.clientConn.GetState()
 
-		// When active connection falling back to IDLE state, no automatic reconnection is happening.
-		// There two options:
-		// - Either try to make a call using this connection, which will trigger reconnection, but may lead
-		// to a failed request (host is unreachable or context deadline happened).
-		// - Or we may try to reconnect manually, and use connection only when it's established and explicitly available.
-		// We choose second option.
+		// When a connection falls back to IDLE, no automatic reconnection
+		// happens. There are two options:
+		// - Let the next outgoing call trigger reconnection, but this may
+		//   lead to a failed request if the host is unreachable or a context
+		//   deadline occurs before the connection is re-established.
+		// - Reconnect manually so the connection is ready before the next call.
+		// We choose the second option.
 		if grpcStatus == connectivity.Idle {
-			p.clientConn.Connect()
+			w.clientConn.Connect()
 		}
 
-		if !p.clientConn.WaitForStateChange(p.ctx, grpcStatus) {
+		// If this connection is Ready the peer is Available regardless of
+		// other connections — no need to scan the pool.  For any other state
+		// (Connecting, TransientFailure, etc.) we must check all connections
+		// to derive the correct aggregate status.
+		p.recomputeConnectionStatus()
+
+		if !w.clientConn.WaitForStateChange(w.ctx, grpcStatus) {
 			break
 		}
 	}
-	p.setConnectionStatus(peer.Unavailable)
+}
 
-	// Close always returns an error.
-	_ = p.clientConn.Close()
-	close(p.stoppedC)
+// recomputeConnectionStatus derives the YARPC peer status from the aggregate
+// gRPC connectivity state across all active pool connections and publishes it.
+// The peer is Available if any connection is Ready, Connecting if any is
+// connecting (and none are Ready), and Unavailable if the pool is empty or
+// all connections are in a terminal/unknown state.
+func (p *grpcPeer) recomputeConnectionStatus() {
+	p.mu.RLock()
+	best := peer.Unavailable
+	for _, c := range p.conns {
+		if !c.isActive() {
+			continue
+		}
+		s := grpcStatusToYARPCStatus(c.clientConn.GetState())
+		if s == peer.Available {
+			best = peer.Available
+			break
+		}
+		if s == peer.Connecting && best == peer.Unavailable {
+			best = peer.Connecting
+		}
+	}
+	p.mu.RUnlock()
+	p.setConnectionStatus(best)
+}
+
+// removeConn removes a wrapper from the peer's connection pool.
+func (p *grpcPeer) removeConn(w *grpcClientConnWrapper) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for i, c := range p.conns {
+		if c == w {
+			p.conns = append(p.conns[:i], p.conns[i+1:]...)
+			return
+		}
+	}
+}
+
+// pickConn returns the active connection in the pool with the lowest current
+// stream count.  Returns nil if the pool contains no active connections.
+func (p *grpcPeer) pickConn() *grpcClientConnWrapper {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	var best *grpcClientConnWrapper
+	for _, c := range p.conns {
+		if !c.isActive() {
+			continue
+		}
+		if best == nil || c.getStreamCount() < best.getStreamCount() {
+			best = c
+		}
+	}
+	return best
 }
 
 func (p *grpcPeer) setConnectionStatus(status peer.ConnectionStatus) {

--- a/transport/grpc/peer_test.go
+++ b/transport/grpc/peer_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc/api/backoff"
 	"go.uber.org/yarpc/api/peer"
@@ -33,9 +34,13 @@ import (
 	"go.uber.org/yarpc/encoding/raw"
 	"go.uber.org/yarpc/internal/integrationtest"
 	"go.uber.org/yarpc/internal/yarpctest"
+	"go.uber.org/yarpc/peer/abstractpeer"
 	"go.uber.org/yarpc/peer/hostport"
 	"go.uber.org/yarpc/peer/roundrobin"
 	"go.uber.org/zap/zaptest"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 var spec = integrationtest.TransportSpec{
@@ -180,4 +185,334 @@ func makeBlastCall(t *testing.T, rawClient raw.Client, timeout time.Duration) {
 	defer cancel()
 
 	integrationtest.Blast(ctx, t, rawClient)
+}
+
+// --- pool unit test helpers ---
+
+// peerForPool builds a grpcPeer with all fields needed for pool unit tests.
+// It dials lazily so no real server is required.
+func peerForPool(t *testing.T) *grpcPeer {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	tr := NewTransport()
+	return &grpcPeer{
+		Peer:     abstractpeer.NewPeer(abstractpeer.PeerIdentifier("127.0.0.1:1"), tr),
+		t:        tr,
+		ctx:      ctx,
+		cancel:   cancel,
+		stoppedC: make(chan struct{}),
+		grpcDialOpts: []grpc.DialOption{
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		},
+		poolCfg: connPoolConfig{
+			dynamicScalingEnabled: true,
+			maxConcurrentStreams:   100,
+			scaleUpThreshold:      0.8, // threshold = 80
+			minConnections:        1,
+			maxConnections:        5,
+		},
+	}
+}
+
+// dialTestClientConn returns a real *grpc.ClientConn to a passthrough address.
+// No actual network connection is made; the conn is registered for cleanup.
+func dialTestClientConn(t *testing.T) *grpc.ClientConn {
+	t.Helper()
+	cc, err := grpc.NewClient(
+		"passthrough:///localhost:0",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cc.Close() })
+	return cc
+}
+
+// --- pickConn ---
+
+func TestPickConn(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc    string
+		conns   []*grpcClientConnWrapper
+		wantNil bool
+		wantIdx int // index into conns of the expected winner (ignored when wantNil)
+	}{
+		{
+			desc:    "empty pool returns nil",
+			conns:   nil,
+			wantNil: true,
+		},
+		{
+			desc: "all non-active returns nil",
+			conns: []*grpcClientConnWrapper{
+				makeConn(connStateDraining, 5),
+				makeConn(connStateIdle, 0),
+			},
+			wantNil: true,
+		},
+		{
+			desc: "single active conn is returned",
+			conns: []*grpcClientConnWrapper{
+				makeConn(connStateActive, 10),
+			},
+			wantIdx: 0,
+		},
+		{
+			// Lowest is at index 1.
+			desc: "picks conn with lowest stream count",
+			conns: []*grpcClientConnWrapper{
+				makeConn(connStateActive, 30),
+				makeConn(connStateActive, 5),
+				makeConn(connStateActive, 20),
+			},
+			wantIdx: 1,
+		},
+		{
+			// Draining conn is excluded; lowest active is at index 2.
+			desc: "skips non-active conns when picking lowest",
+			conns: []*grpcClientConnWrapper{
+				makeConn(connStateDraining, 1),
+				makeConn(connStateActive, 20),
+				makeConn(connStateActive, 10),
+			},
+			wantIdx: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+			p := peerForScaleDown(t, tt.conns, connPoolConfig{})
+			got := p.pickConn()
+			if tt.wantNil {
+				assert.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			assert.Same(t, tt.conns[tt.wantIdx], got)
+		})
+	}
+}
+
+// --- removeConn ---
+
+func TestRemoveConn(t *testing.T) {
+	t.Parallel()
+
+	t.Run("removes from beginning", func(t *testing.T) {
+		t.Parallel()
+		c0, c1, c2 := makeConn(connStateActive, 0), makeConn(connStateActive, 0), makeConn(connStateActive, 0)
+		p := peerForScaleDown(t, []*grpcClientConnWrapper{c0, c1, c2}, connPoolConfig{})
+		p.removeConn(c0)
+		require.Len(t, p.conns, 2)
+		assert.Same(t, c1, p.conns[0])
+		assert.Same(t, c2, p.conns[1])
+	})
+
+	t.Run("removes from middle", func(t *testing.T) {
+		t.Parallel()
+		c0, c1, c2 := makeConn(connStateActive, 0), makeConn(connStateActive, 0), makeConn(connStateActive, 0)
+		p := peerForScaleDown(t, []*grpcClientConnWrapper{c0, c1, c2}, connPoolConfig{})
+		p.removeConn(c1)
+		require.Len(t, p.conns, 2)
+		assert.Same(t, c0, p.conns[0])
+		assert.Same(t, c2, p.conns[1])
+	})
+
+	t.Run("removes from end", func(t *testing.T) {
+		t.Parallel()
+		c0, c1, c2 := makeConn(connStateActive, 0), makeConn(connStateActive, 0), makeConn(connStateActive, 0)
+		p := peerForScaleDown(t, []*grpcClientConnWrapper{c0, c1, c2}, connPoolConfig{})
+		p.removeConn(c2)
+		require.Len(t, p.conns, 2)
+		assert.Same(t, c0, p.conns[0])
+		assert.Same(t, c1, p.conns[1])
+	})
+
+	t.Run("no-op when conn not in pool", func(t *testing.T) {
+		t.Parallel()
+		c0, c1 := makeConn(connStateActive, 0), makeConn(connStateActive, 0)
+		notInPool := makeConn(connStateActive, 0)
+		p := peerForScaleDown(t, []*grpcClientConnWrapper{c0, c1}, connPoolConfig{})
+		assert.NotPanics(t, func() { p.removeConn(notInPool) })
+		assert.Len(t, p.conns, 2)
+	})
+}
+
+// --- monitorConnWrapper ---
+
+func TestMonitorConnWrapperCleanup(t *testing.T) {
+	t.Parallel()
+
+	p := peerForPool(t)
+	cc := dialTestClientConn(t)
+	w := newConnWrapper(p.ctx, cc)
+
+	p.connWg.Add(1)
+	p.mu.Lock()
+	p.conns = append(p.conns, w)
+	p.mu.Unlock()
+
+	go p.monitorConnWrapper(w)
+
+	p.mu.RLock()
+	require.Len(t, p.conns, 1)
+	p.mu.RUnlock()
+
+	p.cancel()
+
+	select {
+	case <-w.stoppedC:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stoppedC not closed after context cancellation")
+	}
+
+	p.mu.RLock()
+	assert.Empty(t, p.conns, "wrapper should be removed from pool on cleanup")
+	p.mu.RUnlock()
+
+	wgDone := make(chan struct{})
+	go func() { p.connWg.Wait(); close(wgDone) }()
+	select {
+	case <-wgDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("connWg did not reach zero after monitorConnWrapper exited")
+	}
+}
+
+// --- stoppedC lifecycle ---
+
+func TestStoppedCClosedAfterAllConnsFinish(t *testing.T) {
+	t.Parallel()
+
+	p := peerForPool(t)
+
+	go func() {
+		<-p.ctx.Done()
+		p.mu.Lock()
+		p.mu.Unlock() //nolint:staticcheck
+		p.connWg.Wait()
+		close(p.stoppedC)
+	}()
+
+	for i := 0; i < 2; i++ {
+		cc := dialTestClientConn(t)
+		w := newConnWrapper(p.ctx, cc)
+		p.connWg.Add(1)
+		p.mu.Lock()
+		p.conns = append(p.conns, w)
+		p.mu.Unlock()
+		go p.monitorConnWrapper(w)
+	}
+
+	p.cancel()
+
+	select {
+	case <-p.stoppedC:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stoppedC not closed after all connections finished")
+	}
+}
+
+// --- addConn context-cancelled branch ---
+
+func TestAddConnContextCancelled(t *testing.T) {
+	t.Parallel()
+
+	p := peerForPool(t)
+	p.cancel()
+
+	err := p.addConn()
+
+	require.Error(t, err)
+	assert.Empty(t, p.conns, "cancelled addConn must not add to pool")
+}
+
+// --- grpcStatusToYARPCStatus ---
+
+func TestGrpcStatusToYARPCStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		grpcStatus connectivity.State
+		wantYARPC  peer.ConnectionStatus
+	}{
+		{connectivity.Ready, peer.Available},
+		{connectivity.Connecting, peer.Connecting},
+		{connectivity.Idle, peer.Unavailable},
+		{connectivity.TransientFailure, peer.Unavailable},
+		{connectivity.Shutdown, peer.Unavailable},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.wantYARPC, grpcStatusToYARPCStatus(tt.grpcStatus), "grpcStatus=%v", tt.grpcStatus)
+	}
+}
+
+// --- recomputeConnectionStatus ---
+
+func TestRecomputeConnectionStatus(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty pool sets unavailable", func(t *testing.T) {
+		t.Parallel()
+		p := peerForPool(t)
+		p.recomputeConnectionStatus()
+		assert.Equal(t, peer.Unavailable, p.Peer.Status().ConnectionStatus)
+	})
+
+	t.Run("all non-active conns sets unavailable", func(t *testing.T) {
+		t.Parallel()
+		p := peerForScaleDown(t, []*grpcClientConnWrapper{
+			makeConn(connStateDraining, 5),
+			makeConn(connStateIdle, 0),
+		}, connPoolConfig{})
+		p.recomputeConnectionStatus()
+		assert.Equal(t, peer.Unavailable, p.Peer.Status().ConnectionStatus)
+	})
+
+	t.Run("active conn in non-ready state sets unavailable or connecting", func(t *testing.T) {
+		t.Parallel()
+		p := peerForPool(t)
+		cc := dialTestClientConn(t)
+		w := newConnWrapper(p.ctx, cc)
+		p.mu.Lock()
+		p.conns = append(p.conns, w)
+		p.mu.Unlock()
+
+		p.recomputeConnectionStatus()
+
+		// A freshly created ClientConn is Idle; grpcStatusToYARPCStatus(Idle)
+		// = Unavailable.  Either way it must not be Available since no server
+		// is listening.
+		status := p.Peer.Status().ConnectionStatus
+		assert.NotEqual(t, peer.Available, status,
+			"no server is listening so the connection cannot be Ready")
+	})
+
+	t.Run("monitorConnWrapper defer sets unavailable after removal", func(t *testing.T) {
+		t.Parallel()
+		p := peerForPool(t)
+		cc := dialTestClientConn(t)
+		w := newConnWrapper(p.ctx, cc)
+		p.connWg.Add(1)
+		p.mu.Lock()
+		p.conns = append(p.conns, w)
+		p.mu.Unlock()
+
+		go p.monitorConnWrapper(w)
+
+		p.cancel()
+
+		select {
+		case <-w.stoppedC:
+		case <-time.After(2 * time.Second):
+			t.Fatal("monitorConnWrapper did not exit")
+		}
+
+		// After the connection is removed, recomputeConnectionStatus sets
+		// the peer to Unavailable.
+		assert.Equal(t, peer.Unavailable, p.Peer.Status().ConnectionStatus)
+	})
 }


### PR DESCRIPTION
## Summary
- Replaces the single clientConn with a addConn(), which adds multiple peers, all managed by monitorConnWrapper for health monitoring and lifecycle. 
- pickConn() selects the active connection with the lowest stream count instead of round-robin, and triggers tryScaleUp() when even the least-loaded connection exceeds the scaleUpThreshold. 
- All pool growth and shrink is gated behind dynamicScalingEnabled; a single connection is always created at startup regardless of the flag to keep changes backward compatible.

## Jira
[RPC-9659](https://t3.uberinternal.com/browse/RPC-9659)
