### PR TITLE
[HTTP] Bench: Adds benchmarking for net/http.Request.GetBody & E2E outbound.Call with HTTP/2 GOAWAY

### DIFF
--- a/transport/http/goaway_test.go
+++ b/transport/http/goaway_test.go
@@ -43,24 +43,42 @@ import (
 func TestHTTP2GoAwayReplay(t *testing.T) {
 	tests := []struct {
 		name    string
+		rejects int32 // Number of requests the server rejects with GOAWAY
 		mw      middleware.UnaryOutbound
 		reqBody io.Reader
 		wantErr bool
 	}{
 		{
-			name:    "no-op middleware, valid Request.Body; relay occurs",
+			name:    "no GOAWAY: no-op middleware, valid Request.Body; usual operation",
+			rejects: 0,
 			mw:      middleware.NopUnaryOutbound,
 			reqBody: getH2ValidBody(),
 			wantErr: false,
 		},
 		{
-			name:    "no-op middleware, invalid Request.Body; relay fails",
+			name:    "no GOAWAY: no-op middleware, invalid Request.Body; usual operation",
+			rejects: 0,
+			mw:      middleware.NopUnaryOutbound,
+			reqBody: getH2InvalidBody(),
+			wantErr: false,
+		},
+		{
+			name:    "one GOAWAY: no-op middleware, valid Request.Body; relay occurs",
+			rejects: 1, // 1 means reject the first request with GOAWAY, then accept the next ones
+			mw:      middleware.NopUnaryOutbound,
+			reqBody: getH2ValidBody(),
+			wantErr: false,
+		},
+		{
+			name:    "one GOAWAY: no-op middleware, invalid Request.Body; relay fails",
+			rejects: 1, // 1 means reject the first request with GOAWAY, then accept the next ones
 			mw:      middleware.NopUnaryOutbound,
 			reqBody: getH2InvalidBody(),
 			wantErr: true,
 		},
 		{
-			name:    "custom middleware, valid Request.Body becomes invalid; replay fails",
+			name:    "one GOAWAY: custom middleware, valid Request.Body becomes invalid; replay fails",
+			rejects: 1, // 1 means reject the first request with GOAWAY, then accept the next ones
 			mw:      someCustomMiddleware{},
 			reqBody: getH2ValidBody(),
 			wantErr: true,
@@ -70,20 +88,8 @@ func TestHTTP2GoAwayReplay(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			server := newH2CGoAwayServer(t)
-
-			httpTransport := NewTransport()
-			require.NoError(t, httpTransport.Start(), "failed to start http transport")
-			t.Cleanup(func() { assert.NoError(t, httpTransport.Stop()) })
-
-			out := httpTransport.NewSingleOutbound("http://"+server.addr(), UseHTTP2())
-			require.NoError(t, out.Start(), "failed to start http2 outbound")
-			t.Cleanup(func() {
-				assert.NoError(t, out.Stop())
-				out.client.CloseIdleConnections()
-			})
-
-			outboundWithMiddleware := middleware.ApplyUnaryOutbound(out, tt.mw)
+			server := newH2CGoAwayServer(t, tt.rejects)
+			outboundWithMiddleware := makeYarpcOutbound(t, server, tt.mw)
 
 			ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
 			t.Cleanup(cancel)
@@ -106,6 +112,115 @@ func TestHTTP2GoAwayReplay(t *testing.T) {
 	}
 }
 
+// BenchmarkHTTP2GoAway exercises HTTP/2 transport implementation w.r.t. GOAWAY frames.
+// In particular, it focuses on net/http.Request creation, reads, and allocations in cases where an
+// HTTP/2 server sends GOAWAY frames.
+func BenchmarkHTTP2GoAway(b *testing.B) {
+	var (
+		blackholeResp *transport.Response
+		blackholeErr  error
+	)
+
+	benchs := []struct {
+		name    string
+		rejects int32 // Number of requests the server rejects with GOAWAY
+		mw      middleware.UnaryOutbound
+		reqBody io.Reader
+	}{
+		{
+			name:    "happy path: no-op middleware, no GOAWAY, valid Request.Body",
+			rejects: 0,
+			mw:      middleware.NopUnaryOutbound,
+			reqBody: getH2ValidBody(),
+		},
+		{
+			name:    "happy path: no-op middleware, no GOAWAY, invalid Request.Body",
+			rejects: 0,
+			mw:      middleware.NopUnaryOutbound,
+			reqBody: getH2InvalidBody(),
+		},
+		{
+			name:    "sad path: no-op middleware, one GOAWAY, valid Request.Body",
+			rejects: 1, // 1 means reject the first request with GOAWAY, then accept the next ones
+			mw:      middleware.NopUnaryOutbound,
+			reqBody: getH2ValidBody(),
+		},
+		{
+			name:    "sad path: no-op middleware, one GOAWAY, invalid Request.Body",
+			rejects: 1, // 1 means reject the first request with GOAWAY, then accept the next ones
+			mw:      middleware.NopUnaryOutbound,
+			reqBody: getH2InvalidBody(),
+		},
+		{
+			name:    "sad path: custom middleware, one GOAWAY, valid Request.Body becomes invalid",
+			rejects: 1, // 1 means reject the first request with GOAWAY, then accept the next ones
+			mw:      someCustomMiddleware{},
+			reqBody: getH2ValidBody(),
+		},
+		{
+			name:    "saddest path: no-op middleware, always GOAWAY, valid Request.Body",
+			rejects: -1, // -1 means always reject with GOAWAY
+			mw:      middleware.NopUnaryOutbound,
+			reqBody: getH2ValidBody(),
+		},
+		{
+			name:    "saddest path: no-op middleware, always GOAWAY, invalid Request.Body",
+			rejects: -1, // -1 means always reject with GOAWAY
+			mw:      middleware.NopUnaryOutbound,
+			reqBody: getH2InvalidBody(),
+		},
+		{
+			name:    "saddest path: custom middleware, always GOAWAY, valid Request.Body becomes invalid",
+			rejects: -1, // -1 means always reject with GOAWAY
+			mw:      someCustomMiddleware{},
+			reqBody: getH2ValidBody(),
+		},
+	}
+	for _, bb := range benchs {
+		b.Run(bb.name, func(b *testing.B) {
+			server := newH2CGoAwayServer(b, bb.rejects)
+			outboundWithMiddleware := makeYarpcOutbound(b, server, bb.mw)
+
+			ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
+			b.Cleanup(cancel)
+
+			treq := &transport.Request{
+				Caller:    "caller",
+				Service:   "service",
+				Encoding:  raw.Encoding,
+				Procedure: "some-procedure",
+				Body:      bb.reqBody,
+			}
+
+			b.ResetTimer()
+			for range b.N {
+				blackholeResp, blackholeErr = outboundWithMiddleware.Call(ctx, treq)
+			}
+			b.StopTimer()
+		})
+	}
+
+	_ = blackholeResp
+	_ = blackholeErr
+}
+
+func makeYarpcOutbound(tb testing.TB, s *h2cGoAwayServer, mw middleware.UnaryOutbound) transport.UnaryOutbound {
+	tb.Helper()
+
+	httpTransport := NewTransport()
+	require.NoError(tb, httpTransport.Start(), "failed to start http transport")
+	tb.Cleanup(func() { assert.NoError(tb, httpTransport.Stop()) })
+
+	out := httpTransport.NewSingleOutbound("http://"+s.addr(), UseHTTP2())
+	require.NoError(tb, out.Start(), "failed to start http2 outbound")
+	tb.Cleanup(func() {
+		assert.NoError(tb, out.Stop())
+		out.client.CloseIdleConnections()
+	})
+
+	return middleware.ApplyUnaryOutbound(out, mw)
+}
+
 func getH2ValidBody() io.Reader {
 	// transport.Request.Body must be one of *bytes.Buffer, *bytes.Reader, or *strings.Reader.
 	return strings.NewReader("some-payload")
@@ -116,26 +231,33 @@ func getH2InvalidBody() io.Reader {
 	return &someCustomBody{reader: strings.NewReader("some-payload")}
 }
 
-// --- HTTP/2 server: immediately send GOAWAY frame ---
+// --- HTTP/2 server: send a configurable number of GOAWAY frames ---
 
 // h2cGoAwayServer is a minimal cleartext HTTP/2 server that sends a GOAWAY on
-// the first request and answers subsequent requests with 200. This reproduces
-// the net/http2 internal replay path that requires http.Request.GetBody to be
-// set.
+// to a configurable number of requests and answers with 200 to the rest.
+// This reproduces the net/http2 internal replay path that requires
+// http.Request.GetBody to be set.
 type h2cGoAwayServer struct {
-	listener net.Listener
-	requests atomic.Int32
+	listener     net.Listener
+	requests     atomic.Int32
+	rejectBefore int32 // Number of requests to reject with GOAWAY before accepting the rest; -1 rejects all requests.
 }
 
-func newH2CGoAwayServer(t *testing.T) *h2cGoAwayServer {
-	t.Helper()
+func newH2CGoAwayServer(tb testing.TB, rejectBefore int32) *h2cGoAwayServer {
+	tb.Helper()
 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err, "failed to listen for the h2c server")
+	require.NoError(tb, err, "failed to listen for the h2c server")
 
-	s := &h2cGoAwayServer{listener: ln}
+	if rejectBefore < -1 {
+		rejectBefore = -1
+	}
+	s := &h2cGoAwayServer{
+		listener:     ln,
+		rejectBefore: rejectBefore,
+	}
 	go s.serve()
-	t.Cleanup(func() { _ = ln.Close() })
+	tb.Cleanup(func() { _ = ln.Close() })
 	return s
 }
 
@@ -168,9 +290,9 @@ func (s *h2cGoAwayServer) handleConn(conn net.Conn) {
 		return
 	}
 
-	// First request ever: send GOAWAY with LastStreamID=0 so net/http2 considers
-	// stream 1 "not processed" and replays it on a new connection.
-	if s.requests.Add(1) == 1 {
+	// Send GOAWAY to any LastStreamID (-1) or LastStreamID <= s.rejectBefore so
+	// net/http2 considers stream "not processed" and replays it on a new connection.
+	if s.rejectBefore == -1 || s.requests.Add(1) <= s.rejectBefore {
 		_ = framer.WriteGoAway(0, http2.ErrCodeNo, nil)
 		return
 	}

--- a/transport/http/goaway_test.go
+++ b/transport/http/goaway_test.go
@@ -49,28 +49,28 @@ func TestHTTP2GoAwayReplay(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "no GOAWAY: no-op middleware, valid Request.Body; usual operation",
+			name:    "no GOAWAY: no-op middleware, valid Request.Body; no replay needed",
 			rejects: 0,
 			mw:      middleware.NopUnaryOutbound,
 			reqBody: getH2ValidBody(),
 			wantErr: false,
 		},
 		{
-			name:    "no GOAWAY: no-op middleware, invalid Request.Body; usual operation",
+			name:    "no GOAWAY: no-op middleware, invalid Request.Body; no replay needed",
 			rejects: 0,
 			mw:      middleware.NopUnaryOutbound,
 			reqBody: getH2InvalidBody(),
 			wantErr: false,
 		},
 		{
-			name:    "one GOAWAY: no-op middleware, valid Request.Body; relay occurs",
+			name:    "one GOAWAY: no-op middleware, valid Request.Body; replay succeeds",
 			rejects: 1, // 1 means reject the first request with GOAWAY, then accept the next ones
 			mw:      middleware.NopUnaryOutbound,
 			reqBody: getH2ValidBody(),
 			wantErr: false,
 		},
 		{
-			name:    "one GOAWAY: no-op middleware, invalid Request.Body; relay fails",
+			name:    "one GOAWAY: no-op middleware, invalid Request.Body; replay fails",
 			rejects: 1, // 1 means reject the first request with GOAWAY, then accept the next ones
 			mw:      middleware.NopUnaryOutbound,
 			reqBody: getH2InvalidBody(),

--- a/transport/http/outbound_test.go
+++ b/transport/http/outbound_test.go
@@ -136,6 +136,7 @@ func getBenchRequestWith(headers transport.Headers) *transport.Request {
 	return treq
 }
 
+// BenchmarkCreateRequest evaluates performance of outbound.CreateRequest().
 func BenchmarkCreateRequest(b *testing.B) {
 	out := &Outbound{urlTemplate: defaultURLTemplate}
 	var (
@@ -171,6 +172,60 @@ func BenchmarkCreateRequest(b *testing.B) {
 	}
 
 	_ = blackholeReq
+	_ = blackholeErr
+}
+
+// BenchmarkRequestGetBody evaluates performance of http.Request.GetBody() returned by outbound.CreateRequest().
+func BenchmarkRequestGetBody(b *testing.B) {
+	out := &Outbound{urlTemplate: defaultURLTemplate}
+	var (
+		blackholeBytes []byte
+		blackholeErr   error
+	)
+
+	benchs := []struct {
+		name    string
+		reqBody io.Reader
+		execs   int // Number of times to call the GetBody function
+	}{
+		{
+			name:    "happy path: one Body read, no GetBody calls, valid Request.Body",
+			reqBody: strings.NewReader("some-payload"),
+			execs:   0,
+		},
+		{
+			name:    "sad path: one Body read, one GetBody calls, valid Request.Body",
+			reqBody: strings.NewReader("some-payload"),
+			execs:   1,
+		},
+		{
+			name:    "saddest path: one Body read, multiple GetBody calls, valid Request.Body",
+			reqBody: strings.NewReader("some-payload"),
+			execs:   5,
+		},
+	}
+	for _, bb := range benchs {
+		b.Run(bb.name, func(b *testing.B) {
+			treq := getBenchRequest()
+			treq.Body = bb.reqBody
+			hreq, _ := out.createRequest(treq)
+			b.ResetTimer()
+			for range b.N {
+				// Simulate first read of net/http.Request.Body
+				blackholeBytes, blackholeErr = io.ReadAll(hreq.Body)
+
+				// Simulate subsequent reads via GetBody
+				for i := 0; i < bb.execs; i++ {
+					ioCloser, err := hreq.GetBody()
+					blackholeErr = err
+					blackholeBytes, blackholeErr = io.ReadAll(ioCloser)
+				}
+			}
+			b.StopTimer()
+		})
+	}
+
+	_ = blackholeBytes
 	_ = blackholeErr
 }
 


### PR DESCRIPTION
## Description
This PR adds benchmarking for HTTP transport, specifically for:
1. `net/http.Request`: reading `Body` field and execution of function in `GetBody` field;
    a. "happy path": `Body` is read once, `GetBody` is never executed;
    b. "sad path": `Body` is read once, `GetBody` is executed once;
    c. "saddest path": `Body` is read once, `GetBody` is executed multiple times.
3. End-to-end YARPC HTTP transport: `Outbound.Call()` method in several scenarios involving HTTP/2 GOAWAY frames ([RFC7540](https://datatracker.ietf.org/doc/html/rfc7540#section-6.8));
    a. "happy path": GOAWAY is never received;
    b. "sad path": GOAWAY is received once, `GetBody` allows replay;
    c. "saddest path": GOAWAY is received multiple times, `GetBody` allows replays.

This is a prerequisite to evaluate fixes for YARPC HTTP/2 transport when receiving HTTP/2 GOAWAY frames.

Baseline benchmarks:
```
goos: darwin
goarch: arm64
pkg: go.uber.org/yarpc/transport/http
cpu: Apple M4 Max
BenchmarkRequestGetBody/happy_path:_one_Body_read,_no_GetBody_calls,_valid_Request.Body-16              11735036                91.82 ns/op          512 B/op          1 allocs/op
BenchmarkRequestGetBody/happy_path:_one_Body_read,_no_GetBody_calls,_valid_Request.Body-16              13486669                89.70 ns/op          512 B/op          1 allocs/op
BenchmarkRequestGetBody/happy_path:_one_Body_read,_no_GetBody_calls,_valid_Request.Body-16              13668560                88.98 ns/op          512 B/op          1 allocs/op
BenchmarkRequestGetBody/happy_path:_one_Body_read,_no_GetBody_calls,_valid_Request.Body-16              13389500                88.54 ns/op          512 B/op          1 allocs/op
BenchmarkRequestGetBody/happy_path:_one_Body_read,_no_GetBody_calls,_valid_Request.Body-16              13492867                88.14 ns/op          512 B/op          1 allocs/op
BenchmarkRequestGetBody/happy_path:_one_Body_read,_no_GetBody_calls,_valid_Request.Body-16              13437416                88.81 ns/op          512 B/op          1 allocs/op
BenchmarkRequestGetBody/happy_path:_one_Body_read,_no_GetBody_calls,_valid_Request.Body-16              12515769                88.70 ns/op          512 B/op          1 allocs/op
BenchmarkRequestGetBody/happy_path:_one_Body_read,_no_GetBody_calls,_valid_Request.Body-16              13280811                88.50 ns/op          512 B/op          1 allocs/op
BenchmarkRequestGetBody/happy_path:_one_Body_read,_no_GetBody_calls,_valid_Request.Body-16              13193626                92.03 ns/op          512 B/op          1 allocs/op
BenchmarkRequestGetBody/happy_path:_one_Body_read,_no_GetBody_calls,_valid_Request.Body-16              13094229                88.93 ns/op          512 B/op          1 allocs/op
BenchmarkRequestGetBody/sad_path:_one_Body_read,_one_GetBody_calls,_valid_Request.Body-16                6781612               182.1 ns/op          1024 B/op          2 allocs/op
BenchmarkRequestGetBody/sad_path:_one_Body_read,_one_GetBody_calls,_valid_Request.Body-16                6695728               179.3 ns/op          1024 B/op          2 allocs/op
BenchmarkRequestGetBody/sad_path:_one_Body_read,_one_GetBody_calls,_valid_Request.Body-16                6879440               178.5 ns/op          1024 B/op          2 allocs/op
BenchmarkRequestGetBody/sad_path:_one_Body_read,_one_GetBody_calls,_valid_Request.Body-16                6475312               181.3 ns/op          1024 B/op          2 allocs/op
BenchmarkRequestGetBody/sad_path:_one_Body_read,_one_GetBody_calls,_valid_Request.Body-16                6502878               178.3 ns/op          1024 B/op          2 allocs/op
BenchmarkRequestGetBody/sad_path:_one_Body_read,_one_GetBody_calls,_valid_Request.Body-16                5954911               184.7 ns/op          1024 B/op          2 allocs/op
BenchmarkRequestGetBody/sad_path:_one_Body_read,_one_GetBody_calls,_valid_Request.Body-16                6697815               179.6 ns/op          1024 B/op          2 allocs/op
BenchmarkRequestGetBody/sad_path:_one_Body_read,_one_GetBody_calls,_valid_Request.Body-16                6376075               180.5 ns/op          1024 B/op          2 allocs/op
BenchmarkRequestGetBody/sad_path:_one_Body_read,_one_GetBody_calls,_valid_Request.Body-16                6318476               186.4 ns/op          1024 B/op          2 allocs/op
BenchmarkRequestGetBody/sad_path:_one_Body_read,_one_GetBody_calls,_valid_Request.Body-16                6530032               189.6 ns/op          1024 B/op          2 allocs/op
BenchmarkRequestGetBody/saddest_path:_one_Body_read,_multiple_GetBody_calls,_valid_Request.Body-16       2005417               602.3 ns/op          3072 B/op          6 allocs/op
BenchmarkRequestGetBody/saddest_path:_one_Body_read,_multiple_GetBody_calls,_valid_Request.Body-16       2210224               555.8 ns/op          3072 B/op          6 allocs/op
BenchmarkRequestGetBody/saddest_path:_one_Body_read,_multiple_GetBody_calls,_valid_Request.Body-16       2195995               547.0 ns/op          3072 B/op          6 allocs/op
BenchmarkRequestGetBody/saddest_path:_one_Body_read,_multiple_GetBody_calls,_valid_Request.Body-16       2229626               540.4 ns/op          3072 B/op          6 allocs/op
BenchmarkRequestGetBody/saddest_path:_one_Body_read,_multiple_GetBody_calls,_valid_Request.Body-16       2216398               546.2 ns/op          3072 B/op          6 allocs/op
BenchmarkRequestGetBody/saddest_path:_one_Body_read,_multiple_GetBody_calls,_valid_Request.Body-16       2170257               553.0 ns/op          3072 B/op          6 allocs/op
BenchmarkRequestGetBody/saddest_path:_one_Body_read,_multiple_GetBody_calls,_valid_Request.Body-16       1911872               572.7 ns/op          3072 B/op          6 allocs/op
BenchmarkRequestGetBody/saddest_path:_one_Body_read,_multiple_GetBody_calls,_valid_Request.Body-16       2201149               540.9 ns/op          3072 B/op          6 allocs/op
BenchmarkRequestGetBody/saddest_path:_one_Body_read,_multiple_GetBody_calls,_valid_Request.Body-16       2182298               558.7 ns/op          3072 B/op          6 allocs/op
BenchmarkRequestGetBody/saddest_path:_one_Body_read,_multiple_GetBody_calls,_valid_Request.Body-16       1895871               555.2 ns/op          3072 B/op          6 allocs/op
PASS
ok      go.uber.org/yarpc/transport/http        45.260s
```

```
goos: darwin
goarch: arm64
pkg: go.uber.org/yarpc/transport/http
cpu: Apple M4 Max
BenchmarkHTTP2GoAway/happy_path:_no-op_middleware,_no_GOAWAY,_valid_Request.Body-16                 5559            180689 ns/op           15824 B/op        135 allocs/op
BenchmarkHTTP2GoAway/happy_path:_no-op_middleware,_no_GOAWAY,_valid_Request.Body-16                 5134            195312 ns/op           16602 B/op        139 allocs/op
BenchmarkHTTP2GoAway/happy_path:_no-op_middleware,_no_GOAWAY,_valid_Request.Body-16                 5137            195180 ns/op           16748 B/op        140 allocs/op
BenchmarkHTTP2GoAway/happy_path:_no-op_middleware,_no_GOAWAY,_valid_Request.Body-16                 5240            191351 ns/op           16536 B/op        139 allocs/op
BenchmarkHTTP2GoAway/happy_path:_no-op_middleware,_no_GOAWAY,_valid_Request.Body-16                 5136            195207 ns/op           16532 B/op        140 allocs/op
BenchmarkHTTP2GoAway/happy_path:_no-op_middleware,_no_GOAWAY,_valid_Request.Body-16                 5197            192914 ns/op           16658 B/op        140 allocs/op
BenchmarkHTTP2GoAway/happy_path:_no-op_middleware,_no_GOAWAY,_valid_Request.Body-16                 4912            203991 ns/op           17092 B/op        143 allocs/op
BenchmarkHTTP2GoAway/happy_path:_no-op_middleware,_no_GOAWAY,_valid_Request.Body-16                 5432            184810 ns/op           15975 B/op        136 allocs/op
BenchmarkHTTP2GoAway/happy_path:_no-op_middleware,_no_GOAWAY,_valid_Request.Body-16                 5090            196948 ns/op           16645 B/op        140 allocs/op
BenchmarkHTTP2GoAway/happy_path:_no-op_middleware,_no_GOAWAY,_valid_Request.Body-16                 5170            193916 ns/op           16531 B/op        139 allocs/op
BenchmarkHTTP2GoAway/happy_path:_no-op_middleware,_no_GOAWAY,_invalid_Request.Body-16               4729            212293 ns/op           16117 B/op        137 allocs/op
BenchmarkHTTP2GoAway/happy_path:_no-op_middleware,_no_GOAWAY,_invalid_Request.Body-16               4179            242316 ns/op            8071 B/op         82 allocs/op
BenchmarkHTTP2GoAway/happy_path:_no-op_middleware,_no_GOAWAY,_invalid_Request.Body-16               2108            476905 ns/op           10636 B/op        118 allocs/op
BenchmarkHTTP2GoAway/happy_path:_no-op_middleware,_no_GOAWAY,_invalid_Request.Body-16               1065            940376 ns/op           10653 B/op        138 allocs/op
BenchmarkHTTP2GoAway/happy_path:_no-op_middleware,_no_GOAWAY,_invalid_Request.Body-16                988           1014701 ns/op           10118 B/op        137 allocs/op
BenchmarkHTTP2GoAway/happy_path:_no-op_middleware,_no_GOAWAY,_invalid_Request.Body-16                936           1069179 ns/op           10464 B/op        141 allocs/op
BenchmarkHTTP2GoAway/happy_path:_no-op_middleware,_no_GOAWAY,_invalid_Request.Body-16                914           1094563 ns/op           10217 B/op        141 allocs/op
BenchmarkHTTP2GoAway/happy_path:_no-op_middleware,_no_GOAWAY,_invalid_Request.Body-16                938           1067563 ns/op           11727 B/op        148 allocs/op
BenchmarkHTTP2GoAway/happy_path:_no-op_middleware,_no_GOAWAY,_invalid_Request.Body-16                885           1132326 ns/op           10478 B/op        142 allocs/op
BenchmarkHTTP2GoAway/happy_path:_no-op_middleware,_no_GOAWAY,_invalid_Request.Body-16                950           1054161 ns/op           11937 B/op        148 allocs/op
BenchmarkHTTP2GoAway/sad_path:_no-op_middleware,_one_GOAWAY,_valid_Request.Body-16                   883           1133850 ns/op            9785 B/op        139 allocs/op
BenchmarkHTTP2GoAway/sad_path:_no-op_middleware,_one_GOAWAY,_valid_Request.Body-16                   763           1311386 ns/op           10179 B/op        145 allocs/op
BenchmarkHTTP2GoAway/sad_path:_no-op_middleware,_one_GOAWAY,_valid_Request.Body-16                   943           1062217 ns/op            6714 B/op         96 allocs/op
BenchmarkHTTP2GoAway/sad_path:_no-op_middleware,_one_GOAWAY,_valid_Request.Body-16                  3345            299307 ns/op           17378 B/op        145 allocs/op
BenchmarkHTTP2GoAway/sad_path:_no-op_middleware,_one_GOAWAY,_valid_Request.Body-16                  5511            182364 ns/op           15458 B/op        133 allocs/op
BenchmarkHTTP2GoAway/sad_path:_no-op_middleware,_one_GOAWAY,_valid_Request.Body-16                  4854            206378 ns/op           17011 B/op        143 allocs/op
BenchmarkHTTP2GoAway/sad_path:_no-op_middleware,_one_GOAWAY,_valid_Request.Body-16                  4874            205509 ns/op           17109 B/op        143 allocs/op
BenchmarkHTTP2GoAway/sad_path:_no-op_middleware,_one_GOAWAY,_valid_Request.Body-16                  5162            194243 ns/op           16457 B/op        140 allocs/op
BenchmarkHTTP2GoAway/sad_path:_no-op_middleware,_one_GOAWAY,_valid_Request.Body-16                  4861            206012 ns/op           17273 B/op        144 allocs/op
BenchmarkHTTP2GoAway/sad_path:_no-op_middleware,_one_GOAWAY,_valid_Request.Body-16                  5193            193127 ns/op           16592 B/op        140 allocs/op
BenchmarkHTTP2GoAway/sad_path:_no-op_middleware,_one_GOAWAY,_invalid_Request.Body-16                4834            207351 ns/op           17221 B/op        143 allocs/op
BenchmarkHTTP2GoAway/sad_path:_no-op_middleware,_one_GOAWAY,_invalid_Request.Body-16                4682            213884 ns/op           17733 B/op        146 allocs/op
BenchmarkHTTP2GoAway/sad_path:_no-op_middleware,_one_GOAWAY,_invalid_Request.Body-16                4570            219044 ns/op           17817 B/op        147 allocs/op
BenchmarkHTTP2GoAway/sad_path:_no-op_middleware,_one_GOAWAY,_invalid_Request.Body-16                4820            207876 ns/op           17271 B/op        144 allocs/op
BenchmarkHTTP2GoAway/sad_path:_no-op_middleware,_one_GOAWAY,_invalid_Request.Body-16                5004            200437 ns/op           17109 B/op        145 allocs/op
BenchmarkHTTP2GoAway/sad_path:_no-op_middleware,_one_GOAWAY,_invalid_Request.Body-16                4666            216352 ns/op           15108 B/op        135 allocs/op
BenchmarkHTTP2GoAway/sad_path:_no-op_middleware,_one_GOAWAY,_invalid_Request.Body-16                2335            430206 ns/op           13025 B/op        124 allocs/op
BenchmarkHTTP2GoAway/sad_path:_no-op_middleware,_one_GOAWAY,_invalid_Request.Body-16                2229            451097 ns/op           14861 B/op        139 allocs/op
BenchmarkHTTP2GoAway/sad_path:_no-op_middleware,_one_GOAWAY,_invalid_Request.Body-16                1642            612709 ns/op            9253 B/op        114 allocs/op
BenchmarkHTTP2GoAway/sad_path:_no-op_middleware,_one_GOAWAY,_invalid_Request.Body-16                1176            852488 ns/op            8862 B/op        122 allocs/op
BenchmarkHTTP2GoAway/sad_path:_custom_middleware,_one_GOAWAY,_valid_Request.Body_becomes_invalid-16                  907           1105610 ns/op           12887 B/op        153 allocs/op
BenchmarkHTTP2GoAway/sad_path:_custom_middleware,_one_GOAWAY,_valid_Request.Body_becomes_invalid-16                  963           1040311 ns/op           11949 B/op        144 allocs/op
BenchmarkHTTP2GoAway/sad_path:_custom_middleware,_one_GOAWAY,_valid_Request.Body_becomes_invalid-16                 1338            755331 ns/op            8217 B/op        112 allocs/op
BenchmarkHTTP2GoAway/sad_path:_custom_middleware,_one_GOAWAY,_valid_Request.Body_becomes_invalid-16                  957           1047072 ns/op           12114 B/op        144 allocs/op
BenchmarkHTTP2GoAway/sad_path:_custom_middleware,_one_GOAWAY,_valid_Request.Body_becomes_invalid-16                  738           1356956 ns/op           10642 B/op        142 allocs/op
BenchmarkHTTP2GoAway/sad_path:_custom_middleware,_one_GOAWAY,_valid_Request.Body_becomes_invalid-16                  901           1113835 ns/op           10184 B/op        135 allocs/op
BenchmarkHTTP2GoAway/sad_path:_custom_middleware,_one_GOAWAY,_valid_Request.Body_becomes_invalid-16                  748           1337262 ns/op           14545 B/op        168 allocs/op
BenchmarkHTTP2GoAway/sad_path:_custom_middleware,_one_GOAWAY,_valid_Request.Body_becomes_invalid-16                 2845            351582 ns/op           21327 B/op        168 allocs/op
BenchmarkHTTP2GoAway/sad_path:_custom_middleware,_one_GOAWAY,_valid_Request.Body_becomes_invalid-16                 5119            197019 ns/op           14665 B/op        125 allocs/op
BenchmarkHTTP2GoAway/sad_path:_custom_middleware,_one_GOAWAY,_valid_Request.Body_becomes_invalid-16                 4714            213767 ns/op           15688 B/op        133 allocs/op
BenchmarkHTTP2GoAway/saddest_path:_no-op_middleware,_always_GOAWAY,_valid_Request.Body-16                              1        1001623125 ns/op          198192 B/op       2450 allocs/op
BenchmarkHTTP2GoAway/saddest_path:_no-op_middleware,_always_GOAWAY,_valid_Request.Body-16                              1        1002123708 ns/op          109688 B/op       1224 allocs/op
BenchmarkHTTP2GoAway/saddest_path:_no-op_middleware,_always_GOAWAY,_valid_Request.Body-16                              1        1001097541 ns/op          279736 B/op       3560 allocs/op
BenchmarkHTTP2GoAway/saddest_path:_no-op_middleware,_always_GOAWAY,_valid_Request.Body-16                              1        1002120167 ns/op          248288 B/op       3190 allocs/op
BenchmarkHTTP2GoAway/saddest_path:_no-op_middleware,_always_GOAWAY,_valid_Request.Body-16                              1        1000922000 ns/op          180376 B/op       2228 allocs/op
BenchmarkHTTP2GoAway/saddest_path:_no-op_middleware,_always_GOAWAY,_valid_Request.Body-16                              1        1001505125 ns/op          153848 B/op       1850 allocs/op
BenchmarkHTTP2GoAway/saddest_path:_no-op_middleware,_always_GOAWAY,_valid_Request.Body-16                              1        1000945083 ns/op          184224 B/op       2281 allocs/op
BenchmarkHTTP2GoAway/saddest_path:_no-op_middleware,_always_GOAWAY,_valid_Request.Body-16                              1        1002133209 ns/op          125992 B/op       1453 allocs/op
BenchmarkHTTP2GoAway/saddest_path:_no-op_middleware,_always_GOAWAY,_valid_Request.Body-16                              1        1000451125 ns/op          139240 B/op       1570 allocs/op
BenchmarkHTTP2GoAway/saddest_path:_no-op_middleware,_always_GOAWAY,_valid_Request.Body-16                              1        1002053042 ns/op          275448 B/op       3577 allocs/op
BenchmarkHTTP2GoAway/saddest_path:_no-op_middleware,_always_GOAWAY,_invalid_Request.Body-16                         3476            288444 ns/op           22769 B/op        198 allocs/op
BenchmarkHTTP2GoAway/saddest_path:_no-op_middleware,_always_GOAWAY,_invalid_Request.Body-16                         3499            286426 ns/op           23030 B/op        199 allocs/op
BenchmarkHTTP2GoAway/saddest_path:_no-op_middleware,_always_GOAWAY,_invalid_Request.Body-16                         3397            294929 ns/op           23693 B/op        204 allocs/op
BenchmarkHTTP2GoAway/saddest_path:_no-op_middleware,_always_GOAWAY,_invalid_Request.Body-16                         3424            292607 ns/op           22701 B/op        191 allocs/op
BenchmarkHTTP2GoAway/saddest_path:_no-op_middleware,_always_GOAWAY,_invalid_Request.Body-16                         3373            299170 ns/op           13163 B/op        125 allocs/op
BenchmarkHTTP2GoAway/saddest_path:_no-op_middleware,_always_GOAWAY,_invalid_Request.Body-16                         1125            891921 ns/op           10264 B/op        103 allocs/op
BenchmarkHTTP2GoAway/saddest_path:_no-op_middleware,_always_GOAWAY,_invalid_Request.Body-16                          627           1600223 ns/op            7061 B/op         87 allocs/op
BenchmarkHTTP2GoAway/saddest_path:_no-op_middleware,_always_GOAWAY,_invalid_Request.Body-16                          603           1660798 ns/op            7297 B/op         88 allocs/op
BenchmarkHTTP2GoAway/saddest_path:_no-op_middleware,_always_GOAWAY,_invalid_Request.Body-16                          680           1478039 ns/op            5689 B/op         78 allocs/op
BenchmarkHTTP2GoAway/saddest_path:_no-op_middleware,_always_GOAWAY,_invalid_Request.Body-16                          754           1331127 ns/op            5989 B/op         81 allocs/op
BenchmarkHTTP2GoAway/saddest_path:_custom_middleware,_always_GOAWAY,_valid_Request.Body_becomes_invalid-16          1077            931151 ns/op           11122 B/op        130 allocs/op
BenchmarkHTTP2GoAway/saddest_path:_custom_middleware,_always_GOAWAY,_valid_Request.Body_becomes_invalid-16          1167            859322 ns/op           13307 B/op        145 allocs/op
BenchmarkHTTP2GoAway/saddest_path:_custom_middleware,_always_GOAWAY,_valid_Request.Body_becomes_invalid-16          1471            681878 ns/op           11020 B/op        121 allocs/op
BenchmarkHTTP2GoAway/saddest_path:_custom_middleware,_always_GOAWAY,_valid_Request.Body_becomes_invalid-16          1292            775993 ns/op            8031 B/op         94 allocs/op
BenchmarkHTTP2GoAway/saddest_path:_custom_middleware,_always_GOAWAY,_valid_Request.Body_becomes_invalid-16          1153            868810 ns/op            5944 B/op         83 allocs/op
BenchmarkHTTP2GoAway/saddest_path:_custom_middleware,_always_GOAWAY,_valid_Request.Body_becomes_invalid-16          1047            956805 ns/op            8441 B/op         96 allocs/op
BenchmarkHTTP2GoAway/saddest_path:_custom_middleware,_always_GOAWAY,_valid_Request.Body_becomes_invalid-16           910           1101312 ns/op            5577 B/op         79 allocs/op
BenchmarkHTTP2GoAway/saddest_path:_custom_middleware,_always_GOAWAY,_valid_Request.Body_becomes_invalid-16           873           1147680 ns/op            5632 B/op         79 allocs/op
BenchmarkHTTP2GoAway/saddest_path:_custom_middleware,_always_GOAWAY,_valid_Request.Body_becomes_invalid-16           925           1084472 ns/op            6302 B/op         81 allocs/op
BenchmarkHTTP2GoAway/saddest_path:_custom_middleware,_always_GOAWAY,_valid_Request.Body_becomes_invalid-16          3354            301353 ns/op            9124 B/op         97 allocs/op
PASS
ok      go.uber.org/yarpc/transport/http        109.627s
```

## Test Plan
- Unit tests (benchmark run)

```
go test -bench=BenchmarkRequestGetBody -benchmem -count=10 -timeout 30s -run='^$' ./transport/http/
```

```
go test -bench=BenchmarkHTTP2GoAway -benchmem -count=10 -timeout 30s -run='^$' ./transport/http/
```

```
SUPPRESS_DOCKER=1 make test
```

## Checklist
- [x] Description and context for reviewers: one partner, one stranger

RELEASE NOTES:
N/a