### PR TITLE
[GRPC-Conn-Pooling] Integrate metrics into connection pooling logic

### DIFF
--- a/transport/grpc/conn_pool_metrics.go
+++ b/transport/grpc/conn_pool_metrics.go
@@ -139,25 +139,43 @@ func newConnPoolMetrics(p connPoolMetricsParams) *connPoolMetrics {
 }
 
 func (m *connPoolMetrics) setConnectionCount(n int64) {
+	if m == nil || m.connectionCount == nil {
+		return
+	}
 	m.connectionCount.Store(n)
 }
 
 func (m *connPoolMetrics) setDrainingConnectionCount(n int64) {
+	if m == nil || m.drainingConnectionCount == nil {
+		return
+	}
 	m.drainingConnectionCount.Store(n)
 }
 
 func (m *connPoolMetrics) setIdleConnectionCount(n int64) {
+	if m == nil || m.idleConnectionCount == nil {
+		return
+	}
 	m.idleConnectionCount.Store(n)
 }
 
 func (m *connPoolMetrics) incScaleUp() {
+	if m == nil || m.scaleUpTotal == nil {
+		return
+	}
 	m.scaleUpTotal.Inc()
 }
 
 func (m *connPoolMetrics) incScaleDown() {
+	if m == nil || m.scaleDownTotal == nil {
+		return
+	}
 	m.scaleDownTotal.Inc()
 }
 
 func (m *connPoolMetrics) incIdleReactivation() {
+	if m == nil || m.idleReactivationTotal == nil {
+		return
+	}
 	m.idleReactivationTotal.Inc()
 }

--- a/transport/grpc/conn_pool_metrics_test.go
+++ b/transport/grpc/conn_pool_metrics_test.go
@@ -210,3 +210,17 @@ func TestNewConnPoolMetrics_LogsRegistrationErrors(t *testing.T) {
 
 	assert.NotZero(t, logs.Len(), "expected error logs for duplicate metric registration")
 }
+
+// TestConnPoolMetrics_NilReceiver verifies that calling any method on a nil
+// *connPoolMetrics pointer does not panic.
+func TestConnPoolMetrics_NilReceiver(t *testing.T) {
+	var m *connPoolMetrics
+	assert.NotPanics(t, func() {
+		m.incScaleUp()
+		m.incScaleDown()
+		m.incIdleReactivation()
+		m.setConnectionCount(5)
+		m.setDrainingConnectionCount(3)
+		m.setIdleConnectionCount(1)
+	})
+}

--- a/transport/grpc/conn_pool_scaler.go
+++ b/transport/grpc/conn_pool_scaler.go
@@ -109,6 +109,8 @@ func (p *grpcPeer) maybeScaleDown() {
 	p.t.options.logger.Debug("grpc: marked connection for draining during scale-down",
 		zap.String("peer", p.HostPort()),
 		zap.Int32("stream_count", mostLoaded.getStreamCount()))
+	p.metrics.incScaleDown()
+	p.refreshPoolMetrics()
 }
 
 // cleanupIdleConns advances draining connections with zero streams to the idle
@@ -158,6 +160,10 @@ func (p *grpcPeer) cleanupIdleConns() {
 		// wrapper from p.conns.
 		c.cancel()
 	}
+
+	if len(drained) > 0 || len(toClose) > 0 {
+		p.refreshPoolMetrics()
+	}
 }
 
 // tryScaleUp triggers a background goroutine to satisfy the need for more
@@ -194,6 +200,8 @@ func (p *grpcPeer) tryScaleUp(leastLoadedConn *grpcClientConnWrapper) {
 		if p.reactivateIdleConn() {
 			p.t.options.logger.Debug("grpc: reactivated idle connection during scale-up",
 				zap.String("peer", p.HostPort()))
+			p.metrics.incIdleReactivation()
+			p.refreshPoolMetrics()
 			return
 		}
 
@@ -212,6 +220,7 @@ func (p *grpcPeer) tryScaleUp(leastLoadedConn *grpcClientConnWrapper) {
 		} else {
 			p.t.options.logger.Debug("grpc: scaled up connection pool",
 				zap.String("peer", p.HostPort()))
+			p.metrics.incScaleUp()
 		}
 	}()
 }
