### PR TITLE
Feature grpc connection pooling write atomic

### DIFF
--- a/transport/grpc/conn_pool_scaler_test.go
+++ b/transport/grpc/conn_pool_scaler_test.go
@@ -502,9 +502,7 @@ func TestTryScaleUp(t *testing.T) {
 		for i := range conns {
 			conns[i] = makeConn(connStateActive, 0)
 		}
-		p.wmu.Lock()
 		p.storeConns(conns)
-		p.wmu.Unlock()
 		p.tryScaleUp(overBudget)
 
 		// atMax check now runs inside the goroutine; wait for it to finish.
@@ -512,9 +510,7 @@ func TestTryScaleUp(t *testing.T) {
 			return atomic.LoadInt32(&p.isScaling) == 0
 		}, 2*time.Second, 10*time.Millisecond)
 
-		p.wmu.Lock()
 		n := len(p.loadConns())
-		p.wmu.Unlock()
 		assert.Equal(t, p.poolCfg.maxConnections, n, "pool should not grow beyond max")
 	})
 
@@ -537,9 +533,7 @@ func TestTryScaleUp(t *testing.T) {
 		}, 2*time.Second, 10*time.Millisecond, "isScaling should reset to 0 after goroutine completes")
 
 		// One connection was added to the pool.
-		p.wmu.Lock()
 		n := len(p.loadConns())
-		p.wmu.Unlock()
 		assert.Equal(t, 1, n, "one connection should be added to the pool")
 	})
 
@@ -553,9 +547,7 @@ func TestTryScaleUp(t *testing.T) {
 		idleConn := &grpcClientConnWrapper{ctx: ctx, cancel: cancel}
 		idleConn.setState(connStateIdle)
 		idleConn.setIdleNow()
-		p.wmu.Lock()
 		p.storeConns(append(p.loadConns(), idleConn))
-		p.wmu.Unlock()
 
 		p.tryScaleUp(overBudget)
 
@@ -564,9 +556,7 @@ func TestTryScaleUp(t *testing.T) {
 		}, 2*time.Second, 10*time.Millisecond)
 
 		// Pool size unchanged — reactivation, not a new dial.
-		p.wmu.Lock()
 		n := len(p.loadConns())
-		p.wmu.Unlock()
 		assert.Equal(t, 1, n, "pool size should not grow on reactivation")
 		assert.Equal(t, connStateActive, idleConn.getState(), "idle conn should be active after reactivation")
 		assert.True(t, idleConn.idleSince().IsZero(), "idle timestamp should be cleared")
