### PR TITLE
transport/grpc: add opt-in dialer connection isolation

### DIFF
--- a/peer/direct/direct_test.go
+++ b/peer/direct/direct_test.go
@@ -161,4 +161,26 @@ func TestPeerSubscriber(t *testing.T) {
 		}
 		wg.Wait()
 	})
+
+	t.Run("isolated grpc dialer shares peer across requests", func(t *testing.T) {
+		const addr = "foohost:barport"
+
+		grpcTransport := grpc.NewTransport()
+		require.NoError(t, grpcTransport.Start())
+		defer func() { require.NoError(t, grpcTransport.Stop()) }()
+
+		dialer := grpcTransport.NewDialer().WithConnectionIsolation()
+		chooser, err := New(Configuration{}, dialer)
+		require.NoError(t, err)
+
+		request := &transport.Request{ShardKey: addr}
+		p1, finish1, err := chooser.Choose(context.Background(), request)
+		require.NoError(t, err)
+		p2, finish2, err := chooser.Choose(context.Background(), request)
+		require.NoError(t, err)
+
+		assert.Same(t, p1, p2)
+		finish1(nil)
+		finish2(nil)
+	})
 }

--- a/transport/grpc/dialer.go
+++ b/transport/grpc/dialer.go
@@ -31,10 +31,9 @@ func (t *Transport) NewDialer(options ...DialOption) *Dialer {
 }
 
 // connectionScope identifies a set of peers that must not be shared with
-// other dialers. The marker makes each allocated scope have a distinct address.
-type connectionScope struct {
-	marker byte
-}
+// other dialers. The non-zero-sized type gives each allocation a distinct
+// address.
+type connectionScope byte
 
 // Dialer is a decorator for a gRPC transport that threads dial options for
 // every retained peer.
@@ -54,7 +53,7 @@ var _ peer.Transport = (*Dialer)(nil)
 // within that outbound continue to share peers normally.
 func (d *Dialer) WithConnectionIsolation() *Dialer {
 	isolated := *d
-	isolated.connectionScope = &connectionScope{}
+	isolated.connectionScope = new(connectionScope)
 	return &isolated
 }
 

--- a/transport/grpc/dialer.go
+++ b/transport/grpc/dialer.go
@@ -30,21 +30,40 @@ func (t *Transport) NewDialer(options ...DialOption) *Dialer {
 	return &Dialer{trans: t, options: newDialOptions(options)}
 }
 
+// connectionScope identifies a set of peers that must not be shared with
+// other dialers. The marker makes each allocated scope have a distinct address.
+type connectionScope struct {
+	marker byte
+}
+
 // Dialer is a decorator for a gRPC transport that threads dial options for
 // every retained peer.
 type Dialer struct {
-	trans   *Transport
-	options *dialOptions
+	trans           *Transport
+	options         *dialOptions
+	connectionScope *connectionScope
 }
 
 var _ peer.Transport = (*Dialer)(nil)
 
+// WithConnectionIsolation returns a copy of the Dialer whose peers, and
+// therefore connections or connection pools, are not shared with other
+// dialers retaining the same address.
+//
+// Callers should create one isolated Dialer per logical outbound. Requests
+// within that outbound continue to share peers normally.
+func (d *Dialer) WithConnectionIsolation() *Dialer {
+	isolated := *d
+	isolated.connectionScope = &connectionScope{}
+	return &isolated
+}
+
 // RetainPeer retains the identified peer, passing dial options.
 func (d *Dialer) RetainPeer(id peer.Identifier, ps peer.Subscriber) (peer.Peer, error) {
-	return d.trans.retainPeer(id, d.options, ps)
+	return d.trans.retainPeer(id, d.options, d.connectionScope, ps)
 }
 
 // ReleasePeer releases the identified peer.
 func (d *Dialer) ReleasePeer(id peer.Identifier, ps peer.Subscriber) error {
-	return d.trans.ReleasePeer(id, ps)
+	return d.trans.releasePeer(id, d.connectionScope, ps)
 }

--- a/transport/grpc/integration_test.go
+++ b/transport/grpc/integration_test.go
@@ -1142,9 +1142,9 @@ func TestMultiOutboundSamePeerCalls(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "value2", got)
 
-	// Both outbounds share a single grpcPeer: only one entry in addressToPeer.
+	// Both outbounds share a single grpcPeer: only one entry in the peers map.
 	env.Transport.lock.Lock()
-	peerCount := len(env.Transport.addressToPeer)
+	peerCount := len(env.Transport.peers)
 	env.Transport.lock.Unlock()
 	assert.Equal(t, 1, peerCount,
 		"two outbounds to the same address must share one grpcPeer, got %d peers", peerCount)
