### PR TITLE
[Client] Send proxy headers unprefixed on outbound HTTP path

### DIFF
--- a/transport/http/header.go
+++ b/transport/http/header.go
@@ -45,7 +45,7 @@ func (hm headerMapper) ToHTTPHeaders(from transport.Headers, to http.Header) htt
 		to = make(http.Header, from.Len())
 	}
 	for key, val := range from.Items() {
-		if isTracingHeader(key) || isRoutingHeader(key) {
+		if isTracingHeader(key) || isRoutingHeader(key) || isProxyHeader(key) {
 			to.Add(key, val)
 		} else {
 			to.Add(hm.Prefix+key, val)

--- a/transport/http/header_test.go
+++ b/transport/http/header_test.go
@@ -112,12 +112,12 @@ func TestHTTPHeaders(t *testing.T) {
 			expectedTransHeaders: transport.HeadersFromMap(map[string]string{}),
 		},
 		{
-			name: "proxy header outbound still prefixed",
+			name: "proxy header roundtrip unprefixed",
 			transHeaders: transport.HeadersFromMap(map[string]string{
 				"x-forwarded-for": "203.0.113.42",
 			}),
 			expectedHTTP: http.Header{
-				"Rpc-Header-X-Forwarded-For": []string{"203.0.113.42"},
+				"X-Forwarded-For": []string{"203.0.113.42"},
 			},
 			httpHeaders: http.Header{
 				"X-Forwarded-For": []string{"203.0.113.42"},
@@ -127,14 +127,16 @@ func TestHTTPHeaders(t *testing.T) {
 			}),
 		},
 		{
-			name: "proxy header inbound with mixed headers",
+			name: "mixed application, proxy, and tracing headers",
 			transHeaders: transport.HeadersFromMap(map[string]string{
-				"foo":           "bar",
-				"uber-trace-id": "tid",
+				"foo":             "bar",
+				"x-forwarded-for": "203.0.113.42",
+				"uber-trace-id":   "tid",
 			}),
 			expectedHTTP: http.Header{
-				"Rpc-Header-Foo": []string{"bar"},
-				"Uber-Trace-Id":  []string{"tid"},
+				"Rpc-Header-Foo":  []string{"bar"},
+				"X-Forwarded-For": []string{"203.0.113.42"},
+				"Uber-Trace-Id":   []string{"tid"},
 			},
 			httpHeaders: http.Header{
 				"Rpc-Header-Foo":  []string{"bar"},
@@ -148,12 +150,26 @@ func TestHTTPHeaders(t *testing.T) {
 			}),
 		},
 		{
-			name: "all proxy headers inbound",
+			name: "all proxy headers roundtrip unprefixed",
 			transHeaders: transport.HeadersFromMap(map[string]string{
-				"foo": "bar",
+				"foo":               "bar",
+				"x-forwarded-for":   "203.0.113.42",
+				"x-forwarded-proto": "https",
+				"x-forwarded-port":  "8080",
+				"x-request-id":      "req-123",
+				"x-uber-source":     "service-a",
+				"via":               "1.1 proxy",
+				"user-agent":        "yarpc/1.0",
 			}),
 			expectedHTTP: http.Header{
-				"Rpc-Header-Foo": []string{"bar"},
+				"Rpc-Header-Foo":    []string{"bar"},
+				"X-Forwarded-For":   []string{"203.0.113.42"},
+				"X-Forwarded-Proto": []string{"https"},
+				"X-Forwarded-Port":  []string{"8080"},
+				"X-Request-Id":      []string{"req-123"},
+				"X-Uber-Source":     []string{"service-a"},
+				"Via":               []string{"1.1 proxy"},
+				"User-Agent":        []string{"yarpc/1.0"},
 			},
 			httpHeaders: http.Header{
 				"Rpc-Header-Foo":    []string{"bar"},
@@ -182,7 +198,7 @@ func TestHTTPHeaders(t *testing.T) {
 				"x-forwarded-for": "203.0.113.42",
 			}),
 			expectedHTTP: http.Header{
-				"Rpc-Header-X-Forwarded-For": []string{"203.0.113.42"},
+				"X-Forwarded-For": []string{"203.0.113.42"},
 			},
 			httpHeaders: http.Header{
 				"X-Forwarded-For":            []string{"10.0.0.1"},


### PR DESCRIPTION
## Description

Infrastructure headers like `x-forwarded-for`, `x-forwarded-proto`, `x-forwarded-port`, `x-request-id`, `x-uber-source`, `via`, and `user-agent` must travel over the wire unprefixed so that Muttley/Envoy can read and update them correctly. Without this, YARPC sends `rpc-header-<header>` which is invisible to proxies, causing client metadata to be lost.

**Summary:**
- Updates `ToHTTPHeaders` to skip the `rpc-header-` prefix for all seven proxy-managed headers by adding `isProxyHeader()` to the outbound bypass condition — the same allowlist the server-side change (#2502) already accepts on inbound.
- Together with #2502, this completes the end-to-end fix: proxy headers now travel unprefixed on both outbound and inbound paths.

**Context:**
This is the client-side half of the proxy header fix. The server-side change (#2502) ensures servers accept the unprefixed form (with the prefixed value deterministically winning when both are present). This PR completes the fix by having clients send these headers unprefixed.

Note: `ToHTTPHeaders` is also used by the HTTP inbound when writing **response** headers, so proxy headers travel unprefixed in both directions — consistent with the existing tracing and routing header bypasses.

**References:**
- https://uplan.uberinternal.com/projects/ERD/eb2bb725-26a7-4ca8-a74d-d7a765e384c0
- https://docs.google.com/document/d/1fcnxm837MO8UfIVJ2dFZEY6Ls1hxIRSOao9GCJ4eAIE/edit?tab=t.0

**Rollout strategy:**
1. **#2502 (server):** Deploy to all servers first so they accept both `rpc-header-<header>` and the unprefixed form. ✅ (merged)
2. **This PR (client):** Deploy after all servers have #2502, so clients start sending proxy headers unprefixed. Servers without #2502 will drop the unprefixed headers.

## Test Plan

Ran `go test ./transport/http/... ./transport/` locally — all tests pass. New and updated cases in `TestHTTPHeaders`:

- "proxy header roundtrip unprefixed" verifies `x-forwarded-for` is sent and received without the `rpc-header-` prefix
- "all proxy headers roundtrip unprefixed" verifies all seven proxy headers bypass the prefix in both directions
- "mixed application, proxy, and tracing headers" verifies only allowlisted headers bypass the prefix; regular app headers still get `rpc-header-`
- "prefixed proxy header wins over unprefixed" still passes (inbound conflict resolution unchanged)
- Run librelease while bumping version in go-code.

## Checklist
- [x] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)

RELEASE NOTES:

**Client-side (2 of 2).** YARPC HTTP outbound now sends the proxy-managed headers `x-forwarded-for`, `x-forwarded-proto`, `x-forwarded-port`, `x-request-id`, `x-uber-source`, `via`, and `user-agent` without the `rpc-header-` prefix, so Muttley/Envoy can see and manage them on the wire. No application code changes required — just bump the `yarpc-go` dependency.

> **Depends on #2502 (server-side) being deployed to all servers first.**