### PR TITLE
transport/tchannel: unwrap ytchanError to underlying SystemError

### DIFF
--- a/transport/tchannel/error.go
+++ b/transport/tchannel/error.go
@@ -61,6 +61,11 @@ type ytchanError struct {
 
 func (y *ytchanError) Error() string { return y.err.Message() }
 
+// Unwrap exposes the underlying tchannel.SystemError so that standard library
+// helpers (errors.As, errors.Is) can inspect the original transport error
+// through the YARPC error chain.
+func (y *ytchanError) Unwrap() error { return y.err }
+
 func fromSystemError(err tchannel.SystemError) error {
 	code, ok := _tchannelCodeToCode[err.Code()]
 	if !ok {

--- a/transport/tchannel/error_test.go
+++ b/transport/tchannel/error_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/uber/tchannel-go"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/yarpcerrors"
@@ -101,4 +102,16 @@ func TestGetResponseErrorMeta(t *testing.T) {
 			assert.Equal(t, tt.want, GetResponseErrorMeta(tt.give), "unexpected")
 		})
 	}
+}
+
+func TestYtchanErrorUnwrap(t *testing.T) {
+	// fromSystemError wraps the tchannel.SystemError transparently; Unwrap on
+	// ytchanError lets errors.As reach it through the YARPC error chain.
+	sysErr := tchannel.NewSystemError(tchannel.ErrCodeTimeout, "timeout").(tchannel.SystemError)
+	err := fromSystemError(sysErr)
+
+	var got tchannel.SystemError
+	require.True(t, errors.As(err, &got), "expected errors.As to reach tchannel.SystemError")
+	assert.Equal(t, tchannel.ErrCodeTimeout, got.Code())
+	assert.Equal(t, "timeout", got.Message())
 }


### PR DESCRIPTION
## Description
YARPC's TChannel outbound wraps a `tchannel.SystemError` in a private
`ytchanError` and threads it through `yarpcerrors.Newf(code, "%w", &ytchanError{...})`.
`ytchanError` only implemented `Error()`, so the error chain dead-ended there:
`errors.As(err, &tchannel.SystemError{})` returned false, and callers had to
reach for the experimental `GetResponseErrorMeta` to recover the transport error.

This adds `Unwrap()` to `ytchanError`, extending the chain to
`*yarpcerrors.Status → *ytchanError → tchannel.SystemError` so the standard
library `errors.As`/`errors.Is` helpers can traverse it.

Non-obvious: this bridges the chain only as far as the `SystemError`. Making
`errors.Is(err, context.DeadlineExceeded)` / `context.Canceled` succeed
end-to-end additionally requires `tchannel.SystemError` itself to unwrap to
those sentinels — a companion change in tchannel-go (v1.34.4's `SystemError`
exposes `Wrapped()` but has no `Unwrap()`/`Is()`).

## Test Plan
`go test ./transport/tchannel/`

- Added `TestYtchanErrorUnwrap`: asserts `errors.As` now reaches the underlying
  `tchannel.SystemError` and recovers its code and message.
- Existing `TestToYARPCError` and `TestGetResponseErrorMeta` still pass —
  adding a method leaves the values' fields (and `reflect.DeepEqual`) unchanged.

## Checklist
- [x] Description and context for reviewers: one partner, one stranger
- [x] Docs (package doc) — N/a; the new method carries a doc comment, no package doc change

RELEASE NOTES:
transport/tchannel: `ytchanError` now implements `Unwrap()`, so `errors.As` and
`errors.Is` can reach the underlying `tchannel.SystemError` through the YARPC
error chain.