### PR TITLE
[Protobuf][1/n] Add internal/protogen: descriptor-agnostic core for annotation-driven accessor generation

### DIFF
--- a/internal/protogen/lower.go
+++ b/internal/protogen/lower.go
@@ -1,0 +1,239 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package protogen
+
+import "fmt"
+
+// Accessor body rendering modes. The lowering classifies each path set
+// into one of these and the plugin's template maps the mode to Go
+// syntax, so the statement-level Go source (return / literal / var /
+// append / range) lives in the template, not in hardcoded strings here.
+const (
+	// ModeSlice: a single path whose `repeated string` leaf is reached
+	// through scalar hops only. The accessor returns that field's slice
+	// directly: `return <SliceExpr>`.
+	ModeSlice = "slice"
+	// ModeLiteral: every path is scalar-only (a plain string leaf
+	// reached through optional message hops). The accessor returns a
+	// composite literal of the nil-safe getter chains:
+	// `return []string{Exprs...}`.
+	ModeLiteral = "literal"
+	// ModeBuilder: at least one path traverses a container (a
+	// repeated/map message hop, or a map leaf), or scalars and slices
+	// mix across paths. The accessor accumulates into `out` via Stmts
+	// and returns it.
+	ModeBuilder = "builder"
+)
+
+// Builder statement kinds. Each maps to one line of Go the plugin's
+// template renders.
+const (
+	// StmtAppend appends a single string expression: out = append(out, Expr).
+	StmtAppend = "append"
+	// StmtAppendSpread spreads a []string expression: out = append(out, Expr...).
+	StmtAppendSpread = "appendSpread"
+	// StmtRangeOpen opens a loop: for _, Var := range Expr {.
+	StmtRangeOpen = "rangeOpen"
+	// StmtClose closes the most recently opened loop: }.
+	StmtClose = "close"
+)
+
+// Stmt is one statement of a ModeBuilder accessor body, kept as
+// structured data so the template (not this package) owns the Go syntax.
+type Stmt struct {
+	Kind string // one of StmtAppend / StmtAppendSpread / StmtRangeOpen / StmtClose
+	Expr string // append value, spread slice, or range source; empty for StmtClose
+	Var  string // loop variable; set only for StmtRangeOpen
+}
+
+// Accessor is the template-ready description of one generated accessor
+// body. Mode selects how the template renders it; only the fields
+// relevant to that mode are populated:
+//   - ModeSlice   -> SliceExpr
+//   - ModeLiteral -> Exprs
+//   - ModeBuilder -> Stmts
+type Accessor struct {
+	// Mode is one of ModeSlice / ModeLiteral / ModeBuilder.
+	Mode string
+	// SliceExpr is the getter chain returned directly in ModeSlice.
+	SliceExpr string
+	// Exprs are the nil-safe getter chains listed in the ModeLiteral
+	// composite literal, in declaration order.
+	Exprs []string
+	// Stmts are the accumulator statements rendered in ModeBuilder, in
+	// order, with loops already balanced (open/close).
+	Stmts []Stmt
+}
+
+// Lower classifies the given non-empty set of paths into a rendering
+// mode and packages the data the template needs to emit an accessor body
+// on receiver expression recv (e.g. "t"). It holds no Go statement
+// syntax: the actual `return`/`[]string{}`/`append`/`for` text is
+// emitted by the template from the Mode and the structured fields.
+//
+// The mode is chosen so the generated body is as simple as the shape
+// allows:
+//   - ModeSlice: a single path whose `repeated string` leaf is reached
+//     through scalar hops only. The getter chain already yields exactly
+//     the []string wanted, so the accessor returns it directly. The
+//     returned slice aliases the message's backing array, matching the
+//     stock getter it delegates to.
+//   - ModeLiteral: every path is scalar-only (a plain string leaf reached
+//     through optional message hops). Each contributes one nil-safe
+//     getter chain to a single composite literal. This is the common
+//     case.
+//   - ModeBuilder: any path traverses a container (repeated/map message
+//     hop, or a map leaf), or scalars and slices mix across paths, so a
+//     single expression cannot express the result (Go cannot spread a
+//     slice or range a map inside `[]string{...}`). Falls back to an
+//     accumulator with append/range statements.
+func Lower(recv string, paths []*Path) *Accessor {
+	a := &Accessor{}
+	if len(paths) == 1 {
+		if expr, ok := slicePathExpr(recv, paths[0]); ok {
+			a.Mode = ModeSlice
+			a.SliceExpr = expr
+			return a
+		}
+	}
+	exprs := make([]string, 0, len(paths))
+	allScalar := true
+	for _, p := range paths {
+		expr, ok := scalarPathExpr(recv, p)
+		if !ok {
+			allScalar = false
+			break
+		}
+		exprs = append(exprs, expr)
+	}
+	if allScalar {
+		a.Mode = ModeLiteral
+		a.Exprs = exprs
+		return a
+	}
+	a.Mode = ModeBuilder
+	for _, p := range paths {
+		a.Stmts = append(a.Stmts, buildStmts(recv, p)...)
+	}
+	return a
+}
+
+// getter returns the nil-safe getter for s invoked on receiver
+// expression recv, e.g. getter("t", actorStep) -> "t.GetActor()".
+// Generated GetXxx() methods return the zero value on a nil receiver, so
+// chaining these stays panic-free through missing intermediate hops.
+func getter(recv string, s Step) string {
+	return recv + ".Get" + s.GoName + "()"
+}
+
+// scalarPathExpr returns the single nil-safe getter-chain expression for
+// a scalar-only path - one whose every message hop is optional (scalar)
+// and whose leaf is a plain string field. It reports false when the path
+// traverses any container (repeated / map) hop or leaf, in which case
+// the caller must emit loop-based statements instead.
+func scalarPathExpr(recv string, p *Path) (string, bool) {
+	expr := recv
+	for _, s := range p.Steps {
+		g := getter(expr, s)
+		switch s.Kind {
+		case StepScalarMessage:
+			expr = g
+		case StepStringLeaf:
+			return g, true
+		default:
+			return "", false
+		}
+	}
+	return "", false
+}
+
+// slicePathExpr returns the nil-safe getter-chain expression for a path
+// whose every message hop is optional (scalar) and whose leaf is a
+// `repeated string` field - i.e. the getter chain already yields exactly
+// the []string the accessor wants (e.g. `t.GetActors()`). When this is
+// the message's only path the accessor returns that slice directly, with
+// no builder. It reports false for any path that traverses a
+// repeated/map message hop or whose leaf is a map (those still need a
+// loop).
+func slicePathExpr(recv string, p *Path) (string, bool) {
+	expr := recv
+	for _, s := range p.Steps {
+		g := getter(expr, s)
+		switch s.Kind {
+		case StepScalarMessage:
+			expr = g
+		case StepRepeatedStringLeaf:
+			return g, true
+		default:
+			return "", false
+		}
+	}
+	return "", false
+}
+
+// buildStmts lowers one path into the ordered, brace-balanced statements
+// a ModeBuilder accessor runs against its `out` accumulator to collect
+// every annotated value reachable along p from the receiver.
+//
+// Consecutive scalar message hops collapse into a single nil-safe getter
+// chain (a missing intermediate hop yields "" rather than panicking). A
+// container hop (repeated / map) opens a `range` loop and the walk
+// continues on the loop variable, so nested containers nest loops.
+// Ranging over a nil slice or map is a no-op, keeping the whole body
+// nil-safe.
+//
+// The result is structured data (no Go syntax): the template turns each
+// Stmt into a line of code.
+func buildStmts(recv string, p *Path) []Stmt {
+	var stmts []Stmt
+	expr := recv
+	varN := 0
+	open := 0
+	for _, s := range p.Steps {
+		g := getter(expr, s)
+		switch s.Kind {
+		case StepScalarMessage:
+			expr = g
+		case StepRepeatedMessage, StepMapMessage:
+			varN++
+			v := fmt.Sprintf("e%d", varN)
+			stmts = append(stmts, Stmt{Kind: StmtRangeOpen, Var: v, Expr: g})
+			expr = v
+			open++
+		case StepStringLeaf:
+			stmts = append(stmts, Stmt{Kind: StmtAppend, Expr: g})
+		case StepRepeatedStringLeaf:
+			stmts = append(stmts, Stmt{Kind: StmtAppendSpread, Expr: g})
+		case StepMapStringLeaf:
+			varN++
+			v := fmt.Sprintf("v%d", varN)
+			stmts = append(stmts,
+				Stmt{Kind: StmtRangeOpen, Var: v, Expr: g},
+				Stmt{Kind: StmtAppend, Expr: v},
+				Stmt{Kind: StmtClose},
+			)
+		}
+	}
+	for ; open > 0; open-- {
+		stmts = append(stmts, Stmt{Kind: StmtClose})
+	}
+	return stmts
+}

