### PR TITLE
[HTTP2] Test: GOAWAY frame handling

### DIFF
--- a/transport/http/goaway_test.go
+++ b/transport/http/goaway_test.go
@@ -233,8 +233,6 @@ func (someCustomMiddleware) Call(ctx context.Context, req *transport.Request, ou
 	return out.Call(ctx, req)
 }
 
-// --- ----- ----- ---
-
 var (
 	_ io.Reader                = someCustomBody{}
 	_ middleware.UnaryOutbound = someCustomMiddleware{}

--- a/transport/http/goaway_test.go
+++ b/transport/http/goaway_test.go
@@ -1,0 +1,223 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package http
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"strings"
+	"go.uber.org/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/api/middleware"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/encoding/raw"
+	"go.uber.org/yarpc/internal/testtime"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/hpack"
+)
+
+// --- HTTP/2 server: immediately send GOAWAY frame ---
+
+// h2cGoAwayServer is a minimal cleartext HTTP/2 server that sends a GOAWAY on
+// the first request and answers subsequent requests with 200. This reproduces
+// the net/http2 internal replay path that requires http.Request.GetBody to be
+// set.
+type h2cGoAwayServer struct {
+	listener net.Listener
+	requests atomic.Int32
+}
+
+func newH2CGoAwayServer(t *testing.T) *h2cGoAwayServer {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err, "failed to listen for the h2c server")
+
+	s := &h2cGoAwayServer{listener: ln}
+	go s.serve()
+	t.Cleanup(func() { _ = ln.Close() })
+	return s
+}
+
+func (s *h2cGoAwayServer) addr() string { return s.listener.Addr().String() }
+
+func (s *h2cGoAwayServer) serve() {
+	for {
+		conn, err := s.listener.Accept()
+		if err != nil {
+			return
+		}
+		go s.handleConn(conn)
+	}
+}
+
+func (s *h2cGoAwayServer) handleConn(conn net.Conn) {
+	defer func() { _ = conn.Close() }()
+
+	preface := make([]byte, len(http2.ClientPreface))
+	if _, err := io.ReadFull(conn, preface); err != nil {
+		return
+	}
+	framer := http2.NewFramer(conn, conn)
+	if err := framer.WriteSettings(); err != nil {
+		return
+	}
+
+	streamID, ok := awaitFullRequest(framer)
+	if !ok {
+		return
+	}
+
+	// First request ever: send GOAWAY with LastStreamID=0 so net/http2 considers
+	// stream 1 "not processed" and replays it on a new connection.
+	if s.requests.Add(1) == 1 {
+		_ = framer.WriteGoAway(0, http2.ErrCodeNo, nil)
+		return
+	}
+	_ = writeH2Status(framer, streamID, "200")
+}
+
+// awaitFullRequest reads frames until the client finishes sending a request
+// (END_STREAM), acking SETTINGS along the way.
+func awaitFullRequest(framer *http2.Framer) (streamID uint32, ok bool) {
+	for {
+		frame, err := framer.ReadFrame()
+		if err != nil {
+			return 0, false
+		}
+		switch f := frame.(type) {
+		case *http2.SettingsFrame:
+			if !f.IsAck() {
+				_ = framer.WriteSettingsAck()
+			}
+		case *http2.HeadersFrame:
+			if f.StreamEnded() {
+				return f.StreamID, true
+			}
+		case *http2.DataFrame:
+			if f.StreamEnded() {
+				return f.StreamID, true
+			}
+		}
+	}
+}
+
+// writeH2Status writes a HEADERS frame with :status and END_STREAM.
+func writeH2Status(framer *http2.Framer, streamID uint32, status string) error {
+	var buf bytes.Buffer
+	if err := hpack.NewEncoder(&buf).WriteField(hpack.HeaderField{Name: ":status", Value: status}); err != nil {
+		return err
+	}
+	return framer.WriteHeaders(http2.HeadersFrameParam{
+		StreamID:      streamID,
+		BlockFragment: buf.Bytes(),
+		EndStream:     true,
+		EndHeaders:    true,
+	})
+}
+
+// --- YARPC outbound middleware manipulating transport.Request.Body ---
+
+// someCustomBody represents a custom transport.Request.Body field type that Go net/http does not match when automatically providing a http.Request.GetBody function.
+type someCustomBody struct{ reader io.Reader }
+
+func (b someCustomBody) Read(p []byte) (int, error) { return b.reader.Read(p) }
+
+// useCustomBodyMiddleware is an outbound middleware that manipulates transport.Request.Body to be of type someCustomBody.
+type useCustomBodyMiddleware struct{}
+
+func (useCustomBodyMiddleware) Call(ctx context.Context, req *transport.Request, out transport.UnaryOutbound) (*transport.Response, error) {
+	req.Body = someCustomBody{reader: req.Body}
+	return out.Call(ctx, req)
+}
+
+// --- ----- ----- ---
+
+// TestHTTP2GoAwayReplay is a test suite covering HTTP/2 transport implementation w.r.t. GOAWAY frames.
+func TestHTTP2GoAwayReplay(t *testing.T) {
+	t.Run("no middleware - body type preserved - replay succeeds", func(t *testing.T) {
+		server := newH2CGoAwayServer(t)
+
+		httpTransport := NewTransport()
+		require.NoError(t, httpTransport.Start(), "failed to start http transport")
+		t.Cleanup(func() { assert.NoError(t, httpTransport.Stop()) })
+
+		out := httpTransport.NewSingleOutbound("http://"+server.addr(), UseHTTP2())
+		require.NoError(t, out.Start(), "failed to start http2 outbound")
+		t.Cleanup(func() {
+			assert.NoError(t, out.Stop())
+			out.client.CloseIdleConnections()
+		})
+
+		ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
+		t.Cleanup(cancel)
+
+		// strings.NewReader is recognized by net/http, so GetBody is populated
+		// and net/http2 can replay the request after the GOAWAY.
+		res, err := out.Call(ctx, &transport.Request{
+			Caller:    "caller",
+			Service:   "service",
+			Encoding:  raw.Encoding,
+			Procedure: "hello",
+			Body:      strings.NewReader("world"),
+		})
+		require.NoError(t, err, "expected net/http2 to replay the request after GOAWAY when GetBody is set")
+		_ = res.Body.Close()
+	})
+
+	t.Run("middleware wraps body - non-rewindable type - replay fails", func(t *testing.T) {
+		server := newH2CGoAwayServer(t)
+
+		httpTransport := NewTransport()
+		require.NoError(t, httpTransport.Start(), "failed to start http transport")
+		t.Cleanup(func() { assert.NoError(t, httpTransport.Stop()) })
+
+		out := httpTransport.NewSingleOutbound("http://"+server.addr(), UseHTTP2())
+		require.NoError(t, out.Start(), "failed to start http2 outbound")
+		t.Cleanup(func() {
+			assert.NoError(t, out.Stop())
+			out.client.CloseIdleConnections()
+		})
+
+		outboundWithMiddleware := middleware.ApplyUnaryOutbound(out, useCustomBodyMiddleware{})
+
+		ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
+		t.Cleanup(cancel)
+
+		// The middleware wraps the body in someCustomBody, which net/http
+		// does not recognize. GetBody stays nil, so after the GOAWAY net/http2
+		// cannot replay the request and returns an error.
+		_, err := outboundWithMiddleware.Call(ctx, &transport.Request{
+			Caller:    "caller",
+			Service:   "service",
+			Encoding:  raw.Encoding,
+			Procedure: "hello",
+			Body:      strings.NewReader("world"),
+		})
+		require.Error(t, err, "expected replay to fail when middleware wraps the body in a non-rewindable type")
+		assert.Contains(t, err.Error(), "GetBody", "error should mention GetBody")
+	})
+}

