### PR TITLE
[yarpc][go] Adding integrationn tests for grpc-connection-pooling

### DIFF
--- a/transport/grpc/conn_pool_scaler_test.go
+++ b/transport/grpc/conn_pool_scaler_test.go
@@ -73,9 +73,9 @@ func peerForScaleDown(t *testing.T, conns []*grpcClientConnWrapper, cfg connPool
 // defaultCfg is a pool config used across maybeScaleDown tests.
 // threshold = int32(100 * 0.8) = 80.
 var defaultScaleDownCfg = connPoolConfig{
-	minConnections:      1,
+	minConnections:       1,
 	maxConcurrentStreams: 100,
-	scaleUpThreshold:    0.8,
+	scaleUpThreshold:     0.8,
 }
 
 // makeConnWithCancel creates a grpcClientConnWrapper with a real context so
@@ -106,7 +106,7 @@ func TestCleanupIdleConns(t *testing.T) {
 		desc string
 		// build returns the conns slice and a slice of contexts corresponding
 		// to wrappers whose cancellation should be verified.
-		build      func() ([]*grpcClientConnWrapper, []context.Context)
+		build       func() ([]*grpcClientConnWrapper, []context.Context)
 		idleTimeout time.Duration
 		// wantStates is the expected state of each conn after the call (index-aligned).
 		wantStates []connState
@@ -242,7 +242,6 @@ func TestCleanupIdleConns(t *testing.T) {
 	}
 }
 
-
 func TestMaybeScaleDown(t *testing.T) {
 	t.Parallel()
 
@@ -277,9 +276,9 @@ func TestMaybeScaleDown(t *testing.T) {
 				makeConn(connStateActive, 10),
 			},
 			cfg: connPoolConfig{
-				minConnections:      2,
+				minConnections:       2,
 				maxConcurrentStreams: 100,
-				scaleUpThreshold:    0.8,
+				scaleUpThreshold:     0.8,
 			},
 			wantStates: []connState{connStateActive},
 		},
@@ -378,9 +377,9 @@ func TestMaybeScaleDown(t *testing.T) {
 				makeConn(connStateActive, 40),
 			},
 			cfg: connPoolConfig{
-				minConnections:      1,
+				minConnections:       1,
 				maxConcurrentStreams: 100,
-				scaleUpThreshold:    0.8, // threshold=80, capacity=80*2=160, total=85 < 160
+				scaleUpThreshold:     0.8, // threshold=80, capacity=80*2=160, total=85 < 160
 			},
 			wantStates: []connState{connStateDraining, connStateActive, connStateDraining, connStateActive},
 		},