--- a/internal/protogen/lower_test.go
+++ b/internal/protogen/lower_test.go
@@ -1,0 +1,209 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package protogen
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// step builds a Step with only the fields lowering reads: the Go name
+// and the kind. Lowering never touches descriptors, so the tests need
+// nothing but these literals.
+func step(goName string, kind StepKind) Step {
+	return Step{GoName: goName, Kind: kind}
+}
+
+func path(steps ...Step) *Path {
+	return &Path{Steps: steps}
+}
+
+// TestBuildStmts asserts the structured builder statements lowered for a
+// few representative paths. The statements carry no Go syntax - the
+// plugin's template turns each into a line of code - so the assertions
+// compare Stmt values directly. GoNames arrive already CamelCased from
+// the converter.
+func TestBuildStmts(t *testing.T) {
+	t.Run("directField", func(t *testing.T) {
+		p := path(step("Actor", StepStringLeaf))
+		assert.Equal(t, []Stmt{
+			{Kind: StmtAppend, Expr: "t.GetActor()"},
+		}, buildStmts("t", p))
+	})
+
+	t.Run("multiStepScalarChain", func(t *testing.T) {
+		p := path(
+			step("Outer", StepScalarMessage),
+			step("Mid", StepScalarMessage),
+			step("InnerUuid", StepStringLeaf),
+		)
+		assert.Equal(t, []Stmt{
+			{Kind: StmtAppend, Expr: "t.GetOuter().GetMid().GetInnerUuid()"},
+		}, buildStmts("t", p))
+	})
+
+	t.Run("repeatedStringLeaf", func(t *testing.T) {
+		p := path(step("Actors", StepRepeatedStringLeaf))
+		assert.Equal(t, []Stmt{
+			{Kind: StmtAppendSpread, Expr: "t.GetActors()"},
+		}, buildStmts("t", p))
+	})
+
+	t.Run("mapStringLeaf", func(t *testing.T) {
+		p := path(step("ActorsByRole", StepMapStringLeaf))
+		assert.Equal(t, []Stmt{
+			{Kind: StmtRangeOpen, Var: "v1", Expr: "t.GetActorsByRole()"},
+			{Kind: StmtAppend, Expr: "v1"},
+			{Kind: StmtClose},
+		}, buildStmts("t", p))
+	})
+
+	t.Run("repeatedMessageHop", func(t *testing.T) {
+		p := path(
+			step("Items", StepRepeatedMessage),
+			step("Uuid", StepStringLeaf),
+		)
+		assert.Equal(t, []Stmt{
+			{Kind: StmtRangeOpen, Var: "e1", Expr: "t.GetItems()"},
+			{Kind: StmtAppend, Expr: "e1.GetUuid()"},
+			{Kind: StmtClose},
+		}, buildStmts("t", p))
+	})
+
+	t.Run("mapMessageHop", func(t *testing.T) {
+		p := path(
+			step("ItemsById", StepMapMessage),
+			step("Uuid", StepStringLeaf),
+		)
+		assert.Equal(t, []Stmt{
+			{Kind: StmtRangeOpen, Var: "e1", Expr: "t.GetItemsById()"},
+			{Kind: StmtAppend, Expr: "e1.GetUuid()"},
+			{Kind: StmtClose},
+		}, buildStmts("t", p))
+	})
+
+	t.Run("nestedContainerLoops", func(t *testing.T) {
+		// repeated Item where Item has a repeated string leaf: a
+		// container hop above a container leaf nests one loop.
+		p := path(
+			step("Items", StepRepeatedMessage),
+			step("Actors", StepRepeatedStringLeaf),
+		)
+		assert.Equal(t, []Stmt{
+			{Kind: StmtRangeOpen, Var: "e1", Expr: "t.GetItems()"},
+			{Kind: StmtAppendSpread, Expr: "e1.GetActors()"},
+			{Kind: StmtClose},
+		}, buildStmts("t", p))
+	})
+
+	t.Run("repeatedMessageContainingMapStringLeaf", func(t *testing.T) {
+		// repeated Item where Item has a map<string,string> leaf nests
+		// the map's value loop inside the slice loop, with distinct
+		// variables.
+		p := path(
+			step("Items", StepRepeatedMessage),
+			step("ActorsByRole", StepMapStringLeaf),
+		)
+		assert.Equal(t, []Stmt{
+			{Kind: StmtRangeOpen, Var: "e1", Expr: "t.GetItems()"},
+			{Kind: StmtRangeOpen, Var: "v2", Expr: "e1.GetActorsByRole()"},
+			{Kind: StmtAppend, Expr: "v2"},
+			{Kind: StmtClose},
+			{Kind: StmtClose},
+		}, buildStmts("t", p))
+	})
+}
+
+// TestLower asserts the mode classification and the data each mode
+// carries: scalar-only paths collapse to a single literal, a lone
+// repeated-string leaf returns its slice directly, and any container hop
+// forces the builder.
+func TestLower(t *testing.T) {
+	scalar := func(goName string) *Path {
+		return path(step(goName, StepStringLeaf))
+	}
+
+	t.Run("singleScalarIsLiteral", func(t *testing.T) {
+		a := Lower("t", []*Path{scalar("Actor")})
+		assert.Equal(t, ModeLiteral, a.Mode)
+		assert.Equal(t, []string{"t.GetActor()"}, a.Exprs)
+	})
+
+	t.Run("multipleScalarsShareOneLiteral", func(t *testing.T) {
+		a := Lower("t", []*Path{scalar("First"), scalar("Second")})
+		assert.Equal(t, ModeLiteral, a.Mode)
+		assert.Equal(t, []string{"t.GetFirst()", "t.GetSecond()"}, a.Exprs)
+	})
+
+	repeated := func(goName string) *Path {
+		return path(step(goName, StepRepeatedStringLeaf))
+	}
+
+	t.Run("loneRepeatedStringLeafReturnsSliceDirectly", func(t *testing.T) {
+		a := Lower("t", []*Path{repeated("Actors")})
+		assert.Equal(t, ModeSlice, a.Mode)
+		assert.Equal(t, "t.GetActors()", a.SliceExpr,
+			"a sole repeated-string leaf returns the getter's slice without a builder")
+	})
+
+	t.Run("loneRepeatedStringLeafThroughScalarHopReturnsChain", func(t *testing.T) {
+		p := path(
+			step("Inner", StepScalarMessage),
+			step("Actors", StepRepeatedStringLeaf),
+		)
+		a := Lower("t", []*Path{p})
+		assert.Equal(t, ModeSlice, a.Mode)
+		assert.Equal(t, "t.GetInner().GetActors()", a.SliceExpr)
+	})
+
+	t.Run("multipleRepeatedStringLeavesFallBackToBuilder", func(t *testing.T) {
+		// The direct-return shortcut only applies to a single path; two
+		// slices must be concatenated, so the builder is used.
+		a := Lower("t", []*Path{repeated("Actors"), repeated("Admins")})
+		assert.Equal(t, ModeBuilder, a.Mode)
+		assert.Equal(t, []Stmt{
+			{Kind: StmtAppendSpread, Expr: "t.GetActors()"},
+			{Kind: StmtAppendSpread, Expr: "t.GetAdmins()"},
+		}, a.Stmts)
+	})
+
+	t.Run("anyContainerForcesBuilderForAllPaths", func(t *testing.T) {
+		// A scalar path mixed with a map leaf: the whole body must use
+		// the builder style; the scalar still appends a single value.
+		mapLeaf := path(step("ActorsByRole", StepMapStringLeaf))
+		a := Lower("t", []*Path{scalar("Actor"), mapLeaf})
+		assert.Equal(t, ModeBuilder, a.Mode)
+		assert.Equal(t, []Stmt{
+			{Kind: StmtAppend, Expr: "t.GetActor()"},
+			{Kind: StmtRangeOpen, Var: "v1", Expr: "t.GetActorsByRole()"},
+			{Kind: StmtAppend, Expr: "v1"},
+			{Kind: StmtClose},
+		}, a.Stmts)
+	})
+
+	t.Run("customReceiverExpression", func(t *testing.T) {
+		// The receiver is a parameter, so a future consumer can lower
+		// against any expression, not just "t".
+		a := Lower("req", []*Path{scalar("Actor")})
+		assert.Equal(t, []string{"req.GetActor()"}, a.Exprs)
+	})
+}

