### PR TITLE
[Server] Allowlist proxy headers and ensure prefixed value wins on conflict

### DIFF
--- a/internal/crossdock/internal/header.go
+++ b/internal/crossdock/internal/header.go
@@ -23,8 +23,7 @@ package internal
 import "go.uber.org/yarpc/transport/tchannel"
 
 // RemoveVariableMapKeys removes any headers that might have been added by tracing,
-// the server handler, or the HTTP stack (including HTTP/2 when User-Agent is not
-// stripped as a hop-by-hop field).
+// the server handler, or the HTTP stack.
 func RemoveVariableMapKeys(headers map[string]string) {
 	delete(headers, "$tracing$uber-trace-id")
 	delete(headers, tchannel.ServiceHeaderKey)

--- a/internal/crossdock/internal/header.go
+++ b/internal/crossdock/internal/header.go
@@ -22,9 +22,11 @@ package internal
 
 import "go.uber.org/yarpc/transport/tchannel"
 
-// RemoveVariableMapKeys removes any headers that might have been added by tracing
-// or server handler
+// RemoveVariableMapKeys removes any headers that might have been added by tracing,
+// the server handler, or the HTTP stack (including HTTP/2 when User-Agent is not
+// stripped as a hop-by-hop field).
 func RemoveVariableMapKeys(headers map[string]string) {
 	delete(headers, "$tracing$uber-trace-id")
 	delete(headers, tchannel.ServiceHeaderKey)
+	delete(headers, "user-agent")
 }

--- a/transport/http/constants.go
+++ b/transport/http/constants.go
@@ -169,3 +169,15 @@ const (
 	UberTraceContextHeaderKey  = "uber-trace-id"
 	UberBaggageHeaderKeyPrefix = "uberctx-"
 )
+
+// Proxy-managed header keys that must travel over the wire unprefixed
+// so that Muttley/Envoy can read and update them correctly.
+const (
+	XForwardedForHeader   = "x-forwarded-for"
+	XForwardedProtoHeader = "x-forwarded-proto"
+	XForwardedPortHeader  = "x-forwarded-port"
+	XRequestIDHeader      = "x-request-id"
+	XUberSourceHeader     = "x-uber-source"
+	ViaHeader             = "via"
+	UserAgentHeader       = "user-agent"
+)

--- a/transport/http/header.go
+++ b/transport/http/header.go
@@ -61,19 +61,24 @@ func (hm headerMapper) ToHTTPHeaders(from transport.Headers, to http.Header) htt
 //
 // If 'to' is nil, a new map will be assigned.
 func (hm headerMapper) FromHTTPHeaders(from http.Header, to transport.Headers) transport.Headers {
+	// Process tracing/proxy headers first, then prefixed headers, so the
+	// prefixed value wins on conflict (e.g. Rpc-Header-X-Forwarded-For
+	// over X-Forwarded-For).
+	// TODO: Remove two-pass once clients stop sending the prefixed form.
 	for origKey, vals := range from {
-		switch {
-		case hasPrefixFold(origKey, hm.Prefix):
-			suffix := origKey[len(hm.Prefix):]
-			for _, v := range vals {
-				to = to.With(suffix, v)
-			}
-		case isTracingHeader(origKey):
+		if isTracingHeader(origKey) || isProxyHeader(origKey) {
 			for _, v := range vals {
 				to = to.With(origKey, v)
 			}
 		}
-		// Note: undefined behavior for multiple occurrences of the same header
+	}
+	for origKey, vals := range from {
+		if hasPrefixFold(origKey, hm.Prefix) {
+			suffix := origKey[len(hm.Prefix):]
+			for _, v := range vals {
+				to = to.With(suffix, v)
+			}
+		}
 	}
 	return to
 }
@@ -125,4 +130,22 @@ func isRoutingHeader(k string) bool {
 func isCrossZoneHeader(k string) bool {
 	// k comes from http.Header.Items() and is always in lowercase
 	return k == RoutingRegionHeader || k == RoutingZoneHeader
+}
+
+// isProxyHeader returns true for standard forwarding and proxy-managed
+// headers that must travel over the wire unprefixed so that
+// Muttley/Envoy can read and update them correctly.
+func isProxyHeader(k string) bool {
+	switch {
+	case strings.EqualFold(k, XForwardedForHeader),
+		strings.EqualFold(k, XForwardedProtoHeader),
+		strings.EqualFold(k, XForwardedPortHeader),
+		strings.EqualFold(k, XRequestIDHeader),
+		strings.EqualFold(k, XUberSourceHeader),
+		strings.EqualFold(k, ViaHeader),
+		strings.EqualFold(k, UserAgentHeader):
+		return true
+	default:
+		return false
+	}
 }

--- a/transport/http/header.go
+++ b/transport/http/header.go
@@ -64,6 +64,7 @@ func (hm headerMapper) FromHTTPHeaders(from http.Header, to transport.Headers) t
 	// Process tracing/proxy headers first, then prefixed headers, so the
 	// prefixed value wins on conflict (e.g. Rpc-Header-X-Forwarded-For
 	// over X-Forwarded-For).
+	// Note: undefined behavior for multiple occurrences of the same header.
 	// TODO: Remove two-pass once clients stop sending the prefixed form.
 	for origKey, vals := range from {
 		if isTracingHeader(origKey) || isProxyHeader(origKey) {

--- a/transport/http/header_test.go
+++ b/transport/http/header_test.go
@@ -111,6 +111,103 @@ func TestHTTPHeaders(t *testing.T) {
 			},
 			expectedTransHeaders: transport.HeadersFromMap(map[string]string{}),
 		},
+		{
+			name: "proxy header outbound still prefixed",
+			transHeaders: transport.HeadersFromMap(map[string]string{
+				"x-forwarded-for": "203.0.113.42",
+			}),
+			expectedHTTP: http.Header{
+				"Rpc-Header-X-Forwarded-For": []string{"203.0.113.42"},
+			},
+			httpHeaders: http.Header{
+				"X-Forwarded-For": []string{"203.0.113.42"},
+			},
+			expectedTransHeaders: transport.HeadersFromMap(map[string]string{
+				"X-Forwarded-For": "203.0.113.42",
+			}),
+		},
+		{
+			name: "proxy header inbound with mixed headers",
+			transHeaders: transport.HeadersFromMap(map[string]string{
+				"foo":           "bar",
+				"uber-trace-id": "tid",
+			}),
+			expectedHTTP: http.Header{
+				"Rpc-Header-Foo": []string{"bar"},
+				"Uber-Trace-Id":  []string{"tid"},
+			},
+			httpHeaders: http.Header{
+				"Rpc-Header-Foo":  []string{"bar"},
+				"X-Forwarded-For": []string{"203.0.113.42"},
+				"Uber-Trace-Id":   []string{"tid"},
+			},
+			expectedTransHeaders: transport.HeadersFromMap(map[string]string{
+				"foo":             "bar",
+				"X-Forwarded-For": "203.0.113.42",
+				"uber-trace-id":   "tid",
+			}),
+		},
+		{
+			name: "all proxy headers inbound",
+			transHeaders: transport.HeadersFromMap(map[string]string{
+				"foo": "bar",
+			}),
+			expectedHTTP: http.Header{
+				"Rpc-Header-Foo": []string{"bar"},
+			},
+			httpHeaders: http.Header{
+				"Rpc-Header-Foo":    []string{"bar"},
+				"X-Forwarded-For":   []string{"203.0.113.42"},
+				"X-Forwarded-Proto": []string{"https"},
+				"X-Forwarded-Port":  []string{"8080"},
+				"X-Request-Id":      []string{"req-123"},
+				"X-Uber-Source":     []string{"service-a"},
+				"Via":               []string{"1.1 proxy"},
+				"User-Agent":        []string{"yarpc/1.0"},
+			},
+			expectedTransHeaders: transport.HeadersFromMap(map[string]string{
+				"foo":               "bar",
+				"X-Forwarded-For":   "203.0.113.42",
+				"X-Forwarded-Proto": "https",
+				"X-Forwarded-Port":  "8080",
+				"X-Request-Id":      "req-123",
+				"X-Uber-Source":     "service-a",
+				"Via":               "1.1 proxy",
+				"User-Agent":        "yarpc/1.0",
+			}),
+		},
+		{
+			name: "prefixed proxy header wins over unprefixed",
+			transHeaders: transport.HeadersFromMap(map[string]string{
+				"x-forwarded-for": "203.0.113.42",
+			}),
+			expectedHTTP: http.Header{
+				"Rpc-Header-X-Forwarded-For": []string{"203.0.113.42"},
+			},
+			httpHeaders: http.Header{
+				"X-Forwarded-For":            []string{"10.0.0.1"},
+				"Rpc-Header-X-Forwarded-For": []string{"203.0.113.42"},
+			},
+			expectedTransHeaders: transport.HeadersFromMap(map[string]string{
+				"X-Forwarded-For": "203.0.113.42",
+			}),
+		},
+		{
+			name: "prefixed tracing header wins over unprefixed",
+			transHeaders: transport.HeadersFromMap(map[string]string{
+				"uber-trace-id": "correct-tid",
+			}),
+			expectedHTTP: http.Header{
+				"Uber-Trace-Id": []string{"correct-tid"},
+			},
+			httpHeaders: http.Header{
+				"Uber-Trace-Id":            []string{"stale-tid"},
+				"Rpc-Header-Uber-Trace-Id": []string{"correct-tid"},
+			},
+			expectedTransHeaders: transport.HeadersFromMap(map[string]string{
+				"Uber-Trace-Id": "correct-tid",
+			}),
+		},
 	}
 
 	for _, tt := range tests {
@@ -132,6 +229,37 @@ func assertHeadersEqualCaseInsensitive(t *testing.T, expected, actual http.Heade
 	}
 
 	assert.Equal(t, normalize(expected), normalize(actual), msg)
+}
+
+func TestIsProxyHeader(t *testing.T) {
+	tests := []struct {
+		key  string
+		want bool
+	}{
+		{"x-forwarded-for", true},
+		{"X-Forwarded-For", true},
+		{"X-FORWARDED-FOR", true},
+		{"x-forwarded-proto", true},
+		{"X-Forwarded-Proto", true},
+		{"x-forwarded-port", true},
+		{"X-Forwarded-Port", true},
+		{"x-request-id", true},
+		{"X-Request-Id", true},
+		{"x-uber-source", true},
+		{"X-Uber-Source", true},
+		{"via", true},
+		{"Via", true},
+		{"user-agent", true},
+		{"User-Agent", true},
+		{"x-other-header", false},
+		{"x-forwarded-host", false},
+		{"rpc-header-foo", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			assert.Equal(t, tt.want, isProxyHeader(tt.key))
+		})
+	}
 }
 
 // TODO(abg): Test handling of duplicate HTTP headers when

--- a/transport/roundtrip_test.go
+++ b/transport/roundtrip_test.go
@@ -348,7 +348,12 @@ func TestSimpleRoundTripOneway(t *testing.T) {
 			handlerDone := make(chan struct{})
 
 			onewayHandler := onewayHandlerFunc(func(_ context.Context, r *transport.Request) error {
+				// The HTTP stack should set User-Agent on inbound requests; strip it so the
+				// request matcher compares only application headers.
+				ua, ok := r.Headers.Get("user-agent")
+				require.True(t, ok && ua != "", "expected non-empty User-Agent header")
 				r.Headers.Del("user-agent")
+
 				assert.True(t, requestMatcher.Matches(r), "request mismatch: received %v", r)
 
 				// Pretend to work: this delay should not slow down tests since it is a

--- a/transport/roundtrip_test.go
+++ b/transport/roundtrip_test.go
@@ -348,6 +348,7 @@ func TestSimpleRoundTripOneway(t *testing.T) {
 			handlerDone := make(chan struct{})
 
 			onewayHandler := onewayHandlerFunc(func(_ context.Context, r *transport.Request) error {
+				r.Headers.Del("user-agent")
 				assert.True(t, requestMatcher.Matches(r), "request mismatch: received %v", r)
 
 				// Pretend to work: this delay should not slow down tests since it is a


### PR DESCRIPTION
## Continuation of #2458 (branch rename)

PR #2458 closed when the head branch `laidbacklevi/whitelist-proxy-headers` was removed after renaming it to `laidbacklevi_whitelist-proxy-headers`. This PR is the same change set on the new branch. **Prior inline review and discussion:** https://github.com/yarpc/yarpc-go/pull/2458

---



Infrastructure headers like `x-forwarded-for`, `x-forwarded-proto`, `x-forwarded-port`, `x-request-id`, `x-uber-source`, `via`, and `user-agent` must travel over the wire unprefixed so that Muttley/Envoy can read and manage them correctly. Without this, YARPC sends `rpc-header-<header>` which is invisible to proxies, causing client metadata to be lost.

- [X] Description and context for reviewers: one partner, one stranger

## Summary
- Expands `isProxyHeader()` to recognize all seven proxy-managed headers on the **inbound** (`FromHTTPHeaders`) path so the YARPC server picks them up when they arrive without the `rpc-header-` prefix (e.g. when set by Muttley/Envoy).
- Uses a two-pass approach (tracing/proxy headers first, then prefixed headers) so the prefixed value deterministically wins when both forms are present for the same key.
- Consolidates the proxy header set into a map-based lookup in `constants.go` for O(1) matching and easy maintenance.
- The **outbound** (`ToHTTPHeaders`) path is intentionally unchanged — clients still send `rpc-header-<header>` until all servers are deployed with this change.

## References
- https://uplan.uberinternal.com/projects/ERD/eb2bb725-26a7-4ca8-a74d-d7a765e384c0
- https://docs.google.com/document/d/1fcnxm837MO8UfIVJ2dFZEY6Ls1hxIRSOao9GCJ4eAIE/edit?tab=t.0

## Context
YARPC HTTP transport prefixes all application headers with `rpc-header-` before sending them. On the inbound side, headers without this prefix were silently dropped. This means headers like `x-forwarded-for` set by Muttley/Envoy (which uses the standard unprefixed form) were lost.

Additionally, when both the prefixed and unprefixed forms of the same header were present (e.g. `Rpc-Header-X-Forwarded-For` and `X-Forwarded-For`), the winner was non-deterministic due to Go map iteration order. The two-pass approach fixes this by always letting the prefixed value win.

## Rollout strategy
1. **This PR (server):** Deploy to all servers so they accept both `rpc-header-<header>` and the unprefixed form.
2. **Follow-up PR (client):** Update `ToHTTPHeaders` to send these headers unprefixed, once all servers have this change.

## Test plan
- [x] `TestIsProxyHeader` — verifies case-insensitive matching for all seven proxy headers and rejection of non-allowlisted headers
- [x] `TestHTTPHeaders` / "all proxy headers inbound" — verifies all seven proxy headers are picked up on inbound
- [x] `TestHTTPHeaders` / "prefixed proxy header wins over unprefixed" — verifies prefixed value wins deterministically (run with `-count=100`)
- [x] `TestHTTPHeaders` / "prefixed tracing header wins over unprefixed" — same for tracing headers
- [x] `TestSimpleRoundTripOneway` — inbound HTTP oneway requests include a non-empty `User-Agent` before it is stripped for header matching (same idea as unary gRPC cleanup in `roundtrip_test.go`).
- [x] Existing tests pass — `rpc-header-` behavior unchanged for non-allowlisted headers

## Benchmarking
Comparison of **switch case** vs **toString + map lookup**:
<img width="698" height="220" alt="Screenshot 2026-05-01 at 15 34 49" src="https://github.com/user-attachments/assets/d266602e-eb9e-4d46-8dd9-9e7631c91ee0" />

## RELEASE NOTES:

**Server-side only (1 of 2).** YARPC HTTP inbound now recognizes unprefixed proxy-managed headers (`x-forwarded-for`, `x-forwarded-proto`, `x-forwarded-port`, `x-request-id`, `x-uber-source`, `via`, `user-agent`) set by Muttley/Envoy. Previously these were silently dropped because they lacked the `rpc-header-` prefix. When both prefixed and unprefixed forms are present, the prefixed value wins deterministically. No application code changes required — just bump the `yarpc-go` dependency.

A follow-up diff will update the client/outbound side to stop prefixing these headers, once all servers are deployed with this change.