@@ -741,9 +740,9 @@ func TestMaybeScaleDownMetrics(t *testing.T) {
 
 	p, root := peerWithMetrics(t)
 	p.poolCfg = connPoolConfig{
-		minConnections:      1,
+		minConnections:       1,
 		maxConcurrentStreams: 100,
-		scaleUpThreshold:    0.8, // threshold = 80
+		scaleUpThreshold:     0.8, // threshold = 80
 	}
 	p.wmu.Lock()
 	p.storeConns([]*grpcClientConnWrapper{

--- a/transport/grpc/external_integration_test.go
+++ b/transport/grpc/external_integration_test.go
@@ -23,24 +23,29 @@ package grpc_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/net/metrics"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/middleware"
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/prototest/example"
 	"go.uber.org/yarpc/internal/prototest/examplepb"
+	yarpcpeer "go.uber.org/yarpc/peer"
 	"go.uber.org/yarpc/peer/hostport"
 	"go.uber.org/yarpc/peer/roundrobin"
 	"go.uber.org/yarpc/transport/grpc"
 	"go.uber.org/yarpc/x/yarpctest"
 	"go.uber.org/yarpc/x/yarpctest/api"
 	"go.uber.org/yarpc/x/yarpctest/types"
+	"go.uber.org/zap"
 )
 
 func TestStreamingWithNoCtxDeadline(t *testing.T) {
@@ -179,4 +184,195 @@ func TestFoo(t *testing.T) {
 		}),
 	)
 	request.Run(t)
+}
+
+// --- connection pool integration tests (public API only) ---
+
+// withPoolTestEnv starts a gRPC server+client pair with the given transport
+// options using only the public API, runs f, then tears everything down.
+func withPoolTestEnv(t *testing.T, opts []grpc.TransportOption, f func(set, get func(ctx context.Context, key, value string) error)) {
+	t.Helper()
+
+	const svcName = "example"
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	// Use a nop logger so goroutines that outlive the test (e.g. monitorConnWrapper
+	// draining after dispatcher.Stop()) cannot trigger zaptest's after-test panic.
+	opts = append(opts, grpc.Logger(zap.NewNop()))
+	trans := grpc.NewTransport(opts...)
+
+	chooser := yarpcpeer.NewSingle(hostport.PeerIdentifier(listener.Addr().String()), trans.NewDialer())
+	dispatcher := yarpc.NewDispatcher(yarpc.Config{
+		Name:     svcName,
+		Inbounds: yarpc.Inbounds{trans.NewInbound(listener)},
+		Outbounds: yarpc.Outbounds{
+			svcName: {ServiceName: svcName, Unary: trans.NewOutbound(chooser)},
+		},
+	})
+	dispatcher.Register(examplepb.BuildKeyValueYARPCProcedures(example.NewKeyValueYARPCServer()))
+	require.NoError(t, dispatcher.Start())
+	defer func() { assert.NoError(t, dispatcher.Stop()) }()
+
+	client := examplepb.NewKeyValueYARPCClient(dispatcher.ClientConfig(svcName))
+
+	set := func(ctx context.Context, key, value string) error {
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		_, err := client.SetValue(ctx, &examplepb.SetValueRequest{Key: key, Value: value})
+		return err
+	}
+	get := func(ctx context.Context, key, _ string) error {
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		_, err := client.GetValue(ctx, &examplepb.GetValueRequest{Key: key})
+		return err
+	}
+	f(set, get)
+}
+
+// extPoolMetricSnapshot reads gauges and counters from a metrics root into maps.
+func extPoolMetricSnapshot(root *metrics.Root) (gauges, counters map[string]int64) {
+	snap := root.Snapshot()
+	gauges = make(map[string]int64, len(snap.Gauges))
+	for _, g := range snap.Gauges {
+		gauges[g.Name] = g.Value
+	}
+	counters = make(map[string]int64, len(snap.Counters))
+	for _, c := range snap.Counters {
+		counters[c.Name] = c.Value
+	}
+	return
+}
+
+func TestConnectionPoolBasicRequest(t *testing.T) {
+	t.Parallel()
+	withPoolTestEnv(t, []grpc.TransportOption{
+		grpc.WithDynamicConnectionScaling(true),
+		grpc.MinConnections(2),
+		grpc.MaxConnections(5),
+	}, func(set, get func(ctx context.Context, key, value string) error) {
+		ctx := context.Background()
+		require.NoError(t, set(ctx, "foo", "bar"))
+		require.NoError(t, get(ctx, "foo", ""))
+	})
+}
+
+func TestConnectionPoolMinConnectionsAtStartup(t *testing.T) {
+	t.Parallel()
+	root := metrics.New()
+	withPoolTestEnv(t, []grpc.TransportOption{
+		grpc.WithDynamicConnectionScaling(true),
+		grpc.MinConnections(2),
+		grpc.MaxConnections(5),
+		grpc.Meter(root.Scope()),
+	}, func(_, _ func(ctx context.Context, key, value string) error) {
+		gauges, _ := extPoolMetricSnapshot(root)
+		assert.Equal(t, int64(2), gauges["conn_pool_active_connections"],
+			"pool should be pre-warmed to minConnections")
+	})
+}
+
+func TestConnectionPoolScaleUpOnLoad(t *testing.T) {
+	t.Parallel()
+	root := metrics.New()
+	withPoolTestEnv(t, []grpc.TransportOption{
+		grpc.WithDynamicConnectionScaling(true),
+		grpc.MinConnections(1),
+		grpc.MaxConnections(5),
+		grpc.MaxConcurrentStreams(2),
+		grpc.ScaleUpThreshold(0.5), // threshold = 1
+		grpc.Meter(root.Scope()),
+	}, func(set, _ func(ctx context.Context, key, value string) error) {
+		require.NoError(t, set(context.Background(), "foo", "bar"))
+
+		assert.Eventually(t, func() bool {
+			_, counters := extPoolMetricSnapshot(root)
+			return counters["conn_pool_scale_up_total"] >= 1
+		}, 3*time.Second, 10*time.Millisecond,
+			"conn_pool_scale_up_total should increment after load exceeds threshold")
+	})
+}
+
+func TestConnectionPoolConcurrentRequests(t *testing.T) {
+	t.Parallel()
+	withPoolTestEnv(t, []grpc.TransportOption{
+		grpc.WithDynamicConnectionScaling(true),
+		grpc.MinConnections(2),
+		grpc.MaxConnections(5),
+	}, func(set, _ func(ctx context.Context, key, value string) error) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		const concurrent = 20
+		errs := make([]error, concurrent)
+		var wg sync.WaitGroup
+		wg.Add(concurrent)
+		for i := range concurrent {
+			go func() {
+				defer wg.Done()
+				errs[i] = set(ctx, fmt.Sprintf("key-%d", i), "value")
+			}()
+		}
+		wg.Wait()
+		for i, err := range errs {
+			assert.NoError(t, err, "request %d should succeed", i)
+		}
+	})
+}
+
+func TestConnectionPoolDisabledFallback(t *testing.T) {
+	t.Parallel()
+	withPoolTestEnv(t, []grpc.TransportOption{
+		grpc.WithDynamicConnectionScaling(false),
+	}, func(set, get func(ctx context.Context, key, value string) error) {
+		ctx := context.Background()
+		require.NoError(t, set(ctx, "foo", "bar"))
+		require.NoError(t, get(ctx, "foo", ""))
+	})
+}
+
+func TestConnectionPoolMinimalSingleConnection(t *testing.T) {
+	t.Parallel()
+	root := metrics.New()
+	withPoolTestEnv(t, []grpc.TransportOption{
+		grpc.WithDynamicConnectionScaling(true),
+		grpc.MinConnections(1),
+		grpc.MaxConnections(3),
+		grpc.Meter(root.Scope()),
+	}, func(set, get func(ctx context.Context, key, value string) error) {
+		ctx := context.Background()
+		require.NoError(t, set(ctx, "foo", "bar"))
+		require.NoError(t, get(ctx, "foo", ""))
+
+		gauges, _ := extPoolMetricSnapshot(root)
+		assert.GreaterOrEqual(t, gauges["conn_pool_active_connections"], int64(1))
+	})
+}
+
+func TestConnectionPoolMaxConnectionsCapRespected(t *testing.T) {
+	t.Parallel()
+	root := metrics.New()
+	withPoolTestEnv(t, []grpc.TransportOption{
+		grpc.WithDynamicConnectionScaling(true),
+		grpc.MinConnections(1),
+		grpc.MaxConnections(1),
+		grpc.MaxConcurrentStreams(2),
+		grpc.ScaleUpThreshold(0.5),
+		grpc.Meter(root.Scope()),
+	}, func(set, get func(ctx context.Context, key, value string) error) {
+		ctx := context.Background()
+		require.NoError(t, set(ctx, "foo", "bar"))
+		require.NoError(t, get(ctx, "foo", ""))
+
+		assert.Eventually(t, func() bool {
+			_, counters := extPoolMetricSnapshot(root)
+			return counters["conn_pool_scale_up_total"] == 0
+		}, 2*time.Second, 10*time.Millisecond,
+			"scale-up must not dial when MaxConnections is already reached")
+
+		gauges, _ := extPoolMetricSnapshot(root)
+		assert.Equal(t, int64(1), gauges["conn_pool_active_connections"])
+	})
 }

