### PR TITLE
encoding/protobuf, transport/grpc: pin buffer ownership invariants with tests

### DIFF
--- a/encoding/protobuf/marshal_test.go
+++ b/encoding/protobuf/marshal_test.go
@@ -110,3 +110,30 @@ func TestUnmarshalFastPath(t *testing.T) {
 		assert.Error(t, err, "Malformed protobuf should return an error on fast path")
 	})
 }
+
+// TestUnmarshalBytesDoesNotAliasBuffer pins an ownership invariant that the
+// decode path already depends on: unmarshalBytes must copy data out of the
+// buffer it is handed, never retain a view into it.
+//
+// unmarshal calls unmarshalBytes with a pooled bufferpool buffer and returns
+// that buffer to the pool as soon as it returns, so a decoder that aliased the
+// input would hand callers a message backed by memory the pool is free to reset
+// and lease to the next request.
+func TestUnmarshalBytesDoesNotAliasBuffer(t *testing.T) {
+	payload := []byte("payload-bytes")
+
+	body, err := proto.Marshal(&types.BytesValue{Value: payload})
+	require.NoError(t, err)
+
+	got := &types.BytesValue{}
+	require.NoError(t, unmarshalBytes(Encoding, body, got, newCodec(nil)))
+	require.Equal(t, payload, got.Value)
+
+	// Scribble over the buffer the way a recycled pool buffer would be.
+	for i := range body {
+		body[i] = 0xff
+	}
+
+	assert.Equal(t, payload, got.Value,
+		"decoded message must not alias the buffer passed to unmarshalBytes")
+}

--- a/encoding/protobuf/v2/marshal_test.go
+++ b/encoding/protobuf/v2/marshal_test.go
@@ -107,3 +107,30 @@ func TestUnmarshalFastPath(t *testing.T) {
 		assert.Error(t, err, "Malformed protobuf should return an error on fast path")
 	})
 }
+
+// TestUnmarshalBytesDoesNotAliasBuffer pins an ownership invariant that the
+// decode path already depends on: unmarshalBytes must copy data out of the
+// buffer it is handed, never retain a view into it.
+//
+// unmarshal calls unmarshalBytes with a pooled bufferpool buffer and returns
+// that buffer to the pool as soon as it returns, so a decoder that aliased the
+// input would hand callers a message backed by memory the pool is free to reset
+// and lease to the next request.
+func TestUnmarshalBytesDoesNotAliasBuffer(t *testing.T) {
+	payload := []byte("payload-bytes")
+
+	body, err := proto.Marshal(&wrapperspb.BytesValue{Value: payload})
+	require.NoError(t, err)
+
+	got := &wrapperspb.BytesValue{}
+	require.NoError(t, unmarshalBytes(Encoding, body, got, newCodec(nil)))
+	require.Equal(t, payload, got.Value)
+
+	// Scribble over the buffer the way a recycled pool buffer would be.
+	for i := range body {
+		body[i] = 0xff
+	}
+
+	assert.Equal(t, payload, got.Value,
+		"decoded message must not alias the buffer passed to unmarshalBytes")
+}

--- a/transport/grpc/codec_test.go
+++ b/transport/grpc/codec_test.go
@@ -164,3 +164,26 @@ func (m *testBufferPool) Put(buf *[]byte) {
 		m.putFunc(buf)
 	}
 }
+
+// TestCustomCodecUnmarshalReturnsCopy pins an ownership invariant that the
+// decode path already depends on: the []byte produced here becomes the
+// transport request/response body, which outlives the gRPC call that produced
+// it. Materialize allocates a fresh slice; switching to a pooled or aliasing
+// variant such as MaterializeToBuffer would recycle memory that transport
+// bodies and decoded messages still reference.
+func TestCustomCodecUnmarshalReturnsCopy(t *testing.T) {
+	wire := []byte("wire-bytes")
+	var got []byte
+
+	err := customCodec{}.Unmarshal(mem.BufferSlice{mem.SliceBuffer(wire)}, &got)
+	assert.NoError(t, err)
+	assert.Equal(t, "wire-bytes", string(got))
+
+	// Scribble over the wire buffer the way a recycled pool buffer would be.
+	for i := range wire {
+		wire[i] = 0xff
+	}
+
+	assert.Equal(t, "wire-bytes", string(got),
+		"Unmarshal must return a copy, not a view of the wire buffer")
+}


### PR DESCRIPTION
## Description

The protobuf decode path depends on two buffer ownership rules that are not stated or covered anywhere:

1. **`customCodec.Unmarshal` must return a private copy of the wire bytes.** The slice it produces becomes the transport request/response body, which outlives the gRPC call that produced it. It holds today because `mem.BufferSlice.Materialize()` allocates a fresh slice but `MaterializeToBuffer()` (pooled, refcounted) sits directly beside it in the same API and is the natural thing to reach for when optimising this path.

2. **`unmarshalBytes` must copy data out of the buffer it is handed**, rather than retain a view into it. `unmarshal` passes a pooled `bufferpool` buffer and returns it to the pool as soon as it returns, so an aliasing decoder would hand callers a message backed by memory the pool is free to reset and lease to the next request.

Both rules hold today. Breaking either produces data races. This PR just writes them down as tests.

## Test Plan

Ran `go test -count=1 ./encoding/protobuf/... ./transport/grpc/...` — 646 tests pass, `gofmt` and `go vet` clean.

Each test was verified to actually fail when its invariant is broken, rather than passing vacuously:

- `TestCustomCodecUnmarshalReturnsCopy` — made `Unmarshal` alias via `data[0].ReadOnlyData()`; fails with `wire-bytes` vs `??????????`.
- `TestUnmarshalBytesDoesNotAliasBuffer` (gogo and v2) — made `unmarshalBytes` alias the wire buffer for `BytesValue`; both fail as intended.

Those deliberate breakages were reverted; only the three test files change.

RELEASE NOTES: N/a
