### PR TITLE
transport/http: restore HTTP/2 support on TLS terminated inbounds

### DIFF
--- a/transport/http/inbound.go
+++ b/transport/http/inbound.go
@@ -326,17 +326,12 @@ func (i *Inbound) start() error {
 		protos.SetUnencryptedHTTP2(true)
 		i.server.Protocols = &protos
 
-		// http.Server.Protocols selects the protocol at the connection layer:
-		// HTTP/2 over TLS is only chosen when ALPN negotiated "h2", and
-		// SetUnencryptedHTTP2 only applies to connections that are not
-		// *tls.Conn.
-		//
-		// When TLS is enabled the mux listener terminates TLS itself and hands
-		// the server an already established *tls.Conn, so a client that speaks
-		// HTTP/2 with prior knowledge without offering ALPN would be served
-		// HTTP/1.1. Wrapping the handler with h2c restores the pre-Go-1.26
-		// behavior of detecting the HTTP/2 client preface at the request layer
-		// for those connections.
+		// http.Server.Protocols decides at the connection layer: over TLS it
+		// selects HTTP/2 from ALPN only, and SetUnencryptedHTTP2 applies just
+		// to non-TLS connections. The mux listener hands the server an already
+		// established *tls.Conn, so a prior-knowledge HTTP/2 client offering no
+		// ALPN would be served HTTP/1.1. h2c restores the pre-Go-1.26 preface
+		// detection at the request layer for those connections.
 		i.server.Handler = h2c.NewHandler(httpHandler, &http2.Server{})
 	}
 
