### PR TITLE
[GRPC-Conn-Pooling] Add peer connection scale up logic

### DIFF
--- a/transport/grpc/conn_pool_scaler.go
+++ b/transport/grpc/conn_pool_scaler.go
@@ -21,6 +21,7 @@
 package grpc
 
 import (
+	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
@@ -113,7 +114,15 @@ func (p *grpcPeer) maybeScaleDown() {
 // cleanupIdleConns advances draining connections with zero streams to the idle
 // state, and cancels connections that have exceeded the idle timeout so their
 // monitor goroutines can close and remove them.
+// It skips closing idle connections while a scale-up is in progress so that
+// tryScaleUp can reactivate them instead of dialing a new connection.
 func (p *grpcPeer) cleanupIdleConns() {
+	// If a scale-up goroutine is running, hold off — idle connections may be
+	// reactivated by tryScaleUp instead of being closed.
+	if atomic.LoadInt32(&p.isScaling) == 1 {
+		return
+	}
+
 	now := time.Now()
 
 	// Use a read lock for the analysis phase
@@ -149,4 +158,78 @@ func (p *grpcPeer) cleanupIdleConns() {
 		// wrapper from p.conns.
 		c.cancel()
 	}
+}
+
+// tryScaleUp triggers a background goroutine to satisfy the need for more
+// connection capacity.  It receives leastLoadedConn — the connection with the
+// fewest active streams, as selected by pickConn.  If even the least-loaded
+// connection is at or above the scale-up threshold then all connections are
+// over budget and the pool needs to grow.  It first tries to reactivate an
+// existing idle connection (avoiding a new dial); only if none are available
+// does it open a new connection, subject to the maxConnections cap.
+// p.isScaling is atomically set to 1 on entry (via CAS) and reset to 0 when
+// the goroutine finishes — this serves a dual purpose: it ensures at most one
+// scale-up goroutine runs at a time, and it signals cleanupIdleConns to hold
+// off closing idle connections while a reactivation may be in progress.
+func (p *grpcPeer) tryScaleUp(leastLoadedConn *grpcClientConnWrapper) {
+	if !p.poolCfg.dynamicScalingEnabled {
+		return
+	}
+
+	threshold := int32(float64(p.poolCfg.maxConcurrentStreams) * p.poolCfg.scaleUpThreshold)
+	if leastLoadedConn.getStreamCount() < threshold {
+		return
+	}
+
+	// Set isScaling to 1 (from 0) to claim the scale-up slot.
+	// If another goroutine already holds it, bail out.
+	if !atomic.CompareAndSwapInt32(&p.isScaling, 0, 1) {
+		return
+	}
+
+	go func() {
+		defer atomic.StoreInt32(&p.isScaling, 0)
+
+		// Prefer reactivating an idle connection over dialing a new one.
+		if p.reactivateIdleConn() {
+			p.t.options.logger.Debug("grpc: reactivated idle connection during scale-up",
+				zap.String("peer", p.HostPort()))
+			return
+		}
+
+		// No idle connection available; dial a new one if below the cap.
+		p.mu.RLock()
+		atMax := len(p.conns) >= p.poolCfg.maxConnections
+		p.mu.RUnlock()
+		if atMax {
+			return
+		}
+
+		if err := p.addConn(); err != nil {
+			p.t.options.logger.Warn("grpc: failed to scale up connection pool",
+				zap.String("peer", p.HostPort()),
+				zap.Error(err))
+		} else {
+			p.t.options.logger.Debug("grpc: scaled up connection pool",
+				zap.String("peer", p.HostPort()))
+		}
+	}()
+}
+
+// reactivateIdleConn finds the first idle connection whose context has not
+// yet been cancelled and transitions it back to active, avoiding an
+// unnecessary dial.  Returns true if a connection was reactivated.
+func (p *grpcPeer) reactivateIdleConn() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, c := range p.conns {
+		// Only reactivate if the connection context is still live; a cancelled
+		// context means cleanupIdleConns has already scheduled it for closure.
+		if c.getState() == connStateIdle && c.ctx.Err() == nil {
+			c.setState(connStateActive)
+			atomic.StoreInt64(&c.lastIdleAtNano, 0)
+			return true
+		}
+	}
+	return false
 }

--- a/transport/grpc/conn_pool_scaler_test.go
+++ b/transport/grpc/conn_pool_scaler_test.go
@@ -22,6 +22,7 @@ package grpc
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -467,4 +468,197 @@ func TestScalingHelperMethodsDoNotPanic(t *testing.T) {
 
 	assert.NotPanics(t, p.cleanupIdleConns)
 	assert.NotPanics(t, p.maybeScaleDown)
+}
+
+// TestTryScaleUp covers all branches of tryScaleUp.
+func TestTryScaleUp(t *testing.T) {
+	t.Parallel()
+
+	// threshold = int32(100 * 0.8) = 80
+	overBudget := makeConn(connStateActive, 85)
+	underBudget := makeConn(connStateActive, 50)
+
+	t.Run("flag disabled - no scale-up", func(t *testing.T) {
+		t.Parallel()
+		p := peerForPool(t)
+		p.poolCfg.dynamicScalingEnabled = false
+		p.tryScaleUp(overBudget)
+		assert.Equal(t, int32(0), atomic.LoadInt32(&p.isScaling))
+	})
+
+	t.Run("under threshold - no scale-up", func(t *testing.T) {
+		t.Parallel()
+		p := peerForPool(t)
+		p.tryScaleUp(underBudget)
+		assert.Equal(t, int32(0), atomic.LoadInt32(&p.isScaling))
+	})
+
+	t.Run("at max connections - no scale-up", func(t *testing.T) {
+		t.Parallel()
+		p := peerForPool(t)
+		conns := make([]*grpcClientConnWrapper, p.poolCfg.maxConnections)
+		for i := range conns {
+			conns[i] = makeConn(connStateActive, 0)
+		}
+		p.mu.Lock()
+		p.conns = conns
+		p.mu.Unlock()
+		p.tryScaleUp(overBudget)
+
+		// atMax check now runs inside the goroutine; wait for it to finish.
+		assert.Eventually(t, func() bool {
+			return atomic.LoadInt32(&p.isScaling) == 0
+		}, 2*time.Second, 10*time.Millisecond)
+
+		p.mu.RLock()
+		n := len(p.conns)
+		p.mu.RUnlock()
+		assert.Equal(t, p.poolCfg.maxConnections, n, "pool should not grow beyond max")
+	})
+
+	t.Run("already scaling - no second goroutine launched", func(t *testing.T) {
+		t.Parallel()
+		p := peerForPool(t)
+		atomic.StoreInt32(&p.isScaling, 1)
+		p.tryScaleUp(overBudget)
+		assert.Equal(t, int32(1), atomic.LoadInt32(&p.isScaling))
+	})
+
+	t.Run("triggers goroutine and adds connection", func(t *testing.T) {
+		t.Parallel()
+		p := peerForPool(t)
+		p.tryScaleUp(overBudget)
+
+		// isScaling resets to 0 once the goroutine completes.
+		assert.Eventually(t, func() bool {
+			return atomic.LoadInt32(&p.isScaling) == 0
+		}, 2*time.Second, 10*time.Millisecond, "isScaling should reset to 0 after goroutine completes")
+
+		// One connection was added to the pool.
+		p.mu.RLock()
+		n := len(p.conns)
+		p.mu.RUnlock()
+		assert.Equal(t, 1, n, "one connection should be added to the pool")
+	})
+
+	t.Run("reactivates idle connection instead of dialing", func(t *testing.T) {
+		t.Parallel()
+		p := peerForPool(t)
+
+		// Seed an idle connection with a live context.
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		idleConn := &grpcClientConnWrapper{ctx: ctx, cancel: cancel}
+		idleConn.setState(connStateIdle)
+		idleConn.setIdleNow()
+		p.mu.Lock()
+		p.conns = append(p.conns, idleConn)
+		p.mu.Unlock()
+
+		p.tryScaleUp(overBudget)
+
+		assert.Eventually(t, func() bool {
+			return atomic.LoadInt32(&p.isScaling) == 0
+		}, 2*time.Second, 10*time.Millisecond)
+
+		// Pool size unchanged — reactivation, not a new dial.
+		p.mu.RLock()
+		n := len(p.conns)
+		p.mu.RUnlock()
+		assert.Equal(t, 1, n, "pool size should not grow on reactivation")
+		assert.Equal(t, connStateActive, idleConn.getState(), "idle conn should be active after reactivation")
+		assert.True(t, idleConn.idleSince().IsZero(), "idle timestamp should be cleared")
+	})
+}
+
+// TestReactivateIdleConn covers all branches of reactivateIdleConn.
+func TestReactivateIdleConn(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty pool returns false", func(t *testing.T) {
+		t.Parallel()
+		p := peerForScaleDown(t, nil, connPoolConfig{})
+		assert.False(t, p.reactivateIdleConn())
+	})
+
+	t.Run("no idle connections returns false", func(t *testing.T) {
+		t.Parallel()
+		conns := []*grpcClientConnWrapper{
+			makeConn(connStateActive, 10),
+			makeConn(connStateDraining, 5),
+		}
+		p := peerForScaleDown(t, conns, connPoolConfig{})
+		assert.False(t, p.reactivateIdleConn())
+	})
+
+	t.Run("idle with cancelled context is skipped", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // already cancelled
+		w := &grpcClientConnWrapper{ctx: ctx, cancel: cancel}
+		w.setState(connStateIdle)
+		p := peerForScaleDown(t, []*grpcClientConnWrapper{w}, connPoolConfig{})
+		assert.False(t, p.reactivateIdleConn())
+		assert.Equal(t, connStateIdle, w.getState(), "cancelled idle conn must not be reactivated")
+	})
+
+	t.Run("reactivates idle connection with live context", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		w := &grpcClientConnWrapper{ctx: ctx, cancel: cancel}
+		w.setState(connStateIdle)
+		w.setIdleNow()
+		p := peerForScaleDown(t, []*grpcClientConnWrapper{w}, connPoolConfig{})
+
+		assert.True(t, p.reactivateIdleConn())
+		assert.Equal(t, connStateActive, w.getState())
+		assert.True(t, w.idleSince().IsZero(), "idle timestamp should be cleared after reactivation")
+	})
+
+	t.Run("skips cancelled idle picks first live idle", func(t *testing.T) {
+		t.Parallel()
+		cancelledCtx, cancelledCancel := context.WithCancel(context.Background())
+		cancelledCancel()
+		cancelled := &grpcClientConnWrapper{ctx: cancelledCtx, cancel: cancelledCancel}
+		cancelled.setState(connStateIdle)
+
+		liveCtx, liveCancel := context.WithCancel(context.Background())
+		defer liveCancel()
+		live := &grpcClientConnWrapper{ctx: liveCtx, cancel: liveCancel}
+		live.setState(connStateIdle)
+
+		p := peerForScaleDown(t, []*grpcClientConnWrapper{cancelled, live}, connPoolConfig{})
+
+		assert.True(t, p.reactivateIdleConn())
+		assert.Equal(t, connStateIdle, cancelled.getState(), "cancelled conn should remain idle")
+		assert.Equal(t, connStateActive, live.getState(), "live idle conn should be reactivated")
+	})
+}
+
+// TestCleanupIdleConnsSkippedWhileScaling verifies that cleanupIdleConns
+// returns early without closing any connections when a scale-up is in progress,
+// so that idle connections remain available for reactivation by tryScaleUp.
+func TestCleanupIdleConnsSkippedWhileScaling(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Build an idle connection past its timeout that would normally be closed.
+	w := &grpcClientConnWrapper{ctx: ctx, cancel: cancel}
+	w.setState(connStateIdle)
+	atomic.StoreInt64(&w.lastIdleAtNano, time.Now().Add(-10*time.Minute).UnixNano())
+
+	cfg := connPoolConfig{idleTimeout: time.Second}
+	p := peerForScaleDown(t, []*grpcClientConnWrapper{w}, cfg)
+
+	// Simulate a scale-up goroutine running.
+	atomic.StoreInt32(&p.isScaling, 1)
+
+	p.cleanupIdleConns()
+
+	// Connection must not have been cancelled — isScaling caused early return.
+	assert.NoError(t, ctx.Err(), "idle connection must not be cancelled while scaling")
+	assert.Equal(t, connStateIdle, w.getState(), "connection state must be unchanged")
 }

