### PR TITLE
Reconciliate main branch after CI is re-enabled

### DIFF
--- a/encoding/protobuf/protoc-gen-yarpc-go/internal/tests/withuuid/validator_test.go
+++ b/encoding/protobuf/protoc-gen-yarpc-go/internal/tests/withuuid/validator_test.go
@@ -45,9 +45,8 @@ import (
 // observed. Only the methods exercised below carry behaviour; the rest
 // satisfy the interface.
 type recordingServer struct {
-	called    bool
-	gotActor  string
-	gotCaller string
+	called   bool
+	gotActor string
 }
 
 func (s *recordingServer) DeleteUser(_ context.Context, req *DeleteUserRequest) (*DeleteUserResponse, error) {


### PR DESCRIPTION
## Description
`make lint` is currently failing on `main`:

```
encoding/protobuf/protoc-gen-yarpc-go/internal/tests/withuuid/validator_test.go:50:2:
    field gotCaller is unused (U1000)
```

Incoming GitHub webhook processing on the `uberopensource/yarpc-go` Buildkite pipeline was disabled on 2026-08-01, so every commit between then and now merged with no CI. 

Webhook intake has since been re-enabled; this PR started as the smoke test that confirmed it.

Test-only change; no production code affected. Needed on `main` before any new release.

## Test Plan
- `staticcheck v0.6.1` (the version CI pins) on the package: U1000 gone, only
  the generated-file `io/ioutil` SA1019 remains, which `FILTER_STATICCHECK`
  already excludes.
- Repo-wide staticcheck: every other finding is in generated files that
  `FILTER_LINT` excludes, so this was the only real break.
- `go vet ./encoding/protobuf/protoc-gen-yarpc-go/internal/tests/withuuid/...`
  passes; the test package still compiles.
- Full Buildkite run on this PR.

## Checklist
- [x] Description and context for reviewers: one partner, one stranger
- [ ] Docs (package doc)

RELEASE NOTES: N/a
