### PR TITLE
[Client] Send x-forwarded-for unprefixed on outbound HTTP path

### DIFF
--- a/transport/http/constants.go
+++ b/transport/http/constants.go
@@ -169,3 +169,9 @@ const (
 	UberTraceContextHeaderKey  = "uber-trace-id"
 	UberBaggageHeaderKeyPrefix = "uberctx-"
 )
+
+// Proxy-managed header keys that must travel over the wire unprefixed
+// so that Muttley/Envoy can read and update them correctly.
+const (
+	XForwardedForHeader = "x-forwarded-for"
+)

--- a/transport/http/header.go
+++ b/transport/http/header.go
@@ -68,7 +68,7 @@ func (hm headerMapper) FromHTTPHeaders(from http.Header, to transport.Headers) t
 			for _, v := range vals {
 				to = to.With(suffix, v)
 			}
-		case isTracingHeader(origKey):
+		case isTracingHeader(origKey), isProxyHeader(origKey):
 			for _, v := range vals {
 				to = to.With(origKey, v)
 			}
@@ -125,4 +125,11 @@ func isRoutingHeader(k string) bool {
 func isCrossZoneHeader(k string) bool {
 	// k comes from http.Header.Items() and is always in lowercase
 	return k == RoutingRegionHeader || k == RoutingZoneHeader
+}
+
+// isProxyHeader returns true for standard forwarding and proxy-managed
+// headers that must travel over the wire unprefixed so that
+// Muttley/Envoy can read and update them correctly.
+func isProxyHeader(k string) bool {
+	return strings.EqualFold(k, XForwardedForHeader)
 }

--- a/transport/http/header.go
+++ b/transport/http/header.go
@@ -45,7 +45,7 @@ func (hm headerMapper) ToHTTPHeaders(from transport.Headers, to http.Header) htt
 		to = make(http.Header, from.Len())
 	}
 	for key, val := range from.Items() {
-		if isTracingHeader(key) || isRoutingHeader(key) {
+		if isTracingHeader(key) || isRoutingHeader(key) || isProxyHeader(key) {
 			to.Add(key, val)
 		} else {
 			to.Add(hm.Prefix+key, val)

--- a/transport/http/header_test.go
+++ b/transport/http/header_test.go
@@ -111,6 +111,42 @@ func TestHTTPHeaders(t *testing.T) {
 			},
 			expectedTransHeaders: transport.HeadersFromMap(map[string]string{}),
 		},
+		{
+			name: "proxy header outbound still prefixed",
+			transHeaders: transport.HeadersFromMap(map[string]string{
+				"x-forwarded-for": "203.0.113.42",
+			}),
+			expectedHTTP: http.Header{
+				"Rpc-Header-X-Forwarded-For": []string{"203.0.113.42"},
+			},
+			httpHeaders: http.Header{
+				"X-Forwarded-For": []string{"203.0.113.42"},
+			},
+			expectedTransHeaders: transport.HeadersFromMap(map[string]string{
+				"X-Forwarded-For": "203.0.113.42",
+			}),
+		},
+		{
+			name: "proxy header inbound with mixed headers",
+			transHeaders: transport.HeadersFromMap(map[string]string{
+				"foo":           "bar",
+				"uber-trace-id": "tid",
+			}),
+			expectedHTTP: http.Header{
+				"Rpc-Header-Foo": []string{"bar"},
+				"Uber-Trace-Id":  []string{"tid"},
+			},
+			httpHeaders: http.Header{
+				"Rpc-Header-Foo":  []string{"bar"},
+				"X-Forwarded-For": []string{"203.0.113.42"},
+				"Uber-Trace-Id":   []string{"tid"},
+			},
+			expectedTransHeaders: transport.HeadersFromMap(map[string]string{
+				"foo":             "bar",
+				"X-Forwarded-For": "203.0.113.42",
+				"uber-trace-id":   "tid",
+			}),
+		},
 	}
 
 	for _, tt := range tests {
@@ -132,6 +168,26 @@ func assertHeadersEqualCaseInsensitive(t *testing.T, expected, actual http.Heade
 	}
 
 	assert.Equal(t, normalize(expected), normalize(actual), msg)
+}
+
+func TestIsProxyHeader(t *testing.T) {
+	tests := []struct {
+		key  string
+		want bool
+	}{
+		{"x-forwarded-for", true},
+		{"X-Forwarded-For", true},
+		{"X-FORWARDED-FOR", true},
+		{"x-uber-source", false},
+		{"x-other-header", false},
+		{"x-forwarded-host", false},
+		{"rpc-header-foo", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			assert.Equal(t, tt.want, isProxyHeader(tt.key))
+		})
+	}
 }
 
 // TODO(abg): Test handling of duplicate HTTP headers when

