### PR TITLE
Emit metrics for unannotated Thrift exceptions

### DIFF
--- a/api/transport/request.go
+++ b/api/transport/request.go
@@ -111,6 +111,9 @@ func (r *Request) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 // Encoding represents an encoding format for requests.
 type Encoding string
 
+// ThriftEncoding A constant definition of the thrift encoding
+const ThriftEncoding = Encoding("thrift")
+
 // ValidateRequest validates the given request. An error is returned if the
 // request is invalid.
 //

--- a/api/transport/router.go
+++ b/api/transport/router.go
@@ -26,6 +26,9 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+// RPCCodeNotSetLiteral is a placeholder value when the "rpc.code" annotation is absent
+const RPCCodeNotSetLiteral = "__not_set__"
+
 // TODO: Until golang/mock#4 is fixed, imports in the generated code have to
 // be fixed by hand. They use vendor/* import paths rather than direct.
 
@@ -47,6 +50,12 @@ type Procedure struct {
 	// Signature of the handler, for introspection. This should be a snippet of
 	// Go code representing the function definition.
 	Signature string
+
+	// Exceptions, when non-empty, maps Thrift exception type names from the
+	// method throws list to rpc.code annotation values (encoding/thrift uses
+	// the "__not_set__" sentinel when an exception has no rpc.code). Other
+	// encodings leave this nil.
+	Exceptions map[string]string
 }
 
 // MarshalLogObject implements zap.ObjectMarshaler.
@@ -57,7 +66,23 @@ func (p Procedure) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	enc.AddString("service", p.Service)
 	enc.AddString("encoding", string(p.Encoding))
 	enc.AddString("signature", p.Signature)
+	if len(p.Exceptions) > 0 {
+		_ = enc.AddObject("exceptions", exceptionsMapLogString(p.Exceptions))
+	}
 	return enc.AddObject("handler", p.HandlerSpec)
+}
+
+func exceptionsMapLogString(m map[string]string) zapcore.ObjectMarshalerFunc {
+	return func(enc zapcore.ObjectEncoder) error {
+		keys := make([]string, 0, len(m))
+		for k := range m {
+			keys = append(keys, k)
+		}
+		for _, k := range keys {
+			enc.AddString(k, m[k])
+		}
+		return nil
+	}
 }
 
 // Less orders procedures lexicographically on (Service, Name, Encoding).

--- a/api/transport/router_test.go
+++ b/api/transport/router_test.go
@@ -29,22 +29,53 @@ import (
 )
 
 func TestProcedureLogMarshaling(t *testing.T) {
-	p := Procedure{
-		Name:    "name",
-		Service: "service",
-		HandlerSpec: NewUnaryHandlerSpec(UnaryHandlerFunc(func(context.Context, *Request, ResponseWriter) error {
-			return nil
-		})),
-		Encoding:  "raw",
-		Signature: "signature",
-	}
-	enc := zapcore.NewMapObjectEncoder()
-	assert.NoError(t, p.MarshalLogObject(enc), "Unexpected error marshaling procedure.")
-	assert.Equal(t, map[string]interface{}{
-		"name":      "name",
-		"service":   "service",
-		"handler":   map[string]interface{}{"rpcType": "Unary"},
-		"encoding":  "raw",
-		"signature": "signature",
-	}, enc.Fields, "Unexpected output from marshaling procedure.")
+	t.Run("without exceptions", func(t *testing.T) {
+		p := Procedure{
+			Name:    "name",
+			Service: "service",
+			HandlerSpec: NewUnaryHandlerSpec(UnaryHandlerFunc(func(context.Context, *Request, ResponseWriter) error {
+				return nil
+			})),
+			Encoding:  "raw",
+			Signature: "signature",
+		}
+		enc := zapcore.NewMapObjectEncoder()
+		assert.NoError(t, p.MarshalLogObject(enc), "Unexpected error marshaling procedure.")
+		assert.Equal(t, map[string]interface{}{
+			"name":      "name",
+			"service":   "service",
+			"handler":   map[string]interface{}{"rpcType": "Unary"},
+			"encoding":  "raw",
+			"signature": "signature",
+		}, enc.Fields, "Unexpected output from marshaling procedure.")
+	})
+
+	t.Run("with exceptions", func(t *testing.T) {
+		p := Procedure{
+			Name:    "name",
+			Service: "service",
+			HandlerSpec: NewUnaryHandlerSpec(UnaryHandlerFunc(func(context.Context, *Request, ResponseWriter) error {
+				return nil
+			})),
+			Encoding:  "thrift",
+			Signature: "signature",
+			Exceptions: map[string]string{
+				"ExB": "__not_set__",
+				"ExA": "INVALID_ARGUMENT",
+			},
+		}
+		enc := zapcore.NewMapObjectEncoder()
+		assert.NoError(t, p.MarshalLogObject(enc), "Unexpected error marshaling procedure.")
+		assert.Equal(t, map[string]interface{}{
+			"name":      "name",
+			"service":   "service",
+			"handler":   map[string]interface{}{"rpcType": "Unary"},
+			"encoding":  "thrift",
+			"signature": "signature",
+			"exceptions": map[string]interface{}{
+				"ExA": "INVALID_ARGUMENT",
+				"ExB": "__not_set__",
+			},
+		}, enc.Fields, "Unexpected output from marshaling procedure.")
+	})
 }

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -359,6 +359,31 @@ func (d *Dispatcher) Register(rs []transport.Procedure) {
 
 		procedures = append(procedures, r)
 		d.log.Info("Registration succeeded.", zap.Object("registeredProcedure", r))
+
+		if r.Encoding == transport.ThriftEncoding {
+			for exceptionName, code := range r.Exceptions {
+				if code != transport.RPCCodeNotSetLiteral {
+					continue
+				}
+				if d.meter != nil {
+					g, err := d.meter.Tagged(metrics.Tags{
+						"service":   d.name,
+						"procedure": r.Name,
+						"exception": exceptionName,
+					}).Gauge(metrics.Spec{
+						Name: "thrift_unannotated_exceptions",
+						Help: "Registered procedure may throw an unannotated Thrift exception.",
+					})
+					if err != nil {
+						d.log.Warn("Failed to create thrift unannotated exceptions gauge", zap.Error(err))
+					}
+					g.Store(1)
+				}
+				d.log.Warn("Registered procedure may throw an unannotated Thrift exception.",
+					zap.String("procedure", r.Name),
+					zap.String("exception", exceptionName))
+			}
+		}
 	}
 
 	d.table.Register(procedures)

