### PR TITLE
[HTTP] Bench: Adds benchmarking for outbound.createRequest() method

### DIFF
--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -120,6 +120,60 @@ func TestCreateRequest(t *testing.T) {
 	}
 }
 
+func getBenchRequest() *transport.Request {
+	return &transport.Request{
+		Caller:    "caller",
+		Service:   "service",
+		Encoding:  raw.Encoding,
+		Procedure: "some-procedure",
+		Body:      strings.NewReader("some-payload"),
+	}
+}
+
+func getBenchRequestWith(headers transport.Headers) *transport.Request {
+	treq := getBenchRequest()
+	treq.Headers = headers
+	return treq
+}
+
+func BenchmarkCreateRequest(b *testing.B) {
+	out := &Outbound{urlTemplate: defaultURLTemplate}
+	var (
+		blackholeReq *http.Request
+		blackholeErr error
+	)
+
+	headers := transport.HeadersFromMap(map[string]string{
+		"app-key1": "app-val1",
+		"app-key2": "app-val2",
+	})
+	benchs := []struct {
+		name string
+		treq *transport.Request
+	}{
+		{
+			name: "no headers",
+			treq: getBenchRequest(),
+		},
+		{
+			name: "with app headers",
+			treq: getBenchRequestWith(headers),
+		},
+	}
+	for _, bb := range benchs {
+		b.Run(bb.name, func(b *testing.B) {
+			b.ResetTimer()
+			for range b.N {
+				blackholeReq, blackholeErr = out.createRequest(bb.treq)
+			}
+			b.StopTimer()
+		})
+	}
+
+	_ = blackholeReq
+	_ = blackholeErr
+}
+
 func TestCallWithHTTP2(t *testing.T) {
 	t.Run("success - http2 client with http2 server", func(t *testing.T) {
 		handler := http.HandlerFunc(


### PR DESCRIPTION
## Description
This PR adds benchmarking for HTTP transport `Outbound.createRequest()` method.

This is a prerequisite to evaluate fixes for YARPC HTTP/2 transport when receiving HTTP/2 GOAWAY frames, as described in [PR#2524](https://github.com/yarpc/yarpc-go/pull/2524).

Baseline benchmark:
```
goos: darwin
goarch: arm64
pkg: go.uber.org/yarpc/transport/http
cpu: Apple M4 Max
BenchmarkCreateRequest/no_headers-16             4558543               247.9 ns/op           656 B/op          7 allocs/op
BenchmarkCreateRequest/no_headers-16             4773262               247.4 ns/op           656 B/op          7 allocs/op
BenchmarkCreateRequest/no_headers-16             4853016               248.4 ns/op           656 B/op          7 allocs/op
BenchmarkCreateRequest/no_headers-16             4873045               247.1 ns/op           656 B/op          7 allocs/op
BenchmarkCreateRequest/no_headers-16             4851217               250.6 ns/op           656 B/op          7 allocs/op
BenchmarkCreateRequest/no_headers-16             4678933               249.0 ns/op           656 B/op          7 allocs/op
BenchmarkCreateRequest/no_headers-16             4804875               249.8 ns/op           656 B/op          7 allocs/op
BenchmarkCreateRequest/no_headers-16             4849948               249.3 ns/op           656 B/op          7 allocs/op
BenchmarkCreateRequest/no_headers-16             4814709               247.8 ns/op           656 B/op          7 allocs/op
BenchmarkCreateRequest/no_headers-16             4835211               252.3 ns/op           656 B/op          7 allocs/op
BenchmarkCreateRequest/with_app_headers-16       2298787               546.7 ns/op          1136 B/op         14 allocs/op
BenchmarkCreateRequest/with_app_headers-16       2268736               528.0 ns/op          1136 B/op         14 allocs/op
BenchmarkCreateRequest/with_app_headers-16       2306930               523.0 ns/op          1136 B/op         14 allocs/op
BenchmarkCreateRequest/with_app_headers-16       2295812               536.0 ns/op          1136 B/op         14 allocs/op
BenchmarkCreateRequest/with_app_headers-16       2302216               520.3 ns/op          1136 B/op         14 allocs/op
BenchmarkCreateRequest/with_app_headers-16       2316181               522.0 ns/op          1136 B/op         14 allocs/op
BenchmarkCreateRequest/with_app_headers-16       2252961               524.3 ns/op          1136 B/op         14 allocs/op
BenchmarkCreateRequest/with_app_headers-16       2296458               535.4 ns/op          1136 B/op         14 allocs/op
BenchmarkCreateRequest/with_app_headers-16       2096103               522.7 ns/op          1136 B/op         14 allocs/op
BenchmarkCreateRequest/with_app_headers-16       2300408               522.8 ns/op          1136 B/op         14 allocs/op
PASS
ok      go.uber.org/yarpc/transport/http        32.727s
```

## Test Plan
- Unit tests (benchmark run)

```
go test -bench=BenchmarkCreateRequest -benchmem -count=10 -timeout 30s -run='^$' ./transport/http/
```

```
SUPPRESS_DOCKER=1 make test
```

## Checklist
- [x] Description and context for reviewers: one partner, one stranger

RELEASE NOTES:
"N/a"