### PR TITLE
Fixing error logs for metrics creation

### DIFF
--- a/transport/grpc/conn_pool_metrics.go
+++ b/transport/grpc/conn_pool_metrics.go
@@ -87,7 +87,7 @@ func newConnPoolMetrics(p connPoolMetricsParams) *connPoolMetrics {
 		ConstTags: tags,
 	})
 	if err != nil {
-		p.Logger.Error("failed to create active connections gauge", zap.Error(err))
+		p.Logger.Warn("failed to create active connections gauge", zap.Error(err))
 	}
 
 	m.drainingConnectionCount, err = p.Meter.Gauge(metrics.Spec{
@@ -96,7 +96,7 @@ func newConnPoolMetrics(p connPoolMetricsParams) *connPoolMetrics {
 		ConstTags: tags,
 	})
 	if err != nil {
-		p.Logger.Error("failed to create draining connections gauge", zap.Error(err))
+		p.Logger.Warn("failed to create draining connections gauge", zap.Error(err))
 	}
 
 	m.idleConnectionCount, err = p.Meter.Gauge(metrics.Spec{
@@ -105,7 +105,7 @@ func newConnPoolMetrics(p connPoolMetricsParams) *connPoolMetrics {
 		ConstTags: tags,
 	})
 	if err != nil {
-		p.Logger.Error("failed to create idle connections gauge", zap.Error(err))
+		p.Logger.Warn("failed to create idle connections gauge", zap.Error(err))
 	}
 
 	m.scaleUpTotal, err = p.Meter.Counter(metrics.Spec{
@@ -114,7 +114,7 @@ func newConnPoolMetrics(p connPoolMetricsParams) *connPoolMetrics {
 		ConstTags: tags,
 	})
 	if err != nil {
-		p.Logger.Error("failed to create scale up counter", zap.Error(err))
+		p.Logger.Warn("failed to create scale up counter", zap.Error(err))
 	}
 
 	m.scaleDownTotal, err = p.Meter.Counter(metrics.Spec{
@@ -123,7 +123,7 @@ func newConnPoolMetrics(p connPoolMetricsParams) *connPoolMetrics {
 		ConstTags: tags,
 	})
 	if err != nil {
-		p.Logger.Error("failed to create scale down counter", zap.Error(err))
+		p.Logger.Warn("failed to create scale down counter", zap.Error(err))
 	}
 
 	m.idleReactivationTotal, err = p.Meter.Counter(metrics.Spec{
@@ -132,7 +132,7 @@ func newConnPoolMetrics(p connPoolMetricsParams) *connPoolMetrics {
 		ConstTags: tags,
 	})
 	if err != nil {
-		p.Logger.Error("failed to create idle reactivation counter", zap.Error(err))
+		p.Logger.Warn("failed to create idle reactivation counter", zap.Error(err))
 	}
 
 	return m

--- a/transport/grpc/conn_pool_metrics_test.go
+++ b/transport/grpc/conn_pool_metrics_test.go
@@ -193,7 +193,7 @@ func TestConnPoolMetrics_ConcurrentAccess(t *testing.T) {
 func TestNewConnPoolMetrics_LogsRegistrationErrors(t *testing.T) {
 	root := metrics.New()
 	scope := root.Scope()
-	core, logs := observer.New(zap.ErrorLevel)
+	core, logs := observer.New(zap.WarnLevel)
 	logger := zap.New(core)
 
 	params := connPoolMetricsParams{
@@ -204,11 +204,11 @@ func TestNewConnPoolMetrics_LogsRegistrationErrors(t *testing.T) {
 	}
 
 	// Register the same metrics twice on the same scope+tags to trigger
-	// duplicate registration errors.
+	// duplicate registration warnings.
 	_ = newConnPoolMetrics(params)
 	_ = newConnPoolMetrics(params)
 
-	assert.NotZero(t, logs.Len(), "expected error logs for duplicate metric registration")
+	assert.NotZero(t, logs.Len(), "expected warn logs for duplicate metric registration")
 }
 
 // TestConnPoolMetrics_NilReceiver verifies that calling any method on a nil

--- a/transport/grpc/peer.go
+++ b/transport/grpc/peer.go
@@ -120,12 +120,7 @@ func (t *Transport) newPeer(address string, options *dialOptions) (*grpcPeer, er
 		cancel:       cancel,
 		stoppedC:     make(chan struct{}),
 		grpcDialOpts: dialOptions,
-		metrics: newConnPoolMetrics(connPoolMetricsParams{
-			Meter:       t.options.meter,
-			Logger:      t.options.logger,
-			ServiceName: t.options.serviceName,
-			Peer:        address,
-		}),
+		metrics:      t.getOrCreatePeerMetrics(address),
 		poolCfg: connPoolConfig{
 			dynamicScalingEnabled:  t.options.clientConnPoolDynamicScalingEnabled,
 			maxConcurrentStreams:   t.options.clientConnPoolMaxConcurrentStreams,

--- a/transport/grpc/transport.go
+++ b/transport/grpc/transport.go
@@ -39,6 +39,10 @@ type Transport struct {
 	once          *lifecycle.Once
 	options       *transportOptions
 	addressToPeer map[string]*grpcPeer
+	// peerMetrics caches connPoolMetrics by peer address so that re-creating a
+	// peer (e.g. after churn) reuses the already-registered metric handles
+	// rather than attempting a duplicate registration, which would error.
+	peerMetrics map[string]*connPoolMetrics
 	// releasedCleanupWg tracks peers released via ReleasePeer. We cannot call
 	// p.wait() inside ReleasePeer because abstractlist.stop() holds list.lock
 	// while calling it, and monitorConnWrapper needs list.lock to exit cleanly
@@ -56,6 +60,7 @@ func newTransport(transportOptions *transportOptions) *Transport {
 		once:          lifecycle.NewOnce(),
 		options:       transportOptions,
 		addressToPeer: make(map[string]*grpcPeer),
+		peerMetrics:   make(map[string]*connPoolMetrics),
 	}
 }
 
@@ -106,6 +111,29 @@ func (t *Transport) NewSingleOutbound(address string, options ...OutboundOption)
 // NewOutbound returns a new Outbound for the given peer.Chooser.
 func (t *Transport) NewOutbound(peerChooser peer.Chooser, options ...OutboundOption) *Outbound {
 	return newOutbound(t, peerChooser, options...)
+}
+
+// getOrCreatePeerMetrics returns cached connPoolMetrics for the given peer
+// address, creating and caching them on first use. Metrics are only registered
+// when dynamic scaling is enabled — for non-scaling peers the pool always has
+// exactly one connection, making the gauges meaningless. Caching prevents
+// duplicate registration errors when a peer is released and re-retained.
+// Must be called with t.lock held.
+func (t *Transport) getOrCreatePeerMetrics(address string) *connPoolMetrics {
+	if !t.options.clientConnPoolDynamicScalingEnabled {
+		return &connPoolMetrics{}
+	}
+	if m, ok := t.peerMetrics[address]; ok {
+		return m
+	}
+	m := newConnPoolMetrics(connPoolMetricsParams{
+		Meter:       t.options.meter,
+		Logger:      t.options.logger,
+		ServiceName: t.options.serviceName,
+		Peer:        address,
+	})
+	t.peerMetrics[address] = m
+	return m
 }
 
 // RetainPeer retains the peer.

--- a/transport/grpc/transport_test.go
+++ b/transport/grpc/transport_test.go
@@ -28,7 +28,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/net/metrics"
 	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 	"google.golang.org/grpc"
 )
 
@@ -166,6 +169,78 @@ func TestStopReleasesLockBeforeWait(t *testing.T) {
 }
 
 type testPeerSubscriber struct{}
+
+// TestPeerReRetainReusesMetrics verifies that releasing and re-retaining the
+// same peer address does not cause duplicate metric registration errors.
+// Peer churn (downstream deploys, health-check flaps) triggers this path in
+// production — without the peerMetrics cache every re-creation logs an error
+// and fires healthline alerts.
+func TestPeerReRetainReusesMetrics(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	grpcServer := grpc.NewServer()
+	go grpcServer.Serve(listener)
+	defer grpcServer.Stop()
+
+	root := metrics.New()
+	scope := root.Scope()
+	core, logs := observer.New(zap.WarnLevel)
+	logger := zap.New(core)
+
+	transport := NewTransport(
+		Meter(scope),
+		Logger(logger),
+	)
+	require.NoError(t, transport.Start())
+	defer func() { assert.NoError(t, transport.Stop()) }()
+
+	address := listener.Addr().String()
+	sub := testPeerSubscriber{}
+
+	// First retain — registers metrics for this peer address.
+	_, err = transport.RetainPeer(testIdentifier{address}, sub)
+	require.NoError(t, err)
+
+	// Release — peer is removed from addressToPeer but metrics stay in peerMetrics.
+	require.NoError(t, transport.ReleasePeer(testIdentifier{address}, sub))
+
+	// Re-retain the same address — must reuse cached metrics, not re-register.
+	_, err = transport.RetainPeer(testIdentifier{address}, sub)
+	require.NoError(t, err)
+
+	assert.Zero(t, logs.Len(), "re-retaining a peer must not produce duplicate metric registration warnings")
+}
+
+// TestPeerMetricsNotRegisteredWhenScalingDisabled verifies that no metrics are
+// registered when dynamic scaling is off — the pool always has one connection,
+// making the gauges meaningless, and skipping registration avoids duplicate
+// registration errors on peer churn for the vast majority of services.
+func TestPeerMetricsNotRegisteredWhenScalingDisabled(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	grpcServer := grpc.NewServer()
+	go grpcServer.Serve(listener)
+	defer grpcServer.Stop()
+
+	root := metrics.New()
+	scope := root.Scope()
+
+	transport := NewTransport(Meter(scope)) // dynamic scaling not enabled
+	require.NoError(t, transport.Start())
+	defer func() { assert.NoError(t, transport.Stop()) }()
+
+	address := listener.Addr().String()
+	sub := testPeerSubscriber{}
+
+	_, err = transport.RetainPeer(testIdentifier{address}, sub)
+	require.NoError(t, err)
+
+	snap := root.Snapshot()
+	assert.Empty(t, snap.Gauges, "conn pool gauges must not be registered when dynamic scaling is disabled")
+	assert.Empty(t, snap.Counters, "conn pool counters must not be registered when dynamic scaling is disabled")
+}
 
 func (testPeerSubscriber) NotifyStatusChanged(peer.Identifier) {}
 


### PR DESCRIPTION
## Summary 
When the gRPC connection pooling changes shipped, healthline alerts fired across multiple services due to a spike in Error-level log lines. The root cause is a peer churn loop:
1. retainPeer calls newPeer → newConnPoolMetrics, which registers 6 metrics (gauges + counters) in go.uber.org/net/metrics under name+tag keys scoped to the peer address.
2. ReleasePeer with 0 remaining subscribers removes the peer from addressToPeer but cannot deregister metrics — go.uber.org/net/metrics has no deregistration API; handles are permanent for the process lifetime.
3. When the same downstream address comes back (downstream deploy, health-check flap, service discovery update), newPeer is called again with the same address → duplicate registration → the metrics library returns an error → previously logged at Error level → healthline fires.

This affects any service with dynamic scaling enabled whose downstream peers churn. The concrete error observed in production: `a metric with name "conn_pool_scale_down_total" and the same constant tag names and values is already registered`

Fix (three layers)

1. Error → Warn (conn_pool_metrics.go)

All 6 metric registration failure log calls downgraded from Error to Warn. Healthline thresholds on Error; Warn is below the alerting threshold. 

2. Per-address metrics cache (transport.go, peer.go)
Added peerMetrics map[string]*connPoolMetrics to Transport. getOrCreatePeerMetrics(address) is called from newPeer instead of newConnPoolMetrics directly:
- On first retain for an address: creates and caches the metrics handles.
- On re-retain after churn: returns the cached handle — same registry slots, no duplicate registration, no log noise.
- The map is cleared on process restart. Access is safe under t.lock (same lock held by retainPeer and ReleasePeer).

3. Dynamic scaling guard (transport.go)
getOrCreatePeerMetrics returns an empty &connPoolMetrics{} (no-op handles) when clientConnPoolDynamicScalingEnabled is false. For non-scaling peers the pool always has exactly one connection, making the gauges meaningless. This eliminates registration entirely for the vast majority of the fleet that does not opt into dynamic scaling.

## Jira
[RPC-10916](https://t3.uberinternal.com/browse/RPC-10916)

## Testing
Deployed branch [adding-peer-churn](https://github.com/uber-code/go-code/tree/adding-peer-churn) in grpc-probe-client to mimic peer churn behavior. Observed errors without the fix and no errors/warning with fix.
<img width="1233" height="400" alt="Screenshot 2026-06-14 at 2 28 35 PM" src="https://github.com/user-attachments/assets/8fcef01b-6605-4eed-8db4-c2a72583c521" />