--- a/dispatcher_internal_test.go
+++ b/dispatcher_internal_test.go
@@ -1,0 +1,201 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpc
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/net/metrics"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/api/transport/transporttest"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func loggedStringFields(e observer.LoggedEntry) map[string]string {
+	m := make(map[string]string)
+	for _, f := range e.Context {
+		if f.Type == zapcore.StringType {
+			m[f.Key] = f.String
+		}
+	}
+	return m
+}
+
+func TestRegister_thriftUnannotatedExceptionWarnLogs(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	core, logs := observer.New(zapcore.WarnLevel)
+	const procName = "mysvc::ping"
+	d := NewDispatcher(Config{
+		Name:    "mysvc",
+		Logging: LoggingConfig{Zap: zap.New(core)},
+	})
+	require.Nil(t, d.meter)
+
+	h := transporttest.NewMockUnaryHandler(mockCtrl)
+	assert.NotPanics(t, func() {
+		d.Register([]transport.Procedure{{
+			Name:        procName,
+			Encoding:    transport.ThriftEncoding,
+			HandlerSpec: transport.NewUnaryHandlerSpec(h),
+			Exceptions: map[string]string{
+				"error.InvalidArgumentError": transport.RPCCodeNotSetLiteral,
+			},
+		}})
+	})
+
+	w := logs.FilterMessage("Registered procedure may throw an unannotated Thrift exception.")
+	require.Equal(t, 1, w.Len())
+	e := w.All()[0]
+	fields := loggedStringFields(e)
+	assert.Equal(t, procName, fields["procedure"])
+	assert.Equal(t, "error.InvalidArgumentError", fields["exception"])
+}
+
+func TestRegister_thriftUnannotatedExceptionWithMetricsScope(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	core, logs := observer.New(zapcore.WarnLevel)
+	const procName = "mysvc::ping"
+	d := NewDispatcher(Config{
+		Name: "mysvc",
+		Metrics: MetricsConfig{
+			Metrics: metrics.New().Scope(),
+		},
+		Logging: LoggingConfig{Zap: zap.New(core)},
+	})
+	require.NotNil(t, d.meter)
+
+	h := transporttest.NewMockUnaryHandler(mockCtrl)
+	assert.NotPanics(t, func() {
+		d.Register([]transport.Procedure{{
+			Name:        procName,
+			Encoding:    transport.ThriftEncoding,
+			HandlerSpec: transport.NewUnaryHandlerSpec(h),
+			Exceptions: map[string]string{
+				"error.InvalidArgumentError": transport.RPCCodeNotSetLiteral,
+			},
+		}})
+	})
+
+	w := logs.FilterMessage("Registered procedure may throw an unannotated Thrift exception.")
+	require.Equal(t, 1, w.Len())
+	e := w.All()[0]
+	fields := loggedStringFields(e)
+	assert.Equal(t, procName, fields["procedure"])
+	assert.Equal(t, "error.InvalidArgumentError", fields["exception"])
+}
+
+func TestRegister_thriftRpcCodeAnnotationSkipsUnannotatedWarn(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	core, logs := observer.New(zapcore.WarnLevel)
+	d := NewDispatcher(Config{
+		Name:    "mysvc",
+		Logging: LoggingConfig{Zap: zap.New(core)},
+	})
+	h := transporttest.NewMockUnaryHandler(mockCtrl)
+	d.Register([]transport.Procedure{{
+		Name:        "mysvc::ping",
+		Encoding:    transport.ThriftEncoding,
+		HandlerSpec: transport.NewUnaryHandlerSpec(h),
+		Exceptions: map[string]string{
+			"SomeErr": "INVALID_ARGUMENT",
+		},
+	}})
+	assert.Equal(t, 0, logs.Len())
+}
+
+func TestRegister_nonThriftEncodingSkipsExceptionInstrumentation(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	core, logs := observer.New(zapcore.WarnLevel)
+	d := NewDispatcher(Config{
+		Name:    "mysvc",
+		Logging: LoggingConfig{Zap: zap.New(core)},
+	})
+	h := transporttest.NewMockUnaryHandler(mockCtrl)
+	d.Register([]transport.Procedure{{
+		Name:        "mysvc::ping",
+		Encoding:    "json",
+		HandlerSpec: transport.NewUnaryHandlerSpec(h),
+		Exceptions: map[string]string{
+			"SomeErr": transport.RPCCodeNotSetLiteral,
+		},
+	}})
+	assert.Equal(t, 0, logs.Len())
+}
+
+func TestRegister_thriftNilExceptionsNoWarn(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	core, logs := observer.New(zapcore.WarnLevel)
+	d := NewDispatcher(Config{
+		Name:    "mysvc",
+		Logging: LoggingConfig{Zap: zap.New(core)},
+	})
+	h := transporttest.NewMockUnaryHandler(mockCtrl)
+	d.Register([]transport.Procedure{{
+		Name:        "mysvc::ping",
+		Encoding:    transport.ThriftEncoding,
+		HandlerSpec: transport.NewUnaryHandlerSpec(h),
+	}})
+	assert.Equal(t, 0, logs.Len())
+}
+
+func TestRegister_thriftMultipleUnannotatedExceptionsWarnEach(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	core, logs := observer.New(zapcore.WarnLevel)
+	d := NewDispatcher(Config{
+		Name:    "mysvc",
+		Logging: LoggingConfig{Zap: zap.New(core)},
+	})
+	h := transporttest.NewMockUnaryHandler(mockCtrl)
+	d.Register([]transport.Procedure{{
+		Name:        "mysvc::ping",
+		Encoding:    transport.ThriftEncoding,
+		HandlerSpec: transport.NewUnaryHandlerSpec(h),
+		Exceptions: map[string]string{
+			"AErr": transport.RPCCodeNotSetLiteral,
+			"BErr": transport.RPCCodeNotSetLiteral,
+		},
+	}})
+	w := logs.FilterMessage("Registered procedure may throw an unannotated Thrift exception.")
+	require.Equal(t, 2, w.Len())
+	got := make(map[string]struct{})
+	for _, e := range w.All() {
+		got[loggedStringFields(e)["exception"]] = struct{}{}
+	}
+	assert.Contains(t, got, "AErr")
+	assert.Contains(t, got, "BErr")
+}

--- a/encoding/thrift/constants.go
+++ b/encoding/thrift/constants.go
@@ -23,6 +23,6 @@ package thrift
 import "go.uber.org/yarpc/api/transport"
 
 // Encoding is the name of this encoding.
-const Encoding transport.Encoding = "thrift"
+const Encoding = transport.ThriftEncoding
 
 const _defaultBufferSize = 1024 // 1k

