### PR TITLE
[GRPC-Conn-Pooling][yarpc-go]  Fix deadlock in ReleasePeer / Stop ineraction

### DIFF
--- a/transport/grpc/transport.go
+++ b/transport/grpc/transport.go
@@ -39,6 +39,11 @@ type Transport struct {
 	once          *lifecycle.Once
 	options       *transportOptions
 	addressToPeer map[string]*grpcPeer
+	// releasedCleanupWg tracks peers released via ReleasePeer. We cannot call
+	// p.wait() inside ReleasePeer because abstractlist.stop() holds list.lock
+	// while calling it, and monitorConnWrapper needs list.lock to exit cleanly
+	// (deadlock). Instead we wait asynchronously and join in Transport.Stop().
+	releasedCleanupWg sync.WaitGroup
 }
 
 // NewTransport returns a new Transport.
@@ -63,14 +68,21 @@ func (t *Transport) Start() error {
 func (t *Transport) Stop() error {
 	return t.once.Stop(func() error {
 		t.lock.Lock()
-		defer t.lock.Unlock()
-
 		for _, grpcPeer := range t.addressToPeer {
 			grpcPeer.stop()
 		}
-		for _, grpcPeer := range t.addressToPeer {
-			grpcPeer.wait()
+		peers := make([]*grpcPeer, 0, len(t.addressToPeer))
+		for _, p := range t.addressToPeer {
+			peers = append(peers, p)
 		}
+		t.lock.Unlock()
+
+		for _, p := range peers {
+			p.wait()
+		}
+		// Wait for peers released via ReleasePeer whose cleanup goroutines
+		// may still be running.
+		t.releasedCleanupWg.Wait()
 		return nil
 	})
 }
@@ -144,7 +156,15 @@ func (t *Transport) ReleasePeer(pid peer.Identifier, ps peer.Subscriber) error {
 	if p.NumSubscribers() == 0 {
 		delete(t.addressToPeer, address)
 		p.stop()
-		p.wait()
+		// Do not call p.wait() here: abstractlist.stop() holds list.lock while
+		// calling ReleasePeer, and monitorConnWrapper needs list.lock to exit.
+		// Waiting synchronously would deadlock. Instead, wait asynchronously so
+		// abstractlist.stop() can finish and release list.lock first.
+		t.releasedCleanupWg.Add(1)
+		go func() {
+			defer t.releasedCleanupWg.Done()
+			p.wait()
+		}()
 	}
 	return nil
 }

--- a/transport/grpc/transport_test.go
+++ b/transport/grpc/transport_test.go
@@ -22,7 +22,9 @@ package grpc
 
 import (
 	"net"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -77,6 +79,90 @@ func TestReleasePeerErrorNoPeer(t *testing.T) {
 		TransportName:  "grpc.Transport",
 		PeerIdentifier: address,
 	}, transport.ReleasePeer(testIdentifier{address}, peerSubscriber))
+}
+
+// TestStopWaitsForReleasedPeerCleanup verifies that Transport.Stop() blocks
+// until the async cleanup goroutine launched by ReleasePeer finishes.
+func TestStopWaitsForReleasedPeerCleanup(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	grpcServer := grpc.NewServer()
+	go grpcServer.Serve(listener)
+	defer grpcServer.Stop()
+
+	transport := NewTransport()
+	require.NoError(t, transport.Start())
+
+	address := listener.Addr().String()
+	sub := testPeerSubscriber{}
+
+	_, err = transport.RetainPeer(testIdentifier{address}, sub)
+	require.NoError(t, err)
+
+	// ReleasePeer with 0 remaining subscribers spawns an async cleanup goroutine.
+	require.NoError(t, transport.ReleasePeer(testIdentifier{address}, sub))
+
+	// Stop must not return until releasedCleanupWg reaches zero.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		assert.NoError(t, transport.Stop())
+	}()
+
+	select {
+	case <-done:
+		// Stop completed — cleanup goroutine finished first.
+	case <-time.After(5 * time.Second):
+		t.Fatal("Transport.Stop() did not return within 5s; releasedCleanupWg may not be awaited")
+	}
+}
+
+// TestStopReleasesLockBeforeWait verifies that Transport.Stop() does not hold
+// t.lock while calling p.wait(), so concurrent operations that need the lock
+// (e.g. ReleasePeer called from a peer-list shutdown) do not deadlock.
+func TestStopReleasesLockBeforeWait(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	grpcServer := grpc.NewServer()
+	go grpcServer.Serve(listener)
+	defer grpcServer.Stop()
+
+	transport := NewTransport()
+	require.NoError(t, transport.Start())
+
+	address := listener.Addr().String()
+	sub := testPeerSubscriber{}
+
+	_, err = transport.RetainPeer(testIdentifier{address}, sub)
+	require.NoError(t, err)
+
+	// Simulate a concurrent ReleasePeer that runs while Stop is in p.wait().
+	// If Stop held t.lock during p.wait() this would deadlock.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// Small delay to let Stop enter p.wait().
+		time.Sleep(10 * time.Millisecond)
+		// This acquires t.lock internally; must not deadlock.
+		_ = transport.ReleasePeer(testIdentifier{address}, sub)
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		assert.NoError(t, transport.Stop())
+	}()
+
+	wg.Wait()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Transport.Stop() deadlocked while holding t.lock during p.wait()")
+	}
 }
 
 type testPeerSubscriber struct{}


### PR DESCRIPTION
## Summary
  ReleasePeer was calling p.wait() synchronously while holding t.lock. This deadlocked because abstractlist.stop() holds list.lock while calling ReleasePeer, and monitorConnWrapper needs list.lock to exit — so p.wait() would block forever.
  Changes:
  - Added releasedCleanupWg sync.WaitGroup to Transport to track in-flight peer cleanup goroutines.
  - ReleasePeer now spawns a goroutine for p.wait() instead of calling it synchronously, tracked by releasedCleanupWg.
  - Stop releases t.lock before calling p.wait() on owned peers (was deferred to end of function), then calls releasedCleanupWg.Wait() to join any async cleanup goroutines from ReleasePeer.

Result: No lock is held during any p.wait() call, eliminating the deadlock. Stop still guarantees all peer cleanup finishes before  returning.

## Jira
[RPC-10840](https://t3.uberinternal.com/browse/RPC-10840)