--- a/internal/protogen/protogen.go
+++ b/internal/protogen/protogen.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package protogen holds the descriptor-library-agnostic core of
+// annotation-driven accessor generation for protoc plugins.
+//
+// The yarpc protobuf plugins come in two flavors that differ only in
+// which descriptor library they are built on: protoc-gen-yarpc-go wraps
+// github.com/gogo/protobuf, protoc-gen-yarpc-go-v2 wraps
+// github.com/golang/protobuf. Those are structurally identical but
+// nominally distinct type families, so code written against one cannot
+// accept the other. This package factors out everything that does not
+// touch descriptors, so each plugin only supplies a small converter:
+//
+//	descriptors --(per-plugin converter)--> Node graph
+//	Node graph  --(Walk)-->                 []*Path
+//	[]*Path     --(Lower)-->                Accessor (template data)
+//
+// The converter owns all per-library concerns: classifying field shapes
+// from label/type enums, resolving type references and synthetic map
+// entries, reading the annotation through the library's extension
+// machinery, and computing Go identifier names with the library's own
+// CamelCase (so getter names always agree with the structs that library
+// generates). The Walk and Lower stages own the semantics that must stay
+// identical across plugins: cycle pruning, path-count capping, rendering
+// mode selection, and loop/brace construction.
+package protogen
+
+// StepKind classifies one hop along a path from a message to an
+// annotated leaf. The kind determines how the generated accessor
+// traverses the hop: a nil-safe getter chain for scalar hops, or a range
+// loop for container (repeated / map) hops.
+type StepKind int
+
+const (
+	// StepScalarMessage is a single (optional) message-typed hop. The
+	// generated code chains a nil-safe GetXxx() and keeps walking on the
+	// returned value.
+	StepScalarMessage StepKind = iota
+	// StepRepeatedMessage is a `repeated Msg` hop. The generated code
+	// ranges over the slice and recurses into every element.
+	StepRepeatedMessage
+	// StepMapMessage is a `map<K, Msg>` hop. The generated code ranges
+	// over the map and recurses into every value.
+	StepMapMessage
+	// StepStringLeaf is a plain `string` leaf carrying the annotation.
+	// The generated code appends the single value.
+	StepStringLeaf
+	// StepRepeatedStringLeaf is a `repeated string` leaf carrying the
+	// annotation. The generated code appends every element of the slice.
+	StepRepeatedStringLeaf
+	// StepMapStringLeaf is a `map<K, string>` leaf carrying the
+	// annotation. The generated code appends every value of the map. Map
+	// iteration order in Go is non-deterministic, so the relative order
+	// of values surfaced from a single map is unspecified.
+	StepMapStringLeaf
+)
+
+// Node is one message in the neutral graph a converter builds from
+// descriptors. Fields holds only the walk-relevant fields, in
+// declaration order: message-typed hops and annotated string-valued
+// leaves. Everything else (non-string scalars, unannotated strings,
+// unresolvable type references) is omitted by the converter.
+//
+// Converters must memoize Nodes per source message so that two fields
+// referencing the same message share one *Node: the walker keys cycle
+// detection on Node identity.
+type Node struct {
+	Fields []*Field
+}
+
+// Field is one walk-relevant field of a Node.
+type Field struct {
+	// Name is the proto field name (e.g. "caller_actor_id"), carried for
+	// diagnostics and tests.
+	Name string
+	// GoName is the Go name of the field as the plugin's generator
+	// library computes it (e.g. "CallerActorId"); the generated getter
+	// is "Get" + GoName + "()". The converter computes it with the same
+	// CamelCase the library uses to name generated struct fields, so the
+	// emitted accessor always matches the generated code.
+	GoName string
+	// Kind classifies the field's shape; see StepKind.
+	Kind StepKind
+	// Child is the target message for message-shaped kinds (the element
+	// message for repeated hops, the value message for map hops); nil
+	// for leaf kinds.
+	Child *Node
+}
+
+// Step is one hop of a resolved Path, a value copy of the Field it was
+// derived from (minus Child).
+type Step struct {
+	Name   string
+	GoName string
+	Kind   StepKind
+}
+
+// Path is a fully resolved chain from a message down to one annotated
+// leaf. Steps is non-empty: the last entry is the leaf, earlier entries
+// are the message-typed (possibly repeated/map) hops the chain walks
+// through.
+type Path struct {
+	Steps []Step
+}

