### PR TITLE
[GRPC-Conn-Pool] Aggregate connection pool metrics at transport level

### DIFF
--- a/transport/grpc/conn_pool_metrics.go
+++ b/transport/grpc/conn_pool_metrics.go
@@ -197,9 +197,11 @@ func (m *connPoolMetrics) incIdleReactivation() {
 // shared, transport-wide gauges. Because the gauges are not tagged by peer,
 // every peer contributes to the same series; this reporter tracks the values it
 // last published and applies the difference so the gauges always reflect the
-// sum across all peers. Deltas telescope, so a peer's contribution naturally
-// returns to zero as its connections are removed during teardown — no explicit
-// cleanup is required. Counter events are pool-wide and forwarded directly.
+// sum across all peers. During normal operation, deltas telescope as
+// connections are added or removed. On peer shutdown, pool goroutines are
+// drained and setCounts(0, 0, 0) withdraws this peer's last published
+// contribution so a late refreshPoolMetrics snapshot cannot leave residual
+// values on the shared gauges. Counter events are pool-wide and forwarded directly.
 type peerPoolReporter struct {
 	shared *connPoolMetrics
 

--- a/transport/grpc/conn_pool_metrics.go
+++ b/transport/grpc/conn_pool_metrics.go
@@ -21,16 +21,25 @@
 package grpc
 
 import (
+	"sync"
+
 	"go.uber.org/net/metrics"
 	"go.uber.org/zap"
 )
 
 // Tags for the connection pool metrics.
+//
+// Note: connection pool metrics are intentionally NOT tagged by peer. Tagging
+// by peer (host:port) is unbounded and dynamic — large fleets and peer churn
+// (e.g. rescheduled pods) would explode metric cardinality, inflate TSDB cost,
+// and risk the aggregation tier rate-limiting or dropping the emitter. The
+// gauges below instead hold the aggregate across all of a transport's peers,
+// and the counters accumulate pool-wide scaling events, which is sufficient to
+// tell whether dynamic scaling is behaving correctly at the service level.
 const (
 	_componentTag = "component"
 	_serviceTag   = "service"
 	_transportTag = "transport"
-	_peerTag      = "peer"
 )
 
 // Tag values for the connection pool metrics.
@@ -44,10 +53,12 @@ type connPoolMetricsParams struct {
 	Meter       *metrics.Scope
 	Logger      *zap.Logger
 	ServiceName string
-	Peer        string
 }
 
-// connPoolMetrics holds metric handles for the gRPC connection pool.
+// connPoolMetrics holds metric handles for the gRPC connection pool. A single
+// instance is shared by all peers of a transport. Gauges hold the aggregate
+// connection counts across peers (each peer applies deltas via a
+// peerPoolReporter) and counters accumulate pool-wide scaling events.
 type connPoolMetrics struct {
 	// connectionCount is the number of active connections accepting new streams.
 	connectionCount *metrics.Gauge
@@ -66,7 +77,7 @@ type connPoolMetrics struct {
 	idleReactivationTotal *metrics.Counter
 }
 
-// newConnPoolMetrics creates metric handles scoped to the given peer address.
+// newConnPoolMetrics creates the transport-wide connection pool metric handles.
 func newConnPoolMetrics(p connPoolMetricsParams) *connPoolMetrics {
 	m := &connPoolMetrics{}
 	if p.Meter == nil {
@@ -77,13 +88,12 @@ func newConnPoolMetrics(p connPoolMetricsParams) *connPoolMetrics {
 		_componentTag: _componentTagValueYarpc,
 		_serviceTag:   p.ServiceName,
 		_transportTag: _transportTagValueGrpc,
-		_peerTag:      p.Peer,
 	}
 
 	var err error
 	m.connectionCount, err = p.Meter.Gauge(metrics.Spec{
 		Name:      "conn_pool_active_connections",
-		Help:      "Number of active connections accepting new streams for this peer.",
+		Help:      "Number of active connections accepting new streams, aggregated across all peers.",
 		ConstTags: tags,
 	})
 	if err != nil {
@@ -92,7 +102,7 @@ func newConnPoolMetrics(p connPoolMetricsParams) *connPoolMetrics {
 
 	m.drainingConnectionCount, err = p.Meter.Gauge(metrics.Spec{
 		Name:      "conn_pool_draining_connections",
-		Help:      "Number of connections draining in-flight streams for this peer.",
+		Help:      "Number of connections draining in-flight streams, aggregated across all peers.",
 		ConstTags: tags,
 	})
 	if err != nil {
@@ -101,7 +111,7 @@ func newConnPoolMetrics(p connPoolMetricsParams) *connPoolMetrics {
 
 	m.idleConnectionCount, err = p.Meter.Gauge(metrics.Spec{
 		Name:      "conn_pool_idle_connections",
-		Help:      "Number of idle connections waiting for timeout before closing for this peer.",
+		Help:      "Number of idle connections waiting for timeout before closing, aggregated across all peers.",
 		ConstTags: tags,
 	})
 	if err != nil {
@@ -110,7 +120,7 @@ func newConnPoolMetrics(p connPoolMetricsParams) *connPoolMetrics {
 
 	m.scaleUpTotal, err = p.Meter.Counter(metrics.Spec{
 		Name:      "conn_pool_scale_up_total",
-		Help:      "Total number of times the pool opened a new connection for this peer.",
+		Help:      "Total number of times the pool opened a new connection, aggregated across all peers.",
 		ConstTags: tags,
 	})
 	if err != nil {
@@ -119,7 +129,7 @@ func newConnPoolMetrics(p connPoolMetricsParams) *connPoolMetrics {
 
 	m.scaleDownTotal, err = p.Meter.Counter(metrics.Spec{
 		Name:      "conn_pool_scale_down_total",
-		Help:      "Total number of times the pool marked a connection for draining for this peer.",
+		Help:      "Total number of times the pool marked a connection for draining, aggregated across all peers.",
 		ConstTags: tags,
 	})
 	if err != nil {
@@ -128,7 +138,7 @@ func newConnPoolMetrics(p connPoolMetricsParams) *connPoolMetrics {
 
 	m.idleReactivationTotal, err = p.Meter.Counter(metrics.Spec{
 		Name:      "conn_pool_idle_reactivation_total",
-		Help:      "Total number of times an idle connection was reactivated instead of opening a new one.",
+		Help:      "Total number of times an idle connection was reactivated instead of opening a new one, aggregated across all peers.",
 		ConstTags: tags,
 	})
 	if err != nil {
@@ -138,25 +148,28 @@ func newConnPoolMetrics(p connPoolMetricsParams) *connPoolMetrics {
 	return m
 }
 
-func (m *connPoolMetrics) setConnectionCount(n int64) {
-	if m == nil || m.connectionCount == nil {
+// addConnectionCount applies a delta to the aggregate active-connections gauge.
+func (m *connPoolMetrics) addConnectionCount(delta int64) {
+	if m == nil || m.connectionCount == nil || delta == 0 {
 		return
 	}
-	m.connectionCount.Store(n)
+	m.connectionCount.Add(delta)
 }
 
-func (m *connPoolMetrics) setDrainingConnectionCount(n int64) {
-	if m == nil || m.drainingConnectionCount == nil {
+// addDrainingConnectionCount applies a delta to the aggregate draining gauge.
+func (m *connPoolMetrics) addDrainingConnectionCount(delta int64) {
+	if m == nil || m.drainingConnectionCount == nil || delta == 0 {
 		return
 	}
-	m.drainingConnectionCount.Store(n)
+	m.drainingConnectionCount.Add(delta)
 }
 
-func (m *connPoolMetrics) setIdleConnectionCount(n int64) {
-	if m == nil || m.idleConnectionCount == nil {
+// addIdleConnectionCount applies a delta to the aggregate idle gauge.
+func (m *connPoolMetrics) addIdleConnectionCount(delta int64) {
+	if m == nil || m.idleConnectionCount == nil || delta == 0 {
 		return
 	}
-	m.idleConnectionCount.Store(n)
+	m.idleConnectionCount.Add(delta)
 }
 
 func (m *connPoolMetrics) incScaleUp() {
@@ -178,4 +191,70 @@ func (m *connPoolMetrics) incIdleReactivation() {
 		return
 	}
 	m.idleReactivationTotal.Inc()
+}
+
+// peerPoolReporter applies a single peer's connection-state counts to the
+// shared, transport-wide gauges. Because the gauges are not tagged by peer,
+// every peer contributes to the same series; this reporter tracks the values it
+// last published and applies the difference so the gauges always reflect the
+// sum across all peers. Deltas telescope, so a peer's contribution naturally
+// returns to zero as its connections are removed during teardown — no explicit
+// cleanup is required. Counter events are pool-wide and forwarded directly.
+type peerPoolReporter struct {
+	shared *connPoolMetrics
+
+	mu           sync.Mutex
+	lastActive   int64
+	lastDraining int64
+	lastIdle     int64
+}
+
+// newPeerPoolReporter creates a reporter that feeds the shared transport metrics.
+func newPeerPoolReporter(shared *connPoolMetrics) *peerPoolReporter {
+	return &peerPoolReporter{shared: shared}
+}
+
+// setCounts publishes this peer's current active/draining/idle connection
+// counts, applying the difference from the previously reported values to the
+// shared aggregate gauges. Safe for concurrent use.
+func (r *peerPoolReporter) setCounts(active, draining, idle int64) {
+	if r == nil {
+		return
+	}
+	// Compute deltas under the lock so concurrent callers for the same peer
+	// chain their updates consistently. The gauge writes themselves are atomic
+	// and commutative, so they can happen outside the lock.
+	r.mu.Lock()
+	dActive := active - r.lastActive
+	dDraining := draining - r.lastDraining
+	dIdle := idle - r.lastIdle
+	r.lastActive = active
+	r.lastDraining = draining
+	r.lastIdle = idle
+	r.mu.Unlock()
+
+	r.shared.addConnectionCount(dActive)
+	r.shared.addDrainingConnectionCount(dDraining)
+	r.shared.addIdleConnectionCount(dIdle)
+}
+
+func (r *peerPoolReporter) incScaleUp() {
+	if r == nil {
+		return
+	}
+	r.shared.incScaleUp()
+}
+
+func (r *peerPoolReporter) incScaleDown() {
+	if r == nil {
+		return
+	}
+	r.shared.incScaleDown()
+}
+
+func (r *peerPoolReporter) incIdleReactivation() {
+	if r == nil {
+		return
+	}
+	r.shared.incIdleReactivation()
 }

--- a/transport/grpc/conn_pool_metrics_test.go
+++ b/transport/grpc/conn_pool_metrics_test.go
@@ -21,8 +21,11 @@
 package grpc
 
 import (
+	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -31,11 +34,42 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 )
 
+const testConnPoolServiceName = "test-svc"
+
 func testMetricsParams(scope *metrics.Scope) connPoolMetricsParams {
 	return connPoolMetricsParams{
 		Meter:       scope,
 		Logger:      zap.NewNop(),
-		ServiceName: "test-svc",
+		ServiceName: testConnPoolServiceName,
+	}
+}
+
+func wantConnPoolMetricTags(serviceName string) map[string]string {
+	return map[string]string{
+		_componentTag: _componentTagValueYarpc,
+		_serviceTag:   serviceName,
+		_transportTag: _transportTagValueGrpc,
+	}
+}
+
+func assertConnPoolMetricTags(t *testing.T, snap *metrics.RootSnapshot, serviceName string) {
+	t.Helper()
+	want := wantConnPoolMetricTags(serviceName)
+	for _, g := range snap.Gauges {
+		if !strings.HasPrefix(g.Name, "conn_pool_") {
+			continue
+		}
+		for k, v := range want {
+			assert.Equal(t, v, g.Tags[k], "gauge %s: tag %q", g.Name, k)
+		}
+	}
+	for _, c := range snap.Counters {
+		if !strings.HasPrefix(c.Name, "conn_pool_") {
+			continue
+		}
+		for k, v := range want {
+			assert.Equal(t, v, c.Tags[k], "counter %s: tag %q", c.Name, k)
+		}
 	}
 }
 
@@ -170,11 +204,7 @@ func TestConnPoolMetrics_Tags(t *testing.T) {
 	m.incScaleUp()
 	m.addConnectionCount(1)
 
-	wantTags := map[string]string{
-		"component": "yarpc",
-		"service":   "test-svc",
-		"transport": "grpc",
-	}
+	wantTags := wantConnPoolMetricTags(testConnPoolServiceName)
 
 	snap := root.Snapshot()
 	for _, c := range snap.Counters {
@@ -268,4 +298,92 @@ func TestConnPoolMetrics_NilReceiver(t *testing.T) {
 		r.incScaleDown()
 		r.incIdleReactivation()
 	})
+}
+
+func testTransportWithConnPoolMetrics(t *testing.T, opts ...TransportOption) (*Transport, *metrics.Root) {
+	t.Helper()
+	root := metrics.New()
+	baseOpts := []TransportOption{
+		Meter(root.Scope()),
+		ServiceName(testConnPoolServiceName),
+		Logger(zap.NewNop()),
+	}
+	return NewTransport(append(baseOpts, opts...)...), root
+}
+
+func assertConnPoolGaugesZero(t *testing.T, root *metrics.Root) {
+	t.Helper()
+	g := gaugesFromSnapshot(root.Snapshot())
+	assert.Equal(t, int64(0), g["conn_pool_active_connections"])
+	assert.Equal(t, int64(0), g["conn_pool_draining_connections"])
+	assert.Equal(t, int64(0), g["conn_pool_idle_connections"])
+}
+
+// TestConnPoolMetrics_PeerTeardownZerosSharedGauges builds a peer with multiple
+// real connections and shared transport metrics, then verifies that stopping
+// the peer drives all conn-pool gauges back to zero.
+func TestConnPoolMetrics_PeerTeardownZerosSharedGauges(t *testing.T) {
+	t.Parallel()
+
+	tr, root := testTransportWithConnPoolMetrics(t)
+	p, err := tr.newPeer("127.0.0.1:1", emptyDialOpts)
+	require.NoError(t, err)
+
+	require.NoError(t, p.addConn())
+	require.NoError(t, p.addConn())
+
+	g := gaugesFromSnapshot(root.Snapshot())
+	require.Greater(t, g["conn_pool_active_connections"], int64(0))
+
+	p.stop()
+	p.wait()
+
+	assertConnPoolGaugesZero(t, root)
+	assertConnPoolMetricTags(t, root.Snapshot(), testConnPoolServiceName)
+}
+
+// TestConnPoolMetrics_DynamicScalingTeardownRace hammers scale-up and scale-down
+// paths while stopping a dynamically scaled peer and checks that shared gauges
+// return to zero. Run with -race -count=1000 to stress the teardown race.
+func TestConnPoolMetrics_DynamicScalingTeardownRace(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping teardown race stress test in short mode")
+	}
+
+	const iterations = 50
+
+	for i := 0; i < iterations; i++ {
+		tr, root := testTransportWithConnPoolMetrics(t,
+			WithDynamicConnectionScaling(true),
+			MinConnections(2),
+			MaxConnections(4),
+		)
+		p, err := tr.newPeer("127.0.0.1:1", emptyDialOpts)
+		require.NoError(t, err)
+
+		var wg sync.WaitGroup
+		for g := 0; g < 4; g++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for j := 0; j < 100; j++ {
+					conn := p.pickConn()
+					if conn == nil {
+						continue
+					}
+					p.tryScaleUp(conn)
+					p.evaluateScaling()
+					atomic.StoreInt32(&conn.streamCount, 85)
+				}
+			}()
+		}
+
+		time.Sleep(5 * time.Millisecond)
+		p.stop()
+		wg.Wait()
+		p.wait()
+
+		assertConnPoolGaugesZero(t, root)
+		assertConnPoolMetricTags(t, root.Snapshot(), testConnPoolServiceName)
+	}
 }

--- a/transport/grpc/conn_pool_metrics_test.go
+++ b/transport/grpc/conn_pool_metrics_test.go
@@ -36,7 +36,6 @@ func testMetricsParams(scope *metrics.Scope) connPoolMetricsParams {
 		Meter:       scope,
 		Logger:      zap.NewNop(),
 		ServiceName: "test-svc",
-		Peer:        "10.0.0.1:8080",
 	}
 }
 
@@ -54,9 +53,10 @@ func TestNewConnPoolMetrics_NilScope(t *testing.T) {
 		m.incScaleUp()
 		m.incScaleDown()
 		m.incIdleReactivation()
-		m.setConnectionCount(5)
-		m.setDrainingConnectionCount(3)
-		m.setIdleConnectionCount(1)
+		m.addConnectionCount(5)
+		m.addDrainingConnectionCount(3)
+		m.addIdleConnectionCount(1)
+		newPeerPoolReporter(m).setCounts(5, 3, 1)
 	})
 }
 
@@ -97,10 +97,9 @@ func TestConnPoolMetrics_CounterIncrements(t *testing.T) {
 func TestConnPoolMetrics_GaugeValues(t *testing.T) {
 	root := metrics.New()
 	m := newConnPoolMetrics(testMetricsParams(root.Scope()))
+	r := newPeerPoolReporter(m)
 
-	m.setConnectionCount(5)
-	m.setDrainingConnectionCount(2)
-	m.setIdleConnectionCount(1)
+	r.setCounts(5, 2, 1)
 
 	snap := root.Snapshot()
 	gaugesByName := make(map[string]int64)
@@ -112,9 +111,9 @@ func TestConnPoolMetrics_GaugeValues(t *testing.T) {
 	assert.Equal(t, int64(2), gaugesByName["conn_pool_draining_connections"])
 	assert.Equal(t, int64(1), gaugesByName["conn_pool_idle_connections"])
 
-	m.setConnectionCount(10)
-	m.setDrainingConnectionCount(0)
-	m.setIdleConnectionCount(3)
+	// Re-publishing new counts for the same peer applies deltas so the gauge
+	// tracks the latest value rather than accumulating.
+	r.setCounts(10, 0, 3)
 
 	snap = root.Snapshot()
 	gaugesByName = make(map[string]int64)
@@ -127,19 +126,54 @@ func TestConnPoolMetrics_GaugeValues(t *testing.T) {
 	assert.Equal(t, int64(3), gaugesByName["conn_pool_idle_connections"])
 }
 
+// TestPeerPoolReporter_AggregatesAcrossPeers verifies that multiple peers
+// sharing one connPoolMetrics contribute to the same gauges (sum across peers)
+// and that a peer's contribution returns to zero as its connections are removed
+// during teardown.
+func TestPeerPoolReporter_AggregatesAcrossPeers(t *testing.T) {
+	root := metrics.New()
+	m := newConnPoolMetrics(testMetricsParams(root.Scope()))
+
+	peerA := newPeerPoolReporter(m)
+	peerB := newPeerPoolReporter(m)
+
+	peerA.setCounts(3, 1, 0)
+	peerB.setCounts(2, 0, 2)
+
+	gauges := func() map[string]int64 {
+		out := make(map[string]int64)
+		for _, g := range root.Snapshot().Gauges {
+			out[g.Name] = g.Value
+		}
+		return out
+	}
+
+	g := gauges()
+	assert.Equal(t, int64(5), g["conn_pool_active_connections"], "active should sum across peers")
+	assert.Equal(t, int64(1), g["conn_pool_draining_connections"])
+	assert.Equal(t, int64(2), g["conn_pool_idle_connections"])
+
+	// Peer A tears down (all connections removed): its contribution must drop
+	// out of the aggregate, leaving only peer B's counts.
+	peerA.setCounts(0, 0, 0)
+
+	g = gauges()
+	assert.Equal(t, int64(2), g["conn_pool_active_connections"])
+	assert.Equal(t, int64(0), g["conn_pool_draining_connections"])
+	assert.Equal(t, int64(2), g["conn_pool_idle_connections"])
+}
+
 func TestConnPoolMetrics_Tags(t *testing.T) {
 	root := metrics.New()
 	m := newConnPoolMetrics(testMetricsParams(root.Scope()))
 
 	m.incScaleUp()
-	m.setConnectionCount(1)
+	m.addConnectionCount(1)
 
 	wantTags := map[string]string{
 		"component": "yarpc",
 		"service":   "test-svc",
 		"transport": "grpc",
-		// The metrics library sanitizes colons to underscores in tag values.
-		"peer": "10.0.0.1_8080",
 	}
 
 	snap := root.Snapshot()
@@ -147,11 +181,15 @@ func TestConnPoolMetrics_Tags(t *testing.T) {
 		for k, v := range wantTags {
 			assert.Equal(t, v, c.Tags[k], "counter %s: tag %q", c.Name, k)
 		}
+		_, hasPeer := c.Tags["peer"]
+		assert.False(t, hasPeer, "counter %s must not carry a peer tag", c.Name)
 	}
 	for _, g := range snap.Gauges {
 		for k, v := range wantTags {
 			assert.Equal(t, v, g.Tags[k], "gauge %s: tag %q", g.Name, k)
 		}
+		_, hasPeer := g.Tags["peer"]
+		assert.False(t, hasPeer, "gauge %s must not carry a peer tag", g.Name)
 	}
 }
 
@@ -171,9 +209,9 @@ func TestConnPoolMetrics_ConcurrentAccess(t *testing.T) {
 				m.incScaleUp()
 				m.incScaleDown()
 				m.incIdleReactivation()
-				m.setConnectionCount(int64(j))
-				m.setDrainingConnectionCount(int64(j))
-				m.setIdleConnectionCount(int64(j))
+				m.addConnectionCount(int64(j))
+				m.addDrainingConnectionCount(int64(j))
+				m.addIdleConnectionCount(int64(j))
 			}
 		}()
 	}
@@ -200,7 +238,6 @@ func TestNewConnPoolMetrics_LogsRegistrationErrors(t *testing.T) {
 		Meter:       scope,
 		Logger:      logger,
 		ServiceName: "test-svc",
-		Peer:        "10.0.0.1:8080",
 	}
 
 	// Register the same metrics twice on the same scope+tags to trigger
@@ -219,8 +256,16 @@ func TestConnPoolMetrics_NilReceiver(t *testing.T) {
 		m.incScaleUp()
 		m.incScaleDown()
 		m.incIdleReactivation()
-		m.setConnectionCount(5)
-		m.setDrainingConnectionCount(3)
-		m.setIdleConnectionCount(1)
+		m.addConnectionCount(5)
+		m.addDrainingConnectionCount(3)
+		m.addIdleConnectionCount(1)
+	})
+
+	var r *peerPoolReporter
+	assert.NotPanics(t, func() {
+		r.setCounts(5, 3, 1)
+		r.incScaleUp()
+		r.incScaleDown()
+		r.incIdleReactivation()
 	})
 }

--- a/transport/grpc/conn_pool_scaler.go
+++ b/transport/grpc/conn_pool_scaler.go
@@ -36,6 +36,8 @@ const _defaultScalingMonitorInterval = 30 * time.Second
 // peer.  It periodically evaluates whether connections should be removed
 // from the pool.  It exits when the peer's context is cancelled.
 func (p *grpcPeer) runScalingMonitor() {
+	defer p.connWg.Done()
+
 	interval := p.poolCfg.scalingMonitorInterval
 	switch {
 	case interval <= 0:
@@ -229,9 +231,21 @@ func (p *grpcPeer) tryScaleUp(leastLoadedConn *grpcClientConnWrapper) {
 	if !atomic.CompareAndSwapInt32(&p.isScaling, 0, 1) {
 		return
 	}
+	if p.shutdownStarted.Load() || p.ctx.Err() != nil {
+		atomic.StoreInt32(&p.isScaling, 0)
+		return
+	}
 
+	p.connWg.Add(1)
 	go func() {
-		defer atomic.StoreInt32(&p.isScaling, 0)
+		defer func() {
+			atomic.StoreInt32(&p.isScaling, 0)
+			p.connWg.Done()
+		}()
+
+		if p.ctx.Err() != nil {
+			return
+		}
 
 		// Prefer reactivating an idle connection over dialing a new one.
 		if p.reactivateIdleConn() {
@@ -250,10 +264,12 @@ func (p *grpcPeer) tryScaleUp(leastLoadedConn *grpcClientConnWrapper) {
 		// No idle connection available; dial a new one if below the cap.
 		// connCount is maintained atomically — no mutex needed for this check.
 		if int(p.connCount.Load()) >= p.poolCfg.maxConnections {
-			p.t.options.logger.Info("grpc: cannot scale up connection pool; at max connections",
-				zap.String("peer", p.HostPort()),
-				zap.Int32("total_connections", p.connCount.Load()),
-				zap.Int("max_connections", p.poolCfg.maxConnections))
+			if p.atMaxConnectionsLogged.CompareAndSwap(false, true) {
+				p.t.options.logger.Info("grpc: cannot scale up connection pool; at max connections",
+					zap.String("peer", p.HostPort()),
+					zap.Int32("total_connections", p.connCount.Load()),
+					zap.Int("max_connections", p.poolCfg.maxConnections))
+			}
 			return
 		}
 
@@ -327,4 +343,7 @@ func (p *grpcPeer) refreshPoolMetrics() {
 		}
 	}
 	p.metrics.setCounts(active, draining, idle)
+	if int(p.connCount.Load()) < p.poolCfg.maxConnections {
+		p.atMaxConnectionsLogged.Store(false)
+	}
 }

--- a/transport/grpc/conn_pool_scaler.go
+++ b/transport/grpc/conn_pool_scaler.go
@@ -123,9 +123,17 @@ func (p *grpcPeer) maybeScaleDown() {
 		return
 	}
 
-	p.t.options.logger.Debug("grpc: marked connection for draining during scale-down",
+	// Logged at Info so pool scaling can be debugged from logs: connection pool
+	// metrics are aggregated across peers (not tagged by peer), so the per-peer
+	// detail lives here instead. Logs can safely carry the peer without the
+	// cardinality concerns that affect metrics.
+	p.t.options.logger.Info("grpc: scaling down connection pool; marked connection for draining",
 		zap.String("peer", p.HostPort()),
-		zap.Int32("stream_count", mostLoaded.getStreamCount()))
+		zap.Int("active_connections_before", len(active)),
+		zap.Int("active_connections_after", len(active)-1),
+		zap.Int32("total_streams", totalStreams),
+		zap.Int32("drained_conn_stream_count", mostLoaded.getStreamCount()),
+		zap.Int32("scale_down_threshold", scaleDownThreshold))
 	p.metrics.incScaleDown()
 	p.refreshPoolMetrics()
 }
@@ -178,9 +186,12 @@ func (p *grpcPeer) cleanupIdleConns() {
 		if !c.transitionState(connStateIdle, connStateClosing) {
 			continue
 		}
-		p.t.options.logger.Debug("grpc: closing idle connection after timeout",
+		// Info: closing an idle connection shrinks the pool, so surface it in
+		// logs for scaling debuggability (metrics are not tagged by peer).
+		p.t.options.logger.Info("grpc: scaling down connection pool; closing idle connection after timeout",
 			zap.String("peer", p.HostPort()),
-			zap.Duration("idle_duration", now.Sub(c.idleSince())))
+			zap.Duration("idle_duration", now.Sub(c.idleSince())),
+			zap.Int32("total_connections", p.connCount.Load()))
 		// Cancelling the wrapper context causes monitorConnWrapper to
 		// exit, which closes the underlying clientConn and removes the
 		// wrapper from the pool via removeConn.
@@ -224,8 +235,13 @@ func (p *grpcPeer) tryScaleUp(leastLoadedConn *grpcClientConnWrapper) {
 
 		// Prefer reactivating an idle connection over dialing a new one.
 		if p.reactivateIdleConn() {
-			p.t.options.logger.Debug("grpc: reactivated idle connection during scale-up",
-				zap.String("peer", p.HostPort()))
+			// Logged at Info so pool scaling is debuggable from logs (metrics
+			// are aggregated across peers and not tagged by peer).
+			p.t.options.logger.Info("grpc: scaling up connection pool; reactivated idle connection",
+				zap.String("peer", p.HostPort()),
+				zap.Int32("active_conn_stream_count", leastLoadedConn.getStreamCount()),
+				zap.Int32("scale_up_threshold", threshold),
+				zap.Int32("total_connections", p.connCount.Load()))
 			p.metrics.incIdleReactivation()
 			p.refreshPoolMetrics()
 			return
@@ -234,6 +250,10 @@ func (p *grpcPeer) tryScaleUp(leastLoadedConn *grpcClientConnWrapper) {
 		// No idle connection available; dial a new one if below the cap.
 		// connCount is maintained atomically — no mutex needed for this check.
 		if int(p.connCount.Load()) >= p.poolCfg.maxConnections {
+			p.t.options.logger.Info("grpc: cannot scale up connection pool; at max connections",
+				zap.String("peer", p.HostPort()),
+				zap.Int32("total_connections", p.connCount.Load()),
+				zap.Int("max_connections", p.poolCfg.maxConnections))
 			return
 		}
 
@@ -242,8 +262,13 @@ func (p *grpcPeer) tryScaleUp(leastLoadedConn *grpcClientConnWrapper) {
 				zap.String("peer", p.HostPort()),
 				zap.Error(err))
 		} else {
-			p.t.options.logger.Debug("grpc: scaled up connection pool",
-				zap.String("peer", p.HostPort()))
+			// Logged at Info so pool scaling is debuggable from logs (metrics
+			// are aggregated across peers and not tagged by peer).
+			p.t.options.logger.Info("grpc: scaling up connection pool; opened new connection",
+				zap.String("peer", p.HostPort()),
+				zap.Int32("active_conn_stream_count", leastLoadedConn.getStreamCount()),
+				zap.Int32("scale_up_threshold", threshold),
+				zap.Int32("total_connections", p.connCount.Load()))
 			p.metrics.incScaleUp()
 		}
 	}()
@@ -287,7 +312,7 @@ func (p *grpcPeer) reactivateIdleConn() bool {
 }
 
 // refreshPoolMetrics scans the pool and updates the active, draining, and idle
-// connection gauges.  Lock-free: reads an immutable snapshot via loadConns().
+// connection gauges.
 func (p *grpcPeer) refreshPoolMetrics() {
 	conns := p.loadConns()
 	var active, draining, idle int64
@@ -301,7 +326,5 @@ func (p *grpcPeer) refreshPoolMetrics() {
 			idle++
 		}
 	}
-	p.metrics.setConnectionCount(active)
-	p.metrics.setDrainingConnectionCount(draining)
-	p.metrics.setIdleConnectionCount(idle)
+	p.metrics.setCounts(active, draining, idle)
 }

--- a/transport/grpc/conn_pool_scaler_test.go
+++ b/transport/grpc/conn_pool_scaler_test.go
@@ -664,12 +664,11 @@ func peerWithMetrics(t *testing.T) (*grpcPeer, *metrics.Root) {
 	t.Helper()
 	root := metrics.New()
 	p := peerForPool(t)
-	p.metrics = newConnPoolMetrics(connPoolMetricsParams{
+	p.metrics = newPeerPoolReporter(newConnPoolMetrics(connPoolMetricsParams{
 		Meter:       root.Scope(),
 		Logger:      zap.NewNop(),
 		ServiceName: "test-svc",
-		Peer:        p.Peer.Identifier(),
-	})
+	}))
 	return p, root
 }
 

--- a/transport/grpc/conn_pool_scaler_test.go
+++ b/transport/grpc/conn_pool_scaler_test.go
@@ -413,6 +413,7 @@ func TestRunScalingMonitorExitsOnContextCancel(t *testing.T) {
 	p := newTestPeer(ctx, cancel)
 
 	done := make(chan struct{})
+	p.connWg.Add(1)
 	go func() {
 		p.runScalingMonitor()
 		close(done)
@@ -442,6 +443,7 @@ func TestRunScalingMonitorTicksEvaluateScaling(t *testing.T) {
 
 	// runScalingMonitor blocks until the context expires; run it inline so the
 	// test waits for it naturally.
+	p.connWg.Add(1)
 	p.runScalingMonitor()
 
 	// If we reach here the monitor exited cleanly on context cancellation – success.
@@ -514,6 +516,28 @@ func TestTryScaleUp(t *testing.T) {
 
 		n := len(p.loadConns())
 		assert.Equal(t, p.poolCfg.maxConnections, n, "pool should not grow beyond max")
+	})
+
+	t.Run("at max connections - logs once per saturation", func(t *testing.T) {
+		t.Parallel()
+		core, logs := observer.New(zap.InfoLevel)
+		p := peerForPool(t)
+		p.t.options.logger = zap.New(core)
+		conns := make([]*grpcClientConnWrapper, p.poolCfg.maxConnections)
+		for i := range conns {
+			conns[i] = makeConn(connStateActive, 85)
+		}
+		p.storeConns(conns)
+
+		for i := 0; i < 10; i++ {
+			p.tryScaleUp(overBudget)
+			assert.Eventually(t, func() bool {
+				return atomic.LoadInt32(&p.isScaling) == 0
+			}, 2*time.Second, 10*time.Millisecond)
+		}
+
+		maxConnLogs := logs.FilterMessage("grpc: cannot scale up connection pool; at max connections")
+		assert.Equal(t, 1, maxConnLogs.Len(), "at-max log should fire once per saturation episode")
 	})
 
 	t.Run("already scaling - no second goroutine launched", func(t *testing.T) {
@@ -664,11 +688,7 @@ func peerWithMetrics(t *testing.T) (*grpcPeer, *metrics.Root) {
 	t.Helper()
 	root := metrics.New()
 	p := peerForPool(t)
-	p.metrics = newPeerPoolReporter(newConnPoolMetrics(connPoolMetricsParams{
-		Meter:       root.Scope(),
-		Logger:      zap.NewNop(),
-		ServiceName: "test-svc",
-	}))
+	p.metrics = newPeerPoolReporter(newConnPoolMetrics(testMetricsParams(root.Scope())))
 	return p, root
 }
 
@@ -886,6 +906,7 @@ func TestRunScalingMonitorUsesConfiguredInterval(t *testing.T) {
 	p.poolCfg.scalingMonitorInterval = 5 * time.Second
 
 	done := make(chan struct{})
+	p.connWg.Add(1)
 	go func() {
 		p.runScalingMonitor()
 		close(done)
@@ -908,6 +929,7 @@ func TestRunScalingMonitorValidCustomInterval(t *testing.T) {
 	p.poolCfg.scalingMonitorInterval = 60 * time.Second // valid, above minimum
 
 	done := make(chan struct{})
+	p.connWg.Add(1)
 	go func() {
 		p.runScalingMonitor()
 		close(done)
@@ -941,6 +963,7 @@ func TestRunScalingMonitorClampsAndWarns(t *testing.T) {
 	t.Cleanup(cancel)
 
 	done := make(chan struct{})
+	p.connWg.Add(1)
 	go func() {
 		p.runScalingMonitor()
 		close(done)

--- a/transport/grpc/peer.go
+++ b/transport/grpc/peer.go
@@ -53,7 +53,9 @@ type grpcPeer struct {
 	// stoppedC is closed once all goroutines finish after the peer is stopped.
 	connWg sync.WaitGroup
 
-	metrics *connPoolMetrics
+	// metrics reports this peer's connection-state counts and scaling events
+	// into the transport-wide shared metrics (which are not tagged by peer).
+	metrics *peerPoolReporter
 
 	// connsPtr holds a pointer to the current immutable connection slice.
 	// Readers (pickConn, recomputeConnectionStatus, refreshPoolMetrics, etc.)
@@ -120,12 +122,7 @@ func (t *Transport) newPeer(address string, options *dialOptions) (*grpcPeer, er
 		cancel:       cancel,
 		stoppedC:     make(chan struct{}),
 		grpcDialOpts: dialOptions,
-		metrics: newConnPoolMetrics(connPoolMetricsParams{
-			Meter:       t.options.meter,
-			Logger:      t.options.logger,
-			ServiceName: t.options.serviceName,
-			Peer:        address,
-		}),
+		metrics: newPeerPoolReporter(t.metrics),
 		poolCfg: connPoolConfig{
 			dynamicScalingEnabled:  t.options.clientConnPoolDynamicScalingEnabled,
 			maxConcurrentStreams:   t.options.clientConnPoolMaxConcurrentStreams,

--- a/transport/grpc/peer.go
+++ b/transport/grpc/peer.go
@@ -49,8 +49,13 @@ type grpcPeer struct {
 	// running.  This prevents multiple concurrent scale-up operations.
 	isScaling int32 // accessed atomically
 
-	// connWg tracks active monitorConnWrapper goroutines.
-	// stoppedC is closed once all goroutines finish after the peer is stopped.
+	// atMaxConnectionsLogged is set after logging the first scale-up attempt while
+	// at maxConnections; cleared when the pool drops below the cap.
+	atMaxConnectionsLogged atomic.Bool
+
+	// connWg tracks background pool goroutines: monitorConnWrapper,
+	// runScalingMonitor, and tryScaleUp workers. stoppedC closes once they have
+	// all finished and this peer's metric contribution has been zeroed.
 	connWg sync.WaitGroup
 
 	// metrics reports this peer's connection-state counts and scaling events
@@ -162,12 +167,13 @@ func (t *Transport) newPeer(address string, options *dialOptions) (*grpcPeer, er
 	}
 
 	if p.poolCfg.dynamicScalingEnabled {
+		p.connWg.Add(1)
 		go p.runScalingMonitor()
 	}
 
-	// Close stoppedC once all monitorConnWrapper goroutines have finished.
-	// shutdownStarted gates new connWg.Add(1) calls; addingCount ensures we
-	// wait for any addConn already past its ctx check before calling Wait.
+	// Close stoppedC once all pool goroutines have finished. shutdownStarted
+	// gates new connWg.Add(1) calls; addingCount ensures we wait for any addConn
+	// already past its ctx check before calling Wait.
 	go func() {
 		<-p.ctx.Done()
 		p.shutdownStarted.Store(true)
@@ -175,6 +181,12 @@ func (t *Transport) newPeer(address string, options *dialOptions) (*grpcPeer, er
 			runtime.Gosched()
 		}
 		p.connWg.Wait()
+		// Zero this peer's contribution after every pool goroutine has stopped so
+		// a late refreshPoolMetrics snapshot cannot leave residual values on the
+		// transport-wide shared gauges.
+		if p.metrics != nil {
+			p.metrics.setCounts(0, 0, 0)
+		}
 		close(p.stoppedC)
 	}()
 

--- a/transport/grpc/peer.go
+++ b/transport/grpc/peer.go
@@ -122,7 +122,7 @@ func (t *Transport) newPeer(address string, options *dialOptions) (*grpcPeer, er
 		cancel:       cancel,
 		stoppedC:     make(chan struct{}),
 		grpcDialOpts: dialOptions,
-		metrics: newPeerPoolReporter(t.metrics),
+		metrics:      newPeerPoolReporter(t.metrics),
 		poolCfg: connPoolConfig{
 			dynamicScalingEnabled:  t.options.clientConnPoolDynamicScalingEnabled,
 			maxConcurrentStreams:   t.options.clientConnPoolMaxConcurrentStreams,

--- a/transport/grpc/peer_test.go
+++ b/transport/grpc/peer_test.go
@@ -517,12 +517,11 @@ func TestMonitorConnWrapperMetrics(t *testing.T) {
 
 	root := metrics.New()
 	p := peerForPool(t)
-	p.metrics = newConnPoolMetrics(connPoolMetricsParams{
+	p.metrics = newPeerPoolReporter(newConnPoolMetrics(connPoolMetricsParams{
 		Meter:       root.Scope(),
 		Logger:      zap.NewNop(),
 		ServiceName: "test-svc",
-		Peer:        p.Peer.Identifier(),
-	})
+	}))
 
 	cc := dialTestClientConn(t)
 	w := newConnWrapper(p.ctx, cc)

--- a/transport/grpc/peer_test.go
+++ b/transport/grpc/peer_test.go
@@ -39,7 +39,6 @@ import (
 	"go.uber.org/yarpc/peer/abstractpeer"
 	"go.uber.org/yarpc/peer/hostport"
 	"go.uber.org/yarpc/peer/roundrobin"
-	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
@@ -517,11 +516,7 @@ func TestMonitorConnWrapperMetrics(t *testing.T) {
 
 	root := metrics.New()
 	p := peerForPool(t)
-	p.metrics = newPeerPoolReporter(newConnPoolMetrics(connPoolMetricsParams{
-		Meter:       root.Scope(),
-		Logger:      zap.NewNop(),
-		ServiceName: "test-svc",
-	}))
+	p.metrics = newPeerPoolReporter(newConnPoolMetrics(testMetricsParams(root.Scope())))
 
 	cc := dialTestClientConn(t)
 	w := newConnWrapper(p.ctx, cc)
@@ -545,4 +540,5 @@ func TestMonitorConnWrapperMetrics(t *testing.T) {
 	// After removal the gauge must drop to zero.
 	g = gaugesFromSnapshot(root.Snapshot())
 	assert.Equal(t, int64(0), g["conn_pool_active_connections"])
+	assertConnPoolMetricTags(t, root.Snapshot(), testConnPoolServiceName)
 }

--- a/transport/grpc/transport.go
+++ b/transport/grpc/transport.go
@@ -39,6 +39,11 @@ type Transport struct {
 	once          *lifecycle.Once
 	options       *transportOptions
 	addressToPeer map[string]*grpcPeer
+	// metrics are the connection pool metrics shared by all peers of this
+	// transport. They are not tagged by peer: gauges hold the aggregate count
+	// across peers and counters accumulate pool-wide scaling events, keeping
+	// metric cardinality bounded regardless of fleet size or peer churn.
+	metrics *connPoolMetrics
 	// releasedCleanupWg tracks peers released via ReleasePeer. We cannot call
 	// p.wait() inside ReleasePeer because abstractlist.stop() holds list.lock
 	// while calling it, and monitorConnWrapper needs list.lock to exit cleanly
@@ -56,6 +61,11 @@ func newTransport(transportOptions *transportOptions) *Transport {
 		once:          lifecycle.NewOnce(),
 		options:       transportOptions,
 		addressToPeer: make(map[string]*grpcPeer),
+		metrics: newConnPoolMetrics(connPoolMetricsParams{
+			Meter:       transportOptions.meter,
+			Logger:      transportOptions.logger,
+			ServiceName: transportOptions.serviceName,
+		}),
 	}
 }
 


### PR DESCRIPTION
## Summary

Per-peer `peer` tags on gRPC connection pool metrics cause unbounded cardinality as downstream fleets grow and peer addresses churn (e.g. pod reschedules). Each retained peer also registered six metric handles; when the same address was re-retained after release, duplicate registration produced Error-level logs in production.

- Drop the `peer` tag from all conn pool metrics; tags are now `component`, `service`, and `transport` only.
- Register metrics once per `Transport` in `newTransport`; peers report into the shared handles via `peerPoolReporter`, which applies per-peer gauge deltas so aggregates stay correct without per-peer registration.
- Add Info-level scaling logs (scale up/down, reactivation) with `peer` and pool context for debugging, since metrics are service-level aggregates.
- Track scaling goroutines in `connWg` and call `setCounts(0, 0, 0)` on peer shutdown so a late `refreshPoolMetrics` snapshot cannot leave residual values on shared transport gauges.
- Log at-max scale-up attempts once per saturation episode (not on every request).

## Testing

- `go build ./...`
- `go test ./transport/grpc/ -race -count=1`
- `TestConnPoolMetrics_Tags` — no `peer` tag on gauges/counters; `transport=grpc` asserted
- `TestPeerPoolReporter_AggregatesAcrossPeers` — multi-peer gauge aggregation and teardown
- `TestConnPoolMetrics_PeerTeardownZerosSharedGauges` — multi-connection peer stop zeros shared gauges
- `TestConnPoolMetrics_DynamicScalingTeardownRace` — concurrent scale-up/down during peer stop
- `TestTryScaleUp/at max connections - logs once per saturation`
- `TestRefreshPoolMetrics`, `TestMaybeScaleDownMetrics`, `TestTryScaleUpDialMetrics`, `TestTryScaleUpReactivationMetrics`, `TestCleanupIdleConnsMetrics`, `TestMonitorConnWrapperMetrics`
- `TestConnPoolMetrics_ConcurrentAccess` — concurrent gauge/counter updates under `-race`