--- a/transport/http/goaway_test.go
+++ b/transport/http/goaway_test.go
@@ -26,11 +26,11 @@ import (
 	"io"
 	"net"
 	"strings"
-	"go.uber.org/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 	"go.uber.org/yarpc/api/middleware"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/raw"
@@ -38,6 +38,83 @@ import (
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/hpack"
 )
+
+// TestHTTP2GoAwayReplay exercises HTTP/2 transport implementation w.r.t. GOAWAY frames.
+func TestHTTP2GoAwayReplay(t *testing.T) {
+	tests := []struct {
+		name    string
+		mw      middleware.UnaryOutbound
+		reqBody io.Reader
+		wantErr bool
+	}{
+		{
+			name:    "no-op middleware, valid Request.Body; relay occurs",
+			mw:      middleware.NopUnaryOutbound,
+			reqBody: getH2ValidBody(),
+			wantErr: false,
+		},
+		{
+			name:    "no-op middleware, invalid Request.Body; relay fails",
+			mw:      middleware.NopUnaryOutbound,
+			reqBody: getH2InvalidBody(),
+			wantErr: true,
+		},
+		{
+			name:    "custom middleware, valid Request.Body becomes invalid; replay fails",
+			mw:      someCustomMiddleware{},
+			reqBody: getH2ValidBody(),
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := newH2CGoAwayServer(t)
+
+			httpTransport := NewTransport()
+			require.NoError(t, httpTransport.Start(), "failed to start http transport")
+			t.Cleanup(func() { assert.NoError(t, httpTransport.Stop()) })
+
+			out := httpTransport.NewSingleOutbound("http://"+server.addr(), UseHTTP2())
+			require.NoError(t, out.Start(), "failed to start http2 outbound")
+			t.Cleanup(func() {
+				assert.NoError(t, out.Stop())
+				out.client.CloseIdleConnections()
+			})
+
+			outboundWithMiddleware := middleware.ApplyUnaryOutbound(out, tt.mw)
+
+			ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
+			t.Cleanup(cancel)
+
+			_, err := outboundWithMiddleware.Call(ctx, &transport.Request{
+				Caller:    "caller",
+				Service:   "service",
+				Encoding:  raw.Encoding,
+				Procedure: "some-procedure",
+				Body:      tt.reqBody,
+			})
+
+			if tt.wantErr {
+				require.Error(t, err, "expected replay to fail when GetBody is not set")
+				assert.Contains(t, err.Error(), "GetBody", "error should mention GetBody")
+				return
+			}
+			require.NoError(t, err, "expected replay to succeed when GetBody is set")
+		})
+	}
+}
+
+func getH2ValidBody() io.Reader {
+	// transport.Request.Body must be one of *bytes.Buffer, *bytes.Reader, or *strings.Reader.
+	return strings.NewReader("some-payload")
+}
+
+func getH2InvalidBody() io.Reader {
+	// Any other transport.Request.Body concrete type that does not allow automatic GetBody creation.
+	return &someCustomBody{reader: strings.NewReader("some-payload")}
+}
 
 // --- HTTP/2 server: immediately send GOAWAY frame ---
 