--- a/transport/grpc/integration_test.go
+++ b/transport/grpc/integration_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 	"go.uber.org/multierr"
+	"go.uber.org/net/metrics"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	yarpctls "go.uber.org/yarpc/api/transport/tls"
@@ -1040,5 +1041,155 @@ func TestYARPCErrorsConverted(t *testing.T) {
 
 		require.Error(t, err)
 		assert.True(t, yarpcerrors.IsUnimplemented(err))
+	})
+}
+
+// --- connection pool integration tests ---
+
+// poolMetricSnapshot reads all gauges and counters from a RootSnapshot into
+// convenient maps keyed by metric name.
+func poolMetricSnapshot(root *metrics.Root) (gauges, counters map[string]int64) {
+	snap := root.Snapshot()
+	gauges = make(map[string]int64, len(snap.Gauges))
+	for _, g := range snap.Gauges {
+		gauges[g.Name] = g.Value
+	}
+	counters = make(map[string]int64, len(snap.Counters))
+	for _, c := range snap.Counters {
+		counters[c.Name] = c.Value
+	}
+	return gauges, counters
+}
+
+// TestConnectionPoolScaleDown verifies that evaluateScaling drains a
+// connection when the aggregate stream load is low enough that the pool can
+// be reduced.  We call evaluateScaling() directly to bypass the 30-second
+// monitor interval.
+func TestConnectionPoolScaleDown(t *testing.T) {
+	t.Parallel()
+	root := metrics.New()
+	te := testEnvOptions{
+		TransportOptions: []TransportOption{
+			WithDynamicConnectionScaling(true),
+			MinConnections(1),
+			MaxConnections(5),
+			MaxConcurrentStreams(100),
+			ScaleUpThreshold(0.8), // threshold = 80
+			Meter(root.Scope()),
+		},
+	}
+	te.do(t, func(t *testing.T, e *testEnv) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		apiPeer, onFinish, err := e.Outbound.peerChooser.Choose(ctx, &transport.Request{})
+		require.NoError(t, err)
+		defer onFinish(nil)
+		p := apiPeer.(*grpcPeer)
+
+		// Grow the pool to 3 connections (minConnections=1 so scale-down is allowed).
+		require.NoError(t, p.addConn())
+		require.NoError(t, p.addConn())
+
+		// With 3 active connections, 0 total streams, and
+		// capacityAfterDrain = threshold*(3-1) = 80*2 = 160 > 0,
+		// maybeScaleDown must drain the most-loaded connection.
+		p.evaluateScaling()
+
+		gauges, counters := poolMetricSnapshot(root)
+		assert.Equal(t, int64(1), counters["conn_pool_scale_down_total"],
+			"scale-down counter should increment")
+		assert.Equal(t, int64(2), gauges["conn_pool_active_connections"])
+		assert.Equal(t, int64(1), gauges["conn_pool_draining_connections"])
+	})
+}
+
+// TestConnectionPoolIdleReactivation verifies that tryScaleUp reactivates an
+// idle connection instead of dialling a new one when capacity is needed.
+func TestConnectionPoolIdleReactivation(t *testing.T) {
+	t.Parallel()
+	root := metrics.New()
+	te := testEnvOptions{
+		TransportOptions: []TransportOption{
+			WithDynamicConnectionScaling(true),
+			MinConnections(1),
+			MaxConnections(3),
+			MaxConcurrentStreams(2),
+			ScaleUpThreshold(0.5), // threshold = 1
+			Meter(root.Scope()),
+		},
+	}
+	te.do(t, func(t *testing.T, e *testEnv) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		apiPeer, onFinish, err := e.Outbound.peerChooser.Choose(ctx, &transport.Request{})
+		require.NoError(t, err)
+		defer onFinish(nil)
+		p := apiPeer.(*grpcPeer)
+
+		// Mark the initial connection as idle (live context, so reactivation is allowed).
+		p.loadConns()[0].setState(connStateIdle)
+
+		// tryScaleUp should reactivate the idle conn instead of dialling.
+		overBudget := makeConn(connStateActive, 85)
+		p.tryScaleUp(overBudget)
+
+		require.Eventually(t, func() bool {
+			return atomic.LoadInt32(&p.isScaling) == 0
+		}, 2*time.Second, 10*time.Millisecond)
+
+		_, counters := poolMetricSnapshot(root)
+		assert.Equal(t, int64(1), counters["conn_pool_idle_reactivation_total"],
+			"idle reactivation counter should increment")
+		assert.Equal(t, int64(0), counters["conn_pool_scale_up_total"],
+			"no new dial should happen when an idle conn is available")
+
+		assert.Equal(t, connStateActive, p.loadConns()[0].getState(),
+			"formerly idle conn should be active after reactivation")
+	})
+}
+
+// TestConnectionPoolNoActiveConnectionsReturnsUnavailable verifies that when
+// all pool connections are draining (non-active) and the YARPC peer is still
+// considered Available by the chooser, invoke() returns UnavailableErrorf
+// rather than hanging or panicking.
+//
+// Marking connections as connStateDraining (our internal state) does not
+// cancel their contexts, so monitorConnWrapper stays blocked in
+// WaitForStateChange and does not update the peer's YARPC status.  The
+// chooser therefore still returns the peer, but pickConn() finds no active
+// connections and the outbound returns UnavailableErrorf immediately.
+func TestConnectionPoolNoActiveConnectionsReturnsUnavailable(t *testing.T) {
+	t.Parallel()
+	te := testEnvOptions{
+		TransportOptions: []TransportOption{
+			WithDynamicConnectionScaling(true),
+			MinConnections(1),
+			MaxConnections(3),
+		},
+	}
+	te.do(t, func(t *testing.T, e *testEnv) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		// Obtain the peer reference then immediately release the chooser hold.
+		apiPeer, onFinish, err := e.Outbound.peerChooser.Choose(ctx, &transport.Request{})
+		require.NoError(t, err)
+		onFinish(nil)
+		p := apiPeer.(*grpcPeer)
+
+		// Mark every connection as draining without cancelling contexts.
+		// monitorConnWrapper goroutines remain blocked in WaitForStateChange,
+		// so the YARPC peer status stays Available — Choose will still return
+		// this peer, but pickConn() will find no active connections.
+		for _, c := range p.loadConns() {
+			c.setState(connStateDraining)
+		}
+
+		err = e.SetValueYARPC(ctx, "foo", "bar")
+		require.Error(t, err)
+		assert.True(t, yarpcerrors.IsUnavailable(err),
+			"expected UnavailableErrorf when all connections are draining, got: %v", err)
 	})
 }

