### PR TITLE
Add klauspost gzip compressor

### DIFF
--- a/compressor/benchmark_test.go
+++ b/compressor/benchmark_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc/api/transport"
 	yarpcgzip "go.uber.org/yarpc/compressor/gzip"
+	yarpcklauspostgzip "go.uber.org/yarpc/compressor/klauspostgzip"
 	yarpczstd "go.uber.org/yarpc/compressor/zstd"
 )
 
@@ -41,6 +42,7 @@ type compressorFactory struct {
 
 var compressors = []compressorFactory{
 	{"gzip", func() transport.Compressor { return yarpcgzip.New() }},
+	{"klauspostgzip", func() transport.Compressor { return yarpcklauspostgzip.New() }},
 	{"zstd", func() transport.Compressor { return yarpczstd.New() }},
 }
 

--- a/compressor/klauspostgzip/klauspostgzip.go
+++ b/compressor/klauspostgzip/klauspostgzip.go
@@ -1,0 +1,253 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package yarpcklauspostgzip provides a YARPC binding for GZIP compression
+// backed by github.com/klauspost/compress/gzip.
+package yarpcklauspostgzip
+
+import (
+	"encoding/binary"
+	"io"
+	"sync"
+
+	"github.com/klauspost/compress/gzip"
+	"go.uber.org/yarpc/api/transport"
+)
+
+const name = "klauspostgzip"
+
+// Option is an option argument for the Gzip compressor constructor, New.
+type Option interface {
+	apply(*Compressor)
+}
+
+// Level sets the compression level for the compressor.
+func Level(level int) Option {
+	return levelOption{level: level}
+}
+
+type levelOption struct {
+	level int
+}
+
+func (o levelOption) apply(opts *Compressor) {
+	opts.level = o.level
+}
+
+// New returns a GZIP compression strategy, suitable for configuring an
+// outbound dialer.
+//
+// The compressor needs to be adapted and registered to be compatible
+// with the gRPC compressor system.
+// Since gRPC requires global registration of compressors, you must arrange for
+// the compressor to be registered in your application initialization.
+// The adapter converts an io.Reader into an io.ReadCloser so that reading EOF
+// will implicitly trigger Close, a behavior gRPC-go relies upon to reuse
+// readers.
+//
+//	import (
+//	    "github.com/klauspost/compress/gzip"
+//
+//	    "google.golang.org/grpc/encoding"
+//	    "go.uber.org/yarpc/compressor/grpc"
+//	    "go.uber.org/yarpc/compressor/klauspostgzip"
+//	)
+//
+//	var GZIPCompressor = yarpcklauspostgzip.New(yarpcklauspostgzip.Level(gzip.BestCompression))
+//
+//	func init()
+//	    gz := yarpcgrpccompressor.New(GZIPCompressor)
+//	    encoding.RegisterCompressor(gz)
+//	}
+//
+// If you are constructing your YARPC clients directly through the API,
+// create a gRPC dialer with the Compressor option.
+//
+//	trans := grpc.NewTransport()
+//	dialer := trans.NewDialer(GZIPCompressor)
+//	peers := roundrobin.New(dialer)
+//	outbound := trans.NewOutbound(peers)
+//
+// If you are using the YARPC configurator to create YARPC objects
+// using config files, you will also need to register the compressor
+// with your configurator.
+//
+//	configurator := yarpcconfig.New()
+//	configurator.MustRegisterCompressor(GZIPCompressor)
+//
+// Then, using the compression strategy for outbound requests
+// on a particular client, just set the compressor to klauspostgzip.
+//
+//	outbounds:
+//	  theirsecureservice:
+//	    grpc:
+//	      address: ":443"
+//	      tls:
+//	        enabled: true
+//	      compressor: klauspostgzip
+func New(opts ...Option) *Compressor {
+	c := &Compressor{
+		level: gzip.DefaultCompression,
+	}
+	for _, opt := range opts {
+		opt.apply(c)
+	}
+	return c
+}
+
+// Compressor represents the gzip compression strategy.
+type Compressor struct {
+	level         int
+	compressors   sync.Pool
+	decompressors sync.Pool
+}
+
+var _ transport.Compressor = (*Compressor)(nil)
+
+// Name is klauspostgzip.
+func (*Compressor) Name() string {
+	return name
+}
+
+// Compress creates a gzip compressor.
+func (c *Compressor) Compress(w io.Writer) (io.WriteCloser, error) {
+	if cw, got := c.compressors.Get().(*writer); got {
+		cw.writer.Reset(w)
+		return cw, nil
+	}
+
+	cw, err := gzip.NewWriterLevel(w, c.level)
+	if err != nil {
+		return nil, err
+	}
+
+	return &writer{
+		writer: cw,
+		pool:   &c.compressors,
+	}, nil
+}
+
+type writer struct {
+	writer *gzip.Writer
+	pool   *sync.Pool
+}
+
+var _ io.WriteCloser = (*writer)(nil)
+
+func (w *writer) Write(buf []byte) (int, error) {
+	return w.writer.Write(buf)
+}
+
+func (w *writer) Close() error {
+	defer w.pool.Put(w)
+	return w.writer.Close()
+}
+
+// Decompress obtains a gzip decompressor.
+//
+// The returned io.ReadCloser is a single-use handle that internally references
+// a pooled *gzip.Reader. The handle ensures Close is idempotent for pooling
+// purposes: only the first Close returns the pooled reader to the pool, and
+// any Read after Close returns io.EOF without touching the (now possibly
+// reused) pooled reader. This is required because the gRPC compressor
+// adapter (compressor/grpc/grpc.go) calls Close on io.EOF inside Read, and
+// gRPC itself may perform an additional Read/Close to drain the stream.
+// Without this guard, a lingering Close from the previous caller would
+// double-Put the pooled reader, handing the same instance to two concurrent
+// goroutines.
+func (c *Compressor) Decompress(r io.Reader) (io.ReadCloser, error) {
+	var dr *reader
+	if pooled, got := c.decompressors.Get().(*reader); got {
+		if err := pooled.reader.Reset(r); err != nil {
+			c.decompressors.Put(pooled)
+			return nil, err
+		}
+		dr = pooled
+	} else {
+		gr, err := gzip.NewReader(r)
+		if err != nil {
+			return nil, err
+		}
+		dr = &reader{
+			reader: gr,
+			pool:   &c.decompressors,
+		}
+	}
+	return &readerHandle{r: dr}, nil
+}
+
+// reader is the pooled gzip decompressor. It is never returned to callers
+// directly; callers always receive a *readerHandle that wraps it.
+type reader struct {
+	reader *gzip.Reader
+	pool   *sync.Pool
+}
+
+// readerHandle is the per-call wrapper handed back from Decompress. It owns
+// exclusive use of the underlying pooled *reader for the lifetime of a single
+// request and guarantees that:
+//
+// - Close is idempotent: subsequent calls are no-ops and do not re-Put the
+// pooled reader.
+// - Read after Close returns io.EOF immediately without touching the
+// pooled reader (which may have been recycled to another goroutine).
+type readerHandle struct {
+	r      *reader
+	closed bool
+}
+
+var _ io.ReadCloser = (*readerHandle)(nil)
+
+func (h *readerHandle) Read(buf []byte) (int, error) {
+	if h.closed {
+		return 0, io.EOF
+	}
+	return h.r.reader.Read(buf)
+}
+
+func (h *readerHandle) Close() error {
+	if h.closed {
+		return nil
+	}
+	h.closed = true
+	h.r.pool.Put(h.r)
+	return nil
+}
+
+// DecompressedSize returns the decompressed size of the given GZIP compressed
+// bytes.
+//
+// gRPC specifically casts the compressor to a DecompressedSizer
+// to pre-check message length.
+//
+// Per gRPC-go, on which this is based:
+// https://github.com/grpc/grpc-go/blob/master/encoding/gzip/gzip.go
+//
+// RFC1952 specifies that the last four bytes "contains the size of
+// the original (uncompressed) input data modulo 2^32."
+// gRPC has a max message size of 2GB so we don't need to worry about
+// wraparound for that transport protocol.
+func (c *Compressor) DecompressedSize(buf []byte) int {
+	last := len(buf)
+	if last < 4 {
+		return -1
+	}
+	return int(binary.LittleEndian.Uint32(buf[last-4 : last]))
+}

--- a/compressor/klauspostgzip/klauspostgzip_race_test.go
+++ b/compressor/klauspostgzip/klauspostgzip_race_test.go
@@ -1,0 +1,278 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpcklauspostgzip_test
+
+import (
+	"bytes"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	yarpcklauspostgzip "go.uber.org/yarpc/compressor/klauspostgzip"
+)
+
+// The tests in this file pin down the reuse-safety contract of the
+// io.ReadCloser returned by (*Compressor).Decompress:
+//
+// 1. Close is idempotent for pooling - calling it more than once must not
+// place the same pooled instance into the internal sync.Pool twice.
+// 2. As a consequence of (1), no two concurrent Decompress callers can ever
+// receive the same underlying *gzip.Reader. The wrapped flate state is
+// not safe for concurrent use.
+//
+// These invariants matter because the production gRPC compressor adapter
+// (compressor/grpc/grpc.go) calls Close from Read on io.EOF, and the gRPC
+// runtime may issue additional Reads / Closes on the same reader. If the
+// invariants are violated, two RPC goroutines decompress through a shared
+// flate state, corrupting heap memory that surfaces later as crashes in
+// unrelated goroutines (e.g. gRPC's loopyWriter).
+
+// TestDecompressorCloseIsIdempotentForPooling is a fast, deterministic
+// regression check: after a caller has driven Decompress through the gRPC
+// drain-after-EOF pattern (which calls Close twice on the same reader),
+// subsequent independent Decompress calls must produce independent readers.
+//
+// On a correct implementation, two follow-up Decompress calls each operate
+// on their own *gzip.Reader, so interleaved Reads produce the two distinct
+// plaintexts. On a regressed implementation, the double-Close double-Puts
+// the same pooled *reader instance into the sync.Pool; the next two Get
+// calls return the same instance, the second Reset clobbers the first, and
+// the two readers race over a shared *gzip.Reader / flate state - typically
+// surfacing here as the first reader yielding the second reader's plaintext
+// (or a flate error).
+func TestDecompressorCloseIsIdempotentForPooling(t *testing.T) {
+	c := yarpcklauspostgzip.New()
+
+	plain1 := []byte("first-payload:" + strings.Repeat("a", 1024))
+	plain2 := []byte("second-payload:" + strings.Repeat("b", 1024))
+	plain3 := []byte("third-payload:" + strings.Repeat("c", 1024))
+
+	// Step 1: drive a Decompress through the production gRPC drain pattern,
+	// which calls Close twice on the underlying reader.
+	rc, err := c.Decompress(bytes.NewReader(compressData(t, c, plain1)))
+	require.NoError(t, err)
+	gw := &grpcAdapter{reader: rc}
+	_, err = io.ReadAll(gw) // reaches EOF -> wrapper calls Close once
+	require.NoError(t, err)
+	// gRPC's post-EOF drain: one more Read on the wrapper. On a regressed
+	// implementation this triggers a second Close -> a second Put.
+	var tail [16]byte
+	_, _ = gw.Read(tail[:])
+
+	// Step 2: two follow-up Decompress calls. On a regressed implementation
+	// both Get the same pooled *reader, the second Reset overwrites the
+	// first, and the readers share state.
+	rc2, err := c.Decompress(bytes.NewReader(compressData(t, c, plain2)))
+	require.NoError(t, err)
+	defer rc2.Close()
+	rc3, err := c.Decompress(bytes.NewReader(compressData(t, c, plain3)))
+	require.NoError(t, err)
+	defer rc3.Close()
+
+	got2, err := io.ReadAll(rc2)
+	require.NoError(t, err, "rc2 Read failed (likely sharing flate state with rc3)")
+	got3, err := io.ReadAll(rc3)
+	require.NoError(t, err, "rc3 Read failed (likely sharing flate state with rc2)")
+
+	require.Equal(t, plain2, got2,
+		"rc2 decoded the wrong plaintext; Close double-Put let rc2 and rc3 share a pooled *reader")
+	require.Equal(t, plain3, got3,
+		"rc3 decoded the wrong plaintext; Close double-Put let rc2 and rc3 share a pooled *reader")
+}
+
+// TestDecompressorErrorPaths covers the two error branches of Decompress:
+//
+// - gzip.NewReader fails on the cold path (empty pool, invalid gzip input).
+// - *gzip.Reader.Reset fails on the warm path (pool primed, invalid gzip
+// input). The pooled *reader must be returned to the pool so it remains
+// available for subsequent valid Decompress calls.
+func TestDecompressorErrorPaths(t *testing.T) {
+	c := yarpcklauspostgzip.New()
+	invalid := []byte("not gzip data")
+	valid := compressData(t, c, input)
+
+	t.Run("NewReader fails with empty pool", func(t *testing.T) {
+		c := yarpcklauspostgzip.New()
+		rc, err := c.Decompress(bytes.NewReader(invalid))
+		require.Error(t, err)
+		require.Nil(t, rc)
+	})
+
+	t.Run("Reset fails with primed pool and pooled reader is recovered", func(t *testing.T) {
+		// Prime the pool with one valid *reader.
+		rc, err := c.Decompress(bytes.NewReader(valid))
+		require.NoError(t, err)
+		_, err = io.ReadAll(rc)
+		require.NoError(t, err)
+		require.NoError(t, rc.Close())
+
+		// Force the warm-path Reset error branch.
+		rc, err = c.Decompress(bytes.NewReader(invalid))
+		require.Error(t, err)
+		require.Nil(t, rc)
+
+		// The pooled *reader must have been returned to the pool: the next
+		// valid Decompress must still succeed.
+		rc, err = c.Decompress(bytes.NewReader(valid))
+		require.NoError(t, err)
+		got, err := io.ReadAll(rc)
+		require.NoError(t, err)
+		require.NoError(t, rc.Close())
+		require.Equal(t, input, got)
+	})
+}
+
+// TestDecompressorIsSafeUnderConcurrentGRPCDrain is the `-race` regression
+// check for the same contract under concurrent load. It drives Decompress
+// through the exact wrapper pattern used by compressor/grpc/grpc.go and
+// includes the post-EOF drain Read that triggers a second Close.
+//
+// On a correct implementation, every iteration verifies its decompressed
+// output and the race detector stays silent. On a regressed implementation,
+// the race detector trips inside compress/flate.(*decompressor) and/or the
+// goroutine panics with a nil deref / corrupted flate state.
+//
+// Run with the race detector enabled:
+//
+// go test -race -run TestDecompressorIsSafeUnderConcurrentGRPCDrain ./compressor/klauspostgzip/ -count=1 -timeout 60s
+//
+// For stronger confidence (re-runs the test 10 times to surface flaky races):
+//
+// go test -race -run TestDecompressorIsSafeUnderConcurrentGRPCDrain ./compressor/klauspostgzip/ -count=10 -timeout 120s
+func TestDecompressorIsSafeUnderConcurrentGRPCDrain(t *testing.T) {
+	compressor := yarpcklauspostgzip.New()
+
+	// A small corpus of sizable, high-entropy payloads. The working set is
+	// intentionally small so goroutines actually contend on a handful of
+	// pooled *reader instances rather than each Get allocating fresh.
+	const numPayloads = 4
+	payloads := make([][]byte, numPayloads)
+	plaintexts := make([][]byte, numPayloads)
+	for i := 0; i < numPayloads; i++ {
+		raw := make([]byte, 8*1024)
+		_, err := rand.Read(raw)
+		require.NoError(t, err)
+		raw = append([]byte(fmt.Sprintf("payload-%d:", i)), raw...)
+		plaintexts[i] = raw
+		payloads[i] = compressData(t, compressor, raw)
+	}
+
+	// Warm the pool so subsequent goroutines reuse rather than allocate.
+	for i := 0; i < 8; i++ {
+		dr, err := compressor.Decompress(bytes.NewReader(payloads[i%numPayloads]))
+		require.NoError(t, err)
+		_, err = io.ReadAll(dr)
+		require.NoError(t, err)
+		require.NoError(t, dr.Close())
+	}
+
+	workers := runtime.GOMAXPROCS(0) * 4
+	if workers < 32 {
+		workers = 32
+	}
+	const iterationsPerWorker = 200
+
+	var (
+		wg         sync.WaitGroup
+		mismatches int64
+	)
+	wg.Add(workers)
+	for w := 0; w < workers; w++ {
+		w := w
+		go func() {
+			defer wg.Done()
+			buf := make([]byte, 0, 16*1024)
+			for i := 0; i < iterationsPerWorker; i++ {
+				idx := (w + i) % numPayloads
+				want := plaintexts[idx]
+
+				dr, err := compressor.Decompress(bytes.NewReader(payloads[idx]))
+				if err != nil {
+					t.Errorf("Decompress failed: %v", err)
+					return
+				}
+
+				// Drive Decompress through the exact wrapper that
+				// compressor/grpc/grpc.go uses: Read calls Close on io.EOF.
+				gw := &grpcAdapter{reader: dr}
+
+				buf = buf[:0]
+				got, err := readAllInto(gw, buf)
+				if err != nil {
+					t.Errorf("Read failed: %v", err)
+					return
+				}
+
+				// gRPC frequently issues one more Read after EOF to drain.
+				// On a regressed implementation this triggers a second Close
+				// and a double-Put into the pool.
+				var tail [16]byte
+				_, _ = gw.Read(tail[:])
+
+				if !bytes.Equal(got, want) {
+					atomic.AddInt64(&mismatches, 1)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	require.Zero(t, atomic.LoadInt64(&mismatches),
+		"decompressed output differed from expected input; pooled *reader was shared across goroutines")
+}
+
+// grpcAdapter mirrors the production wrapper in compressor/grpc/grpc.go: it
+// calls Close on the wrapped ReadCloser whenever Read returns io.EOF.
+type grpcAdapter struct {
+	reader io.ReadCloser
+}
+
+func (r *grpcAdapter) Read(buf []byte) (int, error) {
+	n, err := r.reader.Read(buf)
+	if err == io.EOF {
+		_ = r.reader.Close()
+	}
+	return n, err
+}
+
+// readAllInto drains r into dst, growing it as needed, without allocating a
+// fresh backing array per iteration.
+func readAllInto(r io.Reader, dst []byte) ([]byte, error) {
+	for {
+		if len(dst) == cap(dst) {
+			dst = append(dst, 0)[:len(dst)]
+		}
+		n, err := r.Read(dst[len(dst):cap(dst)])
+		dst = dst[:len(dst)+n]
+		if err == io.EOF {
+			return dst, nil
+		}
+		if err != nil {
+			return dst, err
+		}
+	}
+}

--- a/compressor/klauspostgzip/klauspostgzip_test.go
+++ b/compressor/klauspostgzip/klauspostgzip_test.go
@@ -1,0 +1,224 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package yarpcklauspostgzip_test
+
+import (
+	"bytes"
+	stdgzip "compress/gzip"
+	"io"
+	"strconv"
+	"testing"
+
+	kpgzip "github.com/klauspost/compress/gzip"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	yarpcklauspostgzip "go.uber.org/yarpc/compressor/klauspostgzip"
+)
+
+// This should be compressible:
+var quote = "Now is the time for all good men to come to the aid of their country"
+var input = []byte(quote + quote + quote)
+
+// compressData compresses data using the given compressor and returns the compressed bytes.
+func compressData(tb testing.TB, compressor *yarpcklauspostgzip.Compressor, data []byte) []byte {
+	tb.Helper()
+	buf := bytes.NewBuffer(nil)
+	writer, err := compressor.Compress(buf)
+	require.NoError(tb, err)
+	_, err = writer.Write(data)
+	require.NoError(tb, err)
+	require.NoError(tb, writer.Close())
+	return buf.Bytes()
+}
+
+func TestGzip(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+	writer, err := yarpcklauspostgzip.New().Compress(buf)
+	require.NoError(t, err)
+
+	_, err = writer.Write(input)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	str, err := yarpcklauspostgzip.New().Decompress(buf)
+	require.NoError(t, err)
+
+	output, err := io.ReadAll(str)
+	require.NoError(t, err)
+	require.NoError(t, str.Close())
+
+	assert.Equal(t, input, output)
+}
+
+func TestCompressionPooling(t *testing.T) {
+	compressor := yarpcklauspostgzip.New()
+	for i := 0; i < 128; i++ {
+		buf := bytes.NewBuffer(nil)
+		writer, err := compressor.Compress(buf)
+		require.NoError(t, err)
+
+		_, err = writer.Write(input)
+		require.NoError(t, err)
+		require.NoError(t, writer.Close())
+
+		str, err := compressor.Decompress(buf)
+		require.NoError(t, err)
+
+		output, err := io.ReadAll(str)
+		require.NoError(t, err)
+		require.NoError(t, str.Close())
+
+		assert.Equal(t, input, output)
+	}
+}
+
+func TestEveryCompressionLevel(t *testing.T) {
+	levels := []int{
+		kpgzip.NoCompression,
+		kpgzip.BestSpeed,
+		kpgzip.BestCompression,
+		kpgzip.DefaultCompression,
+		kpgzip.HuffmanOnly,
+		kpgzip.StatelessCompression,
+	}
+
+	for _, level := range levels {
+		t.Run(strconv.Itoa(level), func(t *testing.T) {
+			compressor := yarpcklauspostgzip.New(yarpcklauspostgzip.Level(level))
+
+			buf := bytes.NewBuffer(nil)
+			writer, err := compressor.Compress(buf)
+			require.NoError(t, err)
+
+			_, err = writer.Write(input)
+			require.NoError(t, err)
+			require.NoError(t, writer.Close())
+
+			str, err := compressor.Decompress(buf)
+			require.NoError(t, err)
+
+			output, err := io.ReadAll(str)
+			require.NoError(t, err)
+			require.NoError(t, str.Close())
+
+			assert.Equal(t, input, output)
+		})
+	}
+}
+
+func TestStdlibGzipCompatibility(t *testing.T) {
+	var buf bytes.Buffer
+	writer := stdgzip.NewWriter(&buf)
+	_, err := writer.Write(input)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	str, err := yarpcklauspostgzip.New().Decompress(&buf)
+	require.NoError(t, err)
+
+	output, err := io.ReadAll(str)
+	require.NoError(t, err)
+	require.NoError(t, str.Close())
+
+	assert.Equal(t, input, output)
+}
+
+func TestKlauspostGzipCompatibility(t *testing.T) {
+	compressor := yarpcklauspostgzip.New()
+	compressedData := compressData(t, compressor, input)
+
+	reader, err := stdgzip.NewReader(bytes.NewReader(compressedData))
+	require.NoError(t, err)
+
+	output, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.NoError(t, reader.Close())
+
+	assert.Equal(t, input, output)
+}
+
+func TestGzipName(t *testing.T) {
+	assert.Equal(t, "klauspostgzip", yarpcklauspostgzip.New().Name())
+}
+
+func TestDecompressedSize(t *testing.T) {
+	compressor := yarpcklauspostgzip.New(yarpcklauspostgzip.Level(kpgzip.BestCompression))
+
+	buf := bytes.NewBuffer(nil)
+	writer, err := compressor.Compress(buf)
+	require.NoError(t, err)
+
+	_, err = writer.Write(input)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	assert.Equal(t, len(input), compressor.DecompressedSize(buf.Bytes()))
+
+	// Sanity check
+	assert.True(t, buf.Len() < len(input), "one would think the compressed data would be smaller")
+	t.Logf("decompress: %d\n", len(input))
+	t.Logf("compressed: %d\n", buf.Len())
+}
+
+func TestDecompressedSizeError(t *testing.T) {
+	compressor := yarpcklauspostgzip.New(yarpcklauspostgzip.Level(kpgzip.BestCompression))
+	assert.Equal(t, -1, compressor.DecompressedSize([]byte{}))
+}
+
+func BenchmarkDecompressPooling(b *testing.B) {
+	compressor := yarpcklauspostgzip.New()
+
+	// Pre-compress data for decompression.
+	compressedData := compressData(b, compressor, input)
+
+	// Invalid gzip data that will cause Reset to fail.
+	invalidData := []byte("this is not valid gzip data")
+
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{"HappyPath", compressedData},
+		{"ErrorPath", invalidData},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			// Warm up pool with valid data.
+			r, _ := compressor.Decompress(bytes.NewReader(compressedData))
+			if r != nil {
+				io.Copy(io.Discard, r)
+				r.Close()
+			}
+
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				reader, err := compressor.Decompress(bytes.NewReader(tt.data))
+				if err == nil {
+					io.Copy(io.Discard, reader)
+					reader.Close()
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds a gzip compressor backed by https://github.com/klauspost/compress, following the same pattern as the existing compressors.

**Why klauspost implementation instead of the standard gzip?** 2x faster than stdlib gzip.
**Why klauspost?** Battle-tested library already used by Loki, Thanos, and CockroachDB; widely adopted (260k dependents).


RELEASE NOTES:
- Added support for gzip compression using https://github.com/klauspost/compress.

## Benchmarks (std gzip vs klauspost gzip)
#### Compress
Payload | gzip | klauspostgzip | Speedup | Ratio: gzip | Ratio: klauspostgzip
-- | -- | -- | -- | -- | --
proto-350B | 16.45 µs | 5.56 µs | 2.96x | 0.6332 | 0.6246
proto-10KB | 57.42 µs | 27.51 µs | 2.09x | 0.1760 | 0.1779
proto-1MB | 5.74 ms | 2.21 ms | 2.60x | 0.1277 | 0.1310
json-10KB | 55.55 µs | 23.79 µs | 2.34x | 0.1980 | 0.2011
random-1KB | 32.86 µs | 0.93 µs | 35.47x | 1.027 | 1.024
#### Decompress

Payload | gzip | klauspostgzip | Speedup
-- | -- | -- | --
proto-350B | 2.94 µs | 2.31 µs | 1.27x
proto-10KB | 14.59 µs | 9.64 µs | 1.51x
proto-1MB | 1.21 ms | 0.92 ms | 1.31x
json-10KB | 17.69 µs | 11.01 µs | 1.61x
random-1KB | 0.53 µs | 0.39 µs | 1.35x




## Test plan
Internal Uber libraries release tool
