### PR TITLE
Fix typos in doc comment

### DIFF
--- a/api/transport/outbound.go
+++ b/api/transport/outbound.go
@@ -42,8 +42,8 @@ type Outbound interface {
 // Namer is an additional interface that Outbounds may implement in order
 // properly set the transport.Request#Transport field.
 //
-// This interface is not embeded into Outbound to preserve backwards
-// compatiblity.
+// This interface is not embedded into Outbound to preserve backwards
+// compatibility.
 type Namer interface {
 	TransportName() string
 }


### PR DESCRIPTION
Small typo fixes in the `Namer` interface doc comment: "embeded" -> "embedded" and "compatiblity" -> "compatibility".

RELEASE NOTES: N/a