@@ -232,4 +241,25 @@ func (p *grpcPeer) reactivateIdleConn() bool {
 		}
 	}
 	return false
+}
+
+// refreshPoolMetrics scans the pool and updates the active, draining, and idle
+// connection gauges.  It must be called after any pool state transition.
+func (p *grpcPeer) refreshPoolMetrics() {
+	var active, draining, idle int64
+	p.mu.RLock()
+	for _, c := range p.conns {
+		switch c.getState() {
+		case connStateActive:
+			active++
+		case connStateDraining:
+			draining++
+		case connStateIdle:
+			idle++
+		}
+	}
+	p.mu.RUnlock()
+	p.metrics.setConnectionCount(active)
+	p.metrics.setDrainingConnectionCount(draining)
+	p.metrics.setIdleConnectionCount(idle)
 }

--- a/transport/grpc/conn_pool_scaler_test.go
+++ b/transport/grpc/conn_pool_scaler_test.go
@@ -28,7 +28,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/net/metrics"
 	"go.uber.org/yarpc/peer/abstractpeer"
+	"go.uber.org/zap"
 )
 
 // newTestPeer returns a minimal grpcPeer sufficient for exercising the scaling
@@ -661,4 +663,177 @@ func TestCleanupIdleConnsSkippedWhileScaling(t *testing.T) {
 	// Connection must not have been cancelled — isScaling caused early return.
 	assert.NoError(t, ctx.Err(), "idle connection must not be cancelled while scaling")
 	assert.Equal(t, connStateIdle, w.getState(), "connection state must be unchanged")
+}
+
+// --- metrics wiring ---
+
+// peerWithMetrics creates a peerForPool with a real metrics scope attached.
+func peerWithMetrics(t *testing.T) (*grpcPeer, *metrics.Root) {
+	t.Helper()
+	root := metrics.New()
+	p := peerForPool(t)
+	p.metrics = newConnPoolMetrics(connPoolMetricsParams{
+		Meter:       root.Scope(),
+		Logger:      zap.NewNop(),
+		ServiceName: "test-svc",
+		Peer:        p.Peer.Identifier(),
+	})
+	return p, root
+}
+
+func gaugesFromSnapshot(snap *metrics.RootSnapshot) map[string]int64 {
+	m := make(map[string]int64, len(snap.Gauges))
+	for _, g := range snap.Gauges {
+		m[g.Name] = g.Value
+	}
+	return m
+}
+
+func countersFromSnapshot(snap *metrics.RootSnapshot) map[string]int64 {
+	m := make(map[string]int64, len(snap.Counters))
+	for _, c := range snap.Counters {
+		m[c.Name] = c.Value
+	}
+	return m
+}
+
+// TestRefreshPoolMetrics verifies that refreshPoolMetrics correctly derives
+// active/draining/idle counts from the pool and publishes them as gauges.
+func TestRefreshPoolMetrics(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty pool sets all gauges to zero", func(t *testing.T) {
+		t.Parallel()
+		p, root := peerWithMetrics(t)
+		p.refreshPoolMetrics()
+		g := gaugesFromSnapshot(root.Snapshot())
+		assert.Equal(t, int64(0), g["conn_pool_active_connections"])
+		assert.Equal(t, int64(0), g["conn_pool_draining_connections"])
+		assert.Equal(t, int64(0), g["conn_pool_idle_connections"])
+	})
+
+	t.Run("mixed pool reports correct counts", func(t *testing.T) {
+		t.Parallel()
+		p, root := peerWithMetrics(t)
+		p.mu.Lock()
+		p.conns = []*grpcClientConnWrapper{
+			makeConn(connStateActive, 0),
+			makeConn(connStateActive, 0),
+			makeConn(connStateDraining, 0),
+			makeConn(connStateIdle, 0),
+		}
+		p.mu.Unlock()
+
+		p.refreshPoolMetrics()
+
+		g := gaugesFromSnapshot(root.Snapshot())
+		assert.Equal(t, int64(2), g["conn_pool_active_connections"])
+		assert.Equal(t, int64(1), g["conn_pool_draining_connections"])
+		assert.Equal(t, int64(1), g["conn_pool_idle_connections"])
+	})
+}
+
+// TestMaybeScaleDownMetrics verifies that maybeScaleDown increments the
+// scale-down counter and refreshes the pool gauges when draining a connection.
+func TestMaybeScaleDownMetrics(t *testing.T) {
+	t.Parallel()
+
+	p, root := peerWithMetrics(t)
+	p.poolCfg = connPoolConfig{
+		minConnections:      1,
+		maxConcurrentStreams: 100,
+		scaleUpThreshold:    0.8, // threshold = 80
+	}
+	p.mu.Lock()
+	p.conns = []*grpcClientConnWrapper{
+		makeConn(connStateActive, 10),
+		makeConn(connStateActive, 10),
+		makeConn(connStateActive, 10), // total 30 < capacityAfterDrain=160 → drain
+	}
+	p.mu.Unlock()
+
+	p.maybeScaleDown()
+
+	c := countersFromSnapshot(root.Snapshot())
+	assert.Equal(t, int64(1), c["conn_pool_scale_down_total"], "scale-down counter should increment")
+
+	g := gaugesFromSnapshot(root.Snapshot())
+	assert.Equal(t, int64(2), g["conn_pool_active_connections"])
+	assert.Equal(t, int64(1), g["conn_pool_draining_connections"])
+}
+
+// TestTryScaleUpDialMetrics verifies that tryScaleUp increments the scale-up
+// counter when it opens a new connection.
+func TestTryScaleUpDialMetrics(t *testing.T) {
+	t.Parallel()
+
+	p, root := peerWithMetrics(t)
+	overBudget := makeConn(connStateActive, 85) // threshold=80
+
+	p.tryScaleUp(overBudget)
+
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&p.isScaling) == 0
+	}, 2*time.Second, 10*time.Millisecond)
+
+	c := countersFromSnapshot(root.Snapshot())
+	assert.Equal(t, int64(1), c["conn_pool_scale_up_total"])
+
+	// Gauge must reflect the newly added connection.
+	g := gaugesFromSnapshot(root.Snapshot())
+	assert.Equal(t, int64(1), g["conn_pool_active_connections"])
+}
+
+// TestTryScaleUpReactivationMetrics verifies that tryScaleUp increments the
+// idle-reactivation counter and updates gauges when reactivating an idle conn.
+func TestTryScaleUpReactivationMetrics(t *testing.T) {
+	t.Parallel()
+
+	p, root := peerWithMetrics(t)
+
+	// Seed an idle connection with a live context.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	idleConn := &grpcClientConnWrapper{ctx: ctx, cancel: cancel}
+	idleConn.setState(connStateIdle)
+	p.mu.Lock()
+	p.conns = append(p.conns, idleConn)
+	p.mu.Unlock()
+
+	overBudget := makeConn(connStateActive, 85)
+	p.tryScaleUp(overBudget)
+
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&p.isScaling) == 0
+	}, 2*time.Second, 10*time.Millisecond)
+
+	c := countersFromSnapshot(root.Snapshot())
+	assert.Equal(t, int64(1), c["conn_pool_idle_reactivation_total"])
+	assert.Equal(t, int64(0), c["conn_pool_scale_up_total"], "no new dial should happen")
+
+	g := gaugesFromSnapshot(root.Snapshot())
+	assert.Equal(t, int64(1), g["conn_pool_active_connections"])
+	assert.Equal(t, int64(0), g["conn_pool_idle_connections"])
+}
+
+// TestCleanupIdleConnsMetrics verifies that cleanupIdleConns updates gauges
+// after advancing draining connections to idle.
+func TestCleanupIdleConnsMetrics(t *testing.T) {
+	t.Parallel()
+
+	p, root := peerWithMetrics(t)
+	p.poolCfg = connPoolConfig{idleTimeout: time.Hour}
+	p.mu.Lock()
+	p.conns = []*grpcClientConnWrapper{
+		makeConn(connStateActive, 5),
+		makeConn(connStateDraining, 0), // 0 streams → advances to idle
+	}
+	p.mu.Unlock()
+
+	p.cleanupIdleConns()
+
+	g := gaugesFromSnapshot(root.Snapshot())
+	assert.Equal(t, int64(1), g["conn_pool_active_connections"])
+	assert.Equal(t, int64(0), g["conn_pool_draining_connections"])
+	assert.Equal(t, int64(1), g["conn_pool_idle_connections"])
 }

