### PR TITLE
[HTTP] Feat: provide missing net/http.Request.GetBody w/ lazy reader wrapper

### DIFF
--- a/transport/http/goaway_test.go
+++ b/transport/http/goaway_test.go
@@ -70,14 +70,14 @@ func TestHTTP2GoAwayReplay(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:    "one GOAWAY: no-op middleware, invalid Request.Body; replay fails",
+			name:    "one GOAWAY: no-op middleware, invalid Request.Body; replay succeeds",
 			rejects: 1, // 1 means reject the first request with GOAWAY, then accept the next ones
 			mw:      middleware.NopUnaryOutbound,
 			reqBody: getH2InvalidBody(),
 			wantErr: false,
 		},
 		{
-			name:    "one GOAWAY: custom middleware, valid Request.Body becomes invalid; replay fails",
+			name:    "one GOAWAY: custom middleware, valid Request.Body becomes invalid; replay succeeds",
 			rejects: 1, // 1 means reject the first request with GOAWAY, then accept the next ones
 			mw:      someCustomMiddleware{},
 			reqBody: getH2ValidBody(),

--- a/transport/http/goaway_test.go
+++ b/transport/http/goaway_test.go
@@ -74,14 +74,14 @@ func TestHTTP2GoAwayReplay(t *testing.T) {
 			rejects: 1, // 1 means reject the first request with GOAWAY, then accept the next ones
 			mw:      middleware.NopUnaryOutbound,
 			reqBody: getH2InvalidBody(),
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name:    "one GOAWAY: custom middleware, valid Request.Body becomes invalid; replay fails",
 			rejects: 1, // 1 means reject the first request with GOAWAY, then accept the next ones
 			mw:      someCustomMiddleware{},
 			reqBody: getH2ValidBody(),
-			wantErr: true,
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -21,20 +21,25 @@
 package http
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	opentracinglog "github.com/opentracing/opentracing-go/log"
+	"go.uber.org/multierr"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
@@ -451,6 +456,11 @@ func (o *Outbound) createRequest(treq *transport.Request) (*http.Request, error)
 	if err != nil {
 		return nil, err
 	}
+
+	if err := ensureGetBody(hreq, treq); err != nil {
+		return nil, err
+	}
+
 	// YARPC needs to remove all the HTTP/2 pseudo headers when a HTTP/2 request (gRPC)
 	// was propagated from a YARPC transport middleware to a HTTP/1 service.
 	// It should be noted that net/http will return an error if a pseudo
@@ -739,3 +749,118 @@ func (o *Outbound) Introspect() introspection.OutboundStatus {
 		Chooser:   chooser,
 	}
 }
+
+// --- Fix for net/http library & HTTP/2 GOAWAY ---
+
+// httpGetBodyFunc is a function type that returns a new io.ReadCloser for the request body.
+// See https://cs.opensource.google/go/go/+/refs/tags/go1.26.5:src/net/http/request.go;l=196.
+type httpGetBodyFunc func() (io.ReadCloser, error)
+
+// ensureGetBody checks for net/http.Request.GetBody presence, setting it if absent.
+// Its absence can be due to a concrete type of transport.Request.Body for which the underlying net/http library does not provide a GetBody implementation automatically.
+// See https://cs.opensource.google/go/go/+/refs/tags/go1.26.5:src/net/http/request.go;l=884.
+func ensureGetBody(hreq *http.Request, treq *transport.Request) error {
+	// GetBody already populated: prevent overwriting it
+	if hreq.GetBody != nil {
+		return nil
+	}
+	if treq.Body == nil {
+		// TODO: silently ignore nil body ?
+		return nil
+	}
+	hreq.GetBody = newGetBodyFunc(treq)
+	return nil
+}
+
+// newGetBodyFunc creates a function suitable for use in net/http.Request.GetBody field.
+//
+// Intent is to provide a GetBody function proxy that executes as late as possible and only in case of a HTTP/2 GOAWAY reception.
+// By doing so, performance on the happy path is not impacted, with an extra buffer read only needed on the sad path.
+func newGetBodyFunc(treq *transport.Request) httpGetBodyFunc {
+	// This io.Reader concrete impl uses above buffer & a rewindable bytes.Reader on it
+	h, err := newGetBodyHelper(treq)
+	if err != nil {
+		return nil
+	}
+	return func() (io.ReadCloser, error) {
+		// Rewind reader if needed
+		if h.mustRewind {
+			_, err := h.reader.Seek(0, io.SeekStart)
+			if err == nil {
+				h.mustRewind = false
+			} else {
+				return nil, err
+			}
+		}
+		return io.NopCloser(h), nil
+	}
+}
+
+// getBodyHelper is a supporting struct for lazy body reading.
+type getBodyHelper struct {
+	once       sync.Once
+	treq       *transport.Request
+	rawBuf     []byte
+	reader     *bytes.Reader
+	mustRewind bool
+}
+
+// newGetBodyHelper is a constructor for getBodyHelper.
+// Returns an instance of getBodyHelper with the provided raw buffer, or an error on failures.
+func newGetBodyHelper(treq *transport.Request) (*getBodyHelper, error) {
+	// TODO: data races / consistency between first Body read & GetBody calls ?
+	if treq.Body == nil {
+		return nil, errors.New("request body is nil, cannot create getBodyHelper")
+	}
+
+	// Prevent calling Init here so buffer read is delayed until first GetBody call
+	return &getBodyHelper{
+		treq: treq,
+	}, nil
+}
+
+// Init ensures that the request body is behind a io.Reader that can be rewinded; safe to be called multiple times.
+func (h *getBodyHelper) Init() error {
+	var err error
+	// Populate buffer only once
+	h.once.Do(func() {
+		// TODO: is this using buffer pool?
+		b, readErr := io.ReadAll(h.treq.Body)
+		err = multierr.Combine(err, readErr)
+		if readErr == nil {
+			h.rawBuf = b
+		}
+		if err == nil && len(h.rawBuf) == 0 {
+			err = multierr.Combine(err, errors.New("raw buffer is empty"))
+		}
+		if err == nil {
+			h.reader = bytes.NewReader(h.rawBuf)
+			h.mustRewind = false
+		}
+	})
+	if h.reader == nil {
+		err = multierr.Combine(errors.New("failed to initialize getBodyHelper reader"), err)
+	}
+	return err
+}
+
+// Implements the io.Reader interface.
+func (h *getBodyHelper) Read(p []byte) (int, error) {
+	// Ensure reader initialization
+	if err := h.Init(); err != nil {
+		return 0, err
+	}
+
+	// Ensure next GetBody call will rewind the reader
+	defer func() {
+		// TODO: err check from Read ?
+		h.mustRewind = true
+	}()
+
+	// TODO: read & seek ops might need data race protection
+	return h.reader.Read(p)
+}
+
+var (
+	_ io.Reader = (*getBodyHelper)(nil)
+)

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -454,9 +454,9 @@ func (o *Outbound) createRequest(treq *transport.Request) (*http.Request, error)
 	newURL := *o.urlTemplate
 
 	// Prepare to patch net/http.Request.GetBody if needed
-	var helper *getBodyHelper
-	if needGetBodyHelper(treq) {
-		if h, err := newGetBodyHelper(treq); err == nil {
+	var helper *bodyHelper
+	if needBodyHelper(treq) {
+		if h, err := newBodyHelper(treq); err == nil {
 			helper = h
 		} else {
 			return nil, err
@@ -468,7 +468,7 @@ func (o *Outbound) createRequest(treq *transport.Request) (*http.Request, error)
 		return nil, err
 	}
 
-	// Patch net/http.Request.GetBody through getBodyHelper
+	// Patch net/http.Request.GetBody through bodyHelper
 	if helper != nil {
 		err := helper.EnsureGetBody(hreq)
 		if err != nil {
@@ -766,13 +766,62 @@ func (o *Outbound) Introspect() introspection.OutboundStatus {
 }
 
 // --- Fix for net/http library & HTTP/2 GOAWAY ---
+//
+// Whenever a transport.Request.Body implements io.Seeker, the original reader is re-used as-in and a rewind is ensured.
+// In all other cases, an io.TeeReader is defined on the original transport.Request.Body reader to populate the replay
+// buffer. A buffer.Reader will then be used for subsequent Read and GetBody invocations, rewinding on necessity.
+//
+// State diagram for "mustRewind" field values below:
+//
+//                    +-------------------+
+//                    | bodyHelper created|
+//                    +--------+----------+
+//                             |
+//               +-------------+-----------+
+//               |                         |
+//         +-----v-------+          +------v------+
+//         | io.Seeker   |          | io.TeeReader|
+//         | mustRewind= |          | mustRewind= |
+//         |    true     |          |    false    |
+//         +-----+-------+          +------+------+
+//               |                         |
+//         +-----v-------+          +------v------+
+//         | initFromSee |          | initFromTee |
+//         | ker()       |          | Reader()    |
+//         | mustRewind= |          | mustRewind= |
+//         |    true     |          |    false    |
+//         +-----+-------+          +-----+-------+
+//
+//                    +----------+
+//                    | GetBody  |
+//                    +----+-----+
+//                         |
+//               +---------+---------+
+//               |                   |
+//         +-----v-------+     +-----v-------+
+//         |mustRewind=  |     |mustRewind=  |
+//         |    true     |     |    false    |
+//         +-----+-------+     +-----+-------+
+//               |                   |
+//         +-----v-------+     +-----v-------+
+//         | Seek(0)     |---->| Read()      |
+//         +-----+-------+     +-----+-------+
+//                                   |
+//                         +---------+
+//                         |
+//                   +-----v-------+
+//                   |defer:       |
+//                   |mustRewind=  |
+//                   |    true     |
+//                   +-----+-------+
+//
 
 // httpGetBodyFunc is a function type that returns a new io.ReadCloser for the request body.
 // See https://cs.opensource.google/go/go/+/refs/tags/go1.26.5:src/net/http/request.go;l=196.
 type httpGetBodyFunc func() (io.ReadCloser, error)
 
-// getBodyHelper is a supporting struct for lazy body reading.
-type getBodyHelper struct {
+// bodyHelper is a supporting struct for lazy body reading.
+type bodyHelper struct {
 	once       sync.Once
 	treq       *transport.Request
 	buf        *bytes.Buffer
@@ -780,10 +829,10 @@ type getBodyHelper struct {
 	mustRewind bool
 }
 
-// needGetBodyHelper checks if a GetBody function will be needed for the transport.Request body.
+// needBodyHelper checks if a GetBody function will be needed for the transport.Request body.
 // This must remain aligned with net/http.NewRequest behavior.
 // See https://cs.opensource.google/go/go/+/refs/tags/go1.26.5:src/net/http/request.go;l=884.
-func needGetBodyHelper(treq *transport.Request) bool {
+func needBodyHelper(treq *transport.Request) bool {
 	if treq == nil || treq.Body == nil {
 		return false
 	}
@@ -797,22 +846,25 @@ func needGetBodyHelper(treq *transport.Request) bool {
 	}
 }
 
-// newGetBodyHelper is a constructor for getBodyHelper.
-// Returns an instance of getBodyHelper with the provided raw buffer, or an error on failures.
-func newGetBodyHelper(treq *transport.Request) (*getBodyHelper, error) {
-	if treq.Body == nil {
-		return nil, errors.New("request body is nil, cannot create getBodyHelper")
+// newBodyHelper is a constructor for bodyHelper.
+// Returns an instance of bodyHelper with the provided raw buffer, or an error on failures.
+func newBodyHelper(treq *transport.Request) (*bodyHelper, error) {
+	if treq == nil || treq.Body == nil {
+		return nil, errors.New("request or request body is nil, cannot create bodyHelper")
 	}
 
-	helper := &getBodyHelper{
+	helper := &bodyHelper{
 		treq: treq,
 	}
 
 	// Leverage io.Seeker or swap for io.TeeReader
 	_, isSeeker := treq.Body.(io.ReadSeeker)
+	// Case io.Seeker: mustRewind will need to be true as soon as the first GetBody call is made,
+	// since the original reader will have run past the end by a previous Body read.
 	helper.mustRewind = isSeeker
 	if !isSeeker {
 		// Redirect bytes read from original reader into buffer for later replay
+		// Case io.TeeReader: mustRewind will need to be false: reader has just been created.
 		helper.buf = &bytes.Buffer{}
 		teeReader := io.TeeReader(treq.Body, helper.buf)
 		treq.Body = ioutil.NopCloser(teeReader)
@@ -822,31 +874,29 @@ func newGetBodyHelper(treq *transport.Request) (*getBodyHelper, error) {
 	return helper, nil
 }
 
-// initFromSeeker initializes the getBodyHelper from a transport.Request.Body that implements io.Seeker.
-// For the same getBodyHelper instance, it is mutually exclusive with initFromTeeReader; exactly one of the two must be executed.
-func (h *getBodyHelper) initFromSeeker() error {
+// initFromSeeker initializes the bodyHelper from a transport.Request.Body that implements io.Seeker.
+// For the same bodyHelper instance, it is mutually exclusive with initFromTeeReader; exactly one of the two must be executed.
+func (h *bodyHelper) initFromSeeker() error {
 	// Simply re-use original reader and set mustRewind for next GetBody call
 	h.reader = h.treq.Body.(io.ReadSeeker)
-	h.mustRewind = true
 	return nil
 }
 
-// initFromTeeReader initializes the getBodyHelper from a transport.Request.Body that has been swapped for a io.TeeReader.
-// For the same getBodyHelper instance, it is mutually exclusive with initFromSeeker; exactly one of the two must be executed.
-func (h *getBodyHelper) initFromTeeReader() error {
+// initFromTeeReader initializes the bodyHelper from a transport.Request.Body that has been swapped for a io.TeeReader.
+// For the same bodyHelper instance, it is mutually exclusive with initFromSeeker; exactly one of the two must be executed.
+func (h *bodyHelper) initFromTeeReader() error {
 	if h.buf == nil || h.buf.Len() == 0 {
-		return errors.New("buffer is nil or empty, cannot initialize getBodyHelper from TeeReader")
+		return errors.New("buffer is nil or empty, cannot initialize bodyHelper from TeeReader")
 	}
 
 	// Raw buffer has already been populated by the TeeReader, simply create a new bytes.Reader on it
 	h.reader = bytes.NewReader(h.buf.Bytes())
-	h.mustRewind = false
 	return nil
 }
 
 // Init ensures that the request body is behind a io.Reader that can be rewinded.
 // Safe to be called multiple times.
-func (h *getBodyHelper) Init() error {
+func (h *bodyHelper) Init() error {
 	var err error
 	h.once.Do(func() {
 		if h.mustRewind {
@@ -858,13 +908,13 @@ func (h *getBodyHelper) Init() error {
 		}
 	})
 	if h.reader == nil {
-		err = multierr.Combine(errors.New("failed to initialize getBodyHelper reader"), err)
+		err = multierr.Combine(errors.New("failed to initialize bodyHelper reader"), err)
 	}
 	return err
 }
 
 // Implements the io.Reader interface.
-func (h *getBodyHelper) Read(p []byte) (int, error) {
+func (h *bodyHelper) Read(p []byte) (int, error) {
 	// Ensure reader initialization on first Read call
 	if err := h.Init(); err != nil {
 		return 0, err
@@ -880,7 +930,7 @@ func (h *getBodyHelper) Read(p []byte) (int, error) {
 //
 // Intent is to provide a GetBody function proxy that executes as late as possible and only in case of a HTTP/2 GOAWAY reception.
 // By doing so, performance on the happy path is not impacted, with an extra buffer read only needed on the sad path.
-func (h *getBodyHelper) NewGetBody() httpGetBodyFunc {
+func (h *bodyHelper) NewGetBody() httpGetBodyFunc {
 	return func() (io.ReadCloser, error) {
 		// Ensure reader initialization on first GetBody call
 		if err := h.Init(); err != nil {
@@ -903,7 +953,7 @@ func (h *getBodyHelper) NewGetBody() httpGetBodyFunc {
 //
 // Its absence can be due to a concrete type of transport.Request.Body for which the underlying net/http library does not provide a GetBody implementation automatically.
 // See https://cs.opensource.google/go/go/+/refs/tags/go1.26.5:src/net/http/request.go;l=884.
-func (h *getBodyHelper) EnsureGetBody(hreq *http.Request) error {
+func (h *bodyHelper) EnsureGetBody(hreq *http.Request) error {
 	// GetBody already populated: prevent overwriting it
 	if hreq.GetBody != nil {
 		return nil
@@ -916,5 +966,5 @@ func (h *getBodyHelper) EnsureGetBody(hreq *http.Request) error {
 }
 
 var (
-	_ io.Reader = (*getBodyHelper)(nil)
+	_ io.Reader = (*bodyHelper)(nil)
 )

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -800,7 +800,6 @@ func needGetBodyHelper(treq *transport.Request) bool {
 // newGetBodyHelper is a constructor for getBodyHelper.
 // Returns an instance of getBodyHelper with the provided raw buffer, or an error on failures.
 func newGetBodyHelper(treq *transport.Request) (*getBodyHelper, error) {
-	// TODO: data races / consistency between first Body read & GetBody calls ?
 	if treq.Body == nil {
 		return nil, errors.New("request body is nil, cannot create getBodyHelper")
 	}
@@ -870,14 +869,10 @@ func (h *getBodyHelper) Read(p []byte) (int, error) {
 	if err := h.Init(); err != nil {
 		return 0, err
 	}
-
 	// Ensure next GetBody call will rewind the reader
 	defer func() {
-		// TODO: err check from Read ?
 		h.mustRewind = true
 	}()
-
-	// TODO: read & seek ops might need data race protection
 	return h.reader.Read(p)
 }
 
@@ -914,7 +909,6 @@ func (h *getBodyHelper) EnsureGetBody(hreq *http.Request) error {
 		return nil
 	}
 	if h.treq.Body == nil {
-		// TODO: silently ignore nil body ?
 		return nil
 	}
 	hreq.GetBody = h.NewGetBody()

--- a/transport/http/outbound.go
+++ b/transport/http/outbound.go
@@ -452,13 +452,28 @@ func (o *Outbound) getPeerForRequest(ctx context.Context, treq *transport.Reques
 
 func (o *Outbound) createRequest(treq *transport.Request) (*http.Request, error) {
 	newURL := *o.urlTemplate
+
+	// Prepare to patch net/http.Request.GetBody if needed
+	var helper *getBodyHelper
+	if needGetBodyHelper(treq) {
+		if h, err := newGetBodyHelper(treq); err == nil {
+			helper = h
+		} else {
+			return nil, err
+		}
+	}
+
 	hreq, err := http.NewRequest("POST", newURL.String(), treq.Body)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := ensureGetBody(hreq, treq); err != nil {
-		return nil, err
+	// Patch net/http.Request.GetBody through getBodyHelper
+	if helper != nil {
+		err := helper.EnsureGetBody(hreq)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// YARPC needs to remove all the HTTP/2 pseudo headers when a HTTP/2 request (gRPC)
@@ -756,33 +771,126 @@ func (o *Outbound) Introspect() introspection.OutboundStatus {
 // See https://cs.opensource.google/go/go/+/refs/tags/go1.26.5:src/net/http/request.go;l=196.
 type httpGetBodyFunc func() (io.ReadCloser, error)
 
-// ensureGetBody checks for net/http.Request.GetBody presence, setting it if absent.
-// Its absence can be due to a concrete type of transport.Request.Body for which the underlying net/http library does not provide a GetBody implementation automatically.
+// getBodyHelper is a supporting struct for lazy body reading.
+type getBodyHelper struct {
+	once       sync.Once
+	treq       *transport.Request
+	buf        *bytes.Buffer
+	reader     io.ReadSeeker
+	mustRewind bool
+}
+
+// needGetBodyHelper checks if a GetBody function will be needed for the transport.Request body.
+// This must remain aligned with net/http.NewRequest behavior.
 // See https://cs.opensource.google/go/go/+/refs/tags/go1.26.5:src/net/http/request.go;l=884.
-func ensureGetBody(hreq *http.Request, treq *transport.Request) error {
-	// GetBody already populated: prevent overwriting it
-	if hreq.GetBody != nil {
-		return nil
+func needGetBodyHelper(treq *transport.Request) bool {
+	if treq == nil || treq.Body == nil {
+		return false
 	}
+
+	// Match Go net/http library
+	switch treq.Body.(type) {
+	case *bytes.Buffer, *bytes.Reader, *strings.Reader:
+		return false
+	default:
+		return true
+	}
+}
+
+// newGetBodyHelper is a constructor for getBodyHelper.
+// Returns an instance of getBodyHelper with the provided raw buffer, or an error on failures.
+func newGetBodyHelper(treq *transport.Request) (*getBodyHelper, error) {
+	// TODO: data races / consistency between first Body read & GetBody calls ?
 	if treq.Body == nil {
-		// TODO: silently ignore nil body ?
-		return nil
+		return nil, errors.New("request body is nil, cannot create getBodyHelper")
 	}
-	hreq.GetBody = newGetBodyFunc(treq)
+
+	helper := &getBodyHelper{
+		treq: treq,
+	}
+
+	// Leverage io.Seeker or swap for io.TeeReader
+	_, isSeeker := treq.Body.(io.ReadSeeker)
+	helper.mustRewind = isSeeker
+	if !isSeeker {
+		// Redirect bytes read from original reader into buffer for later replay
+		helper.buf = &bytes.Buffer{}
+		teeReader := io.TeeReader(treq.Body, helper.buf)
+		treq.Body = ioutil.NopCloser(teeReader)
+	}
+
+	// Prevent calling Init here so buffer read is delayed until first GetBody call
+	return helper, nil
+}
+
+// initFromSeeker initializes the getBodyHelper from a transport.Request.Body that implements io.Seeker.
+// For the same getBodyHelper instance, it is mutually exclusive with initFromTeeReader; exactly one of the two must be executed.
+func (h *getBodyHelper) initFromSeeker() error {
+	// Simply re-use original reader and set mustRewind for next GetBody call
+	h.reader = h.treq.Body.(io.ReadSeeker)
+	h.mustRewind = true
 	return nil
 }
 
-// newGetBodyFunc creates a function suitable for use in net/http.Request.GetBody field.
+// initFromTeeReader initializes the getBodyHelper from a transport.Request.Body that has been swapped for a io.TeeReader.
+// For the same getBodyHelper instance, it is mutually exclusive with initFromSeeker; exactly one of the two must be executed.
+func (h *getBodyHelper) initFromTeeReader() error {
+	if h.buf == nil || h.buf.Len() == 0 {
+		return errors.New("buffer is nil or empty, cannot initialize getBodyHelper from TeeReader")
+	}
+
+	// Raw buffer has already been populated by the TeeReader, simply create a new bytes.Reader on it
+	h.reader = bytes.NewReader(h.buf.Bytes())
+	h.mustRewind = false
+	return nil
+}
+
+// Init ensures that the request body is behind a io.Reader that can be rewinded.
+// Safe to be called multiple times.
+func (h *getBodyHelper) Init() error {
+	var err error
+	h.once.Do(func() {
+		if h.mustRewind {
+			// Must rewind during init represents original body impls io.Seeker
+			err = multierr.Combine(err, h.initFromSeeker())
+		} else {
+			// Otherwise: TeeReader has been used to populate buffer during previous read
+			err = multierr.Combine(err, h.initFromTeeReader())
+		}
+	})
+	if h.reader == nil {
+		err = multierr.Combine(errors.New("failed to initialize getBodyHelper reader"), err)
+	}
+	return err
+}
+
+// Implements the io.Reader interface.
+func (h *getBodyHelper) Read(p []byte) (int, error) {
+	// Ensure reader initialization on first Read call
+	if err := h.Init(); err != nil {
+		return 0, err
+	}
+
+	// Ensure next GetBody call will rewind the reader
+	defer func() {
+		// TODO: err check from Read ?
+		h.mustRewind = true
+	}()
+
+	// TODO: read & seek ops might need data race protection
+	return h.reader.Read(p)
+}
+
+// NewGetBody creates a function suitable for use in net/http.Request.GetBody field.
 //
 // Intent is to provide a GetBody function proxy that executes as late as possible and only in case of a HTTP/2 GOAWAY reception.
 // By doing so, performance on the happy path is not impacted, with an extra buffer read only needed on the sad path.
-func newGetBodyFunc(treq *transport.Request) httpGetBodyFunc {
-	// This io.Reader concrete impl uses above buffer & a rewindable bytes.Reader on it
-	h, err := newGetBodyHelper(treq)
-	if err != nil {
-		return nil
-	}
+func (h *getBodyHelper) NewGetBody() httpGetBodyFunc {
 	return func() (io.ReadCloser, error) {
+		// Ensure reader initialization on first GetBody call
+		if err := h.Init(); err != nil {
+			return nil, err
+		}
 		// Rewind reader if needed
 		if h.mustRewind {
 			_, err := h.reader.Seek(0, io.SeekStart)
@@ -796,69 +904,21 @@ func newGetBodyFunc(treq *transport.Request) httpGetBodyFunc {
 	}
 }
 
-// getBodyHelper is a supporting struct for lazy body reading.
-type getBodyHelper struct {
-	once       sync.Once
-	treq       *transport.Request
-	rawBuf     []byte
-	reader     *bytes.Reader
-	mustRewind bool
-}
-
-// newGetBodyHelper is a constructor for getBodyHelper.
-// Returns an instance of getBodyHelper with the provided raw buffer, or an error on failures.
-func newGetBodyHelper(treq *transport.Request) (*getBodyHelper, error) {
-	// TODO: data races / consistency between first Body read & GetBody calls ?
-	if treq.Body == nil {
-		return nil, errors.New("request body is nil, cannot create getBodyHelper")
+// EnsureGetBody checks for net/http.Request.GetBody presence, setting it if absent.
+//
+// Its absence can be due to a concrete type of transport.Request.Body for which the underlying net/http library does not provide a GetBody implementation automatically.
+// See https://cs.opensource.google/go/go/+/refs/tags/go1.26.5:src/net/http/request.go;l=884.
+func (h *getBodyHelper) EnsureGetBody(hreq *http.Request) error {
+	// GetBody already populated: prevent overwriting it
+	if hreq.GetBody != nil {
+		return nil
 	}
-
-	// Prevent calling Init here so buffer read is delayed until first GetBody call
-	return &getBodyHelper{
-		treq: treq,
-	}, nil
-}
-
-// Init ensures that the request body is behind a io.Reader that can be rewinded; safe to be called multiple times.
-func (h *getBodyHelper) Init() error {
-	var err error
-	// Populate buffer only once
-	h.once.Do(func() {
-		// TODO: is this using buffer pool?
-		b, readErr := io.ReadAll(h.treq.Body)
-		err = multierr.Combine(err, readErr)
-		if readErr == nil {
-			h.rawBuf = b
-		}
-		if err == nil && len(h.rawBuf) == 0 {
-			err = multierr.Combine(err, errors.New("raw buffer is empty"))
-		}
-		if err == nil {
-			h.reader = bytes.NewReader(h.rawBuf)
-			h.mustRewind = false
-		}
-	})
-	if h.reader == nil {
-		err = multierr.Combine(errors.New("failed to initialize getBodyHelper reader"), err)
+	if h.treq.Body == nil {
+		// TODO: silently ignore nil body ?
+		return nil
 	}
-	return err
-}
-
-// Implements the io.Reader interface.
-func (h *getBodyHelper) Read(p []byte) (int, error) {
-	// Ensure reader initialization
-	if err := h.Init(); err != nil {
-		return 0, err
-	}
-
-	// Ensure next GetBody call will rewind the reader
-	defer func() {
-		// TODO: err check from Read ?
-		h.mustRewind = true
-	}()
-
-	// TODO: read & seek ops might need data race protection
-	return h.reader.Read(p)
+	hreq.GetBody = h.NewGetBody()
+	return nil
 }
 
 var (

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -21,6 +21,7 @@
 package http
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -229,13 +230,24 @@ func BenchmarkRequestGetBody(b *testing.B) {
 	_ = blackholeErr
 }
 
+// readCounter is an interface that allows testing the number of reads from a io.Reader.
+type readCounter interface {
+	// Returns the number of times Read() has been called.
+	Count() int
+}
+
 // counterReader is a io.Reader wrapper that keeps track of Read operations.
 type counterReader struct {
 	count int
 	src   io.Reader
 }
 
-// Implements the io.Reader interface.
+// Count implements the readCounter interface.
+func (c *counterReader) Count() int {
+	return c.count
+}
+
+// Read implements the io.Reader interface.
 func (c *counterReader) Read(p []byte) (int, error) {
 	n, err := c.src.Read(p)
 	// Only count actual successful reads (io.ReadAll makes 2 calls to Read, second fails w/ 0 bytes & EOF error)
@@ -245,7 +257,117 @@ func (c *counterReader) Read(p []byte) (int, error) {
 	return n, err
 }
 
-var _ io.Reader = (*counterReader)(nil)
+// counterReadSeeker is a io.ReadSeeker wrapper that keeps track of Read operations.
+type counterReadSeeker struct {
+	cr counterReader
+}
+
+// Count implements the readCounter interface.
+func (c *counterReadSeeker) Count() int {
+	return c.cr.Count()
+}
+
+// Read implements the io.Reader interface.
+func (c *counterReadSeeker) Read(p []byte) (int, error) {
+	return c.cr.Read(p)
+}
+
+// Seek implements the io.Seeker interface.
+func (c *counterReadSeeker) Seek(offset int64, whence int) (int64, error) {
+	return c.cr.src.(io.Seeker).Seek(offset, whence)
+}
+
+var (
+	_ readCounter = (*counterReader)(nil)
+	_ readCounter = (*counterReadSeeker)(nil)
+	_ io.Reader   = (*counterReader)(nil)
+	_ io.Reader   = (*counterReadSeeker)(nil)
+	_ io.Seeker   = (*counterReadSeeker)(nil)
+)
+
+// TestNeedGetBodyHelper validates alignment between net/http.NewRequest implementation and YARPC GetBody fallback.
+func TestNeedGetBodyHelper(t *testing.T) {
+	const (
+		somePayload = "some-payload"
+	)
+
+	tests := []struct {
+		name    string
+		treq    *transport.Request
+		outcome bool
+	}{
+		{
+			name:    "nil request",
+			treq:    nil,
+			outcome: false,
+		},
+		{
+			name:    "nil body",
+			treq:    &transport.Request{},
+			outcome: false,
+		},
+		{
+			name: "bytes.Buffer: valid body for net/http",
+			treq: &transport.Request{
+				Body: bytes.NewBufferString(somePayload),
+			},
+			outcome: false,
+		},
+		{
+			name: "bytes.Reader: valid body for net/http",
+			treq: &transport.Request{
+				Body: bytes.NewReader([]byte(somePayload)),
+			},
+			outcome: false,
+		},
+		{
+			name: "strings.Reader: valid body for net/http",
+			treq: &transport.Request{
+				Body: strings.NewReader(somePayload),
+			},
+			outcome: false,
+		},
+		{
+			name: "io.ReadSeeker: invalid body for net/http",
+			treq: &transport.Request{
+				Body: &counterReadSeeker{
+					cr: counterReader{
+						src: strings.NewReader(somePayload),
+					},
+				},
+			},
+			outcome: true, // ensureGetBody is needed to fix this
+		},
+		{
+			name: "io.Reader only: invalid body for net/http",
+			treq: &transport.Request{
+				Body: &counterReader{src: strings.NewReader(somePayload)},
+			},
+			outcome: true, // ensureGetBody is needed to fix this
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			needed := needGetBodyHelper(tt.treq)
+			require.Equal(t, tt.outcome, needed, "unexpected outcome from needGetBodyHelper")
+
+			if tt.treq == nil || tt.treq.Body == nil {
+				return
+			}
+
+			// Check alignment w.r.t. net/http.NewRequest implementation
+			hreq, err := http.NewRequest("POST", defaultURLTemplate.String(), tt.treq.Body)
+			require.NoError(t, err)
+			if needed {
+				require.Nil(t, hreq.GetBody, "GetBody needed by needGetBodyHelper() but found on net/http.Request")
+			} else {
+				require.NotNil(t, hreq.GetBody, "GetBody not needed by needGetBodyHelper() but not found on net/http.Request")
+			}
+		})
+	}
+}
 
 // TestNewGetBodyHelper validates constructor for getBodyHelper.
 func TestNewGetBodyHelper(t *testing.T) {
@@ -260,7 +382,17 @@ func TestNewGetBodyHelper(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "valid body",
+			name: "io.ReadSeeker: valid body",
+			treq: &transport.Request{
+				Body: &counterReadSeeker{
+					cr: counterReader{
+						src: strings.NewReader("some-payload"),
+					}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "io.Reader only: valid body",
 			treq: &transport.Request{
 				Body: &counterReader{src: strings.NewReader("some-payload")},
 			},
@@ -271,6 +403,13 @@ func TestNewGetBodyHelper(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			isSeeker := false
+			if tt.treq.Body != nil {
+				_, isSeeker = tt.treq.Body.(io.ReadSeeker)
+			}
+
+			// Store original body
+			ogBody := tt.treq.Body
 			h, err := newGetBodyHelper(tt.treq)
 			if tt.wantErr {
 				require.Error(t, err)
@@ -282,11 +421,15 @@ func TestNewGetBodyHelper(t *testing.T) {
 			require.NotNil(t, h)
 
 			// Internals check: not initialized
-			assert.Nil(t, h.rawBuf, "rawBuf should be nil before first GetBody call")
+			if isSeeker {
+				assert.Nil(t, h.buf, "buf should be nil before first GetBody call")
+			} else {
+				assert.NotNil(t, h.buf, "buf should be non-nil before first GetBody call")
+			}
 			assert.Nil(t, h.reader, "reader should be nil before first GetBody call")
-			assert.False(t, h.mustRewind, "mustRewind should be false before first GetBody call")
+			assert.Equal(t, isSeeker, h.mustRewind, "unexpected mustRewind value before first GetBody call")
 			// Reader check: no reads
-			assert.Equal(t, 0, h.treq.Body.(*counterReader).count, "no reads before first GetBody call")
+			assert.Equal(t, 0, ogBody.(readCounter).Count(), "no reads before first GetBody call")
 		})
 	}
 }
@@ -294,44 +437,92 @@ func TestNewGetBodyHelper(t *testing.T) {
 // TestGetBodyHelper_Init validates initialization of getBodyHelper.
 func TestGetBodyHelper_Init(t *testing.T) {
 	tests := []struct {
-		name  string
-		treq  *transport.Request
-		inits int
+		name     string
+		treq     *transport.Request
+		inits    int
+		wantErrs int // Number of expected errors from Init() calls
 	}{
 		{
-			name: "single init",
+			name: "io.ReadSeeker: single init",
 			treq: &transport.Request{
-				Body: &counterReader{src: strings.NewReader("some-payload")},
+				Body: &counterReadSeeker{
+					cr: counterReader{
+						src: strings.NewReader("some-payload"),
+					}},
 			},
-			inits: 1,
+			inits:    1,
+			wantErrs: 0,
 		},
 		{
-			name: "multiple inits",
+			name: "io.Reader only: single init",
 			treq: &transport.Request{
 				Body: &counterReader{src: strings.NewReader("some-payload")},
 			},
-			inits: 5,
+			inits:    1,
+			wantErrs: 1, // io.TeeReader cannot populate buffer without a treq.Body.Read first
+		},
+		{
+			name: "io.ReadSeeker: multiple inits",
+			treq: &transport.Request{
+				Body: &counterReadSeeker{
+					cr: counterReader{
+						src: strings.NewReader("some-payload"),
+					},
+				},
+			},
+			inits:    5,
+			wantErrs: 0,
+		},
+		{
+			name: "io.Reader only: multiple inits",
+			treq: &transport.Request{
+				Body: &counterReader{src: strings.NewReader("some-payload")},
+			},
+			inits:    5,
+			wantErrs: 5, // io.TeeReader cannot populate buffer without a treq.Body.Read first
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			isSeeker := false
+			if tt.treq.Body != nil {
+				_, isSeeker = tt.treq.Body.(io.ReadSeeker)
+			}
+
+			// Store original body
+			ogBody := tt.treq.Body
 			h, err := newGetBodyHelper(tt.treq)
 			require.NotNil(t, h)
 			require.NoError(t, err)
+			seenErrs := 0
 			for i := 0; i < tt.inits; i++ {
 				err := h.Init()
-				require.NoError(t, err, "Init failed on iteration %d", i+1)
+				if err != nil {
+					seenErrs++
+				}
 			}
+			require.Equal(t, tt.wantErrs, seenErrs, "unexpected number of errors from Init() calls")
 
 			// Internals check: initialized
-			assert.NotNil(t, h.rawBuf, "rawBuf should be non-nil after Init")
-			assert.NotEmpty(t, h.rawBuf, "rawBuf should be non-empty after Init")
-			assert.NotNil(t, h.reader, "reader should be non-nil after Init")
-			assert.False(t, h.mustRewind, "mustRewind should be false after Init and before Read")
-			// Reader check: only one read
-			assert.Equal(t, 1, h.treq.Body.(*counterReader).count, "should only have read once regardless of multiple Init calls")
+			if isSeeker {
+				assert.Nil(t, h.buf, "buf should be nil after Init")
+				assert.True(t, h.mustRewind, "mustRewind should be true after Init and before Read")
+			} else {
+				assert.NotNil(t, h.buf, "buf should be non-nil after Init")
+				assert.Empty(t, h.buf, "buf should be empty after Init and before Read")
+				assert.False(t, h.mustRewind, "mustRewind should be false after Init and before Read")
+			}
+
+			// Reader is only initialized if no Init() call returned an error
+			if tt.wantErrs == 0 {
+				assert.NotNil(t, h.reader, "reader should be non-nil after Init")
+			} else {
+				assert.Nil(t, h.reader, "reader should be nil after Init if any Init() call returned an error")
+			}
+			// Reader check: no reads
+			assert.Equal(t, 0, ogBody.(readCounter).Count(), "no reads before first GetBody call")
 		})
 	}
 }
@@ -349,20 +540,44 @@ func TestGetBodyHelper_Read(t *testing.T) {
 		wantEOF []bool // Expected EOF status from io.ReadAll on a getBodyHelper; must be same length as "reads"
 	}{
 		{
-			name: "single read",
+			name: "io.ReadSeeker: single read",
 			treq: &transport.Request{
-				Body: &counterReader{src: strings.NewReader(somePayload)},
+				Body: &counterReadSeeker{
+					cr: counterReader{
+						src: strings.NewReader(somePayload),
+					},
+				},
 			},
 			reads:   1,
 			wantEOF: []bool{false},
 		},
 		{
-			name: "first read succeeds, subsequent ones fail with EOF",
+			name: "io.Reader only: single read",
+			treq: &transport.Request{
+				Body: &counterReader{src: strings.NewReader(somePayload)},
+			},
+			reads:   1,
+			wantEOF: []bool{true}, // io.TeeReader cannot populate buffer without a treq.Body.Read first
+		},
+		{
+			name: "io.ReadSeeker: first read succeeds, subsequent ones fail with EOF",
+			treq: &transport.Request{
+				Body: &counterReadSeeker{
+					cr: counterReader{
+						src: strings.NewReader(somePayload),
+					},
+				},
+			},
+			reads:   5,
+			wantEOF: []bool{false, true, true, true, true},
+		},
+		{
+			name: "io.Reader only: first read succeeds, subsequent ones fail with EOF",
 			treq: &transport.Request{
 				Body: &counterReader{src: strings.NewReader(somePayload)},
 			},
 			reads:   5,
-			wantEOF: []bool{false, true, true, true, true},
+			wantEOF: []bool{true, true, true, true, true}, // io.TeeReader cannot populate buffer without a treq.Body.Read first
 		},
 	}
 	for _, tt := range tests {
@@ -375,6 +590,9 @@ func TestGetBodyHelper_Read(t *testing.T) {
 			}
 
 			expected, _ := io.ReadAll(strings.NewReader(somePayload))
+
+			// Store original body
+			ogBody := tt.treq.Body
 			h, err := newGetBodyHelper(tt.treq)
 			require.NotNil(t, h)
 			require.NoError(t, err)
@@ -388,51 +606,95 @@ func TestGetBodyHelper_Read(t *testing.T) {
 				require.NoError(t, err, "unexpected error on read %d", i+1)
 				assert.Equal(t, expected, data, "read data mismatch on read %d", i+1)
 				// Reader check: only one read from actual source
-				assert.Equal(t, 1, h.treq.Body.(*counterReader).count, "should only have read once regardless of multiple Read calls")
+				assert.Equal(t, 1, ogBody.(readCounter).Count(), "should only have read once regardless of multiple Read calls")
 			}
 		})
 	}
 }
 
-// TestNewGetBodyFunc validates constructor for newGetBodyFunc.
-func TestNewGetBodyFunc(t *testing.T) {
+// TestGetBodyHelper_NewGetBody validates constructor for GetBody function.
+func TestGetBodyHelper_NewGetBody(t *testing.T) {
 	const (
 		somePayload = "some-payload"
 	)
 
 	tests := []struct {
-		name    string
-		treq    *transport.Request
-		wantErr bool
-		execs   int // Number of times to call the GetBody function
+		name         string
+		treq         *transport.Request
+		wantErr      bool
+		execs        int // Number of times to call the GetBody function
+		wantExecErrs int // Number of expected errors from GetBody function calls
+		wantReads    int // Number of expected reads from the original reader
 	}{
 		{
-			name:    "nil body",
-			treq:    &transport.Request{},
-			wantErr: true,
+			name:         "nil body",
+			treq:         &transport.Request{},
+			wantErr:      true,
+			execs:        0, // Test case ends before reaching this point
+			wantExecErrs: 0, // Test case ends before reaching this point
+			wantReads:    0, // Test case ends before reaching this point
 		},
 		{
-			name: "valid body, single GetBody call",
+			name: "io.ReadSeeker: valid body, single GetBody call",
+			treq: &transport.Request{
+				Body: &counterReadSeeker{
+					cr: counterReader{
+						src: strings.NewReader(somePayload),
+					},
+				},
+			},
+			wantErr:      false,
+			execs:        1,
+			wantExecErrs: 0,
+			wantReads:    1, // Single read from original reader
+		},
+		{
+			name: "io.Reader only: valid body, single GetBody call",
 			treq: &transport.Request{
 				Body: &counterReader{src: strings.NewReader(somePayload)},
 			},
-			wantErr: false,
-			execs:   1,
+			wantErr:      false, // Will not fail in creating a GetBody function, but:
+			execs:        1,     // This exec call ends with error because...
+			wantExecErrs: 1,     // ... io.TeeReader cannot populate buffer without a treq.Body.Read first
+			wantReads:    0,     // Original reader is never read from
 		},
 		{
-			name: "valid body, multiple GetBody call",
+			name: "io.ReadSeeker: valid body, multiple GetBody calls",
 			treq: &transport.Request{
-				Body: &counterReader{src: strings.NewReader(somePayload)},
+				Body: &counterReadSeeker{
+					cr: counterReader{
+						src: strings.NewReader(somePayload),
+					},
+				},
 			},
-			wantErr: false,
-			execs:   5,
+			wantErr:      false,
+			execs:        5,
+			wantExecErrs: 0,
+			wantReads:    5, // These include rewinds on original reader
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			getBodyFn := newGetBodyFunc(tt.treq)
+			isSeeker := false
+			if tt.treq.Body != nil {
+				_, isSeeker = tt.treq.Body.(io.ReadSeeker)
+			}
+
+			// Store original body
+			ogBody := tt.treq.Body
+			h, err := newGetBodyHelper(tt.treq)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Nil(t, h)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, h)
+
+			getBodyFn := h.NewGetBody()
 			if tt.wantErr {
 				require.Nil(t, getBodyFn)
 				return
@@ -441,107 +703,97 @@ func TestNewGetBodyFunc(t *testing.T) {
 			expected, _ := io.ReadAll(strings.NewReader(somePayload))
 
 			// Reader check: no reads before first GetBody call
-			assert.Equal(t, 0, tt.treq.Body.(*counterReader).count, "no reads before first GetBody call")
-			for i := 0; i < tt.execs; i++ {
-				assert.NotPanics(t, func() {
-					// GetBody call internally rewinds the reader
-					ioCloser, err := getBodyFn()
-					assert.NoError(t, err, "unexpected error on GetBody call %d", i+1)
-					data, err := io.ReadAll(ioCloser)
-					require.NoError(t, err, "unexpected error on read call %d", i+1)
-					assert.Equal(t, expected, data, "read data mismatch on call %d", i+1)
-				})
-
-				// Reader check: only one read from actual source
-				assert.Equal(t, 1, tt.treq.Body.(*counterReader).count, "should only have read once regardless of multiple GetBody calls")
+			if isSeeker {
+				assert.Equal(t, 0, tt.treq.Body.(readCounter).Count(), "no reads before first GetBody call")
 			}
+			seenErrs := 0
+			for i := 0; i < tt.execs; i++ {
+				// GetBody call internally rewinds the reader
+				ioCloser, err := getBodyFn()
+				if err != nil {
+					seenErrs++
+					if tt.wantExecErrs > 0 {
+						continue
+					}
+				}
+				assert.NoError(t, err, "unexpected error on GetBody call %d", i+1)
+				data, err := io.ReadAll(ioCloser)
+				require.NoError(t, err, "unexpected error on read call %d", i+1)
+				assert.Equal(t, expected, data, "read data mismatch on call %d", i+1)
+			}
+			require.Equal(t, tt.wantExecErrs, seenErrs, "unexpected number of errors from GetBody calls")
+			// Reader check
+			assert.Equal(t, tt.wantReads, ogBody.(readCounter).Count(), "unexpected number of reads from original reader after multiple GetBody calls")
 		})
 	}
 }
 
-// TestEnsureGetBody validates that a GetBody function is properly attached to the net/http.Request when needed.
-func TestEnsureGetBody(t *testing.T) {
-	// This reader type should trigger a missing GetBody that is fixed by ensureGetBody
-	type opaqueReader struct{ io.Reader }
+// TestGetBodyHelper_EnsureGetBody validates that a GetBody function is properly attached to the net/http.Request when needed.
+func TestGetBodyHelper_EnsureGetBody(t *testing.T) {
 	const (
 		somePayload = "some-payload"
 	)
 
 	tests := []struct {
-		name           string
-		treq           *transport.Request
-		isHreqGetBody  bool // Whether GetBody is to be found on net/http.Request
-		wantEnsureErr  bool // Whether ensureGetBody is expected to return an error
-		isGetBodyFound bool // Whether GetBody is expected to be found on net/http.Request after ensureGetBody
-		reads          int  // Number of times to call the GetBody function
+		name       string
+		hreq       *http.Request
+		treq       *transport.Request
+		hasGetBody bool // Whether net/http.Request.GetBody is populated after EnsureGetBody() call
 	}{
 		{
-			name:           "nil body",
-			treq:           &transport.Request{},
-			isHreqGetBody:  false,
-			wantEnsureErr:  false,
-			isGetBodyFound: false,
-			reads:          0, // Not expected to call GetBody; test case ends way before
+			name:       "missing GetBody, nil transport.Request.Body",
+			hreq:       &http.Request{},
+			treq:       &transport.Request{},
+			hasGetBody: false,
 		},
 		{
-			name: "valid body, GetBody already provided",
-			treq: &transport.Request{
-				Body: strings.NewReader(somePayload),
+			name: "not overwriting existing GetBody",
+			hreq: &http.Request{
+				GetBody: func() (io.ReadCloser, error) {
+					return io.NopCloser(strings.NewReader(somePayload)), nil
+				},
 			},
-			isHreqGetBody:  true,
-			wantEnsureErr:  false,
-			isGetBodyFound: true,
-			reads:          5,
+			treq: &transport.Request{
+				Body: &counterReader{src: strings.NewReader(somePayload)},
+			},
+			hasGetBody: true,
 		},
 		{
-			name: "valid body, GetBody must be attached",
+			name: "missing GetBody, io.ReadSeeker transport.Request.Body",
+			hreq: &http.Request{},
 			treq: &transport.Request{
-				Body: &opaqueReader{strings.NewReader(somePayload)},
+				Body: &counterReadSeeker{
+					cr: counterReader{
+						src: strings.NewReader(somePayload),
+					},
+				},
 			},
-			isHreqGetBody:  false,
-			wantEnsureErr:  false,
-			isGetBodyFound: true,
-			reads:          5,
+			hasGetBody: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			hreq, err := http.NewRequest("POST", defaultURLTemplate.String(), tt.treq.Body)
-			require.NoError(t, err)
-
-			// Store original GetBody for later checks
-			ogGetBody := hreq.GetBody
-			if tt.isHreqGetBody {
-				require.NotNil(t, ogGetBody)
-			} else {
-				require.Nil(t, ogGetBody)
-			}
-
-			err = ensureGetBody(hreq, tt.treq)
-			if tt.wantEnsureErr {
-				require.Error(t, err)
-			} else {
+			// Create helper if needed
+			var helper *getBodyHelper
+			if needGetBodyHelper(tt.treq) {
+				h, err := newGetBodyHelper(tt.treq)
 				require.NoError(t, err)
+				require.NotNil(t, h)
+				helper = h
 			}
 
-			if tt.isGetBodyFound {
-				require.NotNil(t, hreq.GetBody, "GetBody should be attached to net/http.Request")
+			// Follows what createRequest() does
+			if helper != nil {
+				err := helper.EnsureGetBody(tt.hreq)
+				require.NoError(t, err, "unexpected error from EnsureGetBody()")
+			}
+
+			if tt.hasGetBody {
+				require.NotNil(t, tt.hreq.GetBody, "expected GetBody to be populated on net/http.Request")
 			} else {
-				require.Nil(t, hreq.GetBody, "GetBody should not be attached to net/http.Request")
-				// GetBody was not attached; no point in checking data consistency
-				return
-			}
-
-			// Data consistency
-			expected, _ := io.ReadAll(strings.NewReader(somePayload))
-			for i := 0; i < tt.reads; i++ {
-				ioCloser, err := hreq.GetBody()
-				require.NoError(t, err, "unexpected error on GetBody read %d", i+1)
-				data, err := io.ReadAll(ioCloser)
-				require.NoError(t, err, "unexpected error on read call %d", i+1)
-				assert.Equal(t, expected, data, "read data mismatch on call %d", i+1)
+				require.Nil(t, tt.hreq.GetBody, "expected GetBody to be nil on net/http.Request")
 			}
 		})
 	}

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -229,6 +229,324 @@ func BenchmarkRequestGetBody(b *testing.B) {
 	_ = blackholeErr
 }
 
+// counterReader is a io.Reader wrapper that keeps track of Read operations.
+type counterReader struct {
+	count int
+	src   io.Reader
+}
+
+// Implements the io.Reader interface.
+func (c *counterReader) Read(p []byte) (int, error) {
+	n, err := c.src.Read(p)
+	// Only count actual successful reads (io.ReadAll makes 2 calls to Read, second fails w/ 0 bytes & EOF error)
+	if n > 0 && err == nil {
+		c.count++
+	}
+	return n, err
+}
+
+var _ io.Reader = (*counterReader)(nil)
+
+// TestNewGetBodyHelper validates constructor for getBodyHelper.
+func TestNewGetBodyHelper(t *testing.T) {
+	tests := []struct {
+		name    string
+		treq    *transport.Request
+		wantErr bool
+	}{
+		{
+			name:    "nil body",
+			treq:    &transport.Request{},
+			wantErr: true,
+		},
+		{
+			name: "valid body",
+			treq: &transport.Request{
+				Body: &counterReader{src: strings.NewReader("some-payload")},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h, err := newGetBodyHelper(tt.treq)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Nil(t, h)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, h)
+
+			// Internals check: not initialized
+			assert.Nil(t, h.rawBuf, "rawBuf should be nil before first GetBody call")
+			assert.Nil(t, h.reader, "reader should be nil before first GetBody call")
+			assert.False(t, h.mustRewind, "mustRewind should be false before first GetBody call")
+			// Reader check: no reads
+			assert.Equal(t, 0, h.treq.Body.(*counterReader).count, "no reads before first GetBody call")
+		})
+	}
+}
+
+// TestGetBodyHelper_Init validates initialization of getBodyHelper.
+func TestGetBodyHelper_Init(t *testing.T) {
+	tests := []struct {
+		name  string
+		treq  *transport.Request
+		inits int
+	}{
+		{
+			name: "single init",
+			treq: &transport.Request{
+				Body: &counterReader{src: strings.NewReader("some-payload")},
+			},
+			inits: 1,
+		},
+		{
+			name: "multiple inits",
+			treq: &transport.Request{
+				Body: &counterReader{src: strings.NewReader("some-payload")},
+			},
+			inits: 5,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h, err := newGetBodyHelper(tt.treq)
+			require.NotNil(t, h)
+			require.NoError(t, err)
+			for i := 0; i < tt.inits; i++ {
+				err := h.Init()
+				require.NoError(t, err, "Init failed on iteration %d", i+1)
+			}
+
+			// Internals check: initialized
+			assert.NotNil(t, h.rawBuf, "rawBuf should be non-nil after Init")
+			assert.NotEmpty(t, h.rawBuf, "rawBuf should be non-empty after Init")
+			assert.NotNil(t, h.reader, "reader should be non-nil after Init")
+			assert.False(t, h.mustRewind, "mustRewind should be false after Init and before Read")
+			// Reader check: only one read
+			assert.Equal(t, 1, h.treq.Body.(*counterReader).count, "should only have read once regardless of multiple Init calls")
+		})
+	}
+}
+
+// TestGetBodyHelper_Read validates read & rewind functionalities from getBodyHelper.
+func TestGetBodyHelper_Read(t *testing.T) {
+	const (
+		somePayload = "some-payload"
+	)
+
+	tests := []struct {
+		name    string
+		treq    *transport.Request
+		reads   int    // Number of Read calls to make on a getBodyHelper
+		wantEOF []bool // Expected EOF status from io.ReadAll on a getBodyHelper; must be same length as "reads"
+	}{
+		{
+			name: "single read",
+			treq: &transport.Request{
+				Body: &counterReader{src: strings.NewReader(somePayload)},
+			},
+			reads:   1,
+			wantEOF: []bool{false},
+		},
+		{
+			name: "first read succeeds, subsequent ones fail with EOF",
+			treq: &transport.Request{
+				Body: &counterReader{src: strings.NewReader(somePayload)},
+			},
+			reads:   5,
+			wantEOF: []bool{false, true, true, true, true},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Test sanity check
+			if tt.reads != len(tt.wantEOF) {
+				t.Fatalf("test case misconfigured: mismatch between reads=%d and wantEOF=%d", tt.reads, len(tt.wantEOF))
+			}
+
+			expected, _ := io.ReadAll(strings.NewReader(somePayload))
+			h, err := newGetBodyHelper(tt.treq)
+			require.NotNil(t, h)
+			require.NoError(t, err)
+			for i := 0; i < tt.reads; i++ {
+				data, err := io.ReadAll(h)
+				// io.ReadAll does not report EOF as error, but returns empty data slice
+				if tt.wantEOF[i] {
+					require.Empty(t, data, "expected empty data on read %d", i+1)
+					continue
+				}
+				require.NoError(t, err, "unexpected error on read %d", i+1)
+				assert.Equal(t, expected, data, "read data mismatch on read %d", i+1)
+				// Reader check: only one read from actual source
+				assert.Equal(t, 1, h.treq.Body.(*counterReader).count, "should only have read once regardless of multiple Read calls")
+			}
+		})
+	}
+}
+
+// TestNewGetBodyFunc validates constructor for newGetBodyFunc.
+func TestNewGetBodyFunc(t *testing.T) {
+	const (
+		somePayload = "some-payload"
+	)
+
+	tests := []struct {
+		name    string
+		treq    *transport.Request
+		wantErr bool
+		execs   int // Number of times to call the GetBody function
+	}{
+		{
+			name:    "nil body",
+			treq:    &transport.Request{},
+			wantErr: true,
+		},
+		{
+			name: "valid body, single GetBody call",
+			treq: &transport.Request{
+				Body: &counterReader{src: strings.NewReader(somePayload)},
+			},
+			wantErr: false,
+			execs:   1,
+		},
+		{
+			name: "valid body, multiple GetBody call",
+			treq: &transport.Request{
+				Body: &counterReader{src: strings.NewReader(somePayload)},
+			},
+			wantErr: false,
+			execs:   5,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			getBodyFn := newGetBodyFunc(tt.treq)
+			if tt.wantErr {
+				require.Nil(t, getBodyFn)
+				return
+			}
+			require.NotNil(t, getBodyFn)
+			expected, _ := io.ReadAll(strings.NewReader(somePayload))
+
+			// Reader check: no reads before first GetBody call
+			assert.Equal(t, 0, tt.treq.Body.(*counterReader).count, "no reads before first GetBody call")
+			for i := 0; i < tt.execs; i++ {
+				assert.NotPanics(t, func() {
+					// GetBody call internally rewinds the reader
+					ioCloser, err := getBodyFn()
+					assert.NoError(t, err, "unexpected error on GetBody call %d", i+1)
+					data, err := io.ReadAll(ioCloser)
+					require.NoError(t, err, "unexpected error on read call %d", i+1)
+					assert.Equal(t, expected, data, "read data mismatch on call %d", i+1)
+				})
+
+				// Reader check: only one read from actual source
+				assert.Equal(t, 1, tt.treq.Body.(*counterReader).count, "should only have read once regardless of multiple GetBody calls")
+			}
+		})
+	}
+}
+
+// TestEnsureGetBody validates that a GetBody function is properly attached to the net/http.Request when needed.
+func TestEnsureGetBody(t *testing.T) {
+	// This reader type should trigger a missing GetBody that is fixed by ensureGetBody
+	type opaqueReader struct{ io.Reader }
+	const (
+		somePayload = "some-payload"
+	)
+
+	tests := []struct {
+		name           string
+		treq           *transport.Request
+		isHreqGetBody  bool // Whether GetBody is to be found on net/http.Request
+		wantEnsureErr  bool // Whether ensureGetBody is expected to return an error
+		isGetBodyFound bool // Whether GetBody is expected to be found on net/http.Request after ensureGetBody
+		reads          int  // Number of times to call the GetBody function
+	}{
+		{
+			name:           "nil body",
+			treq:           &transport.Request{},
+			isHreqGetBody:  false,
+			wantEnsureErr:  false,
+			isGetBodyFound: false,
+			reads:          0, // Not expected to call GetBody; test case ends way before
+		},
+		{
+			name: "valid body, GetBody already provided",
+			treq: &transport.Request{
+				Body: strings.NewReader(somePayload),
+			},
+			isHreqGetBody:  true,
+			wantEnsureErr:  false,
+			isGetBodyFound: true,
+			reads:          5,
+		},
+		{
+			name: "valid body, GetBody must be attached",
+			treq: &transport.Request{
+				Body: &opaqueReader{strings.NewReader(somePayload)},
+			},
+			isHreqGetBody:  false,
+			wantEnsureErr:  false,
+			isGetBodyFound: true,
+			reads:          5,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			hreq, err := http.NewRequest("POST", defaultURLTemplate.String(), tt.treq.Body)
+			require.NoError(t, err)
+
+			// Store original GetBody for later checks
+			ogGetBody := hreq.GetBody
+			if tt.isHreqGetBody {
+				require.NotNil(t, ogGetBody)
+			} else {
+				require.Nil(t, ogGetBody)
+			}
+
+			err = ensureGetBody(hreq, tt.treq)
+			if tt.wantEnsureErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			if tt.isGetBodyFound {
+				require.NotNil(t, hreq.GetBody, "GetBody should be attached to net/http.Request")
+			} else {
+				require.Nil(t, hreq.GetBody, "GetBody should not be attached to net/http.Request")
+				// GetBody was not attached; no point in checking data consistency
+				return
+			}
+
+			// Data consistency
+			expected, _ := io.ReadAll(strings.NewReader(somePayload))
+			for i := 0; i < tt.reads; i++ {
+				ioCloser, err := hreq.GetBody()
+				require.NoError(t, err, "unexpected error on GetBody read %d", i+1)
+				data, err := io.ReadAll(ioCloser)
+				require.NoError(t, err, "unexpected error on read call %d", i+1)
+				assert.Equal(t, expected, data, "read data mismatch on call %d", i+1)
+			}
+		})
+	}
+}
+
 func TestCallWithHTTP2(t *testing.T) {
 	t.Run("success - http2 client with http2 server", func(t *testing.T) {
 		handler := http.HandlerFunc(

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -350,8 +350,8 @@ func TestNeedGetBodyHelper(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			needed := needGetBodyHelper(tt.treq)
-			require.Equal(t, tt.outcome, needed, "unexpected outcome from needGetBodyHelper")
+			needed := needBodyHelper(tt.treq)
+			require.Equal(t, tt.outcome, needed, "unexpected outcome from needBodyHelper")
 
 			if tt.treq == nil || tt.treq.Body == nil {
 				return
@@ -361,15 +361,15 @@ func TestNeedGetBodyHelper(t *testing.T) {
 			hreq, err := http.NewRequest("POST", defaultURLTemplate.String(), tt.treq.Body)
 			require.NoError(t, err)
 			if needed {
-				require.Nil(t, hreq.GetBody, "GetBody needed by needGetBodyHelper() but found on net/http.Request")
+				require.Nil(t, hreq.GetBody, "GetBody needed by needBodyHelper() but found on net/http.Request")
 			} else {
-				require.NotNil(t, hreq.GetBody, "GetBody not needed by needGetBodyHelper() but not found on net/http.Request")
+				require.NotNil(t, hreq.GetBody, "GetBody not needed by needBodyHelper() but not found on net/http.Request")
 			}
 		})
 	}
 }
 
-// TestNewGetBodyHelper validates constructor for getBodyHelper.
+// TestNewGetBodyHelper validates constructor for bodyHelper.
 func TestNewGetBodyHelper(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -410,7 +410,7 @@ func TestNewGetBodyHelper(t *testing.T) {
 
 			// Store original body
 			ogBody := tt.treq.Body
-			h, err := newGetBodyHelper(tt.treq)
+			h, err := newBodyHelper(tt.treq)
 			if tt.wantErr {
 				require.Error(t, err)
 				require.Nil(t, h)
@@ -434,7 +434,7 @@ func TestNewGetBodyHelper(t *testing.T) {
 	}
 }
 
-// TestGetBodyHelper_Init validates initialization of getBodyHelper.
+// TestGetBodyHelper_Init validates initialization of bodyHelper.
 func TestGetBodyHelper_Init(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -493,7 +493,7 @@ func TestGetBodyHelper_Init(t *testing.T) {
 
 			// Store original body
 			ogBody := tt.treq.Body
-			h, err := newGetBodyHelper(tt.treq)
+			h, err := newBodyHelper(tt.treq)
 			require.NotNil(t, h)
 			require.NoError(t, err)
 			seenErrs := 0
@@ -527,7 +527,7 @@ func TestGetBodyHelper_Init(t *testing.T) {
 	}
 }
 
-// TestGetBodyHelper_Read validates read & rewind functionalities from getBodyHelper.
+// TestGetBodyHelper_Read validates read & rewind functionalities from bodyHelper.
 func TestGetBodyHelper_Read(t *testing.T) {
 	const (
 		somePayload = "some-payload"
@@ -536,8 +536,8 @@ func TestGetBodyHelper_Read(t *testing.T) {
 	tests := []struct {
 		name    string
 		treq    *transport.Request
-		reads   int    // Number of Read calls to make on a getBodyHelper
-		wantEOF []bool // Expected EOF status from io.ReadAll on a getBodyHelper; must be same length as "reads"
+		reads   int    // Number of Read calls to make on a bodyHelper
+		wantEOF []bool // Expected EOF status from io.ReadAll on a bodyHelper; must be same length as "reads"
 	}{
 		{
 			name: "io.ReadSeeker: single read",
@@ -593,7 +593,7 @@ func TestGetBodyHelper_Read(t *testing.T) {
 
 			// Store original body
 			ogBody := tt.treq.Body
-			h, err := newGetBodyHelper(tt.treq)
+			h, err := newBodyHelper(tt.treq)
 			require.NotNil(t, h)
 			require.NoError(t, err)
 			for i := 0; i < tt.reads; i++ {
@@ -684,7 +684,7 @@ func TestGetBodyHelper_NewGetBody(t *testing.T) {
 
 			// Store original body
 			ogBody := tt.treq.Body
-			h, err := newGetBodyHelper(tt.treq)
+			h, err := newBodyHelper(tt.treq)
 			if tt.wantErr {
 				require.Error(t, err)
 				require.Nil(t, h)
@@ -776,9 +776,9 @@ func TestGetBodyHelper_EnsureGetBody(t *testing.T) {
 			t.Parallel()
 
 			// Create helper if needed
-			var helper *getBodyHelper
-			if needGetBodyHelper(tt.treq) {
-				h, err := newGetBodyHelper(tt.treq)
+			var helper *bodyHelper
+			if needBodyHelper(tt.treq) {
+				h, err := newBodyHelper(tt.treq)
 				require.NoError(t, err)
 				require.NotNil(t, h)
 				helper = h


### PR DESCRIPTION
## Description
This PR introduces a `getBodyHelper` struct to use in HTTP/2 transport outbounds, specifically within the `Outbound::createRequest()` method.

Objects of this type ensure that all `net/http.Request` instances have a not-nil `GetBody` field; the value of this field is in fact used whenever HTTP/2 GOAWAY frames are received ([RFC7540](https://datatracker.ietf.org/doc/html/rfc7540#section-6.8)).
Previously in YARPC Go: this field is left with nil value if Go `net/http.NewRequest` receives a `transport.Request.Body` not matching any of the recognized types ([source](https://cs.opensource.google/go/go/+/refs/tags/go1.26.5:src/net/http/request.go;l=923)).

Type `getBodyHelper` implements `io.Reader` interface s.t. `GetBody` function can be defined on instances of this struct.
This helper wraps `transport.Request.Body` and delays reads/buffering until the first execution of `net/http.Request.GetBody`. Most importantly, if original `transport.Request.Body` implements `io.Seeker` no buffering is performed and the original body is rewinded; in any other case, a `io.TeeReader` is leveraged to redirect contents to an internal `bytes.Buffer`.
Any subsequent `getBodyHelper.Read()` call either rewinds or leverages the internal buffer (by rewinding a `bytes.Reader`).

Benchmarks:
```
goos: darwin
goarch: arm64
pkg: go.uber.org/yarpc/transport/http
cpu: Apple M4 Max
                                  │ src/yarpc-go/baseline_01_CreateRequest.txt │ src/yarpc-go/fix_01_getBodyHelper_01_CreateRequest.txt │
                                  │                   sec/op                   │             sec/op              vs base                │
CreateRequest/no_headers-16                                        250.9n ± 0%                      254.4n ± 0%  +1.39% (p=0.000 n=100)
CreateRequest/with_app_headers-16                                  549.4n ± 1%                      550.1n ± 0%       ~ (p=0.288 n=100)
geomean                                                            371.3n                           374.1n       +0.75%

                                  │ src/yarpc-go/baseline_01_CreateRequest.txt │ src/yarpc-go/fix_01_getBodyHelper_01_CreateRequest.txt │
                                  │                    B/op                    │             B/op              vs base                  │
CreateRequest/no_headers-16                                         656.0 ± 0%                     656.0 ± 0%       ~ (p=1.000 n=100) ¹
CreateRequest/with_app_headers-16                                 1.109Ki ± 0%                   1.109Ki ± 0%       ~ (p=1.000 n=100) ¹
geomean                                                             863.3                          863.3       +0.00%
¹ all samples are equal

                                  │ src/yarpc-go/baseline_01_CreateRequest.txt │ src/yarpc-go/fix_01_getBodyHelper_01_CreateRequest.txt │
                                  │                 allocs/op                  │          allocs/op            vs base                  │
CreateRequest/no_headers-16                                         7.000 ± 0%                     7.000 ± 0%       ~ (p=1.000 n=100) ¹
CreateRequest/with_app_headers-16                                   14.00 ± 0%                     14.00 ± 0%       ~ (p=1.000 n=100) ¹
geomean                                                             9.899                          9.899       +0.00%
¹ all samples are equal
```

```
goos: darwin
goarch: arm64
pkg: go.uber.org/yarpc/transport/http
cpu: Apple M4 Max
                                                                                          │ src/yarpc-go/baseline_02_RequestGetBody.txt │ src/yarpc-go/fix_01_getBodyHelper_02_RequestGetBody.txt │
                                                                                          │                   sec/op                    │             sec/op               vs base                │
RequestGetBody/happy_path:_one_Body_read,_no_GetBody_calls,_valid_Request.Body-16                                           89.98n ± 0%                       89.61n ± 0%  -0.42% (p=0.007 n=100)
RequestGetBody/sad_path:_one_Body_read,_one_GetBody_calls,_valid_Request.Body-16                                            178.4n ± 0%                       181.5n ± 1%  +1.74% (p=0.000 n=100)
RequestGetBody/saddest_path:_one_Body_read,_multiple_GetBody_calls,_valid_Request.Body-16                                   538.2n ± 0%                       542.7n ± 0%  +0.84% (p=0.000 n=100)
geomean                                                                                                                     205.2n                            206.7n       +0.71%

                                                                                          │ src/yarpc-go/baseline_02_RequestGetBody.txt │ src/yarpc-go/fix_01_getBodyHelper_02_RequestGetBody.txt │
                                                                                          │                    B/op                     │             B/op               vs base                  │
RequestGetBody/happy_path:_one_Body_read,_no_GetBody_calls,_valid_Request.Body-16                                            512.0 ± 0%                      512.0 ± 0%       ~ (p=1.000 n=100) ¹
RequestGetBody/sad_path:_one_Body_read,_one_GetBody_calls,_valid_Request.Body-16                                           1.000Ki ± 0%                    1.000Ki ± 0%       ~ (p=1.000 n=100) ¹
RequestGetBody/saddest_path:_one_Body_read,_multiple_GetBody_calls,_valid_Request.Body-16                                  3.000Ki ± 0%                    3.000Ki ± 0%       ~ (p=1.000 n=100) ¹
geomean                                                                                                                    1.145Ki                         1.145Ki       +0.00%
¹ all samples are equal

                                                                                          │ src/yarpc-go/baseline_02_RequestGetBody.txt │ src/yarpc-go/fix_01_getBodyHelper_02_RequestGetBody.txt │
                                                                                          │                  allocs/op                  │           allocs/op            vs base                  │
RequestGetBody/happy_path:_one_Body_read,_no_GetBody_calls,_valid_Request.Body-16                                            1.000 ± 0%                      1.000 ± 0%       ~ (p=1.000 n=100) ¹
RequestGetBody/sad_path:_one_Body_read,_one_GetBody_calls,_valid_Request.Body-16                                             2.000 ± 0%                      2.000 ± 0%       ~ (p=1.000 n=100) ¹
RequestGetBody/saddest_path:_one_Body_read,_multiple_GetBody_calls,_valid_Request.Body-16                                    6.000 ± 0%                      6.000 ± 0%       ~ (p=1.000 n=100) ¹
geomean                                                                                                                      2.289                           2.289       +0.00%
¹ all samples are equal
```

## Test Plan
- Unit tests
- Benchmarks

```
SUPPRESS_DOCKER=1 make test
```
```
go test -bench=BenchmarkCreateRequest -benchmem -count=100 -run='^$' ./transport/http/ > baseline_01_CreateRequest.txt
```
```
go test -bench=BenchmarkRequestGetBody -benchmem -count=100 -run='^$' ./transport/http/ > baseline_02_RequestGetBody.txt
```

## Checklist
- [x] Description and context for reviewers: one partner, one stranger

RELEASE NOTES:
- HTTP/2 transport outbound now ensures a not-nil value for `net/http.Request.GetBody` field in cases where `transport.Request.Body` type is different from `*bytes.Buffer`, `*bytes.Reader`, `*strings.Reader`. This fixes failed replays when receiving HTTP/2 GOAWAY frames ([RFC7540](https://datatracker.ietf.org/doc/html/rfc7540#section-6.8)).