### PR TITLE
transport/grpc: remove redundant header canonicalization

### DIFF
--- a/transport/grpc/headers.go
+++ b/transport/grpc/headers.go
@@ -100,10 +100,11 @@ var (
 	}
 )
 
-// TODO: there are way too many repeat calls to strings.ToLower
-// Note that these calls are done indirectly, primarily through
-// transport.CanonicalizeHeaderKey
-// NOTE: Callers must pass canonical (lowercase) keys.
+// isReserved returns whether the given header is reserved by YARPC.
+// NOTE: Callers must pass canonical (lowercase) keys. All call sites in
+// this package operate on already-lowercase keys: gRPC metadata.MD keys
+// are guaranteed lowercase by the gRPC framework (HTTP/2 + grpc-go API),
+// and transport.Headers stores keys canonicalized via With().
 func isReserved(header string) bool {
 	if routingHeaders[header] {
 		return false
@@ -145,7 +146,7 @@ func metadataToTransportRequest(md metadata.MD) (*transport.Request, error) {
 		default:
 			return nil, yarpcerrors.InvalidArgumentErrorf("header has more than one value: %s:%v", header, values)
 		}
-		header = transport.CanonicalizeHeaderKey(header)
+		// gRPC metadata keys are guaranteed to be lowercase (HTTP/2 spec),
 		// skip routing header
 		if routingHeaders[header] {
 			continue
@@ -202,8 +203,9 @@ func metadataToApplicationErrorMeta(responseMD metadata.MD) *transport.Applicati
 
 // addApplicationHeaders adds the headers to md.
 func addApplicationHeaders(md metadata.MD, headers transport.Headers) error {
+	// transport.Headers.Items() returns keys already canonicalized (lowercased)
+	// via With(), so transport.CanonicalizeHeaderKey is redundant here.
 	for header, value := range headers.Items() {
-		header = transport.CanonicalizeHeaderKey(header)
 		if isReserved(header) {
 			return yarpcerrors.InvalidArgumentErrorf("cannot use reserved header in application headers: %s", header)
 		}
@@ -220,8 +222,9 @@ func getApplicationHeaders(md metadata.MD) (transport.Headers, error) {
 		return transport.Headers{}, nil
 	}
 	headers := transport.NewHeadersWithCapacity(md.Len())
+	// gRPC metadata keys are guaranteed to be lowercase (HTTP/2 spec),
+	// so transport.CanonicalizeHeaderKey (strings.ToLower) is a no-op here.
 	for header, values := range md {
-		header = transport.CanonicalizeHeaderKey(header)
 		if isReserved(header) {
 			continue
 		}

--- a/transport/grpc/headers_bench_test.go
+++ b/transport/grpc/headers_bench_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package grpc
+
+import (
+	"testing"
+
+	"go.uber.org/yarpc/api/transport"
+	"google.golang.org/grpc/metadata"
+)
+
+// BenchmarkTransportRequestToMetadata measures outbound header serialization.
+//
+//	go test -bench=BenchmarkTransportRequestToMetadata -benchmem ./transport/grpc/
+func BenchmarkTransportRequestToMetadata(b *testing.B) {
+	request := &transport.Request{
+		Caller:          "my-caller",
+		Service:         "my-service",
+		Procedure:       "MyService::MyMethod",
+		Encoding:        "proto",
+		ShardKey:        "shard-123",
+		RoutingKey:      "routing-456",
+		RoutingDelegate: "delegate-789",
+		CallerProcedure: "CallerService::CallerMethod",
+		Headers: transport.HeadersFromMap(map[string]string{
+			"x-custom-1": "value1",
+			"x-custom-2": "value2",
+			"x-custom-3": "value3",
+		}),
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = transportRequestToMetadata(request)
+	}
+}
+
+// BenchmarkMetadataToTransportRequest measures inbound header deserialization.
+//
+//	go test -bench=BenchmarkMetadataToTransportRequest -benchmem ./transport/grpc/
+func BenchmarkMetadataToTransportRequest(b *testing.B) {
+	md := metadata.New(map[string]string{
+		CallerHeader:          "my-caller",
+		ServiceHeader:         "my-service",
+		ShardKeyHeader:        "shard-123",
+		RoutingKeyHeader:      "routing-456",
+		RoutingDelegateHeader: "delegate-789",
+		EncodingHeader:        "proto",
+		CallerProcedureHeader: "CallerService::CallerMethod",
+		"x-custom-1":          "value1",
+		"x-custom-2":          "value2",
+		"x-custom-3":          "value3",
+	})
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = metadataToTransportRequest(md)
+	}
+}
+
+// BenchmarkGetApplicationHeaders measures inbound response header extraction.
+//
+//	go test -bench=BenchmarkGetApplicationHeaders -benchmem ./transport/grpc/
+func BenchmarkGetApplicationHeaders(b *testing.B) {
+	md := metadata.New(map[string]string{
+		CallerHeader:   "my-caller",
+		ServiceHeader:  "my-service",
+		EncodingHeader: "proto",
+		"x-custom-1":   "value1",
+		"x-custom-2":   "value2",
+		"x-custom-3":   "value3",
+		"x-custom-4":   "value4",
+		"x-custom-5":   "value5",
+	})
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = getApplicationHeaders(md)
+	}
+}

--- a/transport/grpc/headers_test.go
+++ b/transport/grpc/headers_test.go
@@ -253,7 +253,7 @@ func TestGetApplicationHeaders(t *testing.T) {
 				"rpc-service":         []string{"foo"}, // reserved header
 				"test-header-empty":   []string{},      // no value
 				"test-header-valid-1": []string{"test-value-1"},
-				"test-Header-Valid-2": []string{"test-value-2"},
+				"test-header-valid-2": []string{"test-value-2"},
 			},
 			wantHeaders: map[string]string{
 				"test-header-valid-1": "test-value-1",


### PR DESCRIPTION
RELEASE NOTES:

Removed redundant header canonicalization in gRPC transport

  transportRequestToMetadata   712 ns -> 671 ns  (-6%)
  metadataToTransportRequest   748 ns -> 614 ns  (-18%)
  getApplicationHeaders        488 ns -> 397 ns  (-19%)

Inbound request MD (handler.go:107-111) — metadata.FromIncomingContext(ctx). grpc-go docs: "All keys in the returned MD are lowercase."

Response trailer MD (outbound.go:135-137) — populated by grpc-go from the wire. Same as request MD

Outbound application headers (transportRequestToMetadata, response_writer.go:66-70) — come from transport.Headers.Items(). transport.Headers has unexported fields and its only mutator With() lowercases keys via CanonicalizeHeaderKey; 