--- a/encoding/thrift/internal/observabilitytest/test.thrift
+++ b/encoding/thrift/internal/observabilitytest/test.thrift
@@ -10,7 +10,7 @@ exception ExceptionWithoutCode {
 
 service TestService  {
     string Call(1: required string key) throws (
-      1: ExceptionWithCode exCode,
       2: ExceptionWithoutCode exNoCode,
+      1: ExceptionWithCode exCode,
     )
 }

--- a/encoding/thrift/internal/observabilitytest/test/test.go
+++ b/encoding/thrift/internal/observabilitytest/test/test.go
@@ -467,11 +467,11 @@ var ThriftModule = &thriftreflect.ThriftModule{
 	Name:     "test",
 	Package:  "go.uber.org/yarpc/encoding/thrift/internal/observabilitytest/test",
 	FilePath: "test.thrift",
-	SHA1:     "3c501036fe37f678648dd479c821bc57aa17b7d1",
+	SHA1:     "488477fa89cb79327c14a64d70992f754c3de3b3",
 	Raw:      rawIDL,
 }
 
-const rawIDL = "exception ExceptionWithCode {\n    1: required string val\n} (\n    rpc.code = \"DATA_LOSS\" // server error\n)\n\nexception ExceptionWithoutCode {\n    1: required string val\n}\n\nservice TestService  {\n    string Call(1: required string key) throws (\n      1: ExceptionWithCode exCode,\n      2: ExceptionWithoutCode exNoCode,\n    )\n}\n"
+const rawIDL = "exception ExceptionWithCode {\n    1: required string val\n} (\n    rpc.code = \"DATA_LOSS\" // server error\n)\n\nexception ExceptionWithoutCode {\n    1: required string val\n}\n\nservice TestService  {\n    string Call(1: required string key) throws (\n      2: ExceptionWithoutCode exNoCode,\n      1: ExceptionWithCode exCode,\n    )\n}\n"
 
 // TestService_Call_Args represents the arguments for the TestService.Call function.
 //
@@ -751,9 +751,9 @@ func init() {
 
 	TestService_Call_Helper.IsException = func(err error) bool {
 		switch err.(type) {
-		case *ExceptionWithCode:
-			return true
 		case *ExceptionWithoutCode:
+			return true
+		case *ExceptionWithCode:
 			return true
 		default:
 			return false
@@ -766,27 +766,27 @@ func init() {
 		}
 
 		switch e := err.(type) {
-		case *ExceptionWithCode:
-			if e == nil {
-				return nil, errors.New("WrapResponse received non-nil error type with nil value for TestService_Call_Result.ExCode")
-			}
-			return &TestService_Call_Result{ExCode: e}, nil
 		case *ExceptionWithoutCode:
 			if e == nil {
 				return nil, errors.New("WrapResponse received non-nil error type with nil value for TestService_Call_Result.ExNoCode")
 			}
 			return &TestService_Call_Result{ExNoCode: e}, nil
+		case *ExceptionWithCode:
+			if e == nil {
+				return nil, errors.New("WrapResponse received non-nil error type with nil value for TestService_Call_Result.ExCode")
+			}
+			return &TestService_Call_Result{ExCode: e}, nil
 		}
 
 		return nil, err
 	}
 	TestService_Call_Helper.UnwrapResponse = func(result *TestService_Call_Result) (success string, err error) {
-		if result.ExCode != nil {
-			err = result.ExCode
-			return
-		}
 		if result.ExNoCode != nil {
 			err = result.ExNoCode
+			return
+		}
+		if result.ExCode != nil {
+			err = result.ExCode
 			return
 		}
 
@@ -809,8 +809,8 @@ func init() {
 type TestService_Call_Result struct {
 	// Value returned by Call after a successful execution.
 	Success  *string               `json:"success,omitempty"`
-	ExCode   *ExceptionWithCode    `json:"exCode,omitempty"`
 	ExNoCode *ExceptionWithoutCode `json:"exNoCode,omitempty"`
+	ExCode   *ExceptionWithCode    `json:"exCode,omitempty"`
 }
 
 // ToWire translates a TestService_Call_Result struct into a Thrift-level intermediate
@@ -844,20 +844,20 @@ func (v *TestService_Call_Result) ToWire() (wire.Value, error) {
 		fields[i] = wire.Field{ID: 0, Value: w}
 		i++
 	}
-	if v.ExCode != nil {
-		w, err = v.ExCode.ToWire()
-		if err != nil {
-			return w, err
-		}
-		fields[i] = wire.Field{ID: 1, Value: w}
-		i++
-	}
 	if v.ExNoCode != nil {
 		w, err = v.ExNoCode.ToWire()
 		if err != nil {
 			return w, err
 		}
 		fields[i] = wire.Field{ID: 2, Value: w}
+		i++
+	}
+	if v.ExCode != nil {
+		w, err = v.ExCode.ToWire()
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 1, Value: w}
 		i++
 	}
 
@@ -868,14 +868,14 @@ func (v *TestService_Call_Result) ToWire() (wire.Value, error) {
 	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
 }
 
-func _ExceptionWithCode_Read(w wire.Value) (*ExceptionWithCode, error) {
-	var v ExceptionWithCode
+func _ExceptionWithoutCode_Read(w wire.Value) (*ExceptionWithoutCode, error) {
+	var v ExceptionWithoutCode
 	err := v.FromWire(w)
 	return &v, err
 }
 
-func _ExceptionWithoutCode_Read(w wire.Value) (*ExceptionWithoutCode, error) {
-	var v ExceptionWithoutCode
+func _ExceptionWithCode_Read(w wire.Value) (*ExceptionWithCode, error) {
+	var v ExceptionWithCode
 	err := v.FromWire(w)
 	return &v, err
 }
@@ -912,17 +912,17 @@ func (v *TestService_Call_Result) FromWire(w wire.Value) error {
 				}
 
 			}
-		case 1:
+		case 2:
 			if field.Value.Type() == wire.TStruct {
-				v.ExCode, err = _ExceptionWithCode_Read(field.Value)
+				v.ExNoCode, err = _ExceptionWithoutCode_Read(field.Value)
 				if err != nil {
 					return err
 				}
 
 			}
-		case 2:
+		case 1:
 			if field.Value.Type() == wire.TStruct {
-				v.ExNoCode, err = _ExceptionWithoutCode_Read(field.Value)
+				v.ExCode, err = _ExceptionWithCode_Read(field.Value)
 				if err != nil {
 					return err
 				}
@@ -935,10 +935,10 @@ func (v *TestService_Call_Result) FromWire(w wire.Value) error {
 	if v.Success != nil {
 		count++
 	}
-	if v.ExCode != nil {
+	if v.ExNoCode != nil {
 		count++
 	}
-	if v.ExNoCode != nil {
+	if v.ExCode != nil {
 		count++
 	}
 	if count != 1 {
@@ -969,18 +969,6 @@ func (v *TestService_Call_Result) Encode(sw stream.Writer) error {
 		}
 	}
 
-	if v.ExCode != nil {
-		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TStruct}); err != nil {
-			return err
-		}
-		if err := v.ExCode.Encode(sw); err != nil {
-			return err
-		}
-		if err := sw.WriteFieldEnd(); err != nil {
-			return err
-		}
-	}
-
 	if v.ExNoCode != nil {
 		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 2, Type: wire.TStruct}); err != nil {
 			return err
@@ -993,14 +981,26 @@ func (v *TestService_Call_Result) Encode(sw stream.Writer) error {
 		}
 	}
 
+	if v.ExCode != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 1, Type: wire.TStruct}); err != nil {
+			return err
+		}
+		if err := v.ExCode.Encode(sw); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
 	count := 0
 	if v.Success != nil {
 		count++
 	}
-	if v.ExCode != nil {
+	if v.ExNoCode != nil {
 		count++
 	}
-	if v.ExNoCode != nil {
+	if v.ExCode != nil {
 		count++
 	}
 
@@ -1011,14 +1011,14 @@ func (v *TestService_Call_Result) Encode(sw stream.Writer) error {
 	return sw.WriteStructEnd()
 }
 
-func _ExceptionWithCode_Decode(sr stream.Reader) (*ExceptionWithCode, error) {
-	var v ExceptionWithCode
+func _ExceptionWithoutCode_Decode(sr stream.Reader) (*ExceptionWithoutCode, error) {
+	var v ExceptionWithoutCode
 	err := v.Decode(sr)
 	return &v, err
 }
 
-func _ExceptionWithoutCode_Decode(sr stream.Reader) (*ExceptionWithoutCode, error) {
-	var v ExceptionWithoutCode
+func _ExceptionWithCode_Decode(sr stream.Reader) (*ExceptionWithCode, error) {
+	var v ExceptionWithCode
 	err := v.Decode(sr)
 	return &v, err
 }
@@ -1049,14 +1049,14 @@ func (v *TestService_Call_Result) Decode(sr stream.Reader) error {
 				return err
 			}
 
-		case fh.ID == 1 && fh.Type == wire.TStruct:
-			v.ExCode, err = _ExceptionWithCode_Decode(sr)
+		case fh.ID == 2 && fh.Type == wire.TStruct:
+			v.ExNoCode, err = _ExceptionWithoutCode_Decode(sr)
 			if err != nil {
 				return err
 			}
 
-		case fh.ID == 2 && fh.Type == wire.TStruct:
-			v.ExNoCode, err = _ExceptionWithoutCode_Decode(sr)
+		case fh.ID == 1 && fh.Type == wire.TStruct:
+			v.ExCode, err = _ExceptionWithCode_Decode(sr)
 			if err != nil {
 				return err
 			}
@@ -1084,10 +1084,10 @@ func (v *TestService_Call_Result) Decode(sr stream.Reader) error {
 	if v.Success != nil {
 		count++
 	}
-	if v.ExCode != nil {
+	if v.ExNoCode != nil {
 		count++
 	}
-	if v.ExNoCode != nil {
+	if v.ExCode != nil {
 		count++
 	}
 	if count != 1 {
@@ -1110,12 +1110,12 @@ func (v *TestService_Call_Result) String() string {
 		fields[i] = fmt.Sprintf("Success: %v", *(v.Success))
 		i++
 	}
-	if v.ExCode != nil {
-		fields[i] = fmt.Sprintf("ExCode: %v", v.ExCode)
-		i++
-	}
 	if v.ExNoCode != nil {
 		fields[i] = fmt.Sprintf("ExNoCode: %v", v.ExNoCode)
+		i++
+	}
+	if v.ExCode != nil {
+		fields[i] = fmt.Sprintf("ExCode: %v", v.ExCode)
 		i++
 	}
 
@@ -1145,10 +1145,10 @@ func (v *TestService_Call_Result) Equals(rhs *TestService_Call_Result) bool {
 	if !_String_EqualsPtr(v.Success, rhs.Success) {
 		return false
 	}
-	if !((v.ExCode == nil && rhs.ExCode == nil) || (v.ExCode != nil && rhs.ExCode != nil && v.ExCode.Equals(rhs.ExCode))) {
+	if !((v.ExNoCode == nil && rhs.ExNoCode == nil) || (v.ExNoCode != nil && rhs.ExNoCode != nil && v.ExNoCode.Equals(rhs.ExNoCode))) {
 		return false
 	}
-	if !((v.ExNoCode == nil && rhs.ExNoCode == nil) || (v.ExNoCode != nil && rhs.ExNoCode != nil && v.ExNoCode.Equals(rhs.ExNoCode))) {
+	if !((v.ExCode == nil && rhs.ExCode == nil) || (v.ExCode != nil && rhs.ExCode != nil && v.ExCode.Equals(rhs.ExCode))) {
 		return false
 	}
 
@@ -1164,11 +1164,11 @@ func (v *TestService_Call_Result) MarshalLogObject(enc zapcore.ObjectEncoder) (e
 	if v.Success != nil {
 		enc.AddString("success", *v.Success)
 	}
-	if v.ExCode != nil {
-		err = multierr.Append(err, enc.AddObject("exCode", v.ExCode))
-	}
 	if v.ExNoCode != nil {
 		err = multierr.Append(err, enc.AddObject("exNoCode", v.ExNoCode))
+	}
+	if v.ExCode != nil {
+		err = multierr.Append(err, enc.AddObject("exCode", v.ExCode))
 	}
 	return err
 }
@@ -1188,21 +1188,6 @@ func (v *TestService_Call_Result) IsSetSuccess() bool {
 	return v != nil && v.Success != nil
 }
 
-// GetExCode returns the value of ExCode if it is set or its
-// zero value if it is unset.
-func (v *TestService_Call_Result) GetExCode() (o *ExceptionWithCode) {
-	if v != nil && v.ExCode != nil {
-		return v.ExCode
-	}
-
-	return
-}
-
-// IsSetExCode returns true if ExCode is not nil.
-func (v *TestService_Call_Result) IsSetExCode() bool {
-	return v != nil && v.ExCode != nil
-}
-
 // GetExNoCode returns the value of ExNoCode if it is set or its
 // zero value if it is unset.
 func (v *TestService_Call_Result) GetExNoCode() (o *ExceptionWithoutCode) {
@@ -1216,6 +1201,21 @@ func (v *TestService_Call_Result) GetExNoCode() (o *ExceptionWithoutCode) {
 // IsSetExNoCode returns true if ExNoCode is not nil.
 func (v *TestService_Call_Result) IsSetExNoCode() bool {
 	return v != nil && v.ExNoCode != nil
+}
+
+// GetExCode returns the value of ExCode if it is set or its
+// zero value if it is unset.
+func (v *TestService_Call_Result) GetExCode() (o *ExceptionWithCode) {
+	if v != nil && v.ExCode != nil {
+		return v.ExCode
+	}
+
+	return
+}
+
+// IsSetExCode returns true if ExCode is not nil.
+func (v *TestService_Call_Result) IsSetExCode() bool {
+	return v != nil && v.ExCode != nil
 }
 
 // MethodName returns the name of the Thrift function as specified in

--- a/encoding/thrift/internal/observabilitytest/test/testserviceserver/server.go
+++ b/encoding/thrift/internal/observabilitytest/test/testserviceserver/server.go
@@ -61,6 +61,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					NoWire: call_NoWireHandler{impl},
 				},
 				Signature:    "Call(Key string) (string)",
+				Exceptions:   map[string]string{"ExceptionWithCode": "DATA_LOSS", "ExceptionWithoutCode": "__not_set__"},
 				ThriftModule: test.ThriftModule,
 			},
 		},

--- a/encoding/thrift/register.go
+++ b/encoding/thrift/register.go
@@ -69,6 +69,11 @@ type Method struct {
 	// This is useful for introspection.
 	Signature string
 
+	// Exceptions maps each Thrift exception type as referenced in the method's throws list
+	// (e.g. InvalidArgumentError or error.InvalidArgumentError for an included file)
+	// to the rpc.code annotation value, or __not_set__ when the exception has no rpc.code annotation.
+	Exceptions map[string]string
+
 	// ThriftModule, if non-nil, refers to the Thrift module from where this
 	// method is coming from.
 	ThriftModule *thriftreflect.ThriftModule
@@ -151,6 +156,7 @@ func BuildProcedures(s Service, opts ...RegisterOption) []transport.Procedure {
 			HandlerSpec: spec,
 			Encoding:    Encoding,
 			Signature:   method.Signature,
+			Exceptions:  method.Exceptions,
 		})
 	}
 	return rs

--- a/encoding/thrift/register_test.go
+++ b/encoding/thrift/register_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package thrift
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/thriftrw/wire"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/pkg/procedure"
+)
+
+func TestBuildProcedures_propagatesExceptions(t *testing.T) {
+	t.Parallel()
+
+	exceptions := map[string]string{
+		"KeyDoesNotExist": "INVALID_ARGUMENT",
+		"Other":           transport.RPCCodeNotSetLiteral,
+	}
+
+	svc := Service{
+		Name: "MyService",
+		Methods: []Method{
+			{
+				Name: "myMethod",
+				HandlerSpec: HandlerSpec{
+					Type: transport.Unary,
+					Unary: func(context.Context, wire.Value) (Response, error) {
+						return Response{}, nil
+					},
+				},
+				Signature:  "MyMethod()",
+				Exceptions: exceptions,
+			},
+		},
+	}
+
+	procs := BuildProcedures(svc, NoWire(false))
+	require.Len(t, procs, 1)
+
+	assert.Equal(t, procedure.ToName("MyService", "myMethod"), procs[0].Name)
+	assert.Equal(t, exceptions, procs[0].Exceptions)
+}
+
+func TestBuildProcedures_nilExceptions(t *testing.T) {
+	t.Parallel()
+
+	svc := Service{
+		Name: "MyService",
+		Methods: []Method{
+			{
+				Name: "myMethod",
+				HandlerSpec: HandlerSpec{
+					Type: transport.Unary,
+					Unary: func(context.Context, wire.Value) (Response, error) {
+						return Response{}, nil
+					},
+				},
+				Signature: "MyMethod()",
+			},
+		},
+	}
+
+	procs := BuildProcedures(svc, NoWire(false))
+	require.Len(t, procs, 1)
+	assert.Nil(t, procs[0].Exceptions)
+}

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/readonlystoreserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/readonlystoreserver/server.go
@@ -44,6 +44,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					NoWire: integer_NoWireHandler{impl},
 				},
 				Signature:    "Integer(Key *string) (int64)",
+				Exceptions:   map[string]string{"KeyDoesNotExist": "INVALID_ARGUMENT"},
 				ThriftModule: atomic.ThriftModule,
 			},
 		},

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storeserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/atomic/storeserver/server.go
@@ -55,6 +55,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					NoWire: compareandswap_NoWireHandler{impl},
 				},
 				Signature:    "CompareAndSwap(Request *atomic.CompareAndSwap)",
+				Exceptions:   map[string]string{"IntegerMismatchError": "INVALID_ARGUMENT"},
 				ThriftModule: atomic.ThriftModule,
 			},
 
@@ -67,6 +68,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					NoWire: forget_NoWireHandler{impl},
 				},
 				Signature:    "Forget(Key *string)",
+				Exceptions:   nil,
 				ThriftModule: atomic.ThriftModule,
 			},
 
@@ -79,6 +81,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					NoWire: increment_NoWireHandler{impl},
 				},
 				Signature:    "Increment(Key *string, Value *int64)",
+				Exceptions:   nil,
 				ThriftModule: atomic.ThriftModule,
 			},
 		},

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/baseserviceserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/baseserviceserver/server.go
@@ -40,6 +40,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					NoWire: healthy_NoWireHandler{impl},
 				},
 				Signature:    "Healthy() (bool)",
+				Exceptions:   nil,
 				ThriftModule: common.ThriftModule,
 			},
 		},

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendemptyserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/common/extendemptyserver/server.go
@@ -43,6 +43,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					NoWire: hello_NoWireHandler{impl},
 				},
 				Signature:    "Hello()",