@@ -146,78 +223,19 @@ type someCustomBody struct{ reader io.Reader }
 
 func (b someCustomBody) Read(p []byte) (int, error) { return b.reader.Read(p) }
 
-// useCustomBodyMiddleware is an outbound middleware that manipulates transport.Request.Body to be of type someCustomBody.
-type useCustomBodyMiddleware struct{}
+// someCustomMiddleware is an outbound middleware that manipulates transport.Request.Body to be of type someCustomBody.
+type someCustomMiddleware struct{}
 
-func (useCustomBodyMiddleware) Call(ctx context.Context, req *transport.Request, out transport.UnaryOutbound) (*transport.Response, error) {
-	req.Body = someCustomBody{reader: req.Body}
+// Call implements the middleware.UnaryOutbound interface.
+// This mimics a middleware that manipulates transport.Request.Body into a type that does not let GetBody be automatically populated by net/http.
+func (someCustomMiddleware) Call(ctx context.Context, req *transport.Request, out transport.UnaryOutbound) (*transport.Response, error) {
+	req.Body = &someCustomBody{reader: req.Body}
 	return out.Call(ctx, req)
 }
 
 // --- ----- ----- ---
 
-// TestHTTP2GoAwayReplay is a test suite covering HTTP/2 transport implementation w.r.t. GOAWAY frames.
-func TestHTTP2GoAwayReplay(t *testing.T) {
-	t.Run("no middleware - body type preserved - replay succeeds", func(t *testing.T) {
-		server := newH2CGoAwayServer(t)
-
-		httpTransport := NewTransport()
-		require.NoError(t, httpTransport.Start(), "failed to start http transport")
-		t.Cleanup(func() { assert.NoError(t, httpTransport.Stop()) })
-
-		out := httpTransport.NewSingleOutbound("http://"+server.addr(), UseHTTP2())
-		require.NoError(t, out.Start(), "failed to start http2 outbound")
-		t.Cleanup(func() {
-			assert.NoError(t, out.Stop())
-			out.client.CloseIdleConnections()
-		})
-
-		ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
-		t.Cleanup(cancel)
-
-		// strings.NewReader is recognized by net/http, so GetBody is populated
-		// and net/http2 can replay the request after the GOAWAY.
-		res, err := out.Call(ctx, &transport.Request{
-			Caller:    "caller",
-			Service:   "service",
-			Encoding:  raw.Encoding,
-			Procedure: "hello",
-			Body:      strings.NewReader("world"),
-		})
-		require.NoError(t, err, "expected net/http2 to replay the request after GOAWAY when GetBody is set")
-		_ = res.Body.Close()
-	})
-
-	t.Run("middleware wraps body - non-rewindable type - replay fails", func(t *testing.T) {
-		server := newH2CGoAwayServer(t)
-
-		httpTransport := NewTransport()
-		require.NoError(t, httpTransport.Start(), "failed to start http transport")
-		t.Cleanup(func() { assert.NoError(t, httpTransport.Stop()) })
-
-		out := httpTransport.NewSingleOutbound("http://"+server.addr(), UseHTTP2())
-		require.NoError(t, out.Start(), "failed to start http2 outbound")
-		t.Cleanup(func() {
-			assert.NoError(t, out.Stop())
-			out.client.CloseIdleConnections()
-		})
-
-		outboundWithMiddleware := middleware.ApplyUnaryOutbound(out, useCustomBodyMiddleware{})
-
-		ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
-		t.Cleanup(cancel)
-
-		// The middleware wraps the body in someCustomBody, which net/http
-		// does not recognize. GetBody stays nil, so after the GOAWAY net/http2
-		// cannot replay the request and returns an error.
-		_, err := outboundWithMiddleware.Call(ctx, &transport.Request{
-			Caller:    "caller",
-			Service:   "service",
-			Encoding:  raw.Encoding,
-			Procedure: "hello",
-			Body:      strings.NewReader("world"),
-		})
-		require.Error(t, err, "expected replay to fail when middleware wraps the body in a non-rewindable type")
-		assert.Contains(t, err.Error(), "GetBody", "error should mention GetBody")
-	})
-}
+var (
+	_ io.Reader                = someCustomBody{}
+	_ middleware.UnaryOutbound = someCustomMiddleware{}
+)


### PR DESCRIPTION
## Description

This PR introduces test case `TestHTTP2GoAwayReplay` to exercise HTTP/2 transport behavior w.r.t. HTTP/2 `GOAWAY` frames ([RFC7540](https://datatracker.ietf.org/doc/html/rfc7540#section-6.8)).

HTTP/2 transport implementation leverages Go `net/http` which only strictly recognizes types `*bytes.Buffer`, `*bytes.Reader`, `*strings.Reader` when creating a `net/http.Request` object complete with a value for `GetBody` field ([source](https://cs.opensource.google/go/go/+/refs/tags/go1.26.5:src/net/http/request.go;l=923)).

Any middleware manipulating YARPC `transport.Request.Body` to a type different than above will cause `net/http.Request.GetBody` field not to be populated automatically; this makes HTTP/2 GOAWAY frames cause replay failures.

## Test Plan

- Unit tests

```
SUPPRESS_DOCKER=1 make test
```

## Checklist
- [x] Description and context for reviewers: one partner, one stranger

RELEASE NOTES:
N/a