--- a/transport/http/header_test.go
+++ b/transport/http/header_test.go
@@ -112,12 +112,12 @@ func TestHTTPHeaders(t *testing.T) {
 			expectedTransHeaders: transport.HeadersFromMap(map[string]string{}),
 		},
 		{
-			name: "proxy header outbound still prefixed",
+			name: "proxy header roundtrip unprefixed",
 			transHeaders: transport.HeadersFromMap(map[string]string{
 				"x-forwarded-for": "203.0.113.42",
 			}),
 			expectedHTTP: http.Header{
-				"Rpc-Header-X-Forwarded-For": []string{"203.0.113.42"},
+				"X-Forwarded-For": []string{"203.0.113.42"},
 			},
 			httpHeaders: http.Header{
 				"X-Forwarded-For": []string{"203.0.113.42"},
@@ -127,14 +127,16 @@ func TestHTTPHeaders(t *testing.T) {
 			}),
 		},
 		{
-			name: "proxy header inbound with mixed headers",
+			name: "mixed application, proxy, and tracing headers",
 			transHeaders: transport.HeadersFromMap(map[string]string{
-				"foo":           "bar",
-				"uber-trace-id": "tid",
+				"foo":             "bar",
+				"x-forwarded-for": "203.0.113.42",
+				"uber-trace-id":   "tid",
 			}),
 			expectedHTTP: http.Header{
-				"Rpc-Header-Foo": []string{"bar"},
-				"Uber-Trace-Id":  []string{"tid"},
+				"Rpc-Header-Foo":  []string{"bar"},
+				"X-Forwarded-For": []string{"203.0.113.42"},
+				"Uber-Trace-Id":   []string{"tid"},
 			},
 			httpHeaders: http.Header{
 				"Rpc-Header-Foo":  []string{"bar"},


### PR DESCRIPTION
Infrastructure headers like `x-forwarded-for` must travel over the wire unprefixed so that Muttley/Envoy can read and append to them correctly. Without this, YARPC sends `rpc-header-x-forwarded-for` which is invisible to proxies, causing the real client IP to be lost.

- [X] Description and context for reviewers: one partner, one stranger
## Summary
- Updates `ToHTTPHeaders` to skip the `rpc-header-` prefix for `x-forwarded-for` by adding `isProxyHeader()` to the outbound bypass condition.
- Together with #2458, this completes the end-to-end fix: `x-forwarded-for` now travels unprefixed on both outbound and inbound paths.

## Context
This is the client-side half of the proxy header fix. The server-side change (#2458) ensures servers can accept unprefixed `x-forwarded-for`. This PR completes the fix by having clients send it unprefixed.

## Rollout strategy
1. **#2458 (server):** Deploy to all servers first so they accept both `rpc-header-x-forwarded-for` and `x-forwarded-for`. ✅
2. **This PR (client):** Deploy after all servers have #2458, so clients start sending `x-forwarded-for` unprefixed.

## Test plan
- [x] `TestHTTPHeaders` — "proxy header roundtrip unprefixed" verifies `x-forwarded-for` is sent and received without the `rpc-header-` prefix
- [x] `TestHTTPHeaders` — "mixed application, proxy, and tracing headers" verifies only proxy headers bypass the prefix; regular app headers still get `rpc-header-`
- [x] Existing tests pass — `rpc-header-` behavior unchanged for non-whitelisted headers

## RELEASE NOTES:

**Client-side (2 of 2).** YARPC HTTP outbound now sends `x-forwarded-for` without the `rpc-header-` prefix, so Muttley/Envoy can see it on the wire and correctly append to the existing IP chain. No application code changes required — just bump the `yarpc-go` dependency.

> **Depends on #2458 (server-side) being deployed to all servers first.**