--- a/internal/protogen/walk.go
+++ b/internal/protogen/walk.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package protogen
+
+// Walk walks root's fields depth-first and returns every reachable
+// annotated leaf as its own path, in declaration order, along with the
+// total number of paths produced. The returned slice is empty (nil) when
+// no path exists.
+//
+// Cycle detection tracks Node identities currently on the recursion
+// stack, seeded with root so a self-cycle at the root level cannot loop
+// forever. Because an entry is removed once its subtree is fully walked,
+// the same Node reached through two distinct sibling fields is walked
+// for both (each route yields its own path), while a true cycle back to
+// an ancestor still on the stack is pruned. Cycle detection spans
+// container hops just as it does scalar ones.
+//
+// maxPaths bounds the work: chained diamond-shaped message references
+// multiply the route count (k chained diamonds yield 2^k routes to the
+// same leaf), so once the count passes maxPaths the walk short-circuits
+// (every remaining call returns nil immediately). Callers detect
+// `count > maxPaths` on the returned count and fail generation, so the
+// bound caps the work done, not just the output.
+func Walk(root *Node, maxPaths int) (paths []*Path, count int) {
+	visited := map[*Node]bool{root: true}
+	return walkNode(root, visited, &count, maxPaths), count
+}
+
+// walkNode collects the paths contributed by every field of n, in
+// declaration order.
+func walkNode(n *Node, visited map[*Node]bool, count *int, maxPaths int) []*Path {
+	var out []*Path
+	for _, f := range n.Fields {
+		out = append(out, walkField(f, visited, count, maxPaths)...)
+	}
+	return out
+}
+
+// walkField returns the paths contributed by a single field: a leaf
+// yields one single-step path; a message hop is descended into, with the
+// hop prepended to every sub-path found underneath.
+func walkField(f *Field, visited map[*Node]bool, count *int, maxPaths int) []*Path {
+	// Path budget exhausted: stop producing paths so the walk unwinds
+	// quickly instead of expanding an unbounded route set.
+	if *count > maxPaths {
+		return nil
+	}
+	step := Step{Name: f.Name, GoName: f.GoName, Kind: f.Kind}
+	switch f.Kind {
+	case StepStringLeaf, StepRepeatedStringLeaf, StepMapStringLeaf:
+		*count++
+		return []*Path{{Steps: []Step{step}}}
+	case StepScalarMessage, StepRepeatedMessage, StepMapMessage:
+		if f.Child == nil || visited[f.Child] {
+			return nil
+		}
+		visited[f.Child] = true
+		subs := walkNode(f.Child, visited, count, maxPaths)
+		delete(visited, f.Child)
+		var out []*Path
+		for _, sub := range subs {
+			steps := make([]Step, 0, 1+len(sub.Steps))
+			steps = append(steps, step)
+			steps = append(steps, sub.Steps...)
+			out = append(out, &Path{Steps: steps})
+		}
+		return out
+	}
+	return nil
+}