@@ -715,14 +705,12 @@ func TestRefreshPoolMetrics(t *testing.T) {
 	t.Run("mixed pool reports correct counts", func(t *testing.T) {
 		t.Parallel()
 		p, root := peerWithMetrics(t)
-		p.wmu.Lock()
 		p.storeConns([]*grpcClientConnWrapper{
 			makeConn(connStateActive, 0),
 			makeConn(connStateActive, 0),
 			makeConn(connStateDraining, 0),
 			makeConn(connStateIdle, 0),
 		})
-		p.wmu.Unlock()
 
 		p.refreshPoolMetrics()
 
@@ -744,13 +732,11 @@ func TestMaybeScaleDownMetrics(t *testing.T) {
 		maxConcurrentStreams: 100,
 		scaleUpThreshold:     0.8, // threshold = 80
 	}
-	p.wmu.Lock()
 	p.storeConns([]*grpcClientConnWrapper{
 		makeConn(connStateActive, 10),
 		makeConn(connStateActive, 10),
 		makeConn(connStateActive, 10), // total 30 < capacityAfterDrain=160 → drain
 	})
-	p.wmu.Unlock()
 
 	p.maybeScaleDown()
 
@@ -796,9 +782,7 @@ func TestTryScaleUpReactivationMetrics(t *testing.T) {
 	defer cancel()
 	idleConn := &grpcClientConnWrapper{ctx: ctx, cancel: cancel}
 	idleConn.setState(connStateIdle)
-	p.wmu.Lock()
 	p.storeConns(append(p.loadConns(), idleConn))
-	p.wmu.Unlock()
 
 	overBudget := makeConn(connStateActive, 85)
 	p.tryScaleUp(overBudget)
@@ -823,12 +807,10 @@ func TestCleanupIdleConnsMetrics(t *testing.T) {
 
 	p, root := peerWithMetrics(t)
 	p.poolCfg = connPoolConfig{idleTimeout: time.Hour}
-	p.wmu.Lock()
 	p.storeConns([]*grpcClientConnWrapper{
 		makeConn(connStateActive, 5),
 		makeConn(connStateDraining, 0), // 0 streams → advances to idle
 	})
-	p.wmu.Unlock()
 
 	p.cleanupIdleConns()
 

--- a/transport/grpc/peer.go
+++ b/transport/grpc/peer.go
@@ -22,6 +22,7 @@ package grpc
 
 import (
 	"context"
+	"runtime"
 	"sync"
 	"sync/atomic"
 
@@ -56,17 +57,25 @@ type grpcPeer struct {
 
 	// connsPtr holds a pointer to the current immutable connection slice.
 	// Readers (pickConn, recomputeConnectionStatus, refreshPoolMetrics, etc.)
-	// do a single atomic.Pointer.Load() — no mutex acquired on the read path.
-	// Writers (addConn, removeConn) hold wmu, copy the slice, mutate, then
-	// atomically publish the new pointer.  Readers never block writers.
+	// do a single atomic.Pointer.Load() — no lock acquired on the read path.
+	// Writers (addConn, removeConn) use a CAS loop: load the current pointer,
+	// build the new slice, and CompareAndSwap. connCount is updated after a
+	// successful CAS.
 	connsPtr atomic.Pointer[[](*grpcClientConnWrapper)]
 
-	// wmu is a write-only mutex: only writers (addConn, removeConn) acquire it.
-	// Readers never touch wmu.
-	wmu sync.Mutex
+	// addingCount tracks addConn calls that have passed their entry point but
+	// have not yet called connWg.Add(1) or bailed. The lifecycle goroutine
+	// spins on this counter (after setting shutdownStarted) to guarantee that
+	// connWg.Wait is not called before any racing connWg.Add(1) completes.
+	addingCount atomic.Int32
+
+	// shutdownStarted is set to true when the peer begins shutting down.
+	// addConn checks this after incrementing addingCount to avoid calling
+	// connWg.Add(1) after the lifecycle goroutine has passed its spin.
+	shutdownStarted atomic.Bool
 
 	// connCount mirrors len(loadConns()) atomically so tryScaleUp can check the
-	// pool size without acquiring wmu.
+	// pool size without a full slice load.
 	connCount atomic.Int32
 
 	poolCfg connPoolConfig
@@ -83,7 +92,6 @@ func (p *grpcPeer) loadConns() []*grpcClientConnWrapper {
 }
 
 // storeConns atomically publishes a new connection slice and updates connCount.
-// Callers must hold wmu.
 func (p *grpcPeer) storeConns(conns []*grpcClientConnWrapper) {
 	p.connsPtr.Store(&conns)
 	p.connCount.Store(int32(len(conns)))
@@ -148,18 +156,14 @@ func (t *Transport) newPeer(address string, options *dialOptions) (*grpcPeer, er
 	}
 
 	// Close stoppedC once all monitorConnWrapper goroutines have finished.
-	// We acquire wmu briefly after ctx is cancelled to ensure any in-flight
-	// addConn() that passed its context check has already called connWg.Add(1)
-	// before we call connWg.Wait().
+	// shutdownStarted gates new connWg.Add(1) calls; addingCount ensures we
+	// wait for any addConn already past its ctx check before calling Wait.
 	go func() {
 		<-p.ctx.Done()
-		// Acquire wmu after cancellation to ensure any addConn() call that
-		// passed its ctx.Err() check has already called connWg.Add(1).
-		// The empty critical section is intentional: we need the barrier,
-		// not exclusive access to any data.
-		//lint:ignore SA2001 intentional empty critical section, provides memory barrier for connWg
-		p.wmu.Lock()
-		p.wmu.Unlock()
+		p.shutdownStarted.Store(true)
+		for p.addingCount.Load() > 0 {
+			runtime.Gosched()
+		}
 		p.connWg.Wait()
 		close(p.stoppedC)
 	}()
@@ -178,22 +182,32 @@ func (p *grpcPeer) addConn() error {
 	}
 	w := newConnWrapper(p.ctx, clientConn)
 
-	// Hold wmu while registering with connWg and publishing the new slice.
-	// The lifecycle goroutine acquires wmu after ctx is cancelled to observe
-	// any Add(1) that raced with cancellation.
-	p.wmu.Lock()
-	if p.ctx.Err() != nil {
-		p.wmu.Unlock()
+	// Enter the critical window: increment addingCount so the lifecycle
+	// goroutine's spin waits for us to either bail or call connWg.Add(1).
+	p.addingCount.Add(1)
+	if p.ctx.Err() != nil || p.shutdownStarted.Load() {
+		p.addingCount.Add(-1)
 		_ = clientConn.Close()
 		return p.ctx.Err()
 	}
 	p.connWg.Add(1)
-	old := p.loadConns()
-	next := make([]*grpcClientConnWrapper, len(old)+1)
-	copy(next, old)
-	next[len(old)] = w
-	p.storeConns(next)
-	p.wmu.Unlock()
+	p.addingCount.Add(-1)
+
+	// CAS loop: copy the slice, append the new wrapper, publish atomically.
+	for {
+		old := p.connsPtr.Load()
+		var oldSlice []*grpcClientConnWrapper
+		if old != nil {
+			oldSlice = *old
+		}
+		next := make([]*grpcClientConnWrapper, len(oldSlice)+1)
+		copy(next, oldSlice)
+		next[len(oldSlice)] = w
+		if p.connsPtr.CompareAndSwap(old, &next) {
+			p.connCount.Store(int32(len(next)))
+			break
+		}
+	}
 
 	go p.monitorConnWrapper(w)
 	p.refreshPoolMetrics()
@@ -268,16 +282,29 @@ func (p *grpcPeer) recomputeConnectionStatus() {
 }
 
 // removeConn removes a wrapper from the peer's connection pool.
+// Lock-free: uses a CAS loop to atomically publish the new slice.
 func (p *grpcPeer) removeConn(w *grpcClientConnWrapper) {
-	p.wmu.Lock()
-	defer p.wmu.Unlock()
-	old := p.loadConns()
-	for i, c := range old {
-		if c == w {
-			next := make([]*grpcClientConnWrapper, len(old)-1)
-			copy(next, old[:i])
-			copy(next[i:], old[i+1:])
-			p.storeConns(next)
+	for {
+		old := p.connsPtr.Load()
+		if old == nil {
+			return
+		}
+		oldSlice := *old
+		idx := -1
+		for i, c := range oldSlice {
+			if c == w {
+				idx = i
+				break
+			}
+		}
+		if idx < 0 {
+			return
+		}
+		next := make([]*grpcClientConnWrapper, len(oldSlice)-1)
+		copy(next, oldSlice[:idx])
+		copy(next[idx:], oldSlice[idx+1:])
+		if p.connsPtr.CompareAndSwap(old, &next) {
+			p.connCount.Store(int32(len(next)))
 			return
 		}
 	}

--- a/transport/grpc/peer_test.go
+++ b/transport/grpc/peer_test.go
@@ -23,6 +23,7 @@ package grpc
 import (
 	"context"
 	"net"
+	"runtime"
 	"testing"
 	"time"
 
@@ -353,15 +354,11 @@ func TestMonitorConnWrapperCleanup(t *testing.T) {
 	w := newConnWrapper(p.ctx, cc)
 
 	p.connWg.Add(1)
-	p.wmu.Lock()
 	p.storeConns(append(p.loadConns(), w))
-	p.wmu.Unlock()
 
 	go p.monitorConnWrapper(w)
 
-	p.wmu.Lock()
 	require.Len(t, p.loadConns(), 1)
-	p.wmu.Unlock()
 
 	p.cancel()
 
@@ -371,9 +368,7 @@ func TestMonitorConnWrapperCleanup(t *testing.T) {
 		t.Fatal("stoppedC not closed after context cancellation")
 	}
 
-	p.wmu.Lock()
 	assert.Empty(t, p.loadConns(), "wrapper should be removed from pool on cleanup")
-	p.wmu.Unlock()
 
 	wgDone := make(chan struct{})
 	go func() { p.connWg.Wait(); close(wgDone) }()
@@ -393,9 +388,10 @@ func TestStoppedCClosedAfterAllConnsFinish(t *testing.T) {
 
 	go func() {
 		<-p.ctx.Done()
-		//lint:ignore SA2001 intentional empty critical section, provides memory barrier for connWg
-		p.wmu.Lock()
-		p.wmu.Unlock()
+		p.shutdownStarted.Store(true)
+		for p.addingCount.Load() > 0 {
+			runtime.Gosched()
+		}
 		p.connWg.Wait()
 		close(p.stoppedC)
 	}()
@@ -404,9 +400,7 @@ func TestStoppedCClosedAfterAllConnsFinish(t *testing.T) {
 		cc := dialTestClientConn(t)
 		w := newConnWrapper(p.ctx, cc)
 		p.connWg.Add(1)
-		p.wmu.Lock()
 		p.storeConns(append(p.loadConns(), w))
-		p.wmu.Unlock()
 		go p.monitorConnWrapper(w)
 	}
 
@@ -480,9 +474,7 @@ func TestRecomputeConnectionStatus(t *testing.T) {
 		p := peerForPool(t)
 		cc := dialTestClientConn(t)
 		w := newConnWrapper(p.ctx, cc)
-		p.wmu.Lock()
 		p.storeConns(append(p.loadConns(), w))
-		p.wmu.Unlock()
 
 		p.recomputeConnectionStatus()
 
@@ -500,9 +492,7 @@ func TestRecomputeConnectionStatus(t *testing.T) {
 		cc := dialTestClientConn(t)
 		w := newConnWrapper(p.ctx, cc)
 		p.connWg.Add(1)
-		p.wmu.Lock()
 		p.storeConns(append(p.loadConns(), w))
-		p.wmu.Unlock()
 
 		go p.monitorConnWrapper(w)
 
@@ -537,9 +527,7 @@ func TestMonitorConnWrapperMetrics(t *testing.T) {
 	cc := dialTestClientConn(t)
 	w := newConnWrapper(p.ctx, cc)
 	p.connWg.Add(1)
-	p.wmu.Lock()
 	p.storeConns(append(p.loadConns(), w))
-	p.wmu.Unlock()
 
 	// Reflect the initial active connection in the gauges.
 	p.refreshPoolMetrics()


### PR DESCRIPTION
## Summary
Complete the lock-free conversion of grpcPeer by eliminating the last remaining mutex (wmu). The read path was already atomic after  #2475 .       

## Testing
- Unit Tests
- Tested locally. Works effectively (as noted by following metrics)
<img width="1020" height="347" alt="Screenshot 2026-05-18 at 2 42 47 PM" src="https://github.com/user-attachments/assets/7c5a8204-d00a-43bf-828e-1a5b87930d63" />





## Jira
[RPC-9691](https://t3.uberinternal.com/browse/RPC-9691)