--- a/transport/grpc/outbound.go
+++ b/transport/grpc/outbound.go
@@ -222,6 +222,7 @@ func (o *Outbound) invoke(
 	}
 	conn.incStreamCount()
 	defer conn.decStreamCount()
+	grpcPeer.tryScaleUp(conn)
 
 	tracer := o.t.options.tracer
 	createOpenTracingSpan := &transport.CreateOpenTracingSpan{
@@ -373,6 +374,7 @@ func (o *Outbound) stream(
 		conn.decStreamCount()
 		onFinish(err)
 	}
+	grpcPeer.tryScaleUp(conn)
 
 	tracer := o.t.options.tracer
 	createOpenTracingSpan := &transport.CreateOpenTracingSpan{


### PR DESCRIPTION
## Summary
When the least-loaded connection (selected by pickConn) exceeds the scale-up threshold, tryScaleUp fires a background goroutine guarded by an atomic CAS on isScaling to prevent concurrent scale-ups. The goroutine first checks for idle connections to reactivate before dialing a new one, avoiding unnecessary connection churn. cleanupIdleConns is gated on isScaling so idle connections are preserved while reactivation may be in progress. Scale-up is only triggered when dynamicScalingEnabled is set, and is capped at maxConnections.

## Jira
[RPC-9659](https://t3.uberinternal.com/browse/RPC-9659)