### PR TITLE
[yarpc-go] fixing flaky/failing tests

### DIFF
--- a/transport/grpc/config_test.go
+++ b/transport/grpc/config_test.go
@@ -271,9 +271,8 @@ func TestTransportSpec(t *testing.T) {
 			transportCfg: attrs{
 				"numStreamWorkers": "100",
 			},
-			inboundCfg: attrs{"address": ":54572"},
+			inboundCfg: attrs{"address": "localhost:0"},
 			wantInbound: &wantInbound{
-				Address:          ":54572",
 				NumStreamWorkers: 100,
 			},
 		},

--- a/transport/grpc/integration_test.go
+++ b/transport/grpc/integration_test.go
@@ -230,7 +230,8 @@ func TestYARPCMaxMsgSize(t *testing.T) {
 			},
 		}
 		te.do(t, func(t *testing.T, e *testEnv) {
-			ctx, cancel := context.WithTimeout(context.Background(), testtime.Second*5)
+			// The value is ~64 MB; allow extra headroom under race detector and parallel load.
+			ctx, cancel := context.WithTimeout(context.Background(), testtime.Second*30)
 			defer cancel()
 
 			if assert.NoError(t, e.SetValueYARPC(ctx, "foo", value)) {

--- a/transport/grpc/peer.go
+++ b/transport/grpc/peer.go
@@ -235,7 +235,6 @@ func (p *grpcPeer) addConn() error {
 func (p *grpcPeer) monitorConnWrapper(w *grpcClientConnWrapper) {
 	defer func() {
 		_ = w.clientConn.Close()
-		close(w.stoppedC)
 		p.removeConn(w)
 		// Skip status notification during peer shutdown: NotifyStatusChanged
 		// acquires list.lock, but the caller (abstractlist.stop) already holds
@@ -244,6 +243,9 @@ func (p *grpcPeer) monitorConnWrapper(w *grpcClientConnWrapper) {
 			p.recomputeConnectionStatus()
 		}
 		p.refreshPoolMetrics()
+		// Close stoppedC after metrics are updated so that any goroutine
+		// waiting on stoppedC (e.g. tests) observes a consistent metric state.
+		close(w.stoppedC)
 		p.connWg.Done()
 	}()
 


### PR DESCRIPTION
## Summary
1. Fix data race in monitorConnWrapper — The deferred cleanup closed w.stoppedC before calling p.refreshPoolMetrics(). Any goroutine waiting on w.stoppedC as a "cleanup done" signal would then race against the metric gauge writes. Moved close(w.stoppedC) to after p.refreshPoolMetrics() so waiters always observe a consistent metric state.

2. transport/grpc/integration_test.go — Increase TestYARPCMaxMsgSize/just_right timeout from 5s to 30s (transfers ~64 MB twice over loopback)

3. transport/grpc/config_test.go — Change TestTransportSpec/inbound_and_transport_with_num_stream_workers from hardcoded port :54572 to localhost:0 to avoid port conflicts with parallel tests

## Jira
[RPC-10958](https://t3.uberinternal.com/browse/RPC-10958)
