### PR TITLE
[GRPC-Conn-Polling][yarpc-go] Fixing go leak

### DIFF
--- a/transport/grpc/transport.go
+++ b/transport/grpc/transport.go
@@ -144,6 +144,7 @@ func (t *Transport) ReleasePeer(pid peer.Identifier, ps peer.Subscriber) error {
 	if p.NumSubscribers() == 0 {
 		delete(t.addressToPeer, address)
 		p.stop()
+		p.wait()
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary 
ReleasePeer was deleting the peer from addressToPeer and calling p.stop() (which cancels the context), but never calling p.wait(). Since Transport.Stop() only waits for peers still in addressToPeer, the lifecycle goroutine was orphaned ; still blocking on <-p.ctx.Done() cleanup work after the test finished. Adding p.wait() ensures ReleasePeer blocks until the goroutine fully exits before returning.

## Jira
[RPC-9795](https://t3.uberinternal.com/browse/RPC-9795)