### PR TITLE
Reuse thrift compiled module per module/service generators

### DIFF
--- a/encoding/thrift/thriftrw-plugin-yarpc/exception.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/exception.go
@@ -106,12 +106,6 @@ func yarpcErrorGenerator(data *moduleTemplateData, files map[string][]byte) erro
 	// kv.thrift => .../kv/types_yarpc.go
 	path := filepath.Join(data.Module.Directory, "types_yarpc.go")
 
-	// data.CompiledModule is the result of compiling the original Thrift file.
-	// Plugins do not have access to it via the API, so it is compiled once in
-	// Generate and shared across generators; this generator writes extra
-	// methods to exception types defined in that Thrift file.
-	compiledModule := data.CompiledModule
-
 	templateOptions := append(templateOptions,
 		plugin.TemplateFunc("isException", func(t compile.TypeSpec) bool {
 			if t, ok := t.(*compile.StructSpec); ok {
@@ -128,7 +122,11 @@ func yarpcErrorGenerator(data *moduleTemplateData, files map[string][]byte) erro
 	)
 
 	var err error
-	files[path], err = plugin.GoFileFromTemplate(path, yarpcerrorTemplate, compiledModule, templateOptions...)
+	// data.CompiledModule is the result of compiling the original Thrift file.
+	// Plugins do not have access to it via the API, so it is compiled once in
+	// Generate and shared across generators; this generator writes extra
+	// methods to exception types defined in that Thrift file.
+	files[path], err = plugin.GoFileFromTemplate(path, yarpcerrorTemplate, data.CompiledModule, templateOptions...)
 	return err
 }
 

--- a/encoding/thrift/thriftrw-plugin-yarpc/exception.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/exception.go
@@ -106,16 +106,11 @@ func yarpcErrorGenerator(data *moduleTemplateData, files map[string][]byte) erro
 	// kv.thrift => .../kv/types_yarpc.go
 	path := filepath.Join(data.Module.Directory, "types_yarpc.go")
 
-	// Get the original thrift file path
-	thriftFilePath := data.Module.GetThriftFilePath()
-	// and re-compile it. Plugins do not actually have access to the original
-	// thrift file's module, and this is how we gain access to it, since this
-	// generator writes extra methods to exception types defined in the Thrift
-	// file.
-	compiledModule, err := compile.Compile(thriftFilePath)
-	if err != nil {
-		return fmt.Errorf("error compiling the thrift file: %s", err.Error())
-	}
+	// data.CompiledModule is the result of compiling the original Thrift file.
+	// Plugins do not have access to it via the API, so it is compiled once in
+	// Generate and shared across generators; this generator writes extra
+	// methods to exception types defined in that Thrift file.
+	compiledModule := data.CompiledModule
 
 	templateOptions := append(templateOptions,
 		plugin.TemplateFunc("isException", func(t compile.TypeSpec) bool {
@@ -132,6 +127,7 @@ func yarpcErrorGenerator(data *moduleTemplateData, files map[string][]byte) erro
 		plugin.TemplateFunc("getYARPCErrorName", getYARPCErrorName),
 	)
 
+	var err error
 	files[path], err = plugin.GoFileFromTemplate(path, yarpcerrorTemplate, compiledModule, templateOptions...)
 	return err
 }

--- a/encoding/thrift/thriftrw-plugin-yarpc/golden_test.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/golden_test.go
@@ -34,6 +34,7 @@ import (
 
 	"go.uber.org/atomic"
 	"go.uber.org/thriftrw/plugin"
+	"go.uber.org/thriftrw/plugin/api"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -265,4 +266,70 @@ func hash(name string) (string, error) {
 	}
 
 	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}
+
+// TestGenerateCompileErrors covers the error-return paths in Generate that
+// fire when compile.Compile fails on a Thrift file path.
+//
+// Successful compilation is tested by TestCodeIsUpToDate, which
+// drives the plugin via the same ServiceGenerator entry point but using real
+// Thrift files compiled by thriftrw. This test reuses the same
+// ServiceGenerator (g{}) but points it at a non-existent Thrift file so that
+// compile.Compile fails in both the RootServices and RootModules loops.
+func TestGenerateCompileErrors(t *testing.T) {
+	const bogusThriftPath = "/nonexistent/does-not-exist.thrift"
+
+	t.Run("compile error on root service", func(t *testing.T) {
+		// A RootServices entry whose module points at a bogus Thrift file
+		// path makes getCompiledModule -> compile.Compile fail, exercising
+		// the error wrap in getCompiledModule and the error return inside
+		// the RootServices loop.
+		req := &api.GenerateServiceRequest{
+			RootServices: []api.ServiceID{1},
+			Services: map[api.ServiceID]*api.Service{
+				1: {
+					Name:       "Bogus",
+					ThriftName: "Bogus",
+					ModuleID:   1,
+				},
+			},
+			Modules: map[api.ModuleID]*api.Module{
+				1: {
+					ImportPath:     "example.com/bogus",
+					Directory:      "bogus",
+					ThriftFilePath: bogusThriftPath,
+				},
+			},
+		}
+
+		resp, err := g{}.Generate(req)
+		require.Error(t, err, "expected compile error for missing thrift file")
+		assert.Nil(t, resp)
+		assert.Contains(t, err.Error(), "error compiling the thrift file",
+			"error should be wrapped with the getCompiledModule message")
+	})
+
+	t.Run("compile error on root module", func(t *testing.T) {
+		// Without RootServices, the RootServices loop is skipped and the
+		// RootModules loop runs. A bogus Thrift file path on the root
+		// module triggers the same compile error, this time returned from
+		// the RootModules loop.
+		req := &api.GenerateServiceRequest{
+			RootModules: []api.ModuleID{1},
+			Services:    map[api.ServiceID]*api.Service{},
+			Modules: map[api.ModuleID]*api.Module{
+				1: {
+					ImportPath:     "example.com/bogus",
+					Directory:      "bogus",
+					ThriftFilePath: bogusThriftPath,
+				},
+			},
+		}
+
+		resp, err := g{}.Generate(req)
+		require.Error(t, err, "expected compile error for missing thrift file")
+		assert.Nil(t, resp)
+		assert.Contains(t, err.Error(), "error compiling the thrift file",
+			"error should be wrapped with the getCompiledModule message")
+	})
 }

--- a/encoding/thrift/thriftrw-plugin-yarpc/main.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/main.go
@@ -136,7 +136,7 @@ func (g g) Generate(req *api.GenerateServiceRequest) (*api.GenerateServiceRespon
 		}
 		m, err := compile.Compile(thriftFilePath)
 		if err != nil {
-			return nil, fmt.Errorf("error compiling the thrift file: %s", err.Error())
+			return nil, fmt.Errorf("error compiling the thrift file: %w", err)
 		}
 		compiledModules[thriftFilePath] = m
 		return m, nil

--- a/encoding/thrift/thriftrw-plugin-yarpc/main.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/main.go
@@ -67,6 +67,7 @@ import (
 	"fmt"
 	"strings"
 
+	"go.uber.org/thriftrw/compile"
 	"go.uber.org/thriftrw/plugin"
 	"go.uber.org/thriftrw/plugin/api"
 )
@@ -124,9 +125,31 @@ func (g g) Generate(req *api.GenerateServiceRequest) (*api.GenerateServiceRespon
 
 	files := make(map[string][]byte)
 
+	// Plugins do not have access to the original Thrift file's compiled
+	// module, so generators that need it must re-compile the file. Compilation
+	// is expensive, so we memoize it per Thrift file path and share the result
+	// across all module- and service-level generators.
+	compiledModules := make(map[string]*compile.Module)
+	getCompiledModule := func(thriftFilePath string) (*compile.Module, error) {
+		if m, ok := compiledModules[thriftFilePath]; ok {
+			return m, nil
+		}
+		m, err := compile.Compile(thriftFilePath)
+		if err != nil {
+			return nil, fmt.Errorf("error compiling the thrift file: %s", err.Error())
+		}
+		compiledModules[thriftFilePath] = m
+		return m, nil
+	}
+
 	for _, serviceID := range req.RootServices {
+		svc := buildSvc(serviceID, req)
+		compiledModule, err := getCompiledModule(svc.Module.GetThriftFilePath())
+		if err != nil {
+			return nil, err
+		}
 		data := serviceTemplateData{
-			Svc:                 buildSvc(serviceID, req),
+			Svc:                 svc,
 			ContextImportPath:   *_context,
 			MockLibrary:         *_mockLibrary,
 			UnaryWrapperImport:  unaryWrapperImport,
@@ -134,6 +157,7 @@ func (g g) Generate(req *api.GenerateServiceRequest) (*api.GenerateServiceRespon
 			OnewayWrapperImport: onewayWrapperImport,
 			OnewayWrapperFunc:   onewayWrapperFunc,
 			SanitizeTChannel:    g.SanitizeTChannel,
+			CompiledModule:      compiledModule,
 		}
 		for _, gen := range serviceGenerators {
 			if err := gen(&data, files); err != nil {
@@ -143,9 +167,15 @@ func (g g) Generate(req *api.GenerateServiceRequest) (*api.GenerateServiceRespon
 	}
 
 	for _, moduleID := range req.RootModules {
+		module := req.Modules[moduleID]
+		compiledModule, err := getCompiledModule(module.GetThriftFilePath())
+		if err != nil {
+			return nil, err
+		}
 		data := moduleTemplateData{
-			Module:            req.Modules[moduleID],
+			Module:            module,
 			ContextImportPath: *_context,
+			CompiledModule:    compiledModule,
 		}
 		for _, gen := range moduleGenerators {
 			if err := gen(&data, files); err != nil {

--- a/encoding/thrift/thriftrw-plugin-yarpc/template.go
+++ b/encoding/thrift/thriftrw-plugin-yarpc/template.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"strings"
 
+	"go.uber.org/thriftrw/compile"
 	"go.uber.org/thriftrw/plugin"
 	"go.uber.org/thriftrw/plugin/api"
 )
@@ -106,6 +107,11 @@ type serviceTemplateData struct {
 	OnewayWrapperFunc   string
 	SanitizeTChannel    bool
 	MockLibrary         string
+
+	// CompiledModule is the result of compile.Compile on the service's Thrift
+	// file. It is shared across all generators so the file is compiled at most
+	// once per request.
+	CompiledModule *compile.Module
 }
 
 // moduleTemplateData contains the data for code gen templates. This should be
@@ -116,6 +122,11 @@ type moduleTemplateData struct {
 	Module *api.Module
 
 	ContextImportPath string
+
+	// CompiledModule is the result of compile.Compile on the module's Thrift
+	// file. It is shared across all generators so the file is compiled at most
+	// once per request.
+	CompiledModule *compile.Module
 }
 
 // ParentServerPackagePath returns the import path for the immediate parent


### PR DESCRIPTION
- [x] Description and context for reviewers: one partner, one stranger: Currently, there is only one module generator `yarpcErrorGenerator` for the Thrift `rpc.code` annotation. Extending this set of generators (for example when adding new thrift annotations) would rely on the compiled thrift file.

However currently, there is no shared access to the compiled thrift file between different generators. Compilation will then scale linearly with the number of generators. This change provides a solution to compile the whole thrift module once and share it with all generators.

RELEASE NOTES:
Refactor thrift module compilation to allow extension of module/service generators.