+				Exceptions:   nil,
 				ThriftModule: common.ThriftModule,
 			},
 		},

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/nameserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/extends/nameserver/server.go
@@ -40,6 +40,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					NoWire: name_NoWireHandler{impl},
 				},
 				Signature:    "Name() (string)",
+				Exceptions:   nil,
 				ThriftModule: extends.ThriftModule,
 			},
 		},

--- a/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/weather/weatherserver/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/internal/tests/weather/weatherserver/server.go
@@ -40,6 +40,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					NoWire: check_NoWireHandler{impl},
 				},
 				Signature:    "Check() (string)",
+				Exceptions:   nil,
 				ThriftModule: weather.ThriftModule,
 			},
 		},

--- a/encoding/thrift/thriftrw-plugin-yarpc/main.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/main.go
@@ -125,10 +125,9 @@ func (g g) Generate(req *api.GenerateServiceRequest) (*api.GenerateServiceRespon
 
 	files := make(map[string][]byte)
 
-	// Plugins do not have access to the original Thrift file's compiled
-	// module, so generators that need it must re-compile the file. Compilation
-	// is expensive, so we memoize it per Thrift file path and share the result
-	// across all module- and service-level generators.
+	// Generators share one compile.Module per root Thrift file (memoized below)
+	// across module- and service-level generators - e.g. server templates use it
+	// for exception map keys without compiling again inside template helpers.
 	compiledModules := make(map[string]*compile.Module)
 	getCompiledModule := func(thriftFilePath string) (*compile.Module, error) {
 		if m, ok := compiledModules[thriftFilePath]; ok {

--- a/encoding/thrift/thriftrw-plugin-yarpc/server.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/server.go
@@ -64,6 +64,8 @@ type Interface interface {
 }
 
 <$module := .Module>
+<$compiledModule := .CompiledModule>
+<$svcThriftName := .ThriftName>
 
 // New prepares an implementation of the <.Name> service for
 // registration.
@@ -89,6 +91,7 @@ func New(impl Interface, opts ...<$thrift>.RegisterOption) []<$transport>.Proced
 					NoWire: <(lower .Name)>_NoWireHandler{impl},
 				},
 				Signature: "<.Name>(<range $i, $v := .Arguments><if ne $i 0>, <end><.Name> <formatType .Type><end>)<if not .OneWay | and .ReturnType> (<formatType .ReturnType>)<end>",
+				Exceptions: <methodExceptionsMapLiteral . $compiledModule $svcThriftName>,
 				ThriftModule: <import $module.ImportPath>.ThriftModule,
 				},
 		<end>},

