### PR TITLE
encoding/thrift: fix use-after-Put data race in NoWire client's pooled request buffer

### DIFF
--- a/encoding/thrift/outbound_nowire.go
+++ b/encoding/thrift/outbound_nowire.go
@@ -32,6 +32,7 @@ import (
 	encodingapi "go.uber.org/yarpc/api/encoding"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/encoding/thrift/internal"
+	"go.uber.org/yarpc/internal/bufferpool"
 	"go.uber.org/yarpc/pkg/encoding"
 	"go.uber.org/yarpc/pkg/errors"
 	"go.uber.org/yarpc/pkg/procedure"
@@ -237,8 +238,16 @@ func (c noWireThriftClient) buildTransportRequest(reqBody stream.Enveloper) (*tr
 		)
 	}
 
-	var buffer bytes.Buffer
-	sw := proto.Writer(&buffer)
+	// buffer is only scratch space for the streaming encode below; it is
+	// always returned to the pool before this function returns, and its
+	// backing array must never be reachable from treq.Body. The transport
+	// (and, for retries, retryfx) may read treq.Body an arbitrary number of
+	// times, arbitrarily far in the future and concurrently with other
+	// requests reusing this same pooled buffer — so treq.Body gets its own,
+	// unshared copy of the encoded bytes instead.
+	buffer := bufferpool.Get()
+
+	sw := proto.Writer(buffer)
 	defer sw.Close()
 
 	if err := sw.WriteEnvelopeBegin(stream.EnvelopeHeader{
@@ -246,18 +255,24 @@ func (c noWireThriftClient) buildTransportRequest(reqBody stream.Enveloper) (*tr
 		Type:  envType,
 		SeqID: 1, // don't care
 	}); err != nil {
+		bufferpool.Put(buffer)
 		return nil, nil, errors.RequestBodyEncodeError(&treq, err)
 	}
 
 	if err := reqBody.Encode(sw); err != nil {
+		bufferpool.Put(buffer)
 		return nil, nil, errors.RequestBodyEncodeError(&treq, err)
 	}
 
 	if err := sw.WriteEnvelopeEnd(); err != nil {
+		bufferpool.Put(buffer)
 		return nil, nil, errors.RequestBodyEncodeError(&treq, err)
 	}
 
-	treq.Body = &buffer
-	treq.BodySize = buffer.Len()
+	body := append([]byte(nil), buffer.Bytes()...)
+	bufferpool.Put(buffer)
+
+	treq.Body = bytes.NewReader(body)
+	treq.BodySize = len(body)
 	return &treq, proto, nil
 }

--- a/encoding/thrift/outbound_nowire_race_test.go
+++ b/encoding/thrift/outbound_nowire_race_test.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package thrift
+
+import (
+	"context"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/thriftrw/wire"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/api/transport/transporttest"
+	"go.uber.org/yarpc/internal/clientconfig"
+	"go.uber.org/yarpc/internal/testtime"
+)
+
+// TestNoWireClient_ConcurrentBufferPoolReuseRace is a regression/detector
+// test for the "YARPC bufferpool" use-after-Put race reported in production
+// (Slack "Race 2"): an outbound Thrift NoWire request body backed by a
+// pooled buffer can be returned to the pool (via Close) and reused by an
+// unrelated, concurrent request's Write while the transport is still
+// asynchronously draining the original body's raw bytes (e.g. a slow or
+// backpressured HTTP/2 upload). The bug only manifested under concurrent
+// load in production, so this test drives many overlapping calls at once
+// rather than relying on a single coincidental pool hit.
+//
+// If buildTransportRequest ever sources its request buffer from bufferpool
+// again without otherwise guaranteeing the buffer outlives every reader of
+// it, this test must fail under `go test -race`.
+func TestNoWireClient_ConcurrentBufferPoolReuseRace(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	trans := transporttest.NewMockUnaryOutbound(mockCtrl)
+
+	var readers sync.WaitGroup
+	trans.EXPECT().Call(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, treq *transport.Request) (*transport.Response, error) {
+			// Simulate the HTTP/2 client's writeRequestBody: an independent
+			// goroutine slowly drains the raw request body bytes over the
+			// wire, well after Call() has returned control to its caller.
+			readers.Add(1)
+			go func(body io.Reader) {
+				defer readers.Done()
+				one := make([]byte, 1)
+				for {
+					_, err := body.Read(one)
+					if err != nil {
+						return
+					}
+					time.Sleep(10 * time.Microsecond)
+				}
+			}(treq.Body)
+
+			// Simulate the transport considering the body "done with" and
+			// closing it right away (e.g. on a GOAWAY replay or early
+			// cancellation) without waiting for the above goroutine to
+			// finish physically draining it. If Close() returns the
+			// underlying buffer to the pool, this races with the read above
+			// and with whatever else the pool hands the buffer to next.
+			if closer, ok := treq.Body.(io.Closer); ok {
+				closer.Close()
+			}
+
+			return &transport.Response{
+				Body: io.NopCloser(strings.NewReader(encodeThriftString(t, "response"))),
+			}, nil
+		},
+	).AnyTimes()
+
+	nwc := NewNoWire(Config{
+		Service: "MyService",
+		ClientConfig: clientconfig.MultiOutbound("caller", "service",
+			transport.Outbounds{Unary: trans}),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), testtime.Second)
+	defer cancel()
+
+	// Fire many concurrent, logically unrelated calls (mirroring "high
+	// load" from the incident reports) so the shared bufferpool is under
+	// real contention: some goroutine's Get() is likely to reuse a buffer
+	// that another goroutine's slow reader (above) is still draining.
+	const (
+		numGoroutines     = 50
+		callsPerGoroutine = 20
+	)
+
+	var wg sync.WaitGroup
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < callsPerGoroutine; j++ {
+				var br fakeBodyReader
+				assert.NoError(t, nwc.Call(ctx, fakeEnveloper(wire.Call), &br))
+			}
+		}()
+	}
+	wg.Wait()
+
+	readers.Wait()
+}


### PR DESCRIPTION
## Summary

- The Thrift NoWire outbound client's `buildTransportRequest` previously used bufferpool.Get()/Put() for the request body, returning the pool buffer to the pool via `Close()` on `treq.Body` (a `readCloser` wrapper). This still races: nothing guarantees every reader of the body (a retry, or a slow/async HTTP/2 upload draining it in the background) has finished before something calls `Close()` and the same backing array is handed to an unrelated concurrent request.
- This PR keeps the pooled buffer purely as scratch space during the streaming encode, then copies the final encoded bytes into a fresh, unshared slice and returns the buffer to the pool synchronously — before `buildTransportRequest` even returns. `treq.Body` is a plain `bytes.Reader` over that unshared slice, so retries can re-read it any number of times with no further pool interaction, and no `Close()`-timing dependency exists at all.

## Test plan

- Added `TestNoWireClient_ConcurrentBufferPoolReuseRace`, which drives 50 goroutines x 20 calls each against a mock outbound simulating a slow async body reader plus an early `Close()`. It reproduces the race reliably (5/5 runs) against the previous pooled+readCloser pattern under `go test -race`, and passes cleanly against this fix.
- `go test -race ./encoding/thrift/...` passes.