### PR TITLE
Add tchannel cancellation options

### DIFF
--- a/transport/tchannel/config.go
+++ b/transport/tchannel/config.go
@@ -42,9 +42,16 @@ import (
 //	      exponential:
 //	        first: 10ms
 //	        max: 30s
+//	    propagateCancel: true
+//	    sendCancelOnContextCanceled: true
 type TransportConfig struct {
 	ConnTimeout time.Duration       `config:"connTimeout"`
 	ConnBackoff yarpcconfig.Backoff `config:"connBackoff"`
+	// PropagateCancel overrides the PropagateCancel transport option when set.
+	PropagateCancel *bool `config:"propagateCancel"`
+	// SendCancelOnContextCanceled overrides the
+	// SendCancelOnContextCanceled transport option when set.
+	SendCancelOnContextCanceled *bool `config:"sendCancelOnContextCanceled"`
 }
 
 // InboundConfig configures a TChannel inbound.
@@ -161,6 +168,13 @@ func (ts *transportSpec) buildTransport(tc *TransportConfig, k *yarpcconfig.Kit)
 
 	for _, opt := range ts.transportOptions {
 		opt(&options)
+	}
+
+	if tc.PropagateCancel != nil {
+		options.propagateCancel = *tc.PropagateCancel
+	}
+	if tc.SendCancelOnContextCanceled != nil {
+		options.sendCancelOnContextCanceled = *tc.SendCancelOnContextCanceled
 	}
 
 	if tc.ConnTimeout != 0 {

--- a/transport/tchannel/config_test.go
+++ b/transport/tchannel/config_test.go
@@ -45,6 +45,95 @@ func TestTransportSpecInvalidOption(t *testing.T) {
 	})
 }
 