--- a/encoding/thrift/thriftrw-plugin-yarpc/template.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/template.go
@@ -22,11 +22,15 @@ package main
 
 import (
 	"fmt"
+	"path/filepath"
+	"sort"
+	"strconv"
 	"strings"
 
 	"go.uber.org/thriftrw/compile"
 	"go.uber.org/thriftrw/plugin"
 	"go.uber.org/thriftrw/plugin/api"
+	"go.uber.org/yarpc/api/transport"
 )
 
 // Svc is a Thrift service.
@@ -157,7 +161,121 @@ type moduleGenFunc func(*moduleTemplateData, map[string][]byte) error
 // plugin.
 type serviceGenFunc func(*serviceTemplateData, map[string][]byte) error
 
+// exceptionTypeReference follows PointerType wrappers to the underlying
+// TypeReference for a throws clause (Thrift exceptions are pointers in Go).
+func exceptionTypeReference(t *api.Type) *api.TypeReference {
+	for t != nil {
+		if t.ReferenceType != nil {
+			return t.ReferenceType
+		}
+		if t.PointerType != nil {
+			t = t.PointerType
+			continue
+		}
+		break
+	}
+	return nil
+}
+
+func lookupCompiledFunction(root *compile.Module, serviceThriftName, fnThriftName string) *compile.FunctionSpec {
+	if root == nil || serviceThriftName == "" || fnThriftName == "" {
+		return nil
+	}
+	svc := root.Services[serviceThriftName]
+	if svc == nil {
+		return nil
+	}
+	return svc.Functions[fnThriftName]
+}
+
+// thriftExceptionMapKey returns the map key string for thrift.Method.Exceptions:
+// how the exception type is referenced from the service's Thrift file — either
+// the bare exception name (same file as the service) or includeAlias.TypeName
+// when the exception lives in another included Thrift file (includeAlias is the
+// basename of the included file without .thrift, per ThriftRW compile.Module).
+func thriftExceptionMapKey(serviceModule *compile.Module, exc *compile.StructSpec) string {
+	if serviceModule == nil || exc == nil {
+		return ""
+	}
+	excPath := filepath.Clean(exc.ThriftFile())
+	svcPath := filepath.Clean(serviceModule.ThriftPath)
+	if excPath == svcPath {
+		return exc.Name
+	}
+	for _, inc := range serviceModule.Includes {
+		if inc == nil || inc.Module == nil {
+			continue
+		}
+		if filepath.Clean(inc.Module.ThriftPath) == excPath {
+			return inc.Name + "." + exc.Name
+		}
+	}
+	base := strings.TrimSuffix(filepath.Base(excPath), ".thrift")
+	if base != "" {
+		return base + "." + exc.Name
+	}
+	return exc.Name
+}
+
+// methodExceptionsMapLiteral returns a Go expression for thrift.Method.Exceptions
+// for the given Thrift function (exception type name -> rpc.code or the
+// "__not_set__" sentinel as a string literal).
+// serviceMod is compile.Compile output for the Thrift file that declares this
+// service (from main.go's per-request memo); nil skips compiled metadata and
+// keys fall back to the short type name from the plugin API.
+// serviceThriftName is the Thrift IDL service name.
+func methodExceptionsMapLiteral(f *api.Function, serviceMod *compile.Module, serviceThriftName string) string {
+	if f == nil || len(f.Exceptions) == 0 {
+		return "nil"
+	}
+
+	compileFn := lookupCompiledFunction(serviceMod, serviceThriftName, f.ThriftName)
+
+	// Deduplicate by map key (last wins) so duplicate throws entries do not emit
+	// duplicate composite literal keys.
+	entries := make(map[string]string)
+	for i, ex := range f.Exceptions {
+		if ex == nil || ex.Type == nil {
+			continue
+		}
+		ref := exceptionTypeReference(ex.Type)
+		if ref == nil {
+			continue
+		}
+
+		keyStr := ""
+		if compileFn != nil && compileFn.ResultSpec != nil && i < len(compileFn.ResultSpec.Exceptions) {
+			if ss, ok := compileFn.ResultSpec.Exceptions[i].Type.(*compile.StructSpec); ok {
+				keyStr = thriftExceptionMapKey(serviceMod, ss)
+			}
+		}
+		if keyStr == "" {
+			keyStr = ref.Name
+		}
+
+		if code, ok := ref.Annotations[_errorCodeAnnotationKey]; ok && code != "" {
+			entries[keyStr] = code
+		} else {
+			entries[keyStr] = transport.RPCCodeNotSetLiteral
+		}
+	}
+	if len(entries) == 0 {
+		return "nil"
+	}
+	keys := make([]string, 0, len(entries))
+	for k := range entries {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, strconv.Quote(k)+": "+strconv.Quote(entries[k]))
+	}
+	return "map[string]string{" + strings.Join(parts, ", ") + "}"
+}
+
 // Default options for the template
 var templateOptions = []plugin.TemplateOption{
 	plugin.TemplateFunc("lower", strings.ToLower),
+	plugin.TemplateFunc("methodExceptionsMapLiteral", methodExceptionsMapLiteral),
 }

