### PR TITLE
http: default unannotated Thrift application errors to CodeUnknown

### DIFF
--- a/encoding/thrift/observability_test.go
+++ b/encoding/thrift/observability_test.go
@@ -128,7 +128,11 @@ func TestThriftExceptionObservability(t *testing.T) {
 			})
 
 			t.Run("metrics", func(t *testing.T) {
-				wantCounters := []testutils.CounterAssertion{
+				// The server (inbound) always classifies an unannotated Thrift
+				// exception as a caller failure: the handler flags the
+				// application-error bit but carries no YARPC code, so
+				// observability falls back to caller_failures.
+				wantInbound := []testutils.CounterAssertion{
 					{
 						Name: "caller_failures",
 						Tags: map[string]string{
@@ -142,7 +146,36 @@ func TestThriftExceptionObservability(t *testing.T) {
 					{Name: "successes"},
 				}
 
-				testutils.AssertClientAndServerCounters(t, wantCounters, clientMetricsRoot, serverMetricsRoot)
+				// The client (outbound) classification depends on the transport. Over
+				// HTTP the handler now emits rpc-application-error-code=unknown for
+				// unannotated exceptions so downstream relays can classify the
+				// response as a failure; the client reads that code back and
+				// attributes it to a server fault. TChannel has no equivalent
+				// on-the-wire code, so it still falls back to a caller failure,
+				// matching the inbound counters.
+				wantOutbound := wantInbound
+				if trans == http.TransportName {
+					wantOutbound = []testutils.CounterAssertion{
+						{Name: "calls", Value: 1},
+						{Name: "panics"},
+						{
+							Name: "server_failures",
+							Tags: map[string]string{
+								"error":      "unknown",
+								"error_name": "ExceptionWithoutCode",
+							},
+							Value: 1,
+						},
+						{Name: "successes"},
+					}
+				}
+
+				t.Run("inbound", func(t *testing.T) {
+					testutils.AssertCounters(t, wantInbound, serverMetricsRoot.Snapshot().Counters)
+				})
+				t.Run("outbound", func(t *testing.T) {
+					testutils.AssertCounters(t, wantOutbound, clientMetricsRoot.Snapshot().Counters)
+				})
 			})
 		})
 	}

--- a/transport/http/handler.go
+++ b/transport/http/handler.go
@@ -333,8 +333,17 @@ func (rw *responseWriter) SetApplicationErrorMeta(meta *transport.ApplicationErr
 		return
 	}
 	rw.appErrorMeta = meta
-	if meta.Code != nil {
+	switch {
+	case meta.Code != nil:
 		rw.w.Header().Set(_applicationErrorCodeHeader, strconv.Itoa(int(*meta.Code)))
+	case rw.isApplicationError:
+		// Application errors without an explicit code (e.g. unannotated Thrift
+		// exceptions) still need an on-the-wire failure signal. TChannel conveys
+		// this via the application-error frame bit; HTTP has no equivalent, so
+		// downstream relays rely on the Rpc-Application-Error-Code header to
+		// classify success vs. failure. Default to CodeUnknown so unannotated
+		// errors are still classified as failures.
+		rw.w.Header().Set(_applicationErrorCodeHeader, strconv.Itoa(int(yarpcerrors.CodeUnknown)))
 	}
 	if meta.Name != "" {
 		rw.w.Header().Set(_applicationErrorNameHeader, meta.Name)

--- a/transport/http/handler_test.go
+++ b/transport/http/handler_test.go
@@ -495,6 +495,44 @@ func TestResponseWriter(t *testing.T) {
 	assert.Equal(t, strconv.Itoa(int(appErrCode)), recorder.Header().Get(_applicationErrorCodeHeader))
 }
 
+func TestResponseWriterUnannotatedApplicationError(t *testing.T) {
+	// Thrift exceptions without an rpc.code annotation reach the transport as
+	// an application error whose meta has a nil Code. HTTP must still emit the
+	// Rpc-Application-Error-Code header so downstream relays classify the call
+	// as a failure, matching TChannel's frame-bit behavior. Defaults to
+	// CodeUnknown.
+	recorder := httptest.NewRecorder()
+	writer := newResponseWriter(recorder)
+
+	writer.SetApplicationError()
+	writer.SetApplicationErrorMeta(&transport.ApplicationErrorMeta{
+		Name:    "UnannotatedException",
+		Details: "boom",
+		Code:    nil,
+	})
+	writer.Close(http.StatusOK)
+
+	assert.Equal(t, ApplicationErrorStatus, recorder.Header().Get(ApplicationStatusHeader))
+	assert.Equal(t,
+		strconv.Itoa(int(yarpcerrors.CodeUnknown)),
+		recorder.Header().Get(_applicationErrorCodeHeader),
+		"unannotated application errors must default to CodeUnknown")
+	assert.Equal(t, "UnannotatedException", recorder.Header().Get(_applicationErrorNameHeader))
+}
+
+func TestResponseWriterNoApplicationErrorNoCodeHeader(t *testing.T) {
+	// A meta with a nil Code that is not part of an application error must not
+	// spuriously emit an error-code header on an otherwise successful response.
+	recorder := httptest.NewRecorder()
+	writer := newResponseWriter(recorder)
+
+	writer.SetApplicationErrorMeta(&transport.ApplicationErrorMeta{Name: "name"})
+	writer.Close(http.StatusOK)
+
+	assert.Equal(t, ApplicationSuccessStatus, recorder.Header().Get(ApplicationStatusHeader))
+	assert.Empty(t, recorder.Header().Get(_applicationErrorCodeHeader))
+}
+
 func TestTruncatedHeader(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
The HTTP inbound response writer only emitted the Rpc-Application-Error-Code header when the application error carried an explicit code (i.e. a Thrift exception annotated with rpc.code). Thrift exceptions without an rpc.code annotation reached the wire as HTTP 200 + Rpc-Status: error but with no error-code header.

TChannel conveys application-error success/failure out-of-band via the application-error frame bit, independent of any error-code header. HTTP has no equivalent frame-level signal, so relays such as Muttley classify success vs. failure off the presence of the Rpc-Application-Error-Code header. As a result, unannotated Thrift exceptions over HTTP/2 were counted as successes, diverging from TChannel for the same endpoint.

Default unannotated application errors to CodeUnknown so they carry the error-code header and are classified as failures consistently across transports. The default is applied only when an application error was set, so successful responses are unaffected.
 
RELEASE NOTES:
http: default unannotated Thrift application errors to CodeUnknown