### PR TITLE
Feature grpc connection pooling

### DIFF
--- a/transport/grpc/client_conn_wrapper.go
+++ b/transport/grpc/client_conn_wrapper.go
@@ -45,6 +45,9 @@ const (
 // connPoolConfig holds configuration for the per-peer connection pool.
 // Values are derived from transportOptions at peer creation time.
 type connPoolConfig struct {
+	// dynamicScalingEnabled gates all automatic connection-pool scaling.
+	// When false the pool is never grown or shrunk automatically.
+	dynamicScalingEnabled bool
 	// maxConcurrentStreams is the HTTP/2 SETTINGS_MAX_CONCURRENT_STREAMS
 	// value enforced by the server (default 250).
 	maxConcurrentStreams int32

--- a/transport/grpc/client_conn_wrapper.go
+++ b/transport/grpc/client_conn_wrapper.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package grpc
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	"google.golang.org/grpc"
+)
+
+// connState is the lifecycle state of a pooled gRPC connection.
+type connState int32
+
+const (
+	// connStateActive means the connection accepts new streams.
+	connStateActive connState = iota
+	// connStateDraining means the connection is no longer accepting new
+	// streams but is waiting for in-flight streams to complete.
+	connStateDraining
+	// connStateIdle means all streams have finished; the connection is
+	// waiting for the idle timeout before being closed.
+	connStateIdle
+)
+
+// connPoolConfig holds configuration for the per-peer connection pool.
+// Values are derived from transportOptions at peer creation time.
+type connPoolConfig struct {
+	// maxConcurrentStreams is the HTTP/2 SETTINGS_MAX_CONCURRENT_STREAMS
+	// value enforced by the server (default 250).
+	maxConcurrentStreams int32
+	// scaleUpThreshold is the fraction of maxConcurrentStreams at which a
+	// new connection is opened (e.g. 0.8 → scale up at 200 active streams).
+	scaleUpThreshold float64
+	// minConnections is the minimum number of connections kept in the pool.
+	minConnections int
+	// maxConnections is the maximum number of connections allowed in the pool.
+	maxConnections int
+	// idleTimeout is how long a drained connection stays idle before it is
+	// closed and removed from the pool.
+	idleTimeout time.Duration
+}
+
+// grpcClientConnWrapper wraps a single *grpc.ClientConn with connection-pool
+// metadata.  All fields that are accessed concurrently are updated atomically.
+type grpcClientConnWrapper struct {
+	clientConn *grpc.ClientConn
+
+	// ctx is derived from the peer's context.  Cancelling it stops this
+	// connection's monitor goroutine, which in turn closes clientConn.
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	// streamCount is the number of in-flight streams on this connection.
+	streamCount int32 // accessed atomically
+	// state is the current connState of this wrapper.
+	state connState // accessed atomically
+
+	createdAt      time.Time
+	lastIdleAtNano int64 // atomic unix nanos; set when transitioning to connStateIdle
+
+	// stoppedC is closed by the connection's monitor goroutine after the
+	// underlying clientConn has been closed.
+	stoppedC chan struct{}
+}
+
+func newConnWrapper(parentCtx context.Context, clientConn *grpc.ClientConn) *grpcClientConnWrapper {
+	ctx, cancel := context.WithCancel(parentCtx)
+	return &grpcClientConnWrapper{
+		clientConn: clientConn,
+		ctx:        ctx,
+		cancel:     cancel,
+		state:      connStateActive,
+		createdAt:  time.Now(),
+		stoppedC:   make(chan struct{}),
+	}
+}
+
+// incStreamCount atomically increments the active stream count.
+func (w *grpcClientConnWrapper) incStreamCount() {
+	atomic.AddInt32(&w.streamCount, 1)
+}
+
+// decStreamCount atomically decrements the active stream count.
+func (w *grpcClientConnWrapper) decStreamCount() {
+	atomic.AddInt32(&w.streamCount, -1)
+}
+
+// getStreamCount returns the current number of active streams.
+func (w *grpcClientConnWrapper) getStreamCount() int32 {
+	return atomic.LoadInt32(&w.streamCount)
+}
+
+// getState returns the current connection state.
+func (w *grpcClientConnWrapper) getState() connState {
+	return connState(atomic.LoadInt32((*int32)(&w.state)))
+}
+
+// setState atomically updates the connection state.
+func (w *grpcClientConnWrapper) setState(s connState) {
+	atomic.StoreInt32((*int32)(&w.state), int32(s))
+}
+
+// isActive reports whether the connection is currently accepting new streams.
+func (w *grpcClientConnWrapper) isActive() bool {
+	return w.getState() == connStateActive
+}
+
+// setIdleNow records the current time as the idle start time.
+func (w *grpcClientConnWrapper) setIdleNow() {
+	atomic.StoreInt64(&w.lastIdleAtNano, time.Now().UnixNano())
+}
+
+// idleSince returns the time when this connection entered the idle state,
+// or the zero time if it has not become idle yet.
+func (w *grpcClientConnWrapper) idleSince() time.Time {
+	ns := atomic.LoadInt64(&w.lastIdleAtNano)
+	if ns == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, ns)
+}

--- a/transport/grpc/client_conn_wrapper.go
+++ b/transport/grpc/client_conn_wrapper.go
@@ -40,6 +40,9 @@ const (
 	// connStateIdle means all streams have finished; the connection is
 	// waiting for the idle timeout before being closed.
 	connStateIdle
+	// connStateClosing means cleanupIdleConns has claimed this idle connection
+	// for closure via CAS.  No other goroutine may cancel or reactivate it.
+	connStateClosing
 )
 
 // connPoolConfig holds configuration for the per-peer connection pool.
@@ -54,6 +57,12 @@ type connPoolConfig struct {
 	// scaleUpThreshold is the fraction of maxConcurrentStreams at which a
 	// new connection is opened (e.g. 0.8 → scale up at 200 active streams).
 	scaleUpThreshold float64
+	// scaleDownGap is subtracted from scaleUpThreshold to derive the
+	// scale-down threshold, creating a hysteresis band that prevents
+	// oscillation when stream count hovers near the scale-up boundary.
+	// e.g. scaleUpThreshold=0.8, scaleDownGap=0.1 → drain only when load
+	// would fit within 70% of capacity on the reduced pool.
+	scaleDownGap float64
 	// minConnections is the minimum number of connections kept in the pool.
 	minConnections int
 	// maxConnections is the maximum number of connections allowed in the pool.
@@ -61,6 +70,9 @@ type connPoolConfig struct {
 	// idleTimeout is how long a drained connection stays idle before it is
 	// closed and removed from the pool.
 	idleTimeout time.Duration
+	// scalingMonitorInterval is how often the background monitor evaluates
+	// the pool for scale-down and idle cleanup.
+	scalingMonitorInterval time.Duration
 }
 
 // grpcClientConnWrapper wraps a single *grpc.ClientConn with connection-pool
@@ -121,6 +133,12 @@ func (w *grpcClientConnWrapper) getState() connState {
 // setState atomically updates the connection state.
 func (w *grpcClientConnWrapper) setState(s connState) {
 	atomic.StoreInt32((*int32)(&w.state), int32(s))
+}
+
+// transitionState atomically transitions the connection state from `from` to `to`.
+// Returns true if the transition succeeded, false if the state was not `from`.
+func (w *grpcClientConnWrapper) transitionState(from, to connState) bool {
+	return atomic.CompareAndSwapInt32((*int32)(&w.state), int32(from), int32(to))
 }
 
 // isActive reports whether the connection is currently accepting new streams.

--- a/transport/grpc/client_conn_wrapper_test.go
+++ b/transport/grpc/client_conn_wrapper_test.go
@@ -1,0 +1,193 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package grpc
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// newTestConnWrapper creates a grpcClientConnWrapper backed by a real (but
+// non-connected) *grpc.ClientConn suitable for unit tests.
+func newTestConnWrapper(t *testing.T) *grpcClientConnWrapper {
+	t.Helper()
+	cc, err := grpc.NewClient("passthrough:///localhost:0", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cc.Close() })
+	return newConnWrapper(context.Background(), cc)
+}
+
+// TestNewConnWrapper verifies that newConnWrapper initialises all fields
+// correctly.
+func TestNewConnWrapper(t *testing.T) {
+	before := time.Now()
+	w := newTestConnWrapper(t)
+	after := time.Now()
+
+	assert.NotNil(t, w.clientConn)
+	assert.NotNil(t, w.ctx)
+	assert.NotNil(t, w.cancel)
+	assert.NotNil(t, w.stoppedC)
+	assert.Equal(t, connStateActive, w.getState())
+	assert.Equal(t, int32(0), w.getStreamCount())
+	assert.False(t, w.createdAt.Before(before), "createdAt should be >= before")
+	assert.False(t, w.createdAt.After(after), "createdAt should be <= after")
+}
+
+// TestConnStateConstants verifies the iota ordering that the rest of the pool
+// logic depends on.
+func TestConnStateConstants(t *testing.T) {
+	assert.Equal(t, connState(0), connStateActive)
+	assert.Equal(t, connState(1), connStateDraining)
+	assert.Equal(t, connState(2), connStateIdle)
+}
+
+// TestGetSetState verifies that setState and getState round-trip correctly for
+// all defined states.
+func TestGetSetState(t *testing.T) {
+	w := newTestConnWrapper(t)
+
+	for _, s := range []connState{connStateActive, connStateDraining, connStateIdle} {
+		w.setState(s)
+		assert.Equal(t, s, w.getState())
+	}
+}
+
+// TestIsActive verifies isActive returns true only when state is connStateActive.
+func TestIsActive(t *testing.T) {
+	w := newTestConnWrapper(t)
+
+	assert.True(t, w.isActive(), "newly created wrapper should be active")
+
+	w.setState(connStateDraining)
+	assert.False(t, w.isActive())
+
+	w.setState(connStateIdle)
+	assert.False(t, w.isActive())
+
+	w.setState(connStateActive)
+	assert.True(t, w.isActive())
+}
+
+// TestStreamCountIncDec verifies incStreamCount, decStreamCount, and
+// getStreamCount.
+func TestStreamCountIncDec(t *testing.T) {
+	w := newTestConnWrapper(t)
+
+	assert.Equal(t, int32(0), w.getStreamCount())
+
+	w.incStreamCount()
+	assert.Equal(t, int32(1), w.getStreamCount())
+
+	w.incStreamCount()
+	w.incStreamCount()
+	assert.Equal(t, int32(3), w.getStreamCount())
+
+	w.decStreamCount()
+	assert.Equal(t, int32(2), w.getStreamCount())
+
+	w.decStreamCount()
+	w.decStreamCount()
+	assert.Equal(t, int32(0), w.getStreamCount())
+}
+
+// TestStreamCountConcurrent verifies that inc/dec are safe under concurrent
+// access.
+func TestStreamCountConcurrent(t *testing.T) {
+	w := newTestConnWrapper(t)
+
+	const goroutines = 100
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 2)
+
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			w.incStreamCount()
+		}()
+		go func() {
+			defer wg.Done()
+			w.decStreamCount()
+		}()
+	}
+
+	wg.Wait()
+	assert.Equal(t, int32(0), w.getStreamCount())
+}
+
+// TestSetIdleNow verifies that setIdleNow records a timestamp and idleSince
+// returns it.
+func TestSetIdleNow(t *testing.T) {
+	w := newTestConnWrapper(t)
+
+	// Before setIdleNow, idleSince should return the zero time.
+	assert.True(t, w.idleSince().IsZero(), "idleSince should be zero before setIdleNow")
+
+	before := time.Now()
+	w.setIdleNow()
+	after := time.Now()
+
+	idle := w.idleSince()
+	assert.False(t, idle.IsZero())
+	assert.False(t, idle.Before(before.Truncate(time.Nanosecond)), "idleSince should be >= before")
+	assert.False(t, idle.After(after), "idleSince should be <= after")
+}
+
+// TestIdleSinceZeroBeforeSet verifies the zero-value branch in idleSince.
+func TestIdleSinceZeroBeforeSet(t *testing.T) {
+	w := newTestConnWrapper(t)
+	assert.Equal(t, time.Time{}, w.idleSince())
+}
+
+// TestContextCancelledOnCancel verifies that the context derived inside
+// newConnWrapper is cancelled when cancel() is called.
+func TestContextCancelledOnCancel(t *testing.T) {
+	w := newTestConnWrapper(t)
+
+	require.NoError(t, w.ctx.Err(), "context should not be cancelled initially")
+
+	w.cancel()
+
+	assert.ErrorIs(t, w.ctx.Err(), context.Canceled)
+}
+
+// TestContextInheritsParentCancellation verifies that cancelling the parent
+// context also cancels the wrapper's context.
+func TestContextInheritsParentCancellation(t *testing.T) {
+	parent, cancel := context.WithCancel(context.Background())
+
+	cc, err := grpc.NewClient("passthrough:///localhost:0", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cc.Close() })
+
+	w := newConnWrapper(parent, cc)
+
+	require.NoError(t, w.ctx.Err())
+	cancel()
+	assert.ErrorIs(t, w.ctx.Err(), context.Canceled)
+}

--- a/transport/grpc/client_conn_wrapper_test.go
+++ b/transport/grpc/client_conn_wrapper_test.go
@@ -23,6 +23,7 @@ package grpc
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -65,6 +66,7 @@ func TestConnStateConstants(t *testing.T) {
 	assert.Equal(t, connState(0), connStateActive)
 	assert.Equal(t, connState(1), connStateDraining)
 	assert.Equal(t, connState(2), connStateIdle)
+	assert.Equal(t, connState(3), connStateClosing)
 }
 
 // TestGetSetState verifies that setState and getState round-trip correctly for
@@ -190,4 +192,48 @@ func TestContextInheritsParentCancellation(t *testing.T) {
 	require.NoError(t, w.ctx.Err())
 	cancel()
 	assert.ErrorIs(t, w.ctx.Err(), context.Canceled)
+}
+
+// TestTransitionState verifies transitionState performs atomic compare-and-swap correctly.
+func TestTransitionState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("succeeds when state matches", func(t *testing.T) {
+		t.Parallel()
+		w := newTestConnWrapper(t)
+		assert.Equal(t, connStateActive, w.getState())
+		assert.True(t, w.transitionState(connStateActive, connStateDraining))
+		assert.Equal(t, connStateDraining, w.getState())
+	})
+
+	t.Run("fails when state does not match", func(t *testing.T) {
+		t.Parallel()
+		w := newTestConnWrapper(t)
+		assert.False(t, w.transitionState(connStateDraining, connStateIdle), "transition should fail if current state is not 'from'")
+		assert.Equal(t, connStateActive, w.getState(), "state must be unchanged on transition failure")
+	})
+
+	t.Run("only one of two concurrent transitions succeeds", func(t *testing.T) {
+		t.Parallel()
+		w := newTestConnWrapper(t)
+		w.setState(connStateIdle)
+
+		var wins int32
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			if w.transitionState(connStateIdle, connStateActive) {
+				atomic.AddInt32(&wins, 1)
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			if w.transitionState(connStateIdle, connStateClosing) {
+				atomic.AddInt32(&wins, 1)
+			}
+		}()
+		wg.Wait()
+		assert.Equal(t, int32(1), atomic.LoadInt32(&wins), "exactly one transition must win")
+	})
 }

