### PR TITLE
Move OpenTracing span tags to StartSpan options for correct OTel bridge mapping

### DIFF
--- a/api/transport/propagation.go
+++ b/api/transport/propagation.go
@@ -53,6 +53,8 @@ func (c *CreateOpenTracingSpan) Do(
 		"rpc.service":   req.Service,
 		"rpc.encoding":  req.Encoding,
 		"rpc.transport": c.TransportName,
+		"span.kind":            ext.SpanKindRPCClientEnum,
+		string(ext.PeerService): req.Service,
 	}
 	for k, v := range c.ExtraTags {
 		tags[k] = v
@@ -63,8 +65,6 @@ func (c *CreateOpenTracingSpan) Do(
 		opentracing.ChildOf(parent),
 		tags,
 	)
-	ext.PeerService.Set(span, req.Service)
-	ext.SpanKindRPCClient.Set(span)
 
 	ctx = opentracing.ContextWithSpan(ctx, span)
 	return ctx, span
@@ -91,6 +91,8 @@ func (e *ExtractOpenTracingSpan) Do(
 		"rpc.service":   req.Service,
 		"rpc.encoding":  req.Encoding,
 		"rpc.transport": e.TransportName,
+		"span.kind":            ext.SpanKindRPCServerEnum,
+		string(ext.PeerService): req.Caller,
 	}
 	for k, v := range e.ExtraTags {
 		tags[k] = v
@@ -103,8 +105,6 @@ func (e *ExtractOpenTracingSpan) Do(
 		// this implies ChildOf
 		ext.RPCServerOption(e.ParentSpanContext),
 	)
-	ext.PeerService.Set(span, req.Caller)
-	ext.SpanKindRPCServer.Set(span)
 
 	ctx = opentracing.ContextWithSpan(ctx, span)
 	return ctx, span

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -473,6 +473,9 @@ func (o *Outbound) withOpentracingSpan(ctx context.Context, req *http.Request, t
 		"rpc.service":   treq.Service,
 		"rpc.encoding":  treq.Encoding,
 		"rpc.transport": "http",
+		"span.kind":            ext.SpanKindRPCClientEnum,
+		string(ext.PeerService): treq.Service,
+		string(ext.HTTPUrl):     req.URL.String(),
 	}
 	for k, v := range yarpc.OpentracingTags {
 		tags[k] = v
@@ -483,9 +486,6 @@ func (o *Outbound) withOpentracingSpan(ctx context.Context, req *http.Request, t
 		opentracing.ChildOf(parent),
 		tags,
 	)
-	ext.PeerService.Set(span, treq.Service)
-	ext.SpanKindRPCClient.Set(span)
-	ext.HTTPUrl.Set(span, req.URL.String())
 	ctx = opentracing.ContextWithSpan(ctx, span)
 
 	err := tracer.Inject(


### PR DESCRIPTION
Move span.kind, peer.service, and http.url tags from post-creation Set() calls into the Tags map passed to StartSpan. This ensures the tracer sees all tags at span creation time, which is required for correct SpanKind mapping through the OTel-OpenTracing bridge and for tag-aware sampling.

RELEASE NOTES:
Move some OpenTracing tags into StartSpan