+func TestTransportConfigCancellationOptions(t *testing.T) {
+	type attrs map[string]interface{}
+
+	tests := []struct {
+		name                        string
+		transportConfig             attrs
+		options                     []Option
+		wantPropagateCancel         bool
+		wantSendCancelOnCtxCanceled bool
+	}{
+		{
+			name: "defaults",
+		},
+		{
+			name: "propagate cancel",
+			transportConfig: attrs{
+				"propagateCancel": true,
+			},
+			wantPropagateCancel: true,
+		},
+		{
+			name: "send cancel on context canceled",
+			transportConfig: attrs{
+				"sendCancelOnContextCanceled": true,
+			},
+			wantSendCancelOnCtxCanceled: true,
+		},
+		{
+			name: "both configured",
+			transportConfig: attrs{
+				"propagateCancel":             true,
+				"sendCancelOnContextCanceled": true,
+			},
+			wantPropagateCancel:         true,
+			wantSendCancelOnCtxCanceled: true,
+		},
+		{
+			name: "transport options preserved when config omitted",
+			options: []Option{
+				PropagateCancel(true),
+				SendCancelOnContextCanceled(true),
+			},
+			wantPropagateCancel:         true,
+			wantSendCancelOnCtxCanceled: true,
+		},
+		{
+			name: "config takes precedence over transport options",
+			transportConfig: attrs{
+				"propagateCancel":             false,
+				"sendCancelOnContextCanceled": false,
+			},
+			options: []Option{
+				PropagateCancel(true),
+				SendCancelOnContextCanceled(true),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configurator := yarpcconfig.New()
+			require.NoError(t, configurator.RegisterTransport(TransportSpec(tt.options...)))
+
+			cfgData := attrs{
+				"outbounds": attrs{
+					"myservice": attrs{
+						"tchannel": attrs{
+							"peer": "127.0.0.1:4040",
+						},
+					},
+				},
+			}
+			if tt.transportConfig != nil {
+				cfgData["transports"] = attrs{
+					"tchannel": tt.transportConfig,
+				}
+			}
+
+			cfg, err := configurator.LoadConfig("foo", cfgData)
+			require.NoError(t, err)
+
+			outbound, ok := cfg.Outbounds["myservice"].Unary.(*Outbound)
+			require.True(t, ok)
+			assert.Equal(t, tt.wantPropagateCancel, outbound.transport.propagateCancel)
+			assert.Equal(t, tt.wantSendCancelOnCtxCanceled, outbound.transport.sendCancelOnContextCanceled)
+		})
+	}
+}
+
 type fakeOutboundTLSConfigProvider struct {
 	returnErr         error
 	expectedSpiffeIDs []string

--- a/transport/tchannel/options.go
+++ b/transport/tchannel/options.go
@@ -64,6 +64,8 @@ type transportOptions struct {
 	name                           string
 	connTimeout                    time.Duration
 	connBackoffStrategy            backoffapi.Strategy
+	propagateCancel                bool
+	sendCancelOnContextCanceled    bool
 	originalHeaders                bool
 	nativeTChannelMethods          NativeTChannelMethods
 	excludeServiceHeaderInResponse bool
@@ -221,6 +223,26 @@ func ConnTimeout(d time.Duration) TransportOption {
 func ConnBackoff(s backoffapi.Strategy) TransportOption {
 	return func(options *transportOptions) {
 		options.connBackoffStrategy = s
+	}
+}
+
+// PropagateCancel specifies whether cancel messages should cancel inbound
+// request contexts.
+//
+// The default is false.
+func PropagateCancel(enabled bool) TransportOption {
+	return func(options *transportOptions) {
+		options.propagateCancel = enabled
+	}
+}
+
+// SendCancelOnContextCanceled specifies whether cancel messages should be sent
+// when an outbound request context is canceled before receiving a response.
+//
+// The default is false.
+func SendCancelOnContextCanceled(enabled bool) TransportOption {
+	return func(options *transportOptions) {
+		options.sendCancelOnContextCanceled = enabled
 	}
 }
 

--- a/transport/tchannel/outbound_channel.go
+++ b/transport/tchannel/outbound_channel.go
@@ -64,9 +64,10 @@ func (o *outboundChannel) ReleasePeer(pid peer.Identifier, sub peer.Subscriber) 
 // This is invoked by the transport when it is started.
 func (o *outboundChannel) start() (err error) {
 	o.ch, err = tchannel.NewChannel(o.t.name, &tchannel.ChannelOptions{
-		Dialer:              o.dialer,
-		OnPeerStatusChanged: o.t.onPeerStatusChanged,
-		Tracer:              o.t.tracer,
+		DefaultConnectionOptions: o.t.channelConnectionOptions(),
+		Dialer:                   o.dialer,
+		OnPeerStatusChanged:      o.t.onPeerStatusChanged,
+		Tracer:                   o.t.tracer,
 	})
 	return err
 }

--- a/transport/tchannel/outbound_channel_test.go
+++ b/transport/tchannel/outbound_channel_test.go
@@ -106,3 +106,46 @@ func TestOutboundChannelFailure(t *testing.T) {
 	_, err = transport.createOutboundChannel(nil)
 	assert.EqualError(t, err, "tchannel outbound channel cannot be created after starting transport")
 }
+
+func TestOutboundChannelCancellationOptions(t *testing.T) {
+	tests := []struct {
+		name                        string
+		options                     []TransportOption
+		wantPropagateCancel         bool
+		wantSendCancelOnCtxCanceled bool
+	}{
+		{
+			name: "defaults",
+		},
+		{
+			name: "configured",
+			options: []TransportOption{
+				PropagateCancel(true),
+				SendCancelOnContextCanceled(true),
+			},
+			wantPropagateCancel:         true,
+			wantSendCancelOnCtxCanceled: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			options := append([]TransportOption{ServiceName("test")}, tt.options...)
+			transport, err := NewTransport(options...)
+			require.NoError(t, err)
+
+			peerTransport, err := transport.createOutboundChannel(nil)
+			require.NoError(t, err)
+			outboundChannel := peerTransport.(*outboundChannel)
+
+			require.NoError(t, transport.Start())
+			t.Cleanup(func() {
+				assert.NoError(t, transport.Stop())
+			})
+
+			connectionOptions := outboundChannel.ch.ConnectionOptions()
+			assert.Equal(t, tt.wantPropagateCancel, connectionOptions.PropagateCancel)
+			assert.Equal(t, tt.wantSendCancelOnCtxCanceled, connectionOptions.SendCancelOnContextCanceled)
+		})
+	}
+}

--- a/transport/tchannel/transport.go
+++ b/transport/tchannel/transport.go
@@ -73,10 +73,12 @@ type Transport struct {
 	dialer            func(ctx context.Context, network, hostPort string) (net.Conn, error)
 	newResponseWriter func(inboundCallResponse, tchannel.Format, headerCase) responseWriter
 
-	connTimeout         time.Duration
-	connectorsGroup     sync.WaitGroup
-	connBackoffStrategy backoffapi.Strategy
-	headerCase          headerCase
+	connTimeout                 time.Duration
+	connectorsGroup             sync.WaitGroup
+	connBackoffStrategy         backoffapi.Strategy
+	propagateCancel             bool
+	sendCancelOnContextCanceled bool
+	headerCase                  headerCase
 
 	peers map[string]*tchannelPeer
 
@@ -148,6 +150,8 @@ func (o transportOptions) newTransport() *Transport {
 		dialer:                         o.dialer,
 		connTimeout:                    o.connTimeout,
 		connBackoffStrategy:            o.connBackoffStrategy,
+		propagateCancel:                o.propagateCancel,
+		sendCancelOnContextCanceled:    o.sendCancelOnContextCanceled,
 		peers:                          make(map[string]*tchannelPeer),
 		tracer:                         tracer,
 		logger:                         logger,
@@ -244,7 +248,8 @@ func (t *Transport) start() error {
 	}
 
 	chopts := tchannel.ChannelOptions{
-		Tracer: t.tracer,
+		DefaultConnectionOptions: t.channelConnectionOptions(),
+		Tracer:                   t.tracer,
 		Handler: handler{
 			router:                         t.router,
 			tracer:                         t.tracer,
@@ -319,6 +324,13 @@ func (t *Transport) start() error {
 		}
 	}
 	return nil
+}
+
+func (t *Transport) channelConnectionOptions() tchannel.ConnectionOptions {
+	return tchannel.ConnectionOptions{
+		PropagateCancel:             t.propagateCancel,
+		SendCancelOnContextCanceled: t.sendCancelOnContextCanceled,
+	}
 }
 
 // Stop stops the TChannel transport. It starts rejecting incoming requests

--- a/transport/tchannel/transport_test.go
+++ b/transport/tchannel/transport_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tchannel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransportCancellationOptions(t *testing.T) {
+	tests := []struct {
+		name                        string
+		options                     []TransportOption
+		wantPropagateCancel         bool
+		wantSendCancelOnCtxCanceled bool
+	}{
+		{
+			name: "defaults",
+		},
+		{
+			name:                "propagate cancel",
+			options:             []TransportOption{PropagateCancel(true)},
+			wantPropagateCancel: true,
+		},
+		{
+			name:                        "send cancel on context canceled",
+			options:                     []TransportOption{SendCancelOnContextCanceled(true)},
+			wantSendCancelOnCtxCanceled: true,
+		},
+		{
+			name: "both",
+			options: []TransportOption{
+				PropagateCancel(true),
+				SendCancelOnContextCanceled(true),
+			},
+			wantPropagateCancel:         true,
+			wantSendCancelOnCtxCanceled: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			options := append([]TransportOption{ServiceName("test")}, tt.options...)
+			transport, err := NewTransport(options...)
+			require.NoError(t, err)
+			require.NoError(t, transport.Start())
+			t.Cleanup(func() {
+				assert.NoError(t, transport.Stop())
+			})
+
+			connectionOptions := transport.ch.ConnectionOptions()
+			assert.Equal(t, tt.wantPropagateCancel, connectionOptions.PropagateCancel)
+			assert.Equal(t, tt.wantSendCancelOnCtxCanceled, connectionOptions.SendCancelOnContextCanceled)
+		})
+	}
+}


### PR DESCRIPTION
## Description
Added `PropagateCancel` and `SendCancelOnContextCanceled` TChannel transport options to let TChannel servers and clients propagate client context cancellations.

## Test Plan
- unit tested
- tested in the monorepo that adding the options propagates cancellation as expected and disabling the options via yaml config also works

## Checklist
- [X] Description and context for reviewers

RELEASE NOTES: Added `PropagateCancel` and `SendCancelOnContextCanceled` TChannel transport options to let TChannel servers and clients propagate client context cancellations.