@@ -357,9 +352,8 @@ func (i *Inbound) start() error {
 
 		tlsConfig := i.tlsConfig
 		if !i.disableHTTP2 {
-			// The mux listener terminates TLS with this configuration, not with
-			// http.Server.TLSConfig, so "h2" must be advertised here for ALPN
-			// capable HTTP/2 clients to negotiate HTTP/2.
+			// The mux listener terminates TLS with this config, not with
+			// http.Server.TLSConfig, so "h2" must be advertised here.
 			tlsConfig = withHTTP2ALPN(tlsConfig)
 		}
 
@@ -386,39 +380,60 @@ func (i *Inbound) start() error {
 	return nil
 }
 
-// withHTTP2ALPN returns a copy of the given TLS configuration that also
-// advertises HTTP/2 over ALPN, so that HTTP/2 clients negotiating "h2" are
-// served HTTP/2 instead of failing or being downgraded.
+// withHTTP2ALPN returns a TLS configuration advertising "h2" over ALPN, always
+// ranked below "http/1.1".
 //
-// "h2" is appended with the lowest preference and the relative order of the
-// protocols already configured is preserved. Go's TLS server resolves ALPN
-// using the server's preference order, and clients that offer both "http/1.1"
-// and "h2" are not necessarily able to speak HTTP/2 over TLS: the HTTP/1.1
-// outbound of this package, for instance, advertises both but always speaks
-// HTTP/1.1. Promoting "h2" would break those peers, so the negotiated protocol
-// is only changed for clients that do not offer any of the previously
-// configured protocols. Clients using HTTP/2 with prior knowledge are handled
-// by the h2c handler instead.
+// Go's TLS server picks the first of its own protocols that the client also
+// offers, so whichever of the two is listed first decides the protocol for any
+// client offering both. Offering "h2" does not mean a client can speak it over
+// TLS: the HTTP/1.1 outbound of this package advertises both yet always speaks
+// HTTP/1.1, and answering it in HTTP/2 breaks the connection. Ranking
+// "http/1.1" first protects those peers, while clients offering only "h2" still
+// match it. Clients using HTTP/2 with prior knowledge send no ALPN at all and
+// are handled by the h2c handler instead.
 //
-// "http/1.1" is added when missing: Go's TLS server aborts the handshake with
-// no_application_protocol when a client offers ALPN protocols and none of them
-// is supported by the server, so advertising "h2" alone would break plain
-// HTTPS/1.1 clients rather than downgrading them.
+// An "h2"-first configuration is therefore rewritten rather than honored. The
+// relative order of every other protocol is preserved.
 func withHTTP2ALPN(config *tls.Config) *tls.Config {
-	if slices.Contains(config.NextProtos, http2.NextProtoTLS) {
+	h2Index := slices.Index(config.NextProtos, http2.NextProtoTLS)
+	http11Index := slices.Index(config.NextProtos, http11NextProtoTLS)
+
+	// "http/1.1" already outranks "h2", nothing to do.
+	if h2Index >= 0 && http11Index >= 0 && http11Index < h2Index {
 		return config
 	}
 
-	// Clone so that the configuration owned by the caller is left untouched.
-	// Note that Clone copies the NextProtos slice header, so a fresh slice is
-	// built rather than mutating the existing one in place.
+	// Clone leaves the caller's config untouched, but it copies the NextProtos
+	// slice header, so build a fresh slice rather than appending in place.
 	newConfig := config.Clone()
-	protos := make([]string, 0, len(config.NextProtos)+2)
-	protos = append(protos, config.NextProtos...)
-	if !slices.Contains(protos, http11NextProtoTLS) {
-		protos = append(protos, http11NextProtoTLS)
+
+	if h2Index < 0 {
+		// "h2" is ours to add, so it goes last and outranks nothing.
+		protos := make([]string, 0, len(config.NextProtos)+2)
+		protos = append(protos, config.NextProtos...)
+		if http11Index < 0 {
+			protos = append(protos, http11NextProtoTLS)
+		}
+		newConfig.NextProtos = append(protos, http2.NextProtoTLS)
+		return newConfig
 	}
-	newConfig.NextProtos = append(protos, http2.NextProtoTLS)
+
+	// Move, or add, "http/1.1" immediately before the configured "h2".
+	protos := make([]string, 0, len(config.NextProtos)+1)
+	for _, proto := range config.NextProtos {
+		switch proto {
+		case http11NextProtoTLS:
+			// Re-inserted below, immediately before "h2".
+		case http2.NextProtoTLS:
+			if !slices.Contains(protos, http11NextProtoTLS) {
+				protos = append(protos, http11NextProtoTLS)
+			}
+			protos = append(protos, proto)
+		default:
+			protos = append(protos, proto)
+		}
+	}
+	newConfig.NextProtos = protos
 	return newConfig
 }
 

--- a/transport/http/inbound.go
+++ b/transport/http/inbound.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -39,9 +40,14 @@ import (
 	"go.uber.org/yarpc/transport/internal/tls/muxlistener"
 	"go.uber.org/yarpc/yarpcerrors"
 	"go.uber.org/zap"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
 )
 
 const (
+	// http11NextProtoTLS is the ALPN protocol name for HTTP/1.1.
+	http11NextProtoTLS = "http/1.1"
+
 	// We want a value that's around 5 seconds, but slightly higher than how
 	// long a successful HTTP shutdown can take.
 	// There's a specific path in the HTTP shutdown path that can take 5 seconds:
@@ -319,6 +325,19 @@ func (i *Inbound) start() error {
 		protos.SetHTTP2(true)
 		protos.SetUnencryptedHTTP2(true)
 		i.server.Protocols = &protos
+
+		// http.Server.Protocols selects the protocol at the connection layer:
+		// HTTP/2 over TLS is only chosen when ALPN negotiated "h2", and
+		// SetUnencryptedHTTP2 only applies to connections that are not
+		// *tls.Conn.
+		//
+		// When TLS is enabled the mux listener terminates TLS itself and hands
+		// the server an already established *tls.Conn, so a client that speaks
+		// HTTP/2 with prior knowledge without offering ALPN would be served
+		// HTTP/1.1. Wrapping the handler with h2c restores the pre-Go-1.26
+		// behavior of detecting the HTTP/2 client preface at the request layer
+		// for those connections.
+		i.server.Handler = h2c.NewHandler(httpHandler, &http2.Server{})
 	}
 
 	addr := i.addr
@@ -336,9 +355,17 @@ func (i *Inbound) start() error {
 			return errors.New("HTTP TLS enabled but configuration not provided")
 		}
 
+		tlsConfig := i.tlsConfig
+		if !i.disableHTTP2 {
+			// The mux listener terminates TLS with this configuration, not with
+			// http.Server.TLSConfig, so "h2" must be advertised here for ALPN
+			// capable HTTP/2 clients to negotiate HTTP/2.
+			tlsConfig = withHTTP2ALPN(tlsConfig)
+		}
+
 		listener = muxlistener.NewListener(muxlistener.Config{
 			Listener:      listener,
-			TLSConfig:     i.tlsConfig,
+			TLSConfig:     tlsConfig,
 			ServiceName:   i.transport.serviceName,
 			TransportName: TransportName,
 			Meter:         i.transport.meter,
@@ -357,6 +384,42 @@ func (i *Inbound) start() error {
 		i.logger.Warn("no procedures specified for HTTP inbound")
 	}
 	return nil
+}
+
+// withHTTP2ALPN returns a copy of the given TLS configuration that also
+// advertises HTTP/2 over ALPN, so that HTTP/2 clients negotiating "h2" are
+// served HTTP/2 instead of failing or being downgraded.
+//
+// "h2" is appended with the lowest preference and the relative order of the
+// protocols already configured is preserved. Go's TLS server resolves ALPN
+// using the server's preference order, and clients that offer both "http/1.1"
+// and "h2" are not necessarily able to speak HTTP/2 over TLS: the HTTP/1.1
+// outbound of this package, for instance, advertises both but always speaks
+// HTTP/1.1. Promoting "h2" would break those peers, so the negotiated protocol
+// is only changed for clients that do not offer any of the previously
+// configured protocols. Clients using HTTP/2 with prior knowledge are handled
+// by the h2c handler instead.
+//
+// "http/1.1" is added when missing: Go's TLS server aborts the handshake with
+// no_application_protocol when a client offers ALPN protocols and none of them
+// is supported by the server, so advertising "h2" alone would break plain
+// HTTPS/1.1 clients rather than downgrading them.
+func withHTTP2ALPN(config *tls.Config) *tls.Config {
+	if slices.Contains(config.NextProtos, http2.NextProtoTLS) {
+		return config
+	}
+
+	// Clone so that the configuration owned by the caller is left untouched.
+	// Note that Clone copies the NextProtos slice header, so a fresh slice is
+	// built rather than mutating the existing one in place.
+	newConfig := config.Clone()
+	protos := make([]string, 0, len(config.NextProtos)+2)
+	protos = append(protos, config.NextProtos...)
+	if !slices.Contains(protos, http11NextProtoTLS) {
+		protos = append(protos, http11NextProtoTLS)
+	}
+	newConfig.NextProtos = append(protos, http2.NextProtoTLS)
+	return newConfig
 }
 
 // Stop the inbound using Shutdown.

--- a/transport/http/inbound_test.go
+++ b/transport/http/inbound_test.go
@@ -469,16 +469,18 @@ func TestInboundWithHTTPVersion(t *testing.T) {
 func TestInboundHTTP2OverTLS(t *testing.T) {
 	scenario := testscenario.Create(t, time.Minute, time.Minute)
 
-	// Drop "h2" from the server configuration so that the ALPN case only
-	// succeeds if the inbound adds it back.
-	serverTLSConfig := scenario.ServerTLSConfig()
-	serverTLSConfig.NextProtos = []string{"http/1.1"}
+	// Default server configuration for the cases below. "h2" is dropped so
+	// that the ALPN case only succeeds if the inbound adds it back.
+	defaultServerProtos := []string{"http/1.1"}
 
 	tests := []struct {
-		desc      string
-		scheme    string
-		wantProto string
-		transport func() http.RoundTripper
+		desc string
+		// serverProtos is the ALPN list configured on the inbound. Defaults to
+		// defaultServerProtos when nil.
+		serverProtos []string
+		scheme       string
+		wantProto    string
+		transport    func() http.RoundTripper
 	}{
 		{
 			desc:      "tls client negotiating http2 over alpn",
@@ -536,10 +538,55 @@ func TestInboundHTTP2OverTLS(t *testing.T) {
 				}
 			},
 		},
+		{
+			// Regression guard for an "h2"-first server configuration: Go
+			// returns on the first exact ALPN match in server preference
+			// order, so without reordering the server would negotiate "h2"
+			// with this client and then receive HTTP/1.1.
+			desc:         "tls client speaking http1 while advertising h2 against h2 only server",
+			serverProtos: []string{"h2"},
+			scheme:       "http",
+			wantProto:    "HTTP/1.1",
+			transport: func() http.RoundTripper {
+				return &http.Transport{
+					DialContext: func(_ context.Context, network, addr string) (net.Conn, error) {
+						clientTLSConfig := scenario.ClientTLSConfig()
+						clientTLSConfig.NextProtos = []string{"http/1.1", "h2"}
+						return tls.Dial(network, addr, clientTLSConfig)
+					},
+				}
+			},
+		},
+		{
+			// A proxy that does not implement ALPN offers no protocols at all.
+			// The handshake must succeed, negotiate nothing, and still serve
+			// HTTP/2 through the h2c handler.
+			desc:         "tls client with no alpn against h2 only server",
+			serverProtos: []string{"h2"},
+			scheme:       "http",
+			wantProto:    "HTTP/2.0",
+			transport: func() http.RoundTripper {
+				return &http2.Transport{
+					AllowHTTP: true,
+					DialTLSContext: func(_ context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+						clientTLSConfig := scenario.ClientTLSConfig()
+						clientTLSConfig.NextProtos = nil
+						return tls.Dial(network, addr, clientTLSConfig)
+					},
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
+			serverProtos := tt.serverProtos
+			if serverProtos == nil {
+				serverProtos = defaultServerProtos
+			}
+			serverTLSConfig := scenario.ServerTLSConfig()
+			serverTLSConfig.NextProtos = append([]string(nil), serverProtos...)
+
 			testTransport := NewTransport()
 			inbound := testTransport.NewInbound(
 				"127.0.0.1:0",
@@ -566,15 +613,15 @@ func TestInboundHTTP2OverTLS(t *testing.T) {
 			assert.Equal(t, tt.wantProto, res.Proto, "unexpected protocol used to serve the response")
 
 			// The caller owned configuration must never be mutated.
-			assert.Equal(t, []string{"http/1.1"}, serverTLSConfig.NextProtos)
+			assert.Equal(t, serverProtos, serverTLSConfig.NextProtos)
 		})
 	}
 }
 
 // TestWithHTTP2ALPN verifies that the TLS configuration handed to the mux
-// listener advertises h2 without dropping http/1.1 or reordering the already
-// configured protocols, and that the caller owned configuration is never
-// mutated.
+// listener advertises h2 ranked below http/1.1, that the relative order of the
+// other configured protocols is preserved, and that the caller owned
+// configuration is never mutated.
 func TestWithHTTP2ALPN(t *testing.T) {
 	tests := []struct {
 		desc string
@@ -584,8 +631,19 @@ func TestWithHTTP2ALPN(t *testing.T) {
 		{desc: "empty", give: nil, want: []string{"http/1.1", "h2"}},
 		{desc: "http1 only", give: []string{"http/1.1"}, want: []string{"http/1.1", "h2"}},
 		{desc: "http1 and h2", give: []string{"http/1.1", "h2"}, want: []string{"http/1.1", "h2"}},
-		{desc: "h2 only", give: []string{"h2"}, want: []string{"h2"}},
 		{desc: "custom protocol", give: []string{"myproto"}, want: []string{"myproto", "http/1.1", "h2"}},
+
+		// "h2" must never outrank "http/1.1": a client offering both, such as
+		// this package's HTTP/1.1 outbound, would otherwise negotiate "h2" and
+		// then speak HTTP/1.1.
+		{desc: "h2 only", give: []string{"h2"}, want: []string{"http/1.1", "h2"}},
+		{desc: "h2 before http1", give: []string{"h2", "http/1.1"}, want: []string{"http/1.1", "h2"}},
+		{desc: "h2 before custom protocol", give: []string{"h2", "myproto"}, want: []string{"http/1.1", "h2", "myproto"}},
+		{desc: "custom protocol before h2", give: []string{"myproto", "h2"}, want: []string{"myproto", "http/1.1", "h2"}},
+
+		// Already correct: "http/1.1" outranks "h2", so the list is untouched
+		// even though the two are not adjacent.
+		{desc: "http1 and h2 with protocol between", give: []string{"http/1.1", "myproto", "h2"}, want: []string{"http/1.1", "myproto", "h2"}},
 	}
 
 	for _, tt := range tests {

--- a/transport/http/inbound_test.go
+++ b/transport/http/inbound_test.go
@@ -41,11 +41,13 @@ import (
 	"go.uber.org/net/metrics"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/api/transport"
+	yarpctls "go.uber.org/yarpc/api/transport/tls"
 	"go.uber.org/yarpc/api/transport/transporttest"
 	"go.uber.org/yarpc/encoding/raw"
 	"go.uber.org/yarpc/internal/routertest"
 	"go.uber.org/yarpc/internal/testtime"
 	"go.uber.org/yarpc/internal/yarpctest"
+	"go.uber.org/yarpc/transport/internal/tls/testscenario"
 	"go.uber.org/yarpc/yarpcerrors"
 )
 
@@ -458,6 +460,144 @@ func TestInboundWithHTTPVersion(t *testing.T) {
 		require.Error(t, err, "expected error making request")
 		require.Nil(t, res, "expected response to be nil")
 	})
+}
+
+// TestInboundHTTP2OverTLS is a regression test: when the inbound terminates
+// TLS through the mux listener, the server must still speak HTTP/2 to clients
+// negotiating "h2" over ALPN as well as to clients using HTTP/2 with prior
+// knowledge and offering no ALPN at all.
+func TestInboundHTTP2OverTLS(t *testing.T) {
+	scenario := testscenario.Create(t, time.Minute, time.Minute)
+
+	// Drop "h2" from the server configuration so that the ALPN case only
+	// succeeds if the inbound adds it back.
+	serverTLSConfig := scenario.ServerTLSConfig()
+	serverTLSConfig.NextProtos = []string{"http/1.1"}
+
+	tests := []struct {
+		desc      string
+		scheme    string
+		wantProto string
+		transport func() http.RoundTripper
+	}{
+		{
+			desc:      "tls client negotiating http2 over alpn",
+			scheme:    "https",
+			wantProto: "HTTP/2.0",
+			transport: func() http.RoundTripper {
+				clientTLSConfig := scenario.ClientTLSConfig()
+				clientTLSConfig.NextProtos = []string{"h2"}
+				return &http2.Transport{TLSClientConfig: clientTLSConfig}
+			},
+		},
+		{
+			desc:      "tls client using http2 with prior knowledge and no alpn",
+			scheme:    "http",
+			wantProto: "HTTP/2.0",
+			transport: func() http.RoundTripper {
+				return &http2.Transport{
+					AllowHTTP: true,
+					DialTLSContext: func(_ context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+						clientTLSConfig := scenario.ClientTLSConfig()
+						clientTLSConfig.NextProtos = nil
+						return tls.Dial(network, addr, clientTLSConfig)
+					},
+				}
+			},
+		},
+		{
+			desc:      "plaintext h2c client",
+			scheme:    "http",
+			wantProto: "HTTP/2.0",
+			transport: func() http.RoundTripper {
+				return &http2.Transport{
+					AllowHTTP: true,
+					DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+						var d net.Dialer
+						return d.DialContext(ctx, network, addr)
+					},
+				}
+			},
+		},
+		{
+			// Advertising "h2" must not downgrade peers that offer it over
+			// ALPN but only ever speak HTTP/1.1, as this package's HTTP/1.1
+			// outbound does.
+			desc:      "tls client speaking http1 while advertising h2",
+			scheme:    "http",
+			wantProto: "HTTP/1.1",
+			transport: func() http.RoundTripper {
+				return &http.Transport{
+					DialContext: func(_ context.Context, network, addr string) (net.Conn, error) {
+						clientTLSConfig := scenario.ClientTLSConfig()
+						clientTLSConfig.NextProtos = []string{"http/1.1", "h2"}
+						return tls.Dial(network, addr, clientTLSConfig)
+					},
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			testTransport := NewTransport()
+			inbound := testTransport.NewInbound(
+				"127.0.0.1:0",
+				InboundTLSConfiguration(serverTLSConfig),
+				// Permissive so that the plaintext h2c case is served by the
+				// same inbound configuration.
+				InboundTLSMode(yarpctls.Permissive),
+			)
+
+			dispatcher := yarpc.NewDispatcher(yarpc.Config{
+				Name:     "myservice",
+				Inbounds: yarpc.Inbounds{inbound},
+			})
+			require.NoError(t, dispatcher.Start(), "failed to start dispatcher")
+			t.Cleanup(func() { _ = dispatcher.Stop() })
+
+			client := http.Client{Transport: tt.transport()}
+			t.Cleanup(client.CloseIdleConnections)
+
+			res, err := client.Get(tt.scheme + "://" + inbound.Addr().String() + "/health")
+			require.NoError(t, err, "got error making request")
+			t.Cleanup(func() { _ = res.Body.Close() })
+
+			assert.Equal(t, tt.wantProto, res.Proto, "unexpected protocol used to serve the response")
+
+			// The caller owned configuration must never be mutated.
+			assert.Equal(t, []string{"http/1.1"}, serverTLSConfig.NextProtos)
+		})
+	}
+}
+
+// TestWithHTTP2ALPN verifies that the TLS configuration handed to the mux
+// listener advertises h2 without dropping http/1.1 or reordering the already
+// configured protocols, and that the caller owned configuration is never
+// mutated.
+func TestWithHTTP2ALPN(t *testing.T) {
+	tests := []struct {
+		desc string
+		give []string
+		want []string
+	}{
+		{desc: "empty", give: nil, want: []string{"http/1.1", "h2"}},
+		{desc: "http1 only", give: []string{"http/1.1"}, want: []string{"http/1.1", "h2"}},
+		{desc: "http1 and h2", give: []string{"http/1.1", "h2"}, want: []string{"http/1.1", "h2"}},
+		{desc: "h2 only", give: []string{"h2"}, want: []string{"h2"}},
+		{desc: "custom protocol", give: []string{"myproto"}, want: []string{"myproto", "http/1.1", "h2"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			config := &tls.Config{NextProtos: append([]string(nil), tt.give...)}
+
+			got := withHTTP2ALPN(config)
+
+			assert.Equal(t, tt.want, got.NextProtos)
+			assert.Equal(t, tt.give, config.NextProtos, "the given config must not be mutated")
+		})
+	}
 }
 
 func TestInboundWithTimeouts(t *testing.T) {


### PR DESCRIPTION
## Description

`v1.89.2` regressed HTTP/2 on inbounds that have TLS enabled. An HTTP/2 client now fails against them with:

```
http2: frame too large, note that the frame header looked like an HTTP/1.1 header
```

### Background: how the server decides between HTTP/1.1 and HTTP/2

A server only ever learns that a client wants HTTP/2 in one of two ways:

- **ALPN**: the client lists the protocols it speaks during the TLS handshake and the server picks one. Requires TLS, and requires the client to offer `h2`.
- **The connection preface**: a client with *prior knowledge* skips negotiation entirely and opens with the fixed 24-byte sequence `PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n`.

Both paths have to work, and neither is under the server's control. `v1.89.2` broke both of them on TLS terminated inbounds.

### What changed

The Go 1.26 upgrade (#2494) replaced the `h2c` handler wrapper and the `http2.ConfigureServer` call with `http.Server.Protocols`:

```go
// v1.89.1
h2s := &http2.Server{}
i.server.Handler = h2c.NewHandler(i.server.Handler, h2s)
err := http2.ConfigureServer(i.server.Server, h2s)

// v1.89.2
var protos http.Protocols
protos.SetHTTP1(true)
protos.SetHTTP2(true)
protos.SetUnencryptedHTTP2(true)
i.server.Protocols = &protos
```

Those are not equivalent once TLS is involved, for two reasons.

**1. `Protocols` decides at the connection layer, `h2c` decided at the request layer.**
`http.Server.Protocols` branches on the connection type: for a `*tls.Conn`, HTTP/2 is selected only when ALPN negotiated `h2`, and `SetUnencryptedHTTP2` (as the name says) applies only to connections that are *not* a `*tls.Conn`. So on a TLS connection, preface detection never runs at all.

The `h2c` handler it replaced wrapped the *handler*, not the connection. It ran after TLS termination, where the preface is ordinary plaintext that happens to parse as a valid HTTP/1.1 request line, so it caught prior-knowledge clients on plaintext and TLS connections alike.

**2. The server has never advertised `h2` over ALPN.**
That leaves ALPN as the only surviving path, and it was never wired up. When `tlsMode != Disabled`, the inbound wraps its listener with `muxlistener`, which terminates TLS itself using `i.tlsConfig`, not `i.server.TLSConfig`. `http2.ConfigureServer` only ever appended `h2` to the latter, so the ALPN list actually used by the handshake was untouched. This was latent and harmless while the `h2c` handler caught the preface; with it gone, nothing does.

With both paths dead, a TLS terminated inbound answers every client in HTTP/1.1, whatever the client asked for.

### Fix

- Advertise `h2` on the TLS configuration handed to `muxlistener` (cloned, so the caller's config is not mutated). This restores the ALPN path, for clients that negotiate.
- Restore the `h2c` handler alongside `http.Server.Protocols`, for parity with v1.89.1. This restores the preface path, for clients that dial TLS with prior-knowledge HTTP/2 and offer no ALPN at all (negotiated protocol is `""`). With `SetUnencryptedHTTP2(true)` the stdlib already handles cleartext h2 at the connection layer, so the handler path only fires on the TLS case.

`http.Server.Protocols` is kept. It is correct, just insufficient for TLS.

Deployments behind a proxy that does not implement ALPN are served entirely by the second bullet. Go's `negotiateALPN` returns early when either side offers no protocols, so a client sending no ALPN never reaches the preference comparison and the server's list is irrelevant to it.

#### Note on ALPN ordering

The inbound guarantees one invariant on the list it hands to `muxlistener`: **`http/1.1` always outranks `h2`.**

Go's TLS server iterates its own protocols in order and returns on the first one the client also offers, so whichever of the two is listed first decides the protocol for every client offering both. Offering `h2` does not mean a client can speak it over TLS. This package's own HTTP/1.1 outbound is exactly such a client: it dials through `http.Transport.DialContext` returning a `*tls.Conn`, so it always speaks HTTP/1.1 regardless of what ALPN negotiated, while the TLS config it is given commonly advertises `["http/1.1", "h2"]`. If the server answers it in HTTP/2 the connection fails (`bogus greeting "POST / HTTP/1.1..."`, or `malformed HTTP response "\x00\x00\x1e\x04..."` on the client side).

Concretely:

- When the caller did not configure `h2`, it is appended last, so it never outranks a protocol the caller asked for.
- When the caller did configure `h2` without `http/1.1` above it, `http/1.1` is moved, or added, immediately before it. **An `h2`-first configuration is deliberately rewritten rather than honored**, because the failure it causes is silent and hits yarpc's own outbound.
- Configurations where `http/1.1` already outranks `h2` are returned untouched, adjacent or not.

The relative order of every other protocol is preserved in all cases.

This is not about handshake rejection, and an earlier revision of this PR justified adding `http/1.1` on those grounds incorrectly. Go admits a client offering only `http/1.1` against an `h2`-only server by negotiating no protocol at all (golang/go#46310), and a client offering neither is rejected with `no_application_protocol` whether or not `http/1.1` is advertised. The reason to rank `http/1.1` first is ordering.

## Test Plan

New `TestInboundHTTP2OverTLS` in `transport/http`, covering a TLS-enabled inbound in `Permissive` mode. The server ALPN list is `["http/1.1"]` unless stated, so `h2` cases only pass if the inbound adds it back:

| client | server `NextProtos` | expected |
|---|---|---|
| TLS, negotiates `h2` over ALPN | `[http/1.1]` | HTTP/2 |
| TLS, prior-knowledge HTTP/2, offers no ALPN | `[http/1.1]` | HTTP/2 |
| plaintext h2c | `[http/1.1]` | HTTP/2 |
| TLS, advertises `h2` over ALPN but speaks HTTP/1.1 | `[http/1.1]` | HTTP/1.1 |
| TLS, advertises `h2` over ALPN but speaks HTTP/1.1 | `[h2]` | HTTP/1.1 |
| TLS, offers no ALPN, prior-knowledge HTTP/2 | `[h2]` | HTTP/2 |

The fourth and fifth rows guard the downgrade that promoting `h2` would introduce, the fifth specifically against an `h2`-first server configuration. The last row is the non-ALPN proxy case, and it is deliberately insensitive to the ordering work.

`TestWithHTTP2ALPN` unit-tests the rewrite, including that the caller's `tls.Config` is not mutated (`tls.Config.Clone` copies the `NextProtos` slice header, so the helper builds a fresh slice):

| given | want |
|---|---|
| `nil` | `[http/1.1, h2]` |
| `[http/1.1]` | `[http/1.1, h2]` |
| `[http/1.1, h2]` | unchanged |
| `[myproto]` | `[myproto, http/1.1, h2]` |
| `[h2]` | `[http/1.1, h2]` |
| `[h2, http/1.1]` | `[http/1.1, h2]` |
| `[h2, myproto]` | `[http/1.1, h2, myproto]` |
| `[myproto, h2]` | `[myproto, http/1.1, h2]` |
| `[http/1.1, myproto, h2]` | unchanged |

Every part of the fix was verified to be load-bearing by ablation:

- Without the ALPN rewrite: `tls_client_negotiating_http2_over_alpn` fails with `remote error: tls: no application protocol`.
- Without the `h2c` handler: `tls_client_using_http2_with_prior_knowledge_and_no_alpn` fails with `http2: frame too large, note that the frame header looked like an HTTP/1.1 header`, the reported symptom.
- Restoring the earlier "return unchanged if `h2` is present" shortcut: four `TestWithHTTP2ALPN` cases fail, and `tls_client_speaking_http1_while_advertising_h2_against_h2_only_server` fails end to end with `malformed HTTP response "\x00\x00\x1e\x04\x00\x00\x00\x00\x00..."`, the client choking on an HTTP/2 SETTINGS frame. `tls_client_with_no_alpn_against_h2_only_server` still passes under this ablation, confirming non-ALPN clients are unaffected by the ordering.

```
$ go test ./transport/http/...
ok  	go.uber.org/yarpc/transport/http	0.561s

$ go test -race ./transport/http/...
ok  	go.uber.org/yarpc/transport/http	2.217s

$ go test ./transport/... ./yarpcconfig/... .
ok  	go.uber.org/yarpc/transport	0.037s
ok  	go.uber.org/yarpc/transport/grpc	2.654s
ok  	go.uber.org/yarpc/transport/http	0.568s
ok  	go.uber.org/yarpc/transport/internal/tls/dialer	0.023s
ok  	go.uber.org/yarpc/transport/internal/tls/metrics	0.007s
ok  	go.uber.org/yarpc/transport/internal/tls/muxlistener	0.089s
ok  	go.uber.org/yarpc/transport/tchannel	2.010s
ok  	go.uber.org/yarpc/transport/tchannel/internal	0.005s
ok  	go.uber.org/yarpc/transport/tchannel/tracing	0.005s
ok  	go.uber.org/yarpc/yarpcconfig	0.044s
ok  	go.uber.org/yarpc	0.034s
```

`gofmt -l` is clean.

## Checklist
- [x] Description and context for reviewers: one partner, one stranger
- [x] Docs (package doc)

RELEASE NOTES:
Fixed: HTTP/2 is served again on TLS terminated HTTP inbounds. Since v1.89.2 such inbounds answered HTTP/2 clients in HTTP/1.1, failing them with "http2: frame too large, note that the frame header looked like an HTTP/1.1 header". The inbound now advertises `h2` over ALPN on the TLS configuration used by the mux listener, ranked below `http/1.1` so that clients advertising both are not downgraded, and again detects the HTTP/2 client preface for clients that offer no ALPN.