--- a/transport/grpc/outbound_test.go
+++ b/transport/grpc/outbound_test.go
@@ -33,9 +33,9 @@ import (
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/peer/peertest"
 	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/peer/abstractpeer"
 	"go.uber.org/yarpc/yarpcerrors"
 	"google.golang.org/grpc"
-	"go.uber.org/yarpc/peer/abstractpeer"
 )
 
 // shared between Unary and Streaming InvalidHeaderValue tests.

--- a/transport/grpc/peer.go
+++ b/transport/grpc/peer.go
@@ -120,7 +120,7 @@ func (t *Transport) newPeer(address string, options *dialOptions) (*grpcPeer, er
 		}),
 		poolCfg: connPoolConfig{
 			dynamicScalingEnabled: t.options.clientConnPoolDynamicScalingEnabled,
-			maxConcurrentStreams:   t.options.clientConnPoolMaxConcurrentStreams,
+			maxConcurrentStreams:  t.options.clientConnPoolMaxConcurrentStreams,
 			scaleUpThreshold:      t.options.clientConnPoolScaleUpThreshold,
 			minConnections:        t.options.clientConnPoolMinConnections,
 			maxConnections:        t.options.clientConnPoolMaxConnections,
@@ -339,4 +339,3 @@ func grpcStatusToYARPCStatus(grpcStatus connectivity.State) peer.ConnectionStatu
 		return peer.Unavailable
 	}
 }