--- a/encoding/thrift/thriftrw-plugin-yarpc/template_test.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/template_test.go
@@ -1,0 +1,256 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/thriftrw/compile"
+	"go.uber.org/thriftrw/plugin/api"
+	"go.uber.org/yarpc/api/transport"
+)
+
+// expectedExceptionsMap builds the same shape as methodExceptionsMapLiteral for assertions.
+func expectedExceptionsMap(entries ...string) string {
+	if len(entries) == 0 {
+		return "nil"
+	}
+	return "map[string]string{" + strings.Join(entries, ", ") + "}"
+}
+
+func TestExceptionTypeReference(t *testing.T) {
+	t.Parallel()
+	t.Run("nil", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, exceptionTypeReference(nil))
+	})
+	t.Run("empty type", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, exceptionTypeReference(&api.Type{}))
+	})
+	t.Run("pointer to empty type", func(t *testing.T) {
+		t.Parallel()
+		// Unwraps one pointer level, then hits break (no ReferenceType, no further PointerType).
+		assert.Nil(t, exceptionTypeReference(&api.Type{
+			PointerType: &api.Type{},
+		}))
+	})
+	t.Run("direct reference", func(t *testing.T) {
+		t.Parallel()
+		ref := &api.TypeReference{Name: "E"}
+		assert.Same(t, ref, exceptionTypeReference(&api.Type{ReferenceType: ref}))
+	})
+	t.Run("pointer to reference", func(t *testing.T) {
+		t.Parallel()
+		ref := &api.TypeReference{Name: "E"}
+		assert.Same(t, ref, exceptionTypeReference(&api.Type{
+			PointerType: &api.Type{ReferenceType: ref},
+		}))
+	})
+}
+
+// exceptionArg is a throws-list entry: ThriftRW models exceptions as a pointer to a named type.
+func exceptionArg(typeName string, annotations map[string]string) *api.Argument {
+	return exceptionArgWithImport("", typeName, annotations)
+}
+
+func exceptionArgWithImport(exceptionImportPath, typeName string, annotations map[string]string) *api.Argument {
+	return &api.Argument{
+		Type: &api.Type{
+			PointerType: &api.Type{
+				ReferenceType: &api.TypeReference{
+					Name:        typeName,
+					ImportPath:  exceptionImportPath,
+					Annotations: annotations,
+				},
+			},
+		},
+	}
+}
+
+func TestMethodExceptionsMapLiteral_noThrows(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "nil", methodExceptionsMapLiteral(nil, nil, ""))
+	assert.Equal(t, "nil", methodExceptionsMapLiteral(&api.Function{}, nil, ""))
+	assert.Equal(t, "nil", methodExceptionsMapLiteral(&api.Function{
+		Exceptions: []*api.Argument{},
+	}, nil, ""))
+}
+
+func TestMethodExceptionsMapLiteral_throwsWithoutAnnotations(t *testing.T) {
+	t.Parallel()
+	f := &api.Function{
+		Exceptions: []*api.Argument{
+			exceptionArg("IntegerMismatchError", nil),
+			exceptionArg("AnotherError", map[string]string{}),
+		},
+	}
+	ns := strconv.Quote(transport.RPCCodeNotSetLiteral)
+	want := expectedExceptionsMap(
+		strconv.Quote("AnotherError")+`: `+ns,
+		strconv.Quote("IntegerMismatchError")+`: `+ns,
+	)
+	assert.Equal(t, want, methodExceptionsMapLiteral(f, nil, ""))
+}
+
+func TestMethodExceptionsMapLiteral_throwsWithRPCCode(t *testing.T) {
+	t.Parallel()
+	f := &api.Function{
+		Exceptions: []*api.Argument{
+			exceptionArg("KeyDoesNotExist", map[string]string{
+				_errorCodeAnnotationKey: "INVALID_ARGUMENT",
+			}),
+		},
+	}
+	want := expectedExceptionsMap(
+		strconv.Quote("KeyDoesNotExist") + `: ` + strconv.Quote("INVALID_ARGUMENT"),
+	)
+	assert.Equal(t, want, methodExceptionsMapLiteral(f, nil, ""))
+}
+
+func TestMethodExceptionsMapLiteral_allEntriesSkipped(t *testing.T) {
+	t.Parallel()
+	// nil throws entry -> continue (ex nil)
+	// missing Type -> continue (ex.Type nil)
+	// type with no resolvable ReferenceType -> continue (ref nil)
+	f := &api.Function{
+		Exceptions: []*api.Argument{
+			nil,
+			{Type: nil},
+			{Type: &api.Type{}},
+			{Type: &api.Type{PointerType: &api.Type{}}}, // unwraps to empty Type
+		},
+	}
+	assert.Equal(t, "nil", methodExceptionsMapLiteral(f, nil, ""))
+}
+
+func TestMethodExceptionsMapLiteral_mixedValidAndSkipped(t *testing.T) {
+	t.Parallel()
+	f := &api.Function{
+		Exceptions: []*api.Argument{
+			nil,
+			{Type: &api.Type{}},
+			exceptionArg("Kept", map[string]string{_errorCodeAnnotationKey: "NOT_FOUND"}),
+		},
+	}
+	want := expectedExceptionsMap(
+		strconv.Quote("Kept") + `: ` + strconv.Quote("NOT_FOUND"),
+	)
+	assert.Equal(t, want, methodExceptionsMapLiteral(f, nil, ""))
+}
+
+func TestMethodExceptionsMapLiteral_crossIncludedThriftException(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	const errorThrift = `
+exception InvalidArgumentError {
+  1: required string message
+} (
+  rpc.code = "INVALID_ARGUMENT"
+)
+`
+	const svcThrift = `
+include "./error.thrift"
+
+service Svc {
+  void m() throws (1: error.InvalidArgumentError e)
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "error.thrift"), []byte(errorThrift), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "svc.thrift"), []byte(svcThrift), 0o644))
+
+	svcPath := filepath.Join(dir, "svc.thrift")
+	mod, err := compile.Compile(svcPath)
+	require.NoError(t, err)
+
+	exc := mod.Services["Svc"].Functions["m"].ResultSpec.Exceptions[0].Type.(*compile.StructSpec)
+	assert.Equal(t, "error.InvalidArgumentError", thriftExceptionMapKey(mod, exc))
+
+	f := &api.Function{
+		ThriftName: "m",
+		Exceptions: []*api.Argument{
+			exceptionArg("InvalidArgumentError", map[string]string{_errorCodeAnnotationKey: "INVALID_ARGUMENT"}),
+		},
+	}
+	want := expectedExceptionsMap(
+		strconv.Quote("error.InvalidArgumentError") + `: ` + strconv.Quote("INVALID_ARGUMENT"),
+	)
+	assert.Equal(t, want, methodExceptionsMapLiteral(f, mod, "Svc"))
+}
+
+func TestMethodExceptionsMapLiteral_duplicateThrowsLastWins(t *testing.T) {
+	t.Parallel()
+	ns := strconv.Quote(transport.RPCCodeNotSetLiteral)
+	f := &api.Function{
+		Exceptions: []*api.Argument{
+			exceptionArg("DupError", map[string]string{_errorCodeAnnotationKey: "FIRST"}),
+			exceptionArg("DupError", map[string]string{_errorCodeAnnotationKey: "SECOND"}),
+		},
+	}
+	want := expectedExceptionsMap(strconv.Quote("DupError") + `: ` + strconv.Quote("SECOND"))
+	assert.Equal(t, want, methodExceptionsMapLiteral(f, nil, ""))
+
+	f2 := &api.Function{
+		Exceptions: []*api.Argument{
+			exceptionArg("DupError", nil),
+			exceptionArg("DupError", map[string]string{_errorCodeAnnotationKey: "ONLY"}),
+		},
+	}
+	want2 := expectedExceptionsMap(strconv.Quote("DupError") + `: ` + strconv.Quote("ONLY"))
+	assert.Equal(t, want2, methodExceptionsMapLiteral(f2, nil, ""))
+
+	f3 := &api.Function{
+		Exceptions: []*api.Argument{
+			exceptionArg("DupError", map[string]string{_errorCodeAnnotationKey: "ONLY"}),
+			exceptionArg("DupError", nil),
+		},
+	}
+	want3 := expectedExceptionsMap(strconv.Quote("DupError") + `: ` + ns)
+	assert.Equal(t, want3, methodExceptionsMapLiteral(f3, nil, ""))
+}
+
+func TestThriftExceptionMapKey_sameThriftFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	const oneFile = `
+exception LocalErr {
+  1: required string message
+} (
+  rpc.code = "INVALID_ARGUMENT"
+)
+
+service LocalSvc {
+  void ping() throws (1: LocalErr e)
+}
+`
+	path := filepath.Join(dir, "one.thrift")
+	require.NoError(t, os.WriteFile(path, []byte(oneFile), 0o644))
+	mod, err := compile.Compile(path)
+	require.NoError(t, err)
+	exc := mod.Services["LocalSvc"].Functions["ping"].ResultSpec.Exceptions[0].Type.(*compile.StructSpec)
+	assert.Equal(t, "LocalErr", thriftExceptionMapKey(mod, exc))
+}

--- a/internal/crossdock/thrift/echo/echoserver/server.go
+++ b/internal/crossdock/thrift/echo/echoserver/server.go
@@ -61,6 +61,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					NoWire: echo_NoWireHandler{impl},
 				},
 				Signature:    "Echo(Ping *echo.Ping) (*echo.Pong)",
+				Exceptions:   nil,
 				ThriftModule: echo.ThriftModule,
 			},
 		},

--- a/internal/crossdock/thrift/gauntlet/secondserviceserver/server.go
+++ b/internal/crossdock/thrift/gauntlet/secondserviceserver/server.go
@@ -65,6 +65,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					NoWire: blahblah_NoWireHandler{impl},
 				},
 				Signature:    "BlahBlah()",
+				Exceptions:   nil,
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -77,6 +78,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					NoWire: secondteststring_NoWireHandler{impl},
 				},
 				Signature:    "SecondtestString(Thing *string) (string)",
+				Exceptions:   nil,
 				ThriftModule: gauntlet.ThriftModule,
 			},
 		},

--- a/internal/crossdock/thrift/gauntlet/thrifttestserver/server.go
+++ b/internal/crossdock/thrift/gauntlet/thrifttestserver/server.go
@@ -166,6 +166,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					NoWire: testbinary_NoWireHandler{impl},
 				},
 				Signature:    "TestBinary(Thing []byte) ([]byte)",
+				Exceptions:   nil,
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -178,6 +179,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					NoWire: testbyte_NoWireHandler{impl},
 				},
 				Signature:    "TestByte(Thing *int8) (int8)",
+				Exceptions:   nil,
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -190,6 +192,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					NoWire: testdouble_NoWireHandler{impl},
 				},
 				Signature:    "TestDouble(Thing *float64) (float64)",
+				Exceptions:   nil,
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -202,6 +205,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					NoWire: testenum_NoWireHandler{impl},
 				},
 				Signature:    "TestEnum(Thing *gauntlet.Numberz) (gauntlet.Numberz)",
+				Exceptions:   nil,
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -214,6 +218,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					NoWire: testexception_NoWireHandler{impl},
 				},
 				Signature:    "TestException(Arg *string)",
+				Exceptions:   map[string]string{"Xception": "__not_set__"},
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -226,6 +231,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					NoWire: testi32_NoWireHandler{impl},
 				},
 				Signature:    "TestI32(Thing *int32) (int32)",
+				Exceptions:   nil,
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -238,6 +244,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					NoWire: testi64_NoWireHandler{impl},
 				},
 				Signature:    "TestI64(Thing *int64) (int64)",
+				Exceptions:   nil,
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -250,6 +257,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					NoWire: testinsanity_NoWireHandler{impl},
 				},
 				Signature:    "TestInsanity(Argument *gauntlet.Insanity) (map[gauntlet.UserId]map[gauntlet.Numberz]*gauntlet.Insanity)",
+				Exceptions:   nil,
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -262,6 +270,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					NoWire: testlist_NoWireHandler{impl},
 				},
 				Signature:    "TestList(Thing []int32) ([]int32)",
+				Exceptions:   nil,
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -274,6 +283,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					NoWire: testmap_NoWireHandler{impl},
 				},
 				Signature:    "TestMap(Thing map[int32]int32) (map[int32]int32)",
+				Exceptions:   nil,
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -286,6 +296,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					NoWire: testmapmap_NoWireHandler{impl},
 				},
 				Signature:    "TestMapMap(Hello *int32) (map[int32]map[int32]int32)",
+				Exceptions:   nil,
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -298,6 +309,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					NoWire: testmulti_NoWireHandler{impl},
 				},
 				Signature:    "TestMulti(Arg0 *int8, Arg1 *int32, Arg2 *int64, Arg3 map[int16]string, Arg4 *gauntlet.Numberz, Arg5 *gauntlet.UserId) (*gauntlet.Xtruct)",
+				Exceptions:   nil,
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -310,6 +322,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					NoWire: testmultiexception_NoWireHandler{impl},
 				},
 				Signature:    "TestMultiException(Arg0 *string, Arg1 *string) (*gauntlet.Xtruct)",
+				Exceptions:   map[string]string{"Xception": "__not_set__", "Xception2": "__not_set__"},
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -322,6 +335,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					NoWire: testnest_NoWireHandler{impl},
 				},
 				Signature:    "TestNest(Thing *gauntlet.Xtruct2) (*gauntlet.Xtruct2)",
+				Exceptions:   nil,
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -334,6 +348,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					NoWire: testoneway_NoWireHandler{impl},
 				},
 				Signature:    "TestOneway(SecondsToSleep *int32)",
+				Exceptions:   nil,
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -346,6 +361,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					NoWire: testset_NoWireHandler{impl},
 				},
 				Signature:    "TestSet(Thing map[int32]struct{}) (map[int32]struct{})",
+				Exceptions:   nil,
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -358,6 +374,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					NoWire: teststring_NoWireHandler{impl},
 				},
 				Signature:    "TestString(Thing *string) (string)",
+				Exceptions:   nil,
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -370,6 +387,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					NoWire: teststringmap_NoWireHandler{impl},
 				},
 				Signature:    "TestStringMap(Thing map[string]string) (map[string]string)",
+				Exceptions:   nil,
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -382,6 +400,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					NoWire: teststruct_NoWireHandler{impl},
 				},
 				Signature:    "TestStruct(Thing *gauntlet.Xtruct) (*gauntlet.Xtruct)",
+				Exceptions:   nil,
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -394,6 +413,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					NoWire: testtypedef_NoWireHandler{impl},
 				},
 				Signature:    "TestTypedef(Thing *gauntlet.UserId) (gauntlet.UserId)",
+				Exceptions:   nil,
 				ThriftModule: gauntlet.ThriftModule,
 			},
 
@@ -406,6 +426,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					NoWire: testvoid_NoWireHandler{impl},
 				},
 				Signature:    "TestVoid()",
+				Exceptions:   nil,
 				ThriftModule: gauntlet.ThriftModule,
 			},
 		},

--- a/internal/crossdock/thrift/oneway/onewayserver/server.go
+++ b/internal/crossdock/thrift/oneway/onewayserver/server.go
@@ -60,6 +60,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					NoWire: echo_NoWireHandler{impl},
 				},
 				Signature:    "Echo(Token *string)",
+				Exceptions:   nil,
 				ThriftModule: oneway.ThriftModule,
 			},
 		},

--- a/internal/examples/thrift-hello/hello/echo/helloserver/server.go
+++ b/internal/examples/thrift-hello/hello/echo/helloserver/server.go
@@ -61,6 +61,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					NoWire: echo_NoWireHandler{impl},
 				},
 				Signature:    "Echo(Echo *echo.EchoRequest) (*echo.EchoResponse)",
+				Exceptions:   nil,
 				ThriftModule: echo.ThriftModule,
 			},
 		},

--- a/internal/examples/thrift-keyvalue/keyvalue/kv/keyvalueserver/server.go
+++ b/internal/examples/thrift-keyvalue/keyvalue/kv/keyvalueserver/server.go
@@ -67,6 +67,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					NoWire: getvalue_NoWireHandler{impl},
 				},
 				Signature:    "GetValue(Key *string) (string)",
+				Exceptions:   map[string]string{"ResourceDoesNotExist": "__not_set__"},
 				ThriftModule: kv.ThriftModule,
 			},
 
@@ -79,6 +80,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					NoWire: setvalue_NoWireHandler{impl},
 				},
 				Signature:    "SetValue(Key *string, Value *string)",
+				Exceptions:   nil,
 				ThriftModule: kv.ThriftModule,
 			},
 		},

--- a/internal/examples/thrift-oneway/sink/helloserver/server.go
+++ b/internal/examples/thrift-oneway/sink/helloserver/server.go
@@ -60,6 +60,7 @@ func New(impl Interface, opts ...thrift.RegisterOption) []transport.Procedure {
 					NoWire: sink_NoWireHandler{impl},
 				},
 				Signature:    "Sink(Snk *sink.SinkRequest)",
+				Exceptions:   nil,
 				ThriftModule: sink.ThriftModule,
 			},
 		},

--- a/internal/introspection/router.go
+++ b/internal/introspection/router.go
@@ -31,10 +31,11 @@ const proto = "proto"
 
 // Procedure represent a registered procedure on a dispatcher.
 type Procedure struct {
-	Name      string `json:"name"`
-	Encoding  string `json:"encoding"`
-	Signature string `json:"signature"`
-	RPCType   string `json:"rpcType"`
+	Name       string            `json:"name"`
+	Encoding   string            `json:"encoding"`
+	Signature  string            `json:"signature"`
+	RPCType    string            `json:"rpcType"`
+	Exceptions map[string]string `json:"exceptions,omitempty"`
 }
 
 // ProcedureName outputs a encoding-native procedure name.
@@ -53,10 +54,11 @@ func IntrospectProcedures(routerProcs []transport.Procedure) []Procedure {
 	procedures := make([]Procedure, 0, len(routerProcs))
 	for _, p := range routerProcs {
 		procedures = append(procedures, Procedure{
-			Name:      p.Name,
-			Encoding:  string(p.Encoding),
-			Signature: p.Signature,
-			RPCType:   p.HandlerSpec.Type().String(),
+			Name:       p.Name,
+			Encoding:   string(p.Encoding),
+			Signature:  p.Signature,
+			RPCType:    p.HandlerSpec.Type().String(),
+			Exceptions: p.Exceptions,
 		})
 	}
 	return procedures

--- a/internal/introspection/router_test.go
+++ b/internal/introspection/router_test.go
@@ -21,10 +21,38 @@
 package introspection
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/api/transport"
 )
+
+func TestIntrospectProcedures_propagatesExceptions(t *testing.T) {
+	t.Parallel()
+
+	ex := map[string]string{"E": "INVALID_ARGUMENT"}
+	routerProcs := []transport.Procedure{
+		{
+			Name:        "svc::m",
+			Encoding:    "thrift",
+			Signature:   "M()",
+			HandlerSpec: transport.NewUnaryHandlerSpec(noopUnaryHandler{}),
+			Exceptions:  ex,
+		},
+	}
+
+	out := IntrospectProcedures(routerProcs)
+	require.Len(t, out, 1)
+	assert.Equal(t, ex, out[0].Exceptions)
+}
+
+type noopUnaryHandler struct{}
+
+func (noopUnaryHandler) Handle(ctx context.Context, _ *transport.Request, _ transport.ResponseWriter) error {
+	return nil
+}
 
 func TestProcedureName(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
- [x] Description and context for reviewers: 

When procedures are being registered to a dispatcher, if it is a Thrift procedure, we will now check whether all exceptions in the throwlist are annotated with the `rpc.code` annotation and emit a metric+logline tagging the procedure and exception names. 

--- 

Deployed the changes with procedures where the throw list contains unannotated exceptions. And the following screenshot showed the newly emitted metrics. 
<img width="1230" height="758" alt="image" src="https://github.com/user-attachments/assets/a74b981a-c556-485a-8c87-791d3e33ff5e" />

---

The following screenshots showed the newly added logs
<img width="747" height="447" alt="image" src="https://github.com/user-attachments/assets/842bf39c-b8a8-4ee8-9cbb-f91461bd2bff" />
<img width="735" height="467" alt="image" src="https://github.com/user-attachments/assets/53793ef6-dea3-489e-b8be-95bc4ea8138a" />