--- a/internal/protogen/walk_test.go
+++ b/internal/protogen/walk_test.go
@@ -1,0 +1,189 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package protogen
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// leaf builds a plain string leaf field.
+func leaf(name, goName string) *Field {
+	return &Field{Name: name, GoName: goName, Kind: StepStringLeaf}
+}
+
+// hop builds a scalar message hop into child.
+func hop(name, goName string, child *Node) *Field {
+	return &Field{Name: name, GoName: goName, Kind: StepScalarMessage, Child: child}
+}
+
+// names flattens the per-path step names of a walk result.
+func names(paths []*Path) [][]string {
+	out := make([][]string, 0, len(paths))
+	for _, p := range paths {
+		row := make([]string, 0, len(p.Steps))
+		for _, s := range p.Steps {
+			row = append(row, s.Name)
+		}
+		out = append(out, row)
+	}
+	return out
+}
+
+// TestWalk exercises the shared traversal semantics on literal graphs.
+// Shape classification and annotation reading are converter concerns and
+// are tested with each plugin; here every Field is already walk-relevant.
+func TestWalk(t *testing.T) {
+	t.Run("directLeaf", func(t *testing.T) {
+		root := &Node{Fields: []*Field{leaf("actor", "Actor")}}
+		paths, count := Walk(root, 100)
+		require.Len(t, paths, 1)
+		assert.Equal(t, 1, count)
+		assert.Equal(t, [][]string{{"actor"}}, names(paths))
+		assert.Equal(t, StepStringLeaf, paths[0].Steps[0].Kind)
+		assert.Equal(t, "Actor", paths[0].Steps[0].GoName)
+	})
+
+	t.Run("declarationOrderPreserved", func(t *testing.T) {
+		root := &Node{Fields: []*Field{
+			leaf("first", "First"),
+			leaf("second", "Second"),
+		}}
+		paths, _ := Walk(root, 100)
+		assert.Equal(t, [][]string{{"first"}, {"second"}}, names(paths))
+	})
+
+	t.Run("chainOfScalarHops", func(t *testing.T) {
+		inner := &Node{Fields: []*Field{leaf("uuid", "Uuid")}}
+		mid := &Node{Fields: []*Field{hop("inner", "Inner", inner)}}
+		root := &Node{Fields: []*Field{hop("mid", "Mid", mid)}}
+		paths, _ := Walk(root, 100)
+		require.Len(t, paths, 1)
+		assert.Equal(t, [][]string{{"mid", "inner", "uuid"}}, names(paths))
+	})
+
+	t.Run("siblingRoutesToSharedNodeBothWalked", func(t *testing.T) {
+		// The visited set is unwound after each branch, so two sibling
+		// fields sharing one Node each surface their own path.
+		shared := &Node{Fields: []*Field{leaf("uuid", "Uuid")}}
+		root := &Node{Fields: []*Field{
+			hop("primary", "Primary", shared),
+			hop("secondary", "Secondary", shared),
+		}}
+		paths, count := Walk(root, 100)
+		assert.Equal(t, 2, count)
+		assert.Equal(t, [][]string{
+			{"primary", "uuid"},
+			{"secondary", "uuid"},
+		}, names(paths))
+	})
+
+	t.Run("selfCyclePrunedSiblingLeafWins", func(t *testing.T) {
+		// A node referencing itself must be pruned by the on-stack
+		// visited set; its annotated sibling still surfaces.
+		node := &Node{}
+		node.Fields = []*Field{
+			hop("loop", "Loop", node),
+			leaf("id", "Id"),
+		}
+		paths, _ := Walk(node, 100)
+		assert.Equal(t, [][]string{{"id"}}, names(paths))
+	})
+
+	t.Run("cycleBackToAncestorPruned", func(t *testing.T) {
+		// root -> child -> root: the back-edge is pruned while the
+		// sibling leaf under child still surfaces.
+		root := &Node{}
+		child := &Node{Fields: []*Field{leaf("uuid", "Uuid")}}
+		child.Fields = append(child.Fields, hop("back", "Back", root))
+		root.Fields = []*Field{hop("child", "Child", child)}
+		paths, _ := Walk(root, 100)
+		assert.Equal(t, [][]string{{"child", "uuid"}}, names(paths))
+	})
+
+	t.Run("containerHopsCarryTheirKind", func(t *testing.T) {
+		item := &Node{Fields: []*Field{leaf("uuid", "Uuid")}}
+		root := &Node{Fields: []*Field{
+			{Name: "items", GoName: "Items", Kind: StepRepeatedMessage, Child: item},
+			{Name: "by_id", GoName: "ById", Kind: StepMapMessage, Child: item},
+			{Name: "tags", GoName: "Tags", Kind: StepRepeatedStringLeaf},
+			{Name: "by_role", GoName: "ByRole", Kind: StepMapStringLeaf},
+		}}
+		paths, _ := Walk(root, 100)
+		require.Len(t, paths, 4)
+		assert.Equal(t, StepRepeatedMessage, paths[0].Steps[0].Kind)
+		assert.Equal(t, StepMapMessage, paths[1].Steps[0].Kind)
+		assert.Equal(t, StepRepeatedStringLeaf, paths[2].Steps[0].Kind)
+		assert.Equal(t, StepMapStringLeaf, paths[3].Steps[0].Kind)
+	})
+
+	t.Run("nilChildSkipped", func(t *testing.T) {
+		// A message hop without a resolved child contributes nothing;
+		// the walk moves on to the next field.
+		root := &Node{Fields: []*Field{
+			hop("ghost", "Ghost", nil),
+			leaf("fallback", "Fallback"),
+		}}
+		paths, _ := Walk(root, 100)
+		assert.Equal(t, [][]string{{"fallback"}}, names(paths))
+	})
+
+	t.Run("emptyNodeYieldsNoPaths", func(t *testing.T) {
+		paths, count := Walk(&Node{}, 100)
+		assert.Empty(t, paths)
+		assert.Zero(t, count)
+	})
+
+	t.Run("capShortCircuitsDiamondExpansion", func(t *testing.T) {
+		// 7 chained diamonds expand to 2^7 = 128 routes to the leaf.
+		// With maxPaths 100 the walk must report count > 100 without
+		// producing all 128 paths.
+		next := &Node{Fields: []*Field{leaf("uuid", "Uuid")}}
+		for i := 0; i < 7; i++ {
+			next = &Node{Fields: []*Field{
+				hop("a", "A", next),
+				hop("b", "B", next),
+			}}
+		}
+		root := &Node{Fields: []*Field{hop("root", "Root", next)}}
+		paths, count := Walk(root, 100)
+		assert.Greater(t, count, 100, "the caller detects the overflow on count")
+		assert.LessOrEqual(t, count, 128)
+		assert.LessOrEqual(t, len(paths), count)
+	})
+
+	t.Run("underCapDiamondExpandsFully", func(t *testing.T) {
+		// 6 chained diamonds expand to 2^6 = 64 routes, under the cap.
+		next := &Node{Fields: []*Field{leaf("uuid", "Uuid")}}
+		for i := 0; i < 6; i++ {
+			next = &Node{Fields: []*Field{
+				hop("a", "A", next),
+				hop("b", "B", next),
+			}}
+		}
+		root := &Node{Fields: []*Field{hop("root", "Root", next)}}
+		paths, count := Walk(root, 100)
+		assert.Equal(t, 64, count)
+		assert.Len(t, paths, 64)
+	})
+}


