### PR TITLE
[Yarpc-go][GRPC-Conn-Pooling] Change Rlocks to Atomic integers & swaps

### DIFF
--- a/transport/grpc/config_test.go
+++ b/transport/grpc/config_test.go
@@ -811,13 +811,13 @@ func TestContextDialerOptionUsage(t *testing.T) {
 	require.True(t, ok, "expected a gRPC peer")
 
 	for {
-		state := grpcPeer.conns[0].clientConn.GetState()
+		state := grpcPeer.loadConns()[0].clientConn.GetState()
 		if state == connectivity.Ready {
 			break
 		}
-		grpcPeer.conns[0].clientConn.WaitForStateChange(ctx, state)
+		grpcPeer.loadConns()[0].clientConn.WaitForStateChange(ctx, state)
 	}
-	require.Equal(t, connectivity.Ready, grpcPeer.conns[0].clientConn.GetState(), "expected gRPC connection in Ready state")
+	require.Equal(t, connectivity.Ready, grpcPeer.loadConns()[0].clientConn.GetState(), "expected gRPC connection in Ready state")
 	require.Equal(t, 1, dialContextInvoked, "counter should increment by one from dialer invocation")
 }
 

--- a/transport/grpc/conn_pool_scaler.go
+++ b/transport/grpc/conn_pool_scaler.go
@@ -55,12 +55,12 @@ func (p *grpcPeer) evaluateScaling() {
 // A connection is marked for draining when the remaining active connections
 // can absorb the current aggregate stream load without triggering another
 // scale-up.
+// Lock-free read path: loads an immutable snapshot via atomic.Pointer.Load().
+// The state mutation (setState) is already atomic, so no mutex is needed.
 func (p *grpcPeer) maybeScaleDown() {
-	// Use a read lock for the analysis phase to avoid blocking concurrent
-	// request-path goroutines that also hold RLock when picking a connection.
-	p.mu.RLock()
-	active := make([]*grpcClientConnWrapper, 0, len(p.conns))
-	for _, c := range p.conns {
+	conns := p.loadConns()
+	active := make([]*grpcClientConnWrapper, 0, len(conns))
+	for _, c := range conns {
 		if c.isActive() {
 			active = append(active, c)
 		}
@@ -68,7 +68,6 @@ func (p *grpcPeer) maybeScaleDown() {
 
 	// Never drain below minConnections.
 	if len(active) <= p.poolCfg.minConnections {
-		p.mu.RUnlock()
 		return
 	}
 
@@ -83,7 +82,6 @@ func (p *grpcPeer) maybeScaleDown() {
 	// without crossing the scale-up threshold.
 	capacityAfterDrain := threshold * int32(len(active)-1)
 	if totalStreams >= capacityAfterDrain {
-		p.mu.RUnlock()
 		return
 	}
 
@@ -95,16 +93,13 @@ func (p *grpcPeer) maybeScaleDown() {
 			mostLoaded = c
 		}
 	}
-	p.mu.RUnlock()
 
 	if mostLoaded == nil {
 		return
 	}
 
-	// Acquire the write lock only for the brief state mutation.
-	p.mu.Lock()
+	// setState is an atomic store — no mutex needed.
 	mostLoaded.setState(connStateDraining)
-	p.mu.Unlock()
 
 	p.t.options.logger.Debug("grpc: marked connection for draining during scale-down",
 		zap.String("peer", p.HostPort()),
@@ -118,6 +113,8 @@ func (p *grpcPeer) maybeScaleDown() {
 // monitor goroutines can close and remove them.
 // It skips closing idle connections while a scale-up is in progress so that
 // tryScaleUp can reactivate them instead of dialing a new connection.
+// Lock-free read path: uses atomic.Pointer.Load() for the snapshot, and
+// atomic setState/setIdleNow for mutations (no mutex required).
 func (p *grpcPeer) cleanupIdleConns() {
 	// If a scale-up goroutine is running, hold off — idle connections may be
 	// reactivated by tryScaleUp instead of being closed.
@@ -127,11 +124,10 @@ func (p *grpcPeer) cleanupIdleConns() {
 
 	now := time.Now()
 
-	// Use a read lock for the analysis phase
-	p.mu.RLock()
+	conns := p.loadConns()
 	var drained []*grpcClientConnWrapper
 	var toClose []*grpcClientConnWrapper
-	for _, c := range p.conns {
+	for _, c := range conns {
 		if c.getState() == connStateDraining && c.getStreamCount() == 0 {
 			drained = append(drained, c)
 		} else if c.getState() == connStateIdle && !c.idleSince().IsZero() &&
@@ -139,25 +135,23 @@ func (p *grpcPeer) cleanupIdleConns() {
 			toClose = append(toClose, c)
 		}
 	}
-	p.mu.RUnlock()
 
-	// Advance drained → idle with a brief write lock per connection.
+	// setState and setIdleNow are both atomic operations — no mutex needed.
+	// Re-check state before transitioning to handle any concurrent changes.
 	for _, c := range drained {
-		p.mu.Lock()
 		if c.getState() == connStateDraining && c.getStreamCount() == 0 {
 			c.setState(connStateIdle)
 			c.setIdleNow()
 		}
-		p.mu.Unlock()
 	}
 
 	for _, c := range toClose {
 		p.t.options.logger.Debug("grpc: closing idle connection after timeout",
 			zap.String("peer", p.HostPort()),
 			zap.Duration("idle_duration", now.Sub(c.idleSince())))
-		// Cancelling the wrapper context causes monitorConnectionStatus to
+		// Cancelling the wrapper context causes monitorConnWrapper to
 		// exit, which closes the underlying clientConn and removes the
-		// wrapper from p.conns.
+		// wrapper from the pool via removeConn.
 		c.cancel()
 	}
 
@@ -206,10 +200,8 @@ func (p *grpcPeer) tryScaleUp(leastLoadedConn *grpcClientConnWrapper) {
 		}
 
 		// No idle connection available; dial a new one if below the cap.
-		p.mu.RLock()
-		atMax := len(p.conns) >= p.poolCfg.maxConnections
-		p.mu.RUnlock()
-		if atMax {
+		// connCount is maintained atomically — no mutex needed for this check.
+		if int(p.connCount.Load()) >= p.poolCfg.maxConnections {
 			return
 		}
 
@@ -228,10 +220,11 @@ func (p *grpcPeer) tryScaleUp(leastLoadedConn *grpcClientConnWrapper) {
 // reactivateIdleConn finds the first idle connection whose context has not
 // yet been cancelled and transitions it back to active, avoiding an
 // unnecessary dial.  Returns true if a connection was reactivated.
+// Lock-free: setState is atomic. Only one reactivateIdleConn call runs at a
+// time (guarded by the isScaling CAS in tryScaleUp).
 func (p *grpcPeer) reactivateIdleConn() bool {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	for _, c := range p.conns {
+	conns := p.loadConns()
+	for _, c := range conns {
 		// Only reactivate if the connection context is still live; a cancelled
 		// context means cleanupIdleConns has already scheduled it for closure.
 		if c.getState() == connStateIdle && c.ctx.Err() == nil {
@@ -244,11 +237,11 @@ func (p *grpcPeer) reactivateIdleConn() bool {
 }
 
 // refreshPoolMetrics scans the pool and updates the active, draining, and idle
-// connection gauges.  It must be called after any pool state transition.
+// connection gauges.  Lock-free: reads an immutable snapshot via loadConns().
 func (p *grpcPeer) refreshPoolMetrics() {
+	conns := p.loadConns()
 	var active, draining, idle int64
-	p.mu.RLock()
-	for _, c := range p.conns {
+	for _, c := range conns {
 		switch c.getState() {
 		case connStateActive:
 			active++
@@ -258,7 +251,6 @@ func (p *grpcPeer) refreshPoolMetrics() {
 			idle++
 		}
 	}
-	p.mu.RUnlock()
 	p.metrics.setConnectionCount(active)
 	p.metrics.setDrainingConnectionCount(draining)
 	p.metrics.setIdleConnectionCount(idle)

--- a/transport/grpc/conn_pool_scaler_test.go
+++ b/transport/grpc/conn_pool_scaler_test.go
@@ -59,14 +59,15 @@ func peerForScaleDown(t *testing.T, conns []*grpcClientConnWrapper, cfg connPool
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	transport := NewTransport()
-	return &grpcPeer{
+	p := &grpcPeer{
 		Peer:    abstractpeer.NewPeer(abstractpeer.PeerIdentifier("10.0.0.1:9000"), transport),
 		t:       transport,
 		ctx:     ctx,
 		cancel:  cancel,
-		conns:   conns,
 		poolCfg: cfg,
 	}
+	p.storeConns(conns)
+	return p
 }
 
 // defaultCfg is a pool config used across maybeScaleDown tests.
@@ -221,9 +222,9 @@ func TestCleanupIdleConns(t *testing.T) {
 
 			p.cleanupIdleConns()
 
-			require.Len(t, p.conns, len(tt.wantStates))
+			require.Len(t, p.loadConns(), len(tt.wantStates))
 			for i, want := range tt.wantStates {
-				assert.Equal(t, want, p.conns[i].getState(), "conn[%d] state", i)
+				assert.Equal(t, want, p.loadConns()[i].getState(), "conn[%d] state", i)
 			}
 
 			cancelledSet := make(map[int]bool)
@@ -391,9 +392,9 @@ func TestMaybeScaleDown(t *testing.T) {
 			p := peerForScaleDown(t, tt.conns, tt.cfg)
 			p.maybeScaleDown()
 
-			require.Len(t, p.conns, len(tt.wantStates))
+			require.Len(t, p.loadConns(), len(tt.wantStates))
 			for i, want := range tt.wantStates {
-				assert.Equal(t, want, p.conns[i].getState(),
+				assert.Equal(t, want, p.loadConns()[i].getState(),
 					"conn[%d] state mismatch", i)
 			}
 		})
@@ -502,9 +503,9 @@ func TestTryScaleUp(t *testing.T) {
 		for i := range conns {
 			conns[i] = makeConn(connStateActive, 0)
 		}
-		p.mu.Lock()
-		p.conns = conns
-		p.mu.Unlock()
+		p.wmu.Lock()
+		p.storeConns(conns)
+		p.wmu.Unlock()
 		p.tryScaleUp(overBudget)
 
 		// atMax check now runs inside the goroutine; wait for it to finish.
@@ -512,9 +513,9 @@ func TestTryScaleUp(t *testing.T) {
 			return atomic.LoadInt32(&p.isScaling) == 0
 		}, 2*time.Second, 10*time.Millisecond)
 
-		p.mu.RLock()
-		n := len(p.conns)
-		p.mu.RUnlock()
+		p.wmu.Lock()
+		n := len(p.loadConns())
+		p.wmu.Unlock()
 		assert.Equal(t, p.poolCfg.maxConnections, n, "pool should not grow beyond max")
 	})
 
@@ -537,9 +538,9 @@ func TestTryScaleUp(t *testing.T) {
 		}, 2*time.Second, 10*time.Millisecond, "isScaling should reset to 0 after goroutine completes")
 
 		// One connection was added to the pool.
-		p.mu.RLock()
-		n := len(p.conns)
-		p.mu.RUnlock()
+		p.wmu.Lock()
+		n := len(p.loadConns())
+		p.wmu.Unlock()
 		assert.Equal(t, 1, n, "one connection should be added to the pool")
 	})
 
@@ -553,9 +554,9 @@ func TestTryScaleUp(t *testing.T) {
 		idleConn := &grpcClientConnWrapper{ctx: ctx, cancel: cancel}
 		idleConn.setState(connStateIdle)
 		idleConn.setIdleNow()
-		p.mu.Lock()
-		p.conns = append(p.conns, idleConn)
-		p.mu.Unlock()
+		p.wmu.Lock()
+		p.storeConns(append(p.loadConns(), idleConn))
+		p.wmu.Unlock()
 
 		p.tryScaleUp(overBudget)
 
@@ -564,9 +565,9 @@ func TestTryScaleUp(t *testing.T) {
 		}, 2*time.Second, 10*time.Millisecond)
 
 		// Pool size unchanged — reactivation, not a new dial.
-		p.mu.RLock()
-		n := len(p.conns)
-		p.mu.RUnlock()
+		p.wmu.Lock()
+		n := len(p.loadConns())
+		p.wmu.Unlock()
 		assert.Equal(t, 1, n, "pool size should not grow on reactivation")
 		assert.Equal(t, connStateActive, idleConn.getState(), "idle conn should be active after reactivation")
 		assert.True(t, idleConn.idleSince().IsZero(), "idle timestamp should be cleared")
@@ -715,14 +716,14 @@ func TestRefreshPoolMetrics(t *testing.T) {
 	t.Run("mixed pool reports correct counts", func(t *testing.T) {
 		t.Parallel()
 		p, root := peerWithMetrics(t)
-		p.mu.Lock()
-		p.conns = []*grpcClientConnWrapper{
+		p.wmu.Lock()
+		p.storeConns([]*grpcClientConnWrapper{
 			makeConn(connStateActive, 0),
 			makeConn(connStateActive, 0),
 			makeConn(connStateDraining, 0),
 			makeConn(connStateIdle, 0),
-		}
-		p.mu.Unlock()
+		})
+		p.wmu.Unlock()
 
 		p.refreshPoolMetrics()
 
@@ -744,13 +745,13 @@ func TestMaybeScaleDownMetrics(t *testing.T) {
 		maxConcurrentStreams: 100,
 		scaleUpThreshold:    0.8, // threshold = 80
 	}
-	p.mu.Lock()
-	p.conns = []*grpcClientConnWrapper{
+	p.wmu.Lock()
+	p.storeConns([]*grpcClientConnWrapper{
 		makeConn(connStateActive, 10),
 		makeConn(connStateActive, 10),
 		makeConn(connStateActive, 10), // total 30 < capacityAfterDrain=160 → drain
-	}
-	p.mu.Unlock()
+	})
+	p.wmu.Unlock()
 
 	p.maybeScaleDown()
 
@@ -796,9 +797,9 @@ func TestTryScaleUpReactivationMetrics(t *testing.T) {
 	defer cancel()
 	idleConn := &grpcClientConnWrapper{ctx: ctx, cancel: cancel}
 	idleConn.setState(connStateIdle)
-	p.mu.Lock()
-	p.conns = append(p.conns, idleConn)
-	p.mu.Unlock()
+	p.wmu.Lock()
+	p.storeConns(append(p.loadConns(), idleConn))
+	p.wmu.Unlock()
 
 	overBudget := makeConn(connStateActive, 85)
 	p.tryScaleUp(overBudget)
@@ -823,12 +824,12 @@ func TestCleanupIdleConnsMetrics(t *testing.T) {
 
 	p, root := peerWithMetrics(t)
 	p.poolCfg = connPoolConfig{idleTimeout: time.Hour}
-	p.mu.Lock()
-	p.conns = []*grpcClientConnWrapper{
+	p.wmu.Lock()
+	p.storeConns([]*grpcClientConnWrapper{
 		makeConn(connStateActive, 5),
 		makeConn(connStateDraining, 0), // 0 streams → advances to idle
-	}
-	p.mu.Unlock()
+	})
+	p.wmu.Unlock()
 
 	p.cleanupIdleConns()
 

--- a/transport/grpc/peer.go
+++ b/transport/grpc/peer.go
@@ -23,6 +23,7 @@ package grpc
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/peer/abstractpeer"
@@ -53,9 +54,39 @@ type grpcPeer struct {
 
 	metrics *connPoolMetrics
 
-	mu      sync.RWMutex
-	conns   []*grpcClientConnWrapper
+	// connsPtr holds a pointer to the current immutable connection slice.
+	// Readers (pickConn, recomputeConnectionStatus, refreshPoolMetrics, etc.)
+	// do a single atomic.Pointer.Load() — no mutex acquired on the read path.
+	// Writers (addConn, removeConn) hold wmu, copy the slice, mutate, then
+	// atomically publish the new pointer.  Readers never block writers.
+	connsPtr atomic.Pointer[[](*grpcClientConnWrapper)]
+
+	// wmu is a write-only mutex: only writers (addConn, removeConn) acquire it.
+	// Readers never touch wmu.
+	wmu sync.Mutex
+
+	// connCount mirrors len(loadConns()) atomically so tryScaleUp can check the
+	// pool size without acquiring wmu.
+	connCount atomic.Int32
+
 	poolCfg connPoolConfig
+}
+
+// loadConns returns the current immutable connection snapshot.
+// Safe to call from any goroutine without holding any lock.
+func (p *grpcPeer) loadConns() []*grpcClientConnWrapper {
+	ptr := p.connsPtr.Load()
+	if ptr == nil {
+		return nil
+	}
+	return *ptr
+}
+
+// storeConns atomically publishes a new connection slice and updates connCount.
+// Callers must hold wmu.
+func (p *grpcPeer) storeConns(conns []*grpcClientConnWrapper) {
+	p.connsPtr.Store(&conns)
+	p.connCount.Store(int32(len(conns)))
 }
 
 func (t *Transport) newPeer(address string, options *dialOptions) (*grpcPeer, error) {
@@ -96,6 +127,9 @@ func (t *Transport) newPeer(address string, options *dialOptions) (*grpcPeer, er
 			idleTimeout:           t.options.clientConnPoolIdleTimeout,
 		},
 	}
+	// Publish an empty slice so loadConns() never returns nil before the first
+	// addConn() call.
+	p.storeConns(nil)
 
 	// All connections are created via addConn — no special primary connection.
 	initialConnCount := 1
@@ -114,17 +148,18 @@ func (t *Transport) newPeer(address string, options *dialOptions) (*grpcPeer, er
 	}
 
 	// Close stoppedC once all monitorConnWrapper goroutines have finished.
-	// We acquire mu briefly after ctx is cancelled to ensure any in-flight
+	// We acquire wmu briefly after ctx is cancelled to ensure any in-flight
 	// addConn() that passed its context check has already called connWg.Add(1)
 	// before we call connWg.Wait().
 	go func() {
 		<-p.ctx.Done()
-		// Acquire mu after cancellation to ensure any addConn() call that
+		// Acquire wmu after cancellation to ensure any addConn() call that
 		// passed its ctx.Err() check has already called connWg.Add(1).
-		// The empty critical section is intentional: we need the memory
-		// barrier, not exclusive access to any data.
-		p.mu.Lock()
-		p.mu.Unlock() //nolint:staticcheck
+		// The empty critical section is intentional: we need the barrier,
+		// not exclusive access to any data.
+		//lint:ignore SA2001 intentional empty critical section, provides memory barrier for connWg
+		p.wmu.Lock()
+		p.wmu.Unlock()
 		p.connWg.Wait()
 		close(p.stoppedC)
 	}()
@@ -143,18 +178,22 @@ func (p *grpcPeer) addConn() error {
 	}
 	w := newConnWrapper(p.ctx, clientConn)
 
-	// Hold mu while registering with connWg and appending to conns.  The
-	// lifecycle goroutine in newPeer acquires mu after ctx is cancelled so
-	// that it observes any Add(1) call that raced with cancellation.
-	p.mu.Lock()
+	// Hold wmu while registering with connWg and publishing the new slice.
+	// The lifecycle goroutine acquires wmu after ctx is cancelled to observe
+	// any Add(1) that raced with cancellation.
+	p.wmu.Lock()
 	if p.ctx.Err() != nil {
-		p.mu.Unlock()
+		p.wmu.Unlock()
 		_ = clientConn.Close()
 		return p.ctx.Err()
 	}
 	p.connWg.Add(1)
-	p.conns = append(p.conns, w)
-	p.mu.Unlock()
+	old := p.loadConns()
+	next := make([]*grpcClientConnWrapper, len(old)+1)
+	copy(next, old)
+	next[len(old)] = w
+	p.storeConns(next)
+	p.wmu.Unlock()
 
 	go p.monitorConnWrapper(w)
 	p.refreshPoolMetrics()
@@ -210,9 +249,9 @@ func (p *grpcPeer) monitorConnWrapper(w *grpcClientConnWrapper) {
 // connecting (and none are Ready), and Unavailable if the pool is empty or
 // all connections are in a terminal/unknown state.
 func (p *grpcPeer) recomputeConnectionStatus() {
-	p.mu.RLock()
+	conns := p.loadConns()
 	best := peer.Unavailable
-	for _, c := range p.conns {
+	for _, c := range conns {
 		if !c.isActive() {
 			continue
 		}
@@ -225,17 +264,20 @@ func (p *grpcPeer) recomputeConnectionStatus() {
 			best = peer.Connecting
 		}
 	}
-	p.mu.RUnlock()
 	p.setConnectionStatus(best)
 }
 
 // removeConn removes a wrapper from the peer's connection pool.
 func (p *grpcPeer) removeConn(w *grpcClientConnWrapper) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	for i, c := range p.conns {
+	p.wmu.Lock()
+	defer p.wmu.Unlock()
+	old := p.loadConns()
+	for i, c := range old {
 		if c == w {
-			p.conns = append(p.conns[:i], p.conns[i+1:]...)
+			next := make([]*grpcClientConnWrapper, len(old)-1)
+			copy(next, old[:i])
+			copy(next[i:], old[i+1:])
+			p.storeConns(next)
 			return
 		}
 	}
@@ -243,11 +285,11 @@ func (p *grpcPeer) removeConn(w *grpcClientConnWrapper) {
 
 // pickConn returns the active connection in the pool with the lowest current
 // stream count.  Returns nil if the pool contains no active connections.
+// Lock-free: reads the immutable snapshot via a single atomic.Pointer.Load().
 func (p *grpcPeer) pickConn() *grpcClientConnWrapper {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
+	conns := p.loadConns()
 	var best *grpcClientConnWrapper
-	for _, c := range p.conns {
+	for _, c := range conns {
 		if !c.isActive() {
 			continue
 		}
@@ -297,3 +339,4 @@ func grpcStatusToYARPCStatus(grpcStatus connectivity.State) peer.ConnectionStatu
 		return peer.Unavailable
 	}
 }
+

--- a/transport/grpc/peer_test.go
+++ b/transport/grpc/peer_test.go
@@ -308,9 +308,9 @@ func TestRemoveConn(t *testing.T) {
 		c0, c1, c2 := makeConn(connStateActive, 0), makeConn(connStateActive, 0), makeConn(connStateActive, 0)
 		p := peerForScaleDown(t, []*grpcClientConnWrapper{c0, c1, c2}, connPoolConfig{})
 		p.removeConn(c0)
-		require.Len(t, p.conns, 2)
-		assert.Same(t, c1, p.conns[0])
-		assert.Same(t, c2, p.conns[1])
+		require.Len(t, p.loadConns(), 2)
+		assert.Same(t, c1, p.loadConns()[0])
+		assert.Same(t, c2, p.loadConns()[1])
 	})
 
 	t.Run("removes from middle", func(t *testing.T) {
@@ -318,9 +318,9 @@ func TestRemoveConn(t *testing.T) {
 		c0, c1, c2 := makeConn(connStateActive, 0), makeConn(connStateActive, 0), makeConn(connStateActive, 0)
 		p := peerForScaleDown(t, []*grpcClientConnWrapper{c0, c1, c2}, connPoolConfig{})
 		p.removeConn(c1)
-		require.Len(t, p.conns, 2)
-		assert.Same(t, c0, p.conns[0])
-		assert.Same(t, c2, p.conns[1])
+		require.Len(t, p.loadConns(), 2)
+		assert.Same(t, c0, p.loadConns()[0])
+		assert.Same(t, c2, p.loadConns()[1])
 	})
 
 	t.Run("removes from end", func(t *testing.T) {
@@ -328,9 +328,9 @@ func TestRemoveConn(t *testing.T) {
 		c0, c1, c2 := makeConn(connStateActive, 0), makeConn(connStateActive, 0), makeConn(connStateActive, 0)
 		p := peerForScaleDown(t, []*grpcClientConnWrapper{c0, c1, c2}, connPoolConfig{})
 		p.removeConn(c2)
-		require.Len(t, p.conns, 2)
-		assert.Same(t, c0, p.conns[0])
-		assert.Same(t, c1, p.conns[1])
+		require.Len(t, p.loadConns(), 2)
+		assert.Same(t, c0, p.loadConns()[0])
+		assert.Same(t, c1, p.loadConns()[1])
 	})
 
 	t.Run("no-op when conn not in pool", func(t *testing.T) {
@@ -339,7 +339,7 @@ func TestRemoveConn(t *testing.T) {
 		notInPool := makeConn(connStateActive, 0)
 		p := peerForScaleDown(t, []*grpcClientConnWrapper{c0, c1}, connPoolConfig{})
 		assert.NotPanics(t, func() { p.removeConn(notInPool) })
-		assert.Len(t, p.conns, 2)
+		assert.Len(t, p.loadConns(), 2)
 	})
 }
 
@@ -353,15 +353,15 @@ func TestMonitorConnWrapperCleanup(t *testing.T) {
 	w := newConnWrapper(p.ctx, cc)
 
 	p.connWg.Add(1)
-	p.mu.Lock()
-	p.conns = append(p.conns, w)
-	p.mu.Unlock()
+	p.wmu.Lock()
+	p.storeConns(append(p.loadConns(), w))
+	p.wmu.Unlock()
 
 	go p.monitorConnWrapper(w)
 
-	p.mu.RLock()
-	require.Len(t, p.conns, 1)
-	p.mu.RUnlock()
+	p.wmu.Lock()
+	require.Len(t, p.loadConns(), 1)
+	p.wmu.Unlock()
 
 	p.cancel()
 
@@ -371,9 +371,9 @@ func TestMonitorConnWrapperCleanup(t *testing.T) {
 		t.Fatal("stoppedC not closed after context cancellation")
 	}
 
-	p.mu.RLock()
-	assert.Empty(t, p.conns, "wrapper should be removed from pool on cleanup")
-	p.mu.RUnlock()
+	p.wmu.Lock()
+	assert.Empty(t, p.loadConns(), "wrapper should be removed from pool on cleanup")
+	p.wmu.Unlock()
 
 	wgDone := make(chan struct{})
 	go func() { p.connWg.Wait(); close(wgDone) }()
@@ -393,8 +393,9 @@ func TestStoppedCClosedAfterAllConnsFinish(t *testing.T) {
 
 	go func() {
 		<-p.ctx.Done()
-		p.mu.Lock()
-		p.mu.Unlock() //nolint:staticcheck
+		//lint:ignore SA2001 intentional empty critical section, provides memory barrier for connWg
+		p.wmu.Lock()
+		p.wmu.Unlock()
 		p.connWg.Wait()
 		close(p.stoppedC)
 	}()
@@ -403,9 +404,9 @@ func TestStoppedCClosedAfterAllConnsFinish(t *testing.T) {
 		cc := dialTestClientConn(t)
 		w := newConnWrapper(p.ctx, cc)
 		p.connWg.Add(1)
-		p.mu.Lock()
-		p.conns = append(p.conns, w)
-		p.mu.Unlock()
+		p.wmu.Lock()
+		p.storeConns(append(p.loadConns(), w))
+		p.wmu.Unlock()
 		go p.monitorConnWrapper(w)
 	}
 
@@ -429,7 +430,7 @@ func TestAddConnContextCancelled(t *testing.T) {
 	err := p.addConn()
 
 	require.Error(t, err)
-	assert.Empty(t, p.conns, "cancelled addConn must not add to pool")
+	assert.Empty(t, p.loadConns(), "cancelled addConn must not add to pool")
 }
 
 // --- grpcStatusToYARPCStatus ---
@@ -479,9 +480,9 @@ func TestRecomputeConnectionStatus(t *testing.T) {
 		p := peerForPool(t)
 		cc := dialTestClientConn(t)
 		w := newConnWrapper(p.ctx, cc)
-		p.mu.Lock()
-		p.conns = append(p.conns, w)
-		p.mu.Unlock()
+		p.wmu.Lock()
+		p.storeConns(append(p.loadConns(), w))
+		p.wmu.Unlock()
 
 		p.recomputeConnectionStatus()
 
@@ -499,9 +500,9 @@ func TestRecomputeConnectionStatus(t *testing.T) {
 		cc := dialTestClientConn(t)
 		w := newConnWrapper(p.ctx, cc)
 		p.connWg.Add(1)
-		p.mu.Lock()
-		p.conns = append(p.conns, w)
-		p.mu.Unlock()
+		p.wmu.Lock()
+		p.storeConns(append(p.loadConns(), w))
+		p.wmu.Unlock()
 
 		go p.monitorConnWrapper(w)
 
@@ -536,9 +537,9 @@ func TestMonitorConnWrapperMetrics(t *testing.T) {
 	cc := dialTestClientConn(t)
 	w := newConnWrapper(p.ctx, cc)
 	p.connWg.Add(1)
-	p.mu.Lock()
-	p.conns = append(p.conns, w)
-	p.mu.Unlock()
+	p.wmu.Lock()
+	p.storeConns(append(p.loadConns(), w))
+	p.wmu.Unlock()
 
 	// Reflect the initial active connection in the gauges.
 	p.refreshPoolMetrics()


### PR DESCRIPTION
## Summary
- Replaced sync.RWMutex on the hot read path with atomic.Pointer[[]T] copy-on-write; reads are now fully lock-free, while writes use a write-only mutex with slice copy. 
- Also fixed a pre-existing CI failure: //nolint:staticcheck (golangci-lint format) replaced with //lint:ignore SA2001 (standalone staticcheck v0.5.1 format) for the intentional empty Lock/Unlock memory barrier.       
                        
## Testing
Bechmark Testing for Atomic vs Mutex Locks captured [here](https://docs.google.com/spreadsheets/d/1cb1umghCY2PGM6JyOipEdxGRviyhB6Hoh31ro8S3qyQ/edit?gid=308090366#gid=308090366)
Tl;dr
- Hot read path (pickConn, len check): use atomic.Pointer ; 2x-1600x faster
- Write path (addConn, removeConn): keep write-only mutex + slice copy
- Net effect: every RPC pays zero mutex overhead; scale-up events are invisible

## Jira
[RPC-9771](https://t3.uberinternal.com/browse/RPC-9771)