-

--- a/transport/grpc/peer_test.go
+++ b/transport/grpc/peer_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/net/metrics"
-	"go.uber.org/zap"
 	"go.uber.org/yarpc/api/backoff"
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
@@ -39,6 +38,7 @@ import (
 	"go.uber.org/yarpc/peer/abstractpeer"
 	"go.uber.org/yarpc/peer/hostport"
 	"go.uber.org/yarpc/peer/roundrobin"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
@@ -209,7 +209,7 @@ func peerForPool(t *testing.T) *grpcPeer {
 		},
 		poolCfg: connPoolConfig{
 			dynamicScalingEnabled: true,
-			maxConcurrentStreams:   100,
+			maxConcurrentStreams:  100,
 			scaleUpThreshold:      0.8, // threshold = 80
 			minConnections:        1,
 			maxConnections:        5,


### PR DESCRIPTION
## Summary
Adds integration tests for the gRPC connection pool across test packages : pool initialization, metric-verified scale-up, concurrent request safety, the disabled-flag fallback, a minimal single-connection pool, MaxConnections cap, scale-down (bypassing the 30s monitor via evaluateScaling()), idle-connection reactivation, and the UnavailableErrorf path when all connections are draining.          

## Testing
Tested locally via command :  `go test ./transport/grpc/... -run "TestConnectionPool" -v   `        
<img width="976" height="741" alt="Screenshot 2026-04-20 at 3 13 20 PM" src="https://github.com/user-attachments/assets/7acd2014-56f0-4dec-9242-bd28add90041" />

## Jira
[RPC-9691](https://t3.uberinternal.com/browse/RPC-9691)