### PR TITLE
internal/observability: derive metricProcedure from transport, not encoding

### DIFF
--- a/internal/observability/call.go
+++ b/internal/observability/call.go
@@ -229,7 +229,7 @@ func (c call) endLogs(
 
 	// It would be nice for metricProcedure() to return zap.Skip(), but there
 	// are a bunch of unit tests that fail with the included empty field.
-	metricProcedureField := metricProcedure(c.req.Procedure, string(c.req.Encoding))
+	metricProcedureField := metricProcedure(c.req.Transport, c.req.Procedure, string(c.req.Encoding))
 	if metricProcedureField != "" {
 		fields = append(fields, zap.String("metricProcedure", metricProcedureField))
 	}
@@ -275,8 +275,18 @@ func (c call) endLogs(
 	ce.Write(fields...)
 }
 
+// _grpcTransport matches transport/grpc.TransportName. We compare against it
+// directly rather than importing transport/grpc to avoid an import cycle.
+const _grpcTransport = "grpc"
+
+// metricProcedure returns the value M3 records as the "procedure" tag for the
+// given request, so it can be logged and used to correlate alerts (which query
+// M3) with the relevant logs. The shape of that tag depends on the transport,
+// not the encoding: gRPC uses a short, slash-delimited form with the package
+// path dropped, while every other transport keeps the fully-qualified name.
+//
 // https://docs.google.com/document/d/1B45wjZDQL0olCoENh3XYMyvCPI2A3hw8OeU2IhrtBtA
-func metricProcedure(procedure, encoding string) string {
+func metricProcedure(transport, procedure, encoding string) string {
 	if procedure == "" {
 		return "__no_procedure__"
 	}
@@ -285,34 +295,37 @@ func metricProcedure(procedure, encoding string) string {
 		return ""
 	}
 
-	return encodeMetricProcedure(procedure, encoding == "thrift")
+	return encodeMetricProcedure(procedure, transport == _grpcTransport)
 }
 
-func encodeMetricProcedure(procedure string, thrift bool) string {
+func encodeMetricProcedure(procedure string, grpc bool) string {
 	var (
 		b = []byte(procedure)
 		w = 0
 	)
 
 	for i := 0; i < len(b); i++ {
-		if b[i] == '.' {
-			w = 0
-			continue
-		}
-
-		if b[i] == ':' {
-			if thrift {
-				b[w] = '-'
-				w++
-				b[w] = '-'
-			} else {
-				b[w] = '/'
+		switch {
+		case b[i] == '.':
+			if grpc {
+				// gRPC drops the package path (e.g. "uber.infra.uown.").
+				w = 0
+				continue
 			}
-
-			i++
-		} else if 'A' <= b[i] && b[i] <= 'Z' {
+			// Other transports keep the fully-qualified name.
+			b[w] = '.'
+		case b[i] == ':':
+			if grpc {
+				// "::" -> "/"
+				b[w] = '/'
+				i++ // skip the second ':'
+			} else {
+				// each ':' -> '-', so "::" -> "--"
+				b[w] = '-'
+			}
+		case 'A' <= b[i] && b[i] <= 'Z':
 			b[w] = b[i] + 32
-		} else {
+		default:
 			b[w] = b[i]
 		}
 

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -3812,45 +3812,70 @@ func TestMiddlewareLoggingWithMetricProcedure(t *testing.T) {
 
 	for testName, tt := range map[string]struct {
 		encoding  string
+		transport string
 		procedure string
 		expected  string
 	}{
 		"EmptyProcedure": {
-			"proto", "",
-			"__no_procedure__",
+			encoding: "proto", transport: "http", procedure: "",
+			expected: "__no_procedure__",
 		},
 		"Raw": {
-			"raw", "hello",
-			"",
+			encoding: "raw", transport: "http", procedure: "hello",
+			expected: "",
 		},
 		"EmptyRawProcedure": {
-			"raw", "",
-			"__no_procedure__",
+			encoding: "raw", transport: "http", procedure: "",
+			expected: "__no_procedure__",
 		},
-		"Proto1": {
-			"proto", "synoptic.SignalCatalog::ExecuteQuery",
-			"signalcatalog/executequery",
+		// gRPC and HTTP carry the same YARPC procedure name, but M3 records a
+		// different "procedure" tag for each, so the log field must match the
+		// transport-specific tag (otherwise alerts link to empty log queries).
+		"GRPC_uown": {
+			encoding: "proto", transport: "grpc",
+			procedure: "uber.infra.uown.UOwnService::SearchAssets",
+			expected:  "uownservice/searchassets",
 		},
-		"Proto2": {
-			"proto", "uber.infra.net.rpc.probe.Probe::Echo",
-			"probe/echo",
+		"HTTP_uown": {
+			encoding: "proto", transport: "http",
+			procedure: "uber.infra.uown.UOwnService::SearchAssets",
+			expected:  "uber.infra.uown.uownservice--searchassets",
 		},
-		"Thrift1": {
-			"thrift", "Umonitor::deleteAlert",
-			"umonitor--deletealert",
+		"GRPC_proto1": {
+			encoding: "proto", transport: "grpc",
+			procedure: "synoptic.SignalCatalog::ExecuteQuery",
+			expected:  "signalcatalog/executequery",
 		},
-		"Thrift2": {
-			"thrift", "Probe::echo",
-			"probe--echo",
+		"GRPC_proto2": {
+			encoding: "proto", transport: "grpc",
+			procedure: "uber.infra.net.rpc.probe.Probe::Echo",
+			expected:  "probe/echo",
 		},
-		"JSON1": {
-			"json", "uber.infra.umonitor.Umonitor::UpsertAlertThresholds",
-			"umonitor/upsertalertthresholds",
+		"TChannel_thrift1": {
+			encoding: "thrift", transport: "tchannel",
+			procedure: "Umonitor::deleteAlert",
+			expected:  "umonitor--deletealert",
+		},
+		"TChannel_thrift2": {
+			encoding: "thrift", transport: "tchannel",
+			procedure: "Probe::echo",
+			expected:  "probe--echo",
+		},
+		"GRPC_json": {
+			encoding: "json", transport: "grpc",
+			procedure: "uber.infra.umonitor.Umonitor::UpsertAlertThresholds",
+			expected:  "umonitor/upsertalertthresholds",
+		},
+		"HTTP_json": {
+			encoding: "json", transport: "http",
+			procedure: "uber.infra.umonitor.Umonitor::UpsertAlertThresholds",
+			expected:  "uber.infra.umonitor.umonitor--upsertalertthresholds",
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {
 			req := &transport.Request{
 				Encoding:  transport.Encoding(tt.encoding),
+				Transport: tt.transport,
 				Procedure: tt.procedure,
 			}
 


### PR DESCRIPTION
## Problem

`metricProcedure` (added in #2359) is emitted on logs so an M3 alert can be
mapped back to the matching logs — its value is meant to equal the M3
`procedure` tag. It was derived from the **encoding**, but the M3 tag is shaped
by the **transport**, so the two diverge when a proto service is called over
HTTP:

| Transport | M3 `procedure` tag | logged `metricProcedure` (before) | match |
|-----------|--------------------|-----------------------------------|-------|
| gRPC | `uownservice/searchassets` | `uownservice/searchassets` | ✅ |
| HTTP | `uber.infra.uown.uownservice--searchassets` | `uownservice/searchassets` | ❌ |

As a result, availability alerts on HTTP-invoked endpoints linked to log
queries that returned no results, making them hard to debug.

## Fix

Derive `metricProcedure` from `req.Transport` instead of the encoding:

- **gRPC** → short, slash-delimited form with the package path dropped
  (`uownservice/searchassets`)
- **every other transport (HTTP, TChannel)** → fully-qualified name,
  lowercased, with `::` → `--` (`uber.infra.uown.uownservice--searchassets`)

The M3 `procedure` tag itself is unchanged; only the log field is corrected to
match it. Encoding is still used to skip `raw`/unknown encodings.

## Test plan

- Updated `TestMiddlewareLoggingWithMetricProcedure` to be transport-aware,
  including the gRPC-vs-HTTP regression pair described above.
- `go test ./internal/observability/...` passes; `gofmt` and `go build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