### PR DESCRIPTION
## Description
<!--
What does this change do, and why? Give reviewers the context they need to
review it: the problem, the approach, and anything non-obvious.
-->

We are adding `ActorUUID()` accessor generation (driven by the `actor_uuid` field annotation, mirroring thriftrw-plugin-yarpc) to our protobuf plugins. The logic splits naturally into two halves:
- **Traversal and lowering** — walking a message graph to find every annotated string leaf, and turning those paths into a template-ready description of the accessor body. This is pure algorithm: nothing about it depends on which protobuf library produced the descriptors.
- **Descriptor reading** — classifying field shapes from label/type enums, resolving map entries, reading extensions, CamelCasing getter names. This is inherently library-specific. The complication is that our plugins sit on two incompatible descriptor stacks: protoc-gen-yarpc-go uses gogo/protobuf, while the v2 plugin uses
golang/protobuf. The two libraries define structurally similar but nominally distinct descriptor types, so Go's type system does not let one walker consume both. Without a shared core, the traversal, capping, cycle detection, and
lowering logic would have to be written (and kept bug-for-bug identical) twice.

This PR adds `internal/protogen`, a package with **no descriptor-library dependencies**, containing:
- **Neutral graph types** (`Node`, `Field`, `StepKind`): a minimal representation of a message graph holding only what the walk needs — field name, Go getter name, shape classification (scalar/repeated/map × message-hop/string-leaf), and child references.
- **`Walk(root, maxPaths)`**: depth-first traversal that returns every path from the root to an annotated leaf, in declaration order. It prunes cycles with an on-stack visited set (keyed on Node pointer identity) while still exploring
  sibling routes to a shared type, and it aborts as soon as the path count passes `maxPaths`, so a pathological schema (e.g. chained diamond-shaped references, which multiply routes exponentially) bounds the work done, not
  just the output.