--- a/transport/grpc/config.go
+++ b/transport/grpc/config.go
@@ -70,6 +70,13 @@ func TransportSpec(opts ...Option) yarpcconfig.TransportSpec {
 //	        max: 30s
 //	    clientMaxHeaderListSize: 1024
 //	    serverMaxHeaderListSize: 2048
+//	    clientConnectionPool:
+//	      dynamicScalingEnabled: true
+//	      maxConcurrentStreams: 250
+//	      scaleUpThreshold: 0.8
+//	      minConnections: 1
+//	      maxConnections: 10
+//	      idleTimeout: 5m
 //
 // All parameters of TransportConfig are optional. This section
 // may be omitted in the transports section.
@@ -88,6 +95,52 @@ type TransportConfig struct {
 	// incoming streams.
 	// See: https://pkg.go.dev/google.golang.org/grpc#NumStreamWorkers
 	NumStreamWorkers uint32 `config:"numStreamWorkers"`
+	// ClientConnectionPool configures the per-peer gRPC connection pool that
+	// enables dynamic scaling beyond the HTTP/2 250-stream-per-connection limit.
+	ClientConnectionPool ClientConnectionPoolConfig `config:"clientConnectionPool"`
+}
+
+// ClientConnectionPoolConfig configures the dynamic gRPC connection pool for all
+// peers on this transport.
+//
+//	transports:
+//	  grpc:
+//	    clientConnectionPool:
+//	      dynamicScalingEnabled: true   # enable background auto-scaling
+//	      maxConcurrentStreams: 250     # assumed server HTTP/2 stream limit
+//	      scaleUpThreshold: 0.8         # open a new conn at 80% utilization
+//	      minConnections: 1             # minimum connections per peer
+//	      maxConnections: 10            # maximum connections per peer
+//	      idleTimeout: 5m               # close idle connections after this duration
+type ClientConnectionPoolConfig struct {
+	// DynamicScalingEnabled enables the background connection scaling monitor.
+	// When true, YARPC automatically opens and drains connections based on
+	// stream utilization.  Disabled by default to allow controlled rollout.
+	DynamicScalingEnabled bool `config:"dynamicScalingEnabled"`
+
+	// MaxConcurrentStreams is the assumed HTTP/2 SETTINGS_MAX_CONCURRENT_STREAMS
+	// value enforced by the server.  YARPC uses this to decide when to open an
+	// additional connection.  Defaults to 250 (Go's net/http2 default).
+	MaxConcurrentStreams int32 `config:"maxConcurrentStreams"`
+
+	// ScaleUpThreshold is the fraction of MaxConcurrentStreams at which a
+	// new connection is opened (e.g. 0.8 → scale up at 200 active streams).
+	// Must be in the range (0, 1].  Defaults to 0.8.
+	ScaleUpThreshold float64 `config:"scaleUpThreshold"`
+
+	// MinConnections is the minimum number of connections kept per peer.
+	// Connections are pre-established up to this count at peer creation time.
+	// Defaults to 1.
+	MinConnections int `config:"minConnections"`
+
+	// MaxConnections is the maximum number of connections allowed per peer.
+	// Defaults to 5.
+	MaxConnections int `config:"maxConnections"`
+
+	// IdleTimeout is how long a fully-drained connection stays idle before
+	// YARPC closes it.
+	// Defaults to 15 minutes.
+	IdleTimeout time.Duration `config:"idleTimeout"`
 }
 
 // InboundConfig configures a gRPC Inbound.
@@ -342,12 +395,57 @@ func (t *transportSpec) buildTransport(transportConfig *TransportConfig, kit *ya
 	if transportConfig.NumStreamWorkers > 0 {
 		options = append(options, NumStreamWorkers(transportConfig.NumStreamWorkers))
 	}
+	// Connection pool options — only apply non-zero values so that
+	// programmatic TransportOption defaults set by the caller are not
+	// silently overridden by the zero value of an omitted YAML field.
+	cp := transportConfig.ClientConnectionPool
+	if cp.MinConnections < 0 {
+		return nil, fmt.Errorf("clientConnectionPool.minConnections must be non-negative, got %d", cp.MinConnections)
+	}
+	if cp.MaxConnections < 0 {
+		return nil, fmt.Errorf("clientConnectionPool.maxConnections must be non-negative, got %d", cp.MaxConnections)
+	}
+	if cp.MaxConcurrentStreams < 0 {
+		return nil, fmt.Errorf("clientConnectionPool.maxConcurrentStreams must be non-negative, got %d", cp.MaxConcurrentStreams)
+	}
+	if cp.ScaleUpThreshold < 0 || cp.ScaleUpThreshold > 1 {
+		return nil, fmt.Errorf("clientConnectionPool.scaleUpThreshold must be in [0, 1], got %v", cp.ScaleUpThreshold)
+	}
+	if cp.IdleTimeout < 0 {
+		return nil, fmt.Errorf("clientConnectionPool.idleTimeout must be non-negative, got %v", cp.IdleTimeout)
+	}
+	options = append(options, WithDynamicConnectionScaling(cp.DynamicScalingEnabled))
+	if cp.MaxConcurrentStreams > 0 {
+		options = append(options, MaxConcurrentStreams(cp.MaxConcurrentStreams))
+	}
+	if cp.ScaleUpThreshold > 0 {
+		options = append(options, ScaleUpThreshold(cp.ScaleUpThreshold))
+	}
+	if cp.MinConnections > 0 {
+		options = append(options, MinConnections(cp.MinConnections))
+	}
+	if cp.MaxConnections > 0 {
+		options = append(options, MaxConnections(cp.MaxConnections))
+	}
+	if cp.IdleTimeout > 0 {
+		options = append(options, ConnIdleTimeout(cp.IdleTimeout))
+	}
 	backoffStrategy, err := transportConfig.Backoff.Strategy()
 	if err != nil {
 		return nil, err
 	}
 	options = append(options, BackoffStrategy(backoffStrategy), ServiceName(kit.ServiceName()))
-	return newTransport(newTransportOptions(options)), nil
+	opts := newTransportOptions(options)
+	if opts.clientConnPoolMaxConnections < opts.clientConnPoolMinConnections {
+		return nil, fmt.Errorf("clientConnectionPool.maxConnections (%d) must be >= minConnections (%d)", opts.clientConnPoolMaxConnections, opts.clientConnPoolMinConnections)
+	}
+	if opts.clientConnPoolScaleUpThreshold <= 0 || opts.clientConnPoolScaleUpThreshold > 1 {
+		return nil, fmt.Errorf("clientConnectionPool.scaleUpThreshold must be in (0, 1], got %v", opts.clientConnPoolScaleUpThreshold)
+	}
+	if opts.clientConnPoolMaxConcurrentStreams < 1 {
+		return nil, fmt.Errorf("clientConnectionPool.maxConcurrentStreams must be at least 1, got %d", opts.clientConnPoolMaxConcurrentStreams)
+	}
+	return newTransport(opts), nil
 }
 
 func (t *transportSpec) buildInbound(inboundConfig *InboundConfig, tr transport.Transport, _ *yarpcconfig.Kit) (transport.Inbound, error) {

--- a/transport/grpc/config.go
+++ b/transport/grpc/config.go
@@ -106,17 +106,26 @@ type TransportConfig struct {
 //	transports:
 //	  grpc:
 //	    clientConnectionPool:
-//	      dynamicScalingEnabled: true   # enable background auto-scaling
+//	      dynamicScalingEnabled: false  # explicit opt-out (overrides central OC control)
 //	      maxConcurrentStreams: 250     # assumed server HTTP/2 stream limit
 //	      scaleUpThreshold: 0.8         # open a new conn at 80% utilization
+//	      scaleDownGap: 0.1             # hysteresis gap below scaleUpThreshold for drain decisions
 //	      minConnections: 1             # minimum connections per peer
 //	      maxConnections: 10            # maximum connections per peer
 //	      idleTimeout: 5m               # close idle connections after this duration
+//	      scalingMonitorInterval: 30s   # how often to evaluate scale-down and idle cleanup
 type ClientConnectionPoolConfig struct {
-	// DynamicScalingEnabled enables the background connection scaling monitor.
-	// When true, YARPC automatically opens and drains connections based on
-	// stream utilization.  Disabled by default to allow controlled rollout.
-	DynamicScalingEnabled bool `config:"dynamicScalingEnabled"`
+	// DynamicScalingEnabled controls the background connection scaling monitor.
+	// This field uses a pointer so that YAML "not set" and "explicitly false" can
+	// be distinguished:
+	//
+	//   - nil (field omitted from YAML): the central ObjectConfig value is used.
+	//   - false (explicitly set in YAML): always disabled, overrides ObjectConfig.
+	//   - true (explicitly set in YAML): ignored — enabling requires ObjectConfig.
+	//
+	// In practice, services should leave this field unset and rely on ObjectConfig.
+	// Set it to false only to explicitly opt out of dynamic scaling for this service.
+	DynamicScalingEnabled *bool `config:"dynamicScalingEnabled"`
 
 	// MaxConcurrentStreams is the assumed HTTP/2 SETTINGS_MAX_CONCURRENT_STREAMS
 	// value enforced by the server.  YARPC uses this to decide when to open an
@@ -127,6 +136,11 @@ type ClientConnectionPoolConfig struct {
 	// new connection is opened (e.g. 0.8 → scale up at 200 active streams).
 	// Must be in the range (0, 1].  Defaults to 0.8.
 	ScaleUpThreshold float64 `config:"scaleUpThreshold"`
+
+	// ScaleDownGap is the hysteresis gap subtracted from ScaleUpThreshold to
+	// derive the scale-down threshold.  Prevents oscillation when stream counts
+	// hover near the scale-up boundary.  Defaults to 0.1.
+	ScaleDownGap float64 `config:"scaleDownGap"`
 
 	// MinConnections is the minimum number of connections kept per peer.
 	// Connections are pre-established up to this count at peer creation time.
@@ -141,6 +155,11 @@ type ClientConnectionPoolConfig struct {
 	// YARPC closes it.
 	// Defaults to 15 minutes.
 	IdleTimeout time.Duration `config:"idleTimeout"`
+
+	// ScalingMonitorInterval is how often the background monitor evaluates
+	// the pool for scale-down and idle cleanup.
+	// Defaults to 30 seconds.
+	ScalingMonitorInterval time.Duration `config:"scalingMonitorInterval"`
 }
 
 // InboundConfig configures a gRPC Inbound.
@@ -411,15 +430,30 @@ func (t *transportSpec) buildTransport(transportConfig *TransportConfig, kit *ya
 	if cp.ScaleUpThreshold < 0 || cp.ScaleUpThreshold > 1 {
 		return nil, fmt.Errorf("clientConnectionPool.scaleUpThreshold must be in [0, 1], got %v", cp.ScaleUpThreshold)
 	}
+	if cp.ScaleDownGap < 0 || cp.ScaleDownGap >= 1 {
+		return nil, fmt.Errorf("clientConnectionPool.scaleDownGap must be in [0, 1), got %v", cp.ScaleDownGap)
+	}
 	if cp.IdleTimeout < 0 {
 		return nil, fmt.Errorf("clientConnectionPool.idleTimeout must be non-negative, got %v", cp.IdleTimeout)
 	}
-	options = append(options, WithDynamicConnectionScaling(cp.DynamicScalingEnabled))
+	if cp.ScalingMonitorInterval < 0 {
+		return nil, fmt.Errorf("clientConnectionPool.scalingMonitorInterval must be non-negative, got %v", cp.ScalingMonitorInterval)
+	}
+	// DynamicScalingEnabled is only applied when explicitly set to false in YAML,
+	// which acts as a service-level opt-out that overrides the central OC value.
+	// YAML true and YAML unset both leave the OC-provided programmatic option intact.
+	// This means: enabling requires OC to set it; services can only opt out via YAML.
+	if cp.DynamicScalingEnabled != nil && !*cp.DynamicScalingEnabled {
+		options = append(options, WithDynamicConnectionScaling(false))
+	}
 	if cp.MaxConcurrentStreams > 0 {
 		options = append(options, MaxConcurrentStreams(cp.MaxConcurrentStreams))
 	}
 	if cp.ScaleUpThreshold > 0 {
 		options = append(options, ScaleUpThreshold(cp.ScaleUpThreshold))
+	}
+	if cp.ScaleDownGap > 0 {
+		options = append(options, ScaleDownGap(cp.ScaleDownGap))
 	}
 	if cp.MinConnections > 0 {
 		options = append(options, MinConnections(cp.MinConnections))
@@ -429,6 +463,9 @@ func (t *transportSpec) buildTransport(transportConfig *TransportConfig, kit *ya
 	}
 	if cp.IdleTimeout > 0 {
 		options = append(options, ConnIdleTimeout(cp.IdleTimeout))
+	}
+	if cp.ScalingMonitorInterval > 0 {
+		options = append(options, ScalingMonitorInterval(cp.ScalingMonitorInterval))
 	}
 	backoffStrategy, err := transportConfig.Backoff.Strategy()
 	if err != nil {
@@ -441,6 +478,10 @@ func (t *transportSpec) buildTransport(transportConfig *TransportConfig, kit *ya
 	}
 	if opts.clientConnPoolScaleUpThreshold <= 0 || opts.clientConnPoolScaleUpThreshold > 1 {
 		return nil, fmt.Errorf("clientConnectionPool.scaleUpThreshold must be in (0, 1], got %v", opts.clientConnPoolScaleUpThreshold)
+	}
+	if opts.clientConnPoolScaleUpThreshold-opts.clientConnPoolScaleDownGap <= 0 {
+		return nil, fmt.Errorf("clientConnectionPool.scaleUpThreshold (%.2f) minus scaleDownGap (%.2f) must be > 0",
+			opts.clientConnPoolScaleUpThreshold, opts.clientConnPoolScaleDownGap)
 	}
 	if opts.clientConnPoolMaxConcurrentStreams < 1 {
 		return nil, fmt.Errorf("clientConnectionPool.maxConcurrentStreams must be at least 1, got %d", opts.clientConnPoolMaxConcurrentStreams)

--- a/transport/grpc/config_test.go
+++ b/transport/grpc/config_test.go
@@ -552,6 +552,99 @@ func TestTransportSpec(t *testing.T) {
 			},
 			wantErrors: []string{"outbound TLS enforced but outbound TLS config provider is nil"},
 		},
+		{
+			desc: "negative minConnections",
+			transportCfg: attrs{
+				"clientConnectionPool": attrs{
+					"minConnections": "-1",
+				},
+			},
+			outboundCfg: attrs{
+				"myservice": attrs{
+					TransportName: attrs{"address": "localhost:54580"},
+				},
+			},
+			wantErrors: []string{"clientConnectionPool.minConnections must be non-negative"},
+		},
+		{
+			desc: "negative maxConnections",
+			transportCfg: attrs{
+				"clientConnectionPool": attrs{
+					"maxConnections": "-1",
+				},
+			},
+			outboundCfg: attrs{
+				"myservice": attrs{
+					TransportName: attrs{"address": "localhost:54581"},
+				},
+			},
+			wantErrors: []string{"clientConnectionPool.maxConnections must be non-negative"},
+		},
+		{
+			desc: "maxConnections less than minConnections",
+			transportCfg: attrs{
+				"clientConnectionPool": attrs{
+					"minConnections": "5",
+					"maxConnections": "2",
+				},
+			},
+			outboundCfg: attrs{
+				"myservice": attrs{
+					TransportName: attrs{"address": "localhost:54582"},
+				},
+			},
+			wantErrors: []string{"clientConnectionPool.maxConnections (2) must be >= minConnections (5)"},
+		},
+		{
+			desc: "minConnections exceeds default maxConnections",
+			transportCfg: attrs{
+				"clientConnectionPool": attrs{
+					"minConnections": "10",
+				},
+			},
+			outboundCfg: attrs{
+				"myservice": attrs{
+					TransportName: attrs{"address": "localhost:54583"},
+				},
+			},
+			wantErrors: []string{"clientConnectionPool.maxConnections (5) must be >= minConnections (10)"},
+		},
+		{
+			desc: "scaleUpThreshold out of range",
+			transportCfg: attrs{
+				"clientConnectionPool": attrs{
+					"scaleUpThreshold": "1.5",
+				},
+			},
+			outboundCfg: attrs{
+				"myservice": attrs{
+					TransportName: attrs{"address": "localhost:54584"},
+				},
+			},
+			wantErrors: []string{"clientConnectionPool.scaleUpThreshold must be in [0, 1]"},
+		},
+		{
+			desc: "valid connection pool config",
+			transportCfg: attrs{
+				"clientConnectionPool": attrs{
+					"minConnections":       "2",
+					"maxConnections":       "8",
+					"scaleUpThreshold":     "0.7",
+					"maxConcurrentStreams": "200",
+					"idleTimeout":          "10m",
+				},
+			},
+			outboundCfg: attrs{
+				"myservice": attrs{
+					TransportName: attrs{"address": "localhost:54585"},
+				},
+			},
+			wantOutbounds: map[string]wantOutbound{
+				"myservice": {
+					Address: "localhost:54585",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/transport/grpc/config_test.go
+++ b/transport/grpc/config_test.go
@@ -811,13 +811,13 @@ func TestContextDialerOptionUsage(t *testing.T) {
 	require.True(t, ok, "expected a gRPC peer")
 
 	for {
-		state := grpcPeer.clientConn.GetState()
+		state := grpcPeer.conns[0].clientConn.GetState()
 		if state == connectivity.Ready {
 			break
 		}
-		grpcPeer.clientConn.WaitForStateChange(ctx, state)
+		grpcPeer.conns[0].clientConn.WaitForStateChange(ctx, state)
 	}
-	require.Equal(t, connectivity.Ready, grpcPeer.clientConn.GetState(), "expected gRPC connection in Ready state")
+	require.Equal(t, connectivity.Ready, grpcPeer.conns[0].clientConn.GetState(), "expected gRPC connection in Ready state")
 	require.Equal(t, 1, dialContextInvoked, "counter should increment by one from dialer invocation")
 }
 

--- a/transport/grpc/config_test.go
+++ b/transport/grpc/config_test.go
@@ -627,11 +627,13 @@ func TestTransportSpec(t *testing.T) {
 			desc: "valid connection pool config",
 			transportCfg: attrs{
 				"clientConnectionPool": attrs{
-					"minConnections":       "2",
-					"maxConnections":       "8",
-					"scaleUpThreshold":     "0.7",
-					"maxConcurrentStreams": "200",
-					"idleTimeout":          "10m",
+					"minConnections":         "2",
+					"maxConnections":         "8",
+					"scaleUpThreshold":       "0.7",
+					"maxConcurrentStreams":   "200",
+					"idleTimeout":            "10m",
+					"scaleDownGap":           "0.1",
+					"scalingMonitorInterval": "60s",
 				},
 			},
 			outboundCfg: attrs{
@@ -643,6 +645,130 @@ func TestTransportSpec(t *testing.T) {
 				"myservice": {
 					Address: "localhost:54585",
 				},
+			},
+		},
+		{
+			desc: "negative scaleDownGap rejected",
+			transportCfg: attrs{
+				"clientConnectionPool": attrs{
+					"scaleDownGap": "-0.1",
+				},
+			},
+			outboundCfg: attrs{
+				"myservice": attrs{
+					TransportName: attrs{"address": "localhost:54586"},
+				},
+			},
+			wantErrors: []string{"clientConnectionPool.scaleDownGap must be in [0, 1)"},
+		},
+		{
+			desc: "scaleDownGap >= 1 rejected",
+			transportCfg: attrs{
+				"clientConnectionPool": attrs{
+					"scaleDownGap": "1.0",
+				},
+			},
+			outboundCfg: attrs{
+				"myservice": attrs{
+					TransportName: attrs{"address": "localhost:54587"},
+				},
+			},
+			wantErrors: []string{"clientConnectionPool.scaleDownGap must be in [0, 1)"},
+		},
+		{
+			desc: "scaleDownGap eliminates positive scale-down threshold",
+			transportCfg: attrs{
+				"clientConnectionPool": attrs{
+					"scaleUpThreshold": "0.8",
+					"scaleDownGap":     "0.85",
+				},
+			},
+			outboundCfg: attrs{
+				"myservice": attrs{
+					TransportName: attrs{"address": "localhost:54588"},
+				},
+			},
+			wantErrors: []string{"scaleUpThreshold"},
+		},
+		{
+			desc: "negative scalingMonitorInterval rejected",
+			transportCfg: attrs{
+				"clientConnectionPool": attrs{
+					"scalingMonitorInterval": "-30s",
+				},
+			},
+			outboundCfg: attrs{
+				"myservice": attrs{
+					TransportName: attrs{"address": "localhost:54589"},
+				},
+			},
+			wantErrors: []string{"clientConnectionPool.scalingMonitorInterval must be non-negative"},
+		},
+		{
+			desc: "scalingMonitorInterval below 30s is clamped with a warning (no error)",
+			transportCfg: attrs{
+				"clientConnectionPool": attrs{
+					"scalingMonitorInterval": "10s",
+				},
+			},
+			outboundCfg: attrs{
+				"myservice": attrs{
+					TransportName: attrs{"address": "localhost:54590"},
+				},
+			},
+			wantOutbounds: map[string]wantOutbound{
+				"myservice": {Address: "localhost:54590"},
+			},
+		},
+		{
+			desc: "YAML dynamicScalingEnabled:true is ignored (OC controls enabling)",
+			// YAML true alone must not enable dynamic scaling — only OC can.
+			// The transport should build successfully; enabling is via programmatic option.
+			transportCfg: attrs{
+				"clientConnectionPool": attrs{
+					"dynamicScalingEnabled": true,
+					"maxConnections":        "2",
+				},
+			},
+			outboundCfg: attrs{
+				"myservice": attrs{
+					TransportName: attrs{"address": "localhost:54591"},
+				},
+			},
+			wantOutbounds: map[string]wantOutbound{
+				"myservice": {Address: "localhost:54591"},
+			},
+		},
+		{
+			desc: "YAML dynamicScalingEnabled:false overrides a programmatic true (explicit opt-out)",
+			// opts sets dynamic scaling true (simulating OC); YAML false must override it.
+			opts: []Option{WithDynamicConnectionScaling(true)},
+			transportCfg: attrs{
+				"clientConnectionPool": attrs{
+					"dynamicScalingEnabled": false,
+				},
+			},
+			outboundCfg: attrs{
+				"myservice": attrs{
+					TransportName: attrs{"address": "localhost:54592"},
+				},
+			},
+			wantOutbounds: map[string]wantOutbound{
+				"myservice": {Address: "localhost:54592"},
+			},
+		},
+		{
+			desc: "YAML dynamicScalingEnabled unset does not override a programmatic true",
+			// opts sets dynamic scaling true (simulating OC); YAML omits the field.
+			// The programmatic true must survive.
+			opts: []Option{WithDynamicConnectionScaling(true)},
+			outboundCfg: attrs{
+				"myservice": attrs{
+					TransportName: attrs{"address": "localhost:54593"},
+				},
+			},
+			wantOutbounds: map[string]wantOutbound{
+				"myservice": {Address: "localhost:54593"},
 			},
 		},
 	}

--- a/transport/grpc/config_test.go
+++ b/transport/grpc/config_test.go
@@ -811,13 +811,13 @@ func TestContextDialerOptionUsage(t *testing.T) {
 	require.True(t, ok, "expected a gRPC peer")
 
 	for {
-		state := grpcPeer.conns[0].clientConn.GetState()
+		state := grpcPeer.loadConns()[0].clientConn.GetState()
 		if state == connectivity.Ready {
 			break
 		}
-		grpcPeer.conns[0].clientConn.WaitForStateChange(ctx, state)
+		grpcPeer.loadConns()[0].clientConn.WaitForStateChange(ctx, state)
 	}
-	require.Equal(t, connectivity.Ready, grpcPeer.conns[0].clientConn.GetState(), "expected gRPC connection in Ready state")
+	require.Equal(t, connectivity.Ready, grpcPeer.loadConns()[0].clientConn.GetState(), "expected gRPC connection in Ready state")
 	require.Equal(t, 1, dialContextInvoked, "counter should increment by one from dialer invocation")
 }
 

--- a/transport/grpc/conn_pool_metrics.go
+++ b/transport/grpc/conn_pool_metrics.go
@@ -139,25 +139,43 @@ func newConnPoolMetrics(p connPoolMetricsParams) *connPoolMetrics {
 }
 
 func (m *connPoolMetrics) setConnectionCount(n int64) {
+	if m == nil || m.connectionCount == nil {
+		return
+	}
 	m.connectionCount.Store(n)
 }
 
 func (m *connPoolMetrics) setDrainingConnectionCount(n int64) {
+	if m == nil || m.drainingConnectionCount == nil {
+		return
+	}
 	m.drainingConnectionCount.Store(n)
 }
 
 func (m *connPoolMetrics) setIdleConnectionCount(n int64) {
+	if m == nil || m.idleConnectionCount == nil {
+		return
+	}
 	m.idleConnectionCount.Store(n)
 }
 
 func (m *connPoolMetrics) incScaleUp() {
+	if m == nil || m.scaleUpTotal == nil {
+		return
+	}
 	m.scaleUpTotal.Inc()
 }
 
 func (m *connPoolMetrics) incScaleDown() {
+	if m == nil || m.scaleDownTotal == nil {
+		return
+	}
 	m.scaleDownTotal.Inc()
 }
 
 func (m *connPoolMetrics) incIdleReactivation() {
+	if m == nil || m.idleReactivationTotal == nil {
+		return
+	}
 	m.idleReactivationTotal.Inc()
 }

--- a/transport/grpc/conn_pool_metrics.go
+++ b/transport/grpc/conn_pool_metrics.go
@@ -1,0 +1,163 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package grpc
+
+import (
+	"go.uber.org/net/metrics"
+	"go.uber.org/zap"
+)
+
+// Tags for the connection pool metrics.
+const (
+	_componentTag = "component"
+	_serviceTag   = "service"
+	_transportTag = "transport"
+	_peerTag      = "peer"
+)
+
+// Tag values for the connection pool metrics.
+const (
+	_componentTagValueYarpc = "yarpc"
+	_transportTagValueGrpc  = "grpc"
+)
+
+// connPoolMetricsParams holds parameters needed for creating connection pool metrics.
+type connPoolMetricsParams struct {
+	Meter       *metrics.Scope
+	Logger      *zap.Logger
+	ServiceName string
+	Peer        string
+}
+
+// connPoolMetrics holds metric handles for the gRPC connection pool.
+type connPoolMetrics struct {
+	// connectionCount is the number of active connections accepting new streams.
+	connectionCount *metrics.Gauge
+	// drainingConnectionCount is the number of connections that are no longer
+	// accepting new streams but still have in-flight streams completing.
+	drainingConnectionCount *metrics.Gauge
+	// idleConnectionCount is the number of connections with zero streams,
+	// waiting for the idle timeout before being closed.
+	idleConnectionCount *metrics.Gauge
+	// scaleUpTotal counts the number of times a new connection was opened.
+	scaleUpTotal *metrics.Counter
+	// scaleDownTotal counts the number of times a connection was marked for draining.
+	scaleDownTotal *metrics.Counter
+	// idleReactivationTotal counts the number of times a draining connection
+	// was reactivated rather than opening a new one.
+	idleReactivationTotal *metrics.Counter
+}
+
+// newConnPoolMetrics creates metric handles scoped to the given peer address.
+func newConnPoolMetrics(p connPoolMetricsParams) *connPoolMetrics {
+	m := &connPoolMetrics{}
+	if p.Meter == nil {
+		return m
+	}
+
+	tags := metrics.Tags{
+		_componentTag: _componentTagValueYarpc,
+		_serviceTag:   p.ServiceName,
+		_transportTag: _transportTagValueGrpc,
+		_peerTag:      p.Peer,
+	}
+
+	var err error
+	m.connectionCount, err = p.Meter.Gauge(metrics.Spec{
+		Name:      "conn_pool_active_connections",
+		Help:      "Number of active connections accepting new streams for this peer.",
+		ConstTags: tags,
+	})
+	if err != nil {
+		p.Logger.Error("failed to create active connections gauge", zap.Error(err))
+	}
+
+	m.drainingConnectionCount, err = p.Meter.Gauge(metrics.Spec{
+		Name:      "conn_pool_draining_connections",
+		Help:      "Number of connections draining in-flight streams for this peer.",
+		ConstTags: tags,
+	})
+	if err != nil {
+		p.Logger.Error("failed to create draining connections gauge", zap.Error(err))
+	}
+
+	m.idleConnectionCount, err = p.Meter.Gauge(metrics.Spec{
+		Name:      "conn_pool_idle_connections",
+		Help:      "Number of idle connections waiting for timeout before closing for this peer.",
+		ConstTags: tags,
+	})
+	if err != nil {
+		p.Logger.Error("failed to create idle connections gauge", zap.Error(err))
+	}
+
+	m.scaleUpTotal, err = p.Meter.Counter(metrics.Spec{
+		Name:      "conn_pool_scale_up_total",
+		Help:      "Total number of times the pool opened a new connection for this peer.",
+		ConstTags: tags,
+	})
+	if err != nil {
+		p.Logger.Error("failed to create scale up counter", zap.Error(err))
+	}
+
+	m.scaleDownTotal, err = p.Meter.Counter(metrics.Spec{
+		Name:      "conn_pool_scale_down_total",
+		Help:      "Total number of times the pool marked a connection for draining for this peer.",
+		ConstTags: tags,
+	})
+	if err != nil {
+		p.Logger.Error("failed to create scale down counter", zap.Error(err))
+	}
+
+	m.idleReactivationTotal, err = p.Meter.Counter(metrics.Spec{
+		Name:      "conn_pool_idle_reactivation_total",
+		Help:      "Total number of times an idle connection was reactivated instead of opening a new one.",
+		ConstTags: tags,
+	})
+	if err != nil {
+		p.Logger.Error("failed to create idle reactivation counter", zap.Error(err))
+	}
+
+	return m
+}
+
+func (m *connPoolMetrics) setConnectionCount(n int64) {
+	m.connectionCount.Store(n)
+}
+
+func (m *connPoolMetrics) setDrainingConnectionCount(n int64) {
+	m.drainingConnectionCount.Store(n)
+}
+
+func (m *connPoolMetrics) setIdleConnectionCount(n int64) {
+	m.idleConnectionCount.Store(n)
+}
+
+func (m *connPoolMetrics) incScaleUp() {
+	m.scaleUpTotal.Inc()
+}
+
+func (m *connPoolMetrics) incScaleDown() {
+	m.scaleDownTotal.Inc()
+}
+
+func (m *connPoolMetrics) incIdleReactivation() {
+	m.idleReactivationTotal.Inc()
+}

--- a/transport/grpc/conn_pool_metrics_test.go
+++ b/transport/grpc/conn_pool_metrics_test.go
@@ -210,3 +210,17 @@ func TestNewConnPoolMetrics_LogsRegistrationErrors(t *testing.T) {
 
 	assert.NotZero(t, logs.Len(), "expected error logs for duplicate metric registration")
 }
+
+// TestConnPoolMetrics_NilReceiver verifies that calling any method on a nil
+// *connPoolMetrics pointer does not panic.
+func TestConnPoolMetrics_NilReceiver(t *testing.T) {
+	var m *connPoolMetrics
+	assert.NotPanics(t, func() {
+		m.incScaleUp()
+		m.incScaleDown()
+		m.incIdleReactivation()
+		m.setConnectionCount(5)
+		m.setDrainingConnectionCount(3)
+		m.setIdleConnectionCount(1)
+	})
+}

--- a/transport/grpc/conn_pool_metrics_test.go
+++ b/transport/grpc/conn_pool_metrics_test.go
@@ -1,0 +1,212 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package grpc
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/net/metrics"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func testMetricsParams(scope *metrics.Scope) connPoolMetricsParams {
+	return connPoolMetricsParams{
+		Meter:       scope,
+		Logger:      zap.NewNop(),
+		ServiceName: "test-svc",
+		Peer:        "10.0.0.1:8080",
+	}
+}
+
+func TestNewConnPoolMetrics_NilScope(t *testing.T) {
+	m := newConnPoolMetrics(testMetricsParams(nil))
+	require.NotNil(t, m)
+	assert.Nil(t, m.connectionCount)
+	assert.Nil(t, m.drainingConnectionCount)
+	assert.Nil(t, m.idleConnectionCount)
+	assert.Nil(t, m.scaleUpTotal)
+	assert.Nil(t, m.scaleDownTotal)
+	assert.Nil(t, m.idleReactivationTotal)
+
+	assert.NotPanics(t, func() {
+		m.incScaleUp()
+		m.incScaleDown()
+		m.incIdleReactivation()
+		m.setConnectionCount(5)
+		m.setDrainingConnectionCount(3)
+		m.setIdleConnectionCount(1)
+	})
+}
+
+func TestNewConnPoolMetrics_ValidScope(t *testing.T) {
+	root := metrics.New()
+	m := newConnPoolMetrics(testMetricsParams(root.Scope()))
+	require.NotNil(t, m)
+	assert.NotNil(t, m.connectionCount)
+	assert.NotNil(t, m.drainingConnectionCount)
+	assert.NotNil(t, m.idleConnectionCount)
+	assert.NotNil(t, m.scaleUpTotal)
+	assert.NotNil(t, m.scaleDownTotal)
+	assert.NotNil(t, m.idleReactivationTotal)
+}
+
+func TestConnPoolMetrics_CounterIncrements(t *testing.T) {
+	root := metrics.New()
+	m := newConnPoolMetrics(testMetricsParams(root.Scope()))
+
+	m.incScaleUp()
+	m.incScaleUp()
+	m.incScaleDown()
+	m.incIdleReactivation()
+	m.incIdleReactivation()
+	m.incIdleReactivation()
+
+	snap := root.Snapshot()
+	countersByName := make(map[string]int64)
+	for _, c := range snap.Counters {
+		countersByName[c.Name] = c.Value
+	}
+
+	assert.Equal(t, int64(2), countersByName["conn_pool_scale_up_total"])
+	assert.Equal(t, int64(1), countersByName["conn_pool_scale_down_total"])
+	assert.Equal(t, int64(3), countersByName["conn_pool_idle_reactivation_total"])
+}
+
+func TestConnPoolMetrics_GaugeValues(t *testing.T) {
+	root := metrics.New()
+	m := newConnPoolMetrics(testMetricsParams(root.Scope()))
+
+	m.setConnectionCount(5)
+	m.setDrainingConnectionCount(2)
+	m.setIdleConnectionCount(1)
+
+	snap := root.Snapshot()
+	gaugesByName := make(map[string]int64)
+	for _, g := range snap.Gauges {
+		gaugesByName[g.Name] = g.Value
+	}
+
+	assert.Equal(t, int64(5), gaugesByName["conn_pool_active_connections"])
+	assert.Equal(t, int64(2), gaugesByName["conn_pool_draining_connections"])
+	assert.Equal(t, int64(1), gaugesByName["conn_pool_idle_connections"])
+
+	m.setConnectionCount(10)
+	m.setDrainingConnectionCount(0)
+	m.setIdleConnectionCount(3)
+
+	snap = root.Snapshot()
+	gaugesByName = make(map[string]int64)
+	for _, g := range snap.Gauges {
+		gaugesByName[g.Name] = g.Value
+	}
+
+	assert.Equal(t, int64(10), gaugesByName["conn_pool_active_connections"])
+	assert.Equal(t, int64(0), gaugesByName["conn_pool_draining_connections"])
+	assert.Equal(t, int64(3), gaugesByName["conn_pool_idle_connections"])
+}
+
+func TestConnPoolMetrics_Tags(t *testing.T) {
+	root := metrics.New()
+	m := newConnPoolMetrics(testMetricsParams(root.Scope()))
+
+	m.incScaleUp()
+	m.setConnectionCount(1)
+
+	wantTags := map[string]string{
+		"component": "yarpc",
+		"service":   "test-svc",
+		"transport": "grpc",
+		// The metrics library sanitizes colons to underscores in tag values.
+		"peer": "10.0.0.1_8080",
+	}
+
+	snap := root.Snapshot()
+	for _, c := range snap.Counters {
+		for k, v := range wantTags {
+			assert.Equal(t, v, c.Tags[k], "counter %s: tag %q", c.Name, k)
+		}
+	}
+	for _, g := range snap.Gauges {
+		for k, v := range wantTags {
+			assert.Equal(t, v, g.Tags[k], "gauge %s: tag %q", g.Name, k)
+		}
+	}
+}
+
+func TestConnPoolMetrics_ConcurrentAccess(t *testing.T) {
+	root := metrics.New()
+	m := newConnPoolMetrics(testMetricsParams(root.Scope()))
+
+	const goroutines = 10
+	const iterations = 100
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				m.incScaleUp()
+				m.incScaleDown()
+				m.incIdleReactivation()
+				m.setConnectionCount(int64(j))
+				m.setDrainingConnectionCount(int64(j))
+				m.setIdleConnectionCount(int64(j))
+			}
+		}()
+	}
+	wg.Wait()
+
+	snap := root.Snapshot()
+	countersByName := make(map[string]int64)
+	for _, c := range snap.Counters {
+		countersByName[c.Name] = c.Value
+	}
+
+	assert.Equal(t, int64(goroutines*iterations), countersByName["conn_pool_scale_up_total"])
+	assert.Equal(t, int64(goroutines*iterations), countersByName["conn_pool_scale_down_total"])
+	assert.Equal(t, int64(goroutines*iterations), countersByName["conn_pool_idle_reactivation_total"])
+}
+
+func TestNewConnPoolMetrics_LogsRegistrationErrors(t *testing.T) {
+	root := metrics.New()
+	scope := root.Scope()
+	core, logs := observer.New(zap.ErrorLevel)
+	logger := zap.New(core)
+
+	params := connPoolMetricsParams{
+		Meter:       scope,
+		Logger:      logger,
+		ServiceName: "test-svc",
+		Peer:        "10.0.0.1:8080",
+	}
+
+	// Register the same metrics twice on the same scope+tags to trigger
+	// duplicate registration errors.
+	_ = newConnPoolMetrics(params)
+	_ = newConnPoolMetrics(params)
+
+	assert.NotZero(t, logs.Len(), "expected error logs for duplicate metric registration")
+}

--- a/transport/grpc/conn_pool_scaler.go
+++ b/transport/grpc/conn_pool_scaler.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package grpc
+
+import (
+	"time"
+)
+
+// _scalingMonitorInterval is how often the scaling monitor evaluates the pool.
+const _scalingMonitorInterval = 30 * time.Second
+
+// runScalingMonitor runs as a background goroutine for the lifetime of the
+// peer.  It periodically evaluates whether connections should be removed
+// from the pool.  It exits when the peer's context is cancelled.
+func (p *grpcPeer) runScalingMonitor() {
+	ticker := time.NewTicker(_scalingMonitorInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			p.evaluateScaling()
+		case <-p.ctx.Done():
+			return
+		}
+	}
+}
+
+func (p *grpcPeer) evaluateScaling() {
+	p.cleanupIdleConns()
+	p.maybeScaleDown()
+}
+
+// maybeScaleDown checks whether the pool can be reduced by one connection.
+// A connection is marked for draining when the remaining active connections
+// can absorb the current aggregate stream load without triggering another
+// scale-up.
+func (p *grpcPeer) maybeScaleDown() {
+	// TODO
+}
+
+// cleanupIdleConns advances draining connections with zero streams to the idle
+// state, and cancels connections that have exceeded the idle timeout so their
+// monitor goroutines can close and remove them.
+func (p *grpcPeer) cleanupIdleConns() {
+	// TODO
+}

--- a/transport/grpc/conn_pool_scaler.go
+++ b/transport/grpc/conn_pool_scaler.go
@@ -114,5 +114,39 @@ func (p *grpcPeer) maybeScaleDown() {
 // state, and cancels connections that have exceeded the idle timeout so their
 // monitor goroutines can close and remove them.
 func (p *grpcPeer) cleanupIdleConns() {
-	// TODO
+	now := time.Now()
+
+	// Use a read lock for the analysis phase
+	p.mu.RLock()
+	var drained []*grpcClientConnWrapper
+	var toClose []*grpcClientConnWrapper
+	for _, c := range p.conns {
+		if c.getState() == connStateDraining && c.getStreamCount() == 0 {
+			drained = append(drained, c)
+		} else if c.getState() == connStateIdle && !c.idleSince().IsZero() &&
+			now.Sub(c.idleSince()) >= p.poolCfg.idleTimeout {
+			toClose = append(toClose, c)
+		}
+	}
+	p.mu.RUnlock()
+
+	// Advance drained → idle with a brief write lock per connection.
+	for _, c := range drained {
+		p.mu.Lock()
+		if c.getState() == connStateDraining && c.getStreamCount() == 0 {
+			c.setState(connStateIdle)
+			c.setIdleNow()
+		}
+		p.mu.Unlock()
+	}
+
+	for _, c := range toClose {
+		p.t.options.logger.Debug("grpc: closing idle connection after timeout",
+			zap.String("peer", p.HostPort()),
+			zap.Duration("idle_duration", now.Sub(c.idleSince())))
+		// Cancelling the wrapper context causes monitorConnectionStatus to
+		// exit, which closes the underlying clientConn and removes the
+		// wrapper from p.conns.
+		c.cancel()
+	}
 }

--- a/transport/grpc/conn_pool_scaler.go
+++ b/transport/grpc/conn_pool_scaler.go
@@ -109,6 +109,8 @@ func (p *grpcPeer) maybeScaleDown() {
 	p.t.options.logger.Debug("grpc: marked connection for draining during scale-down",
 		zap.String("peer", p.HostPort()),
 		zap.Int32("stream_count", mostLoaded.getStreamCount()))
+	p.metrics.incScaleDown()
+	p.refreshPoolMetrics()
 }
 
 // cleanupIdleConns advances draining connections with zero streams to the idle
@@ -158,6 +160,10 @@ func (p *grpcPeer) cleanupIdleConns() {
 		// wrapper from p.conns.
 		c.cancel()
 	}
+
+	if len(drained) > 0 || len(toClose) > 0 {
+		p.refreshPoolMetrics()
+	}
 }
 
 // tryScaleUp triggers a background goroutine to satisfy the need for more
@@ -194,6 +200,8 @@ func (p *grpcPeer) tryScaleUp(leastLoadedConn *grpcClientConnWrapper) {
 		if p.reactivateIdleConn() {
 			p.t.options.logger.Debug("grpc: reactivated idle connection during scale-up",
 				zap.String("peer", p.HostPort()))
+			p.metrics.incIdleReactivation()
+			p.refreshPoolMetrics()
 			return
 		}
 
@@ -212,6 +220,7 @@ func (p *grpcPeer) tryScaleUp(leastLoadedConn *grpcClientConnWrapper) {
 		} else {
 			p.t.options.logger.Debug("grpc: scaled up connection pool",
 				zap.String("peer", p.HostPort()))
+			p.metrics.incScaleUp()
 		}
 	}()
 }
@@ -232,4 +241,25 @@ func (p *grpcPeer) reactivateIdleConn() bool {
 		}
 	}
 	return false
+}
+
+// refreshPoolMetrics scans the pool and updates the active, draining, and idle
+// connection gauges.  It must be called after any pool state transition.
+func (p *grpcPeer) refreshPoolMetrics() {
+	var active, draining, idle int64
+	p.mu.RLock()
+	for _, c := range p.conns {
+		switch c.getState() {
+		case connStateActive:
+			active++
+		case connStateDraining:
+			draining++
+		case connStateIdle:
+			idle++
+		}
+	}
+	p.mu.RUnlock()
+	p.metrics.setConnectionCount(active)
+	p.metrics.setDrainingConnectionCount(draining)
+	p.metrics.setIdleConnectionCount(idle)
 }

--- a/transport/grpc/conn_pool_scaler.go
+++ b/transport/grpc/conn_pool_scaler.go
@@ -21,6 +21,7 @@
 package grpc
 
 import (
+	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
@@ -113,7 +114,15 @@ func (p *grpcPeer) maybeScaleDown() {
 // cleanupIdleConns advances draining connections with zero streams to the idle
 // state, and cancels connections that have exceeded the idle timeout so their
 // monitor goroutines can close and remove them.
+// It skips closing idle connections while a scale-up is in progress so that
+// tryScaleUp can reactivate them instead of dialing a new connection.
 func (p *grpcPeer) cleanupIdleConns() {
+	// If a scale-up goroutine is running, hold off — idle connections may be
+	// reactivated by tryScaleUp instead of being closed.
+	if atomic.LoadInt32(&p.isScaling) == 1 {
+		return
+	}
+
 	now := time.Now()
 
 	// Use a read lock for the analysis phase
@@ -149,4 +158,78 @@ func (p *grpcPeer) cleanupIdleConns() {
 		// wrapper from p.conns.
 		c.cancel()
 	}
+}
+
+// tryScaleUp triggers a background goroutine to satisfy the need for more
+// connection capacity.  It receives leastLoadedConn — the connection with the
+// fewest active streams, as selected by pickConn.  If even the least-loaded
+// connection is at or above the scale-up threshold then all connections are
+// over budget and the pool needs to grow.  It first tries to reactivate an
+// existing idle connection (avoiding a new dial); only if none are available
+// does it open a new connection, subject to the maxConnections cap.
+// p.isScaling is atomically set to 1 on entry (via CAS) and reset to 0 when
+// the goroutine finishes — this serves a dual purpose: it ensures at most one
+// scale-up goroutine runs at a time, and it signals cleanupIdleConns to hold
+// off closing idle connections while a reactivation may be in progress.
+func (p *grpcPeer) tryScaleUp(leastLoadedConn *grpcClientConnWrapper) {
+	if !p.poolCfg.dynamicScalingEnabled {
+		return
+	}
+
+	threshold := int32(float64(p.poolCfg.maxConcurrentStreams) * p.poolCfg.scaleUpThreshold)
+	if leastLoadedConn.getStreamCount() < threshold {
+		return
+	}
+
+	// Set isScaling to 1 (from 0) to claim the scale-up slot.
+	// If another goroutine already holds it, bail out.
+	if !atomic.CompareAndSwapInt32(&p.isScaling, 0, 1) {
+		return
+	}
+
+	go func() {
+		defer atomic.StoreInt32(&p.isScaling, 0)
+
+		// Prefer reactivating an idle connection over dialing a new one.
+		if p.reactivateIdleConn() {
+			p.t.options.logger.Debug("grpc: reactivated idle connection during scale-up",
+				zap.String("peer", p.HostPort()))
+			return
+		}
+
+		// No idle connection available; dial a new one if below the cap.
+		p.mu.RLock()
+		atMax := len(p.conns) >= p.poolCfg.maxConnections
+		p.mu.RUnlock()
+		if atMax {
+			return
+		}
+
+		if err := p.addConn(); err != nil {
+			p.t.options.logger.Warn("grpc: failed to scale up connection pool",
+				zap.String("peer", p.HostPort()),
+				zap.Error(err))
+		} else {
+			p.t.options.logger.Debug("grpc: scaled up connection pool",
+				zap.String("peer", p.HostPort()))
+		}
+	}()
+}
+
+// reactivateIdleConn finds the first idle connection whose context has not
+// yet been cancelled and transitions it back to active, avoiding an
+// unnecessary dial.  Returns true if a connection was reactivated.
+func (p *grpcPeer) reactivateIdleConn() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, c := range p.conns {
+		// Only reactivate if the connection context is still live; a cancelled
+		// context means cleanupIdleConns has already scheduled it for closure.
+		if c.getState() == connStateIdle && c.ctx.Err() == nil {
+			c.setState(connStateActive)
+			atomic.StoreInt64(&c.lastIdleAtNano, 0)
+			return true
+		}
+	}
+	return false
 }

--- a/transport/grpc/conn_pool_scaler.go
+++ b/transport/grpc/conn_pool_scaler.go
@@ -22,6 +22,8 @@ package grpc
 
 import (
 	"time"
+
+	"go.uber.org/zap"
 )
 
 // _scalingMonitorInterval is how often the scaling monitor evaluates the pool.
@@ -53,7 +55,59 @@ func (p *grpcPeer) evaluateScaling() {
 // can absorb the current aggregate stream load without triggering another
 // scale-up.
 func (p *grpcPeer) maybeScaleDown() {
-	// TODO
+	// Use a read lock for the analysis phase to avoid blocking concurrent
+	// request-path goroutines that also hold RLock when picking a connection.
+	p.mu.RLock()
+	active := make([]*grpcClientConnWrapper, 0, len(p.conns))
+	for _, c := range p.conns {
+		if c.isActive() {
+			active = append(active, c)
+		}
+	}
+
+	// Never drain below minConnections.
+	if len(active) <= p.poolCfg.minConnections {
+		p.mu.RUnlock()
+		return
+	}
+
+	threshold := int32(float64(p.poolCfg.maxConcurrentStreams) * p.poolCfg.scaleUpThreshold)
+
+	var totalStreams int32
+	for _, c := range active {
+		totalStreams += c.getStreamCount()
+	}
+
+	// Only drain if the remaining (n-1) connections can absorb current load
+	// without crossing the scale-up threshold.
+	capacityAfterDrain := threshold * int32(len(active)-1)
+	if totalStreams >= capacityAfterDrain {
+		p.mu.RUnlock()
+		return
+	}
+
+	// Drain the most-loaded active connection: this maximises residual
+	// stream capacity in the surviving connections, improving burst absorption.
+	var mostLoaded *grpcClientConnWrapper
+	for _, c := range active {
+		if mostLoaded == nil || c.getStreamCount() > mostLoaded.getStreamCount() {
+			mostLoaded = c
+		}
+	}
+	p.mu.RUnlock()
+
+	if mostLoaded == nil {
+		return
+	}
+
+	// Acquire the write lock only for the brief state mutation.
+	p.mu.Lock()
+	mostLoaded.setState(connStateDraining)
+	p.mu.Unlock()
+
+	p.t.options.logger.Debug("grpc: marked connection for draining during scale-down",
+		zap.String("peer", p.HostPort()),
+		zap.Int32("stream_count", mostLoaded.getStreamCount()))
 }
 
 // cleanupIdleConns advances draining connections with zero streams to the idle

--- a/transport/grpc/conn_pool_scaler.go
+++ b/transport/grpc/conn_pool_scaler.go
@@ -27,14 +27,27 @@ import (
 	"go.uber.org/zap"
 )
 
-// _scalingMonitorInterval is how often the scaling monitor evaluates the pool.
-const _scalingMonitorInterval = 30 * time.Second
+// _defaultScalingMonitorInterval is both the default and the minimum allowed
+// interval for the scaling monitor. Values below this would cause excessive
+// pool churn and are rejected at config validation time.
+const _defaultScalingMonitorInterval = 30 * time.Second
 
 // runScalingMonitor runs as a background goroutine for the lifetime of the
 // peer.  It periodically evaluates whether connections should be removed
 // from the pool.  It exits when the peer's context is cancelled.
 func (p *grpcPeer) runScalingMonitor() {
-	ticker := time.NewTicker(_scalingMonitorInterval)
+	interval := p.poolCfg.scalingMonitorInterval
+	switch {
+	case interval <= 0:
+		interval = _defaultScalingMonitorInterval
+	case interval < _defaultScalingMonitorInterval:
+		p.t.options.logger.Warn("grpc: scalingMonitorInterval is below the minimum; clamping to avoid pool thrashing",
+			zap.Duration("configured", interval),
+			zap.Duration("effective", _defaultScalingMonitorInterval),
+			zap.String("peer", p.HostPort()))
+		interval = _defaultScalingMonitorInterval
+	}
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
 		select {
@@ -54,9 +67,12 @@ func (p *grpcPeer) evaluateScaling() {
 // maybeScaleDown checks whether the pool can be reduced by one connection.
 // A connection is marked for draining when the remaining active connections
 // can absorb the current aggregate stream load without triggering another
-// scale-up.
+// scale-up.  The scale-down threshold applies a hysteresis gap below
+// scaleUpThreshold to prevent oscillation when stream count hovers near
+// the scale-up boundary.
 // Lock-free read path: loads an immutable snapshot via atomic.Pointer.Load().
-// The state mutation (setState) is already atomic, so no mutex is needed.
+// The state mutation uses transitionState so that concurrent reactivation by
+// tryScaleUp is mutually exclusive with the draining transition.
 func (p *grpcPeer) maybeScaleDown() {
 	conns := p.loadConns()
 	active := make([]*grpcClientConnWrapper, 0, len(conns))
@@ -71,7 +87,10 @@ func (p *grpcPeer) maybeScaleDown() {
 		return
 	}
 
-	threshold := int32(float64(p.poolCfg.maxConcurrentStreams) * p.poolCfg.scaleUpThreshold)
+	// scaleDownThreshold introduces a hysteresis band below scaleUpThreshold.
+	// Scale down only when load would fit within the lower threshold on the
+	// reduced pool, preventing oscillation near the scale-up boundary.
+	scaleDownThreshold := int32(float64(p.poolCfg.maxConcurrentStreams) * (p.poolCfg.scaleUpThreshold - p.poolCfg.scaleDownGap))
 
 	var totalStreams int32
 	for _, c := range active {
@@ -79,8 +98,8 @@ func (p *grpcPeer) maybeScaleDown() {
 	}
 
 	// Only drain if the remaining (n-1) connections can absorb current load
-	// without crossing the scale-up threshold.
-	capacityAfterDrain := threshold * int32(len(active)-1)
+	// without crossing the scale-down threshold.
+	capacityAfterDrain := scaleDownThreshold * int32(len(active)-1)
 	if totalStreams >= capacityAfterDrain {
 		return
 	}
@@ -98,8 +117,11 @@ func (p *grpcPeer) maybeScaleDown() {
 		return
 	}
 
-	// setState is an atomic store — no mutex needed.
-	mostLoaded.setState(connStateDraining)
+	// Use CAS so that a concurrent reactivation by tryScaleUp cannot race
+	// with this draining transition on the same connection.
+	if !mostLoaded.transitionState(connStateActive, connStateDraining) {
+		return
+	}
 
 	p.t.options.logger.Debug("grpc: marked connection for draining during scale-down",
 		zap.String("peer", p.HostPort()),
@@ -113,8 +135,13 @@ func (p *grpcPeer) maybeScaleDown() {
 // monitor goroutines can close and remove them.
 // It skips closing idle connections while a scale-up is in progress so that
 // tryScaleUp can reactivate them instead of dialing a new connection.
-// Lock-free read path: uses atomic.Pointer.Load() for the snapshot, and
-// atomic setState/setIdleNow for mutations (no mutex required).
+// Lock-free read path: uses atomic.Pointer.Load() for the snapshot.
+// All state transitions use transitionState so they are mutually exclusive with
+// concurrent reactivation by tryScaleUp, closing the race identified in review:
+//
+//	Time 1 cleanupIdleConns: reads isScaling==0, adds c to toClose
+//	Time 2 tryScaleUp:       CAS isScaling 0→1, reactivates c (idle→active)
+//	Time 3 cleanupIdleConns: transitionState(idle→closing) fails → skips cancel
 func (p *grpcPeer) cleanupIdleConns() {
 	// If a scale-up goroutine is running, hold off — idle connections may be
 	// reactivated by tryScaleUp instead of being closed.
@@ -136,16 +163,21 @@ func (p *grpcPeer) cleanupIdleConns() {
 		}
 	}
 
-	// setState and setIdleNow are both atomic operations — no mutex needed.
-	// Re-check state before transitioning to handle any concurrent changes.
+	// Use CAS for the draining→idle transition so a concurrent reactivation
+	// by tryScaleUp (idle→active) cannot race on the same connection.
 	for _, c := range drained {
-		if c.getState() == connStateDraining && c.getStreamCount() == 0 {
-			c.setState(connStateIdle)
+		if c.transitionState(connStateDraining, connStateIdle) {
 			c.setIdleNow()
 		}
 	}
 
 	for _, c := range toClose {
+		// Claim the connection for closure via CAS before calling cancel.
+		// If tryScaleUp wins the CAS first (idle→active), we skip this
+		// connection — it has been reactivated and must not be cancelled.
+		if !c.transitionState(connStateIdle, connStateClosing) {
+			continue
+		}
 		p.t.options.logger.Debug("grpc: closing idle connection after timeout",
 			zap.String("peer", p.HostPort()),
 			zap.Duration("idle_duration", now.Sub(c.idleSince())))
@@ -217,22 +249,40 @@ func (p *grpcPeer) tryScaleUp(leastLoadedConn *grpcClientConnWrapper) {
 	}()
 }
 
-// reactivateIdleConn finds the first idle connection whose context has not
-// yet been cancelled and transitions it back to active, avoiding an
-// unnecessary dial.  Returns true if a connection was reactivated.
-// Lock-free: setState is atomic. Only one reactivateIdleConn call runs at a
-// time (guarded by the isScaling CAS in tryScaleUp).
+// reactivateIdleConn finds a connection to bring back to active, avoiding an
+// unnecessary dial.  It prefers idle connections (zero in-flight streams) over
+// draining ones (streams still in flight), and uses CAS so that a concurrent
+// cleanupIdleConns cannot cancel a connection that is being reactivated.
+// Only one reactivateIdleConn call runs at a time (guarded by the isScaling
+// CAS in tryScaleUp).
+// Returns true if a connection was reactivated.
 func (p *grpcPeer) reactivateIdleConn() bool {
 	conns := p.loadConns()
+
+	// First pass: prefer idle connections (no in-flight streams, cheapest to reactivate).
 	for _, c := range conns {
 		// Only reactivate if the connection context is still live; a cancelled
 		// context means cleanupIdleConns has already scheduled it for closure.
 		if c.getState() == connStateIdle && c.ctx.Err() == nil {
-			c.setState(connStateActive)
-			atomic.StoreInt64(&c.lastIdleAtNano, 0)
-			return true
+			if c.transitionState(connStateIdle, connStateActive) {
+				atomic.StoreInt64(&c.lastIdleAtNano, 0)
+				return true
+			}
 		}
 	}
+
+	// Second pass: reactivate a draining connection if no idle one is available.
+	// A draining connection still has in-flight streams but can accept new ones
+	// once reactivated, preventing accumulation of stuck draining connections
+	// under sustained load.
+	for _, c := range conns {
+		if c.getState() == connStateDraining && c.ctx != nil && c.ctx.Err() == nil {
+			if c.transitionState(connStateDraining, connStateActive) {
+				return true
+			}
+		}
+	}
+
 	return false
 }
 

--- a/transport/grpc/conn_pool_scaler.go
+++ b/transport/grpc/conn_pool_scaler.go
@@ -55,12 +55,12 @@ func (p *grpcPeer) evaluateScaling() {
 // A connection is marked for draining when the remaining active connections
 // can absorb the current aggregate stream load without triggering another
 // scale-up.
+// Lock-free read path: loads an immutable snapshot via atomic.Pointer.Load().
+// The state mutation (setState) is already atomic, so no mutex is needed.
 func (p *grpcPeer) maybeScaleDown() {
-	// Use a read lock for the analysis phase to avoid blocking concurrent
-	// request-path goroutines that also hold RLock when picking a connection.
-	p.mu.RLock()
-	active := make([]*grpcClientConnWrapper, 0, len(p.conns))
-	for _, c := range p.conns {
+	conns := p.loadConns()
+	active := make([]*grpcClientConnWrapper, 0, len(conns))
+	for _, c := range conns {
 		if c.isActive() {
 			active = append(active, c)
 		}
@@ -68,7 +68,6 @@ func (p *grpcPeer) maybeScaleDown() {
 
 	// Never drain below minConnections.
 	if len(active) <= p.poolCfg.minConnections {
-		p.mu.RUnlock()
 		return
 	}
 
@@ -83,7 +82,6 @@ func (p *grpcPeer) maybeScaleDown() {
 	// without crossing the scale-up threshold.
 	capacityAfterDrain := threshold * int32(len(active)-1)
 	if totalStreams >= capacityAfterDrain {
-		p.mu.RUnlock()
 		return
 	}
 
@@ -95,16 +93,13 @@ func (p *grpcPeer) maybeScaleDown() {
 			mostLoaded = c
 		}
 	}
-	p.mu.RUnlock()
 
 	if mostLoaded == nil {
 		return
 	}
 
-	// Acquire the write lock only for the brief state mutation.
-	p.mu.Lock()
+	// setState is an atomic store — no mutex needed.
 	mostLoaded.setState(connStateDraining)
-	p.mu.Unlock()
 
 	p.t.options.logger.Debug("grpc: marked connection for draining during scale-down",
 		zap.String("peer", p.HostPort()),
@@ -118,6 +113,8 @@ func (p *grpcPeer) maybeScaleDown() {
 // monitor goroutines can close and remove them.
 // It skips closing idle connections while a scale-up is in progress so that
 // tryScaleUp can reactivate them instead of dialing a new connection.
+// Lock-free read path: uses atomic.Pointer.Load() for the snapshot, and
+// atomic setState/setIdleNow for mutations (no mutex required).
 func (p *grpcPeer) cleanupIdleConns() {
 	// If a scale-up goroutine is running, hold off — idle connections may be
 	// reactivated by tryScaleUp instead of being closed.
@@ -127,11 +124,10 @@ func (p *grpcPeer) cleanupIdleConns() {
 
 	now := time.Now()
 
-	// Use a read lock for the analysis phase
-	p.mu.RLock()
+	conns := p.loadConns()
 	var drained []*grpcClientConnWrapper
 	var toClose []*grpcClientConnWrapper
-	for _, c := range p.conns {
+	for _, c := range conns {
 		if c.getState() == connStateDraining && c.getStreamCount() == 0 {
 			drained = append(drained, c)
 		} else if c.getState() == connStateIdle && !c.idleSince().IsZero() &&
@@ -139,25 +135,23 @@ func (p *grpcPeer) cleanupIdleConns() {
 			toClose = append(toClose, c)
 		}
 	}
-	p.mu.RUnlock()
 
-	// Advance drained → idle with a brief write lock per connection.
+	// setState and setIdleNow are both atomic operations — no mutex needed.
+	// Re-check state before transitioning to handle any concurrent changes.
 	for _, c := range drained {
-		p.mu.Lock()
 		if c.getState() == connStateDraining && c.getStreamCount() == 0 {
 			c.setState(connStateIdle)
 			c.setIdleNow()
 		}
-		p.mu.Unlock()
 	}
 
 	for _, c := range toClose {
 		p.t.options.logger.Debug("grpc: closing idle connection after timeout",
 			zap.String("peer", p.HostPort()),
 			zap.Duration("idle_duration", now.Sub(c.idleSince())))
-		// Cancelling the wrapper context causes monitorConnectionStatus to
+		// Cancelling the wrapper context causes monitorConnWrapper to
 		// exit, which closes the underlying clientConn and removes the
-		// wrapper from p.conns.
+		// wrapper from the pool via removeConn.
 		c.cancel()
 	}
 
@@ -206,10 +200,8 @@ func (p *grpcPeer) tryScaleUp(leastLoadedConn *grpcClientConnWrapper) {
 		}
 
 		// No idle connection available; dial a new one if below the cap.
-		p.mu.RLock()
-		atMax := len(p.conns) >= p.poolCfg.maxConnections
-		p.mu.RUnlock()
-		if atMax {
+		// connCount is maintained atomically — no mutex needed for this check.
+		if int(p.connCount.Load()) >= p.poolCfg.maxConnections {
 			return
 		}
 
@@ -228,10 +220,11 @@ func (p *grpcPeer) tryScaleUp(leastLoadedConn *grpcClientConnWrapper) {
 // reactivateIdleConn finds the first idle connection whose context has not
 // yet been cancelled and transitions it back to active, avoiding an
 // unnecessary dial.  Returns true if a connection was reactivated.
+// Lock-free: setState is atomic. Only one reactivateIdleConn call runs at a
+// time (guarded by the isScaling CAS in tryScaleUp).
 func (p *grpcPeer) reactivateIdleConn() bool {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	for _, c := range p.conns {
+	conns := p.loadConns()
+	for _, c := range conns {
 		// Only reactivate if the connection context is still live; a cancelled
 		// context means cleanupIdleConns has already scheduled it for closure.
 		if c.getState() == connStateIdle && c.ctx.Err() == nil {
@@ -244,11 +237,11 @@ func (p *grpcPeer) reactivateIdleConn() bool {
 }
 
 // refreshPoolMetrics scans the pool and updates the active, draining, and idle
-// connection gauges.  It must be called after any pool state transition.
+// connection gauges.  Lock-free: reads an immutable snapshot via loadConns().
 func (p *grpcPeer) refreshPoolMetrics() {
+	conns := p.loadConns()
 	var active, draining, idle int64
-	p.mu.RLock()
-	for _, c := range p.conns {
+	for _, c := range conns {
 		switch c.getState() {
 		case connStateActive:
 			active++
@@ -258,7 +251,6 @@ func (p *grpcPeer) refreshPoolMetrics() {
 			idle++
 		}
 	}
-	p.mu.RUnlock()
 	p.metrics.setConnectionCount(active)
 	p.metrics.setDrainingConnectionCount(draining)
 	p.metrics.setIdleConnectionCount(idle)

--- a/transport/grpc/conn_pool_scaler_test.go
+++ b/transport/grpc/conn_pool_scaler_test.go
@@ -74,7 +74,171 @@ var defaultScaleDownCfg = connPoolConfig{
 	scaleUpThreshold:    0.8,
 }
 
-// TestMaybeScaleDown covers every branch of the maybeScaleDown function.
+// makeConnWithCancel creates a grpcClientConnWrapper with a real context so
+// that c.cancel() can be observed in tests.  Returns the wrapper and the
+// context so callers can assert it was cancelled.
+func makeConnWithCancel(state connState, streams int32, idleAt time.Time) (*grpcClientConnWrapper, context.Context) {
+	ctx, cancel := context.WithCancel(context.Background())
+	w := &grpcClientConnWrapper{
+		state:  state,
+		cancel: cancel,
+	}
+	if streams > 0 {
+		w.streamCount = streams
+	}
+	if !idleAt.IsZero() {
+		w.lastIdleAtNano = idleAt.UnixNano()
+	}
+	return w, ctx
+}
+
+// TestCleanupIdleConns covers every line/branch of cleanupIdleConns.
+func TestCleanupIdleConns(t *testing.T) {
+	t.Parallel()
+
+	const shortTimeout = 100 * time.Millisecond
+
+	tests := []struct {
+		desc string
+		// build returns the conns slice and a slice of contexts corresponding
+		// to wrappers whose cancellation should be verified.
+		build      func() ([]*grpcClientConnWrapper, []context.Context)
+		idleTimeout time.Duration
+		// wantStates is the expected state of each conn after the call (index-aligned).
+		wantStates []connState
+		// wantCancelled is the index set of contexts that must be cancelled after the call.
+		wantCancelled []int
+	}{
+		{
+			// Empty pool: lock/unlock + empty loop, nothing happens.
+			desc: "empty pool - no-op",
+			build: func() ([]*grpcClientConnWrapper, []context.Context) {
+				return nil, nil
+			},
+			idleTimeout: time.Minute,
+			wantStates:  nil,
+		},
+		{
+			// Active connection: neither if-branch fires, state unchanged.
+			desc: "active connection - no state change",
+			build: func() ([]*grpcClientConnWrapper, []context.Context) {
+				w, ctx := makeConnWithCancel(connStateActive, 5, time.Time{})
+				return []*grpcClientConnWrapper{w}, []context.Context{ctx}
+			},
+			idleTimeout:   time.Minute,
+			wantStates:    []connState{connStateActive},
+			wantCancelled: nil,
+		},
+		{
+			// Draining with streams > 0: first if is false (streams != 0),
+			// second if is false (state != idle) → stays draining.
+			desc: "draining with active streams - stays draining",
+			build: func() ([]*grpcClientConnWrapper, []context.Context) {
+				w, ctx := makeConnWithCancel(connStateDraining, 3, time.Time{})
+				return []*grpcClientConnWrapper{w}, []context.Context{ctx}
+			},
+			idleTimeout:   time.Minute,
+			wantStates:    []connState{connStateDraining},
+			wantCancelled: nil,
+		},
+		{
+			// Draining with zero streams: first if fires → setState(idle) + setIdleNow().
+			// Second if then checks: state is idle, but idleSince was just set so
+			// duration < idleTimeout → not collected for closing.
+			desc: "draining with zero streams - advances to idle, not yet timed out",
+			build: func() ([]*grpcClientConnWrapper, []context.Context) {
+				w, ctx := makeConnWithCancel(connStateDraining, 0, time.Time{})
+				return []*grpcClientConnWrapper{w}, []context.Context{ctx}
+			},
+			idleTimeout:   time.Hour,
+			wantStates:    []connState{connStateIdle},
+			wantCancelled: nil,
+		},
+		{
+			// Already idle but lastIdleAtNano == 0 (defensive guard):
+			// second if short-circuits on !c.idleSince().IsZero() → not collected.
+			desc: "idle with zero idleSince - not collected",
+			build: func() ([]*grpcClientConnWrapper, []context.Context) {
+				w, ctx := makeConnWithCancel(connStateIdle, 0, time.Time{}) // lastIdleAtNano stays 0
+				return []*grpcClientConnWrapper{w}, []context.Context{ctx}
+			},
+			idleTimeout:   shortTimeout,
+			wantStates:    []connState{connStateIdle},
+			wantCancelled: nil,
+		},
+		{
+			// Idle within timeout: all conditions true except duration < timeout → not collected.
+			desc: "idle within timeout - not collected",
+			build: func() ([]*grpcClientConnWrapper, []context.Context) {
+				w, ctx := makeConnWithCancel(connStateIdle, 0, time.Now()) // idleSince = now
+				return []*grpcClientConnWrapper{w}, []context.Context{ctx}
+			},
+			idleTimeout:   time.Hour,
+			wantStates:    []connState{connStateIdle},
+			wantCancelled: nil,
+		},
+		{
+			// Idle past timeout: all conditions met → appended to toClose,
+			// logger.Debug called, c.cancel() called.
+			desc: "idle past timeout - cancel called",
+			build: func() ([]*grpcClientConnWrapper, []context.Context) {
+				pastTime := time.Now().Add(-10 * time.Minute)
+				w, ctx := makeConnWithCancel(connStateIdle, 0, pastTime)
+				return []*grpcClientConnWrapper{w}, []context.Context{ctx}
+			},
+			idleTimeout:   shortTimeout,
+			wantStates:    []connState{connStateIdle},
+			wantCancelled: []int{0},
+		},
+		{
+			// Mixed pool: one draining→idle transition, one past-timeout cancel,
+			// one active unchanged. Exercises all branches in a single call.
+			desc: "mixed pool - correct per-conn behavior",
+			build: func() ([]*grpcClientConnWrapper, []context.Context) {
+				w0, ctx0 := makeConnWithCancel(connStateActive, 10, time.Time{})
+				w1, ctx1 := makeConnWithCancel(connStateDraining, 0, time.Time{}) // → idle
+				pastTime := time.Now().Add(-5 * time.Minute)
+				w2, ctx2 := makeConnWithCancel(connStateIdle, 0, pastTime) // → cancel
+				return []*grpcClientConnWrapper{w0, w1, w2},
+					[]context.Context{ctx0, ctx1, ctx2}
+			},
+			idleTimeout:   shortTimeout,
+			wantStates:    []connState{connStateActive, connStateIdle, connStateIdle},
+			wantCancelled: []int{2},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			conns, ctxs := tt.build()
+			cfg := connPoolConfig{idleTimeout: tt.idleTimeout}
+			p := peerForScaleDown(t, conns, cfg)
+
+			p.cleanupIdleConns()
+
+			require.Len(t, p.conns, len(tt.wantStates))
+			for i, want := range tt.wantStates {
+				assert.Equal(t, want, p.conns[i].getState(), "conn[%d] state", i)
+			}
+
+			cancelledSet := make(map[int]bool)
+			for _, i := range tt.wantCancelled {
+				cancelledSet[i] = true
+			}
+			for i, ctx := range ctxs {
+				if cancelledSet[i] {
+					assert.Error(t, ctx.Err(), "conn[%d] context should be cancelled", i)
+				} else {
+					assert.NoError(t, ctx.Err(), "conn[%d] context should not be cancelled", i)
+				}
+			}
+		})
+	}
+}
+
+
 func TestMaybeScaleDown(t *testing.T) {
 	t.Parallel()
 
@@ -304,4 +468,3 @@ func TestScalingHelperMethodsDoNotPanic(t *testing.T) {
 	assert.NotPanics(t, p.cleanupIdleConns)
 	assert.NotPanics(t, p.maybeScaleDown)
 }
-

--- a/transport/grpc/conn_pool_scaler_test.go
+++ b/transport/grpc/conn_pool_scaler_test.go
@@ -28,7 +28,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/net/metrics"
 	"go.uber.org/yarpc/peer/abstractpeer"
+	"go.uber.org/zap"
 )
 
 // newTestPeer returns a minimal grpcPeer sufficient for exercising the scaling
@@ -661,4 +663,177 @@ func TestCleanupIdleConnsSkippedWhileScaling(t *testing.T) {
 	// Connection must not have been cancelled — isScaling caused early return.
 	assert.NoError(t, ctx.Err(), "idle connection must not be cancelled while scaling")
 	assert.Equal(t, connStateIdle, w.getState(), "connection state must be unchanged")
+}
+
+// --- metrics wiring ---
+
+// peerWithMetrics creates a peerForPool with a real metrics scope attached.
+func peerWithMetrics(t *testing.T) (*grpcPeer, *metrics.Root) {
+	t.Helper()
+	root := metrics.New()
+	p := peerForPool(t)
+	p.metrics = newConnPoolMetrics(connPoolMetricsParams{
+		Meter:       root.Scope(),
+		Logger:      zap.NewNop(),
+		ServiceName: "test-svc",
+		Peer:        p.Peer.Identifier(),
+	})
+	return p, root
+}
+
+func gaugesFromSnapshot(snap *metrics.RootSnapshot) map[string]int64 {
+	m := make(map[string]int64, len(snap.Gauges))
+	for _, g := range snap.Gauges {
+		m[g.Name] = g.Value
+	}
+	return m
+}
+
+func countersFromSnapshot(snap *metrics.RootSnapshot) map[string]int64 {
+	m := make(map[string]int64, len(snap.Counters))
+	for _, c := range snap.Counters {
+		m[c.Name] = c.Value
+	}
+	return m
+}
+
+// TestRefreshPoolMetrics verifies that refreshPoolMetrics correctly derives
+// active/draining/idle counts from the pool and publishes them as gauges.
+func TestRefreshPoolMetrics(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty pool sets all gauges to zero", func(t *testing.T) {
+		t.Parallel()
+		p, root := peerWithMetrics(t)
+		p.refreshPoolMetrics()
+		g := gaugesFromSnapshot(root.Snapshot())
+		assert.Equal(t, int64(0), g["conn_pool_active_connections"])
+		assert.Equal(t, int64(0), g["conn_pool_draining_connections"])
+		assert.Equal(t, int64(0), g["conn_pool_idle_connections"])
+	})
+
+	t.Run("mixed pool reports correct counts", func(t *testing.T) {
+		t.Parallel()
+		p, root := peerWithMetrics(t)
+		p.mu.Lock()
+		p.conns = []*grpcClientConnWrapper{
+			makeConn(connStateActive, 0),
+			makeConn(connStateActive, 0),
+			makeConn(connStateDraining, 0),
+			makeConn(connStateIdle, 0),
+		}
+		p.mu.Unlock()
+
+		p.refreshPoolMetrics()
+
+		g := gaugesFromSnapshot(root.Snapshot())
+		assert.Equal(t, int64(2), g["conn_pool_active_connections"])
+		assert.Equal(t, int64(1), g["conn_pool_draining_connections"])
+		assert.Equal(t, int64(1), g["conn_pool_idle_connections"])
+	})
+}
+
+// TestMaybeScaleDownMetrics verifies that maybeScaleDown increments the
+// scale-down counter and refreshes the pool gauges when draining a connection.
+func TestMaybeScaleDownMetrics(t *testing.T) {
+	t.Parallel()
+
+	p, root := peerWithMetrics(t)
+	p.poolCfg = connPoolConfig{
+		minConnections:      1,
+		maxConcurrentStreams: 100,
+		scaleUpThreshold:    0.8, // threshold = 80
+	}
+	p.mu.Lock()
+	p.conns = []*grpcClientConnWrapper{
+		makeConn(connStateActive, 10),
+		makeConn(connStateActive, 10),
+		makeConn(connStateActive, 10), // total 30 < capacityAfterDrain=160 → drain
+	}
+	p.mu.Unlock()
+
+	p.maybeScaleDown()
+
+	c := countersFromSnapshot(root.Snapshot())
+	assert.Equal(t, int64(1), c["conn_pool_scale_down_total"], "scale-down counter should increment")
+
+	g := gaugesFromSnapshot(root.Snapshot())
+	assert.Equal(t, int64(2), g["conn_pool_active_connections"])
+	assert.Equal(t, int64(1), g["conn_pool_draining_connections"])
+}
+
+// TestTryScaleUpDialMetrics verifies that tryScaleUp increments the scale-up
+// counter when it opens a new connection.
+func TestTryScaleUpDialMetrics(t *testing.T) {
+	t.Parallel()
+
+	p, root := peerWithMetrics(t)
+	overBudget := makeConn(connStateActive, 85) // threshold=80
+
+	p.tryScaleUp(overBudget)
+
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&p.isScaling) == 0
+	}, 2*time.Second, 10*time.Millisecond)
+
+	c := countersFromSnapshot(root.Snapshot())
+	assert.Equal(t, int64(1), c["conn_pool_scale_up_total"])
+
+	// Gauge must reflect the newly added connection.
+	g := gaugesFromSnapshot(root.Snapshot())
+	assert.Equal(t, int64(1), g["conn_pool_active_connections"])
+}
+
+// TestTryScaleUpReactivationMetrics verifies that tryScaleUp increments the
+// idle-reactivation counter and updates gauges when reactivating an idle conn.
+func TestTryScaleUpReactivationMetrics(t *testing.T) {
+	t.Parallel()
+
+	p, root := peerWithMetrics(t)
+
+	// Seed an idle connection with a live context.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	idleConn := &grpcClientConnWrapper{ctx: ctx, cancel: cancel}
+	idleConn.setState(connStateIdle)
+	p.mu.Lock()
+	p.conns = append(p.conns, idleConn)
+	p.mu.Unlock()
+
+	overBudget := makeConn(connStateActive, 85)
+	p.tryScaleUp(overBudget)
+
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&p.isScaling) == 0
+	}, 2*time.Second, 10*time.Millisecond)
+
+	c := countersFromSnapshot(root.Snapshot())
+	assert.Equal(t, int64(1), c["conn_pool_idle_reactivation_total"])
+	assert.Equal(t, int64(0), c["conn_pool_scale_up_total"], "no new dial should happen")
+
+	g := gaugesFromSnapshot(root.Snapshot())
+	assert.Equal(t, int64(1), g["conn_pool_active_connections"])
+	assert.Equal(t, int64(0), g["conn_pool_idle_connections"])
+}
+
+// TestCleanupIdleConnsMetrics verifies that cleanupIdleConns updates gauges
+// after advancing draining connections to idle.
+func TestCleanupIdleConnsMetrics(t *testing.T) {
+	t.Parallel()
+
+	p, root := peerWithMetrics(t)
+	p.poolCfg = connPoolConfig{idleTimeout: time.Hour}
+	p.mu.Lock()
+	p.conns = []*grpcClientConnWrapper{
+		makeConn(connStateActive, 5),
+		makeConn(connStateDraining, 0), // 0 streams → advances to idle
+	}
+	p.mu.Unlock()
+
+	p.cleanupIdleConns()
+
+	g := gaugesFromSnapshot(root.Snapshot())
+	assert.Equal(t, int64(1), g["conn_pool_active_connections"])
+	assert.Equal(t, int64(0), g["conn_pool_draining_connections"])
+	assert.Equal(t, int64(1), g["conn_pool_idle_connections"])
 }

--- a/transport/grpc/conn_pool_scaler_test.go
+++ b/transport/grpc/conn_pool_scaler_test.go
@@ -26,17 +26,214 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/peer/abstractpeer"
 )
 
 // newTestPeer returns a minimal grpcPeer sufficient for exercising the scaling
-// monitor.  None of the TODO methods access peer fields, so we only need the
-// context wiring.
+// monitor goroutine lifecycle. Methods that reach p.t will panic, so only use
+// this for tests that exercise early-return paths.
 func newTestPeer(ctx context.Context, cancel context.CancelFunc) *grpcPeer {
 	return &grpcPeer{
 		ctx:    ctx,
 		cancel: cancel,
 	}
 }
+
+// makeConn creates a grpcClientConnWrapper with the given state and stream
+// count. Intended for use in unit tests only.
+func makeConn(state connState, streams int32) *grpcClientConnWrapper {
+	return &grpcClientConnWrapper{
+		state:       state,
+		streamCount: streams,
+	}
+}
+
+// peerForScaleDown builds a grpcPeer suitable for maybeScaleDown tests. It
+// wires up a real Transport (for its nop logger) and a cancellable context.
+func peerForScaleDown(t *testing.T, conns []*grpcClientConnWrapper, cfg connPoolConfig) *grpcPeer {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	transport := NewTransport()
+	return &grpcPeer{
+		Peer:    abstractpeer.NewPeer(abstractpeer.PeerIdentifier("10.0.0.1:9000"), transport),
+		t:       transport,
+		ctx:     ctx,
+		cancel:  cancel,
+		conns:   conns,
+		poolCfg: cfg,
+	}
+}
+
+// defaultCfg is a pool config used across maybeScaleDown tests.
+// threshold = int32(100 * 0.8) = 80.
+var defaultScaleDownCfg = connPoolConfig{
+	minConnections:      1,
+	maxConcurrentStreams: 100,
+	scaleUpThreshold:    0.8,
+}
+
+// TestMaybeScaleDown covers every branch of the maybeScaleDown function.
+func TestMaybeScaleDown(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc string
+		// conns is the initial pool state.
+		conns []*grpcClientConnWrapper
+		cfg   connPoolConfig
+		// afterCall maps each conn (by index) to its expected state after the call.
+		wantStates []connState
+	}{
+		{
+			// Empty pool: active slice is empty → len(active)=0 <= minConnections=1 → return.
+			desc:       "empty pool - returns at minConnections guard",
+			conns:      nil,
+			cfg:        defaultScaleDownCfg,
+			wantStates: nil,
+		},
+		{
+			// One active conn, minConnections=1: len(active)=1 <= 1 → return, no drain.
+			desc: "active equals minConnections - no drain",
+			conns: []*grpcClientConnWrapper{
+				makeConn(connStateActive, 10),
+			},
+			cfg:        defaultScaleDownCfg,
+			wantStates: []connState{connStateActive},
+		},
+		{
+			// One active conn, minConnections=2: len(active)=1 <= 2 → return, no drain.
+			desc: "active below minConnections - no drain",
+			conns: []*grpcClientConnWrapper{
+				makeConn(connStateActive, 10),
+			},
+			cfg: connPoolConfig{
+				minConnections:      2,
+				maxConcurrentStreams: 100,
+				scaleUpThreshold:    0.8,
+			},
+			wantStates: []connState{connStateActive},
+		},
+		{
+			// Only draining conns: active slice is empty → returns at minConnections guard.
+			// The existing draining connections are not modified.
+			desc: "only draining conns - active=0, no change",
+			conns: []*grpcClientConnWrapper{
+				makeConn(connStateDraining, 5),
+				makeConn(connStateDraining, 5),
+			},
+			cfg:        defaultScaleDownCfg, // minConnections=1, active=0
+			wantStates: []connState{connStateDraining, connStateDraining},
+		},
+		{
+			// Mix of active and draining. Only active conns count toward the
+			// pool size, but the pool is at minConnections after filtering.
+			desc: "mixed pool at minConnections - no drain",
+			conns: []*grpcClientConnWrapper{
+				makeConn(connStateActive, 10),
+				makeConn(connStateDraining, 20),
+			},
+			cfg:        defaultScaleDownCfg, // minConnections=1, active=1
+			wantStates: []connState{connStateActive, connStateDraining},
+		},
+		{
+			// 3 active conns, load too high: threshold=80, capacityAfterDrain=80*2=160,
+			// totalStreams=180 >= 160 → return without draining.
+			desc: "total streams exceed capacity after drain - no drain",
+			conns: []*grpcClientConnWrapper{
+				makeConn(connStateActive, 60),
+				makeConn(connStateActive, 60),
+				makeConn(connStateActive, 60),
+			},
+			cfg:        defaultScaleDownCfg,
+			wantStates: []connState{connStateActive, connStateActive, connStateActive},
+		},
+		{
+			// 3 active conns, load exactly equal to capacityAfterDrain:
+			// totalStreams=160 >= 160 → return (boundary check).
+			desc: "total streams exactly equal to capacity after drain - no drain",
+			conns: []*grpcClientConnWrapper{
+				makeConn(connStateActive, 54),
+				makeConn(connStateActive, 53),
+				makeConn(connStateActive, 53),
+			},
+			cfg:        defaultScaleDownCfg, // threshold=80, capacity=160, total=160
+			wantStates: []connState{connStateActive, connStateActive, connStateActive},
+		},
+		{
+			// 3 active conns, low load: threshold=80, capacityAfterDrain=160,
+			// totalStreams=60 < 160 → drain the most-loaded (last conn, 30 streams)
+			// to maximise residual capacity in the surviving connections.
+			desc: "low load - drains most-loaded connection",
+			conns: []*grpcClientConnWrapper{
+				makeConn(connStateActive, 10),
+				makeConn(connStateActive, 20),
+				makeConn(connStateActive, 30), // most loaded → drained
+			},
+			cfg:        defaultScaleDownCfg,
+			wantStates: []connState{connStateActive, connStateActive, connStateDraining},
+		},
+		{
+			// Most-loaded is the first conn. Verifies the comparison loop
+			// picks the globally largest stream count, not just the last.
+			desc: "most-loaded is first - correct conn drained",
+			conns: []*grpcClientConnWrapper{
+				makeConn(connStateActive, 30), // most loaded → drained
+				makeConn(connStateActive, 5),
+				makeConn(connStateActive, 25),
+			},
+			cfg:        defaultScaleDownCfg,
+			wantStates: []connState{connStateDraining, connStateActive, connStateActive},
+		},
+		{
+			// All active conns have equal stream counts. The first one is selected
+			// (mostLoaded == nil on first iteration, then no subsequent conn wins
+			// because equal counts don't satisfy >).
+			desc: "equal stream counts - first active conn drained",
+			conns: []*grpcClientConnWrapper{
+				makeConn(connStateActive, 10), // selected (first, tied)
+				makeConn(connStateActive, 10),
+				makeConn(connStateActive, 10),
+			},
+			cfg:        defaultScaleDownCfg,
+			wantStates: []connState{connStateDraining, connStateActive, connStateActive},
+		},
+		{
+			// Draining conn interspersed: draining conn is excluded from active
+			// list and from scale-down candidate selection.
+			desc: "draining conn excluded from candidate selection",
+			conns: []*grpcClientConnWrapper{
+				makeConn(connStateDraining, 1), // excluded from active
+				makeConn(connStateActive, 5),
+				makeConn(connStateActive, 40), // most loaded active → drained
+				makeConn(connStateActive, 40),
+			},
+			cfg: connPoolConfig{
+				minConnections:      1,
+				maxConcurrentStreams: 100,
+				scaleUpThreshold:    0.8, // threshold=80, capacity=80*2=160, total=85 < 160
+			},
+			wantStates: []connState{connStateDraining, connStateActive, connStateDraining, connStateActive},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+			p := peerForScaleDown(t, tt.conns, tt.cfg)
+			p.maybeScaleDown()
+
+			require.Len(t, p.conns, len(tt.wantStates))
+			for i, want := range tt.wantStates {
+				assert.Equal(t, want, p.conns[i].getState(),
+					"conn[%d] state mismatch", i)
+			}
+		})
+	}
+}
+
+// --- scaling monitor lifecycle tests ---
 
 // TestRunScalingMonitorExitsOnContextCancel verifies that runScalingMonitor
 // returns promptly when the peer's context is cancelled.
@@ -62,9 +259,8 @@ func TestRunScalingMonitorExitsOnContextCancel(t *testing.T) {
 	}
 }
 
-// TestRunScalingMonitorTicksEvaluateScaling verifies that the monitor calls
-// evaluateScaling at least once within a reasonable window.  We use a short
-// context deadline so that the test does not run indefinitely.
+// TestRunScalingMonitorTicksEvaluateScaling verifies that the monitor exits
+// cleanly when its context is cancelled.
 func TestRunScalingMonitorTicksEvaluateScaling(t *testing.T) {
 	t.Parallel()
 
@@ -108,3 +304,4 @@ func TestScalingHelperMethodsDoNotPanic(t *testing.T) {
 	assert.NotPanics(t, p.cleanupIdleConns)
 	assert.NotPanics(t, p.maybeScaleDown)
 }
+

--- a/transport/grpc/conn_pool_scaler_test.go
+++ b/transport/grpc/conn_pool_scaler_test.go
@@ -22,6 +22,7 @@ package grpc
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -467,4 +468,197 @@ func TestScalingHelperMethodsDoNotPanic(t *testing.T) {
 
 	assert.NotPanics(t, p.cleanupIdleConns)
 	assert.NotPanics(t, p.maybeScaleDown)
+}
+
+// TestTryScaleUp covers all branches of tryScaleUp.
+func TestTryScaleUp(t *testing.T) {
+	t.Parallel()
+
+	// threshold = int32(100 * 0.8) = 80
+	overBudget := makeConn(connStateActive, 85)
+	underBudget := makeConn(connStateActive, 50)
+
+	t.Run("flag disabled - no scale-up", func(t *testing.T) {
+		t.Parallel()
+		p := peerForPool(t)
+		p.poolCfg.dynamicScalingEnabled = false
+		p.tryScaleUp(overBudget)
+		assert.Equal(t, int32(0), atomic.LoadInt32(&p.isScaling))
+	})
+
+	t.Run("under threshold - no scale-up", func(t *testing.T) {
+		t.Parallel()
+		p := peerForPool(t)
+		p.tryScaleUp(underBudget)
+		assert.Equal(t, int32(0), atomic.LoadInt32(&p.isScaling))
+	})
+
+	t.Run("at max connections - no scale-up", func(t *testing.T) {
+		t.Parallel()
+		p := peerForPool(t)
+		conns := make([]*grpcClientConnWrapper, p.poolCfg.maxConnections)
+		for i := range conns {
+			conns[i] = makeConn(connStateActive, 0)
+		}
+		p.mu.Lock()
+		p.conns = conns
+		p.mu.Unlock()
+		p.tryScaleUp(overBudget)
+
+		// atMax check now runs inside the goroutine; wait for it to finish.
+		assert.Eventually(t, func() bool {
+			return atomic.LoadInt32(&p.isScaling) == 0
+		}, 2*time.Second, 10*time.Millisecond)
+
+		p.mu.RLock()
+		n := len(p.conns)
+		p.mu.RUnlock()
+		assert.Equal(t, p.poolCfg.maxConnections, n, "pool should not grow beyond max")
+	})
+
+	t.Run("already scaling - no second goroutine launched", func(t *testing.T) {
+		t.Parallel()
+		p := peerForPool(t)
+		atomic.StoreInt32(&p.isScaling, 1)
+		p.tryScaleUp(overBudget)
+		assert.Equal(t, int32(1), atomic.LoadInt32(&p.isScaling))
+	})
+
+	t.Run("triggers goroutine and adds connection", func(t *testing.T) {
+		t.Parallel()
+		p := peerForPool(t)
+		p.tryScaleUp(overBudget)
+
+		// isScaling resets to 0 once the goroutine completes.
+		assert.Eventually(t, func() bool {
+			return atomic.LoadInt32(&p.isScaling) == 0
+		}, 2*time.Second, 10*time.Millisecond, "isScaling should reset to 0 after goroutine completes")
+
+		// One connection was added to the pool.
+		p.mu.RLock()
+		n := len(p.conns)
+		p.mu.RUnlock()
+		assert.Equal(t, 1, n, "one connection should be added to the pool")
+	})
+
+	t.Run("reactivates idle connection instead of dialing", func(t *testing.T) {
+		t.Parallel()
+		p := peerForPool(t)
+
+		// Seed an idle connection with a live context.
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		idleConn := &grpcClientConnWrapper{ctx: ctx, cancel: cancel}
+		idleConn.setState(connStateIdle)
+		idleConn.setIdleNow()
+		p.mu.Lock()
+		p.conns = append(p.conns, idleConn)
+		p.mu.Unlock()
+
+		p.tryScaleUp(overBudget)
+
+		assert.Eventually(t, func() bool {
+			return atomic.LoadInt32(&p.isScaling) == 0
+		}, 2*time.Second, 10*time.Millisecond)
+
+		// Pool size unchanged — reactivation, not a new dial.
+		p.mu.RLock()
+		n := len(p.conns)
+		p.mu.RUnlock()
+		assert.Equal(t, 1, n, "pool size should not grow on reactivation")
+		assert.Equal(t, connStateActive, idleConn.getState(), "idle conn should be active after reactivation")
+		assert.True(t, idleConn.idleSince().IsZero(), "idle timestamp should be cleared")
+	})
+}
+
+// TestReactivateIdleConn covers all branches of reactivateIdleConn.
+func TestReactivateIdleConn(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty pool returns false", func(t *testing.T) {
+		t.Parallel()
+		p := peerForScaleDown(t, nil, connPoolConfig{})
+		assert.False(t, p.reactivateIdleConn())
+	})
+
+	t.Run("no idle connections returns false", func(t *testing.T) {
+		t.Parallel()
+		conns := []*grpcClientConnWrapper{
+			makeConn(connStateActive, 10),
+			makeConn(connStateDraining, 5),
+		}
+		p := peerForScaleDown(t, conns, connPoolConfig{})
+		assert.False(t, p.reactivateIdleConn())
+	})
+
+	t.Run("idle with cancelled context is skipped", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // already cancelled
+		w := &grpcClientConnWrapper{ctx: ctx, cancel: cancel}
+		w.setState(connStateIdle)
+		p := peerForScaleDown(t, []*grpcClientConnWrapper{w}, connPoolConfig{})
+		assert.False(t, p.reactivateIdleConn())
+		assert.Equal(t, connStateIdle, w.getState(), "cancelled idle conn must not be reactivated")
+	})
+
+	t.Run("reactivates idle connection with live context", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		w := &grpcClientConnWrapper{ctx: ctx, cancel: cancel}
+		w.setState(connStateIdle)
+		w.setIdleNow()
+		p := peerForScaleDown(t, []*grpcClientConnWrapper{w}, connPoolConfig{})
+
+		assert.True(t, p.reactivateIdleConn())
+		assert.Equal(t, connStateActive, w.getState())
+		assert.True(t, w.idleSince().IsZero(), "idle timestamp should be cleared after reactivation")
+	})
+
+	t.Run("skips cancelled idle picks first live idle", func(t *testing.T) {
+		t.Parallel()
+		cancelledCtx, cancelledCancel := context.WithCancel(context.Background())
+		cancelledCancel()
+		cancelled := &grpcClientConnWrapper{ctx: cancelledCtx, cancel: cancelledCancel}
+		cancelled.setState(connStateIdle)
+
+		liveCtx, liveCancel := context.WithCancel(context.Background())
+		defer liveCancel()
+		live := &grpcClientConnWrapper{ctx: liveCtx, cancel: liveCancel}
+		live.setState(connStateIdle)
+
+		p := peerForScaleDown(t, []*grpcClientConnWrapper{cancelled, live}, connPoolConfig{})
+
+		assert.True(t, p.reactivateIdleConn())
+		assert.Equal(t, connStateIdle, cancelled.getState(), "cancelled conn should remain idle")
+		assert.Equal(t, connStateActive, live.getState(), "live idle conn should be reactivated")
+	})
+}
+
+// TestCleanupIdleConnsSkippedWhileScaling verifies that cleanupIdleConns
+// returns early without closing any connections when a scale-up is in progress,
+// so that idle connections remain available for reactivation by tryScaleUp.
+func TestCleanupIdleConnsSkippedWhileScaling(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Build an idle connection past its timeout that would normally be closed.
+	w := &grpcClientConnWrapper{ctx: ctx, cancel: cancel}
+	w.setState(connStateIdle)
+	atomic.StoreInt64(&w.lastIdleAtNano, time.Now().Add(-10*time.Minute).UnixNano())
+
+	cfg := connPoolConfig{idleTimeout: time.Second}
+	p := peerForScaleDown(t, []*grpcClientConnWrapper{w}, cfg)
+
+	// Simulate a scale-up goroutine running.
+	atomic.StoreInt32(&p.isScaling, 1)
+
+	p.cleanupIdleConns()
+
+	// Connection must not have been cancelled — isScaling caused early return.
+	assert.NoError(t, ctx.Err(), "idle connection must not be cancelled while scaling")
+	assert.Equal(t, connStateIdle, w.getState(), "connection state must be unchanged")
 }

--- a/transport/grpc/conn_pool_scaler_test.go
+++ b/transport/grpc/conn_pool_scaler_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package grpc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// newTestPeer returns a minimal grpcPeer sufficient for exercising the scaling
+// monitor.  None of the TODO methods access peer fields, so we only need the
+// context wiring.
+func newTestPeer(ctx context.Context, cancel context.CancelFunc) *grpcPeer {
+	return &grpcPeer{
+		ctx:    ctx,
+		cancel: cancel,
+	}
+}
+
+// TestRunScalingMonitorExitsOnContextCancel verifies that runScalingMonitor
+// returns promptly when the peer's context is cancelled.
+func TestRunScalingMonitorExitsOnContextCancel(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	p := newTestPeer(ctx, cancel)
+
+	done := make(chan struct{})
+	go func() {
+		p.runScalingMonitor()
+		close(done)
+	}()
+
+	cancel()
+
+	select {
+	case <-done:
+		// expected – monitor exited after context cancellation
+	case <-time.After(2 * time.Second):
+		t.Fatal("runScalingMonitor did not exit after context cancellation")
+	}
+}
+
+// TestRunScalingMonitorTicksEvaluateScaling verifies that the monitor calls
+// evaluateScaling at least once within a reasonable window.  We use a short
+// context deadline so that the test does not run indefinitely.
+func TestRunScalingMonitorTicksEvaluateScaling(t *testing.T) {
+	t.Parallel()
+
+	// Cancel after a short fixed window rather than a multiple of
+	// _scalingMonitorInterval, which is now 30s and would make the test too slow.
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	p := newTestPeer(ctx, cancel)
+
+	// runScalingMonitor blocks until the context expires; run it inline so the
+	// test waits for it naturally.
+	p.runScalingMonitor()
+
+	// If we reach here the monitor exited cleanly on context cancellation – success.
+}
+
+// TestEvaluateScalingDoesNotPanic ensures that evaluateScaling (and its
+// constituent helpers) can be called on a peer without panicking.
+func TestEvaluateScalingDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	p := newTestPeer(ctx, cancel)
+
+	assert.NotPanics(t, p.evaluateScaling)
+}
+
+// TestScalingHelperMethodsDoNotPanic verifies individual scaling helpers
+// independently to make future implementation easier to validate.
+func TestScalingHelperMethodsDoNotPanic(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	p := newTestPeer(ctx, cancel)
+
+	assert.NotPanics(t, p.cleanupIdleConns)
+	assert.NotPanics(t, p.maybeScaleDown)
+}

--- a/transport/grpc/conn_pool_scaler_test.go
+++ b/transport/grpc/conn_pool_scaler_test.go
@@ -73,9 +73,9 @@ func peerForScaleDown(t *testing.T, conns []*grpcClientConnWrapper, cfg connPool
 // defaultCfg is a pool config used across maybeScaleDown tests.
 // threshold = int32(100 * 0.8) = 80.
 var defaultScaleDownCfg = connPoolConfig{
-	minConnections:      1,
+	minConnections:       1,
 	maxConcurrentStreams: 100,
-	scaleUpThreshold:    0.8,
+	scaleUpThreshold:     0.8,
 }
 
 // makeConnWithCancel creates a grpcClientConnWrapper with a real context so
@@ -106,7 +106,7 @@ func TestCleanupIdleConns(t *testing.T) {
 		desc string
 		// build returns the conns slice and a slice of contexts corresponding
 		// to wrappers whose cancellation should be verified.
-		build      func() ([]*grpcClientConnWrapper, []context.Context)
+		build       func() ([]*grpcClientConnWrapper, []context.Context)
 		idleTimeout time.Duration
 		// wantStates is the expected state of each conn after the call (index-aligned).
 		wantStates []connState
@@ -242,7 +242,6 @@ func TestCleanupIdleConns(t *testing.T) {
 	}
 }
 
-
 func TestMaybeScaleDown(t *testing.T) {
 	t.Parallel()
 
@@ -277,9 +276,9 @@ func TestMaybeScaleDown(t *testing.T) {
 				makeConn(connStateActive, 10),
 			},
 			cfg: connPoolConfig{
-				minConnections:      2,
+				minConnections:       2,
 				maxConcurrentStreams: 100,
-				scaleUpThreshold:    0.8,
+				scaleUpThreshold:     0.8,
 			},
 			wantStates: []connState{connStateActive},
 		},
@@ -378,9 +377,9 @@ func TestMaybeScaleDown(t *testing.T) {
 				makeConn(connStateActive, 40),
 			},
 			cfg: connPoolConfig{
-				minConnections:      1,
+				minConnections:       1,
 				maxConcurrentStreams: 100,
-				scaleUpThreshold:    0.8, // threshold=80, capacity=80*2=160, total=85 < 160
+				scaleUpThreshold:     0.8, // threshold=80, capacity=80*2=160, total=85 < 160
 			},
 			wantStates: []connState{connStateDraining, connStateActive, connStateDraining, connStateActive},
 		},
@@ -741,9 +740,9 @@ func TestMaybeScaleDownMetrics(t *testing.T) {
 
 	p, root := peerWithMetrics(t)
 	p.poolCfg = connPoolConfig{
-		minConnections:      1,
+		minConnections:       1,
 		maxConcurrentStreams: 100,
-		scaleUpThreshold:    0.8, // threshold = 80
+		scaleUpThreshold:     0.8, // threshold = 80
 	}
 	p.wmu.Lock()
 	p.storeConns([]*grpcClientConnWrapper{

--- a/transport/grpc/conn_pool_scaler_test.go
+++ b/transport/grpc/conn_pool_scaler_test.go
@@ -502,9 +502,7 @@ func TestTryScaleUp(t *testing.T) {
 		for i := range conns {
 			conns[i] = makeConn(connStateActive, 0)
 		}
-		p.wmu.Lock()
 		p.storeConns(conns)
-		p.wmu.Unlock()
 		p.tryScaleUp(overBudget)
 
 		// atMax check now runs inside the goroutine; wait for it to finish.
@@ -512,9 +510,7 @@ func TestTryScaleUp(t *testing.T) {
 			return atomic.LoadInt32(&p.isScaling) == 0
 		}, 2*time.Second, 10*time.Millisecond)
 
-		p.wmu.Lock()
 		n := len(p.loadConns())
-		p.wmu.Unlock()
 		assert.Equal(t, p.poolCfg.maxConnections, n, "pool should not grow beyond max")
 	})
 
@@ -537,9 +533,7 @@ func TestTryScaleUp(t *testing.T) {
 		}, 2*time.Second, 10*time.Millisecond, "isScaling should reset to 0 after goroutine completes")
 
 		// One connection was added to the pool.
-		p.wmu.Lock()
 		n := len(p.loadConns())
-		p.wmu.Unlock()
 		assert.Equal(t, 1, n, "one connection should be added to the pool")
 	})
 
@@ -553,9 +547,7 @@ func TestTryScaleUp(t *testing.T) {
 		idleConn := &grpcClientConnWrapper{ctx: ctx, cancel: cancel}
 		idleConn.setState(connStateIdle)
 		idleConn.setIdleNow()
-		p.wmu.Lock()
 		p.storeConns(append(p.loadConns(), idleConn))
-		p.wmu.Unlock()
 
 		p.tryScaleUp(overBudget)
 
@@ -564,9 +556,7 @@ func TestTryScaleUp(t *testing.T) {
 		}, 2*time.Second, 10*time.Millisecond)
 
 		// Pool size unchanged — reactivation, not a new dial.
-		p.wmu.Lock()
 		n := len(p.loadConns())
-		p.wmu.Unlock()
 		assert.Equal(t, 1, n, "pool size should not grow on reactivation")
 		assert.Equal(t, connStateActive, idleConn.getState(), "idle conn should be active after reactivation")
 		assert.True(t, idleConn.idleSince().IsZero(), "idle timestamp should be cleared")
@@ -715,14 +705,12 @@ func TestRefreshPoolMetrics(t *testing.T) {
 	t.Run("mixed pool reports correct counts", func(t *testing.T) {
 		t.Parallel()
 		p, root := peerWithMetrics(t)
-		p.wmu.Lock()
 		p.storeConns([]*grpcClientConnWrapper{
 			makeConn(connStateActive, 0),
 			makeConn(connStateActive, 0),
 			makeConn(connStateDraining, 0),
 			makeConn(connStateIdle, 0),
 		})
-		p.wmu.Unlock()
 
 		p.refreshPoolMetrics()
 
@@ -744,13 +732,11 @@ func TestMaybeScaleDownMetrics(t *testing.T) {
 		maxConcurrentStreams: 100,
 		scaleUpThreshold:     0.8, // threshold = 80
 	}
-	p.wmu.Lock()
 	p.storeConns([]*grpcClientConnWrapper{
 		makeConn(connStateActive, 10),
 		makeConn(connStateActive, 10),
 		makeConn(connStateActive, 10), // total 30 < capacityAfterDrain=160 → drain
 	})
-	p.wmu.Unlock()
 
 	p.maybeScaleDown()
 
@@ -796,9 +782,7 @@ func TestTryScaleUpReactivationMetrics(t *testing.T) {
 	defer cancel()
 	idleConn := &grpcClientConnWrapper{ctx: ctx, cancel: cancel}
 	idleConn.setState(connStateIdle)
-	p.wmu.Lock()
 	p.storeConns(append(p.loadConns(), idleConn))
-	p.wmu.Unlock()
 
 	overBudget := makeConn(connStateActive, 85)
 	p.tryScaleUp(overBudget)
@@ -823,12 +807,10 @@ func TestCleanupIdleConnsMetrics(t *testing.T) {
 
 	p, root := peerWithMetrics(t)
 	p.poolCfg = connPoolConfig{idleTimeout: time.Hour}
-	p.wmu.Lock()
 	p.storeConns([]*grpcClientConnWrapper{
 		makeConn(connStateActive, 5),
 		makeConn(connStateDraining, 0), // 0 streams → advances to idle
 	})
-	p.wmu.Unlock()
 
 	p.cleanupIdleConns()
 

--- a/transport/grpc/conn_pool_scaler_test.go
+++ b/transport/grpc/conn_pool_scaler_test.go
@@ -59,14 +59,15 @@ func peerForScaleDown(t *testing.T, conns []*grpcClientConnWrapper, cfg connPool
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	transport := NewTransport()
-	return &grpcPeer{
+	p := &grpcPeer{
 		Peer:    abstractpeer.NewPeer(abstractpeer.PeerIdentifier("10.0.0.1:9000"), transport),
 		t:       transport,
 		ctx:     ctx,
 		cancel:  cancel,
-		conns:   conns,
 		poolCfg: cfg,
 	}
+	p.storeConns(conns)
+	return p
 }
 
 // defaultCfg is a pool config used across maybeScaleDown tests.
@@ -221,9 +222,9 @@ func TestCleanupIdleConns(t *testing.T) {
 
 			p.cleanupIdleConns()
 
-			require.Len(t, p.conns, len(tt.wantStates))
+			require.Len(t, p.loadConns(), len(tt.wantStates))
 			for i, want := range tt.wantStates {
-				assert.Equal(t, want, p.conns[i].getState(), "conn[%d] state", i)
+				assert.Equal(t, want, p.loadConns()[i].getState(), "conn[%d] state", i)
 			}
 
 			cancelledSet := make(map[int]bool)
@@ -391,9 +392,9 @@ func TestMaybeScaleDown(t *testing.T) {
 			p := peerForScaleDown(t, tt.conns, tt.cfg)
 			p.maybeScaleDown()
 
-			require.Len(t, p.conns, len(tt.wantStates))
+			require.Len(t, p.loadConns(), len(tt.wantStates))
 			for i, want := range tt.wantStates {
-				assert.Equal(t, want, p.conns[i].getState(),
+				assert.Equal(t, want, p.loadConns()[i].getState(),
 					"conn[%d] state mismatch", i)
 			}
 		})
@@ -502,9 +503,9 @@ func TestTryScaleUp(t *testing.T) {
 		for i := range conns {
 			conns[i] = makeConn(connStateActive, 0)
 		}
-		p.mu.Lock()
-		p.conns = conns
-		p.mu.Unlock()
+		p.wmu.Lock()
+		p.storeConns(conns)
+		p.wmu.Unlock()
 		p.tryScaleUp(overBudget)
 
 		// atMax check now runs inside the goroutine; wait for it to finish.
@@ -512,9 +513,9 @@ func TestTryScaleUp(t *testing.T) {
 			return atomic.LoadInt32(&p.isScaling) == 0
 		}, 2*time.Second, 10*time.Millisecond)
 
-		p.mu.RLock()
-		n := len(p.conns)
-		p.mu.RUnlock()
+		p.wmu.Lock()
+		n := len(p.loadConns())
+		p.wmu.Unlock()
 		assert.Equal(t, p.poolCfg.maxConnections, n, "pool should not grow beyond max")
 	})
 
@@ -537,9 +538,9 @@ func TestTryScaleUp(t *testing.T) {
 		}, 2*time.Second, 10*time.Millisecond, "isScaling should reset to 0 after goroutine completes")
 
 		// One connection was added to the pool.
-		p.mu.RLock()
-		n := len(p.conns)
-		p.mu.RUnlock()
+		p.wmu.Lock()
+		n := len(p.loadConns())
+		p.wmu.Unlock()
 		assert.Equal(t, 1, n, "one connection should be added to the pool")
 	})
 
@@ -553,9 +554,9 @@ func TestTryScaleUp(t *testing.T) {
 		idleConn := &grpcClientConnWrapper{ctx: ctx, cancel: cancel}
 		idleConn.setState(connStateIdle)
 		idleConn.setIdleNow()
-		p.mu.Lock()
-		p.conns = append(p.conns, idleConn)
-		p.mu.Unlock()
+		p.wmu.Lock()
+		p.storeConns(append(p.loadConns(), idleConn))
+		p.wmu.Unlock()
 
 		p.tryScaleUp(overBudget)
 
@@ -564,9 +565,9 @@ func TestTryScaleUp(t *testing.T) {
 		}, 2*time.Second, 10*time.Millisecond)
 
 		// Pool size unchanged — reactivation, not a new dial.
-		p.mu.RLock()
-		n := len(p.conns)
-		p.mu.RUnlock()
+		p.wmu.Lock()
+		n := len(p.loadConns())
+		p.wmu.Unlock()
 		assert.Equal(t, 1, n, "pool size should not grow on reactivation")
 		assert.Equal(t, connStateActive, idleConn.getState(), "idle conn should be active after reactivation")
 		assert.True(t, idleConn.idleSince().IsZero(), "idle timestamp should be cleared")
@@ -715,14 +716,14 @@ func TestRefreshPoolMetrics(t *testing.T) {
 	t.Run("mixed pool reports correct counts", func(t *testing.T) {
 		t.Parallel()
 		p, root := peerWithMetrics(t)
-		p.mu.Lock()
-		p.conns = []*grpcClientConnWrapper{
+		p.wmu.Lock()
+		p.storeConns([]*grpcClientConnWrapper{
 			makeConn(connStateActive, 0),
 			makeConn(connStateActive, 0),
 			makeConn(connStateDraining, 0),
 			makeConn(connStateIdle, 0),
-		}
-		p.mu.Unlock()
+		})
+		p.wmu.Unlock()
 
 		p.refreshPoolMetrics()
 
@@ -744,13 +745,13 @@ func TestMaybeScaleDownMetrics(t *testing.T) {
 		maxConcurrentStreams: 100,
 		scaleUpThreshold:    0.8, // threshold = 80
 	}
-	p.mu.Lock()
-	p.conns = []*grpcClientConnWrapper{
+	p.wmu.Lock()
+	p.storeConns([]*grpcClientConnWrapper{
 		makeConn(connStateActive, 10),
 		makeConn(connStateActive, 10),
 		makeConn(connStateActive, 10), // total 30 < capacityAfterDrain=160 → drain
-	}
-	p.mu.Unlock()
+	})
+	p.wmu.Unlock()
 
 	p.maybeScaleDown()
 
@@ -796,9 +797,9 @@ func TestTryScaleUpReactivationMetrics(t *testing.T) {
 	defer cancel()
 	idleConn := &grpcClientConnWrapper{ctx: ctx, cancel: cancel}
 	idleConn.setState(connStateIdle)
-	p.mu.Lock()
-	p.conns = append(p.conns, idleConn)
-	p.mu.Unlock()
+	p.wmu.Lock()
+	p.storeConns(append(p.loadConns(), idleConn))
+	p.wmu.Unlock()
 
 	overBudget := makeConn(connStateActive, 85)
 	p.tryScaleUp(overBudget)
@@ -823,12 +824,12 @@ func TestCleanupIdleConnsMetrics(t *testing.T) {
 
 	p, root := peerWithMetrics(t)
 	p.poolCfg = connPoolConfig{idleTimeout: time.Hour}
-	p.mu.Lock()
-	p.conns = []*grpcClientConnWrapper{
+	p.wmu.Lock()
+	p.storeConns([]*grpcClientConnWrapper{
 		makeConn(connStateActive, 5),
 		makeConn(connStateDraining, 0), // 0 streams → advances to idle
-	}
-	p.mu.Unlock()
+	})
+	p.wmu.Unlock()
 
 	p.cleanupIdleConns()
 

--- a/transport/grpc/conn_pool_scaler_test.go
+++ b/transport/grpc/conn_pool_scaler_test.go
@@ -22,6 +22,7 @@ package grpc
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -31,6 +32,7 @@ import (
 	"go.uber.org/net/metrics"
 	"go.uber.org/yarpc/peer/abstractpeer"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 // newTestPeer returns a minimal grpcPeer sufficient for exercising the scaling
@@ -182,7 +184,7 @@ func TestCleanupIdleConns(t *testing.T) {
 			wantCancelled: nil,
 		},
 		{
-			// Idle past timeout: all conditions met → appended to toClose,
+			// Idle past timeout: all conditions met → CAS idle→closing succeeds,
 			// logger.Debug called, c.cancel() called.
 			desc: "idle past timeout - cancel called",
 			build: func() ([]*grpcClientConnWrapper, []context.Context) {
@@ -191,7 +193,7 @@ func TestCleanupIdleConns(t *testing.T) {
 				return []*grpcClientConnWrapper{w}, []context.Context{ctx}
 			},
 			idleTimeout:   shortTimeout,
-			wantStates:    []connState{connStateIdle},
+			wantStates:    []connState{connStateClosing},
 			wantCancelled: []int{0},
 		},
 		{
@@ -202,12 +204,12 @@ func TestCleanupIdleConns(t *testing.T) {
 				w0, ctx0 := makeConnWithCancel(connStateActive, 10, time.Time{})
 				w1, ctx1 := makeConnWithCancel(connStateDraining, 0, time.Time{}) // → idle
 				pastTime := time.Now().Add(-5 * time.Minute)
-				w2, ctx2 := makeConnWithCancel(connStateIdle, 0, pastTime) // → cancel
+				w2, ctx2 := makeConnWithCancel(connStateIdle, 0, pastTime) // → closing + cancel
 				return []*grpcClientConnWrapper{w0, w1, w2},
 					[]context.Context{ctx0, ctx1, ctx2}
 			},
 			idleTimeout:   shortTimeout,
-			wantStates:    []connState{connStateActive, connStateIdle, connStateIdle},
+			wantStates:    []connState{connStateActive, connStateIdle, connStateClosing},
 			wantCancelled: []int{2},
 		},
 	}
@@ -818,4 +820,366 @@ func TestCleanupIdleConnsMetrics(t *testing.T) {
 	assert.Equal(t, int64(1), g["conn_pool_active_connections"])
 	assert.Equal(t, int64(0), g["conn_pool_draining_connections"])
 	assert.Equal(t, int64(1), g["conn_pool_idle_connections"])
+}
+
+// TestMaybeScaleDownWithExistingDrainingConn verifies that when some
+// connections are already draining, maybeScaleDown only considers active
+// connections for the pool size check and candidate selection.  The
+// already-draining connection is left untouched; one of the active ones is
+// drained if load is low enough.
+func TestMaybeScaleDownWithExistingDrainingConn(t *testing.T) {
+	t.Parallel()
+	// 2 active + 1 already-draining. active=2 > minConnections=1, low load → drain one active.
+	conns := []*grpcClientConnWrapper{
+		makeConn(connStateActive, 5),
+		makeConn(connStateActive, 5),
+		makeConn(connStateDraining, 30), // already draining — excluded from active pool
+	}
+	p := peerForScaleDown(t, conns, defaultScaleDownCfg)
+	p.maybeScaleDown()
+
+	// conns[2] must remain draining — it was never in the active selection pool.
+	assert.Equal(t, connStateDraining, conns[2].getState(), "pre-existing draining conn must not change state")
+
+	// Exactly one of the active conns must now be draining.
+	drained := 0
+	for _, c := range conns[:2] {
+		if c.getState() == connStateDraining {
+			drained++
+		}
+	}
+	assert.Equal(t, 1, drained, "exactly one active conn should be drained")
+}
+
+// TestCleanupIdleConnsDrainingCASFailure verifies that cleanupIdleConns skips
+// the draining→idle transition when another goroutine has already changed the
+// connection state away from draining (CAS failure path).
+func TestCleanupIdleConnsDrainingCASFailure(t *testing.T) {
+	t.Parallel()
+
+	// Connection starts draining with zero streams — would normally advance to idle.
+	w, ctx := makeConnWithCancel(connStateDraining, 0, time.Time{})
+
+	// Simulate a concurrent reactivation: state is changed to active before
+	// cleanupIdleConns gets to the CAS.
+	w.setState(connStateActive)
+
+	cfg := connPoolConfig{idleTimeout: time.Hour}
+	p := peerForScaleDown(t, []*grpcClientConnWrapper{w}, cfg)
+	p.cleanupIdleConns()
+
+	// CAS draining→idle failed (state was active) — connection stays active.
+	assert.Equal(t, connStateActive, w.getState())
+	assert.NoError(t, ctx.Err(), "active connection must not be cancelled")
+}
+
+// TestRunScalingMonitorUsesConfiguredInterval verifies that a non-zero
+// scalingMonitorInterval from poolCfg is used instead of the default,
+// and that a value below the 30s minimum is clamped (with a warning) rather
+// than causing a panic or hard error.
+func TestRunScalingMonitorUsesConfiguredInterval(t *testing.T) {
+	t.Parallel()
+	// peerForPool provides a transport with a nop logger so the clamping warning
+	// in runScalingMonitor does not panic.
+	p := peerForPool(t)
+	// 5s is below the 30s minimum → will be clamped; the monitor still exits
+	// promptly when the context is cancelled.
+	p.poolCfg.scalingMonitorInterval = 5 * time.Second
+
+	done := make(chan struct{})
+	go func() {
+		p.runScalingMonitor()
+		close(done)
+	}()
+
+	p.cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runScalingMonitor did not exit after context cancellation with clamped interval")
+	}
+}
+
+// TestRunScalingMonitorValidCustomInterval verifies that an interval at or
+// above the 30s minimum is used as-is without clamping.
+func TestRunScalingMonitorValidCustomInterval(t *testing.T) {
+	t.Parallel()
+	p := peerForPool(t)
+	p.poolCfg.scalingMonitorInterval = 60 * time.Second // valid, above minimum
+
+	done := make(chan struct{})
+	go func() {
+		p.runScalingMonitor()
+		close(done)
+	}()
+
+	p.cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runScalingMonitor did not exit after context cancellation with 60s interval")
+	}
+}
+
+// TestRunScalingMonitorClampsAndWarns verifies that a below-minimum interval
+// emits a Warn log and the monitor still exits cleanly on context cancellation.
+func TestRunScalingMonitorClampsAndWarns(t *testing.T) {
+	t.Parallel()
+	core, logs := observer.New(zap.WarnLevel)
+	observedLogger := zap.New(core)
+
+	tr := NewTransport(Logger(observedLogger))
+	ctx, cancel := context.WithCancel(context.Background())
+	p := &grpcPeer{
+		Peer:    abstractpeer.NewPeer(abstractpeer.PeerIdentifier("10.0.0.1:9000"), tr),
+		t:       tr,
+		ctx:     ctx,
+		cancel:  cancel,
+		poolCfg: connPoolConfig{scalingMonitorInterval: 5 * time.Second},
+	}
+	t.Cleanup(cancel)
+
+	done := make(chan struct{})
+	go func() {
+		p.runScalingMonitor()
+		close(done)
+	}()
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runScalingMonitor did not exit")
+	}
+
+	require.Equal(t, 1, logs.Len(), "expected exactly one warning log")
+	assert.Contains(t, logs.All()[0].Message, "scalingMonitorInterval")
+	assert.Equal(t, zap.WarnLevel, logs.All()[0].Level)
+}
+
+// TestTransportOptionDefaults verifies that newTransportOptions applies the
+// correct default values for the two new pool config fields.
+func TestTransportOptionDefaults(t *testing.T) {
+	t.Parallel()
+	opts := newTransportOptions(nil)
+	assert.Equal(t, defaultClientConnPoolScaleDownGap, opts.clientConnPoolScaleDownGap,
+		"scaleDownGap default should be %.2f", defaultClientConnPoolScaleDownGap)
+	assert.Equal(t, defaultClientConnPoolScalingMonitorInterval, opts.clientConnPoolScalingMonitorInterval,
+		"scalingMonitorInterval default should be %v", defaultClientConnPoolScalingMonitorInterval)
+}
+
+// between cleanupIdleConns (which cancels idle connections) and
+// reactivateIdleConn (which transitions idle connections back to active).
+// Run with -race to catch the race described in the review:
+//
+//	Time 1 cleanupIdleConns: reads isScaling==0, adds c to toClose
+//	Time 2 reactivateIdleConn: CAS idle→active
+//	Time 3 cleanupIdleConns: would cancel an active connection without CAS guard
+//
+// With CAS, only one of the two wins the idle→closing or idle→active transition.
+func TestConcurrentCleanupAndReactivationRace(t *testing.T) {
+	t.Parallel()
+
+	const iterations = 500
+	for i := 0; i < iterations; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+
+		w := &grpcClientConnWrapper{ctx: ctx, cancel: cancel}
+		w.setState(connStateIdle)
+		atomic.StoreInt64(&w.lastIdleAtNano, time.Now().Add(-10*time.Minute).UnixNano())
+
+		cfg := connPoolConfig{idleTimeout: time.Second}
+		p := peerForScaleDown(t, []*grpcClientConnWrapper{w}, cfg)
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			p.cleanupIdleConns()
+		}()
+		go func() {
+			defer wg.Done()
+			p.reactivateIdleConn()
+		}()
+		wg.Wait()
+
+		// Invariant: if the connection is active, its context must not be cancelled.
+		// This would fire if cleanupIdleConns cancelled a connection that
+		// reactivateIdleConn had already transitioned to active.
+		if w.getState() == connStateActive {
+			assert.NoError(t, ctx.Err(),
+				"active connection must not have a cancelled context (iteration %d)", i)
+		}
+	}
+}
+
+// TestConcurrentScaleDownAndScaleUpRace verifies that concurrent maybeScaleDown
+// and tryScaleUp calls on the same pool do not corrupt connection state.
+// The race being guarded: both functions read the pool snapshot and evaluate the
+// same connection; the CAS in each (active→draining for scaleDown, draining→active
+// or dial for scaleUp) ensures only one winner per transition.
+//
+// Invariant: after each iteration no connection is simultaneously draining and
+// receiving new streams (stream count on a draining conn must not increase after
+// the CAS succeeds, because pickConn skips non-active connections).
+// Run with -race to catch any unsynchronised reads/writes.
+func TestConcurrentScaleDownAndScaleUpRace(t *testing.T) {
+	t.Parallel()
+
+	const iterations = 500
+	for i := 0; i < iterations; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+
+		// Two active connections each at 80% load (scaleUpThreshold=0.8, streams=80/100).
+		// maybeScaleDown: totalStreams=160, capacityAfterDrain=80*1=80 → 160>=80 → no drain.
+		// Keep load high so tryScaleUp also fires (least-loaded is at threshold).
+		cfg := connPoolConfig{
+			minConnections:       1,
+			maxConnections:       5,
+			maxConcurrentStreams: 100,
+			scaleUpThreshold:     0.8,
+			scaleDownGap:         0.1,
+		}
+		c1 := &grpcClientConnWrapper{ctx: ctx, cancel: cancel}
+		c1.setState(connStateActive)
+		atomic.StoreInt32(&c1.streamCount, 80)
+		c2 := &grpcClientConnWrapper{ctx: ctx, cancel: cancel}
+		c2.setState(connStateActive)
+		atomic.StoreInt32(&c2.streamCount, 80)
+
+		p := peerForScaleDown(t, []*grpcClientConnWrapper{c1, c2}, cfg)
+		t.Cleanup(cancel)
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			p.maybeScaleDown()
+		}()
+		go func() {
+			defer wg.Done()
+			// tryScaleUp picks the least-loaded conn; both are at threshold.
+			p.tryScaleUp(c1)
+		}()
+		wg.Wait()
+		cancel() // stop any scale-up dial goroutine
+
+		// Invariant: draining connections must not be treated as active by pickConn.
+		// If a connection is draining its state must be consistent — no connection
+		// should be both draining AND still selected as active by pickConn.
+		picked := p.pickConn()
+		for _, c := range p.loadConns() {
+			if c.getState() == connStateDraining {
+				assert.NotEqual(t, c, picked,
+					"iteration %d: draining connection must not be picked as active", i)
+			}
+		}
+	}
+}
+
+// TestMaybeScaleDownHysteresis verifies that the scaleDownGap prevents draining
+// when stream count is between the scale-down and scale-up thresholds.
+func TestMaybeScaleDownHysteresis(t *testing.T) {
+	t.Parallel()
+
+	// scaleUpThreshold=0.8, scaleDownGap=0.1 → scaleDownThreshold=0.7
+	// maxConcurrentStreams=100 → scaleDownThreshold=70
+	// With 3 active conns: capacityAfterDrain = 70 * 2 = 140
+	cfg := connPoolConfig{
+		minConnections:       1,
+		maxConcurrentStreams: 100,
+		scaleUpThreshold:     0.8,
+		scaleDownGap:         0.1,
+	}
+
+	t.Run("load between scale-down and scale-up thresholds - no drain", func(t *testing.T) {
+		t.Parallel()
+		// totalStreams=150: above scaleDownThreshold capacity (140) but below scaleUpThreshold capacity (160)
+		// Without hysteresis this would drain; with gap it should not.
+		conns := []*grpcClientConnWrapper{
+			makeConn(connStateActive, 50),
+			makeConn(connStateActive, 50),
+			makeConn(connStateActive, 50), // total=150, capacityAfterDrain=140, 150>=140 → no drain
+		}
+		p := peerForScaleDown(t, conns, cfg)
+		p.maybeScaleDown()
+		for i, c := range p.loadConns() {
+			assert.Equal(t, connStateActive, c.getState(), "conn[%d] should stay active", i)
+		}
+	})
+
+	t.Run("load below scale-down threshold - drains", func(t *testing.T) {
+		t.Parallel()
+		// totalStreams=60: below capacityAfterDrain=140 → should drain
+		conns := []*grpcClientConnWrapper{
+			makeConn(connStateActive, 20),
+			makeConn(connStateActive, 20),
+			makeConn(connStateActive, 20), // total=60 < 140 → drain
+		}
+		p := peerForScaleDown(t, conns, cfg)
+		p.maybeScaleDown()
+		draining := 0
+		for _, c := range p.loadConns() {
+			if c.getState() == connStateDraining {
+				draining++
+			}
+		}
+		assert.Equal(t, 1, draining, "exactly one connection should be draining")
+	})
+}
+
+// TestReactivateDrainingConn verifies that reactivateIdleConn falls back to
+// reactivating a draining connection when no idle connection is available,
+// preventing accumulation of stuck draining connections under sustained load.
+func TestReactivateDrainingConn(t *testing.T) {
+	t.Parallel()
+
+	t.Run("reactivates draining connection when no idle available", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		draining := &grpcClientConnWrapper{ctx: ctx, cancel: cancel}
+		draining.setState(connStateDraining)
+		draining.streamCount = 5 // has in-flight streams
+
+		p := peerForScaleDown(t, []*grpcClientConnWrapper{draining}, connPoolConfig{})
+		assert.True(t, p.reactivateIdleConn(), "should reactivate draining conn")
+		assert.Equal(t, connStateActive, draining.getState())
+	})
+
+	t.Run("prefers idle over draining for reactivation", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		idle := &grpcClientConnWrapper{ctx: ctx, cancel: cancel}
+		idle.setState(connStateIdle)
+
+		ctx2, cancel2 := context.WithCancel(context.Background())
+		defer cancel2()
+		draining := &grpcClientConnWrapper{ctx: ctx2, cancel: cancel2}
+		draining.setState(connStateDraining)
+
+		p := peerForScaleDown(t, []*grpcClientConnWrapper{draining, idle}, connPoolConfig{})
+		assert.True(t, p.reactivateIdleConn())
+		assert.Equal(t, connStateActive, idle.getState(), "idle conn should be reactivated first")
+		assert.Equal(t, connStateDraining, draining.getState(), "draining conn should be untouched")
+	})
+
+	t.Run("skips draining conn with cancelled context", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // already cancelled
+
+		draining := &grpcClientConnWrapper{ctx: ctx, cancel: cancel}
+		draining.setState(connStateDraining)
+
+		p := peerForScaleDown(t, []*grpcClientConnWrapper{draining}, connPoolConfig{})
+		assert.False(t, p.reactivateIdleConn(), "cancelled draining conn must not be reactivated")
+		assert.Equal(t, connStateDraining, draining.getState())
+	})
 }

--- a/transport/grpc/external_integration_test.go
+++ b/transport/grpc/external_integration_test.go
@@ -23,24 +23,29 @@ package grpc_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/net/metrics"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/middleware"
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/internal/prototest/example"
 	"go.uber.org/yarpc/internal/prototest/examplepb"
+	yarpcpeer "go.uber.org/yarpc/peer"
 	"go.uber.org/yarpc/peer/hostport"
 	"go.uber.org/yarpc/peer/roundrobin"
 	"go.uber.org/yarpc/transport/grpc"
 	"go.uber.org/yarpc/x/yarpctest"
 	"go.uber.org/yarpc/x/yarpctest/api"
 	"go.uber.org/yarpc/x/yarpctest/types"
+	"go.uber.org/zap"
 )
 
 func TestStreamingWithNoCtxDeadline(t *testing.T) {
@@ -179,4 +184,195 @@ func TestFoo(t *testing.T) {
 		}),
 	)
 	request.Run(t)
+}
+
+// --- connection pool integration tests (public API only) ---
+
+// withPoolTestEnv starts a gRPC server+client pair with the given transport
+// options using only the public API, runs f, then tears everything down.
+func withPoolTestEnv(t *testing.T, opts []grpc.TransportOption, f func(set, get func(ctx context.Context, key, value string) error)) {
+	t.Helper()
+
+	const svcName = "example"
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	// Use a nop logger so goroutines that outlive the test (e.g. monitorConnWrapper
+	// draining after dispatcher.Stop()) cannot trigger zaptest's after-test panic.
+	opts = append(opts, grpc.Logger(zap.NewNop()))
+	trans := grpc.NewTransport(opts...)
+
+	chooser := yarpcpeer.NewSingle(hostport.PeerIdentifier(listener.Addr().String()), trans.NewDialer())
+	dispatcher := yarpc.NewDispatcher(yarpc.Config{
+		Name:     svcName,
+		Inbounds: yarpc.Inbounds{trans.NewInbound(listener)},
+		Outbounds: yarpc.Outbounds{
+			svcName: {ServiceName: svcName, Unary: trans.NewOutbound(chooser)},
+		},
+	})
+	dispatcher.Register(examplepb.BuildKeyValueYARPCProcedures(example.NewKeyValueYARPCServer()))
+	require.NoError(t, dispatcher.Start())
+	defer func() { assert.NoError(t, dispatcher.Stop()) }()
+
+	client := examplepb.NewKeyValueYARPCClient(dispatcher.ClientConfig(svcName))
+
+	set := func(ctx context.Context, key, value string) error {
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		_, err := client.SetValue(ctx, &examplepb.SetValueRequest{Key: key, Value: value})
+		return err
+	}
+	get := func(ctx context.Context, key, _ string) error {
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		_, err := client.GetValue(ctx, &examplepb.GetValueRequest{Key: key})
+		return err
+	}
+	f(set, get)
+}
+
+// extPoolMetricSnapshot reads gauges and counters from a metrics root into maps.
+func extPoolMetricSnapshot(root *metrics.Root) (gauges, counters map[string]int64) {
+	snap := root.Snapshot()
+	gauges = make(map[string]int64, len(snap.Gauges))
+	for _, g := range snap.Gauges {
+		gauges[g.Name] = g.Value
+	}
+	counters = make(map[string]int64, len(snap.Counters))
+	for _, c := range snap.Counters {
+		counters[c.Name] = c.Value
+	}
+	return
+}
+
+func TestConnectionPoolBasicRequest(t *testing.T) {
+	t.Parallel()
+	withPoolTestEnv(t, []grpc.TransportOption{
+		grpc.WithDynamicConnectionScaling(true),
+		grpc.MinConnections(2),
+		grpc.MaxConnections(5),
+	}, func(set, get func(ctx context.Context, key, value string) error) {
+		ctx := context.Background()
+		require.NoError(t, set(ctx, "foo", "bar"))
+		require.NoError(t, get(ctx, "foo", ""))
+	})
+}
+
+func TestConnectionPoolMinConnectionsAtStartup(t *testing.T) {
+	t.Parallel()
+	root := metrics.New()
+	withPoolTestEnv(t, []grpc.TransportOption{
+		grpc.WithDynamicConnectionScaling(true),
+		grpc.MinConnections(2),
+		grpc.MaxConnections(5),
+		grpc.Meter(root.Scope()),
+	}, func(_, _ func(ctx context.Context, key, value string) error) {
+		gauges, _ := extPoolMetricSnapshot(root)
+		assert.Equal(t, int64(2), gauges["conn_pool_active_connections"],
+			"pool should be pre-warmed to minConnections")
+	})
+}
+
+func TestConnectionPoolScaleUpOnLoad(t *testing.T) {
+	t.Parallel()
+	root := metrics.New()
+	withPoolTestEnv(t, []grpc.TransportOption{
+		grpc.WithDynamicConnectionScaling(true),
+		grpc.MinConnections(1),
+		grpc.MaxConnections(5),
+		grpc.MaxConcurrentStreams(2),
+		grpc.ScaleUpThreshold(0.5), // threshold = 1
+		grpc.Meter(root.Scope()),
+	}, func(set, _ func(ctx context.Context, key, value string) error) {
+		require.NoError(t, set(context.Background(), "foo", "bar"))
+
+		assert.Eventually(t, func() bool {
+			_, counters := extPoolMetricSnapshot(root)
+			return counters["conn_pool_scale_up_total"] >= 1
+		}, 3*time.Second, 10*time.Millisecond,
+			"conn_pool_scale_up_total should increment after load exceeds threshold")
+	})
+}
+
+func TestConnectionPoolConcurrentRequests(t *testing.T) {
+	t.Parallel()
+	withPoolTestEnv(t, []grpc.TransportOption{
+		grpc.WithDynamicConnectionScaling(true),
+		grpc.MinConnections(2),
+		grpc.MaxConnections(5),
+	}, func(set, _ func(ctx context.Context, key, value string) error) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		const concurrent = 20
+		errs := make([]error, concurrent)
+		var wg sync.WaitGroup
+		wg.Add(concurrent)
+		for i := range concurrent {
+			go func() {
+				defer wg.Done()
+				errs[i] = set(ctx, fmt.Sprintf("key-%d", i), "value")
+			}()
+		}
+		wg.Wait()
+		for i, err := range errs {
+			assert.NoError(t, err, "request %d should succeed", i)
+		}
+	})
+}
+
+func TestConnectionPoolDisabledFallback(t *testing.T) {
+	t.Parallel()
+	withPoolTestEnv(t, []grpc.TransportOption{
+		grpc.WithDynamicConnectionScaling(false),
+	}, func(set, get func(ctx context.Context, key, value string) error) {
+		ctx := context.Background()
+		require.NoError(t, set(ctx, "foo", "bar"))
+		require.NoError(t, get(ctx, "foo", ""))
+	})
+}
+
+func TestConnectionPoolMinimalSingleConnection(t *testing.T) {
+	t.Parallel()
+	root := metrics.New()
+	withPoolTestEnv(t, []grpc.TransportOption{
+		grpc.WithDynamicConnectionScaling(true),
+		grpc.MinConnections(1),
+		grpc.MaxConnections(3),
+		grpc.Meter(root.Scope()),
+	}, func(set, get func(ctx context.Context, key, value string) error) {
+		ctx := context.Background()
+		require.NoError(t, set(ctx, "foo", "bar"))
+		require.NoError(t, get(ctx, "foo", ""))
+
+		gauges, _ := extPoolMetricSnapshot(root)
+		assert.GreaterOrEqual(t, gauges["conn_pool_active_connections"], int64(1))
+	})
+}
+
+func TestConnectionPoolMaxConnectionsCapRespected(t *testing.T) {
+	t.Parallel()
+	root := metrics.New()
+	withPoolTestEnv(t, []grpc.TransportOption{
+		grpc.WithDynamicConnectionScaling(true),
+		grpc.MinConnections(1),
+		grpc.MaxConnections(1),
+		grpc.MaxConcurrentStreams(2),
+		grpc.ScaleUpThreshold(0.5),
+		grpc.Meter(root.Scope()),
+	}, func(set, get func(ctx context.Context, key, value string) error) {
+		ctx := context.Background()
+		require.NoError(t, set(ctx, "foo", "bar"))
+		require.NoError(t, get(ctx, "foo", ""))
+
+		assert.Eventually(t, func() bool {
+			_, counters := extPoolMetricSnapshot(root)
+			return counters["conn_pool_scale_up_total"] == 0
+		}, 2*time.Second, 10*time.Millisecond,
+			"scale-up must not dial when MaxConnections is already reached")
+
+		gauges, _ := extPoolMetricSnapshot(root)
+		assert.Equal(t, int64(1), gauges["conn_pool_active_connections"])
+	})
 }

--- a/transport/grpc/integration_test.go
+++ b/transport/grpc/integration_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 	"go.uber.org/multierr"
+	"go.uber.org/net/metrics"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
 	yarpctls "go.uber.org/yarpc/api/transport/tls"
@@ -1040,5 +1041,155 @@ func TestYARPCErrorsConverted(t *testing.T) {
 
 		require.Error(t, err)
 		assert.True(t, yarpcerrors.IsUnimplemented(err))
+	})
+}
+
+// --- connection pool integration tests ---
+
+// poolMetricSnapshot reads all gauges and counters from a RootSnapshot into
+// convenient maps keyed by metric name.
+func poolMetricSnapshot(root *metrics.Root) (gauges, counters map[string]int64) {
+	snap := root.Snapshot()
+	gauges = make(map[string]int64, len(snap.Gauges))
+	for _, g := range snap.Gauges {
+		gauges[g.Name] = g.Value
+	}
+	counters = make(map[string]int64, len(snap.Counters))
+	for _, c := range snap.Counters {
+		counters[c.Name] = c.Value
+	}
+	return gauges, counters
+}
+
+// TestConnectionPoolScaleDown verifies that evaluateScaling drains a
+// connection when the aggregate stream load is low enough that the pool can
+// be reduced.  We call evaluateScaling() directly to bypass the 30-second
+// monitor interval.
+func TestConnectionPoolScaleDown(t *testing.T) {
+	t.Parallel()
+	root := metrics.New()
+	te := testEnvOptions{
+		TransportOptions: []TransportOption{
+			WithDynamicConnectionScaling(true),
+			MinConnections(1),
+			MaxConnections(5),
+			MaxConcurrentStreams(100),
+			ScaleUpThreshold(0.8), // threshold = 80
+			Meter(root.Scope()),
+		},
+	}
+	te.do(t, func(t *testing.T, e *testEnv) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		apiPeer, onFinish, err := e.Outbound.peerChooser.Choose(ctx, &transport.Request{})
+		require.NoError(t, err)
+		defer onFinish(nil)
+		p := apiPeer.(*grpcPeer)
+
+		// Grow the pool to 3 connections (minConnections=1 so scale-down is allowed).
+		require.NoError(t, p.addConn())
+		require.NoError(t, p.addConn())
+
+		// With 3 active connections, 0 total streams, and
+		// capacityAfterDrain = threshold*(3-1) = 80*2 = 160 > 0,
+		// maybeScaleDown must drain the most-loaded connection.
+		p.evaluateScaling()
+
+		gauges, counters := poolMetricSnapshot(root)
+		assert.Equal(t, int64(1), counters["conn_pool_scale_down_total"],
+			"scale-down counter should increment")
+		assert.Equal(t, int64(2), gauges["conn_pool_active_connections"])
+		assert.Equal(t, int64(1), gauges["conn_pool_draining_connections"])
+	})
+}
+
+// TestConnectionPoolIdleReactivation verifies that tryScaleUp reactivates an
+// idle connection instead of dialling a new one when capacity is needed.
+func TestConnectionPoolIdleReactivation(t *testing.T) {
+	t.Parallel()
+	root := metrics.New()
+	te := testEnvOptions{
+		TransportOptions: []TransportOption{
+			WithDynamicConnectionScaling(true),
+			MinConnections(1),
+			MaxConnections(3),
+			MaxConcurrentStreams(2),
+			ScaleUpThreshold(0.5), // threshold = 1
+			Meter(root.Scope()),
+		},
+	}
+	te.do(t, func(t *testing.T, e *testEnv) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		apiPeer, onFinish, err := e.Outbound.peerChooser.Choose(ctx, &transport.Request{})
+		require.NoError(t, err)
+		defer onFinish(nil)
+		p := apiPeer.(*grpcPeer)
+
+		// Mark the initial connection as idle (live context, so reactivation is allowed).
+		p.loadConns()[0].setState(connStateIdle)
+
+		// tryScaleUp should reactivate the idle conn instead of dialling.
+		overBudget := makeConn(connStateActive, 85)
+		p.tryScaleUp(overBudget)
+
+		require.Eventually(t, func() bool {
+			return atomic.LoadInt32(&p.isScaling) == 0
+		}, 2*time.Second, 10*time.Millisecond)
+
+		_, counters := poolMetricSnapshot(root)
+		assert.Equal(t, int64(1), counters["conn_pool_idle_reactivation_total"],
+			"idle reactivation counter should increment")
+		assert.Equal(t, int64(0), counters["conn_pool_scale_up_total"],
+			"no new dial should happen when an idle conn is available")
+
+		assert.Equal(t, connStateActive, p.loadConns()[0].getState(),
+			"formerly idle conn should be active after reactivation")
+	})
+}
+
+// TestConnectionPoolNoActiveConnectionsReturnsUnavailable verifies that when
+// all pool connections are draining (non-active) and the YARPC peer is still
+// considered Available by the chooser, invoke() returns UnavailableErrorf
+// rather than hanging or panicking.
+//
+// Marking connections as connStateDraining (our internal state) does not
+// cancel their contexts, so monitorConnWrapper stays blocked in
+// WaitForStateChange and does not update the peer's YARPC status.  The
+// chooser therefore still returns the peer, but pickConn() finds no active
+// connections and the outbound returns UnavailableErrorf immediately.
+func TestConnectionPoolNoActiveConnectionsReturnsUnavailable(t *testing.T) {
+	t.Parallel()
+	te := testEnvOptions{
+		TransportOptions: []TransportOption{
+			WithDynamicConnectionScaling(true),
+			MinConnections(1),
+			MaxConnections(3),
+		},
+	}
+	te.do(t, func(t *testing.T, e *testEnv) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		// Obtain the peer reference then immediately release the chooser hold.
+		apiPeer, onFinish, err := e.Outbound.peerChooser.Choose(ctx, &transport.Request{})
+		require.NoError(t, err)
+		onFinish(nil)
+		p := apiPeer.(*grpcPeer)
+
+		// Mark every connection as draining without cancelling contexts.
+		// monitorConnWrapper goroutines remain blocked in WaitForStateChange,
+		// so the YARPC peer status stays Available — Choose will still return
+		// this peer, but pickConn() will find no active connections.
+		for _, c := range p.loadConns() {
+			c.setState(connStateDraining)
+		}
+
+		err = e.SetValueYARPC(ctx, "foo", "bar")
+		require.Error(t, err)
+		assert.True(t, yarpcerrors.IsUnavailable(err),
+			"expected UnavailableErrorf when all connections are draining, got: %v", err)
 	})
 }

--- a/transport/grpc/options.go
+++ b/transport/grpc/options.go
@@ -25,6 +25,7 @@ import (
 	"crypto/tls"
 	"math"
 	"net"
+	"time"
 
 	opentracing "github.com/opentracing/opentracing-go"
 	"go.uber.org/net/metrics"
@@ -53,6 +54,13 @@ const (
 	// receive sizes to 64MB.
 	defaultServerMaxRecvMsgSize = 1024 * 1024 * 64
 	defaultClientMaxRecvMsgSize = 1024 * 1024 * 64
+	// Client connection pool defaults.
+	// defaultClientConnPoolMaxConcurrentStreams matches Go's net/http2 server default (SETTINGS_MAX_CONCURRENT_STREAMS = 250).
+	defaultClientConnPoolMaxConcurrentStreams int32         = 250
+	defaultClientConnPoolScaleUpThreshold     float64       = 0.8
+	defaultClientConnPoolMinConnections       int           = 1
+	defaultClientConnPoolMaxConnections       int           = 5
+	defaultClientConnPoolIdleTimeout          time.Duration = 15 * time.Minute
 )
 
 // Option is an interface shared by TransportOption, InboundOption, and OutboundOption
@@ -204,6 +212,81 @@ func ClientMaxHeaderListSize(clientMaxHeaderListSize uint32) TransportOption {
 	}
 }
 
+// MaxConcurrentStreams sets the assumed HTTP/2 SETTINGS_MAX_CONCURRENT_STREAMS
+// value enforced by the server.  YARPC uses this value to decide when to open
+// an additional connection to a peer.
+//
+// The gRPC client does not expose the server-advertised limit, so this must be
+// configured manually.  The default is 250, which matches Go's net/http2 server
+// default.
+func MaxConcurrentStreams(n int32) TransportOption {
+	return func(transportOptions *transportOptions) {
+		transportOptions.clientConnPoolMaxConcurrentStreams = n
+	}
+}
+
+// ScaleUpThreshold sets the fraction of MaxConcurrentStreams at which YARPC
+// opens an additional connection to a peer.  For example, a value of 0.8 means
+// a new connection is opened when any existing connection carries more than
+// 80% of its stream budget.
+//
+// The default is 0.8.
+func ScaleUpThreshold(f float64) TransportOption {
+	return func(transportOptions *transportOptions) {
+		transportOptions.clientConnPoolScaleUpThreshold = f
+	}
+}
+
+// MinConnections sets the minimum number of connections YARPC maintains to
+// each peer.  Connections are pre-established up to this count when the peer
+// is first retained.
+//
+// The default is 1.
+func MinConnections(n int) TransportOption {
+	return func(transportOptions *transportOptions) {
+		transportOptions.clientConnPoolMinConnections = n
+	}
+}
+
+// MaxConnections sets the maximum number of connections YARPC may open to a
+// single peer.
+//
+// The default is 5.
+func MaxConnections(n int) TransportOption {
+	return func(transportOptions *transportOptions) {
+		transportOptions.clientConnPoolMaxConnections = n
+	}
+}
+
+// ConnIdleTimeout sets how long a fully-drained connection remains idle before
+// YARPC closes it and removes it from the pool.
+//
+// The default is 15 minutes.
+func ConnIdleTimeout(d time.Duration) TransportOption {
+	return func(transportOptions *transportOptions) {
+		transportOptions.clientConnPoolIdleTimeout = d
+	}
+}
+
+// WithDynamicConnectionScaling enables or disables automatic gRPC connection
+// pool scaling based on stream utilization.
+//
+// When enabled, YARPC monitors stream usage on each pooled connection and
+// automatically opens new connections when any connection exceeds
+// ScaleUpThreshold, and drains connections when aggregate utilization drops
+// low enough to consolidate load onto fewer connections.
+//
+// Because YARPC is an open-source project, Flipr/ObjectConfig based rollout is handled
+// externally: set this option to true only after validating the change in a
+// controlled environment.
+//
+// The default is false (disabled).
+func WithDynamicConnectionScaling(enabled bool) TransportOption {
+	return func(transportOptions *transportOptions) {
+		transportOptions.clientConnPoolDynamicScalingEnabled = enabled
+	}
+}
+
 // InboundOption is an option for an inbound.
 type InboundOption func(*inboundOptions)
 
@@ -337,6 +420,13 @@ type transportOptions struct {
 	unaryOutboundInterceptor  []interceptor.UnaryOutbound
 	streamInboundInterceptor  interceptor.StreamInbound
 	streamOutboundInterceptor []interceptor.StreamOutbound
+	// Client connection pool options.
+	clientConnPoolMaxConcurrentStreams  int32
+	clientConnPoolScaleUpThreshold      float64
+	clientConnPoolMinConnections        int
+	clientConnPoolMaxConnections        int
+	clientConnPoolIdleTimeout           time.Duration
+	clientConnPoolDynamicScalingEnabled bool
 }
 
 func newTransportOptions(options []TransportOption) *transportOptions {
@@ -346,6 +436,12 @@ func newTransportOptions(options []TransportOption) *transportOptions {
 		serverMaxSendMsgSize: defaultServerMaxSendMsgSize,
 		clientMaxRecvMsgSize: defaultClientMaxRecvMsgSize,
 		clientMaxSendMsgSize: defaultClientMaxSendMsgSize,
+		// Client connection pool defaults.
+		clientConnPoolMaxConcurrentStreams: defaultClientConnPoolMaxConcurrentStreams,
+		clientConnPoolScaleUpThreshold:     defaultClientConnPoolScaleUpThreshold,
+		clientConnPoolMinConnections:       defaultClientConnPoolMinConnections,
+		clientConnPoolMaxConnections:       defaultClientConnPoolMaxConnections,
+		clientConnPoolIdleTimeout:          defaultClientConnPoolIdleTimeout,
 	}
 	for _, option := range options {
 		option(transportOptions)

--- a/transport/grpc/options.go
+++ b/transport/grpc/options.go
@@ -56,11 +56,13 @@ const (
 	defaultClientMaxRecvMsgSize = 1024 * 1024 * 64
 	// Client connection pool defaults.
 	// defaultClientConnPoolMaxConcurrentStreams matches Go's net/http2 server default (SETTINGS_MAX_CONCURRENT_STREAMS = 250).
-	defaultClientConnPoolMaxConcurrentStreams int32         = 250
-	defaultClientConnPoolScaleUpThreshold     float64       = 0.8
-	defaultClientConnPoolMinConnections       int           = 1
-	defaultClientConnPoolMaxConnections       int           = 5
-	defaultClientConnPoolIdleTimeout          time.Duration = 15 * time.Minute
+	defaultClientConnPoolMaxConcurrentStreams   int32         = 250
+	defaultClientConnPoolScaleUpThreshold       float64       = 0.8
+	defaultClientConnPoolScaleDownGap           float64       = 0.1
+	defaultClientConnPoolMinConnections         int           = 1
+	defaultClientConnPoolMaxConnections         int           = 5
+	defaultClientConnPoolIdleTimeout            time.Duration = 15 * time.Minute
+	defaultClientConnPoolScalingMonitorInterval time.Duration = 30 * time.Second
 )
 
 // Option is an interface shared by TransportOption, InboundOption, and OutboundOption
@@ -237,6 +239,19 @@ func ScaleUpThreshold(f float64) TransportOption {
 	}
 }
 
+// ScaleDownGap sets the hysteresis gap subtracted from ScaleUpThreshold to
+// derive the scale-down threshold.  For example, with ScaleUpThreshold=0.8
+// and ScaleDownGap=0.1, connections are drained only when aggregate load would
+// fit within 70% of capacity on the reduced pool.  This prevents oscillation
+// when stream counts hover near the scale-up boundary.
+//
+// The default is 0.1.
+func ScaleDownGap(f float64) TransportOption {
+	return func(transportOptions *transportOptions) {
+		transportOptions.clientConnPoolScaleDownGap = f
+	}
+}
+
 // MinConnections sets the minimum number of connections YARPC maintains to
 // each peer.  Connections are pre-established up to this count when the peer
 // is first retained.
@@ -265,6 +280,16 @@ func MaxConnections(n int) TransportOption {
 func ConnIdleTimeout(d time.Duration) TransportOption {
 	return func(transportOptions *transportOptions) {
 		transportOptions.clientConnPoolIdleTimeout = d
+	}
+}
+
+// ScalingMonitorInterval sets how often the background monitor goroutine
+// evaluates the connection pool for scale-down and idle cleanup.
+//
+// The default is 30 seconds.
+func ScalingMonitorInterval(d time.Duration) TransportOption {
+	return func(transportOptions *transportOptions) {
+		transportOptions.clientConnPoolScalingMonitorInterval = d
 	}
 }
 
@@ -421,12 +446,14 @@ type transportOptions struct {
 	streamInboundInterceptor  interceptor.StreamInbound
 	streamOutboundInterceptor []interceptor.StreamOutbound
 	// Client connection pool options.
-	clientConnPoolMaxConcurrentStreams  int32
-	clientConnPoolScaleUpThreshold      float64
-	clientConnPoolMinConnections        int
-	clientConnPoolMaxConnections        int
-	clientConnPoolIdleTimeout           time.Duration
-	clientConnPoolDynamicScalingEnabled bool
+	clientConnPoolMaxConcurrentStreams   int32
+	clientConnPoolScaleUpThreshold       float64
+	clientConnPoolScaleDownGap           float64
+	clientConnPoolMinConnections         int
+	clientConnPoolMaxConnections         int
+	clientConnPoolIdleTimeout            time.Duration
+	clientConnPoolScalingMonitorInterval time.Duration
+	clientConnPoolDynamicScalingEnabled  bool
 }
 
 func newTransportOptions(options []TransportOption) *transportOptions {
@@ -437,11 +464,13 @@ func newTransportOptions(options []TransportOption) *transportOptions {
 		clientMaxRecvMsgSize: defaultClientMaxRecvMsgSize,
 		clientMaxSendMsgSize: defaultClientMaxSendMsgSize,
 		// Client connection pool defaults.
-		clientConnPoolMaxConcurrentStreams: defaultClientConnPoolMaxConcurrentStreams,
-		clientConnPoolScaleUpThreshold:     defaultClientConnPoolScaleUpThreshold,
-		clientConnPoolMinConnections:       defaultClientConnPoolMinConnections,
-		clientConnPoolMaxConnections:       defaultClientConnPoolMaxConnections,
-		clientConnPoolIdleTimeout:          defaultClientConnPoolIdleTimeout,
+		clientConnPoolMaxConcurrentStreams:   defaultClientConnPoolMaxConcurrentStreams,
+		clientConnPoolScaleUpThreshold:       defaultClientConnPoolScaleUpThreshold,
+		clientConnPoolScaleDownGap:           defaultClientConnPoolScaleDownGap,
+		clientConnPoolMinConnections:         defaultClientConnPoolMinConnections,
+		clientConnPoolMaxConnections:         defaultClientConnPoolMaxConnections,
+		clientConnPoolIdleTimeout:            defaultClientConnPoolIdleTimeout,
+		clientConnPoolScalingMonitorInterval: defaultClientConnPoolScalingMonitorInterval,
 	}
 	for _, option := range options {
 		option(transportOptions)

--- a/transport/grpc/outbound.go
+++ b/transport/grpc/outbound.go
@@ -215,6 +215,14 @@ func (o *Outbound) invoke(
 		}
 	}
 
+	// Pick the pool connection with the fewest active streams.
+	conn := grpcPeer.pickConn()
+	if conn == nil {
+		return yarpcerrors.UnavailableErrorf("no available connections for peer %s", grpcPeer.HostPort())
+	}
+	conn.incStreamCount()
+	defer conn.decStreamCount()
+
 	tracer := o.t.options.tracer
 	createOpenTracingSpan := &transport.CreateOpenTracingSpan{
 		Tracer:        tracer,
@@ -231,7 +239,7 @@ func (o *Outbound) invoke(
 
 	err = transport.UpdateSpanWithErr(
 		span,
-		grpcPeer.clientConn.Invoke(
+		conn.clientConn.Invoke(
 			metadata.NewOutgoingContext(ctx, md),
 			fullMethod,
 			msg,
@@ -352,6 +360,20 @@ func (o *Outbound) stream(
 		return nil, err
 	}
 
+	// Pick the pool connection with the fewest active streams.
+	conn := grpcPeer.pickConn()
+	if conn == nil {
+		onFinish(yarpcerrors.UnavailableErrorf("no available connections for peer %s", grpcPeer.HostPort()))
+		return nil, yarpcerrors.UnavailableErrorf("no available connections for peer %s", grpcPeer.HostPort())
+	}
+	conn.incStreamCount()
+	// Wrap the release callback so stream count is decremented when
+	// the stream actually closes, not when stream() returns.
+	release := func(err error) {
+		conn.decStreamCount()
+		onFinish(err)
+	}
+
 	tracer := o.t.options.tracer
 	createOpenTracingSpan := &transport.CreateOpenTracingSpan{
 		Tracer:        tracer,
@@ -363,12 +385,12 @@ func (o *Outbound) stream(
 
 	if err := tracer.Inject(span.Context(), opentracing.HTTPHeaders, mdReadWriter(md)); err != nil {
 		span.Finish()
-		onFinish(err)
+		release(err)
 		return nil, err
 	}
 
 	streamCtx := metadata.NewOutgoingContext(ctx, md)
-	clientStream, err := grpcPeer.clientConn.NewStream(
+	clientStream, err := conn.clientConn.NewStream(
 		streamCtx,
 		&grpc.StreamDesc{
 			ClientStreams: true,
@@ -378,13 +400,13 @@ func (o *Outbound) stream(
 	)
 	if err != nil {
 		span.Finish()
-		onFinish(err)
+		release(err)
 		return nil, err
 	}
-	stream := newClientStream(streamCtx, req, clientStream, span, onFinish)
+	stream := newClientStream(streamCtx, req, clientStream, span, release)
 	tClientStream, err := transport.NewClientStream(stream)
 	if err != nil {
-		onFinish(err)
+		release(err)
 		span.Finish()
 		return nil, err
 	}

--- a/transport/grpc/outbound.go
+++ b/transport/grpc/outbound.go
@@ -222,6 +222,7 @@ func (o *Outbound) invoke(
 	}
 	conn.incStreamCount()
 	defer conn.decStreamCount()
+	grpcPeer.tryScaleUp(conn)
 
 	tracer := o.t.options.tracer
 	createOpenTracingSpan := &transport.CreateOpenTracingSpan{
@@ -373,6 +374,7 @@ func (o *Outbound) stream(
 		conn.decStreamCount()
 		onFinish(err)
 	}
+	grpcPeer.tryScaleUp(conn)
 
 	tracer := o.t.options.tracer
 	createOpenTracingSpan := &transport.CreateOpenTracingSpan{

--- a/transport/grpc/outbound_test.go
+++ b/transport/grpc/outbound_test.go
@@ -35,6 +35,7 @@ import (
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/yarpcerrors"
 	"google.golang.org/grpc"
+	"go.uber.org/yarpc/peer/abstractpeer"
 )
 
 // shared between Unary and Streaming InvalidHeaderValue tests.
@@ -362,4 +363,81 @@ func TestOutboundIntrospection(t *testing.T) {
 
 	require.NoError(t, o.Stop(), "could not stop outbound")
 	assert.Equal(t, "Stopped", o.Introspect().State)
+}
+
+// emptyGRPCPeer returns a *grpcPeer with no connections in the pool, so that
+// pickConn() returns nil.  Only p.Peer is set; p.t is intentionally left nil
+// because the nil-conn path returns before any transport access.
+func emptyGRPCPeer(t *testing.T) *grpcPeer {
+	t.Helper()
+	tr := NewTransport()
+	return &grpcPeer{
+		Peer: abstractpeer.NewPeer(abstractpeer.PeerIdentifier("127.0.0.1:1"), tr),
+	}
+}
+
+// TestInvokeWithNoActiveConnections verifies that DirectCall returns an
+// UnavailableError when pickConn finds no active connections.
+func TestInvokeWithNoActiveConnections(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	chooser := peertest.NewMockChooser(mockCtrl)
+	chooser.EXPECT().Start()
+	chooser.EXPECT().Stop()
+	chooser.EXPECT().Choose(gomock.Any(), gomock.Any()).Return(emptyGRPCPeer(t), func(error) {}, nil)
+
+	tran := NewTransport()
+	out := tran.NewOutbound(chooser)
+	require.NoError(t, tran.Start())
+	require.NoError(t, out.Start())
+	defer tran.Stop()
+	defer out.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	_, err := out.DirectCall(ctx, &transport.Request{
+		Caller:    "caller",
+		Service:   "service",
+		Encoding:  transport.Encoding("raw"),
+		Procedure: "procedure",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no available connections")
+}
+
+// TestStreamWithNoActiveConnections verifies that CallStream returns an
+// UnavailableError when pickConn finds no active connections.
+func TestStreamWithNoActiveConnections(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	chooser := peertest.NewMockChooser(mockCtrl)
+	chooser.EXPECT().Start()
+	chooser.EXPECT().Stop()
+	chooser.EXPECT().Choose(gomock.Any(), gomock.Any()).Return(emptyGRPCPeer(t), func(error) {}, nil)
+
+	tran := NewTransport()
+	out := tran.NewOutbound(chooser)
+	require.NoError(t, tran.Start())
+	require.NoError(t, out.Start())
+	defer tran.Stop()
+	defer out.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	_, err := out.CallStream(ctx, &transport.StreamRequest{
+		Meta: &transport.RequestMeta{
+			Caller:    "caller",
+			Service:   "service",
+			Encoding:  transport.Encoding("raw"),
+			Procedure: "procedure",
+		},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no available connections")
 }

--- a/transport/grpc/outbound_test.go
+++ b/transport/grpc/outbound_test.go
@@ -33,9 +33,9 @@ import (
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/peer/peertest"
 	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/peer/abstractpeer"
 	"go.uber.org/yarpc/yarpcerrors"
 	"google.golang.org/grpc"
-	"go.uber.org/yarpc/peer/abstractpeer"
 )
 
 // shared between Unary and Streaming InvalidHeaderValue tests.

--- a/transport/grpc/peer.go
+++ b/transport/grpc/peer.go
@@ -34,11 +34,22 @@ import (
 type grpcPeer struct {
 	*abstractpeer.Peer
 
-	t          *Transport
-	ctx        context.Context
-	cancel     context.CancelFunc
-	clientConn *grpc.ClientConn
-	stoppedC   chan struct{}
+	t        *Transport
+	ctx      context.Context
+	cancel   context.CancelFunc
+	stoppedC chan struct{}
+
+	// grpcDialOpts are stored so that additional pooled connections can be
+	// dialled with the same parameters as the initial connection.
+	grpcDialOpts []grpc.DialOption
+
+	// isScaling is set to 1 (via CAS) while a background scale-up goroutine is
+	// running.  This prevents multiple concurrent scale-up operations.
+	isScaling int32 // accessed atomically
+
+	// connWg tracks active monitorConnWrapper goroutines.
+	// stoppedC is closed once all goroutines finish after the peer is stopped.
+	connWg sync.WaitGroup
 
 	mu      sync.RWMutex
 	conns   []*grpcClientConnWrapper
@@ -58,55 +69,183 @@ func (t *Transport) newPeer(address string, options *dialOptions) (*grpcPeer, er
 	if t.options.clientMaxHeaderListSize != nil {
 		dialOptions = append(dialOptions, grpc.WithMaxHeaderListSize(*t.options.clientMaxHeaderListSize))
 	}
-	//lint:ignore SA1019 grpc.Dial is deprecated
-	clientConn, err := grpc.Dial(address, dialOptions...)
-	if err != nil {
-		return nil, err
-	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	grpcPeer := &grpcPeer{
-		Peer:       abstractpeer.NewPeer(abstractpeer.PeerIdentifier(address), t),
-		t:          t,
-		ctx:        ctx,
-		cancel:     cancel,
-		clientConn: clientConn,
-		stoppedC:   make(chan struct{}),
+	p := &grpcPeer{
+		Peer:         abstractpeer.NewPeer(abstractpeer.PeerIdentifier(address), t),
+		t:            t,
+		ctx:          ctx,
+		cancel:       cancel,
+		stoppedC:     make(chan struct{}),
+		grpcDialOpts: dialOptions,
+		poolCfg: connPoolConfig{
+			dynamicScalingEnabled: t.options.clientConnPoolDynamicScalingEnabled,
+			maxConcurrentStreams:   t.options.clientConnPoolMaxConcurrentStreams,
+			scaleUpThreshold:      t.options.clientConnPoolScaleUpThreshold,
+			minConnections:        t.options.clientConnPoolMinConnections,
+			maxConnections:        t.options.clientConnPoolMaxConnections,
+			idleTimeout:           t.options.clientConnPoolIdleTimeout,
+		},
 	}
 
-	go grpcPeer.monitorConnectionStatus()
+	// All connections are created via addConn — no special primary connection.
+	initialConnCount := 1
+	if p.poolCfg.dynamicScalingEnabled {
+		initialConnCount = p.poolCfg.minConnections
+	}
+	for i := 0; i < initialConnCount; i++ {
+		if err := p.addConn(); err != nil {
+			p.cancel()
+			return nil, err
+		}
+	}
 
-	return grpcPeer, nil
+	if p.poolCfg.dynamicScalingEnabled {
+		go p.runScalingMonitor()
+	}
+
+	// Close stoppedC once all monitorConnWrapper goroutines have finished.
+	// We acquire mu briefly after ctx is cancelled to ensure any in-flight
+	// addConn() that passed its context check has already called connWg.Add(1)
+	// before we call connWg.Wait().
+	go func() {
+		<-p.ctx.Done()
+		// Acquire mu after cancellation to ensure any addConn() call that
+		// passed its ctx.Err() check has already called connWg.Add(1).
+		// The empty critical section is intentional: we need the memory
+		// barrier, not exclusive access to any data.
+		p.mu.Lock()
+		p.mu.Unlock() //nolint:staticcheck
+		p.connWg.Wait()
+		close(p.stoppedC)
+	}()
+
+	return p, nil
 }
 
-func (p *grpcPeer) monitorConnectionStatus() {
-	p.setConnectionStatus(peer.Unavailable)
+// addConn dials a new connection to the peer's address using the same options
+// as the initial connection, appends the wrapper to the pool, and starts its
+// monitor goroutine.
+func (p *grpcPeer) addConn() error {
+	//lint:ignore SA1019 grpc.Dial is deprecated
+	clientConn, err := grpc.Dial(p.Peer.Identifier(), p.grpcDialOpts...)
+	if err != nil {
+		return err
+	}
+	w := newConnWrapper(p.ctx, clientConn)
+
+	// Hold mu while registering with connWg and appending to conns.  The
+	// lifecycle goroutine in newPeer acquires mu after ctx is cancelled so
+	// that it observes any Add(1) call that raced with cancellation.
+	p.mu.Lock()
+	if p.ctx.Err() != nil {
+		p.mu.Unlock()
+		_ = clientConn.Close()
+		return p.ctx.Err()
+	}
+	p.connWg.Add(1)
+	p.conns = append(p.conns, w)
+	p.mu.Unlock()
+
+	go p.monitorConnWrapper(w)
+	return nil
+}
+
+// monitorConnWrapper runs the per-connection health loop: it watches gRPC
+// connectivity state changes, keeps the peer status up to date, and triggers
+// reconnection when a connection goes idle.  It cleans up when the wrapper's
+// context is cancelled (i.e. when the peer is stopped or the connection is
+// evicted by the pool).
+func (p *grpcPeer) monitorConnWrapper(w *grpcClientConnWrapper) {
+	defer func() {
+		_ = w.clientConn.Close()
+		close(w.stoppedC)
+		p.removeConn(w)
+		// Recompute connection status now that this peer is gone.
+		p.recomputeConnectionStatus()
+		p.connWg.Done()
+	}()
+
 	var grpcStatus connectivity.State
 	for {
-		grpcStatus = p.clientConn.GetState()
-		yarpcStatus := grpcStatusToYARPCStatus(grpcStatus)
-		p.setConnectionStatus(yarpcStatus)
+		grpcStatus = w.clientConn.GetState()
 
-		// When active connection falling back to IDLE state, no automatic reconnection is happening.
-		// There two options:
-		// - Either try to make a call using this connection, which will trigger reconnection, but may lead
-		// to a failed request (host is unreachable or context deadline happened).
-		// - Or we may try to reconnect manually, and use connection only when it's established and explicitly available.
-		// We choose second option.
+		// When a connection falls back to IDLE, no automatic reconnection
+		// happens. There are two options:
+		// - Let the next outgoing call trigger reconnection, but this may
+		//   lead to a failed request if the host is unreachable or a context
+		//   deadline occurs before the connection is re-established.
+		// - Reconnect manually so the connection is ready before the next call.
+		// We choose the second option.
 		if grpcStatus == connectivity.Idle {
-			p.clientConn.Connect()
+			w.clientConn.Connect()
 		}
 
-		if !p.clientConn.WaitForStateChange(p.ctx, grpcStatus) {
+		// If this connection is Ready the peer is Available regardless of
+		// other connections — no need to scan the pool.  For any other state
+		// (Connecting, TransientFailure, etc.) we must check all connections
+		// to derive the correct aggregate status.
+		p.recomputeConnectionStatus()
+
+		if !w.clientConn.WaitForStateChange(w.ctx, grpcStatus) {
 			break
 		}
 	}
-	p.setConnectionStatus(peer.Unavailable)
+}
 
-	// Close always returns an error.
-	_ = p.clientConn.Close()
-	close(p.stoppedC)
+// recomputeConnectionStatus derives the YARPC peer status from the aggregate
+// gRPC connectivity state across all active pool connections and publishes it.
+// The peer is Available if any connection is Ready, Connecting if any is
+// connecting (and none are Ready), and Unavailable if the pool is empty or
+// all connections are in a terminal/unknown state.
+func (p *grpcPeer) recomputeConnectionStatus() {
+	p.mu.RLock()
+	best := peer.Unavailable
+	for _, c := range p.conns {
+		if !c.isActive() {
+			continue
+		}
+		s := grpcStatusToYARPCStatus(c.clientConn.GetState())
+		if s == peer.Available {
+			best = peer.Available
+			break
+		}
+		if s == peer.Connecting && best == peer.Unavailable {
+			best = peer.Connecting
+		}
+	}
+	p.mu.RUnlock()
+	p.setConnectionStatus(best)
+}
+
+// removeConn removes a wrapper from the peer's connection pool.
+func (p *grpcPeer) removeConn(w *grpcClientConnWrapper) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for i, c := range p.conns {
+		if c == w {
+			p.conns = append(p.conns[:i], p.conns[i+1:]...)
+			return
+		}
+	}
+}
+
+// pickConn returns the active connection in the pool with the lowest current
+// stream count.  Returns nil if the pool contains no active connections.
+func (p *grpcPeer) pickConn() *grpcClientConnWrapper {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	var best *grpcClientConnWrapper
+	for _, c := range p.conns {
+		if !c.isActive() {
+			continue
+		}
+		if best == nil || c.getStreamCount() < best.getStreamCount() {
+			best = c
+		}
+	}
+	return best
 }
 
 func (p *grpcPeer) setConnectionStatus(status peer.ConnectionStatus) {

--- a/transport/grpc/peer.go
+++ b/transport/grpc/peer.go
@@ -22,6 +22,7 @@ package grpc
 
 import (
 	"context"
+	"sync"
 
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/peer/abstractpeer"
@@ -38,6 +39,10 @@ type grpcPeer struct {
 	cancel     context.CancelFunc
 	clientConn *grpc.ClientConn
 	stoppedC   chan struct{}
+
+	mu      sync.RWMutex
+	conns   []*grpcClientConnWrapper
+	poolCfg connPoolConfig
 }
 
 func (t *Transport) newPeer(address string, options *dialOptions) (*grpcPeer, error) {

--- a/transport/grpc/peer.go
+++ b/transport/grpc/peer.go
@@ -51,6 +51,8 @@ type grpcPeer struct {
 	// stoppedC is closed once all goroutines finish after the peer is stopped.
 	connWg sync.WaitGroup
 
+	metrics *connPoolMetrics
+
 	mu      sync.RWMutex
 	conns   []*grpcClientConnWrapper
 	poolCfg connPoolConfig
@@ -79,6 +81,12 @@ func (t *Transport) newPeer(address string, options *dialOptions) (*grpcPeer, er
 		cancel:       cancel,
 		stoppedC:     make(chan struct{}),
 		grpcDialOpts: dialOptions,
+		metrics: newConnPoolMetrics(connPoolMetricsParams{
+			Meter:       t.options.meter,
+			Logger:      t.options.logger,
+			ServiceName: t.options.serviceName,
+			Peer:        address,
+		}),
 		poolCfg: connPoolConfig{
 			dynamicScalingEnabled: t.options.clientConnPoolDynamicScalingEnabled,
 			maxConcurrentStreams:   t.options.clientConnPoolMaxConcurrentStreams,
@@ -149,6 +157,7 @@ func (p *grpcPeer) addConn() error {
 	p.mu.Unlock()
 
 	go p.monitorConnWrapper(w)
+	p.refreshPoolMetrics()
 	return nil
 }
 
@@ -164,6 +173,7 @@ func (p *grpcPeer) monitorConnWrapper(w *grpcClientConnWrapper) {
 		p.removeConn(w)
 		// Recompute connection status now that this peer is gone.
 		p.recomputeConnectionStatus()
+		p.refreshPoolMetrics()
 		p.connWg.Done()
 	}()
 

--- a/transport/grpc/peer.go
+++ b/transport/grpc/peer.go
@@ -23,6 +23,7 @@ package grpc
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/peer/abstractpeer"
@@ -53,9 +54,39 @@ type grpcPeer struct {
 
 	metrics *connPoolMetrics
 
-	mu      sync.RWMutex
-	conns   []*grpcClientConnWrapper
+	// connsPtr holds a pointer to the current immutable connection slice.
+	// Readers (pickConn, recomputeConnectionStatus, refreshPoolMetrics, etc.)
+	// do a single atomic.Pointer.Load() — no mutex acquired on the read path.
+	// Writers (addConn, removeConn) hold wmu, copy the slice, mutate, then
+	// atomically publish the new pointer.  Readers never block writers.
+	connsPtr atomic.Pointer[[](*grpcClientConnWrapper)]
+
+	// wmu is a write-only mutex: only writers (addConn, removeConn) acquire it.
+	// Readers never touch wmu.
+	wmu sync.Mutex
+
+	// connCount mirrors len(loadConns()) atomically so tryScaleUp can check the
+	// pool size without acquiring wmu.
+	connCount atomic.Int32
+
 	poolCfg connPoolConfig
+}
+
+// loadConns returns the current immutable connection snapshot.
+// Safe to call from any goroutine without holding any lock.
+func (p *grpcPeer) loadConns() []*grpcClientConnWrapper {
+	ptr := p.connsPtr.Load()
+	if ptr == nil {
+		return nil
+	}
+	return *ptr
+}
+
+// storeConns atomically publishes a new connection slice and updates connCount.
+// Callers must hold wmu.
+func (p *grpcPeer) storeConns(conns []*grpcClientConnWrapper) {
+	p.connsPtr.Store(&conns)
+	p.connCount.Store(int32(len(conns)))
 }
 
 func (t *Transport) newPeer(address string, options *dialOptions) (*grpcPeer, error) {
@@ -96,6 +127,9 @@ func (t *Transport) newPeer(address string, options *dialOptions) (*grpcPeer, er
 			idleTimeout:           t.options.clientConnPoolIdleTimeout,
 		},
 	}
+	// Publish an empty slice so loadConns() never returns nil before the first
+	// addConn() call.
+	p.storeConns(nil)
 
 	// All connections are created via addConn — no special primary connection.
 	initialConnCount := 1
@@ -114,17 +148,18 @@ func (t *Transport) newPeer(address string, options *dialOptions) (*grpcPeer, er
 	}
 
 	// Close stoppedC once all monitorConnWrapper goroutines have finished.
-	// We acquire mu briefly after ctx is cancelled to ensure any in-flight
+	// We acquire wmu briefly after ctx is cancelled to ensure any in-flight
 	// addConn() that passed its context check has already called connWg.Add(1)
 	// before we call connWg.Wait().
 	go func() {
 		<-p.ctx.Done()
-		// Acquire mu after cancellation to ensure any addConn() call that
+		// Acquire wmu after cancellation to ensure any addConn() call that
 		// passed its ctx.Err() check has already called connWg.Add(1).
-		// The empty critical section is intentional: we need the memory
-		// barrier, not exclusive access to any data.
-		p.mu.Lock()
-		p.mu.Unlock() //nolint:staticcheck
+		// The empty critical section is intentional: we need the barrier,
+		// not exclusive access to any data.
+		//lint:ignore SA2001 intentional empty critical section, provides memory barrier for connWg
+		p.wmu.Lock()
+		p.wmu.Unlock()
 		p.connWg.Wait()
 		close(p.stoppedC)
 	}()
@@ -143,18 +178,22 @@ func (p *grpcPeer) addConn() error {
 	}
 	w := newConnWrapper(p.ctx, clientConn)
 
-	// Hold mu while registering with connWg and appending to conns.  The
-	// lifecycle goroutine in newPeer acquires mu after ctx is cancelled so
-	// that it observes any Add(1) call that raced with cancellation.
-	p.mu.Lock()
+	// Hold wmu while registering with connWg and publishing the new slice.
+	// The lifecycle goroutine acquires wmu after ctx is cancelled to observe
+	// any Add(1) that raced with cancellation.
+	p.wmu.Lock()
 	if p.ctx.Err() != nil {
-		p.mu.Unlock()
+		p.wmu.Unlock()
 		_ = clientConn.Close()
 		return p.ctx.Err()
 	}
 	p.connWg.Add(1)
-	p.conns = append(p.conns, w)
-	p.mu.Unlock()
+	old := p.loadConns()
+	next := make([]*grpcClientConnWrapper, len(old)+1)
+	copy(next, old)
+	next[len(old)] = w
+	p.storeConns(next)
+	p.wmu.Unlock()
 
 	go p.monitorConnWrapper(w)
 	p.refreshPoolMetrics()
@@ -210,9 +249,9 @@ func (p *grpcPeer) monitorConnWrapper(w *grpcClientConnWrapper) {
 // connecting (and none are Ready), and Unavailable if the pool is empty or
 // all connections are in a terminal/unknown state.
 func (p *grpcPeer) recomputeConnectionStatus() {
-	p.mu.RLock()
+	conns := p.loadConns()
 	best := peer.Unavailable
-	for _, c := range p.conns {
+	for _, c := range conns {
 		if !c.isActive() {
 			continue
 		}
@@ -225,17 +264,20 @@ func (p *grpcPeer) recomputeConnectionStatus() {
 			best = peer.Connecting
 		}
 	}
-	p.mu.RUnlock()
 	p.setConnectionStatus(best)
 }
 
 // removeConn removes a wrapper from the peer's connection pool.
 func (p *grpcPeer) removeConn(w *grpcClientConnWrapper) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	for i, c := range p.conns {
+	p.wmu.Lock()
+	defer p.wmu.Unlock()
+	old := p.loadConns()
+	for i, c := range old {
 		if c == w {
-			p.conns = append(p.conns[:i], p.conns[i+1:]...)
+			next := make([]*grpcClientConnWrapper, len(old)-1)
+			copy(next, old[:i])
+			copy(next[i:], old[i+1:])
+			p.storeConns(next)
 			return
 		}
 	}
@@ -243,11 +285,11 @@ func (p *grpcPeer) removeConn(w *grpcClientConnWrapper) {
 
 // pickConn returns the active connection in the pool with the lowest current
 // stream count.  Returns nil if the pool contains no active connections.
+// Lock-free: reads the immutable snapshot via a single atomic.Pointer.Load().
 func (p *grpcPeer) pickConn() *grpcClientConnWrapper {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
+	conns := p.loadConns()
 	var best *grpcClientConnWrapper
-	for _, c := range p.conns {
+	for _, c := range conns {
 		if !c.isActive() {
 			continue
 		}
@@ -297,3 +339,4 @@ func grpcStatusToYARPCStatus(grpcStatus connectivity.State) peer.ConnectionStatu
 		return peer.Unavailable
 	}
 }
+

--- a/transport/grpc/peer.go
+++ b/transport/grpc/peer.go
@@ -120,7 +120,7 @@ func (t *Transport) newPeer(address string, options *dialOptions) (*grpcPeer, er
 		}),
 		poolCfg: connPoolConfig{
 			dynamicScalingEnabled: t.options.clientConnPoolDynamicScalingEnabled,
-			maxConcurrentStreams:   t.options.clientConnPoolMaxConcurrentStreams,
+			maxConcurrentStreams:  t.options.clientConnPoolMaxConcurrentStreams,
 			scaleUpThreshold:      t.options.clientConnPoolScaleUpThreshold,
 			minConnections:        t.options.clientConnPoolMinConnections,
 			maxConnections:        t.options.clientConnPoolMaxConnections,
@@ -339,4 +339,3 @@ func grpcStatusToYARPCStatus(grpcStatus connectivity.State) peer.ConnectionStatu
 		return peer.Unavailable
 	}
 }
-

--- a/transport/grpc/peer.go
+++ b/transport/grpc/peer.go
@@ -224,8 +224,12 @@ func (p *grpcPeer) monitorConnWrapper(w *grpcClientConnWrapper) {
 		_ = w.clientConn.Close()
 		close(w.stoppedC)
 		p.removeConn(w)
-		// Recompute connection status now that this peer is gone.
-		p.recomputeConnectionStatus()
+		// Skip status notification during peer shutdown: NotifyStatusChanged
+		// acquires list.lock, but the caller (abstractlist.stop) already holds
+		// it while waiting on p.wait() — deadlock. Metrics are safe to update.
+		if p.ctx.Err() == nil {
+			p.recomputeConnectionStatus()
+		}
 		p.refreshPoolMetrics()
 		p.connWg.Done()
 	}()
@@ -249,6 +253,12 @@ func (p *grpcPeer) monitorConnWrapper(w *grpcClientConnWrapper) {
 		// other connections — no need to scan the pool.  For any other state
 		// (Connecting, TransientFailure, etc.) we must check all connections
 		// to derive the correct aggregate status.
+		// Skip when shutting down: NotifyStatusChanged acquires list.lock,
+		// but the caller (abstractlist.stop) may already hold it while
+		// waiting on p.wait().
+		if p.ctx.Err() != nil {
+			break
+		}
 		p.recomputeConnectionStatus()
 
 		if !w.clientConn.WaitForStateChange(w.ctx, grpcStatus) {

--- a/transport/grpc/peer.go
+++ b/transport/grpc/peer.go
@@ -127,14 +127,27 @@ func (t *Transport) newPeer(address string, options *dialOptions) (*grpcPeer, er
 			Peer:        address,
 		}),
 		poolCfg: connPoolConfig{
-			dynamicScalingEnabled: t.options.clientConnPoolDynamicScalingEnabled,
-			maxConcurrentStreams:  t.options.clientConnPoolMaxConcurrentStreams,
-			scaleUpThreshold:      t.options.clientConnPoolScaleUpThreshold,
-			minConnections:        t.options.clientConnPoolMinConnections,
-			maxConnections:        t.options.clientConnPoolMaxConnections,
-			idleTimeout:           t.options.clientConnPoolIdleTimeout,
+			dynamicScalingEnabled:  t.options.clientConnPoolDynamicScalingEnabled,
+			maxConcurrentStreams:   t.options.clientConnPoolMaxConcurrentStreams,
+			scaleUpThreshold:       t.options.clientConnPoolScaleUpThreshold,
+			scaleDownGap:           t.options.clientConnPoolScaleDownGap,
+			minConnections:         t.options.clientConnPoolMinConnections,
+			maxConnections:         t.options.clientConnPoolMaxConnections,
+			idleTimeout:            t.options.clientConnPoolIdleTimeout,
+			scalingMonitorInterval: t.options.clientConnPoolScalingMonitorInterval,
 		},
 	}
+	t.options.logger.Debug("grpc: connection pool config resolved",
+		zap.String("peer", address),
+		zap.Bool("dynamicScalingEnabled", p.poolCfg.dynamicScalingEnabled),
+		zap.Int("minConnections", p.poolCfg.minConnections),
+		zap.Int("maxConnections", p.poolCfg.maxConnections),
+		zap.Int32("maxConcurrentStreams", p.poolCfg.maxConcurrentStreams),
+		zap.Float64("scaleUpThreshold", p.poolCfg.scaleUpThreshold),
+		zap.Float64("scaleDownGap", p.poolCfg.scaleDownGap),
+		zap.Duration("idleTimeout", p.poolCfg.idleTimeout),
+		zap.Duration("scalingMonitorInterval", p.poolCfg.scalingMonitorInterval),
+	)
 	// Publish an empty slice so loadConns() never returns nil before the first
 	// addConn() call.
 	p.storeConns(nil)

--- a/transport/grpc/peer.go
+++ b/transport/grpc/peer.go
@@ -22,6 +22,7 @@ package grpc
 
 import (
 	"context"
+	"runtime"
 	"sync"
 	"sync/atomic"
 
@@ -56,17 +57,25 @@ type grpcPeer struct {
 
 	// connsPtr holds a pointer to the current immutable connection slice.
 	// Readers (pickConn, recomputeConnectionStatus, refreshPoolMetrics, etc.)
-	// do a single atomic.Pointer.Load() — no mutex acquired on the read path.
-	// Writers (addConn, removeConn) hold wmu, copy the slice, mutate, then
-	// atomically publish the new pointer.  Readers never block writers.
+	// do a single atomic.Pointer.Load() — no lock acquired on the read path.
+	// Writers (addConn, removeConn) use a CAS loop: load the current pointer,
+	// build the new slice, and CompareAndSwap. connCount is updated after a
+	// successful CAS.
 	connsPtr atomic.Pointer[[](*grpcClientConnWrapper)]
 
-	// wmu is a write-only mutex: only writers (addConn, removeConn) acquire it.
-	// Readers never touch wmu.
-	wmu sync.Mutex
+	// addingCount tracks addConn calls that have passed their entry point but
+	// have not yet called connWg.Add(1) or bailed. The lifecycle goroutine
+	// spins on this counter (after setting shutdownStarted) to guarantee that
+	// connWg.Wait is not called before any racing connWg.Add(1) completes.
+	addingCount atomic.Int32
+
+	// shutdownStarted is set to true when the peer begins shutting down.
+	// addConn checks this after incrementing addingCount to avoid calling
+	// connWg.Add(1) after the lifecycle goroutine has passed its spin.
+	shutdownStarted atomic.Bool
 
 	// connCount mirrors len(loadConns()) atomically so tryScaleUp can check the
-	// pool size without acquiring wmu.
+	// pool size without a full slice load.
 	connCount atomic.Int32
 
 	poolCfg connPoolConfig
@@ -83,7 +92,6 @@ func (p *grpcPeer) loadConns() []*grpcClientConnWrapper {
 }
 
 // storeConns atomically publishes a new connection slice and updates connCount.
-// Callers must hold wmu.
 func (p *grpcPeer) storeConns(conns []*grpcClientConnWrapper) {
 	p.connsPtr.Store(&conns)
 	p.connCount.Store(int32(len(conns)))
@@ -148,18 +156,14 @@ func (t *Transport) newPeer(address string, options *dialOptions) (*grpcPeer, er
 	}
 
 	// Close stoppedC once all monitorConnWrapper goroutines have finished.
-	// We acquire wmu briefly after ctx is cancelled to ensure any in-flight
-	// addConn() that passed its context check has already called connWg.Add(1)
-	// before we call connWg.Wait().
+	// shutdownStarted gates new connWg.Add(1) calls; addingCount ensures we
+	// wait for any addConn already past its ctx check before calling Wait.
 	go func() {
 		<-p.ctx.Done()
-		// Acquire wmu after cancellation to ensure any addConn() call that
-		// passed its ctx.Err() check has already called connWg.Add(1).
-		// The empty critical section is intentional: we need the barrier,
-		// not exclusive access to any data.
-		//lint:ignore SA2001 intentional empty critical section, provides memory barrier for connWg
-		p.wmu.Lock()
-		p.wmu.Unlock()
+		p.shutdownStarted.Store(true)
+		for p.addingCount.Load() > 0 {
+			runtime.Gosched()
+		}
 		p.connWg.Wait()
 		close(p.stoppedC)
 	}()
@@ -178,22 +182,32 @@ func (p *grpcPeer) addConn() error {
 	}
 	w := newConnWrapper(p.ctx, clientConn)
 
-	// Hold wmu while registering with connWg and publishing the new slice.
-	// The lifecycle goroutine acquires wmu after ctx is cancelled to observe
-	// any Add(1) that raced with cancellation.
-	p.wmu.Lock()
-	if p.ctx.Err() != nil {
-		p.wmu.Unlock()
+	// Enter the critical window: increment addingCount so the lifecycle
+	// goroutine's spin waits for us to either bail or call connWg.Add(1).
+	p.addingCount.Add(1)
+	if p.ctx.Err() != nil || p.shutdownStarted.Load() {
+		p.addingCount.Add(-1)
 		_ = clientConn.Close()
 		return p.ctx.Err()
 	}
 	p.connWg.Add(1)
-	old := p.loadConns()
-	next := make([]*grpcClientConnWrapper, len(old)+1)
-	copy(next, old)
-	next[len(old)] = w
-	p.storeConns(next)
-	p.wmu.Unlock()
+	p.addingCount.Add(-1)
+
+	// CAS loop: copy the slice, append the new wrapper, publish atomically.
+	for {
+		old := p.connsPtr.Load()
+		var oldSlice []*grpcClientConnWrapper
+		if old != nil {
+			oldSlice = *old
+		}
+		next := make([]*grpcClientConnWrapper, len(oldSlice)+1)
+		copy(next, oldSlice)
+		next[len(oldSlice)] = w
+		if p.connsPtr.CompareAndSwap(old, &next) {
+			p.connCount.Store(int32(len(next)))
+			break
+		}
+	}
 
 	go p.monitorConnWrapper(w)
 	p.refreshPoolMetrics()
@@ -268,16 +282,29 @@ func (p *grpcPeer) recomputeConnectionStatus() {
 }
 
 // removeConn removes a wrapper from the peer's connection pool.
+// Lock-free: uses a CAS loop to atomically publish the new slice.
 func (p *grpcPeer) removeConn(w *grpcClientConnWrapper) {
-	p.wmu.Lock()
-	defer p.wmu.Unlock()
-	old := p.loadConns()
-	for i, c := range old {
-		if c == w {
-			next := make([]*grpcClientConnWrapper, len(old)-1)
-			copy(next, old[:i])
-			copy(next[i:], old[i+1:])
-			p.storeConns(next)
+	for {
+		old := p.connsPtr.Load()
+		if old == nil {
+			return
+		}
+		oldSlice := *old
+		idx := -1
+		for i, c := range oldSlice {
+			if c == w {
+				idx = i
+				break
+			}
+		}
+		if idx < 0 {
+			return
+		}
+		next := make([]*grpcClientConnWrapper, len(oldSlice)-1)
+		copy(next, oldSlice[:idx])
+		copy(next[idx:], oldSlice[idx+1:])
+		if p.connsPtr.CompareAndSwap(old, &next) {
+			p.connCount.Store(int32(len(next)))
 			return
 		}
 	}

--- a/transport/grpc/peer_test.go
+++ b/transport/grpc/peer_test.go
@@ -28,6 +28,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/net/metrics"
+	"go.uber.org/zap"
 	"go.uber.org/yarpc/api/backoff"
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
@@ -515,4 +517,44 @@ func TestRecomputeConnectionStatus(t *testing.T) {
 		// the peer to Unavailable.
 		assert.Equal(t, peer.Unavailable, p.Peer.Status().ConnectionStatus)
 	})
+}
+
+// TestMonitorConnWrapperMetrics verifies that the monitorConnWrapper defer
+// calls refreshPoolMetrics so gauges drop to zero after the connection exits.
+func TestMonitorConnWrapperMetrics(t *testing.T) {
+	t.Parallel()
+
+	root := metrics.New()
+	p := peerForPool(t)
+	p.metrics = newConnPoolMetrics(connPoolMetricsParams{
+		Meter:       root.Scope(),
+		Logger:      zap.NewNop(),
+		ServiceName: "test-svc",
+		Peer:        p.Peer.Identifier(),
+	})
+
+	cc := dialTestClientConn(t)
+	w := newConnWrapper(p.ctx, cc)
+	p.connWg.Add(1)
+	p.mu.Lock()
+	p.conns = append(p.conns, w)
+	p.mu.Unlock()
+
+	// Reflect the initial active connection in the gauges.
+	p.refreshPoolMetrics()
+	g := gaugesFromSnapshot(root.Snapshot())
+	assert.Equal(t, int64(1), g["conn_pool_active_connections"])
+
+	go p.monitorConnWrapper(w)
+	p.cancel()
+
+	select {
+	case <-w.stoppedC:
+	case <-time.After(2 * time.Second):
+		t.Fatal("monitorConnWrapper did not exit")
+	}
+
+	// After removal the gauge must drop to zero.
+	g = gaugesFromSnapshot(root.Snapshot())
+	assert.Equal(t, int64(0), g["conn_pool_active_connections"])
 }

--- a/transport/grpc/peer_test.go
+++ b/transport/grpc/peer_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc/api/backoff"
 	"go.uber.org/yarpc/api/peer"
@@ -33,9 +34,13 @@ import (
 	"go.uber.org/yarpc/encoding/raw"
 	"go.uber.org/yarpc/internal/integrationtest"
 	"go.uber.org/yarpc/internal/yarpctest"
+	"go.uber.org/yarpc/peer/abstractpeer"
 	"go.uber.org/yarpc/peer/hostport"
 	"go.uber.org/yarpc/peer/roundrobin"
 	"go.uber.org/zap/zaptest"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 var spec = integrationtest.TransportSpec{
@@ -180,4 +185,334 @@ func makeBlastCall(t *testing.T, rawClient raw.Client, timeout time.Duration) {
 	defer cancel()
 
 	integrationtest.Blast(ctx, t, rawClient)
+}
+
+// --- pool unit test helpers ---
+
+// peerForPool builds a grpcPeer with all fields needed for pool unit tests.
+// It dials lazily so no real server is required.
+func peerForPool(t *testing.T) *grpcPeer {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	tr := NewTransport()
+	return &grpcPeer{
+		Peer:     abstractpeer.NewPeer(abstractpeer.PeerIdentifier("127.0.0.1:1"), tr),
+		t:        tr,
+		ctx:      ctx,
+		cancel:   cancel,
+		stoppedC: make(chan struct{}),
+		grpcDialOpts: []grpc.DialOption{
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		},
+		poolCfg: connPoolConfig{
+			dynamicScalingEnabled: true,
+			maxConcurrentStreams:   100,
+			scaleUpThreshold:      0.8, // threshold = 80
+			minConnections:        1,
+			maxConnections:        5,
+		},
+	}
+}
+
+// dialTestClientConn returns a real *grpc.ClientConn to a passthrough address.
+// No actual network connection is made; the conn is registered for cleanup.
+func dialTestClientConn(t *testing.T) *grpc.ClientConn {
+	t.Helper()
+	cc, err := grpc.NewClient(
+		"passthrough:///localhost:0",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cc.Close() })
+	return cc
+}
+
+// --- pickConn ---
+
+func TestPickConn(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc    string
+		conns   []*grpcClientConnWrapper
+		wantNil bool
+		wantIdx int // index into conns of the expected winner (ignored when wantNil)
+	}{
+		{
+			desc:    "empty pool returns nil",
+			conns:   nil,
+			wantNil: true,
+		},
+		{
+			desc: "all non-active returns nil",
+			conns: []*grpcClientConnWrapper{
+				makeConn(connStateDraining, 5),
+				makeConn(connStateIdle, 0),
+			},
+			wantNil: true,
+		},
+		{
+			desc: "single active conn is returned",
+			conns: []*grpcClientConnWrapper{
+				makeConn(connStateActive, 10),
+			},
+			wantIdx: 0,
+		},
+		{
+			// Lowest is at index 1.
+			desc: "picks conn with lowest stream count",
+			conns: []*grpcClientConnWrapper{
+				makeConn(connStateActive, 30),
+				makeConn(connStateActive, 5),
+				makeConn(connStateActive, 20),
+			},
+			wantIdx: 1,
+		},
+		{
+			// Draining conn is excluded; lowest active is at index 2.
+			desc: "skips non-active conns when picking lowest",
+			conns: []*grpcClientConnWrapper{
+				makeConn(connStateDraining, 1),
+				makeConn(connStateActive, 20),
+				makeConn(connStateActive, 10),
+			},
+			wantIdx: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+			p := peerForScaleDown(t, tt.conns, connPoolConfig{})
+			got := p.pickConn()
+			if tt.wantNil {
+				assert.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			assert.Same(t, tt.conns[tt.wantIdx], got)
+		})
+	}
+}
+
+// --- removeConn ---
+
+func TestRemoveConn(t *testing.T) {
+	t.Parallel()
+
+	t.Run("removes from beginning", func(t *testing.T) {
+		t.Parallel()
+		c0, c1, c2 := makeConn(connStateActive, 0), makeConn(connStateActive, 0), makeConn(connStateActive, 0)
+		p := peerForScaleDown(t, []*grpcClientConnWrapper{c0, c1, c2}, connPoolConfig{})
+		p.removeConn(c0)
+		require.Len(t, p.conns, 2)
+		assert.Same(t, c1, p.conns[0])
+		assert.Same(t, c2, p.conns[1])
+	})
+
+	t.Run("removes from middle", func(t *testing.T) {
+		t.Parallel()
+		c0, c1, c2 := makeConn(connStateActive, 0), makeConn(connStateActive, 0), makeConn(connStateActive, 0)
+		p := peerForScaleDown(t, []*grpcClientConnWrapper{c0, c1, c2}, connPoolConfig{})
+		p.removeConn(c1)
+		require.Len(t, p.conns, 2)
+		assert.Same(t, c0, p.conns[0])
+		assert.Same(t, c2, p.conns[1])
+	})
+
+	t.Run("removes from end", func(t *testing.T) {
+		t.Parallel()
+		c0, c1, c2 := makeConn(connStateActive, 0), makeConn(connStateActive, 0), makeConn(connStateActive, 0)
+		p := peerForScaleDown(t, []*grpcClientConnWrapper{c0, c1, c2}, connPoolConfig{})
+		p.removeConn(c2)
+		require.Len(t, p.conns, 2)
+		assert.Same(t, c0, p.conns[0])
+		assert.Same(t, c1, p.conns[1])
+	})
+
+	t.Run("no-op when conn not in pool", func(t *testing.T) {
+		t.Parallel()
+		c0, c1 := makeConn(connStateActive, 0), makeConn(connStateActive, 0)
+		notInPool := makeConn(connStateActive, 0)
+		p := peerForScaleDown(t, []*grpcClientConnWrapper{c0, c1}, connPoolConfig{})
+		assert.NotPanics(t, func() { p.removeConn(notInPool) })
+		assert.Len(t, p.conns, 2)
+	})
+}
+
+// --- monitorConnWrapper ---
+
+func TestMonitorConnWrapperCleanup(t *testing.T) {
+	t.Parallel()
+
+	p := peerForPool(t)
+	cc := dialTestClientConn(t)
+	w := newConnWrapper(p.ctx, cc)
+
+	p.connWg.Add(1)
+	p.mu.Lock()
+	p.conns = append(p.conns, w)
+	p.mu.Unlock()
+
+	go p.monitorConnWrapper(w)
+
+	p.mu.RLock()
+	require.Len(t, p.conns, 1)
+	p.mu.RUnlock()
+
+	p.cancel()
+
+	select {
+	case <-w.stoppedC:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stoppedC not closed after context cancellation")
+	}
+
+	p.mu.RLock()
+	assert.Empty(t, p.conns, "wrapper should be removed from pool on cleanup")
+	p.mu.RUnlock()
+
+	wgDone := make(chan struct{})
+	go func() { p.connWg.Wait(); close(wgDone) }()
+	select {
+	case <-wgDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("connWg did not reach zero after monitorConnWrapper exited")
+	}
+}
+
+// --- stoppedC lifecycle ---
+
+func TestStoppedCClosedAfterAllConnsFinish(t *testing.T) {
+	t.Parallel()
+
+	p := peerForPool(t)
+
+	go func() {
+		<-p.ctx.Done()
+		p.mu.Lock()
+		p.mu.Unlock() //nolint:staticcheck
+		p.connWg.Wait()
+		close(p.stoppedC)
+	}()
+
+	for i := 0; i < 2; i++ {
+		cc := dialTestClientConn(t)
+		w := newConnWrapper(p.ctx, cc)
+		p.connWg.Add(1)
+		p.mu.Lock()
+		p.conns = append(p.conns, w)
+		p.mu.Unlock()
+		go p.monitorConnWrapper(w)
+	}
+
+	p.cancel()
+
+	select {
+	case <-p.stoppedC:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stoppedC not closed after all connections finished")
+	}
+}
+
+// --- addConn context-cancelled branch ---
+
+func TestAddConnContextCancelled(t *testing.T) {
+	t.Parallel()
+
+	p := peerForPool(t)
+	p.cancel()
+
+	err := p.addConn()
+
+	require.Error(t, err)
+	assert.Empty(t, p.conns, "cancelled addConn must not add to pool")
+}
+
+// --- grpcStatusToYARPCStatus ---
+
+func TestGrpcStatusToYARPCStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		grpcStatus connectivity.State
+		wantYARPC  peer.ConnectionStatus
+	}{
+		{connectivity.Ready, peer.Available},
+		{connectivity.Connecting, peer.Connecting},
+		{connectivity.Idle, peer.Unavailable},
+		{connectivity.TransientFailure, peer.Unavailable},
+		{connectivity.Shutdown, peer.Unavailable},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.wantYARPC, grpcStatusToYARPCStatus(tt.grpcStatus), "grpcStatus=%v", tt.grpcStatus)
+	}
+}
+
+// --- recomputeConnectionStatus ---
+
+func TestRecomputeConnectionStatus(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty pool sets unavailable", func(t *testing.T) {
+		t.Parallel()
+		p := peerForPool(t)
+		p.recomputeConnectionStatus()
+		assert.Equal(t, peer.Unavailable, p.Peer.Status().ConnectionStatus)
+	})
+
+	t.Run("all non-active conns sets unavailable", func(t *testing.T) {
+		t.Parallel()
+		p := peerForScaleDown(t, []*grpcClientConnWrapper{
+			makeConn(connStateDraining, 5),
+			makeConn(connStateIdle, 0),
+		}, connPoolConfig{})
+		p.recomputeConnectionStatus()
+		assert.Equal(t, peer.Unavailable, p.Peer.Status().ConnectionStatus)
+	})
+
+	t.Run("active conn in non-ready state sets unavailable or connecting", func(t *testing.T) {
+		t.Parallel()
+		p := peerForPool(t)
+		cc := dialTestClientConn(t)
+		w := newConnWrapper(p.ctx, cc)
+		p.mu.Lock()
+		p.conns = append(p.conns, w)
+		p.mu.Unlock()
+
+		p.recomputeConnectionStatus()
+
+		// A freshly created ClientConn is Idle; grpcStatusToYARPCStatus(Idle)
+		// = Unavailable.  Either way it must not be Available since no server
+		// is listening.
+		status := p.Peer.Status().ConnectionStatus
+		assert.NotEqual(t, peer.Available, status,
+			"no server is listening so the connection cannot be Ready")
+	})
+
+	t.Run("monitorConnWrapper defer sets unavailable after removal", func(t *testing.T) {
+		t.Parallel()
+		p := peerForPool(t)
+		cc := dialTestClientConn(t)
+		w := newConnWrapper(p.ctx, cc)
+		p.connWg.Add(1)
+		p.mu.Lock()
+		p.conns = append(p.conns, w)
+		p.mu.Unlock()
+
+		go p.monitorConnWrapper(w)
+
+		p.cancel()
+
+		select {
+		case <-w.stoppedC:
+		case <-time.After(2 * time.Second):
+			t.Fatal("monitorConnWrapper did not exit")
+		}
+
+		// After the connection is removed, recomputeConnectionStatus sets
+		// the peer to Unavailable.
+		assert.Equal(t, peer.Unavailable, p.Peer.Status().ConnectionStatus)
+	})
 }

--- a/transport/grpc/peer_test.go
+++ b/transport/grpc/peer_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/net/metrics"
-	"go.uber.org/zap"
 	"go.uber.org/yarpc/api/backoff"
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
@@ -39,6 +38,7 @@ import (
 	"go.uber.org/yarpc/peer/abstractpeer"
 	"go.uber.org/yarpc/peer/hostport"
 	"go.uber.org/yarpc/peer/roundrobin"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
@@ -209,7 +209,7 @@ func peerForPool(t *testing.T) *grpcPeer {
 		},
 		poolCfg: connPoolConfig{
 			dynamicScalingEnabled: true,
-			maxConcurrentStreams:   100,
+			maxConcurrentStreams:  100,
 			scaleUpThreshold:      0.8, // threshold = 80
 			minConnections:        1,
 			maxConnections:        5,

--- a/transport/grpc/peer_test.go
+++ b/transport/grpc/peer_test.go
@@ -23,6 +23,7 @@ package grpc
 import (
 	"context"
 	"net"
+	"runtime"
 	"testing"
 	"time"
 
@@ -353,15 +354,11 @@ func TestMonitorConnWrapperCleanup(t *testing.T) {
 	w := newConnWrapper(p.ctx, cc)
 
 	p.connWg.Add(1)
-	p.wmu.Lock()
 	p.storeConns(append(p.loadConns(), w))
-	p.wmu.Unlock()
 
 	go p.monitorConnWrapper(w)
 
-	p.wmu.Lock()
 	require.Len(t, p.loadConns(), 1)
-	p.wmu.Unlock()
 
 	p.cancel()
 
@@ -371,9 +368,7 @@ func TestMonitorConnWrapperCleanup(t *testing.T) {
 		t.Fatal("stoppedC not closed after context cancellation")
 	}
 
-	p.wmu.Lock()
 	assert.Empty(t, p.loadConns(), "wrapper should be removed from pool on cleanup")
-	p.wmu.Unlock()
 
 	wgDone := make(chan struct{})
 	go func() { p.connWg.Wait(); close(wgDone) }()
@@ -393,9 +388,10 @@ func TestStoppedCClosedAfterAllConnsFinish(t *testing.T) {
 
 	go func() {
 		<-p.ctx.Done()
-		//lint:ignore SA2001 intentional empty critical section, provides memory barrier for connWg
-		p.wmu.Lock()
-		p.wmu.Unlock()
+		p.shutdownStarted.Store(true)
+		for p.addingCount.Load() > 0 {
+			runtime.Gosched()
+		}
 		p.connWg.Wait()
 		close(p.stoppedC)
 	}()
@@ -404,9 +400,7 @@ func TestStoppedCClosedAfterAllConnsFinish(t *testing.T) {
 		cc := dialTestClientConn(t)
 		w := newConnWrapper(p.ctx, cc)
 		p.connWg.Add(1)
-		p.wmu.Lock()
 		p.storeConns(append(p.loadConns(), w))
-		p.wmu.Unlock()
 		go p.monitorConnWrapper(w)
 	}
 
@@ -480,9 +474,7 @@ func TestRecomputeConnectionStatus(t *testing.T) {
 		p := peerForPool(t)
 		cc := dialTestClientConn(t)
 		w := newConnWrapper(p.ctx, cc)
-		p.wmu.Lock()
 		p.storeConns(append(p.loadConns(), w))
-		p.wmu.Unlock()
 
 		p.recomputeConnectionStatus()
 
@@ -500,9 +492,7 @@ func TestRecomputeConnectionStatus(t *testing.T) {
 		cc := dialTestClientConn(t)
 		w := newConnWrapper(p.ctx, cc)
 		p.connWg.Add(1)
-		p.wmu.Lock()
 		p.storeConns(append(p.loadConns(), w))
-		p.wmu.Unlock()
 
 		go p.monitorConnWrapper(w)
 
@@ -537,9 +527,7 @@ func TestMonitorConnWrapperMetrics(t *testing.T) {
 	cc := dialTestClientConn(t)
 	w := newConnWrapper(p.ctx, cc)
 	p.connWg.Add(1)
-	p.wmu.Lock()
 	p.storeConns(append(p.loadConns(), w))
-	p.wmu.Unlock()
 
 	// Reflect the initial active connection in the gauges.
 	p.refreshPoolMetrics()

--- a/transport/grpc/peer_test.go
+++ b/transport/grpc/peer_test.go
@@ -308,9 +308,9 @@ func TestRemoveConn(t *testing.T) {
 		c0, c1, c2 := makeConn(connStateActive, 0), makeConn(connStateActive, 0), makeConn(connStateActive, 0)
 		p := peerForScaleDown(t, []*grpcClientConnWrapper{c0, c1, c2}, connPoolConfig{})
 		p.removeConn(c0)
-		require.Len(t, p.conns, 2)
-		assert.Same(t, c1, p.conns[0])
-		assert.Same(t, c2, p.conns[1])
+		require.Len(t, p.loadConns(), 2)
+		assert.Same(t, c1, p.loadConns()[0])
+		assert.Same(t, c2, p.loadConns()[1])
 	})
 
 	t.Run("removes from middle", func(t *testing.T) {
@@ -318,9 +318,9 @@ func TestRemoveConn(t *testing.T) {
 		c0, c1, c2 := makeConn(connStateActive, 0), makeConn(connStateActive, 0), makeConn(connStateActive, 0)
 		p := peerForScaleDown(t, []*grpcClientConnWrapper{c0, c1, c2}, connPoolConfig{})
 		p.removeConn(c1)
-		require.Len(t, p.conns, 2)
-		assert.Same(t, c0, p.conns[0])
-		assert.Same(t, c2, p.conns[1])
+		require.Len(t, p.loadConns(), 2)
+		assert.Same(t, c0, p.loadConns()[0])
+		assert.Same(t, c2, p.loadConns()[1])
 	})
 
 	t.Run("removes from end", func(t *testing.T) {
@@ -328,9 +328,9 @@ func TestRemoveConn(t *testing.T) {
 		c0, c1, c2 := makeConn(connStateActive, 0), makeConn(connStateActive, 0), makeConn(connStateActive, 0)
 		p := peerForScaleDown(t, []*grpcClientConnWrapper{c0, c1, c2}, connPoolConfig{})
 		p.removeConn(c2)
-		require.Len(t, p.conns, 2)
-		assert.Same(t, c0, p.conns[0])
-		assert.Same(t, c1, p.conns[1])
+		require.Len(t, p.loadConns(), 2)
+		assert.Same(t, c0, p.loadConns()[0])
+		assert.Same(t, c1, p.loadConns()[1])
 	})
 
 	t.Run("no-op when conn not in pool", func(t *testing.T) {
@@ -339,7 +339,7 @@ func TestRemoveConn(t *testing.T) {
 		notInPool := makeConn(connStateActive, 0)
 		p := peerForScaleDown(t, []*grpcClientConnWrapper{c0, c1}, connPoolConfig{})
 		assert.NotPanics(t, func() { p.removeConn(notInPool) })
-		assert.Len(t, p.conns, 2)
+		assert.Len(t, p.loadConns(), 2)
 	})
 }
 
@@ -353,15 +353,15 @@ func TestMonitorConnWrapperCleanup(t *testing.T) {
 	w := newConnWrapper(p.ctx, cc)
 
 	p.connWg.Add(1)
-	p.mu.Lock()
-	p.conns = append(p.conns, w)
-	p.mu.Unlock()
+	p.wmu.Lock()
+	p.storeConns(append(p.loadConns(), w))
+	p.wmu.Unlock()
 
 	go p.monitorConnWrapper(w)
 
-	p.mu.RLock()
-	require.Len(t, p.conns, 1)
-	p.mu.RUnlock()
+	p.wmu.Lock()
+	require.Len(t, p.loadConns(), 1)
+	p.wmu.Unlock()
 
 	p.cancel()
 
@@ -371,9 +371,9 @@ func TestMonitorConnWrapperCleanup(t *testing.T) {
 		t.Fatal("stoppedC not closed after context cancellation")
 	}
 
-	p.mu.RLock()
-	assert.Empty(t, p.conns, "wrapper should be removed from pool on cleanup")
-	p.mu.RUnlock()
+	p.wmu.Lock()
+	assert.Empty(t, p.loadConns(), "wrapper should be removed from pool on cleanup")
+	p.wmu.Unlock()
 
 	wgDone := make(chan struct{})
 	go func() { p.connWg.Wait(); close(wgDone) }()
@@ -393,8 +393,9 @@ func TestStoppedCClosedAfterAllConnsFinish(t *testing.T) {
 
 	go func() {
 		<-p.ctx.Done()
-		p.mu.Lock()
-		p.mu.Unlock() //nolint:staticcheck
+		//lint:ignore SA2001 intentional empty critical section, provides memory barrier for connWg
+		p.wmu.Lock()
+		p.wmu.Unlock()
 		p.connWg.Wait()
 		close(p.stoppedC)
 	}()
@@ -403,9 +404,9 @@ func TestStoppedCClosedAfterAllConnsFinish(t *testing.T) {
 		cc := dialTestClientConn(t)
 		w := newConnWrapper(p.ctx, cc)
 		p.connWg.Add(1)
-		p.mu.Lock()
-		p.conns = append(p.conns, w)
-		p.mu.Unlock()
+		p.wmu.Lock()
+		p.storeConns(append(p.loadConns(), w))
+		p.wmu.Unlock()
 		go p.monitorConnWrapper(w)
 	}
 
@@ -429,7 +430,7 @@ func TestAddConnContextCancelled(t *testing.T) {
 	err := p.addConn()
 
 	require.Error(t, err)
-	assert.Empty(t, p.conns, "cancelled addConn must not add to pool")
+	assert.Empty(t, p.loadConns(), "cancelled addConn must not add to pool")
 }
 
 // --- grpcStatusToYARPCStatus ---
@@ -479,9 +480,9 @@ func TestRecomputeConnectionStatus(t *testing.T) {
 		p := peerForPool(t)
 		cc := dialTestClientConn(t)
 		w := newConnWrapper(p.ctx, cc)
-		p.mu.Lock()
-		p.conns = append(p.conns, w)
-		p.mu.Unlock()
+		p.wmu.Lock()
+		p.storeConns(append(p.loadConns(), w))
+		p.wmu.Unlock()
 
 		p.recomputeConnectionStatus()
 
@@ -499,9 +500,9 @@ func TestRecomputeConnectionStatus(t *testing.T) {
 		cc := dialTestClientConn(t)
 		w := newConnWrapper(p.ctx, cc)
 		p.connWg.Add(1)
-		p.mu.Lock()
-		p.conns = append(p.conns, w)
-		p.mu.Unlock()
+		p.wmu.Lock()
+		p.storeConns(append(p.loadConns(), w))
+		p.wmu.Unlock()
 
 		go p.monitorConnWrapper(w)
 
@@ -536,9 +537,9 @@ func TestMonitorConnWrapperMetrics(t *testing.T) {
 	cc := dialTestClientConn(t)
 	w := newConnWrapper(p.ctx, cc)
 	p.connWg.Add(1)
-	p.mu.Lock()
-	p.conns = append(p.conns, w)
-	p.mu.Unlock()
+	p.wmu.Lock()
+	p.storeConns(append(p.loadConns(), w))
+	p.wmu.Unlock()
 
 	// Reflect the initial active connection in the gauges.
 	p.refreshPoolMetrics()

--- a/transport/grpc/stream_test.go
+++ b/transport/grpc/stream_test.go
@@ -21,14 +21,19 @@
 package grpc
 
 import (
+	"bytes"
 	"context"
 	"io"
+	"sync/atomic"
 	"testing"
 
+	"github.com/opentracing/opentracing-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/yarpcerrors"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/mem"
 	"google.golang.org/grpc/status"
 )
@@ -219,11 +224,27 @@ func (m *mockGRPCServerStream) SendMsg(msg any) error {
 type mockGRPCClientStream struct {
 	grpc.ClientStream
 	sendMsgFunc func(m any) error
+	recvMsgFunc func(m any) error
+	closeSendFn func() error
 }
 
 func (m *mockGRPCClientStream) SendMsg(msg any) error {
 	if m.sendMsgFunc != nil {
 		return m.sendMsgFunc(msg)
+	}
+	return nil
+}
+
+func (m *mockGRPCClientStream) RecvMsg(msg any) error {
+	if m.recvMsgFunc != nil {
+		return m.recvMsgFunc(msg)
+	}
+	return io.EOF
+}
+
+func (m *mockGRPCClientStream) CloseSend() error {
+	if m.closeSendFn != nil {
+		return m.closeSendFn()
 	}
 	return nil
 }
@@ -263,4 +284,106 @@ func (m *testMemBufferPool) Put(buf *[]byte) {
 	if m.cleanup != nil {
 		m.cleanup()
 	}
+}
+
+// newTestClientStream builds a clientStream backed by mock with a tracked release callback.
+// releaseCalls is incremented each time the release (decStreamCount) callback fires.
+func newTestClientStream(mock *mockGRPCClientStream) (cs *clientStream, releaseCalls *int32) {
+	var calls int32
+	span := opentracing.GlobalTracer().StartSpan("test")
+	cs = newClientStream(
+		context.Background(),
+		&transport.StreamRequest{Meta: &transport.RequestMeta{}},
+		mock,
+		span,
+		func(error) { atomic.AddInt32(&calls, 1) },
+	)
+	return cs, &calls
+}
+
+// TestStreamTerminationDecrementsStreamCount verifies that the release callback
+// (which decrements grpcClientConnWrapper.streamCount) is called exactly once
+// for every way a client stream can terminate.
+func TestStreamTerminationDecrementsStreamCount(t *testing.T) {
+	t.Parallel()
+
+	t.Run("normal close via Close()", func(t *testing.T) {
+		t.Parallel()
+		cs, calls := newTestClientStream(&mockGRPCClientStream{})
+		_ = cs.Close(context.Background())
+		assert.Equal(t, int32(1), atomic.LoadInt32(calls),
+			"release must be called exactly once on normal close")
+	})
+
+	t.Run("caller context cancellation causes ReceiveMessage error", func(t *testing.T) {
+		t.Parallel()
+		cs, calls := newTestClientStream(&mockGRPCClientStream{
+			recvMsgFunc: func(any) error { return context.Canceled },
+		})
+		_, err := cs.ReceiveMessage(context.Background())
+		require.Error(t, err)
+		assert.Equal(t, int32(1), atomic.LoadInt32(calls),
+			"release must be called when context is cancelled")
+	})
+
+	t.Run("server-side abort via gRPC status error", func(t *testing.T) {
+		t.Parallel()
+		serverErr := status.Error(codes.Aborted, "server aborted")
+		cs, calls := newTestClientStream(&mockGRPCClientStream{
+			recvMsgFunc: func(any) error { return serverErr },
+		})
+		_, err := cs.ReceiveMessage(context.Background())
+		require.Error(t, err)
+		assert.Equal(t, int32(1), atomic.LoadInt32(calls),
+			"release must be called on server-side abort")
+	})
+
+	t.Run("TCP connection dropped - io.ErrUnexpectedEOF", func(t *testing.T) {
+		t.Parallel()
+		cs, calls := newTestClientStream(&mockGRPCClientStream{
+			recvMsgFunc: func(any) error { return io.ErrUnexpectedEOF },
+		})
+		_, err := cs.ReceiveMessage(context.Background())
+		require.Error(t, err)
+		assert.Equal(t, int32(1), atomic.LoadInt32(calls),
+			"release must be called on TCP drop")
+	})
+
+	t.Run("send error also triggers release", func(t *testing.T) {
+		t.Parallel()
+		cs, calls := newTestClientStream(&mockGRPCClientStream{
+			sendMsgFunc: func(any) error { return io.ErrUnexpectedEOF },
+		})
+		err := cs.SendMessage(context.Background(), &transport.StreamMessage{
+			Body: io.NopCloser(bytes.NewReader([]byte("msg"))),
+		})
+		require.Error(t, err)
+		assert.Equal(t, int32(1), atomic.LoadInt32(calls),
+			"release must be called on send error")
+	})
+
+	t.Run("release called at most once even if multiple paths fire", func(t *testing.T) {
+		t.Parallel()
+		cs, calls := newTestClientStream(&mockGRPCClientStream{
+			recvMsgFunc: func(any) error { return context.Canceled },
+		})
+		_, _ = cs.ReceiveMessage(context.Background())
+		_ = cs.Close(context.Background()) // second termination — must be a no-op
+		assert.Equal(t, int32(1), atomic.LoadInt32(calls),
+			"release must fire exactly once regardless of how many close paths are triggered")
+	})
+
+	t.Run("GC leak - release is NOT called if stream is never read, written, or closed", func(t *testing.T) {
+		t.Parallel()
+		// This test documents the known limitation: if a caller obtains a stream
+		// and then drops the reference without calling Close or reading/writing,
+		// decStreamCount is never called because there is no finalizer on clientStream.
+		// The goroutine goroutine leak detector (goleak) will surface this if there
+		// are active goroutines, but the streamCount itself will not self-correct.
+		_, calls := newTestClientStream(&mockGRPCClientStream{})
+		// Deliberately do nothing with the stream — simulate a caller that leaks it.
+		assert.Equal(t, int32(0), atomic.LoadInt32(calls),
+			"streamCount is not decremented when a stream is leaked without Close/read/write — "+
+				"this is a known limitation; adding a runtime.SetFinalizer would address it")
+	})
 }

--- a/transport/grpc/transport.go
+++ b/transport/grpc/transport.go
@@ -144,6 +144,7 @@ func (t *Transport) ReleasePeer(pid peer.Identifier, ps peer.Subscriber) error {
 	if p.NumSubscribers() == 0 {
 		delete(t.addressToPeer, address)
 		p.stop()
+		p.wait()
 	}
 	return nil
 }

--- a/transport/grpc/transport.go
+++ b/transport/grpc/transport.go
@@ -39,6 +39,11 @@ type Transport struct {
 	once          *lifecycle.Once
 	options       *transportOptions
 	addressToPeer map[string]*grpcPeer
+	// releasedCleanupWg tracks peers released via ReleasePeer. We cannot call
+	// p.wait() inside ReleasePeer because abstractlist.stop() holds list.lock
+	// while calling it, and monitorConnWrapper needs list.lock to exit cleanly
+	// (deadlock). Instead we wait asynchronously and join in Transport.Stop().
+	releasedCleanupWg sync.WaitGroup
 }
 
 // NewTransport returns a new Transport.
@@ -63,14 +68,21 @@ func (t *Transport) Start() error {
 func (t *Transport) Stop() error {
 	return t.once.Stop(func() error {
 		t.lock.Lock()
-		defer t.lock.Unlock()
-
 		for _, grpcPeer := range t.addressToPeer {
 			grpcPeer.stop()
 		}
-		for _, grpcPeer := range t.addressToPeer {
-			grpcPeer.wait()
+		peers := make([]*grpcPeer, 0, len(t.addressToPeer))
+		for _, p := range t.addressToPeer {
+			peers = append(peers, p)
 		}
+		t.lock.Unlock()
+
+		for _, p := range peers {
+			p.wait()
+		}
+		// Wait for peers released via ReleasePeer whose cleanup goroutines
+		// may still be running.
+		t.releasedCleanupWg.Wait()
 		return nil
 	})
 }
@@ -144,7 +156,15 @@ func (t *Transport) ReleasePeer(pid peer.Identifier, ps peer.Subscriber) error {
 	if p.NumSubscribers() == 0 {
 		delete(t.addressToPeer, address)
 		p.stop()
-		p.wait()
+		// Do not call p.wait() here: abstractlist.stop() holds list.lock while
+		// calling ReleasePeer, and monitorConnWrapper needs list.lock to exit.
+		// Waiting synchronously would deadlock. Instead, wait asynchronously so
+		// abstractlist.stop() can finish and release list.lock first.
+		t.releasedCleanupWg.Add(1)
+		go func() {
+			defer t.releasedCleanupWg.Done()
+			p.wait()
+		}()
 	}
 	return nil
 }

--- a/transport/grpc/transport_test.go
+++ b/transport/grpc/transport_test.go
@@ -22,7 +22,9 @@ package grpc
 
 import (
 	"net"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -77,6 +79,90 @@ func TestReleasePeerErrorNoPeer(t *testing.T) {
 		TransportName:  "grpc.Transport",
 		PeerIdentifier: address,
 	}, transport.ReleasePeer(testIdentifier{address}, peerSubscriber))
+}
+
+// TestStopWaitsForReleasedPeerCleanup verifies that Transport.Stop() blocks
+// until the async cleanup goroutine launched by ReleasePeer finishes.
+func TestStopWaitsForReleasedPeerCleanup(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	grpcServer := grpc.NewServer()
+	go grpcServer.Serve(listener)
+	defer grpcServer.Stop()
+
+	transport := NewTransport()
+	require.NoError(t, transport.Start())
+
+	address := listener.Addr().String()
+	sub := testPeerSubscriber{}
+
+	_, err = transport.RetainPeer(testIdentifier{address}, sub)
+	require.NoError(t, err)
+
+	// ReleasePeer with 0 remaining subscribers spawns an async cleanup goroutine.
+	require.NoError(t, transport.ReleasePeer(testIdentifier{address}, sub))
+
+	// Stop must not return until releasedCleanupWg reaches zero.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		assert.NoError(t, transport.Stop())
+	}()
+
+	select {
+	case <-done:
+		// Stop completed — cleanup goroutine finished first.
+	case <-time.After(5 * time.Second):
+		t.Fatal("Transport.Stop() did not return within 5s; releasedCleanupWg may not be awaited")
+	}
+}
+
+// TestStopReleasesLockBeforeWait verifies that Transport.Stop() does not hold
+// t.lock while calling p.wait(), so concurrent operations that need the lock
+// (e.g. ReleasePeer called from a peer-list shutdown) do not deadlock.
+func TestStopReleasesLockBeforeWait(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	grpcServer := grpc.NewServer()
+	go grpcServer.Serve(listener)
+	defer grpcServer.Stop()
+
+	transport := NewTransport()
+	require.NoError(t, transport.Start())
+
+	address := listener.Addr().String()
+	sub := testPeerSubscriber{}
+
+	_, err = transport.RetainPeer(testIdentifier{address}, sub)
+	require.NoError(t, err)
+
+	// Simulate a concurrent ReleasePeer that runs while Stop is in p.wait().
+	// If Stop held t.lock during p.wait() this would deadlock.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// Small delay to let Stop enter p.wait().
+		time.Sleep(10 * time.Millisecond)
+		// This acquires t.lock internally; must not deadlock.
+		_ = transport.ReleasePeer(testIdentifier{address}, sub)
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		assert.NoError(t, transport.Stop())
+	}()
+
+	wg.Wait()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Transport.Stop() deadlocked while holding t.lock during p.wait()")
+	}
 }
 
 type testPeerSubscriber struct{}

--- a/version.go
+++ b/version.go
@@ -21,4 +21,4 @@
 package yarpc // import "go.uber.org/yarpc"
 
 // Version is the current version of YARPC.
-const Version = "1.0.0-dev"
+const Version = "1.88.5"


### PR DESCRIPTION
## Summary

### Problem
  gRPC connections hit HTTP/2's 250-stream limit, causing latency spikes under high load. Need to automatically scale the connection pool per-peer without per-service YAML changes.

[gRPC Connection Pool — Dynamic Scaling Testing Report](https://docs.google.com/document/d/1AShgJxH7-A8V9t4KMN-76tUDcfhImSFGmwWB14rXSHs/edit?tab=t.0)

### Solution
- yarpc-go: Added a dynamic connection pool scaler that monitors stream utilization per peer. When streams exceed a threshold, it opens  new connections; when idle, it drains and closes them.
- yarpcfx: Added a centrally-managed OC guard so the RPC team can enable/disable per service without touching each service's config.

 #### yarpc-go Changes

  - conn_pool_scaler.go — background goroutine per peer: scale-up, scale-down, idle cleanup, reactivation
  - peer.go — atomic connection slice (connPtr), lock-free read path, connStateActive/Draining/Idle
  - options.go — WithDynamicConnectionScaling(bool)
  - config.go — YAML field kept for compatibility but no longer applied; only programmatic option counts
  - client_conn_wrapper.go — per-connection state machine + stream counter

####  yarpcfx Changes (go-code)

  - yarpcfx.git/internal/grpcdynamicscaling/ — new private module: subscribes to yarpcfx-config@grpc-dynamic-scaling via OC, reads  ["service-a", "service-b"] list, calls WithDynamicConnectionScaling(true/false) at startup
  - yarpcfx.git/yarpcfx.go — appended OC option last so it overrides any YAML setting
  - control@yarpcfx-config — OC control repo with schema and access control (rpc group)

###  Rollout
- For enabling a rollout of service, we need to add a service name to yarpcfx-config@grpc-dynamic-scaling/grpc_dynamic_scaling.json
- Services need to set-up custom yaml; otherwise grpc picks up default config
```
clientConnectionPool:
     dynamicScalingEnabled: true
     maxConcurrentStreams: 250
     scaleUpThreshold: 0.8
     minConnections: 1
     maxConnections: 5
     idleTimeout: 15m
     scalingMonitorInterval: 30s
```

####  Outstanding

  - Uncomment new body once library changes ships in staging yarpc.
  