@@ -1218,7 +1218,7 @@ func TestMultiOutboundPeerChurnRemainingOutboundStaysHealthy(t *testing.T) {
 	require.NoError(t, list2.Update(yarpcpeer.ListUpdates{Removals: []yarpcpeer.Identifier{serverID}}))
 
 	trans.lock.Lock()
-	_, peerAlive := trans.addressToPeer[serverAddr]
+	_, peerAlive := trans.peers[peerKey{address: serverAddr}]
 	trans.lock.Unlock()
 	assert.True(t, peerAlive, "peer must remain when one of two subscribers releases it")
 
@@ -1229,7 +1229,7 @@ func TestMultiOutboundPeerChurnRemainingOutboundStaysHealthy(t *testing.T) {
 	require.NoError(t, list1.Update(yarpcpeer.ListUpdates{Removals: []yarpcpeer.Identifier{serverID}}))
 
 	trans.lock.Lock()
-	_, peerGone := trans.addressToPeer[serverAddr]
+	_, peerGone := trans.peers[peerKey{address: serverAddr}]
 	trans.lock.Unlock()
 	assert.False(t, peerGone, "peer must be removed when all subscribers release it")
 

--- a/transport/grpc/options.go
+++ b/transport/grpc/options.go
@@ -116,24 +116,6 @@ func TracingInterceptorEnabled(enabled bool) TransportOption {
 	}
 }
 
-// ConnectionPerOutbound makes the transport open a dedicated connection (or
-// connection pool, under dynamic scaling) for each outbound, even when several
-// outbounds dial the same address.
-//
-// By default the transport shares one peer — and thus one connection/pool —
-// among all outbounds that dial the same address. With this option, peers are
-// additionally keyed by the subscribing outbound, so each outbound gets its own
-// peer. This isolates each downstream at the connection level (HTTP/2
-// head-of-line blocking, flow-control window, and stream budget are no longer
-// shared across outbounds) and, when dialing a local sidecar/host-agent, spreads
-// connections across its worker threads. Outbounds dialing distinct addresses
-// are unaffected.
-func ConnectionPerOutbound() TransportOption {
-	return func(transportOptions *transportOptions) {
-		transportOptions.connectionPerOutbound = true
-	}
-}
-
 // Logger sets a logger to use for internal logging.
 //
 // The default is to not write any logs.
@@ -472,7 +454,6 @@ type transportOptions struct {
 	clientConnPoolIdleTimeout            time.Duration
 	clientConnPoolScalingMonitorInterval time.Duration
 	clientConnPoolDynamicScalingEnabled  bool
-	connectionPerOutbound                bool
 }
 
 func newTransportOptions(options []TransportOption) *transportOptions {

--- a/transport/grpc/options.go
+++ b/transport/grpc/options.go
@@ -116,6 +116,24 @@ func TracingInterceptorEnabled(enabled bool) TransportOption {
 	}
 }
 
+// ConnectionPerOutbound makes the transport open a dedicated connection (or
+// connection pool, under dynamic scaling) for each outbound, even when several
+// outbounds dial the same address.
+//
+// By default the transport shares one peer — and thus one connection/pool —
+// among all outbounds that dial the same address. With this option, peers are
+// additionally keyed by the subscribing outbound, so each outbound gets its own
+// peer. This isolates each downstream at the connection level (HTTP/2
+// head-of-line blocking, flow-control window, and stream budget are no longer
+// shared across outbounds) and, when dialing a local sidecar/host-agent, spreads
+// connections across its worker threads. Outbounds dialing distinct addresses
+// are unaffected.
+func ConnectionPerOutbound() TransportOption {
+	return func(transportOptions *transportOptions) {
+		transportOptions.connectionPerOutbound = true
+	}
+}
+
 // Logger sets a logger to use for internal logging.
 //
 // The default is to not write any logs.
@@ -454,6 +472,7 @@ type transportOptions struct {
 	clientConnPoolIdleTimeout            time.Duration
 	clientConnPoolScalingMonitorInterval time.Duration
 	clientConnPoolDynamicScalingEnabled  bool
+	connectionPerOutbound                bool
 }
 
 func newTransportOptions(options []TransportOption) *transportOptions {

--- a/transport/grpc/transport.go
+++ b/transport/grpc/transport.go
@@ -35,10 +35,10 @@ var emptyDialOpts = &dialOptions{}
 // This currently does not have any additional functionality over creating
 // an Inbound or Outbound separately, but may in the future.
 type Transport struct {
-	lock          sync.Mutex
-	once          *lifecycle.Once
-	options       *transportOptions
-	addressToPeer map[string]*grpcPeer
+	lock    sync.Mutex
+	once    *lifecycle.Once
+	options *transportOptions
+	peers   map[peerKey]*grpcPeer
 	// metrics are the connection pool metrics shared by all peers of this
 	// transport. They are not tagged by peer: gauges hold the aggregate count
 	// across peers and counters accumulate pool-wide scaling events, keeping
@@ -51,6 +51,18 @@ type Transport struct {
 	releasedCleanupWg sync.WaitGroup
 }
 
+// peerKey identifies a peer in the transport's peer map.
+//
+// Peers are keyed by the address they dial. When the transport is configured
+// with ConnectionPerOutbound, the subscribing outbound is added to the key so
+// that each outbound dialing the same address gets its own peer — and therefore
+// its own connection (or connection pool, under dynamic scaling).
+type peerKey struct {
+	address string
+	// subscriber is the zero value unless ConnectionPerOutbound is set.
+	subscriber peer.Subscriber
+}
+
 // NewTransport returns a new Transport.
 func NewTransport(options ...TransportOption) *Transport {
 	return newTransport(newTransportOptions(options))
@@ -58,9 +70,9 @@ func NewTransport(options ...TransportOption) *Transport {
 
 func newTransport(transportOptions *transportOptions) *Transport {
 	return &Transport{
-		once:          lifecycle.NewOnce(),
-		options:       transportOptions,
-		addressToPeer: make(map[string]*grpcPeer),
+		once:    lifecycle.NewOnce(),
+		options: transportOptions,
+		peers:   make(map[peerKey]*grpcPeer),
 		metrics: newConnPoolMetrics(connPoolMetricsParams{
 			Meter:       transportOptions.meter,
 			Logger:      transportOptions.logger,
@@ -78,16 +90,16 @@ func (t *Transport) Start() error {
 func (t *Transport) Stop() error {
 	return t.once.Stop(func() error {
 		t.lock.Lock()
-		for _, grpcPeer := range t.addressToPeer {
+		for _, grpcPeer := range t.peers {
 			grpcPeer.stop()
 		}
-		peers := make([]*grpcPeer, 0, len(t.addressToPeer))
-		for _, p := range t.addressToPeer {
-			peers = append(peers, p)
+		toWait := make([]*grpcPeer, 0, len(t.peers))
+		for _, p := range t.peers {
+			toWait = append(toWait, p)
 		}
 		t.lock.Unlock()
 
-		for _, p := range peers {
+		for _, p := range toWait {
 			p.wait()
 		}
 		// Wait for peers released via ReleasePeer whose cleanup goroutines
@@ -131,17 +143,28 @@ func (t *Transport) retainPeer(pid peer.Identifier, options *dialOptions, ps pee
 	t.lock.Lock()
 	defer t.lock.Unlock()
 	address := pid.Identifier()
-	p, ok := t.addressToPeer[address]
+	key := t.peerKey(address, ps)
+	p, ok := t.peers[key]
 	if !ok {
 		var err error
 		p, err = t.newPeer(address, options)
 		if err != nil {
 			return nil, err
 		}
-		t.addressToPeer[address] = p
+		t.peers[key] = p
 	}
 	p.Subscribe(ps)
 	return p, nil
+}
+
+// peerKey builds the map key for a peer. When ConnectionPerOutbound is set, the
+// subscribing outbound is part of the key so each outbound dialing the same
+// address gets its own peer (and its own connection / pool).
+func (t *Transport) peerKey(address string, ps peer.Subscriber) peerKey {
+	if t.options.connectionPerOutbound {
+		return peerKey{address: address, subscriber: ps}
+	}
+	return peerKey{address: address}
 }
 
 // ReleasePeer releases the peer.
@@ -153,7 +176,8 @@ func (t *Transport) ReleasePeer(pid peer.Identifier, ps peer.Subscriber) error {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 	address := pid.Identifier()
-	p, ok := t.addressToPeer[address]
+	key := t.peerKey(address, ps)
+	p, ok := t.peers[key]
 	if !ok {
 		return peer.ErrTransportHasNoReferenceToPeer{
 			TransportName:  "grpc.Transport",
@@ -164,7 +188,7 @@ func (t *Transport) ReleasePeer(pid peer.Identifier, ps peer.Subscriber) error {
 		return err
 	}
 	if p.NumSubscribers() == 0 {
-		delete(t.addressToPeer, address)
+		delete(t.peers, key)
 		p.stop()
 		// Do not call p.wait() here: abstractlist.stop() holds list.lock while
 		// calling ReleasePeer, and monitorConnWrapper needs list.lock to exit.

--- a/transport/grpc/transport.go
+++ b/transport/grpc/transport.go
@@ -53,14 +53,12 @@ type Transport struct {
 
 // peerKey identifies a peer in the transport's peer map.
 //
-// Peers are keyed by the address they dial. When the transport is configured
-// with ConnectionPerOutbound, the subscribing outbound is added to the key so
-// that each outbound dialing the same address gets its own peer — and therefore
-// its own connection (or connection pool, under dynamic scaling).
+// Peers are keyed by the address they dial. Dialers that opt into connection
+// isolation add a stable scope to the key so they do not share peers,
+// connections, or connection pools with other dialers.
 type peerKey struct {
-	address string
-	// subscriber is the zero value unless ConnectionPerOutbound is set.
-	subscriber peer.Subscriber
+	address         string
+	connectionScope *connectionScope
 }
 
 // NewTransport returns a new Transport.
@@ -136,14 +134,19 @@ func (t *Transport) NewOutbound(peerChooser peer.Chooser, options ...OutboundOpt
 // peer.Transport that supports custom DialOptions instead of using the
 // grpc.Transport as a peer.Transport.
 func (t *Transport) RetainPeer(pid peer.Identifier, ps peer.Subscriber) (peer.Peer, error) {
-	return t.retainPeer(pid, emptyDialOpts, ps)
+	return t.retainPeer(pid, emptyDialOpts, nil, ps)
 }
 
-func (t *Transport) retainPeer(pid peer.Identifier, options *dialOptions, ps peer.Subscriber) (peer.Peer, error) {
+func (t *Transport) retainPeer(
+	pid peer.Identifier,
+	options *dialOptions,
+	connectionScope *connectionScope,
+	ps peer.Subscriber,
+) (peer.Peer, error) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 	address := pid.Identifier()
-	key := t.peerKey(address, ps)
+	key := peerKey{address: address, connectionScope: connectionScope}
 	p, ok := t.peers[key]
 	if !ok {
 		var err error
@@ -157,26 +160,24 @@ func (t *Transport) retainPeer(pid peer.Identifier, options *dialOptions, ps pee
 	return p, nil
 }
 
-// peerKey builds the map key for a peer. When ConnectionPerOutbound is set, the
-// subscribing outbound is part of the key so each outbound dialing the same
-// address gets its own peer (and its own connection / pool).
-func (t *Transport) peerKey(address string, ps peer.Subscriber) peerKey {
-	if t.options.connectionPerOutbound {
-		return peerKey{address: address, subscriber: ps}
-	}
-	return peerKey{address: address}
-}
-
 // ReleasePeer releases the peer.
 //
 // Deprecated: use grpcTransport.NewDialer(...grpc.DialOption) to create a
 // peer.Transport that supports custom DialOptions instead of using the
 // grpc.Transport as a peer.Transport.
 func (t *Transport) ReleasePeer(pid peer.Identifier, ps peer.Subscriber) error {
+	return t.releasePeer(pid, nil, ps)
+}
+
+func (t *Transport) releasePeer(
+	pid peer.Identifier,
+	connectionScope *connectionScope,
+	ps peer.Subscriber,
+) error {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 	address := pid.Identifier()
-	key := t.peerKey(address, ps)
+	key := peerKey{address: address, connectionScope: connectionScope}
 	p, ok := t.peers[key]
 	if !ok {
 		return peer.ErrTransportHasNoReferenceToPeer{

--- a/transport/grpc/transport_test.go
+++ b/transport/grpc/transport_test.go
@@ -202,7 +202,7 @@ func TestPeerChurnNoDuplicateMetricRegistration(t *testing.T) {
 	_, err = transport.RetainPeer(testIdentifier{address}, sub)
 	require.NoError(t, err)
 
-	// Release drops subscriber count to 0, deleting the peer from addressToPeer.
+	// Release drops subscriber count to 0, deleting the peer from the peers map.
 	require.NoError(t, transport.ReleasePeer(testIdentifier{address}, sub))
 
 	// Second retain: peer object is recreated for the same address. With the
@@ -253,7 +253,7 @@ func TestMultiSubscriberPeerChurnNoDuplicateMetricRegistration(t *testing.T) {
 	// sub1 releases: subscriber count drops to 1, peer stays alive.
 	require.NoError(t, transport.ReleasePeer(testIdentifier{address}, sub1))
 
-	// sub2 releases: subscriber count drops to 0, peer deleted from addressToPeer.
+	// sub2 releases: subscriber count drops to 0, peer deleted from the peers map.
 	require.NoError(t, transport.ReleasePeer(testIdentifier{address}, sub2))
 
 	// Re-retain: same address comes back (e.g. health-check recovery).

--- a/transport/grpc/transport_test.go
+++ b/transport/grpc/transport_test.go
@@ -61,7 +61,7 @@ func TestRetainReleasePeerSuccess(t *testing.T) {
 
 	peer, err := transport.RetainPeer(testIdentifier{address}, peerSubscriber)
 	assert.NoError(t, err)
-	assert.Equal(t, peer, transport.addressToPeer[address])
+	assert.Equal(t, peer, transport.peers[peerKey{address: address}])
 	assert.NoError(t, transport.ReleasePeer(testIdentifier{address}, peerSubscriber))
 }
 
@@ -278,10 +278,114 @@ type namedPeerSubscriber struct{ name string }
 
 func (namedPeerSubscriber) NotifyStatusChanged(peer.Identifier) {}
 
+// idSubscriber is a comparable subscriber with a distinct identity, used to
+// model distinct outbounds in tests.
+type idSubscriber struct{ id int }
+
+func (idSubscriber) NotifyStatusChanged(peer.Identifier) {}
+
 type testIdentifier struct {
 	id string
 }
 
 func (i testIdentifier) Identifier() string {
 	return i.id
+}
+
+// countingListener counts accepted connections and signals each on acceptedC.
+type countingListener struct {
+	net.Listener
+	acceptedC chan struct{}
+}
+
+func (l *countingListener) Accept() (net.Conn, error) {
+	c, err := l.Listener.Accept()
+	if err == nil {
+		l.acceptedC <- struct{}{}
+	}
+	return c, err
+}
+
+func waitAccepts(t *testing.T, ch <-chan struct{}, n int) {
+	t.Helper()
+	timeout := time.After(5 * time.Second)
+	for range n {
+		select {
+		case <-ch:
+		case <-timeout:
+			t.Fatalf("timed out waiting for %d connection(s)", n)
+		}
+	}
+}
+
+// TestRetainPeerConnectionPerOutbound verifies that, with ConnectionPerOutbound,
+// distinct outbounds (subscribers) dialing the same address each get their own
+// peer and connection, while reusing the same subscriber dedups.
+func TestRetainPeerConnectionPerOutbound(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	cl := &countingListener{Listener: listener, acceptedC: make(chan struct{}, 8)}
+
+	grpcServer := grpc.NewServer()
+	go grpcServer.Serve(cl)
+	defer grpcServer.Stop()
+
+	address := listener.Addr().String()
+
+	transport := NewTransport(ConnectionPerOutbound())
+	require.NoError(t, transport.Start())
+	defer func() { assert.NoError(t, transport.Stop()) }()
+
+	id := testIdentifier{address}
+	// Distinct subscribers model distinct outbounds. Use a type with identity:
+	// pointers to the zero-size testPeerSubscriber can compare equal.
+	sub1, sub2 := idSubscriber{1}, idSubscriber{2}
+
+	p1, err := transport.RetainPeer(id, sub1)
+	require.NoError(t, err)
+	p2, err := transport.RetainPeer(id, sub2)
+	require.NoError(t, err)
+
+	// Two outbounds to the same address get two peers and two connections.
+	assert.NotSame(t, p1, p2)
+	assert.Len(t, transport.peers, 2)
+	waitAccepts(t, cl.acceptedC, 2)
+
+	// Reusing the same subscriber dedups: no new peer, no new connection.
+	p1Again, err := transport.RetainPeer(id, sub1)
+	require.NoError(t, err)
+	assert.Same(t, p1, p1Again)
+	assert.Len(t, transport.peers, 2)
+
+	// Releasing one outbound leaves the other's connection intact.
+	require.NoError(t, transport.ReleasePeer(id, sub1))
+	assert.Len(t, transport.peers, 1)
+}
+
+// TestRetainPeerSharedByDefault verifies that without ConnectionPerOutbound,
+// outbounds dialing the same address share a single peer and connection.
+func TestRetainPeerSharedByDefault(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	grpcServer := grpc.NewServer()
+	go grpcServer.Serve(listener)
+	defer grpcServer.Stop()
+
+	address := listener.Addr().String()
+
+	transport := NewTransport()
+	require.NoError(t, transport.Start())
+	defer func() { assert.NoError(t, transport.Stop()) }()
+
+	id := testIdentifier{address}
+	sub1, sub2 := idSubscriber{1}, idSubscriber{2}
+
+	p1, err := transport.RetainPeer(id, sub1)
+	require.NoError(t, err)
+	p2, err := transport.RetainPeer(id, sub2)
+	require.NoError(t, err)
+
+	assert.Same(t, p1, p2)
+	assert.Len(t, transport.peers, 1)
 }

--- a/transport/grpc/transport_test.go
+++ b/transport/grpc/transport_test.go
@@ -330,10 +330,10 @@ func startTestServer(tb testing.TB) string {
 	return listener.Addr().String()
 }
 
-// TestRetainPeerConnectionPerOutbound verifies that, with ConnectionPerOutbound,
-// distinct outbounds (subscribers) dialing the same address each get their own
-// peer and connection, while reusing the same subscriber dedups.
-func TestRetainPeerConnectionPerOutbound(t *testing.T) {
+// TestIsolatedDialersDoNotSharePeer verifies that isolated dialers get distinct
+// peers and connections, while subscribers using the same dialer continue to
+// share a peer.
+func TestIsolatedDialersDoNotSharePeer(t *testing.T) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	cl := &countingListener{Listener: listener, acceptedC: make(chan struct{}, 8)}
@@ -344,39 +344,46 @@ func TestRetainPeerConnectionPerOutbound(t *testing.T) {
 
 	address := listener.Addr().String()
 
-	transport := NewTransport(ConnectionPerOutbound())
+	transport := NewTransport()
 	require.NoError(t, transport.Start())
 	defer func() { assert.NoError(t, transport.Stop()) }()
 
 	id := testIdentifier{address}
-	// Distinct subscribers model distinct outbounds. Use a type with identity:
-	// pointers to the zero-size testPeerSubscriber can compare equal.
-	sub1, sub2 := idSubscriber{1}, idSubscriber{2}
+	baseDialer := transport.NewDialer()
+	dialer1 := baseDialer.WithConnectionIsolation()
+	dialer2 := baseDialer.WithConnectionIsolation()
+	sub1, sub2, sub3 := idSubscriber{1}, idSubscriber{2}, idSubscriber{3}
 
-	p1, err := transport.RetainPeer(id, sub1)
+	p1, err := dialer1.RetainPeer(id, sub1)
 	require.NoError(t, err)
-	p2, err := transport.RetainPeer(id, sub2)
+	p1Again, err := dialer1.RetainPeer(id, sub2)
 	require.NoError(t, err)
 
-	// Two outbounds to the same address get two peers and two connections.
+	// Request-scoped subscribers within one outbound share its peer. This is
+	// required by the direct chooser, which creates a subscriber per request.
+	assert.Same(t, p1, p1Again)
+	assert.Len(t, transport.peers, 1)
+
+	p2, err := dialer2.RetainPeer(id, sub3)
+	require.NoError(t, err)
+
+	// Two isolated dialers to the same address get separate connections.
 	assert.NotSame(t, p1, p2)
 	assert.Len(t, transport.peers, 2)
 	waitAccepts(t, cl.acceptedC, 2)
 
-	// Reusing the same subscriber dedups: no new peer, no new connection.
-	p1Again, err := transport.RetainPeer(id, sub1)
-	require.NoError(t, err)
-	assert.Same(t, p1, p1Again)
+	// Releasing one subscriber leaves the other subscriber and dialer's
+	// connection intact.
+	require.NoError(t, dialer1.ReleasePeer(id, sub1))
 	assert.Len(t, transport.peers, 2)
 
-	// Releasing one outbound leaves the other's connection intact.
-	require.NoError(t, transport.ReleasePeer(id, sub1))
+	require.NoError(t, dialer1.ReleasePeer(id, sub2))
 	assert.Len(t, transport.peers, 1)
 }
 
-// TestRetainPeerSharedByDefault verifies that without ConnectionPerOutbound,
-// outbounds dialing the same address share a single peer and connection.
-func TestRetainPeerSharedByDefault(t *testing.T) {
+// TestDialersSharePeerByDefault verifies that ordinary dialers retain the
+// existing address-based peer sharing behavior.
+func TestDialersSharePeerByDefault(t *testing.T) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
@@ -391,27 +398,27 @@ func TestRetainPeerSharedByDefault(t *testing.T) {
 	defer func() { assert.NoError(t, transport.Stop()) }()
 
 	id := testIdentifier{address}
+	dialer1 := transport.NewDialer()
+	dialer2 := transport.NewDialer()
 	sub1, sub2 := idSubscriber{1}, idSubscriber{2}
 
-	p1, err := transport.RetainPeer(id, sub1)
+	p1, err := dialer1.RetainPeer(id, sub1)
 	require.NoError(t, err)
-	p2, err := transport.RetainPeer(id, sub2)
+	p2, err := dialer2.RetainPeer(id, sub2)
 	require.NoError(t, err)
 
 	assert.Same(t, p1, p2)
 	assert.Len(t, transport.peers, 1)
 }
 
-// TestRetainReleasePeerConcurrent hammers RetainPeer/ReleasePeer from many
-// goroutines with ConnectionPerOutbound enabled. Each goroutine uses a distinct
-// subscriber, so each retains and releases its own peer independently — this
-// exercises concurrent creation/deletion of distinct peers against the shared
-// t.peers map and the transport-wide shared metrics reporter. Run with -race to
-// detect data races on that shared state.
-func TestRetainReleasePeerConcurrent(t *testing.T) {
+// TestIsolatedDialersConcurrent hammers RetainPeer/ReleasePeer from many
+// independently isolated dialers. This exercises concurrent creation/deletion
+// of distinct peers against the shared map and transport-wide metrics reporter.
+// Run with -race to detect data races on that shared state.
+func TestIsolatedDialersConcurrent(t *testing.T) {
 	address := startTestServer(t)
 
-	transport := NewTransport(ConnectionPerOutbound())
+	transport := NewTransport()
 	require.NoError(t, transport.Start())
 	defer func() { assert.NoError(t, transport.Stop()) }()
 
@@ -426,77 +433,76 @@ func TestRetainReleasePeerConcurrent(t *testing.T) {
 		wg.Add(1)
 		go func(g int) {
 			defer wg.Done()
-			// Distinct subscriber per goroutine: refcounting is by subscriber
-			// set (not a counter), so a shared subscriber across goroutines that
-			// independently release would race at the API level. Keeping each
-			// goroutine's subscriber unique keeps retain/release well-defined.
+			dialer := transport.NewDialer().WithConnectionIsolation()
 			sub := idSubscriber{g}
 			for range iterations {
-				if _, err := transport.RetainPeer(id, sub); !assert.NoError(t, err) {
+				if _, err := dialer.RetainPeer(id, sub); !assert.NoError(t, err) {
 					return
 				}
-				assert.NoError(t, transport.ReleasePeer(id, sub))
+				assert.NoError(t, dialer.ReleasePeer(id, sub))
 			}
 		}(g)
 	}
 	wg.Wait()
 }
 
-// benchRetainPeer measures the retain hot path (lock + peerKey + map lookup +
-// Subscribe) on an already-created peer, isolating the cost of the peerKey change
-// from connection dialing. With ConnectionPerOutbound the map key carries a
-// non-nil subscriber interface; without it the subscriber is the zero value.
-func benchRetainPeer(b *testing.B, opts ...TransportOption) {
+// benchRetainPeer measures the retain hot path on an already-created peer,
+// isolating the cost of a scoped peer key from connection dialing.
+func benchRetainPeer(b *testing.B, isolated bool) {
 	address := startTestServer(b)
 
-	transport := NewTransport(opts...)
+	transport := NewTransport()
 	require.NoError(b, transport.Start())
 	defer func() { assert.NoError(b, transport.Stop()) }()
 
 	id := testIdentifier{address}
 	sub := idSubscriber{1}
+	dialer := transport.NewDialer()
+	if isolated {
+		dialer = dialer.WithConnectionIsolation()
+	}
 
 	// Warm up: create the peer once so the loop measures cache hits only.
-	_, err := transport.RetainPeer(id, sub)
+	_, err := dialer.RetainPeer(id, sub)
 	require.NoError(b, err)
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	for range b.N {
-		if _, err := transport.RetainPeer(id, sub); err != nil {
+		if _, err := dialer.RetainPeer(id, sub); err != nil {
 			b.Fatal(err)
 		}
 	}
 }
 
 func BenchmarkRetainPeerShared(b *testing.B) {
-	benchRetainPeer(b)
+	benchRetainPeer(b, false)
 }
 
-func BenchmarkRetainPeerConnectionPerOutbound(b *testing.B) {
-	benchRetainPeer(b, ConnectionPerOutbound())
+func BenchmarkRetainPeerIsolated(b *testing.B) {
+	benchRetainPeer(b, true)
 }
 
 // BenchmarkRetainPeerParallel measures the retain hot path under lock contention
-// with ConnectionPerOutbound enabled: all goroutines retain the same peer (a
-// cache hit), contending on t.lock and hashing the interface-bearing peerKey.
+// with connection isolation enabled: all goroutines retain the same peer.
 func BenchmarkRetainPeerParallel(b *testing.B) {
 	address := startTestServer(b)
 
-	transport := NewTransport(ConnectionPerOutbound())
+	transport := NewTransport()
 	require.NoError(b, transport.Start())
 	defer func() { assert.NoError(b, transport.Stop()) }()
 
 	id := testIdentifier{address}
 	sub := idSubscriber{1}
-	_, err := transport.RetainPeer(id, sub)
+	dialer := transport.NewDialer().WithConnectionIsolation()
+	_, err := dialer.RetainPeer(id, sub)
 	require.NoError(b, err)
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			if _, err := transport.RetainPeer(id, sub); err != nil {
+			if _, err := dialer.RetainPeer(id, sub); err != nil {
 				b.Error(err)
 				return
 			}

--- a/transport/grpc/transport_test.go
+++ b/transport/grpc/transport_test.go
@@ -318,6 +318,18 @@ func waitAccepts(t *testing.T, ch <-chan struct{}, n int) {
 	}
 }
 
+// startTestServer starts a gRPC server on an ephemeral local port and returns
+// its address. The server is stopped via tb.Cleanup.
+func startTestServer(tb testing.TB) string {
+	tb.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(tb, err)
+	grpcServer := grpc.NewServer()
+	go grpcServer.Serve(listener)
+	tb.Cleanup(grpcServer.Stop)
+	return listener.Addr().String()
+}
+
 // TestRetainPeerConnectionPerOutbound verifies that, with ConnectionPerOutbound,
 // distinct outbounds (subscribers) dialing the same address each get their own
 // peer and connection, while reusing the same subscriber dedups.
@@ -388,4 +400,106 @@ func TestRetainPeerSharedByDefault(t *testing.T) {
 
 	assert.Same(t, p1, p2)
 	assert.Len(t, transport.peers, 1)
+}
+
+// TestRetainReleasePeerConcurrent hammers RetainPeer/ReleasePeer from many
+// goroutines with ConnectionPerOutbound enabled. Each goroutine uses a distinct
+// subscriber, so each retains and releases its own peer independently — this
+// exercises concurrent creation/deletion of distinct peers against the shared
+// t.peers map and the transport-wide shared metrics reporter. Run with -race to
+// detect data races on that shared state.
+func TestRetainReleasePeerConcurrent(t *testing.T) {
+	address := startTestServer(t)
+
+	transport := NewTransport(ConnectionPerOutbound())
+	require.NoError(t, transport.Start())
+	defer func() { assert.NoError(t, transport.Stop()) }()
+
+	id := testIdentifier{address}
+
+	const (
+		goroutines = 16
+		iterations = 50
+	)
+	var wg sync.WaitGroup
+	for g := range goroutines {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			// Distinct subscriber per goroutine: refcounting is by subscriber
+			// set (not a counter), so a shared subscriber across goroutines that
+			// independently release would race at the API level. Keeping each
+			// goroutine's subscriber unique keeps retain/release well-defined.
+			sub := idSubscriber{g}
+			for range iterations {
+				if _, err := transport.RetainPeer(id, sub); !assert.NoError(t, err) {
+					return
+				}
+				assert.NoError(t, transport.ReleasePeer(id, sub))
+			}
+		}(g)
+	}
+	wg.Wait()
+}
+
+// benchRetainPeer measures the retain hot path (lock + peerKey + map lookup +
+// Subscribe) on an already-created peer, isolating the cost of the peerKey change
+// from connection dialing. With ConnectionPerOutbound the map key carries a
+// non-nil subscriber interface; without it the subscriber is the zero value.
+func benchRetainPeer(b *testing.B, opts ...TransportOption) {
+	address := startTestServer(b)
+
+	transport := NewTransport(opts...)
+	require.NoError(b, transport.Start())
+	defer func() { assert.NoError(b, transport.Stop()) }()
+
+	id := testIdentifier{address}
+	sub := idSubscriber{1}
+
+	// Warm up: create the peer once so the loop measures cache hits only.
+	_, err := transport.RetainPeer(id, sub)
+	require.NoError(b, err)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if _, err := transport.RetainPeer(id, sub); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkRetainPeerShared(b *testing.B) {
+	benchRetainPeer(b)
+}
+
+func BenchmarkRetainPeerConnectionPerOutbound(b *testing.B) {
+	benchRetainPeer(b, ConnectionPerOutbound())
+}
+
+// BenchmarkRetainPeerParallel measures the retain hot path under lock contention
+// with ConnectionPerOutbound enabled: all goroutines retain the same peer (a
+// cache hit), contending on t.lock and hashing the interface-bearing peerKey.
+func BenchmarkRetainPeerParallel(b *testing.B) {
+	address := startTestServer(b)
+
+	transport := NewTransport(ConnectionPerOutbound())
+	require.NoError(b, transport.Start())
+	defer func() { assert.NoError(b, transport.Stop()) }()
+
+	id := testIdentifier{address}
+	sub := idSubscriber{1}
+	_, err := transport.RetainPeer(id, sub)
+	require.NoError(b, err)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if _, err := transport.RetainPeer(id, sub); err != nil {
+				b.Error(err)
+				return
+			}
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Adds `(*grpc.Dialer).WithConnectionIsolation()`, allowing selected logical
outbounds to use a dedicated peer—and therefore a dedicated connection or
connection pool—even when other outbounds dial the same address.

## Motivation

gRPC outbounds dialing the same address currently deduplicate to one shared
peer and connection pool. Some callers need connection-level isolation so that
HTTP/2 head-of-line blocking, flow control, and stream budgets are not shared
across otherwise independent outbounds.

Connection isolation should be explicit and targeted rather than enabled for
every outbound on a transport.

## Approach

The transport peer map is keyed by `{address, connectionScope}`:

- Ordinary dialers have a nil scope and retain the existing address-only
  sharing behavior.
- `WithConnectionIsolation` returns a dialer with a unique, stable scope.
- Subscribers using the same isolated dialer still share its peer.
- Separate isolated dialers get separate peers and connections for the same
  address.

The scope belongs to the dialer rather than the subscriber. This preserves the
direct chooser's existing behavior because its request-scoped subscribers still
use one stable dialer scope.

Peer identity and dial address remain unchanged; `Identifier()` and
`HostPort()` continue to report the real address.

## Relationship to the connection pool

Each isolated peer scales its own dynamic connection pool. Connection-pool
metrics remain aggregated at the transport level, so additional isolated peers
do not increase metric cardinality or duplicate metric registration.

## Test Plan

- `go test ./transport/grpc ./peer/direct -race -count=1`
- `go vet ./transport/grpc ./peer/direct`
- Verify ordinary dialers continue sharing peers by address.
- Verify isolated dialers receive distinct peers and connections.
- Verify overlapping direct-chooser requests through one isolated dialer reuse
  the same peer.

## Revert Plan

Revert this PR and remove callers' connection-isolation opt-ins.