- **`Lower(recv, paths)`**: classifies the path set into a rendering mode (direct slice return / composite literal / statement builder) and produces structured expressions and statements. It emits no Go syntax itself — the plugin's template owns that — just data the template renders.
### How it is used
Each plugin contributes a small converter that transforms its library's descriptors into the neutral graph (reading annotations and CamelCasing with that library's own machinery), then calls `Walk` and `Lower`. The traversal and lowering semantics are therefore shared and tested once.
<img width="1920" height="1920" alt="protogen_architecture_diagram" src="https://github.com/user-attachments/assets/3570d6dd-e9e0-4a38-a6c2-871219d6f47b" />
Implementation for protoc-gen-yarpc-go (v1) lives in [PR#2519](https://github.com/yarpc/yarpc-go/pull/2519) and [PR#2520](https://github.com/yarpc/yarpc-go/pull/2520)
### Stacked PRs
1. **this PR** — `internal/protogen` — shared descriptor-agnostic core [PR#2535](https://github.com/yarpc/yarpc-go/pull/2535)
2. gogo converter + `ActorUUID()` emission in protoc-gen-yarpc-go [PR#2519](https://github.com/yarpc/yarpc-go/pull/2519)
3. server-side validator wiring [PR#2520](https://github.com/yarpc/yarpc-go/pull/2520)
## Test Plan
<!--
How did you verify this works? e.g. `make test`, specific cases exercised,
before/after behaviour. Write "N/a" for docs-only or comment-only changes.
-->
The package is fully covered by tests that build literal `Node` graphs and `Step` values — no descriptors involved: declaration order, sibling routes vs. true cycles, container hops/leaves, cap enforcement (under/over the limit), and
mode classification with balanced loop generation.

RELEASE NOTES:
<!-- Significant changes, used to compile the release notes. Write "N/a" if none. -->
Introduce descriptor-agnostic core for annotation-driven accessor generator