--- a/transport/grpc/peer.go
+++ b/transport/grpc/peer.go
@@ -51,6 +51,8 @@ type grpcPeer struct {
 	// stoppedC is closed once all goroutines finish after the peer is stopped.
 	connWg sync.WaitGroup
 
+	metrics *connPoolMetrics
+
 	mu      sync.RWMutex
 	conns   []*grpcClientConnWrapper
 	poolCfg connPoolConfig
@@ -79,6 +81,12 @@ func (t *Transport) newPeer(address string, options *dialOptions) (*grpcPeer, er
 		cancel:       cancel,
 		stoppedC:     make(chan struct{}),
 		grpcDialOpts: dialOptions,
+		metrics: newConnPoolMetrics(connPoolMetricsParams{
+			Meter:       t.options.meter,
+			Logger:      t.options.logger,
+			ServiceName: t.options.serviceName,
+			Peer:        address,
+		}),
 		poolCfg: connPoolConfig{
 			dynamicScalingEnabled: t.options.clientConnPoolDynamicScalingEnabled,
 			maxConcurrentStreams:   t.options.clientConnPoolMaxConcurrentStreams,
@@ -149,6 +157,7 @@ func (p *grpcPeer) addConn() error {
 	p.mu.Unlock()
 
 	go p.monitorConnWrapper(w)
+	p.refreshPoolMetrics()
 	return nil
 }
 
@@ -164,6 +173,7 @@ func (p *grpcPeer) monitorConnWrapper(w *grpcClientConnWrapper) {
 		p.removeConn(w)
 		// Recompute connection status now that this peer is gone.
 		p.recomputeConnectionStatus()
+		p.refreshPoolMetrics()
 		p.connWg.Done()
 	}()
 

--- a/transport/grpc/peer_test.go
+++ b/transport/grpc/peer_test.go
@@ -28,6 +28,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/net/metrics"
+	"go.uber.org/zap"
 	"go.uber.org/yarpc/api/backoff"
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
@@ -515,4 +517,44 @@ func TestRecomputeConnectionStatus(t *testing.T) {
 		// the peer to Unavailable.
 		assert.Equal(t, peer.Unavailable, p.Peer.Status().ConnectionStatus)
 	})
+}
+
+// TestMonitorConnWrapperMetrics verifies that the monitorConnWrapper defer
+// calls refreshPoolMetrics so gauges drop to zero after the connection exits.
+func TestMonitorConnWrapperMetrics(t *testing.T) {
+	t.Parallel()
+
+	root := metrics.New()
+	p := peerForPool(t)
+	p.metrics = newConnPoolMetrics(connPoolMetricsParams{
+		Meter:       root.Scope(),
+		Logger:      zap.NewNop(),
+		ServiceName: "test-svc",
+		Peer:        p.Peer.Identifier(),
+	})
+
+	cc := dialTestClientConn(t)
+	w := newConnWrapper(p.ctx, cc)
+	p.connWg.Add(1)
+	p.mu.Lock()
+	p.conns = append(p.conns, w)
+	p.mu.Unlock()
+
+	// Reflect the initial active connection in the gauges.
+	p.refreshPoolMetrics()
+	g := gaugesFromSnapshot(root.Snapshot())
+	assert.Equal(t, int64(1), g["conn_pool_active_connections"])
+
+	go p.monitorConnWrapper(w)
+	p.cancel()
+
+	select {
+	case <-w.stoppedC:
+	case <-time.After(2 * time.Second):
+		t.Fatal("monitorConnWrapper did not exit")
+	}
+
+	// After removal the gauge must drop to zero.
+	g = gaugesFromSnapshot(root.Snapshot())
+	assert.Equal(t, int64(0), g["conn_pool_active_connections"])
 }


### PR DESCRIPTION
## Summary
Wires the existing connPoolMetrics handles into the connection pool lifecycle.
- refreshPoolMetrics() scans the pool and updates active/draining/idle connection gauges
- Event counters (incScaleUp, incScaleDown, incIdleReactivation) are incremented at the exact moment each event occurs. 

## Jira
[RPC-9676](https://t3.uberinternal.com/browse/RPC-9676)
